### PR TITLE
Fix visitor request pattern when amount is not displayed

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -137,7 +137,7 @@ object ItemUtils {
 
     fun isSkyBlockMenuItem(stack: ItemStack?): Boolean = stack?.getInternalName() == "SKYBLOCK_MENU"
 
-    private val patternInFront = Pattern.compile("(?: *§8(?<amount>[\\d,]+)x )?(?<name>.*)")
+    private val patternInFront = Pattern.compile("(?: *)(?:§8(?<amount>[\\d,]+)x )?(?<name>.*)")
     private val patternBehind = Pattern.compile("(?<name>(?:['\\w-]+ ?)+)(?:§8x(?<amount>[\\d,]+))?")
 
     private val itemAmountCache = mutableMapOf<String, Pair<String, Int>>()


### PR DESCRIPTION
Minor change to patternInFront, which previously extracted "&nbsp;Polished Pumpkin" as itemName and then failed to find an internal name.
<img width="209" alt="Screenshot 2023-03-31 at 3 03 30 PM" src="https://user-images.githubusercontent.com/16139460/229241073-07c0201b-032f-45d3-b0a0-b725e9ec4c02.png">
