### PR TITLE
Reworked the blocks/second feature

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -239,12 +239,32 @@ public class Garden {
                     "§e12,300§8/§e100,000",
                     "§7In §b12m 34s",
                     "§7Crops/Minute§8: §e12,345",
-                    "§7Blocks/Second§8: §e20",
+                    "§7Blocks/Second§8: §e19.85",
                     "§7Percentage: §e12.34%",
             }
     )
     @ConfigAccordionId(id = 6)
-    public List<Integer> cropMilestoneText = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4));
+    public List<Integer> cropMilestoneText = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4, 5));
+
+    @Expose
+    @ConfigOption(name = "Block Broken Precision", desc = "The amount of decimals displayed in blocks/second.")
+    @ConfigEditorSlider(
+            minValue = 0,
+            maxValue = 6,
+            minStep = 1
+    )
+    @ConfigAccordionId(id = 6)
+    public int blocksBrokenPrecision = 2;
+
+    @Expose
+    @ConfigOption(name = "Seconds Before Reset", desc = "How many seconds of not farming until blocks/second resets.")
+    @ConfigEditorSlider(
+            minValue = 2,
+            maxValue = 60,
+            minStep = 1
+    )
+    @ConfigAccordionId(id = 6)
+    public int blocksBrokenResetTime = 5;
 
     @Expose
     public Position cropMilestoneProgressDisplayPos = new Position(376, 19, false, true);
@@ -1064,7 +1084,7 @@ public class Garden {
     @Expose
     @ConfigOption(
             name = "FF for Contest",
-            desc = "Show the minimum needed Farming Fortune for reaching a medal in the Jacob's Farming Contest inventory."
+            desc = "Show the minimum needed Farming Fortune for reaching each medal in Jacob's Farming Contest inventory."
     )
     @ConfigEditorBoolean
     public boolean farmingFortuneForContest = true;

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -186,7 +186,7 @@ object GardenCropMilestoneDisplay {
 
             val format = LorenzUtils.formatInteger(farmingFortuneSpeed * 60)
             lineMap[4] = Collections.singletonList("§7Crops/Minute§8: §e$format")
-            val formatBps = LorenzUtils.formatDouble(speed, 2)
+            val formatBps = LorenzUtils.formatDouble(speed, config.blocksBrokenPrecision)
             lineMap[5] = Collections.singletonList("§7Blocks/Second§8: §e$formatBps")
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
@@ -82,9 +82,7 @@ object GardenCropSpeed {
                 blocksSpeedList.removeFirst()
                 blocksSpeedList.add(blocksBroken)
             }
-            val copy: MutableList<Int> = blocksSpeedList.toMutableList()
-            copy.removeLast()
-            averageBlocksPerSecond = copy.average()
+            averageBlocksPerSecond = blocksSpeedList.dropLast(1).average()
             GardenAPI.getCurrentlyFarmedCrop()?.let {
                 latestBlocksPerSecond[it] = averageBlocksPerSecond
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.concurrent.fixedRateTimer
-import kotlin.math.abs
 
 object GardenCropSpeed {
     private val config get() = SkyHanniMod.feature.garden
@@ -27,7 +26,7 @@ object GardenCropSpeed {
 
     private val blocksSpeedList = mutableListOf<Int>()
     private var blocksBroken = 0
-    private var lastBlocksBroken = 0
+    private var secondsStopped = 0
 
 
     init {
@@ -67,30 +66,35 @@ object GardenCropSpeed {
         val blocksBroken = blocksBroken.coerceAtMost(20)
         this.blocksBroken = 0
 
-        // If the difference in speed between the current and the previous bps value is too high, disregard this value
-        if (abs(lastBlocksBroken - blocksBroken) > 4) {
-            if (blocksSpeedList.isNotEmpty()) {
-                blocksSpeedList.removeLast()
+        if (blocksBroken == 0) {
+            if (blocksSpeedList.size == 0) return
+            secondsStopped ++
+        } else {
+            if (secondsStopped >= config.blocksBrokenResetTime) {
+                resetSpeed()
             }
-        } else if (blocksBroken >= 2) {
+            while (secondsStopped > 0) {
+                blocksSpeedList.add(0)
+                secondsStopped -= 1
+            }
             blocksSpeedList.add(blocksBroken)
-            while (blocksSpeedList.size > 120) {
+            if (blocksSpeedList.size == 2) {
                 blocksSpeedList.removeFirst()
+                blocksSpeedList.add(blocksBroken)
             }
-            averageBlocksPerSecond = blocksSpeedList.average()
+            val copy: MutableList<Int> = blocksSpeedList.toMutableList()
+            copy.removeLast()
+            averageBlocksPerSecond = copy.average()
             GardenAPI.getCurrentlyFarmedCrop()?.let {
                 latestBlocksPerSecond[it] = averageBlocksPerSecond
             }
-
-
         }
-        lastBlocksBroken = blocksBroken
     }
 
     private fun resetSpeed() {
         averageBlocksPerSecond = 0.0
-        blocksBroken = 0
         blocksSpeedList.clear()
+        secondsStopped = 0
     }
 
     fun finneganPerkActive(): Boolean {


### PR DESCRIPTION
Slightly changed the description of certain things in config (blocks/second and contest farming fortune display)
Made blocks/second on by default as people will use it as it is mentioned in the fortune overlay
Blocks/second value now rounds to the specified config value
Changes to blocks/second: 
- Does not count seconds where 0 crops are farmed and stores how many "seconds stopped" have passed
       - If the user starts farming again within these seconds that many scores of 0 are added
       - If they exceed their set reset value then the counter will reset
- Remove the first and last value in the list as they are likely not to be full seconds