### PR TITLE
Changed suggested cactus speed values

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -558,7 +558,8 @@ public class Garden {
         @Expose
         @ConfigOption(name = "Cactus", desc = "Suggested farm speed:\n" +
                 "§eNormal§7: §f✦ 400 speed\n" +
-                "§eRacing Helmet§7: §f✦ 500 speed")
+                "§eRacing Helmet§7: §f✦ 464 speed\n" +
+                "§eBlack Cat§7: §f✦ 464 speed")
         @ConfigEditorSlider(minValue = 1, maxValue = 500, minStep = 1)
         public int cactus = 400;
 


### PR DESCRIPTION
Changed Suggested Cactus Speed Value for Racing helmet From 500 to 464 and added Black Cat with a Speed of 464.