### PR TITLE
Fixed level 0 skill names being parsed as levels

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -128,6 +128,7 @@ class ItemDisplayOverlayFeatures {
         if (SkyHanniMod.feature.inventory.itemNumberAsStackSize.contains(9)) {
             if (InventoryUtils.openInventoryName() == "Your Skills") {
                 if (item.getLore().any { it.contains("Click to view!") }) {
+                    if (CollectionAPI.isCollectionTier0(item.getLore())) return "0"
                     if (!itemName.contains("Dungeon")) {
                         val text = itemName.split(" ").last()
                         return "" + text.romanToDecimalIfNeeded()


### PR DESCRIPTION
Level 0 skills don't have a roman level, so the skill name was being parsed. I changed the code to use CollectionAPI (probably needs a better name) to check if the skill level is 0