### PR TITLE
Trophy fishing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 + Added **Unclaimed Rewards** - Highlight contests with unclaimed rewards in the jacob inventory.
 + Added **Duplicate Hider** - Hides duplicate farming contests in the inventory.
 + Added **Contest Time** - Adds the real time format to the farming contest description.
++ Added **Hide Repeated Catches** - Delete past catches of the same trophy fish from chat. - (Thanks appable0)
++ Added **Trophy Counter Design** - Change the way trophy fish messages gets displayed in the chat. - (Thanks appable0)
 
 ### Garden Features
 + Added **Copper Price** - Show copper to coin prices inside the Sky Mart inventory.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -107,7 +107,9 @@
 - Highlight Thunder Sparks that spawn after killing a Thunder.
 - **Barn Timer** - Show the time and amount of sea creatures while fishing on the barn via hub.
 - **Shark Fish Counter** - Counts how many sharks have been caught.
-- **Added Odger waypoint** - Show the Odger waypoint when trophy fishes are in the inventory and no lava rod in hand.
+- **Odger waypoint** - Show the Odger waypoint when trophy fishes are in the inventory and no lava rod in hand.
++ **Hide Repeated Catches** - Delete past catches of the same trophy fish from chat. - (Thanks appable0
++ **Trophy Counter Design** - Change the way trophy fish messages gets displayed in the chat. - (Thanks appable0)
 
 ## Damage Indicator
 - Show the remaining health of selected bosses in the game in a bigger GUI.

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Fishing.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Fishing.java
@@ -31,7 +31,7 @@ public class Fishing {
     public int trophyDesign = 0;
 
     @Expose
-    @ConfigOption(name = "Hide Repeated Catches", desc = "Delete past catches of the same fish from chat.")
+    @ConfigOption(name = "Hide Repeated Catches", desc = "Delete past catches of the same trophy fish from chat.")
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 0)
     public boolean trophyFishDuplicateHider = false;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Fishing.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Fishing.java
@@ -32,6 +32,12 @@ public class Fishing {
     public int trophyDesign = 0;
 
     @Expose
+    @ConfigOption(name = "Hide Repeated Catches", desc = "Delete past catches of the same fish from chat.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 0)
+    public boolean trophyFishDuplicateHider = false;
+
+    @Expose
     @ConfigOption(name = "Bronze Duplicates", desc = "Hide duplicate messages for bronze trophy fishes from chat.")
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 0)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Fishing.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Fishing.java
@@ -20,6 +20,18 @@ public class Fishing {
     public boolean trophyCounter = false;
 
     @Expose
+    @ConfigOption(
+            name = "Trophy Counter Design",
+            desc = "Change the way trophy fish are displayed in chat."
+    )
+    @ConfigEditorDropdown(values = {
+            "§72. §6§lGOLD §5Moldfin",
+            "§bYou caught a §5Moldfin §6§lGOLD§6. §7(2)",
+            "§bYou caught your 2nd §5Moldfin §6§lGOLD§6."})
+    @ConfigAccordionId(id = 0)
+    public int trophyDesign = 0;
+
+    @Expose
     @ConfigOption(name = "Bronze Duplicates", desc = "Hide duplicate messages for bronze trophy fishes from chat.")
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 0)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Fishing.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Fishing.java
@@ -22,12 +22,11 @@ public class Fishing {
     @Expose
     @ConfigOption(
             name = "Trophy Counter Design",
-            desc = "Change the way trophy fish are displayed in chat."
+            desc = "§fStyle 1: §72. §6§lGOLD §5Moldfin\n" +
+                    "§fStyle 2: §bYou caught a §5Moldfin §6§lGOLD§b. §7(2)\n" +
+                    "§fStyle 3: §bYou caught your 2nd §6§lGOLD §5Moldfin§b."
     )
-    @ConfigEditorDropdown(values = {
-            "§72. §6§lGOLD §5Moldfin",
-            "§bYou caught a §5Moldfin §6§lGOLD§6. §7(2)",
-            "§bYou caught your 2nd §5Moldfin §6§lGOLD§6."})
+    @ConfigEditorDropdown(values = {"Style 1", "Style 2", "Style 3"})
     @ConfigAccordionId(id = 0)
     public int trophyDesign = 0;
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TrophyFishMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TrophyFishMessages.kt
@@ -16,7 +16,7 @@ class TrophyFishMessages {
     private var hasLoadedTrophyFish = false
     private val fishAmounts = mutableMapOf<String, Int>()
     private val trophyFishPattern =
-        Regex("§6§lTROPHY FISH! §r§bYou caught an? §r(?<displayName>§[0-9a-f](?:§k)?[\\w ].+)§r§r§r §r§l§r(?<displayRarity>§[0-9a-f]§l\\w+)§r§b\\.")
+        Regex("§6§lTROPHY FISH! §r§bYou caught an? §r(?<displayName>§[0-9a-f](?:§k)?[\\w -]+)§r§r§r §r§l§r(?<displayRarity>§[0-9a-f]§l\\w+)§r§b\\.")
 
     @SubscribeEvent
     fun onProfileJoin(event: ProfileJoinEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TrophyFishMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TrophyFishMessages.kt
@@ -17,6 +17,7 @@ class TrophyFishMessages {
     private val fishAmounts = mutableMapOf<String, Int>()
     private val trophyFishPattern =
         Regex("§6§lTROPHY FISH! §r§bYou caught an? §r(?<displayName>§[0-9a-f](?:§k)?[\\w -]+)§r§r§r §r§l§r(?<displayRarity>§[0-9a-f]§l\\w+)§r§b\\.")
+    private val config get() = SkyHanniMod.feature.fishing
 
     @SubscribeEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
@@ -52,7 +53,7 @@ class TrophyFishMessages {
 
     @SubscribeEvent
     fun onStatusBar(event: LorenzChatEvent) {
-        if (!LorenzUtils.inSkyBlock || !SkyHanniMod.feature.fishing.trophyCounter) return
+        if (!LorenzUtils.inSkyBlock || !config.trophyCounter) return
 
         val match = trophyFishPattern.matchEntire(event.message)?.groups ?: return
         val displayName = match["displayName"]!!.value.replace("§k", "")
@@ -67,15 +68,15 @@ class TrophyFishMessages {
         fishAmounts[fish] = amount
         event.blockedReason = "trophy_fish"
 
-        if (SkyHanniMod.feature.fishing.trophyDesign == 0 && amount == 1) {
+        if (config.trophyDesign == 0 && amount == 1) {
             LorenzUtils.chat("§6§lTROPHY FISH! §c§lFIRST §r$displayRarity $displayName")
             return
         }
 
-        if (SkyHanniMod.feature.fishing.trophyFishBronzeHider && rarity == "bronze" && amount != 1) return
-        if (SkyHanniMod.feature.fishing.trophyFishSilverHider && rarity == "silver" && amount != 1) return
+        if (config.trophyFishBronzeHider && rarity == "bronze" && amount != 1) return
+        if (config.trophyFishSilverHider && rarity == "silver" && amount != 1) return
 
-        val trophyMessage = "§6§lTROPHY FISH! " + when (SkyHanniMod.feature.fishing.trophyDesign) {
+        val trophyMessage = "§6§lTROPHY FISH! " + when (config.trophyDesign) {
             0 -> "§7$amount. §r$displayRarity $displayName"
             1 -> "§bYou caught a $displayName $displayRarity§b. §7(${amount.addSeparators()})"
             else -> "§bYou caught your ${amount.addSeparators()}${amount.ordinal()} $displayRarity $displayName§b."
@@ -83,7 +84,7 @@ class TrophyFishMessages {
 
         Minecraft.getMinecraft().ingameGUI.chatGUI.printChatMessageWithOptionalDeletion(
             ChatComponentText(trophyMessage),
-            if (SkyHanniMod.feature.fishing.trophyFishDuplicateHider) fish.hashCode() else 0
+            if (config.trophyFishDuplicateHider) fish.hashCode() else 0
         )
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TrophyFishMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TrophyFishMessages.kt
@@ -3,14 +3,20 @@ package at.hannibal2.skyhanni.features.fishing
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.ProfileApiDataLoadedEvent
+import at.hannibal2.skyhanni.utils.LorenzDebug
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.between
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.addSuffix
+import at.hannibal2.skyhanni.utils.NumberUtil.ordinal
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.util.regex.Pattern
 
 class TrophyFishMessages {
 
     private val map = mutableMapOf<String, Int>()
+    private val trophyFishPattern = Regex("§6§lTROPHY FISH! §r§bYou caught an? §r(?<displayName>§[0-9a-f](?:§k)?[\\w ].+)§r§r§r §r§l§r(?<displayRarity>§[0-9a-f]§l\\w+)§r§b\\.")
 
     @SubscribeEvent
     fun onProfileDataLoad(event: ProfileApiDataLoadedEvent) {
@@ -30,7 +36,6 @@ class TrophyFishMessages {
             val displayName = text.substring(0, text.length - rarity.length)
 
             val amount = value.asInt
-
 //            LorenzDebug.log("$rarity: $displayName: $amount")
             val name = rarity + "_" + displayName
             map[name] = amount
@@ -44,34 +49,42 @@ class TrophyFishMessages {
         if (!SkyHanniMod.feature.fishing.trophyCounter) return
 
         val message = event.message
-        //TODO replace logic with regex
-        if (!message.startsWith("§6§lTROPHY FISH! §r§bYou caught a")) return
 
-        var displayName =
-            if (message.contains(" a §r")) message.between(" a §r", "§r §r") else message.between(" an §r", "§r §r")
-        if (displayName.contains("§k")) {
-            displayName = displayName.replace("§k", "")
-            displayName = displayName.replace("Obfuscated", "Obfuscated Fish")
-        }
-        val rarity = message.between("§r §r", "§b.").lowercase().replace("§l", "")
+        val groups = trophyFishPattern.matchEntire(message)?.groups ?: return
+        val displayName = groups["displayName"]!!.value.replace("§k", "")
+        val displayRarity = groups["displayRarity"]!!.value
 
-        val name = (rarity + "_" + displayName).removeColor().lowercase().replace(" ", "").replace("-", "")
-        val amount = map.getOrDefault(name, 0) + 1
+        val name = displayName
+            .replace("Obfuscated", "Obfuscated Fish")
+            .replace("[- ]".toRegex(), "")
+            .lowercase()
+            .removeColor()
+
+        val rarity = displayRarity.lowercase().removeColor()
+
+        val amount = map.getOrDefault("${rarity}_${name}", 0) + 1
         map[name] = amount
         event.blockedReason = "trophy_fish"
 
-        if (amount == 1) {
-            LorenzUtils.chat("§6TROPHY FISH! §c§lFIRST §r$rarity $displayName")
+        if (SkyHanniMod.feature.fishing.trophyDesign == 0 && amount == 1) {
+            LorenzUtils.chat("§6TROPHY FISH! §c§lFIRST §r$displayRarity $displayName")
             return
         }
 
-        if (rarity.contains("bronze")) {
+        if (rarity == "bronze" && amount != 1) {
             if (SkyHanniMod.feature.fishing.trophyFishBronzeHider) return
         }
-        if (rarity.contains("silver")) {
+        if (rarity == "silver" && amount != 1) {
             if (SkyHanniMod.feature.fishing.trophyFishSilverHider) return
         }
 
-        LorenzUtils.chat("§6TROPHY FISH! §7$amount. §r$rarity $displayName")
+        val trophyMessage = when (SkyHanniMod.feature.fishing.trophyDesign) {
+            0 -> "§7$amount. §r$displayRarity $displayName"
+            1 -> "§bYou caught a $displayName $displayRarity§b. §7(${amount.addSeparators()})"
+            2 -> "§bYou caught your ${amount.addSeparators()}${amount.ordinal()} $displayRarity $displayName§b."
+            else -> return
+        }
+
+        LorenzUtils.chat("§6§lTROPHY FISH! $trophyMessage")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TrophyFishMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TrophyFishMessages.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.fishing
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.ProfileApiDataLoadedEvent
+import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.ordinal
@@ -12,12 +13,19 @@ import net.minecraft.util.ChatComponentText
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class TrophyFishMessages {
-
+    private var hasLoadedTrophyFish = false
     private val fishAmounts = mutableMapOf<String, Int>()
-    private val trophyFishPattern = Regex("§6§lTROPHY FISH! §r§bYou caught an? §r(?<displayName>§[0-9a-f](?:§k)?[\\w ].+)§r§r§r §r§l§r(?<displayRarity>§[0-9a-f]§l\\w+)§r§b\\.")
+    private val trophyFishPattern =
+        Regex("§6§lTROPHY FISH! §r§bYou caught an? §r(?<displayName>§[0-9a-f](?:§k)?[\\w ].+)§r§r§r §r§l§r(?<displayRarity>§[0-9a-f]§l\\w+)§r§b\\.")
+
+    @SubscribeEvent
+    fun onProfileJoin(event: ProfileJoinEvent) {
+        hasLoadedTrophyFish = false
+    }
 
     @SubscribeEvent
     fun onProfileDataLoad(event: ProfileApiDataLoadedEvent) {
+        if (hasLoadedTrophyFish) return
         val profileData = event.profileData
 
         fishAmounts.clear()
@@ -35,56 +43,47 @@ class TrophyFishMessages {
 
             val amount = value.asInt
 //            LorenzDebug.log("$rarity: $displayName: $amount")
-            val name = rarity + "_" + displayName
-            fishAmounts[name] = amount
-//            LorenzDebug.log("loaded trophy: $name = $amount")
+            val fish = rarity + "_" + displayName
+            fishAmounts[fish] = amount
+//            LorenzDebug.log("loaded trophy: $fish = $amount")
+            hasLoadedTrophyFish = true
         }
     }
 
     @SubscribeEvent
     fun onStatusBar(event: LorenzChatEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-        if (!SkyHanniMod.feature.fishing.trophyCounter) return
+        if (!LorenzUtils.inSkyBlock || !SkyHanniMod.feature.fishing.trophyCounter) return
 
-        val message = event.message
+        val match = trophyFishPattern.matchEntire(event.message)?.groups ?: return
+        val displayName = match["displayName"]!!.value.replace("§k", "")
+        val displayRarity = match["displayRarity"]!!.value
 
-        val groups = trophyFishPattern.matchEntire(message)?.groups ?: return
-        val displayName = groups["displayName"]!!.value.replace("§k", "")
-        val displayRarity = groups["displayRarity"]!!.value
-
-        val name = displayName
-            .replace("Obfuscated", "Obfuscated Fish")
-            .replace("[- ]".toRegex(), "")
-            .lowercase()
-            .removeColor()
-
+        val name = displayName.replace("Obfuscated", "Obfuscated Fish")
+            .replace("[- ]".toRegex(), "").lowercase().removeColor()
         val rarity = displayRarity.lowercase().removeColor()
+
         val fish = "${rarity}_${name}"
         val amount = fishAmounts.getOrDefault(fish, 0) + 1
-        fishAmounts[name] = amount
+        fishAmounts[fish] = amount
         event.blockedReason = "trophy_fish"
 
         if (SkyHanniMod.feature.fishing.trophyDesign == 0 && amount == 1) {
-            LorenzUtils.chat("§6TROPHY FISH! §c§lFIRST §r$displayRarity $displayName")
+            LorenzUtils.chat("§6§lTROPHY FISH! §c§lFIRST §r$displayRarity $displayName")
             return
         }
 
-        if (rarity == "bronze" && amount != 1) {
-            if (SkyHanniMod.feature.fishing.trophyFishBronzeHider) return
-        }
-        if (rarity == "silver" && amount != 1) {
-            if (SkyHanniMod.feature.fishing.trophyFishSilverHider) return
-        }
+        if (SkyHanniMod.feature.fishing.trophyFishBronzeHider && rarity == "bronze" && amount != 1) return
+        if (SkyHanniMod.feature.fishing.trophyFishSilverHider && rarity == "silver" && amount != 1) return
 
-        val trophyMessage = ChatComponentText(when (SkyHanniMod.feature.fishing.trophyDesign) {
+        val trophyMessage = "§6§lTROPHY FISH! " + when (SkyHanniMod.feature.fishing.trophyDesign) {
             0 -> "§7$amount. §r$displayRarity $displayName"
             1 -> "§bYou caught a $displayName $displayRarity§b. §7(${amount.addSeparators()})"
-            2 -> "§bYou caught your ${amount.addSeparators()}${amount.ordinal()} $displayRarity $displayName§b."
-            else -> return
-        })
+            else -> "§bYou caught your ${amount.addSeparators()}${amount.ordinal()} $displayRarity $displayName§b."
+        }
 
-        val chatGui = Minecraft.getMinecraft().ingameGUI.chatGUI
-        val chatLineId = if (SkyHanniMod.feature.fishing.trophyFishDuplicateHider) fish.hashCode() else 0
-        chatGui.printChatMessageWithOptionalDeletion(trophyMessage, chatLineId)
+        Minecraft.getMinecraft().ingameGUI.chatGUI.printChatMessageWithOptionalDeletion(
+            ChatComponentText(trophyMessage),
+            if (SkyHanniMod.feature.fishing.trophyFishDuplicateHider) fish.hashCode() else 0
+        )
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -77,7 +77,7 @@ object NumberUtil {
 
     fun Number.ordinal(): String {
         val long = this.toLong()
-        if (long % 100 in 11..13) return "${this}th"
+        if (long % 100 in 11..13) return "th"
         return when (long % 10) {
             1L -> "st"
             2L -> "nd"

--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.utils.NumberUtil.addSuffix
 import java.text.NumberFormat
 import java.util.*
 import java.util.regex.Pattern
@@ -74,15 +75,23 @@ object NumberUtil {
         return (this * scale).roundToInt().toFloat() / scale
     }
 
-    fun Number.addSuffix(): String {
+    fun Number.ordinal(): String {
         val long = this.toLong()
-        if (long in 11..13) return "${this}th"
+        if (long % 100 in 11..13) return "${this}th"
         return when (long % 10) {
-            1L -> "${this}st"
-            2L -> "${this}nd"
-            3L -> "${this}rd"
-            else -> "${this}th"
+            1L -> "st"
+            2L -> "nd"
+            3L -> "rd"
+            else -> "th"
         }
+    }
+
+    fun Number.addSuffix(): String {
+        return this.toString() + this.ordinal()
+    }
+
+    fun Number.addSeparators(): String {
+        return NumberFormat.getNumberInstance().format(this)
     }
 
     fun String.romanToDecimalIfNeeded() = toIntOrNull() ?: romanToDecimal()


### PR DESCRIPTION
- Option to select formats for trophy fishing messages
- Option to hide duplicate trophy fish messages of the same tier and type
- Only load trophy data once per profile join event to prevent trophy fish count from occasionally decreasing 
- Replace some manual string operations with regular expressions

<img width="353" alt="Screenshot 2023-03-22 at 10 05 36 PM" src="https://user-images.githubusercontent.com/16139460/227108493-12e71d35-ca5b-4499-9272-a7b9c131c62f.png">
<img width="501" alt="Screenshot 2023-03-22 at 10 06 49 PM" src="https://user-images.githubusercontent.com/16139460/227108682-c4747ee5-5973-4fe8-ad75-28a468f867af.png">
<img width="575" alt="Screenshot 2023-03-22 at 10 03 11 PM" src="https://user-images.githubusercontent.com/16139460/227108147-41fb6d20-3afe-4331-9d1a-cc26c0ec1b29.png">

Note: the "compact" style is similar but not identical to the existing message—this can be reverted to the original style if that's preferred, of course.