### PR TITLE
Add sixth visitor to visitor timer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/VisitorArrivalEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/VisitorArrivalEvent.kt
@@ -1,0 +1,5 @@
+package at.hannibal2.skyhanni.events
+
+import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorFeatures.Visitor
+
+class VisitorArrivalEvent(val visitor: Visitor): LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -416,7 +416,10 @@ class GardenVisitorFeatures {
     }
 
     private fun addVisitor(name: String) {
-        visitors[name] = Visitor(name, status = VisitorStatus.NEW)
+        val visitor = Visitor(name, status = VisitorStatus.NEW)
+        visitors[name] = visitor
+        VisitorArrivalEvent(visitor).postAndCatch()
+
         logger.log("New visitor detected: '$name'")
 
         if (config.visitorNotificationTitle) {


### PR DESCRIPTION
Correctly show "6 visitors" in the Visitor Timer when a sixth visitor arrives. Also, when six visitors are ready and one is accepted/rejected, correctly set new estimated sixth visitor arrival time.