### PR TITLE
6th visitor changes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -62,7 +62,7 @@ public class Garden {
 
     @Expose
     @ConfigOption(name = "Sixth Visitor Warning", desc = "Notifies when it is believed that the sixth visitor has arrived. " +
-            "May be inaccurate with coop members farming simultaneously or when joining the server.")
+            "May be inaccurate with coop members farming simultaneously.")
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 2)
     public boolean visitorTimerSixthVisitorWarning = false;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -61,6 +61,13 @@ public class Garden {
     public boolean visitorTimerSixthVisitorEnabled = true;
 
     @Expose
+    @ConfigOption(name = "Sixth Visitor Warning", desc = "Notifies when it is believed that the sixth visitor has arrived. " +
+            "May be inaccurate with coop members farming simultaneously or when joining the server.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 2)
+    public boolean visitorTimerSixthVisitorWarning = false;
+
+    @Expose
 //    @ConfigOption(name = "Visitor Timer Position", desc = "")
 //    @ConfigEditorButton(runnableId = "visitorTimer", buttonText = "Edit")
 //    @ConfigAccordionId(id = 2)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
@@ -64,6 +64,9 @@ public class Hidden {
     public long visitorInterval = 15 * 60_000L;
 
     @Expose
+    public long nextSixthVisitorArrival = 0;
+
+    @Expose
     public Map<Long, List<CropType>> gardenJacobFarmingContestTimes = new HashMap<>();
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -39,7 +39,7 @@ class GardenVisitorTimer {
             updateVisitorDisplay()
         }
     }
-// check money/hr display try reset command made
+
     private fun updateVisitorDisplay() {
         if (!isEnabled()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -74,10 +74,12 @@ class GardenVisitorTimer {
             millis = sixthVisitorArrivalTime - System.currentTimeMillis()
             if (isSixthVisitorEnabled() &&  millis < 0) {
                 visitorsAmount++
-                if (!sixthVisitorReady && isSixthVisitorWarningEnabled()) {
-                    sixthVisitorReady = true
-                    SoundUtils.playBeepSound()
+                if (sixthVisitorReady == false) {
                     TitleUtils.sendTitle("§a6th Visitor Ready", 2_000)
+                    sixthVisitorReady = true
+                    if (isSixthVisitorWarningEnabled()) {
+                        SoundUtils.playBeepSound()
+                    }
                 }
             } else {
                 SkyHanniMod.feature.hidden.nextSixthVisitorArrival = System.currentTimeMillis() + millis + (5 - lastVisitors) * visitorInterval

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -75,8 +75,6 @@ class GardenVisitorTimer {
         if (queueFull) {
             if (visitorJustArrived && visitorsAmount - lastVisitors == 1) {
                 updateSixthVisitorArrivalTime()
-                println(visitorsAmount)
-                println(lastVisitors)
                 visitorJustArrived = false
                 sixthVisitorReady = false
             }
@@ -87,9 +85,7 @@ class GardenVisitorTimer {
                 if (!sixthVisitorReady) {
                     TitleUtils.sendTitle("§a6th Visitor Ready", 2_000)
                     sixthVisitorReady = true
-                    if (isSixthVisitorWarningEnabled()) {
-                        SoundUtils.playBeepSound()
-                    }
+                    if (isSixthVisitorWarningEnabled()) SoundUtils.playBeepSound()
                 }
             }
         }


### PR DESCRIPTION
Making the 6th visitor display persist after restarting the game or rejoining the garden (if you are in a coop and you join and there is 5 visitors but not a 6th ready it will still show 6 as ready)
Added a visual pop up when the 6th visitor should be waiting
Added config option for a ding to play when this is the case (default off) this also will ding when joining the garden and 6 visitors are predicted to be waiting)
Made visitor timer not rely on tabList updates and instead update once a second 