### PR TITLE
Contest fortune changes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -994,7 +994,7 @@ public class Garden {
     @Expose
     @ConfigOption(
             name = "FF for Contest",
-            desc = "Show the minimum needed Farming Fortune for reaching a medal in the Jacob's Farming Contest inventory."
+            desc = "Show the minimum needed Farming Fortune for reaching each medal in the Jacob's Farming Contest inventory."
     )
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 24)
@@ -1008,7 +1008,7 @@ public class Garden {
             minStep = .1f
     )
     @ConfigAccordionId(id = 24)
-    public float farmingBlocksBrokenPerSecond = 19.9f;
+    public float farmingBlocksBrokenPerSecond = 19.8f;
 
     @Expose
     @ConfigOption(name = "Above 400 Speed", desc = "Toggle if you farm cactus over 400 speed.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -1058,7 +1058,7 @@ public class Garden {
     public boolean cactusAboveSpeedLimit = false;
 
     @Expose
-    public Position pos = new Position(180, 156, false, true);
+    public Position gardenFortuneDisplayPos = new Position(180, 156, false, true);
 
     @Expose
     @ConfigOption(name = "Plot Price", desc = "Show the price of the plot in coins when inside the Configure Plots inventory.")
@@ -1069,7 +1069,6 @@ public class Garden {
     @ConfigOption(name = "Desk in Menu", desc = "Show a Desk button in the SkyBlock Menu. Opens the /desk command on click.")
     @ConfigEditorBoolean
     public boolean deskInSkyBlockMenu = true;
-
 
     @Expose
     @ConfigOption(name = "Fungi Cutter Warning", desc = "Warn when breaking mushroom with the wrong Fungi Cutter mode.")
@@ -1085,9 +1084,6 @@ public class Garden {
     @ConfigOption(name = "Wild Strawberry", desc = "Show a notification when a Wild Strawberry Dye drops during farming.")
     @ConfigEditorBoolean
     public boolean wildStrawberryDyeNotification = true;
-
-    @Expose
-    public Position farmingFortuneForContestPos = new Position(180, 156, false, true);
 
     @Expose
     @ConfigOption(name = "Always Finnegan", desc = "Forcefully set the Finnegan Farming Simulator perk to be active. This is useful if the auto mayor detection fails.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -1030,33 +1030,36 @@ public class Garden {
 
     @Expose
     @ConfigOption(name = "Contest Farming Fortune", desc = "")
-    @ConfigEditorAccordion(id = 24)
-    public boolean contestFortunDisplay = false;
+    @Accordion
+    public ContestFarmingFortune contestFarmingFortune = new ContestFarmingFortune();
 
-    @Expose
-    @ConfigOption(
-            name = "FF for Contest",
-            desc = "Show the minimum needed Farming Fortune for reaching each medal in the Jacob's Farming Contest inventory."
-    )
-    @ConfigEditorBoolean
-    @ConfigAccordionId(id = 24)
-    public boolean farmingFortuneForContest = true;
+    public static class ContestFarmingFortune {
 
-    @Expose
-    @ConfigOption(name = "Average Blocks/Second", desc = "The average amount of blocks you break per second while farming. Does not include cactus.")
-    @ConfigEditorSlider(
-            minValue = 18,
-            maxValue = 20,
-            minStep = .1f
-    )
-    @ConfigAccordionId(id = 24)
-    public float farmingBlocksBrokenPerSecond = 19.8f;
+        @Expose
+        @ConfigOption(
+                name = "Enabled",
+                desc = "Show the minimum needed Farming Fortune for reaching each medal in the Jacob's Farming Contest inventory."
+        )
+        @ConfigEditorBoolean
+        public boolean enabled = true;
 
-    @Expose
-    @ConfigOption(name = "Above 400 Speed", desc = "Toggle if you farm cactus over 400 speed.")
-    @ConfigEditorBoolean
-    @ConfigAccordionId(id = 24)
-    public boolean cactusAboveSpeedLimit = false;
+        @Expose
+        @ConfigOption(name = "Average Blocks/Second", desc = "The average amount of blocks you break per second while farming. Does not include cactus.")
+        @ConfigEditorSlider(
+                minValue = 18,
+                maxValue = 20,
+                minStep = .1f
+        )
+        public float blocksPerSecond = 19.8f;
+
+        @Expose
+        @ConfigOption(name = "Above 400 Speed", desc = "Toggle if you farm cactus over 400 speed.")
+        @ConfigEditorBoolean
+        public boolean cactusAboveSpeedLimit = false;
+
+        @Expose
+        public Position pos = new Position(180, 156, false, true);
+    }
 
     @Expose
     @ConfigOption(name = "Plot Price", desc = "Show the price of the plot in coins when inside the Configure Plots inventory.")
@@ -1086,8 +1089,6 @@ public class Garden {
 
 
 
-    @Expose
-    public Position farmingFortuneForContestPos = new Position(180, 156, false, true);
 
     @Expose
     @ConfigOption(name = "Always Finnegan", desc = "Forcefully set the Finnegan Farming Simulator perk to be active. This is useful if the auto mayor detection fails.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -987,6 +987,36 @@ public class Garden {
     public int cropTooltipFortune = 1;
 
     @Expose
+    @ConfigOption(name = "Contest Farming Fortune", desc = "")
+    @ConfigEditorAccordion(id = 24)
+    public boolean contestFortunDisplay = false;
+
+    @Expose
+    @ConfigOption(
+            name = "FF for Contest",
+            desc = "Show the minimum needed Farming Fortune for reaching a medal in the Jacob's Farming Contest inventory."
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 24)
+    public boolean farmingFortuneForContest = true;
+
+    @Expose
+    @ConfigOption(name = "Average Blocks/Second", desc = "The average amount of blocks you break per second while farming. Does not include cactus.")
+    @ConfigEditorSlider(
+            minValue = 18,
+            maxValue = 20,
+            minStep = .1f
+    )
+    @ConfigAccordionId(id = 24)
+    public float farmingBlocksBrokenPerSecond = 19.9f;
+
+    @Expose
+    @ConfigOption(name = "Above 400 Speed", desc = "Toggle if you farm cactus over 400 speed.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 24)
+    public boolean cactusAboveSpeedLimit = false;
+
+    @Expose
     @ConfigOption(name = "Plot Price", desc = "Show the price of the plot in coins when inside the Configure Plots inventory.")
     @ConfigEditorBoolean
     public boolean plotPrice = true;
@@ -1012,13 +1042,7 @@ public class Garden {
     @ConfigEditorBoolean
     public boolean wildStrawberryDyeNotification = true;
 
-    @Expose
-    @ConfigOption(
-            name = "FF for Contest",
-            desc = "Show the minimum needed Farming Fortune for reaching a medal in the Jacob's Farming Contest inventory."
-    )
-    @ConfigEditorBoolean
-    public boolean farmingFortuneForContest = true;
+
 
     @Expose
     public Position farmingFortuneForContestPos = new Position(180, 156, false, true);

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -1029,6 +1029,38 @@ public class Garden {
     }
 
     @Expose
+    @ConfigOption(name = "Contest Farming Fortune", desc = "")
+    @ConfigEditorAccordion(id = 24)
+    public boolean contestFortunDisplay = false;
+
+    @Expose
+    @ConfigOption(
+            name = "FF for Contest",
+            desc = "Show the minimum needed Farming Fortune for reaching a medal in the Jacob's Farming Contest inventory."
+    )
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 24)
+    public boolean farmingFortuneForContest = true;
+
+    @Expose
+    @ConfigOption(name = "Average Blocks/Second", desc = "The average amount of blocks you break per second while farming. Does not include cactus.")
+    @ConfigEditorSlider(
+            minValue = 18,
+            maxValue = 20,
+            minStep = .1f
+    )
+    @ConfigAccordionId(id = 24)
+    public float farmingBlocksBrokenPerSecond = 19.8f;
+
+    @Expose
+    @ConfigOption(name = "Above 400 Speed", desc = "Toggle if you farm cactus over 400 speed.")
+    @ConfigEditorBoolean
+    public boolean cactusAboveSpeedLimit = false;
+
+    @Expose
+    public Position pos = new Position(180, 156, false, true);
+
+    @Expose
     @ConfigOption(name = "Plot Price", desc = "Show the price of the plot in coins when inside the Configure Plots inventory.")
     @ConfigEditorBoolean
     public boolean plotPrice = true;
@@ -1053,14 +1085,6 @@ public class Garden {
     @ConfigOption(name = "Wild Strawberry", desc = "Show a notification when a Wild Strawberry Dye drops during farming.")
     @ConfigEditorBoolean
     public boolean wildStrawberryDyeNotification = true;
-
-    @Expose
-    @ConfigOption(
-            name = "FF for Contest",
-            desc = "Show the minimum needed Farming Fortune for reaching a medal in the Jacob's Farming Contest inventory."
-    )
-    @ConfigEditorBoolean
-    public boolean farmingFortuneForContest = true;
 
     @Expose
     public Position farmingFortuneForContestPos = new Position(180, 156, false, true);

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
@@ -72,7 +72,10 @@ class JacobContestFFNeededDisplay {
     private fun getLine(rank: ContestRank, map: Map<ContestRank, Int>, crop: CropType): String {
         val counter = map[rank]!!
         val cropsPerSecond = counter.toDouble() / 20 / 60
-        val farmingFortune = ceil(cropsPerSecond * 100 / 20 / crop.baseDrops)
+        val blocksPerSecond = if (crop.cropName == "Cactus" && !config.cactusAboveSpeedLimit) 17 else config.farmingBlocksBrokenPerSecond
+        var farmingFortune = ceil(cropsPerSecond * 100 / blocksPerSecond.toDouble() / crop.baseDrops)
+        if (!config.farmingFortuneDropMultiplier)  farmingFortune -= 100
+        if (farmingFortune < 0) farmingFortune = 0.toDouble()
         return " ${rank.displayName}§f: §6${farmingFortune.addSeparators()} FF §7(${counter.addSeparators()} crops)"
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
@@ -72,7 +72,10 @@ class JacobContestFFNeededDisplay {
     private fun getLine(rank: ContestRank, map: Map<ContestRank, Int>, crop: CropType): String {
         val counter = map[rank]!!
         val cropsPerSecond = counter.toDouble() / 20 / 60
-        val farmingFortune = ceil(cropsPerSecond * 100 / 20 / crop.baseDrops)
+        // allows for crop specific block/second data from the user in the future either through config or through the existing block/second function
+        val blocksPerSecond = if (crop.cropName == "Cactus" && !config.cactusAboveSpeedLimit) 17 else config.farmingBlocksBrokenPerSecond
+        var farmingFortune = ceil(cropsPerSecond * 100 / blocksPerSecond.toDouble() / crop.baseDrops)
+        if (!config.farmingFortuneDropMultiplier)  farmingFortune -= 100
         return " ${rank.displayName}§f: §6${farmingFortune.addSeparators()} FF §7(${counter.addSeparators()} crops)"
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
@@ -18,7 +18,7 @@ import kotlin.math.ceil
 
 class JacobContestFFNeededDisplay {
     private val gardenConfig get() = SkyHanniMod.feature.garden
-    private val config get() = gardenConfig.contestFarmingFortune
+    private val config get() = gardenConfig
     private var display = listOf<List<Any>>()
     private var lastToolTipTime = 0L
     private val cache = mutableMapOf<ItemStack, List<List<Any>>>()
@@ -74,9 +74,10 @@ class JacobContestFFNeededDisplay {
         val counter = map[rank]!!
         val cropsPerSecond = counter.toDouble() / 20 / 60
         // allows for crop specific block/second data from the user in the future either through config or through the existing block/second function
-        val blocksPerSecond = if (crop.cropName == "Cactus" && !config.cactusAboveSpeedLimit) 17 else config.blocksPerSecond
+        val blocksPerSecond = if (crop.cropName == "Cactus" && !config.cactusAboveSpeedLimit) 17 else config.farmingBlocksBrokenPerSecond
         var farmingFortune = ceil(cropsPerSecond * 100 / blocksPerSecond.toDouble() / crop.baseDrops)
         if (!gardenConfig.farmingFortuneDropMultiplier)  farmingFortune -= 100
+        if (farmingFortune <= 0) farmingFortune = 0.toDouble()
         return " ${rank.displayName}§f: §6${farmingFortune.addSeparators()} FF §7(${counter.addSeparators()} crops)"
     }
 
@@ -99,8 +100,8 @@ class JacobContestFFNeededDisplay {
         if (!isEnabled()) return
         if (!FarmingContestAPI.inInventory) return
         if (System.currentTimeMillis() > lastToolTipTime + 200) return
-        config.pos.renderStringsAndItems(display, posLabel = "Estimated Item Value")
+        config.gardenFortuneDisplayPos.renderStringsAndItems(display, posLabel = "Estimated Item Value")
     }
 
-    fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
+    fun isEnabled() = LorenzUtils.inSkyBlock && config.farmingFortuneForContest
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
@@ -17,7 +17,8 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.math.ceil
 
 class JacobContestFFNeededDisplay {
-    private val config get() = SkyHanniMod.feature.garden
+    private val gardenConfig get() = SkyHanniMod.feature.garden
+    private val config get() = gardenConfig.contestFarmingFortune
     private var display = listOf<List<Any>>()
     private var lastToolTipTime = 0L
     private val cache = mutableMapOf<ItemStack, List<List<Any>>>()
@@ -73,9 +74,9 @@ class JacobContestFFNeededDisplay {
         val counter = map[rank]!!
         val cropsPerSecond = counter.toDouble() / 20 / 60
         // allows for crop specific block/second data from the user in the future either through config or through the existing block/second function
-        val blocksPerSecond = if (crop.cropName == "Cactus" && !config.cactusAboveSpeedLimit) 17 else config.farmingBlocksBrokenPerSecond
+        val blocksPerSecond = if (crop.cropName == "Cactus" && !config.cactusAboveSpeedLimit) 17 else config.blocksPerSecond
         var farmingFortune = ceil(cropsPerSecond * 100 / blocksPerSecond.toDouble() / crop.baseDrops)
-        if (!config.farmingFortuneDropMultiplier)  farmingFortune -= 100
+        if (!gardenConfig.farmingFortuneDropMultiplier)  farmingFortune -= 100
         return " ${rank.displayName}§f: §6${farmingFortune.addSeparators()} FF §7(${counter.addSeparators()} crops)"
     }
 
@@ -98,8 +99,8 @@ class JacobContestFFNeededDisplay {
         if (!isEnabled()) return
         if (!FarmingContestAPI.inInventory) return
         if (System.currentTimeMillis() > lastToolTipTime + 200) return
-        config.farmingFortuneForContestPos.renderStringsAndItems(display, posLabel = "Estimated Item Value")
+        config.pos.renderStringsAndItems(display, posLabel = "Estimated Item Value")
     }
 
-    fun isEnabled() = LorenzUtils.inSkyBlock && config.farmingFortuneForContest
+    fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
 }


### PR DESCRIPTION
Made the needed farming fortune reflect the user's setting of "Show as drop multiplier"
Added setting to toggle cactus mode (sets blocks/sec to 17) - rough value but much more accurate than ~20
Added slider so that users can put in a rough estimate of their blocks/second (19.8 default value which is probably still higher than most users get)