### PR TITLE
Farming fortune display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 + Added **Unclaimed Rewards** - Highlight contests with unclaimed rewards in the jacob inventory.
 + Added **Duplicate Hider** - Hides duplicate farming contests in the inventory.
 + Added **Contest Time** - Adds the real time format to the farming contest description.
-+ Added **Hide Repeated Catches** - Delete past catches of the same trophy fish from chat. - (Thanks appable0)
-+ Added **Trophy Counter Design** - Change the way trophy fish messages gets displayed in the chat. - (Thanks appable0)
++ Added **Hide Repeated Catches** - Delete past catches of the same trophy fish from chat. - (contributed by appable)
++ Added **Trophy Counter Design** - Change the way trophy fish messages gets displayed in the chat. - (contributed by appable)
 + Added **CH Join** - Helps buy a Pass for accessing the Crystal Hollows if needed.
 + Added **Estimated Item Value** - Displays an estimated item value for the item you hover over.
 
@@ -57,6 +57,10 @@
 + Added **Highlight Upgrade** - Highlight Upgrades that can be bought right now.
 + Added **Number Composter Upgrades** - Show the number of upgrades in the composter upgrades inventory.
 + Added **Composter Inventory Numbers** - Show the amount of Organic Matter, Fuel and Composts Available while inside the composter inventory.
++ Added **True Farming Fortune - Displays** current farming fortune, including crop-specific bonuses. (contributed by appable)
++ Added **Tooltip Tweaks Compact Descriptions** - Hides redundant parts of reforge descriptions, generic counter description, and Farmhand perk explanation. (contributed by appable)
++ Added **Tooltip Tweaks Breakdown Hotkey** - When the keybind is pressed, show a breakdown of all fortune sources on a tool. (contributed by appable)
++ Added **Tooltip Tweaks Tooltip Format** - Show crop-specific farming fortune in tooltip. (contributed by appable)
 
 
 ### Features from other Mods

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -204,6 +204,10 @@
 + **Highlight Upgrade** - Highlight Upgrades that can be bought right now.
 + **Number Composter Upgrades** - Show the number of upgrades in the composter upgrades inventory.
 + **Composter Inventory Numbers** - Show the amount of Organic Matter, Fuel and Composts Available while inside the composter inventory.
