### PR TITLE
Visitor drop counter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -32,8 +32,8 @@ import at.hannibal2.skyhanni.features.garden.contest.JacobFarmingContestsInvento
 import at.hannibal2.skyhanni.features.garden.farming.*
 import at.hannibal2.skyhanni.features.garden.inventory.*
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorColorNames
+import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorDropStatistics
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorFeatures
-import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorStats
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorTimer
 import at.hannibal2.skyhanni.features.inventory.*
 import at.hannibal2.skyhanni.features.itemabilities.FireVeilWandParticles
@@ -269,7 +269,7 @@ class SkyHanniMod {
         loadModule(TrevorFeatures())
         loadModule(TrevorSolver)
         loadModule(BingoCardTips())
-        loadModule(GardenVisitorStats)
+        loadModule(GardenVisitorDropStatistics)
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -33,6 +33,7 @@ import at.hannibal2.skyhanni.features.garden.farming.*
 import at.hannibal2.skyhanni.features.garden.inventory.*
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorColorNames
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorFeatures
+import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorStats
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorTimer
 import at.hannibal2.skyhanni.features.inventory.*
 import at.hannibal2.skyhanni.features.itemabilities.FireVeilWandParticles
@@ -268,6 +269,7 @@ class SkyHanniMod {
         loadModule(TrevorFeatures())
         loadModule(TrevorSolver)
         loadModule(BingoCardTips())
+        loadModule(GardenVisitorStats)
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -175,6 +175,69 @@ public class Garden {
     public boolean visitorHideChat = true;
 
     @Expose
+    @ConfigOption(name = "Visitor Drops", desc = "")
+    @ConfigEditorAccordion(id = 23)
+    public boolean visitorDrops = false;
+
+    @Expose
+    @ConfigOption(name = "Visitor Drop Summary", desc = "Tallies up statistic about visitors and the rewards you have received from them." +
+            "\n§eThis feature is in beta please report issues on the discord!") // cannot test all the chat messages
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 23)
+    public boolean visitorDropsDisplay = true;
+
+    @Expose
+    @ConfigOption(
+            name = "Milestone Text",
+            desc = "Drag text to change the appearance of the overlay."
+    )
+    @ConfigEditorDraggableList(
+            exampleText = {
+                    "§e§lVisitor Statistics",
+                    "§e1,636 Total",
+                    "§a1,172§f-§9382§f-§681§f-§c1",
+                    "§21,382 Accepted",
+                    "§c254 Denied",
+                    " ",
+                    "§c62,072 Copper",
+                    "§23.2m Farming EXP",
+                    "§647.2m Coins Spent",
+                    "§b23 §9Flowering Bouquet",
+                    "§b4 §9Overgrown Grass",
+                    "§b2 §9Green Bandana",
+                    "§b1 §9Dedication IV",
+                    "§b6 §9Music Rune",
+                    "§b1 §cSpace Helmet",
+                    " ", // If they want another empty row
+            }
+    )
+    @ConfigAccordionId(id = 23)
+    public List<Integer> visitorDropText = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12));
+
+    @Expose
+    @ConfigOption(name = "Display Numbers First", desc = "Determines whether the number or drop name displays first. " +
+            "§eNote: Will not update the preview above!")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 23)
+    public boolean displayNumbersFirst = true;
+
+    @Expose
+    @ConfigOption(name = "Display Icons Instead", desc = "Replaces the drop names with icons. " +
+            "§eNote: Will not update the preview above!")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 23)
+    public boolean displayIcons = false;
+
+    @Expose
+    @ConfigOption(name = "Only On Bar Plot", desc = "Only shows the overlay while on the barn plot.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 23)
+    public boolean onlyOnBarn = false;
+
+    @Expose
+    public Position visitorDropPos = new Position(10, 80, false, true);
+
+    @Expose
     @ConfigOption(name = "Numbers", desc = "")
     @ConfigEditorAccordion(id = 5)
     public boolean numbers = false;
@@ -997,7 +1060,7 @@ public class Garden {
     )
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 22)
-    public boolean farmingFortuneDropMultiplier = false;
+    public boolean farmingFortuneDropMultiplier = true;
 
     @Expose
     public Position farmingFortunePos = new Position(-375, -200, false, true);

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -174,68 +174,67 @@ public class Garden {
     @ConfigAccordionId(id = 1)
     public boolean visitorHideChat = true;
 
-    @Expose
-    @ConfigOption(name = "Visitor Drops", desc = "")
-    @ConfigEditorAccordion(id = 23)
-    public boolean visitorDrops = false;
 
     @Expose
-    @ConfigOption(name = "Visitor Drop Summary", desc = "Tallies up statistic about visitors and the rewards you have received from them." +
-            "\n§eThis feature is in beta please report issues on the discord!") // cannot test all the chat messages
-    @ConfigEditorBoolean
-    @ConfigAccordionId(id = 23)
-    public boolean visitorDropsDisplay = true;
+    @ConfigOption(name = "Visitor Drops", desc = "Change the exact speed for every single crop.")
+    @Accordion
+    public VisitorDrops visitorDrops = new VisitorDrops();
 
-    @Expose
-    @ConfigOption(
-            name = "Milestone Text",
-            desc = "Drag text to change the appearance of the overlay."
-    )
-    @ConfigEditorDraggableList(
-            exampleText = {
-                    "§e§lVisitor Statistics",
-                    "§e1,636 Total",
-                    "§a1,172§f-§9382§f-§681§f-§c1",
-                    "§21,382 Accepted",
-                    "§c254 Denied",
-                    " ",
-                    "§c62,072 Copper",
-                    "§23.2m Farming EXP",
-                    "§647.2m Coins Spent",
-                    "§b23 §9Flowering Bouquet",
-                    "§b4 §9Overgrown Grass",
-                    "§b2 §9Green Bandana",
-                    "§b1 §9Dedication IV",
-                    "§b6 §9Music Rune",
-                    "§b1 §cSpace Helmet",
-                    " ", // If they want another empty row
-            }
-    )
-    @ConfigAccordionId(id = 23)
-    public List<Integer> visitorDropText = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12));
+    public static class VisitorDrops {
 
-    @Expose
-    @ConfigOption(name = "Display Numbers First", desc = "Determines whether the number or drop name displays first. " +
-            "§eNote: Will not update the preview above!")
-    @ConfigEditorBoolean
-    @ConfigAccordionId(id = 23)
-    public boolean displayNumbersFirst = true;
+        @Expose
+        @ConfigOption(name = "Visitor Drop Summary", desc = "Tallies up statistic about visitors and the rewards you have received from them." +
+                "\n§eThis feature is in beta please report issues on the discord!") // cannot test all the chat messages
+        @ConfigEditorBoolean
+        public boolean visitorDropsDisplay = true;
 
-    @Expose
-    @ConfigOption(name = "Display Icons Instead", desc = "Replaces the drop names with icons. " +
-            "§eNote: Will not update the preview above!")
-    @ConfigEditorBoolean
-    @ConfigAccordionId(id = 23)
-    public boolean displayIcons = false;
+        @Expose
+        @ConfigOption(
+                name = "Milestone Text",
+                desc = "Drag text to change the appearance of the overlay."
+        )
+        @ConfigEditorDraggableList(
+                exampleText = {
+                        "§e§lVisitor Statistics",
+                        "§e1,636 Total",
+                        "§a1,172§f-§9382§f-§681§f-§c1",
+                        "§21,382 Accepted",
+                        "§c254 Denied",
+                        " ",
+                        "§c62,072 Copper",
+                        "§23.2m Farming EXP",
+                        "§647.2m Coins Spent",
+                        "§b23 §9Flowering Bouquet",
+                        "§b4 §9Overgrown Grass",
+                        "§b2 §9Green Bandana",
+                        "§b1 §9Dedication IV",
+                        "§b6 §9Music Rune",
+                        "§b1 §cSpace Helmet",
+                        " ", // If they want another empty row
+                }
+        )
+        public List<Integer> visitorDropText = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12));
 
