### PR TITLE
Sixth visitor changes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -61,6 +61,13 @@ public class Garden {
     public boolean visitorTimerSixthVisitorEnabled = true;
 
     @Expose
+    @ConfigOption(name = "Sixth Visitor Warning", desc = "Notifies when it is believed that the sixth visitor has arrived. " +
+            "May be inaccurate with coop members farming simultaneously.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 2)
+    public boolean visitorTimerSixthVisitorWarning = true;
+
+    @Expose
 //    @ConfigOption(name = "Visitor Timer Position", desc = "")
 //    @ConfigEditorButton(runnableId = "visitorTimer", buttonText = "Edit")
 //    @ConfigAccordionId(id = 2)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -61,6 +61,13 @@ public class Garden {
     public boolean visitorTimerSixthVisitorEnabled = true;
 
     @Expose
+    @ConfigOption(name = "Sixth Visitor Warning", desc = "Notifies when it is believed that the sixth visitor has arrived. " +
+            "May be inaccurate with coop members farming simultaneously.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 2)
+    public boolean visitorTimerSixthVisitorWarning = false;
+
+    @Expose
 //    @ConfigOption(name = "Visitor Timer Position", desc = "")
 //    @ConfigEditorButton(runnableId = "visitorTimer", buttonText = "Edit")
 //    @ConfigAccordionId(id = 2)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
@@ -64,6 +64,9 @@ public class Hidden {
     public long visitorInterval = 15 * 60_000L;
 
     @Expose
+    public long nextSixthVisitorArrival = 0;
+
+    @Expose
     public Map<Long, List<CropType>> gardenJacobFarmingContestTimes = new HashMap<>();
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -1,22 +1,23 @@
 package at.hannibal2.skyhanni.features.garden.visitor
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.TitleUtils
 import at.hannibal2.skyhanni.events.CropClickEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.events.VisitorArrivalEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
-import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.TimeUtils
-import at.hannibal2.skyhanni.data.TitleUtils
 import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.concurrent.fixedRateTimer
 import kotlin.math.roundToLong
 
 class GardenVisitorTimer {
+    private val config get() = SkyHanniMod.feature.garden
     private val patternNextVisitor = " Next Visitor: §r§b(?<time>.*)".toPattern()
     private val patternVisitors = "§b§lVisitors: §r§f\\((?<amount>\\d)\\)".toPattern()
     private var render = ""
@@ -115,7 +116,7 @@ class GardenVisitorTimer {
     fun onRenderOverlay(event: GuiRenderEvent.GameOverlayRenderEvent) {
         if (!isEnabled()) return
 
-        SkyHanniMod.feature.garden.visitorTimerPos.renderString(render, posLabel = "Garden Visitor Timer")
+        config.visitorTimerPos.renderString(render, posLabel = "Garden Visitor Timer")
     }
 
     @SubscribeEvent
@@ -136,7 +137,7 @@ class GardenVisitorTimer {
         sixthVisitorArrivalTime = System.currentTimeMillis() + visitorInterval
     }
 
-    private fun isSixthVisitorEnabled() = SkyHanniMod.feature.garden.visitorTimerSixthVisitorEnabled
-    private fun isSixthVisitorWarningEnabled() = SkyHanniMod.feature.garden.visitorTimerSixthVisitorWarning
-    private fun isEnabled() = GardenAPI.inGarden() && SkyHanniMod.feature.garden.visitorTimerEnabled
+    private fun isSixthVisitorEnabled() = config.visitorTimerSixthVisitorEnabled
+    private fun isSixthVisitorWarningEnabled() = config.visitorTimerSixthVisitorWarning
+    private fun isEnabled() = GardenAPI.inGarden() && config.visitorTimerEnabled
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -3,15 +3,18 @@ package at.hannibal2.skyhanni.features.garden.visitor
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.TabListUpdateEvent
+import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.events.VisitorArrivalEvent
 import at.hannibal2.skyhanni.features.garden.CropType.Companion.getCropType
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
+import at.hannibal2.skyhanni.data.TitleUtils
 import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.concurrent.fixedRateTimer
 import kotlin.math.roundToLong
 
 class GardenVisitorTimer {
@@ -22,6 +25,7 @@ class GardenVisitorTimer {
     private var lastVisitors: Int = -1
     private var sixthVisitorArrivalTime: Long = 0
     private var visitorJustArrived: Boolean = false
+    private var sixthVisitorReady: Boolean = false
     private var visitorInterval
         get() = SkyHanniMod.feature.hidden.visitorInterval
         set(value) { SkyHanniMod.feature.hidden.visitorInterval = value }
@@ -31,14 +35,19 @@ class GardenVisitorTimer {
         visitorJustArrived = true
     }
 
-    @SubscribeEvent
-    fun onTabListUpdate(event: TabListUpdateEvent) {
+    init {
+        fixedRateTimer(name = "skyhanni-update-visitor-display", period = 1000L) {
+            updateVisitorDisplay()
+        }
+    }
+
+    private fun updateVisitorDisplay() {
         if (!isEnabled()) return
 
         var visitorsAmount = 0
         var millis = visitorInterval
         var queueFull = false
-        for (line in event.tabList) {
+        for (line in TabListData.getTabList()) {
             val matcher = patternNextVisitor.matcher(line)
             if (matcher.matches()) {
                 val rawTime = matcher.group("time")
@@ -64,13 +73,20 @@ class GardenVisitorTimer {
         }
 
         if (queueFull) {
-            if (sixthVisitorArrivalTime != 0L && visitorJustArrived) {
+            if (visitorJustArrived && visitorsAmount - lastVisitors == 1) {
                 updateSixthVisitorArrivalTime()
                 visitorJustArrived = false
+                sixthVisitorReady = false
             }
             millis = sixthVisitorArrivalTime - System.currentTimeMillis()
-            if (isSixthVisitorEnabled() && sixthVisitorArrivalTime != 0L && millis < 0) {
+            SkyHanniMod.feature.hidden.nextSixthVisitorArrival = System.currentTimeMillis() + millis + (5 - visitorsAmount) * visitorInterval
+            if (isSixthVisitorEnabled() &&  millis < 0) {
                 visitorsAmount++
+                if (!sixthVisitorReady) {
+                    TitleUtils.sendTitle("§a6th Visitor Ready", 5_000)
+                    sixthVisitorReady = true
+                    if (isSixthVisitorWarningEnabled()) SoundUtils.playBeepSound()
+                }
             }
         }
 
@@ -88,8 +104,8 @@ class GardenVisitorTimer {
 
         val formatDuration = TimeUtils.formatDuration(millis)
         val next = if (queueFull && (!isSixthVisitorEnabled() || millis < 0)) "§cQueue Full!" else {
-                "Next in §$formatColor$formatDuration$extraSpeed"
-            }
+            "Next in §$formatColor$formatDuration$extraSpeed"
+        }
         val visitorLabel = if (visitorsAmount == 1) "visitor" else "visitors"
         render = "§b$visitorsAmount $visitorLabel §7($next§7)"
     }
@@ -104,7 +120,9 @@ class GardenVisitorTimer {
     @SubscribeEvent
     fun onWorldLoad(event: WorldEvent.Load) {
         lastVisitors = -1
-        sixthVisitorArrivalTime = 0
+        sixthVisitorArrivalTime = SkyHanniMod.feature.hidden.nextSixthVisitorArrival
+        sixthVisitorReady = false
+        lastMillis = sixthVisitorArrivalTime - System.currentTimeMillis()
     }
 
     @SubscribeEvent
@@ -117,5 +135,6 @@ class GardenVisitorTimer {
         sixthVisitorArrivalTime = System.currentTimeMillis() + visitorInterval
     }
     private fun isSixthVisitorEnabled() = SkyHanniMod.feature.garden.visitorTimerSixthVisitorEnabled
+    private fun isSixthVisitorWarningEnabled() = SkyHanniMod.feature.garden.visitorTimerSixthVisitorWarning
     private fun isEnabled() = GardenAPI.inGarden() && SkyHanniMod.feature.garden.visitorTimerEnabled
 }


### PR DESCRIPTION
Made visitor timer not rely on tab list updates and instead update once a second
6th visitor timer persists on restarting the game and joining/leaving the garden
warning for when the 6th visitor is predicted to be ready
sound for when this occurs that is toggleable (default on)
