### PR TITLE
Restore Bought Piece Of Wizard Portal Lore

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -293,6 +293,7 @@ class SkyHanniMod {
         loadModule(ShowFishingItemName())
         loadModule(WarpTabComplete)
         loadModule(PlayerTabComplete)
+        loadModule(RestorePieceOfWizardPortalLore())
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Misc.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Misc.java
@@ -508,5 +508,10 @@ public class Misc {
     public boolean configButtonOnPause = true;
 
     @Expose
+    @ConfigOption(name = "Piece Of Wizard Portal", desc = "Restore the Earned By lore line on bought Piece Of Wizard Portal.")
+    @ConfigEditorBoolean
+    public boolean restorePieceOfWizardPortalLore = true;
+
+    @Expose
     public Position inventoryLoadPos = new Position(394, 124, false, true);
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/RestorePieceOfWizardPortalLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/RestorePieceOfWizardPortalLore.kt
@@ -1,0 +1,24 @@
+package at.hannibal2.skyhanni.features.misc
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getRecipientName
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class RestorePieceOfWizardPortalLore {
+
+    private val config get() = SkyHanniMod.feature.misc
+
+    @SubscribeEvent
+    fun onTooltip(event: LorenzToolTipEvent) {
+        if (!config.restorePieceOfWizardPortalLore) return
+        val stack = event.itemStack
+        if (stack.getInternalName() != "WIZARD_PORTAL_MEMENTO") return
+        val recipient = stack.getRecipientName()
+        if (!event.toolTip[5].contains(recipient!!)) {
+            event.toolTip.add(5, "§7Earned by: $recipient")
+        }
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -153,6 +153,8 @@ object SkyBlockItemModifierUtils {
         return data.sackInASack
     }
 
+    fun ItemStack.getRecipientName() = getAttributeString("recipient_name")
+
     fun ItemStack.getGemstones() = getExtraAttributes()?.let {
         val list = mutableListOf<GemstoneSlot>()
         for (attributes in it.keySet) {


### PR DESCRIPTION
Restore the "Earned By" line lore on bought Piece Of Wizard Portal (can be turned off, on by default)