-    @Expose
-    @ConfigOption(name = "Only On Bar Plot", desc = "Only shows the overlay while on the barn plot.")
-    @ConfigEditorBoolean
-    @ConfigAccordionId(id = 23)
-    public boolean onlyOnBarn = false;
+        @Expose
+        @ConfigOption(name = "Display Numbers First", desc = "Determines whether the number or drop name displays first. " +
+                "§eNote: Will not update the preview above!")
+        @ConfigEditorBoolean
+        public boolean displayNumbersFirst = true;
 
-    @Expose
-    public Position visitorDropPos = new Position(10, 80, false, true);
+        @Expose
+        @ConfigOption(name = "Display Icons Instead", desc = "Replaces the drop names with icons. " +
+                "§eNote: Will not update the preview above!")
+        @ConfigEditorBoolean
+        public boolean displayIcons = false;
+
+        @Expose
+        @ConfigOption(name = "Only On Bar Plot", desc = "Only shows the overlay while on the barn plot.")
+        @ConfigEditorBoolean
+        public boolean onlyOnBarn = false;
+
+        @Expose
+        public Position visitorDropPos = new Position(10, 80, false, true);
+    }
 
     @Expose
     @ConfigOption(name = "Numbers", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -176,21 +176,24 @@ public class Garden {
 
 
     @Expose
-    @ConfigOption(name = "Visitor Drops", desc = "Change the exact speed for every single crop.")
+    @ConfigOption(name = "Visitor Drops Statistics", desc = "")
     @Accordion
-    public VisitorDrops visitorDrops = new VisitorDrops();
+    public VisitorDrops visitorDropsStatistics = new VisitorDrops();
 
     public static class VisitorDrops {
 
         @Expose
-        @ConfigOption(name = "Visitor Drop Summary", desc = "Tallies up statistic about visitors and the rewards you have received from them." +
-                "\n§eThis feature is in beta please report issues on the discord!") // cannot test all the chat messages
+        @ConfigOption(
+                name = "Enabled",
+                desc = "Tallies up statistic about visitors and the rewards you have received from them.\n" +
+                        "§eThis feature is in beta please report issues on the discord!"
+        )
         @ConfigEditorBoolean
-        public boolean visitorDropsDisplay = true;
+        public boolean enabled = false;
 
         @Expose
         @ConfigOption(
-                name = "Milestone Text",
+                name = "Text Format",
                 desc = "Drag text to change the appearance of the overlay."
         )
         @ConfigEditorDraggableList(
@@ -213,7 +216,7 @@ public class Garden {
                         " ", // If they want another empty row
                 }
         )
-        public List<Integer> visitorDropText = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12));
+        public List<Integer> textFormat = new ArrayList<>(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12));
 
         @Expose
         @ConfigOption(name = "Display Numbers First", desc = "Determines whether the number or drop name displays first. " +
@@ -222,15 +225,15 @@ public class Garden {
         public boolean displayNumbersFirst = true;
 
         @Expose
-        @ConfigOption(name = "Display Icons Instead", desc = "Replaces the drop names with icons. " +
+        @ConfigOption(name = "Display Icons", desc = "Replaces the drop names with icons. " +
                 "§eNote: Will not update the preview above!")
         @ConfigEditorBoolean
         public boolean displayIcons = false;
 
         @Expose
-        @ConfigOption(name = "Only On Bar Plot", desc = "Only shows the overlay while on the barn plot.")
+        @ConfigOption(name = "Only On Barn Plot", desc = "Only shows the overlay while on the barn plot.")
         @ConfigEditorBoolean
-        public boolean onlyOnBarn = false;
+        public boolean onlyOnBarn = true;
 
         @Expose
         public Position visitorDropPos = new Position(10, 80, false, true);

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
@@ -106,13 +106,13 @@ public class Hidden {
         public List<Long> visitorRarities = new ArrayList<>();
 
         @Expose
-        public int totalCopper = 0;
+        public int copper = 0;
 
         @Expose
-        public long totalEXP = 0;
+        public long farmingExp = 0;
 
         @Expose
-        public long totalCost = 0;
+        public long coinsSpent = 0;
 
         @Expose
         public Map<VisitorReward, Integer> rewardsCount = new HashMap<>();

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
@@ -89,4 +89,40 @@ public class Hidden {
 
     @Expose
     public String gardenComposterCurrentFuelItem = "";
+
+    @Expose
+    public int acceptedVisitors = 0;
+
+    @Expose
+    public int deniedVisitors = 0;
+
+    @Expose
+    public List<Long> visitorRarities = new ArrayList<>();
+
+    @Expose
+    public int totalCopper = 0;
+
+    @Expose
+    public long totalEXP = 0;
+
+    @Expose
+    public long totalCost = 0;
+
+    @Expose
+    public int bandanaCount = 0;
+
+    @Expose
+    public int grassCount = 0;
+
+    @Expose
+    public int bouquetCount = 0;
+
+    @Expose
+    public int dedicationCount = 0;
+
+    @Expose
+    public int musicCount = 0;
+
+    @Expose
+    public int helmetCount = 0;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features;
 import at.hannibal2.skyhanni.data.model.ComposterUpgrade;
 import at.hannibal2.skyhanni.features.garden.CropAccessory;
 import at.hannibal2.skyhanni.features.garden.CropType;
+import at.hannibal2.skyhanni.features.garden.visitor.VisitorReward;
 import com.google.gson.annotations.Expose;
 
 import java.util.ArrayList;
@@ -114,21 +115,6 @@ public class Hidden {
         public long totalCost = 0;
 
         @Expose
-        public int bandanaCount = 0;
-
-        @Expose
-        public int grassCount = 0;
-
-        @Expose
-        public int bouquetCount = 0;
-
-        @Expose
-        public int dedicationCount = 0;
-
-        @Expose
-        public int musicCount = 0;
-
-        @Expose
-        public int helmetCount = 0;
+        public Map<VisitorReward, Integer> rewardsCount = new HashMap<>();
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Hidden.java
@@ -90,39 +90,45 @@ public class Hidden {
     @Expose
     public String gardenComposterCurrentFuelItem = "";
 
-    @Expose
-    public int acceptedVisitors = 0;
 
     @Expose
-    public int deniedVisitors = 0;
+    public VisitorDrops visitorDrops = new VisitorDrops();
 
-    @Expose
-    public List<Long> visitorRarities = new ArrayList<>();
+    public static class VisitorDrops {
+        @Expose
+        public int acceptedVisitors = 0;
 
-    @Expose
-    public int totalCopper = 0;
+        @Expose
+        public int deniedVisitors = 0;
 
-    @Expose
-    public long totalEXP = 0;
+        @Expose
+        public List<Long> visitorRarities = new ArrayList<>();
 
-    @Expose
-    public long totalCost = 0;
+        @Expose
+        public int totalCopper = 0;
 
-    @Expose
-    public int bandanaCount = 0;
+        @Expose
+        public long totalEXP = 0;
 
-    @Expose
-    public int grassCount = 0;
+        @Expose
+        public long totalCost = 0;
 
-    @Expose
-    public int bouquetCount = 0;
+        @Expose
+        public int bandanaCount = 0;
 
-    @Expose
-    public int dedicationCount = 0;
+        @Expose
+        public int grassCount = 0;
 
-    @Expose
-    public int musicCount = 0;
+        @Expose
+        public int bouquetCount = 0;
 
-    @Expose
-    public int helmetCount = 0;
+        @Expose
+        public int dedicationCount = 0;
+
+        @Expose
+        public int musicCount = 0;
+
+        @Expose
+        public int helmetCount = 0;
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -34,7 +34,8 @@ object GardenAPI {
     var itemInHand: ItemStack? = null
     var cropInHand: CropType? = null
     var mushroomCowPet = false
-    var onBarnPlot = false
+    var inBarn = false
+    val onBarnPlot get() = inBarn && inGarden()
 
     var tick = 0
 
@@ -57,7 +58,7 @@ object GardenAPI {
         if (!inGarden()) return
         tick++
         if (tick % 10 == 0) {
-            onBarnPlot = ScoreboardData.sidebarLinesFormatted.contains(" §7⏣ §aThe Garden")
+            inBarn = ScoreboardData.sidebarLinesFormatted.contains(" §7⏣ §aThe Garden")
 
             // We ignore random hypixel moments
             Minecraft.getMinecraft().currentScreen ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
@@ -16,8 +16,8 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-object GardenVisitorStats {
-    private val config get() = SkyHanniMod.feature.garden.visitorDrops
+object GardenVisitorDropStatistics {
+    private val config get() = SkyHanniMod.feature.garden.visitorDropsStatistics
     private val hidden get() = SkyHanniMod.feature.hidden.visitorDrops
     private var display = listOf<List<Any>>()
 
@@ -25,9 +25,9 @@ object GardenVisitorStats {
     var deniedVisitors = 0
     private var totalVisitors = 0
     private var visitorRarities = mutableListOf<Long>()
-    private var totalCopper = 0
-    private var totalEXP = 0L
-    var totalCost = 0L
+    private var copper = 0
+    private var farmingExp = 0L
+    var coinsSpent = 0L
 
     private val acceptPattern = "OFFER ACCEPTED with (?<visitor>.*) [(](?<rarity>.*)[)]".toPattern()
     private val copperPattern = "[+](?<amount>.*) Copper".toPattern()
@@ -36,7 +36,7 @@ object GardenVisitorStats {
 
     private fun formatDisplay(map: List<List<Any>>): MutableList<List<Any>> {
         val newList = mutableListOf<List<Any>>()
-        for (index in config.visitorDropText) {
+        for (index in config.textFormat) {
             newList.add(map[index])
         }
         return newList
@@ -49,12 +49,12 @@ object GardenVisitorStats {
 
         copperPattern.matchMatcher(message) {
             val amount = group("amount").formatNumber().toInt()
-            totalCopper += amount
+            copper += amount
             saveAndUpdate()
         }
         farmingExpPattern.matchMatcher(message) {
             val amount = group("amount").formatNumber()
-            totalEXP += amount
+            farmingExp += amount
             saveAndUpdate()
         }
         acceptPattern.matchMatcher(message) {
@@ -98,11 +98,11 @@ object GardenVisitorStats {
         //5
         addAsSingletonList("")
         //6
-        addAsSingletonList(format(totalCopper, "Copper", "§c", ""))
+        addAsSingletonList(format(copper, "Copper", "§c", ""))
         //7
-        addAsSingletonList(format(totalEXP, "Farming EXP", "§3", "§7"))
+        addAsSingletonList(format(farmingExp, "Farming EXP", "§3", "§7"))
         //8
-        addAsSingletonList(format(totalCost, "Coins Spent", "§6", ""))
+        addAsSingletonList(format(coinsSpent, "Coins Spent", "§6", ""))
 
         //9 - 14
         for (reward in VisitorReward.values()) {
@@ -136,9 +136,9 @@ object GardenVisitorStats {
         hidden.deniedVisitors = deniedVisitors
         totalVisitors = acceptedVisitors + deniedVisitors
         hidden.visitorRarities = visitorRarities
-        hidden.totalCopper = totalCopper
-        hidden.totalEXP = totalEXP
-        hidden.totalCost = totalCost
+        hidden.copper = copper
+        hidden.farmingExp = farmingExp
+        hidden.coinsSpent = coinsSpent
         hidden.rewardsCount = rewardsCount
         display = formatDisplay(drawVisitorStatsDisplay())
     }
@@ -155,16 +155,16 @@ object GardenVisitorStats {
         deniedVisitors = hidden.deniedVisitors
         totalVisitors = acceptedVisitors + deniedVisitors
         visitorRarities = hidden.visitorRarities
-        totalCopper = hidden.totalCopper
-        totalEXP = hidden.totalEXP
-        totalCost = hidden.totalCost
+        copper = hidden.copper
+        farmingExp = hidden.farmingExp
+        coinsSpent = hidden.coinsSpent
         rewardsCount = hidden.rewardsCount
         saveAndUpdate()
     }
 
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GameOverlayRenderEvent) {
-        if (!config.visitorDropsDisplay) return
+        if (!config.enabled) return
         if (!GardenAPI.inGarden()) return
         if (GardenAPI.hideExtraGuis()) return
         if (config.onlyOnBarn && !GardenAPI.onBarnPlot) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -223,15 +223,15 @@ class GardenVisitorFeatures {
             if (event.slot.stack?.name != "§cRefuse Offer") return
             changeStatus(visitor, VisitorStatus.REFUSED, "refused")
             update()
-            GardenVisitorStats.deniedVisitors += 1
-            GardenVisitorStats.saveAndUpdate()
+            GardenVisitorDropStatistics.deniedVisitors += 1
+            GardenVisitorDropStatistics.saveAndUpdate()
             return
         }
         if (event.slotId == 29) {
             if (event.slot.stack?.getLore()?.any { it == "§eClick to give!" } == true) {
                 changeStatus(visitor, VisitorStatus.ACCEPTED, "accepted")
                 update()
-                GardenVisitorStats.totalCost += round(price).toLong()
+                GardenVisitorDropStatistics.coinsSpent += round(price).toLong()
                 return
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorStats.kt
@@ -15,8 +15,8 @@ import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 object GardenVisitorStats {
-    private val config get() = SkyHanniMod.feature.garden
-    private val hidden get() = SkyHanniMod.feature.hidden
+    private val config get() = SkyHanniMod.feature.garden.visitorDrops
+    private val hidden get() = SkyHanniMod.feature.hidden.visitorDrops
     private var visitorStats = listOf<List<Any>>()
 
     private var acceptedVisitors = 0

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorStats.kt
@@ -39,13 +39,10 @@ object GardenVisitorStats {
     private val bandanaPattern = "[+]1x Green Bandana".toPattern()
     private val grassPattern = "[+]1x Overgrown Grass".toPattern()
     private val bouquetPattern = "[+]1x Flowering Bouquet".toPattern()
-    private val dedicationPattern = "Dedication IV Book".toPattern()
-    // not sure if some mods change the name from IV -> 4 before we can see
-    private val dedicationPattern2 = "Dedication 4 Book".toPattern()
+    private val dedicationPattern = "Dedication (IV|4) Book".toPattern()
     private val spacePattern = "[+]Space Helmet".toPattern()
     // Pretty sure that the symbol is ◆ but not 100%
-    private val musicPattern = "[+]1x ◆ Music Rune I".toPattern()
-    private val musicPattern2 = "[+]1x ◆ Music Rune 1".toPattern()
+    private val musicPattern = "[+]1x ◆ Music Rune [1I]".toPattern()
 
     private fun formatDisplay(map: List<List<Any>>): MutableList<List<Any>> {
         val newList = mutableListOf<List<Any>>()
@@ -80,9 +77,7 @@ object GardenVisitorStats {
         else if (grassPattern.matcher(message).matches()) grassCount += 1
         else if (bouquetPattern.matcher(message).matches()) bouquetCount += 1
         else if (dedicationPattern.matcher(message).matches()) dedicationCount += 1
-        else if (dedicationPattern2.matcher(message).matches()) dedicationCount += 1
         else if (musicPattern.matcher(message).matches()) musicCount += 1
-        else if (musicPattern2.matcher(message).matches()) musicCount += 1
         else if (spacePattern.matcher(message).matches()) helmetCount += 1
         // we only need to update if something matched
         else return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorStats.kt
@@ -1,0 +1,231 @@
+package at.hannibal2.skyhanni.features.garden.visitor
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.features.garden.GardenAPI
+import at.hannibal2.skyhanni.utils.LorenzUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.NEUItems
+import at.hannibal2.skyhanni.utils.NumberUtil
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatNumber
+import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import net.minecraftforge.event.world.WorldEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+object GardenVisitorStats {
+    private val config get() = SkyHanniMod.feature.garden
+    private val hidden get() = SkyHanniMod.feature.hidden
+    private var visitorStats = listOf<List<Any>>()
+
+    private var acceptedVisitors = 0
+    var deniedVisitors = 0
+    private var totalVisitors = 0
+    private var visitorRarities = mutableListOf<Long>()
+    private var totalCopper = 0
+    private var totalEXP = 0L
+    var totalCost = 0L
+    private var bandanaCount = 0
+    private var grassCount = 0
+    private var bouquetCount = 0
+    private var dedicationCount = 0
+    private var musicCount = 0
+    private var helmetCount = 0
+
+    private val acceptPattern = "OFFER ACCEPTED with (?<visitor>.*) [(](?<rarity>.*)[)]".toPattern()
+    private val copperPattern = "[+](?<amount>.*) Copper".toPattern()
+    private val farmingExpPattern = "[+](?<amount>.*) Farming XP".toPattern()
+    private val bandanaPattern = "[+]1x Green Bandana".toPattern()
+    private val grassPattern = "[+]1x Overgrown Grass".toPattern()
+    private val bouquetPattern = "[+]1x Flowering Bouquet".toPattern()
+    private val dedicationPattern = "Dedication IV Book".toPattern()
+    // not sure if some mods change the name from IV -> 4 before we can see
+    private val dedicationPattern2 = "Dedication 4 Book".toPattern()
+    private val spacePattern = "[+]Space Helmet".toPattern()
+    // Pretty sure that the symbol is ◆ but not 100%
+    private val musicPattern = "[+]1x ◆ Music Rune I".toPattern()
+    private val musicPattern2 = "[+]1x ◆ Music Rune 1".toPattern()
+
+    private fun formatDisplay(map: List<List<Any>>): MutableList<List<Any>> {
+        val newList = mutableListOf<List<Any>>()
+        for (index in config.visitorDropText) {
+            newList.add(map[index])
+        }
+        return newList
+    }
+
+
+
+    @SubscribeEvent
+    fun onChat(event: LorenzChatEvent) {
+        if (!GardenAPI.onBarnPlot) return
+        val message = event.message.removeColor().trim()
+
+        var matcher = copperPattern.matcher(message)
+        if (matcher.matches()) {
+            val amount = matcher.group("amount").formatNumber().toInt()
+            totalCopper += amount
+        }
+        matcher = farmingExpPattern.matcher(message)
+        if (matcher.matches()) {
+            val amount = matcher.group("amount").formatNumber()
+            totalEXP += amount
+        }
+        matcher = acceptPattern.matcher(message)
+        if (matcher.matches()) {
+            setRarities(matcher.group("rarity"))
+        }
+        else if (bandanaPattern.matcher(message).matches()) bandanaCount += 1
+        else if (grassPattern.matcher(message).matches()) grassCount += 1
+        else if (bouquetPattern.matcher(message).matches()) bouquetCount += 1
+        else if (dedicationPattern.matcher(message).matches()) dedicationCount += 1
+        else if (dedicationPattern2.matcher(message).matches()) dedicationCount += 1
+        else if (musicPattern.matcher(message).matches()) musicCount += 1
+        else if (musicPattern2.matcher(message).matches()) musicCount += 1
+        else if (spacePattern.matcher(message).matches()) helmetCount += 1
+        // we only need to update if something matched
+        else return
+        saveAndUpdate()
+    }
+
+    private fun setRarities(rarity: String) {
+        acceptedVisitors += 1
+        val currentRarity = VisitorRarity.values().first { it.rarity == rarity }
+        val temp = visitorRarities[currentRarity.index] + 1
+        visitorRarities[currentRarity.index] = temp
+        saveAndUpdate()
+    }
+
+    private fun drawVisitorStatsDisplay() = buildList<List<Any>> {
+        //0
+        addAsSingletonList("§e§lVisitor Statistics")
+        //1
+        addAsSingletonList(if (config.displayNumbersFirst) "§e${totalVisitors.addSeparators()} Total"
+        else "§eTotal: ${totalVisitors.addSeparators()}")
+        //2
+        addAsSingletonList("§a${visitorRarities[0].addSeparators()}§f-§9${visitorRarities[1].addSeparators()}" +
+                "§f-§6${visitorRarities[2].addSeparators()}§f-§c${visitorRarities[3].addSeparators()}")
+        //3
+        addAsSingletonList(if (config.displayNumbersFirst) "§2${acceptedVisitors.addSeparators()} Accepted"
+        else "§2Accepted: ${acceptedVisitors.addSeparators()}")
+        //4
+        addAsSingletonList(if (config.displayNumbersFirst) "§c${deniedVisitors.addSeparators()} Denied"
+        else "§cDenied: ${deniedVisitors.addSeparators()}")
+        //5
+        addAsSingletonList("")
+        //6
+        addAsSingletonList(if (config.displayNumbersFirst) "§c${totalCopper.addSeparators()} Copper"
+        else "§cCopper: ${totalCopper.addSeparators()}")
+        //7
+        addAsSingletonList(if (config.displayNumbersFirst) "§2${NumberUtil.format(totalEXP)} Farming EXP"
+        else "§2Farming EXP: ${NumberUtil.format(totalEXP)}")
+        //8
+        addAsSingletonList(if (config.displayNumbersFirst) "§6${NumberUtil.format(totalCost)} Coins Spent"
+        else "§6Coins Spent: ${NumberUtil.format(totalCost)}")
+        // Icons
+        if (config.displayIcons) {
+            //9
+            if (config.displayNumbersFirst) add(listOf("§b${bouquetCount.addSeparators()} ", NEUItems.getItemStack("FLOWERING_BOUQUET")))
+            else add(listOf(NEUItems.getItemStack("FLOWERING_BOUQUET"), " §b${bouquetCount.addSeparators()}"))
+            //10
+            if (config.displayNumbersFirst) add(listOf("§b${grassCount.addSeparators()} ", NEUItems.getItemStack("OVERGROWN_GRASS")))
+            else add(listOf(NEUItems.getItemStack("OVERGROWN_GRASS"), " §b${grassCount.addSeparators()}"))
+            //11
+            if (config.displayNumbersFirst) add(listOf("§b${bandanaCount.addSeparators()} ", NEUItems.getItemStack("GREEN_BANDANA")))
+            else add(listOf(NEUItems.getItemStack("GREEN_BANDANA"), " §b${bandanaCount.addSeparators()}"))
+            //12
+            if (config.displayNumbersFirst) add(listOf("§b${dedicationCount.addSeparators()} ", NEUItems.getItemStack("DEDICATION;4")))
+            else add(listOf(NEUItems.getItemStack("DEDICATION;4"), " §b${dedicationCount.addSeparators()}"))
+            //13
+            if (config.displayNumbersFirst) add(listOf("§b${musicCount.addSeparators()} ", NEUItems.getItemStack("MUSIC_RUNE;1")))
+            else add(listOf(NEUItems.getItemStack("MUSIC_RUNE;1"), " §b${musicCount.addSeparators()}"))
+            //14
+            if (config.displayNumbersFirst) add(listOf("§b${helmetCount.addSeparators()} ", NEUItems.getItemStack("DCTR_SPACE_HELM")))
+            else add(listOf(NEUItems.getItemStack("DCTR_SPACE_HELM"), " §b${helmetCount.addSeparators()}"))
+        }
+        // No Icons
+        else {
+            //9
+            addAsSingletonList(if (config.displayNumbersFirst) "§b${bouquetCount.addSeparators()} §9Flowering Bouquet"
+            else "§9Flowering Bouquet: §b${bouquetCount.addSeparators()}")
+            //10
+            addAsSingletonList(if (config.displayNumbersFirst) "§b${grassCount.addSeparators()} §9Overgrown Grass"
+            else "§9Overgrown Grass: §b${grassCount.addSeparators()}")
+            //11
+            addAsSingletonList(if (config.displayNumbersFirst) "§b${bandanaCount.addSeparators()} §9Green Bandana"
+            else "§9Green Bandana: §b${bandanaCount.addSeparators()}")
+            //12
+            addAsSingletonList(if (config.displayNumbersFirst) "§b${dedicationCount.addSeparators()} §9Dedication IV"
+            else "§9Dedication IV: §b${dedicationCount.addSeparators()}")
+            //13
+            addAsSingletonList(if (config.displayNumbersFirst) "§b${musicCount.addSeparators()} §9Music Rune"
+            else "§9Music Rune: §b${musicCount.addSeparators()}")
+            //14
+            addAsSingletonList(if (config.displayNumbersFirst) "§b${helmetCount.addSeparators()} §cSpace Helmet"
+            else "§cSpace Helmet: §b${helmetCount.addSeparators()}")
+        }
+        //15
+        addAsSingletonList("")
+    }
+
+    fun saveAndUpdate() {
+        if (!GardenAPI.inGarden()) return
+        hidden.acceptedVisitors = acceptedVisitors
+        hidden.deniedVisitors = deniedVisitors
+        totalVisitors = acceptedVisitors + deniedVisitors
+        hidden.visitorRarities = visitorRarities
+        hidden.totalCopper = totalCopper
+        hidden.totalEXP = totalEXP
+        hidden.totalCost = totalCost
+        hidden.bandanaCount = bandanaCount
+        hidden.grassCount = grassCount
+        hidden.bouquetCount = bouquetCount
+        hidden.dedicationCount = dedicationCount
+        hidden.musicCount = musicCount
+        hidden.helmetCount = helmetCount
+        visitorStats = emptyList()
+        visitorStats = drawVisitorStatsDisplay()
+        visitorStats = formatDisplay(visitorStats)
+    }
+
+    @SubscribeEvent
+    fun onWorldLoad(event: WorldEvent.Load) {
+        if (hidden.visitorRarities.size == 0) {
+            hidden.visitorRarities.add(0)
+            hidden.visitorRarities.add(0)
+            hidden.visitorRarities.add(0)
+            hidden.visitorRarities.add(0)
+        }
+        acceptedVisitors = hidden.acceptedVisitors
+        deniedVisitors = hidden.deniedVisitors
+        totalVisitors = acceptedVisitors + deniedVisitors
+        visitorRarities = hidden.visitorRarities
+        totalCopper = hidden.totalCopper
+        totalEXP = hidden.totalEXP
+        totalCost = hidden.totalCost
+        bandanaCount = hidden.bandanaCount
+        grassCount = hidden.grassCount
+        bouquetCount = hidden.bouquetCount
+        dedicationCount = hidden.dedicationCount
+        musicCount = hidden.musicCount
+        helmetCount = hidden.helmetCount
+        saveAndUpdate()
+    }
+
+    @SubscribeEvent
+    fun onRenderOverlay(event: GuiRenderEvent.GameOverlayRenderEvent) {
+        if (!config.visitorDropsDisplay) return
+        if (!GardenAPI.inGarden()) return
+        if (GardenAPI.hideExtraGuis()) return
+        if (config.onlyOnBarn && !GardenAPI.onBarnPlot) return
+        config.visitorDropPos.renderStringsAndItems(visitorStats, posLabel = "Visitor Stats")
+    }
+}
+// not sure if there is a better way to do this
+enum class VisitorRarity(val rarity: String, val index: Int) {
+    UNCOMMON("UNCOMMON", 0),
+    RARE("RARE", 1),
+    LEGENDARY("LEGENDARY", 2),
+    SPECIAL("SPECIAL", 3),
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -48,6 +48,9 @@ class GardenVisitorTimer {
                 CopyErrorCommand.errorStackTrace = error.stackTrace.asList()
                 LorenzUtils.chat("§c[SkyHanni] encountered an error when updating visitor display, please run /shcopyerror")
             }
+            try {
+                GardenVisitorStats.saveAndUpdate()
+            } catch (_: Throwable) {} // no config yet
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -49,7 +49,7 @@ class GardenVisitorTimer {
                 LorenzUtils.chat("§c[SkyHanni] encountered an error when updating visitor display, please run /shcopyerror")
             }
             try {
-                GardenVisitorStats.saveAndUpdate()
+                GardenVisitorDropStatistics.saveAndUpdate()
             } catch (_: Throwable) {} // no config yet
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
@@ -1,0 +1,13 @@
+package at.hannibal2.skyhanni.features.garden.visitor
+
+import java.util.regex.Pattern
+
+enum class VisitorReward(val displayName: String, val internalName: String, val pattern: Pattern) {
+    GREEN_BANDANA("§9Green Bandana", "GREEN_BANDANA", "[+]1x Green Bandana".toPattern()),
+    OVERGROWN_GRASS("§9Overgrown Grass", "OVERGROWN_GRASS", "[+]1x Overgrown Grass".toPattern()),
+    FLOWERING_BOUQUET("§9Flowering Bouquet", "FLOWERING_BOUQUET", "[+]1x Flowering Bouquet".toPattern()),
+    DEDICATION("§9Dedication IV", "DEDICATION;4", "Dedication (IV|4) Book".toPattern()),
+    SPACE_HELMET("§cSpace Helmet", "DCTR_SPACE_HELM", "[+]Space Helmet".toPattern()),
+    // Pretty sure that the symbol is ◆ but not 100%
+    MUSIC_RUNE("§9Music Rune", "MUSIC_RUNE;1", "[+]1x ◆ Music Rune [1I]".toPattern()),
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -178,7 +178,12 @@ object NumberUtil {
     }
 
     fun String.formatNumber(): Long {
+        var hasDecimal = false
         var text = replace(",", "")
+        if (text.contains(".")) {
+            text = replace(".", "")
+            hasDecimal = true
+        }
         val multiplier = if (text.endsWith("k")) {
             text = text.substring(0, text.length - 1)
             1_000
@@ -186,7 +191,8 @@ object NumberUtil {
             text = text.substring(0, text.length - 1)
             1_000_000
         } else 1
-        val d = text.toDouble()
+        var d = text.toDouble()
+        if (hasDecimal) d /= 10
         return (d * multiplier).toLong()
     }
 }


### PR DESCRIPTION
Visitor Drop Counter
**Excuse the repeating lines of code, I don't know if they can be compressed**
Counts up all the drops that you get from visitors
- Count each rarity of visitor **Accepted**
- Count copper and farming exp
   - The xp count is not affected by wisdom, just the raw xp it says in chat
- Count coins "spent", Bazaar prices so market manipulation will show
- Count rare drops

Settings:
- Setting to show number or drop first
- Setting to show as the icon instead of the name
- Setting to show only on the barn plot


Made show as drop multiplier default on
Added support for numbers that have 1 decimal into format number