### PR TITLE
Farming fortune accessory support

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.java
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.java
@@ -126,6 +126,7 @@ public class SkyHanniMod {
         loadModule(new OwnInventoryData());
         loadModule(new ToolTipData());
         loadModule(new GuiEditManager());
+        loadModule(new CropAccessoryData());
 
         // APIs
         loadModule(new BazaarApi());

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Bazaar.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Bazaar.java
@@ -18,7 +18,7 @@ public class Bazaar {
     public boolean bestSellMethod = false;
 
     @Expose
-    public Position bestSellMethodPos = new Position(10, 10, false, true);
+    public Position bestSellMethodPos = new Position(394, 142, false, true);
 
     @Expose
     @ConfigOption(name = "Cancelled Buy Order Clipboard", desc = "Saves missing items from cancelled buy orders to clipboard for faster re-entry.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -772,6 +772,16 @@ public class Garden {
     public boolean farmingFortuneDisplay = true;
 
     @Expose
+    @ConfigOption(
+            name = "Show As Drop Multiplier",
+            desc = "Adds 100 to the displayed farming fortune so that it represents a drop multiplier rather than" +
+                    " the chance for bonus drops. "
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 18)
+    public boolean farmingFortuneDropMultiplier = false;
+
+    @Expose
     public Position farmingFortunePos = new Position(-375, -200, false, true);
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.features;
 
+import at.hannibal2.skyhanni.features.garden.CropAccessory;
 import at.hannibal2.skyhanni.features.garden.CropType;
 import com.google.gson.annotations.Expose;
 
@@ -45,6 +46,9 @@ public class Hidden {
 
     @Expose
     public int gardenExp = -1;
+
+    @Expose
+    public CropAccessory savedCropAccessory = null;
 
     @Expose
     public Map<String, Integer> gardenDicerRngDrops = new HashMap<>();

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Misc.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Misc.java
@@ -276,4 +276,7 @@ public class Misc {
     @ConfigOption(name = "Config Button", desc = "Add a button to the pause menu to configure SkyHanni.")
     @ConfigEditorBoolean
     public boolean configButtonOnPause = true;
+
+    @Expose
+    public Position inventoryLoadPos = new Position(394, 124, false, true);
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/CropAccessoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/CropAccessoryData.kt
@@ -1,0 +1,136 @@
+package at.hannibal2.skyhanni.data
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.InventoryOpenEvent
+import at.hannibal2.skyhanni.events.ProfileApiDataLoadedEvent
+import at.hannibal2.skyhanni.events.ProfileJoinEvent
+import at.hannibal2.skyhanni.features.garden.CropAccessory
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.NEUItems
+import com.google.gson.JsonElement
+import net.minecraft.item.ItemStack
+import net.minecraft.nbt.CompressedStreamTools
+import net.minecraftforge.client.event.GuiScreenEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import net.minecraftforge.fml.common.gameevent.TickEvent
+import java.io.ByteArrayInputStream
+import java.util.*
+
+class CropAccessoryData {
+    private val accessoryBagNamePattern = "Accessory Bag \\((\\d)/(\\d)\\)".toRegex()
+    private var loadedAccessoryThisProfile: Boolean = false
+    private var ticks = 0
+    private var accessoryInBag: CropAccessory? = null
+    private var accessoryInInventory: CropAccessory = CropAccessory.NONE
+
+    private var accessoryBagPageNumber = 0
+
+    // Handle API detection
+    @SubscribeEvent
+    fun onProfileJoin(event: ProfileJoinEvent) {
+        loadedAccessoryThisProfile = false
+    }
+
+    @SubscribeEvent
+    fun onProfileDataLoad(event: ProfileApiDataLoadedEvent) {
+        if (loadedAccessoryThisProfile) return
+        val inventoryData = event.profileData["inv_contents"] ?: return
+        val accessories = getCropAccessories(event.profileData["talisman_bag"]).also {
+            it.addAll(getCropAccessories(inventoryData))
+        }
+        cropAccessory = accessories.maxOrNull() ?: CropAccessory.NONE
+        loadedAccessoryThisProfile = true
+    }
+
+    // Handle accessory bag detection
+    @SubscribeEvent
+    fun onInventoryOpen(event: InventoryOpenEvent) {
+        val groups = accessoryBagNamePattern.matchEntire(event.inventoryName)?.groups ?: return
+        isLoadingAccessories = true
+        accessoryBagPageCount = groups[2]!!.value.toInt()
+        accessoryBagPageNumber = groups[1]!!.value.toInt()
+    }
+
+    @SubscribeEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        isLoadingAccessories = false
+    }
+
+    @SubscribeEvent
+    fun onGuiDraw(event: GuiScreenEvent.DrawScreenEvent) {
+        if (!isLoadingAccessories) return
+        val items = runCatching {
+            InventoryUtils.getItemsInOpenChest()
+        }.getOrNull() ?: return
+        val bestCropAccessoryPage = bestCropAccessory(items.map { it.stack })
+        accessoryPage[accessoryBagPageNumber] = bestCropAccessoryPage
+        if (accessoryBagPageCount == accessoryPage.size) {
+            accessoryInBag = accessoryPage.values.max().also {
+                cropAccessory = maxOf(it, accessoryInInventory)
+            }
+            loadedAccessoryThisProfile = true
+        }
+    }
+
+    // Handle inventory detection
+    @SubscribeEvent
+    fun onTick(event: TickEvent.ClientTickEvent) {
+        if (event.phase != TickEvent.Phase.START || ticks++ % 20 != 0) return
+        accessoryInInventory = inventoryCropAccessory()
+        if (accessoryInInventory == CropAccessory.NONE) return
+        if (accessoryInInventory > (accessoryInBag ?: CropAccessory.NONE)) {
+            cropAccessory = accessoryInInventory
+        }
+    }
+
+
+    private fun inventoryCropAccessory(): CropAccessory {
+        val inventory = runCatching {
+            InventoryUtils.getItemsInOwnInventory()
+        }.getOrNull() ?: return CropAccessory.NONE
+        return bestCropAccessory(inventory.asIterable())
+    }
+
+    private fun bestCropAccessory(items: Iterable<ItemStack?>): CropAccessory {
+        return items.mapNotNull { item ->
+            item?.let { CropAccessory.getByName(it.getInternalName()) }
+        }.maxOrNull() ?: CropAccessory.NONE
+    }
+
+    companion object {
+        var accessoryBagPageCount = 0
+            private set
+
+        private var accessoryPage = mutableMapOf<Int, CropAccessory>()
+
+        var isLoadingAccessories = false
+            private set
+
+        val pagesLoaded get() = accessoryPage.size
+
+        var cropAccessory: CropAccessory?
+            get() = SkyHanniMod.feature.hidden.savedCropAccessory
+            private set(accessory) { SkyHanniMod.feature.hidden.savedCropAccessory = accessory }
+
+        // Derived partially from NotEnoughUpdates/NotEnoughUpdates, ProfileViewer.Profile#getInventoryInfo
+        private fun getCropAccessories(inventory: JsonElement?): MutableList<CropAccessory> {
+            if (inventory == null) return mutableListOf()
+            val cropAccessories = mutableListOf<CropAccessory>()
+            val data = inventory.asJsonObject["data"]?.asString
+            val accessoryBagItems = CompressedStreamTools.readCompressed(
+                ByteArrayInputStream(Base64.getDecoder().decode(data))
+            ).getTagList("i", 10)
+            for (j in 0 until accessoryBagItems.tagCount()) {
+                val itemStackTag = accessoryBagItems.getCompoundTagAt(j)
+                if (!itemStackTag.hasKey("tag")) continue
+                val itemTag = itemStackTag.getCompoundTag("tag")
+                val itemName = NEUItems.getInternalNameOrNull(itemTag) ?: continue
+                val itemAsCropAccessory = CropAccessory.getByName(itemName) ?: continue
+                cropAccessories.add(itemAsCropAccessory)
+            }
+            return cropAccessories
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/CropAccessory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/CropAccessory.kt
@@ -1,0 +1,19 @@
+package at.hannibal2.skyhanni.features.garden
+
+enum class CropAccessory(val internalName: String, private val affectedCrops: Set<CropType>, private val fortune: Double) {
+    CROPIE("CROPIE_TALISMAN", setOf(CropType.WHEAT, CropType.POTATO, CropType.CARROT), 10.0),
+    SQUASH(
+        "SQUASH_RING",
+        setOf(CropType.WHEAT, CropType.POTATO, CropType.CARROT, CropType.COCOA_BEANS, CropType.MELON, CropType.PUMPKIN),
+        20.0
+    ),
+    FERMENTO("FERMENTO_ARTIFACT", CropType.values().toSet(), 30.0);
+
+    fun getFortune(cropType: CropType): Double {
+        return if (this.affectedCrops.contains(cropType)) this.fortune else 0.0
+    }
+
+    companion object {
+        fun getByName(internalName: String) = values().firstOrNull { it.internalName == internalName }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/CropAccessory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/CropAccessory.kt
@@ -8,7 +8,8 @@ enum class CropAccessory(val internalName: String, private val affectedCrops: Se
         setOf(CropType.WHEAT, CropType.POTATO, CropType.CARROT, CropType.COCOA_BEANS, CropType.MELON, CropType.PUMPKIN),
         20.0
     ),
-    FERMENTO("FERMENTO_ARTIFACT", CropType.values().toSet(), 30.0);
+    FERMENTO("FERMENTO_ARTIFACT", CropType.values().toSet(), 30.0),
+    ;
 
     fun getFortune(cropType: CropType): Double {
         return if (this.affectedCrops.contains(cropType)) this.fortune else 0.0

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/CropAccessory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/CropAccessory.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.garden
 
 enum class CropAccessory(val internalName: String, private val affectedCrops: Set<CropType>, private val fortune: Double) {
+    NONE("NONE", emptySet(), 0.0),
     CROPIE("CROPIE_TALISMAN", setOf(CropType.WHEAT, CropType.POTATO, CropType.CARROT), 10.0),
     SQUASH(
         "SQUASH_RING",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.garden
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.CropAccessoryData
 import at.hannibal2.skyhanni.data.GardenCropMilestones
 import at.hannibal2.skyhanni.data.GardenCropMilestones.Companion.getCounter
 import at.hannibal2.skyhanni.data.GardenCropUpgrades.Companion.getUpgradeLevel
@@ -9,18 +10,13 @@ import at.hannibal2.skyhanni.features.garden.CropType.Companion.getTurboCrop
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.RenderUtils.renderSingleLineWithItems
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getCounter
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
-import com.google.gson.JsonElement
 import net.minecraft.item.ItemStack
-import net.minecraft.nbt.CompressedStreamTools
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
-import java.io.ByteArrayInputStream
-import java.util.*
 import kotlin.math.floor
 import kotlin.math.log10
 
@@ -29,28 +25,18 @@ class FarmingFortuneDisplay {
 
     private val tabFortunePattern = " Farming Fortune: §r§6☘(\\d+)".toRegex()
 
-    private var cropAccessory: CropAccessory?
-        get() = SkyHanniMod.feature.hidden.savedCropAccessory
-        set(accessory) { SkyHanniMod.feature.hidden.savedCropAccessory = accessory }
-
     private var display = listOf<Any>()
     private var currentCrop: CropType? = null
 
     private var tabFortune: Double = 0.0
     private var toolFortune: Double = 0.0
     private val upgradeFortune: Double? get() = currentCrop?.getUpgradeLevel()?.let { it * 5.0 }
-    private val accessoryFortune: Double get() = currentCrop?.let { cropAccessory?.getFortune(it) } ?: 0.0
+    private val accessoryFortune: Double? get() = currentCrop?.let {
+        CropAccessoryData.cropAccessory?.getFortune(it)
+    }
 
     private var lastToolSwitch: Long = 0
     private var ticks: Int = 0
-
-    @SubscribeEvent
-    fun onProfileDataLoad(event: ProfileApiDataLoadedEvent) {
-        val accessories = getCropAccessories(event.profileData["talisman_bag"]).also {
-            it.addAll(getCropAccessories(event.profileData["inv_contents"]))
-        }
-        cropAccessory = accessories.maxOrNull()
-    }
 
     @SubscribeEvent
     fun onTabListUpdate(event: TabListUpdateEvent) {
@@ -92,18 +78,35 @@ class FarmingFortuneDisplay {
     }
 
     @SubscribeEvent
+    fun onRenderOverlay(event: GuiRenderEvent.ChestBackgroundRenderEvent) {
+        if (!isEnabled()) return
+        if (!CropAccessoryData.isLoadingAccessories) return
+        config.farmingFortunePos.renderSingleLineWithItems(display, posLabel = "True Farming Fortune")
+    }
+
+    @SubscribeEvent
     fun onTick(event: TickEvent.ClientTickEvent) {
         if (event.phase != TickEvent.Phase.START || ticks++ % 5 != 0) return
         val displayCrop = currentCrop ?: return
         val updatedDisplay = mutableListOf<Any>()
-        GardenAPI.addGardenCropToList(displayCrop, updatedDisplay)
         val recentlySwitchedTool = System.currentTimeMillis() < lastToolSwitch + 1000
-        val displayString = upgradeFortune?.let {
-            "§6Farming Fortune§7: §e" + if (!recentlySwitchedTool) {
-                val totalFortune = it + tabFortune + toolFortune + accessoryFortune
-                LorenzUtils.formatDouble(totalFortune, 0)
-            } else "?"
-        } ?: "§cOpen §e/cropupgrades§c to use!"
+        val upgradeFortune = upgradeFortune
+        val accessoryFortune = accessoryFortune
+        val displayString = when {
+            upgradeFortune == null -> "§cOpen §e/cropupgrades§c to use!"
+            accessoryFortune == null -> {
+                if (CropAccessoryData.isLoadingAccessories) {
+                    "§e${CropAccessoryData.pagesLoaded}/${CropAccessoryData.accessoryBagPageCount} pages viewed"
+                } else "§cOpen §e/accessories§c to use!"
+            }
+            else -> {
+                GardenAPI.addGardenCropToList(displayCrop, updatedDisplay)
+                "§6Farming Fortune§7: §e" + if (!recentlySwitchedTool) {
+                    val totalFortune = upgradeFortune + tabFortune + toolFortune + accessoryFortune
+                    LorenzUtils.formatDouble(totalFortune, 0)
+                } else "?"
+            }
+        }
         updatedDisplay.add(displayString)
         display = updatedDisplay
     }
@@ -163,23 +166,6 @@ class FarmingFortuneDisplay {
             return dedicationMultiplier * cropMilestone
         }
 
-        // Derived partially from NotEnoughUpdates/NotEnoughUpdates, ProfileViewer.Profile#getInventoryInfo
-        private fun getCropAccessories(inventory: JsonElement?): MutableList<CropAccessory> {
-            if (inventory == null) return mutableListOf()
-            val cropAccessories = mutableListOf<CropAccessory>()
-            val data = inventory.asJsonObject["data"]?.asString
-            val accessoryBagItems = CompressedStreamTools.readCompressed(
-                ByteArrayInputStream(Base64.getDecoder().decode(data))
-            ).getTagList("i", 10)
-            for (j in 0 until accessoryBagItems.tagCount()) {
-                val itemStackTag = accessoryBagItems.getCompoundTagAt(j)
-                if (!itemStackTag.hasKey("tag")) continue
-                val itemTag = itemStackTag.getCompoundTag("tag")
-                val itemName = NEUItems.getInternalNameOrNull(itemTag) ?: continue
-                val itemAsCropAccessory = CropAccessory.getByName(itemName) ?: continue
-                cropAccessories.add(itemAsCropAccessory)
-            }
-            return cropAccessories
-        }
+
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -30,6 +30,7 @@ class FarmingFortuneDisplay {
 
     private var tabFortune: Double = 0.0
     private var toolFortune: Double = 0.0
+    private val baseFortune: Double get() = if (config.farmingFortuneDropMultiplier) 100.0 else 0.0
     private val upgradeFortune: Double? get() = currentCrop?.getUpgradeLevel()?.let { it * 5.0 }
     private val accessoryFortune: Double? get() = currentCrop?.let {
         CropAccessoryData.cropAccessory?.getFortune(it)
@@ -102,7 +103,7 @@ class FarmingFortuneDisplay {
             else -> {
                 GardenAPI.addGardenCropToList(displayCrop, updatedDisplay)
                 "§6Farming Fortune§7: §e" + if (!recentlySwitchedTool) {
-                    val totalFortune = upgradeFortune + tabFortune + toolFortune + accessoryFortune
+                    val totalFortune = baseFortune + upgradeFortune + tabFortune + toolFortune + accessoryFortune
                     LorenzUtils.formatDouble(totalFortune, 0)
                 } else "?"
             }
@@ -121,8 +122,12 @@ class FarmingFortuneDisplay {
 
     private fun isEnabled(): Boolean = GardenAPI.inGarden() && config.farmingFortuneDisplay
 
+
+
     companion object {
         private val collectionPattern = "§7You have §6\\+([\\d]{1,3})☘ Farming Fortune".toRegex()
+
+
 
         fun getToolFortune(tool: ItemStack?): Double {
             val internalName = tool?.getInternalName() ?: return 0.0

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -218,7 +218,7 @@ class GardenNextJacobContest {
         if (!inCalendar) return
 
         if (display.isNotEmpty()) {
-            config.nextJacobContestPos.renderSingleLineWithItems(display, posLabel = "Garden Next Jacob Contest")
+            SkyHanniMod.feature.misc.inventoryLoadPos.renderSingleLineWithItems(display, posLabel = "Load SkyBlock Calendar")
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -12,6 +12,7 @@ import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.client.renderer.RenderHelper
 import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
+import net.minecraft.nbt.NBTTagCompound
 
 object NEUItems {
     private val manager: NEUManager get() = NotEnoughUpdates.INSTANCE.manager
@@ -45,6 +46,10 @@ object NEUItems {
             .withCurrentGuiContext()
             .withItemStack(itemStack)
             .resolveInternalName() ?: ""
+    }
+
+    fun getInternalNameOrNull(nbt: NBTTagCompound): String? {
+        return ItemResolutionQuery(manager).withItemNBT(nbt).resolveInternalName()
     }
 
     fun getPriceOrNull(internalName: String, useSellingPrice: Boolean = false): Double? {


### PR DESCRIPTION
Adds crop accessory support:
- Attempts to use inventory API on profile join
- Also reads inventory and accessory bag for farming accessories
- Persistently saves farming accessory or lack thereof

Includes alert to user to open accessory bag if no farming accessory is known already (through inventory API or inventory)
<img width="289" alt="Screenshot 2023-04-11 at 10 37 32 PM" src="https://user-images.githubusercontent.com/16139460/231360869-9376fc76-9459-4e24-9f22-5b25c4d87310.png">
<img width="188" alt="Screenshot 2023-04-11 at 10 38 37 PM" src="https://user-images.githubusercontent.com/16139460/231361031-9846709b-66e3-4986-9fc8-b344dda22f1d.png">

Also adds simple toggle to add 100 farming fortune (off by default because it's a terrible idea that people want for some reason!)


