### PR TITLE
Copy nearby particles to clipboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -69,6 +69,7 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.PacketTest
 import at.hannibal2.skyhanni.test.SkyHanniTestCommand
 import at.hannibal2.skyhanni.test.TestBingo
+import at.hannibal2.skyhanni.test.command.CopyNearbyParticlesCommand
 import at.hannibal2.skyhanni.utils.MinecraftConsoleFilter.Companion.initLogging
 import at.hannibal2.skyhanni.utils.NEUVersionCheck.checkIfNeuIsLoaded
 import at.hannibal2.skyhanni.utils.TabListData
@@ -267,6 +268,7 @@ class SkyHanniMod {
         loadModule(MovementSpeedDisplay())
         loadModule(ChumBucketHider())
         loadModule(GardenRecentTeleportPadsDisplay())
+        loadModule(CopyNearbyParticlesCommand)
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -48,6 +48,7 @@ object Commands {
         registerCommand("shcopytablist") { CopyTabListCommand.command(it) }
         registerCommand("shcopyscoreboard") { CopyScoreboardCommand.command(it) }
         registerCommand("shcopyitem") { CopyItemCommand.command(it) }
+        registerCommand("shcopyparticles") { CopyNearbyParticlesCommand.command(it) }
         registerCommand("shconfigsave") { SkyHanniMod.configManager.saveConfig("manual-command") }
         registerCommand("shmarkplayer") { MarkedPlayerManager.command(it) }
         registerCommand("shtestpacket") { PacketTest.toggle() }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -214,7 +214,3 @@ class GriffinBurrowParticleFinder {
 //        }
     }
 }
-
-private fun S2APacketParticles.toLorenzVec(): LorenzVec {
-    return LorenzVec(xCoordinate, yCoordinate, zCoordinate)
-}

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyParticlesCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyParticlesCommand.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.test.command
 
 import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.utils.*
+import at.hannibal2.skyhanni.utils.LorenzUtils.round
 import net.minecraft.network.play.server.S2APacketParticles
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -47,24 +48,20 @@ object CopyNearbyParticlesCommand {
 
         val packet = event.packet
         if (packet is S2APacketParticles) {
-            val location = packet.toLorenzVec()
+            val location = packet.toLorenzVec().round(2)
             if (LocationUtils.playerLocation().distance(location) > searchRadius) return
-            val offset = LorenzVec(packet.xOffset, packet.yOffset, packet.zOffset)
+            val offset = LorenzVec(packet.xOffset, packet.yOffset, packet.zOffset).round(2)
             resultList.add("particle type: ${packet.particleType}")
             resultList.add("particle location: $location")
-            resultList.add("distance from player: ${LocationUtils.playerLocation().distance(location)}")
+            resultList.add("distance from player: ${LocationUtils.playerLocation().distance(location).round(2)}")
             resultList.add("particle offset: $offset")
             resultList.add("is long distance: ${packet.isLongDistance}")
             resultList.add("particle count: ${packet.particleCount}")
             resultList.add("particle speed: ${packet.particleSpeed}")
-            resultList.add("particle arguments: ${packet.particleArgs}")
+            resultList.add("particle arguments: ${packet.particleArgs.asList()}")
             resultList.add("")
             resultList.add("")
             counter ++
         }
     }
-}
-
-private fun S2APacketParticles.toLorenzVec(): LorenzVec {
-    return LorenzVec(xCoordinate, yCoordinate, zCoordinate)
 }

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyParticlesCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyParticlesCommand.kt
@@ -1,0 +1,70 @@
+package at.hannibal2.skyhanni.test.command
+
+import at.hannibal2.skyhanni.events.PacketEvent
+import at.hannibal2.skyhanni.utils.*
+import net.minecraft.network.play.server.S2APacketParticles
+import net.minecraftforge.fml.common.eventhandler.EventPriority
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+// note: Each particle is copied anywhere between 1-3 times. Different each time. Should not affect using this for debugging or developing
+object CopyNearbyParticlesCommand {
+    private var searchRadius = 0
+    private var saveNextTick = false
+    private var searchTime: Long = 0
+    private val resultList = mutableListOf<String>()
+    private var tickTime: Long = 0
+    private var counter = 0
+
+    fun command(args: Array<String>) {
+        searchRadius = 10
+        if (args.size == 1) {
+            searchRadius = args[0].toInt()
+        }
+        saveNextTick = true
+        searchTime = System.currentTimeMillis()
+        resultList.clear()
+        counter = 0
+        tickTime = 0L
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW, receiveCanceled = true)
+    fun onChatPacket(event: PacketEvent.ReceiveEvent) {
+        if (!saveNextTick) return
+        // command was sent in or around a tick so skipping the tick
+        if (System.currentTimeMillis() <= searchTime + 5) return
+
+        if (resultList.isEmpty() && tickTime == 0L) tickTime = System.currentTimeMillis()
+
+        if (System.currentTimeMillis() > tickTime + 30) {
+            if (counter == 0) LorenzUtils.chat("§e[SkyHanni] No particles found nearby, try a larger search radius") else {
+                val string = resultList.joinToString("\n")
+                OSUtils.copyToClipboard(string)
+                LorenzUtils.chat("§e[SkyHanni] $counter particles copied into the clipboard!")
+            }
+            saveNextTick = false
+            return
+        }
+
+        val packet = event.packet
+        if (packet is S2APacketParticles) {
+            val location = packet.toLorenzVec()
+            if (LocationUtils.playerLocation().distance(location) > searchRadius) return
+            val offset = LorenzVec(packet.xOffset, packet.yOffset, packet.zOffset)
+            resultList.add("particle type: ${packet.particleType}")
+            resultList.add("particle location: $location")
+            resultList.add("distance from player: ${LocationUtils.playerLocation().distance(location)}")
+            resultList.add("particle offset: $offset")
+            resultList.add("is long distance: ${packet.isLongDistance}")
+            resultList.add("particle count: ${packet.particleCount}")
+            resultList.add("particle speed: ${packet.particleSpeed}")
+            resultList.add("particle arguments: ${packet.particleArgs}")
+            resultList.add("")
+            resultList.add("")
+            counter ++
+        }
+    }
+}
+
+private fun S2APacketParticles.toLorenzVec(): LorenzVec {
+    return LorenzVec(xCoordinate, yCoordinate, zCoordinate)
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyTabListCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyTabListCommand.kt
@@ -12,7 +12,7 @@ object CopyTabListCommand {
             val noColor = args.size == 1 && args[0] == "true"
             for (line in TabListData.getTabList()) {
                 val tabListLine = if (noColor) line.removeColor() else line
-                resultList.add("'$tabListLine'")
+                if (tabListLine != "") resultList.add("'$tabListLine'")
             }
             val string = resultList.joinToString("\n")
             OSUtils.copyToClipboard(string)

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.utils.LorenzUtils.round
 import net.minecraft.entity.Entity
+import net.minecraft.network.play.server.S2APacketParticles
 import net.minecraft.util.BlockPos
 import net.minecraft.util.Rotations
 import net.minecraft.util.Vec3
@@ -92,6 +94,8 @@ data class LorenzVec(
 
     fun equalsIgnoreY(other: LorenzVec) = x == other.x && z == other.z
 
+    fun round(decimals: Int) = LorenzVec(x.round(decimals), y.round(decimals), z.round(decimals))
+
     companion object {
         fun getFromYawPitch(yaw: Double, pitch: Double): LorenzVec {
             val yaw: Double = (yaw + 90) * Math.PI / 180
@@ -126,6 +130,8 @@ fun Entity.getLorenzVec(): LorenzVec = LorenzVec(posX, posY, posZ)
 fun Vec3.toLorenzVec(): LorenzVec = LorenzVec(xCoord, yCoord, zCoord)
 
 fun Rotations.toLorenzVec(): LorenzVec = LorenzVec(x, y, z)
+
+fun S2APacketParticles.toLorenzVec() = LorenzVec(xCoordinate, yCoordinate, zCoordinate)
 
 fun Array<Double>.toLorenzVec(): LorenzVec {
     return LorenzVec(this[0], this[1], this[2])


### PR DESCRIPTION
Added the ability to copy nearby particles
Also removed empty lines returned from /shcopytablist 
Fun fact players names are on a second hidden tablist (the old one without the extra info)