++ **True Farming Fortune - Displays** current farming fortune, including crop-specific bonuses. (contributed by appable)
++ **Tooltip Tweaks Compact Descriptions** - Hides redundant parts of reforge descriptions, generic counter description, and Farmhand perk explanation. (contributed by appable)
++ **Tooltip Tweaks Breakdown Hotkey** - When the keybind is pressed, show a breakdown of all fortune sources on a tool. (contributed by appable)
++ **Tooltip Tweaks Tooltip Format** - Show crop-specific farming fortune in tooltip. (contributed by appable)
 
 ## Commands
 - /wiki (using hypixel-skyblock.fandom.com instead of Hypixel wiki)

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.java
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.java
@@ -244,6 +244,7 @@ public class SkyHanniMod {
         loadModule(new PasteIntoSigns());
         loadModule(new EstimatedItemValue());
         loadModule(new FarmingFortuneDisplay());
+        loadModule(new ToolTooltipTweaks());
 
         Commands.INSTANCE.init();
 

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.java
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.java
@@ -121,6 +121,7 @@ public class SkyHanniMod {
         loadModule(new TabListData());
         loadModule(new RenderGuiData());
         loadModule(new GardenCropMilestones());
+        loadModule(new GardenCropUpgrades());
         loadModule(new OwnInventoryData());
         loadModule(new ToolTipData());
         loadModule(new GuiEditManager());
@@ -242,6 +243,7 @@ public class SkyHanniMod {
         loadModule(new MinionCollectLogic());
         loadModule(new PasteIntoSigns());
         loadModule(new EstimatedItemValue());
+        loadModule(new FarmingFortuneDisplay());
 
         Commands.INSTANCE.init();
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -758,13 +758,13 @@ public class Garden {
     public boolean composterInventoryNumbers = true;
 
     @Expose
-    @ConfigOption(name = "Farming Fortune", desc = "")
+    @ConfigOption(name = "True Farming Fortune", desc = "")
     @ConfigEditorAccordion(id = 18)
     public boolean farmingFortune = false;
 
     @Expose
     @ConfigOption(
-            name = "Farming Fortune Display",
+            name = "FF Display",
             desc = "Displays current farming fortune, including crop-specific bonuses."
     )
     @ConfigEditorBoolean
@@ -776,36 +776,36 @@ public class Garden {
 
     @Expose
     @ConfigOption(name = "Tooltip Tweaks", desc = "")
-    @ConfigEditorAccordion(id = 19)
+    @ConfigEditorAccordion(id = 20)
     public boolean tooltipTweaks = false;
 
     @Expose
     @ConfigOption(
-            name = "Compact Tool Tooltips",
+            name = "Compact Descriptions",
             desc = "Hides redundant parts of reforge descriptions, generic counter description, and Farmhand perk explanation."
     )
     @ConfigEditorBoolean
-    @ConfigAccordionId(id = 19)
+    @ConfigAccordionId(id = 20)
     public boolean compactToolTooltips = false;
 
     @Expose
     @ConfigOption(
-            name = "Tooltip Crop Fortune Breakdown",
-            desc = "When keybind pressed, show a breakdown of all fortune sources on a tool."
+            name = "Breakdown Hotkey",
+            desc = "When the keybind is pressed, show a breakdown of all fortune sources on a tool."
     )
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_LSHIFT)
-    @ConfigAccordionId(id = 19)
+    @ConfigAccordionId(id = 20)
     public int fortuneTooltipKeybind = Keyboard.KEY_LSHIFT;
 
     @Expose
     @ConfigOption(
-            name = "Farming Fortune Tooltip Format",
-            desc = "Show crop-specific farming fortune in tooltip. \n" +
+            name = "Tooltip Format",
+            desc = "Show crop-specific farming fortune in tooltip.\n" +
                     "§fShow: §7Crop-specific fortune indicated as §6[+196]\n" +
-                    "§fReplace: §7Edits the total fortune to include crop-specific fortune"
+                    "§fReplace: §7Edits the total fortune to include crop-specific fortune."
     )
     @ConfigEditorDropdown(values = {"Default", "Show", "Replace"})
-    @ConfigAccordionId(id = 19)
+    @ConfigAccordionId(id = 20)
     public int cropTooltipFortune = 1;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -749,6 +749,23 @@ public class Garden {
     public Position composterDisplayPos = new Position(-363, 13, false, true);
 
     @Expose
+    @ConfigOption(name = "Farming Fortune", desc = "")
+    @ConfigEditorAccordion(id = 18)
+    public boolean farmingFortune = false;
+
+    @Expose
+    @ConfigOption(
+            name = "Farming Fortune Display",
+            desc = "Displays current farming fortune, including crop-specific bonuses."
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 18)
+    public boolean farmingFortuneDisplay = true;
+
+    @Expose
+    public Position farmingFortunePos = new Position(-375, -200, false, true);
+
+    @Expose
     @ConfigOption(name = "Plot Price", desc = "Show the price of the plot in coins when inside the Configure Plots inventory.")
     @ConfigEditorBoolean
     public boolean plotPrice = true;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -766,6 +766,40 @@ public class Garden {
     public Position farmingFortunePos = new Position(-375, -200, false, true);
 
     @Expose
+    @ConfigOption(name = "Tooltip Tweaks", desc = "")
+    @ConfigEditorAccordion(id = 19)
+    public boolean tooltipTweaks = false;
+
+    @Expose
+    @ConfigOption(
+            name = "Compact Tool Tooltips",
+            desc = "Hides redundant parts of reforge descriptions, generic counter description, and Farmhand perk explanation."
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 19)
+    public boolean compactToolTooltips = false;
+
+    @Expose
+    @ConfigOption(
+            name = "Tooltip Crop Fortune Breakdown",
+            desc = "When keybind pressed, show a breakdown of all fortune sources on a tool."
+    )
+    @ConfigEditorKeybind(defaultKey = Keyboard.KEY_LSHIFT)
+    @ConfigAccordionId(id = 19)
+    public int fortuneTooltipKeybind = Keyboard.KEY_LSHIFT;
+
+    @Expose
+    @ConfigOption(
+            name = "Farming Fortune Tooltip Format",
+            desc = "Show crop-specific farming fortune in tooltip. \n" +
+                    "§fShow: §7Crop-specific fortune indicated as §6[+196]\n" +
+                    "§fReplace: §7Edits the total fortune to include crop-specific fortune"
+    )
+    @ConfigEditorDropdown(values = {"Default", "Show", "Replace"})
+    @ConfigAccordionId(id = 19)
+    public int cropTooltipFortune = 1;
+
+    @Expose
     @ConfigOption(name = "Plot Price", desc = "Show the price of the plot in coins when inside the Configure Plots inventory.")
     @ConfigEditorBoolean
     public boolean plotPrice = true;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
@@ -38,6 +38,9 @@ public class Hidden {
     public Map<CropType, Long> gardenCropCounter = new HashMap<>();
 
     @Expose
+    public Map<CropType, Integer> gardenCropUpgrades = new HashMap<>();
+
+    @Expose
     public Map<CropType, Integer> gardenCropsPerSecond = new HashMap<>();
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/data/GardenCropUpgrades.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GardenCropUpgrades.kt
@@ -1,0 +1,59 @@
+package at.hannibal2.skyhanni.data
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.InventoryOpenEvent
+import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.features.garden.CropType
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.name
+import io.github.moulberry.notenoughupdates.util.stripControlCodes
+import net.minecraftforge.event.world.WorldEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class GardenCropUpgrades {
+    private val tierPattern = "§7Current Tier: §[0-9a-e](\\d)§7/§a9".toRegex()
+    private val chatUpgradePattern = "\\s*§r§6§lCROP UPGRADE §e§f([\\w ]+)§7 #(\\d)§r".toRegex()
+
+    @SubscribeEvent
+    fun onChat(event: LorenzChatEvent) {
+        chatUpgradePattern.matchEntire(event.message)?.groups?.let { matches ->
+            val crop = CropType.getByItemName(matches[1]!!.value) ?: return
+            val level = matches[2]!!.value.toInt()
+            cropUpgrades[crop] = level
+        }
+    }
+
+    @SubscribeEvent
+    fun onWorldChange(event: WorldEvent.Load) {
+        if (cropUpgrades.isEmpty()) {
+            for (crop in CropType.values()) {
+                cropUpgrades[crop] = 0
+            }
+        }
+    }
+
+    @SubscribeEvent
+    fun onInventoryOpen(event: InventoryOpenEvent) {
+        if (event.inventoryName != "Crop Upgrades") return
+        event.inventoryItems.forEach { (_, item) ->
+            val crop = item.name?.stripControlCodes()?.let {
+                CropType.getByName(it)
+            } ?: return@forEach
+            val level = item.getLore().firstNotNullOfOrNull {
+                tierPattern.matchEntire(it)?.groups?.get(1)?.value?.toIntOrNull()
+            } ?: return@forEach
+            crop.setUpgradeLevel(level)
+        }
+    }
+
+    companion object {
+        val cropUpgrades: MutableMap<CropType, Int> get() = SkyHanniMod.feature.hidden.gardenCropUpgrades
+
+        fun CropType.getUpgradeLevel() = cropUpgrades[this]!!
+
+        fun CropType.setUpgradeLevel(level: Int) {
+            cropUpgrades[this] = level
+        }
+
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/events/CropUpgradeUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/CropUpgradeUpdateEvent.kt
@@ -1,0 +1,3 @@
+package at.hannibal2.skyhanni.events
+
+class CropUpgradeUpdateEvent: LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.garden
 
+import net.minecraft.block.state.IBlockState
 import net.minecraft.init.Blocks
 import net.minecraft.init.Items
 import net.minecraft.item.EnumDyeColor
@@ -32,6 +33,33 @@ enum class CropType(val cropName: String, val toolName: String, iconSupplier: ()
                 return MUSHROOM
             }
             return getByName(itemName)
+        }
+
+        fun getByBlock(blockState: IBlockState): CropType? {
+            return when (blockState.block) {
+                Blocks.wheat -> WHEAT
+                Blocks.carrots -> CARROT
+                Blocks.potatoes -> POTATO
+                Blocks.pumpkin -> PUMPKIN
+                Blocks.reeds -> SUGAR_CANE
+                Blocks.melon_block -> MELON
+                Blocks.cactus -> CACTUS
+                Blocks.cocoa -> COCOA_BEANS
+                Blocks.red_mushroom -> MUSHROOM
+                Blocks.brown_mushroom -> MUSHROOM
+                Blocks.nether_wart -> NETHER_WART
+                else -> null
+            }
+        }
+
+        fun CropType.getTurboCrop(): String {
+            return when (this) {
+                COCOA_BEANS -> "turbo_coco"
+                SUGAR_CANE -> "turbo_cane"
+                NETHER_WART -> "turbo_warts"
+                MUSHROOM -> "turbo_mushrooms"
+                else -> "turbo_${this.cropName.lowercase()}"
+            }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -1,0 +1,129 @@
+package at.hannibal2.skyhanni.features.garden
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.GardenCropMilestones
+import at.hannibal2.skyhanni.data.GardenCropMilestones.Companion.getCounter
+import at.hannibal2.skyhanni.data.GardenCropUpgrades.Companion.getUpgradeLevel
+import at.hannibal2.skyhanni.events.*
+import at.hannibal2.skyhanni.features.garden.CropType.Companion.getTurboCrop
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.RenderUtils.renderSingleLineWithItems
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
+import net.minecraft.item.ItemStack
+import net.minecraftforge.fml.common.eventhandler.EventPriority
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class FarmingFortuneDisplay {
+    private val config get() = SkyHanniMod.feature.garden
+
+    private val tabFortunePattern = " Farming Fortune: §r§6☘(\\d+)".toRegex()
+    private val counterPattern = "§7You have §6\\+([\\d]{1,3})☘ Farming Fortune".toRegex()
+
+    private var display = mutableListOf<Any>()
+    private var currentCrop: CropType? = null
+
+    private var tabFortune: Double = 0.0
+    private var toolFortune: Double = 0.0
+    private var counterFortune: Double = 0.0
+    private var turboCropFortune: Double = 0.0
+    private var dedicationFortune: Double = 0.0
+    private var upgradeFortune: Double = 0.0
+
+    private val totalFortune: Double
+        get() = tabFortune +
+                toolFortune +
+                counterFortune +
+                turboCropFortune +
+                dedicationFortune +
+                upgradeFortune
+
+    @SubscribeEvent
+    fun onBlockBreak(event: BlockClickEvent) {
+        if (!GardenAPI.inGarden()) return
+        val cropBroken = CropType.getByBlock(event.getBlockState) ?: return
+        if (cropBroken != currentCrop) {
+            currentCrop = cropBroken
+            updateCropSpecificFortune(event.itemInHand)
+        }
+    }
+
+    @SubscribeEvent
+    fun onGardenToolChange(event: GardenToolChangeEvent) {
+        val heldTool = event.toolItem
+        currentCrop = event.crop ?: currentCrop
+        updateCropSpecificFortune(heldTool)
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    fun onInventoryUpdate(event: OwnInventorItemUpdateEvent) {
+        if (!GardenAPI.inGarden()) return
+        if (GardenAPI.getCropTypeFromItem(event.itemStack) == null) return
+        updateCropSpecificFortune(event.itemStack)
+    }
+
+    @SubscribeEvent
+    fun onTabListUpdate(event: TabListUpdateEvent) {
+        if (!GardenAPI.inGarden()) return
+        tabFortune = event.tabList.firstNotNullOfOrNull {
+            tabFortunePattern.matchEntire(it)?.groups?.get(1)?.value?.toDoubleOrNull()
+        } ?: tabFortune
+        drawDisplay()
+    }
+
+    @SubscribeEvent
+    fun onRenderOverlay(event: GuiRenderEvent.GameOverlayRenderEvent) {
+        if (!GardenAPI.inGarden() || !config.farmingFortuneDisplay) return
+        config.farmingFortunePos.renderSingleLineWithItems(display, posLabel = "Farming Fortune")
+    }
+
+    private fun drawDisplay() {
+        val displayCrop = currentCrop ?: return
+        display.clear()
+        GardenAPI.addGardenCropToList(displayCrop, display)
+        display.add("§6Farming Fortune§7: §e${LorenzUtils.formatDouble(totalFortune, 0)}")
+    }
+
+    private fun updateCropSpecificFortune(tool: ItemStack?) {
+        val cropMatchesTool = currentCrop == GardenAPI.getCropTypeFromItem(tool)
+        toolFortune = if (cropMatchesTool) getToolFortune(tool) else 0.0
+        counterFortune = if (cropMatchesTool) getCounterFortune(tool) else 0.0
+
+        turboCropFortune = getTurboCropFortune(tool)
+        dedicationFortune = getDedicationFortune(tool)
+        upgradeFortune = (currentCrop?.getUpgradeLevel() ?: 0) * 5.0
+    }
+
+    private fun getTurboCropFortune(tool: ItemStack?): Double {
+        val crop = currentCrop ?: return 0.0
+        return tool?.getEnchantments()?.get(crop.getTurboCrop())?.let { it * 5.0 } ?: 0.0
+    }
+
+    private fun getToolFortune(tool: ItemStack?): Double {
+        val internalName = tool?.getInternalName() ?: return 0.0
+        return if (internalName.startsWith("THEORETICAL_HOE")) {
+            listOf(10.0, 25.0, 50.0)[internalName.last().digitToInt() - 1]
+        } else when (internalName) {
+            "FUNGI_CUTTER" -> 30.0
+            "COCO_CHOPPER" -> 20.0
+            else -> 0.0
+        }
+    }
+
+    private fun getDedicationFortune(tool: ItemStack?): Double {
+        val dedicationLevel = tool?.getEnchantments()?.get("dedication") ?: 0
+        val dedicationMultiplier = listOf(0.0, 0.5, 0.75, 1.0, 2.0)[dedicationLevel]
+        val cropMilestone = GardenCropMilestones.getTierForCrops(
+            currentCrop?.getCounter() ?: 0
+        )
+        return dedicationMultiplier * cropMilestone
+    }
+
+    private fun getCounterFortune(tool: ItemStack?): Double {
+        val lore = tool?.getLore() ?: return 0.0
+        return lore.sumOf {
+            counterPattern.matchEntire(it)?.groups?.get(1)?.value?.toDoubleOrNull() ?: 0.0
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -155,7 +155,6 @@ class FarmingFortuneDisplay {
             val lore = tool?.getLore() ?: return 0.0
             var hasCollectionAbility = false
             return lore.firstNotNullOfOrNull {
-                println(it)
                 if (hasCollectionAbility || it == "§6Collection Analysis") {
                     hasCollectionAbility = true
                     collectionPattern.matchEntire(it)?.groups?.get(1)?.value?.toDoubleOrNull()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -6,6 +6,8 @@ import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.events.*
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getCounter
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getCultivatingCount
 import net.minecraft.client.Minecraft
 import net.minecraft.item.ItemStack
 import net.minecraft.network.play.client.C09PacketHeldItemChange
@@ -91,23 +93,7 @@ class GardenAPI {
             return CropType.values().firstOrNull { internalName.startsWith(it.toolName) }
         }
 
-        fun readCounter(itemStack: ItemStack): Int {
-            if (itemStack.hasTagCompound()) {
-                val tag = itemStack.tagCompound
-                if (tag.hasKey("ExtraAttributes", 10)) {
-                    val ea = tag.getCompoundTag("ExtraAttributes")
-                    if (ea.hasKey("mined_crops", 99)) {
-                        return ea.getInteger("mined_crops")
-                    }
-
-                    // only using cultivating when no crops counter is there
-                    if (ea.hasKey("farmed_cultivating", 99)) {
-                        return ea.getInteger("farmed_cultivating")
-                    }
-                }
-            }
-            return -1
-        }
+        fun readCounter(itemStack: ItemStack): Int = itemStack.getCounter() ?: itemStack.getCultivatingCount() ?: -1
 
         fun CropType.getSpeed(): Int {
             val speed = cropsPerSecond[this]

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
@@ -17,7 +17,7 @@ class ToolTooltipTweaks {
     private val tooltipFortunePattern = "^§5§o§7Farming Fortune: §a\\+([\\d.]+)(?: §2\\(\\+\\d\\))?(?: §9\\(\\+(\\d+)\\))\$".toRegex()
     private val counterStartLine = setOf("§5§o§6Logarithmic Counter", "§5§o§6Collection Analysis")
 
-    private val reforgeEndLine = setOf("§5§o", "§5§o§7Grants §6+0.2 coins §7per crop.")
+    private val reforgeEndLine = setOf("§5§o", "§5§o§7chance for multiple crops.")
 
     @SubscribeEvent
     fun onTooltip(event: LorenzToolTipEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
@@ -1,0 +1,116 @@
+package at.hannibal2.skyhanni.features.garden
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getFarmingForDummiesCount
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeName
+import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import org.lwjgl.input.Keyboard
+import java.text.DecimalFormat
+import kotlin.math.roundToInt
+
+class ToolTooltipTweaks {
+    private val config get() = SkyHanniMod.feature.garden
+    private val tooltipFortunePattern = "^§5§o§7Farming Fortune: §a\\+([\\d.]+)(?: §2\\(\\+\\d\\))?(?: §9\\(\\+(\\d+)\\))\$".toRegex()
+    private val counterStartLine = setOf("§5§o§6Logarithmic Counter", "§5§o§6Collection Analysis")
+
+    private val reforgeEndLine = setOf("§5§o", "§5§o§7Grants §6+0.2 coins §7per crop.")
+
+    @SubscribeEvent
+    fun onTooltip(event: LorenzToolTipEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+        val crop = GardenAPI.getCropTypeFromItem(event.itemStack) ?: return
+        val toolFortune = FarmingFortuneDisplay.getToolFortune(event.itemStack)
+        val counterFortune = FarmingFortuneDisplay.getCounterFortune(event.itemStack)
+        val collectionFortune = FarmingFortuneDisplay.getCollectionFortune(event.itemStack)
+        val turboCropFortune = FarmingFortuneDisplay.getTurboCropFortune(event.itemStack, crop)
+        val dedicationFortune = FarmingFortuneDisplay.getDedicationFortune(event.itemStack, crop)
+
+        val reforgeName = event.itemStack.getReforgeName()?.firstLetterUppercase()
+        val enchantments = event.itemStack.getEnchantments()
+        val sunderFortune = (enchantments["sunder"] ?: 0) * 12.5
+        val harvestingFortune = (enchantments["harvesting"] ?: 0) * 12.5
+        val cultivatingFortune = (enchantments["cultivating"] ?: 0).toDouble()
+
+        val ffdFortune = event.itemStack.getFarmingForDummiesCount().toDouble()
+        val cropFortune = (toolFortune + counterFortune + collectionFortune + turboCropFortune + dedicationFortune)
+        val iterator = event.toolTip.listIterator()
+
+        var removingFarmhandDescription = false
+        var removingCounterDescription = false
+        var removingReforgeDescription = false
+
+        for (line in iterator) {
+            val match = tooltipFortunePattern.matchEntire(line)?.groups
+            if (match != null) {
+                val displayedFortune = match[1]!!.value.toDouble()
+                val reforgeFortune = match[2]!!.value.toDouble()
+                val totalFortune = displayedFortune + cropFortune
+
+                val ffdString = if (ffdFortune != 0.0) " §2(+${ffdFortune.formatStat()})" else ""
+                val reforgeString = if (reforgeFortune != 0.0) " §9(+${reforgeFortune.formatStat()})" else ""
+                val cropString = if (cropFortune != 0.0) " §6[+${cropFortune.roundToInt()}]" else ""
+
+                val fortuneLine = when (config.cropTooltipFortune) {
+                    0 -> "§7Farming Fortune: §a+${displayedFortune.formatStat()}$ffdString$reforgeString"
+                    1 -> "§7Farming Fortune: §a+${displayedFortune.formatStat()}$ffdString$reforgeString$cropString"
+                    else -> "§7Farming Fortune: §a+${totalFortune.formatStat()}$ffdString$reforgeString$cropString"
+                }
+                iterator.set(fortuneLine)
+
+                if (Keyboard.isKeyDown(config.fortuneTooltipKeybind)) {
+                    iterator.addStat("  §7Sunder: §a+", sunderFortune)
+                    iterator.addStat("  §7Harvesting: §a+", harvestingFortune)
+                    iterator.addStat("  §7Cultivating: §a+", cultivatingFortune)
+                    iterator.addStat("  §7Farming for Dummies: §2+", ffdFortune)
+                    iterator.addStat("  §7$reforgeName: §9+", reforgeFortune)
+                    iterator.addStat("  §7Tool: §6+", toolFortune)
+                    iterator.addStat("  §7Counter: §6+", counterFortune)
+                    iterator.addStat("  §7Collection: §6+", collectionFortune)
+                    iterator.addStat("  §7Dedication: §6+", dedicationFortune)
+                    iterator.addStat("  §7Turbo-Crop: §6+", turboCropFortune)
+                }
+            }
+            // Beware, dubious control flow beyond these lines
+            if (config.compactToolTooltips) {
+                if (line.startsWith("§5§o§7§8Bonus ")) removingFarmhandDescription = true
+                if (removingFarmhandDescription) {
+                    iterator.remove()
+                    removingFarmhandDescription = line != "§5§o"
+                }
+
+                if (removingCounterDescription && !line.startsWith("§5§o§7You have")) {
+                    iterator.remove()
+                } else {
+                    removingCounterDescription = false
+                }
+                if (counterStartLine.contains(line)) removingCounterDescription = true
+
+                if (line == "§5§o§9Blessed Bonus") removingReforgeDescription = true
+                if (removingReforgeDescription ) {
+                    iterator.remove()
+                    removingReforgeDescription = !reforgeEndLine.contains(line)
+                }
+                if (line == "§5§o§9Bountiful Bonus") removingReforgeDescription = true
+            }
+
+        }
+    }
+
+    companion object {
+        private fun Double.formatStat(): String {
+            val formatter = DecimalFormat("0.##")
+            return formatter.format(this)
+        }
+
+
+        private fun MutableListIterator<String>.addStat(description: String, value: Double) {
+            if (value != 0.0) {
+                this.add("$description${value.formatStat()}")
+            }
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -32,6 +32,30 @@ object SkyBlockItemModifierUtils {
         return 0
     }
 
+    fun ItemStack.getCultivatingCount(): Int? {
+        for (tags in tagCompound.keySet) {
+            if (tags != "ExtraAttributes") continue
+            val extraAttributes = tagCompound.getCompoundTag(tags)
+            for (attributes in extraAttributes.keySet) {
+                if (attributes != "farmed_cultivating") continue
+                return extraAttributes.getInteger(attributes)
+            }
+        }
+        return null
+    }
+
+    fun ItemStack.getCounter(): Int? {
+        for (tags in tagCompound.keySet) {
+            if (tags != "ExtraAttributes") continue
+            val extraAttributes = tagCompound.getCompoundTag(tags)
+            for (attributes in extraAttributes.keySet) {
+                if (attributes != "mined_crops") continue
+                return extraAttributes.getInteger(attributes)
+            }
+        }
+        return null
+    }
+
     fun ItemStack.getSilexCount(): Int {
         var silexTier = 0
         for ((name, amount) in getEnchantments()) {


### PR DESCRIPTION
<img width="254" alt="Screenshot 2023-04-07 at 11 53 38 PM" src="https://user-images.githubusercontent.com/16139460/230707877-ac603241-36db-4498-a38a-25b0c52ef05e.png">

This adds a simple farming fortune display that takes crop-specific farming fortune into account (specifically: dedication, turbo-crop, tool counter, tool passive ability, and crop upgrades).
- Added farming fortune display
- Added crop upgrade data manager and update event
- Some various utility methods in CropType, SkyBlockItemModifierUtils, etc