### PR TITLE
fix tps display getting getting too large

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -47,7 +47,7 @@ class TpsCounter {
 
             display = if (tpsList.size < minDataAmount) {
                 val current = minDataAmount - tpsList.size
-                "§eTps: §fCalculating.. (${current}s)"
+                "§eTps: §f[(${current}s])"
             } else {
                 val sum = tpsList.sum().toDouble()
                 var tps = (sum / tpsList.size).round(1)
@@ -100,7 +100,7 @@ class TpsCounter {
         } else if (tps > 12) {
             "§c"
         } else {
-            "§8NOT PLAYABLE - "
+            "§8"
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -100,7 +100,7 @@ class TpsCounter {
         } else if (tps > 12) {
             "§c"
         } else {
-            "§8"
+            "§4"
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -47,7 +47,7 @@ class TpsCounter {
 
             display = if (tpsList.size < minDataAmount) {
                 val current = minDataAmount - tpsList.size
-                "§eTps: §f[(${current}s])"
+                "§eTps: §f(${current}s)"
             } else {
                 val sum = tpsList.sum().toDouble()
                 var tps = (sum / tpsList.size).round(1)


### PR DESCRIPTION
the tps display looks really bad when it gets too large
and the dark gray for tps under 12 is not really readable, so I changed it to dark red