### PR TITLE
Fix features and copy error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -68,7 +68,6 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.PacketTest
 import at.hannibal2.skyhanni.test.SkyHanniTestCommand
 import at.hannibal2.skyhanni.test.TestBingo
-import at.hannibal2.skyhanni.test.command.CopyErrorCommand
 import at.hannibal2.skyhanni.test.command.CopyNearbyParticlesCommand
 import at.hannibal2.skyhanni.utils.MinecraftConsoleFilter.Companion.initLogging
 import at.hannibal2.skyhanni.utils.NEUVersionCheck.checkIfNeuIsLoaded
@@ -140,10 +139,6 @@ class SkyHanniMod {
         loadModule(GardenAPI)
         loadModule(CollectionAPI())
         loadModule(FarmingContestAPI)
-
-        //commands
-        loadModule(CopyErrorCommand)
-        loadModule(CopyNearbyParticlesCommand)
 
         // features
         loadModule(BazaarOrderHelper())
@@ -278,7 +273,9 @@ class SkyHanniMod {
 
         init()
 
+        // test stuff
         loadModule(SkyHanniTestCommand())
+        loadModule(CopyNearbyParticlesCommand)
         loadModule(ButtonOnPause())
         loadModule(PacketTest())
         loadModule(TestBingo)

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -68,6 +68,7 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.PacketTest
 import at.hannibal2.skyhanni.test.SkyHanniTestCommand
 import at.hannibal2.skyhanni.test.TestBingo
+import at.hannibal2.skyhanni.test.command.CopyErrorCommand
 import at.hannibal2.skyhanni.test.command.CopyNearbyParticlesCommand
 import at.hannibal2.skyhanni.utils.MinecraftConsoleFilter.Companion.initLogging
 import at.hannibal2.skyhanni.utils.NEUVersionCheck.checkIfNeuIsLoaded
@@ -139,6 +140,10 @@ class SkyHanniMod {
         loadModule(GardenAPI)
         loadModule(CollectionAPI())
         loadModule(FarmingContestAPI)
+
+        //commands
+        loadModule(CopyErrorCommand)
+        loadModule(CopyNearbyParticlesCommand)
 
         // features
         loadModule(BazaarOrderHelper())
@@ -268,7 +273,6 @@ class SkyHanniMod {
         loadModule(ChumBucketHider())
         loadModule(GardenRecentTeleportPadsDisplay())
         loadModule(InquisitorWaypointShare)
-        loadModule(CopyNearbyParticlesCommand)
         loadModule(TrevorFeatures())
         loadModule(TrevorSolver)
 

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -83,6 +83,7 @@ object Commands {
         registerCommand("shcopyparticles") { CopyNearbyParticlesCommand.command(it) }
         registerCommand("shtestpacket") { PacketTest.toggle() }
         registerCommand("shtestmessage") { TestChatCommand.command(it) }
+        registerCommand("shcopyerror") { CopyErrorCommand.command() }
 
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -81,6 +81,7 @@ object Commands {
         registerCommand("shcopyparticles") { CopyNearbyParticlesCommand.command(it) }
         registerCommand("shtestpacket") { PacketTest.toggle() }
         registerCommand("shtestmessage") { TestChatCommand.command(it) }
+        registerCommand("shcopyerror") { CopyErrorCommand.command() }
 
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -6,6 +6,8 @@ import at.hannibal2.skyhanni.events.CropClickEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.VisitorArrivalEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
+import at.hannibal2.skyhanni.test.command.CopyErrorCommand
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
@@ -39,7 +41,13 @@ class GardenVisitorTimer {
 
     init {
         fixedRateTimer(name = "skyhanni-update-visitor-display", period = 1000L) {
-            updateVisitorDisplay()
+            try {
+                updateVisitorDisplay()
+            } catch (error: Throwable) {
+                CopyErrorCommand.errorMessage = error.toString()
+                CopyErrorCommand.errorStackTrace = error.stackTrace.asList()
+                LorenzUtils.chat("§c[SkyHanni] encountered an error when updating visitor display, please run /shcopyerror")
+            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
+import at.hannibal2.skyhanni.test.command.CopyErrorCommand
 import at.hannibal2.skyhanni.utils.*
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
@@ -50,9 +51,15 @@ class TrevorFeatures {
 
     init {
         fixedRateTimer(name = "skyhanni-update-trapper", period = 1000L) {
-            if (onFarmingIsland()) {
-                updateTrapper()
-                TrevorSolver.findMob()
+            try {
+                if (onFarmingIsland()) {
+                    updateTrapper()
+                    TrevorSolver.findMob()
+                }
+            } catch (error: Throwable) {
+                CopyErrorCommand.errorMessage = error.toString()
+                CopyErrorCommand.errorStackTrace = error.stackTrace.asList()
+                LorenzUtils.chat("§c[SkyHanni] encountered an error when updating the trapper solver, please run /shcopyerror")
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.Minecraft
+import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
 
@@ -42,6 +43,7 @@ object TrevorSolver {
         val world = Minecraft.getMinecraft().theWorld ?: return
         for (entity in world.getLoadedEntityList()) {
             val name = entity.name
+            if (entity is EntityOtherPlayerMP) return
             // looking at 2 diff entities rn
             val entityHealth = if (entity is EntityLivingBase) entity.baseMaxHealth else 0
             if (intArrayOf(100, 500, 1000, 5000, 10000).any { it == entityHealth }) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
@@ -43,33 +43,35 @@ object TrevorSolver {
         val world = Minecraft.getMinecraft().theWorld ?: return
         for (entity in world.getLoadedEntityList()) {
             val name = entity.name
-            if (entity is EntityOtherPlayerMP) return
-            // looking at 2 diff entities rn
-            val entityHealth = if (entity is EntityLivingBase) entity.baseMaxHealth else 0
-            if (intArrayOf(100, 500, 1000, 5000, 10000).any { it == entityHealth }) {
-                if (animalNames.any { it == name }) {
-                    if (LocationUtils.canSee(LocationUtils.playerLocation(), entity.position.toLorenzVec())) {
-                        if (entity.isInvisibleToPlayer(Minecraft.getMinecraft().thePlayer)) return
-
-                        if (foundID == entity.entityId) {
-                            mobLocation = CurrentMobArea.FOUND
-                            mobCoordinates = entity.position.toLorenzVec()
-                        } else {
-                            foundID = entity.entityId
+            if (entity !is EntityOtherPlayerMP) {
+                // looking at 2 diff entities rn - Mostly fixed I think as it returns
+                val entityHealth = if (entity is EntityLivingBase) entity.baseMaxHealth else 0
+                if (intArrayOf(100, 500, 1000, 5000, 10000).any { it == entityHealth }) {
+                    if (animalNames.any { it == name }) {
+                        if (LocationUtils.canSee(LocationUtils.playerLocation(), entity.position.toLorenzVec())) {
+                            if (!entity.isInvisibleToPlayer(Minecraft.getMinecraft().thePlayer)) {
+                                if (foundID == entity.entityId) {
+                                    mobLocation = CurrentMobArea.FOUND
+                                    mobCoordinates = entity.position.toLorenzVec()
+                                } else {
+                                    foundID = entity.entityId
+                                }
+                                return
+                            }
                         }
-                        return
                     }
                 }
-            }
 
-            if (entity is EntityArmorStand) {
-                for (animal in animalNames) {
-                    if (name.contains(animal)) {
-                        if (foundID == entity.entityId) {
-                            mobLocation = CurrentMobArea.FOUND
-                            mobCoordinates = entity.position.toLorenzVec()
-                        } else {
-                            foundID = entity.entityId
+                if (entity is EntityArmorStand) {
+                    for (animal in animalNames) {
+                        if (name.contains(animal)) {
+                            if (foundID == entity.entityId) {
+                                mobLocation = CurrentMobArea.FOUND
+                                mobCoordinates = entity.position.toLorenzVec()
+                            } else {
+                                foundID = entity.entityId
+                            }
+                            return
                         }
                     }
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
@@ -43,28 +43,13 @@ object TrevorSolver {
         val world = Minecraft.getMinecraft().theWorld ?: return
         for (entity in world.getLoadedEntityList()) {
             val name = entity.name
-            if (entity !is EntityOtherPlayerMP) {
-                // looking at 2 diff entities rn - Mostly fixed I think as it returns
-                val entityHealth = if (entity is EntityLivingBase) entity.baseMaxHealth else 0
-                if (intArrayOf(100, 500, 1000, 5000, 10000).any { it == entityHealth }) {
-                    if (animalNames.any { it == name }) {
-                        if (LocationUtils.canSee(LocationUtils.playerLocation(), entity.position.toLorenzVec())) {
-                            if (!entity.isInvisibleToPlayer(Minecraft.getMinecraft().thePlayer)) {
-                                if (foundID == entity.entityId) {
-                                    mobLocation = CurrentMobArea.FOUND
-                                    mobCoordinates = entity.position.toLorenzVec()
-                                } else {
-                                    foundID = entity.entityId
-                                }
-                                return
-                            }
-                        }
-                    }
-                }
-
-                if (entity is EntityArmorStand) {
-                    for (animal in animalNames) {
-                        if (name.contains(animal) && name.contains("§c❤")) {
+            if (entity is EntityOtherPlayerMP) continue
+            // looking at 2 diff entities rn - Mostly fixed I think as it returns
+            val entityHealth = if (entity is EntityLivingBase) entity.baseMaxHealth else 0
+            if (intArrayOf(100, 500, 1000, 5000, 10000).any { it == entityHealth }) {
+                if (animalNames.any { it == name }) {
+                    if (LocationUtils.canSee(LocationUtils.playerLocation(), entity.position.toLorenzVec())) {
+                        if (!entity.isInvisibleToPlayer(Minecraft.getMinecraft().thePlayer)) {
                             if (foundID == entity.entityId) {
                                 mobLocation = CurrentMobArea.FOUND
                                 mobCoordinates = entity.position.toLorenzVec()
@@ -73,6 +58,20 @@ object TrevorSolver {
                             }
                             return
                         }
+                    }
+                }
+            }
+
+            if (entity is EntityArmorStand) {
+                for (animal in animalNames) {
+                    if (name.contains(animal) && name.contains("§c❤")) {
+                        if (foundID == entity.entityId) {
+                            mobLocation = CurrentMobArea.FOUND
+                            mobCoordinates = entity.position.toLorenzVec()
+                        } else {
+                            foundID = entity.entityId
+                        }
+                        return
                     }
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
@@ -63,7 +63,6 @@ object TrevorSolver {
                 }
 
                 if (entity is EntityArmorStand) {
-
                     for (animal in animalNames) {
                         if (name.contains(animal) && name.contains("§c❤")) {
                             if (foundID == entity.entityId) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
@@ -63,8 +63,9 @@ object TrevorSolver {
                 }
 
                 if (entity is EntityArmorStand) {
+
                     for (animal in animalNames) {
-                        if (name.contains(animal)) {
+                        if (name.contains(animal) && name.contains("§c❤")) {
                             if (foundID == entity.entityId) {
                                 mobLocation = CurrentMobArea.FOUND
                                 mobCoordinates = entity.position.toLorenzVec()

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyErrorCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyErrorCommand.kt
@@ -1,0 +1,21 @@
+package at.hannibal2.skyhanni.test.command
+
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.OSUtils
+
+object CopyErrorCommand {
+    var errorMessage = ""
+    var errorStackTrace = listOf<StackTraceElement>()
+    fun command() {
+        try {
+            if (errorMessage == "") LorenzUtils.chat("§c[SkyHanni] no error to copy") else {
+                val result = errorMessage + "\nCaused at:\n" + errorStackTrace.joinToString("\n")
+                OSUtils.copyToClipboard(result)
+                LorenzUtils.chat("§e[SkyHanni] error message copied into the clipboard, please report it on the SkyHanni discord!")
+            }
+        } catch (error: Throwable) {
+            OSUtils.copyToClipboard(error.toString())
+            LorenzUtils.chat("§c[SkyHanni] error occurred while fetching error, please report this on the SkyHanni discord!")
+        }
+    }
+}


### PR DESCRIPTION
Hopefully fixed the fixedRateTimers breaking when an error occurs in them -> when it happens the user can run /shcopyerror to get the error message and send it to discord so we can fix the actual error.
I think I found the source of the Trevor features not working but this should make sure

Slightly changed trapper mob detection to exit once it has a match, slightly improving fps and also ignoring other player entities

Other timers or functions can be added to /shcopyerror but these were the main ones I knew of for now