### PR TITLE
Sixth Visitor Timer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -54,6 +54,13 @@ public class Garden {
     public boolean visitorTimerEnabled = true;
 
     @Expose
+    @ConfigOption(name = "Sixth Visitor Estimate", desc = "Estimate when the sixth visitor in the queue will arrive. " +
+            "May be inaccurate with coop members farming simultaneously.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 2)
+    public boolean visitorTimerSixthVisitorEnabled = true;
+
+    @Expose
 //    @ConfigOption(name = "Visitor Timer Position", desc = "")
 //    @ConfigEditorButton(runnableId = "visitorTimer", buttonText = "Edit")
 //    @ConfigAccordionId(id = 2)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
@@ -61,6 +61,9 @@ public class Hidden {
     public long informedAboutLowFuel = 0;
 
     @Expose
+    public long visitorInterval = 15 * 60_000L;
+
+    @Expose
     public Map<Long, List<CropType>> gardenJacobFarmingContestTimes = new HashMap<>();
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -1,27 +1,36 @@
 package at.hannibal2.skyhanni.features.garden.visitor
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
+import at.hannibal2.skyhanni.features.garden.CropType.Companion.getCropType
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.TimeUtils
+import net.minecraftforge.event.world.WorldEvent
+import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.regex.Pattern
+import kotlin.math.roundToLong
 
 class GardenVisitorTimer {
     private val patternNextVisitor = Pattern.compile(" Next Visitor: §r§b(.*)")
     private val patternVisitors = Pattern.compile("§b§lVisitors: §r§f\\((\\d)\\)")
     private var render = ""
     private var lastMillis = 0L
-    private var lastVisitors = 0
+    private var lastVisitors: Int = -1
+    private var sixthVisitorArrivalTime: Long = 0
+    private var visitorInterval
+        get() = SkyHanniMod.feature.hidden.visitorInterval
+        set(value) { SkyHanniMod.feature.hidden.visitorInterval = value }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOW)
     fun onTabListUpdate(event: TabListUpdateEvent) {
         if (!isEnabled()) return
 
         var visitorsAmount = 0
-        var millis = 15 * 60_000L
+        var millis = visitorInterval
         var queueFull = false
         for (line in event.tabList) {
             var matcher = patternNextVisitor.matcher(line)
@@ -41,20 +50,34 @@ class GardenVisitorTimer {
             }
         }
 
+        if (lastVisitors != -1 && visitorsAmount - lastVisitors == 1) {
+            if (!queueFull) {
+                visitorInterval = ((millis - 1) / 60_000L + 1) * 60_000L
+            } else {
+                sixthVisitorArrivalTime = System.currentTimeMillis() + visitorInterval
+            }
+        }
+
+        if (queueFull) {
+            millis = sixthVisitorArrivalTime - System.currentTimeMillis()
+        }
+
         val diff = lastMillis - millis
         if (diff == 0L && visitorsAmount == lastVisitors) return
         lastMillis = millis
         lastVisitors = visitorsAmount
 
-        val extraSpeed = if (diff in 1001..10_000) {
-            val factor = diff / 1000
-            "§7/§e" + TimeUtils.formatDuration(millis / factor)
+        val formatColor = if (queueFull) "6" else "e"
+
+        val extraSpeed = if (diff in 2000..10_000) {
+            val factor = diff / 1000.0
+            "§7/§$formatColor" + TimeUtils.formatDuration((millis / factor).roundToLong())
         } else ""
 
         val formatDuration = TimeUtils.formatDuration(millis)
-        val next = if (queueFull) "§cQueue Full!" else {
-            "Next in §e$formatDuration$extraSpeed"
-        }
+        val next = if (queueFull && (!isSixthVisitorEnabled() || millis < 0)) "§cQueue Full!" else {
+                "Next in §$formatColor$formatDuration$extraSpeed"
+            }
         val visitorLabel = if (visitorsAmount == 1) "visitor" else "visitors"
         render = "§b$visitorsAmount $visitorLabel §7($next§7)"
     }
@@ -66,5 +89,18 @@ class GardenVisitorTimer {
         SkyHanniMod.feature.garden.visitorTimerPos.renderString(render, posLabel = "Garden Visitor Timer")
     }
 
+    @SubscribeEvent
+    fun onWorldLoad(event: WorldEvent.Load) {
+        lastVisitors = -1
+        sixthVisitorArrivalTime = 0
+    }
+
+    @SubscribeEvent
+    fun onBlockBreak(event: BlockClickEvent) {
+        if (!isEnabled() || event.getBlockState.getCropType() == null) return
+        sixthVisitorArrivalTime -= 100
+    }
+
+    private fun isSixthVisitorEnabled() = SkyHanniMod.feature.garden.visitorTimerSixthVisitorEnabled
     private fun isEnabled() = GardenAPI.inGarden() && SkyHanniMod.feature.garden.visitorTimerEnabled
 }


### PR DESCRIPTION
This PR adds a simple, optional estimate of the sixth visitor arrival time to the visitor timer display.

The estimate is shown in orange, and seems typically accurate to around 10 seconds, both when AFKing and when breaking crops. Obviously it is invalid if coop members are farming simultaneously.

<img width="324" alt="Screenshot 2023-04-17 at 12 13 31 AM" src="https://user-images.githubusercontent.com/16139460/232411378-8aaaa1e6-3684-4e3a-a072-b5bd78a1c3af.png">
