### PR TITLE
Made visitor drop statistics on by defualt

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -245,7 +245,7 @@ public class Garden {
                         "§eThis feature is in beta please report issues on the discord!"
         )
         @ConfigEditorBoolean
-        public boolean enabled = false;
+        public boolean enabled = true;
 
         @Expose
         @ConfigOption(


### PR DESCRIPTION
I think a lot of people don't know about this
It also only shows on barn plot by default so it doesn't clutter their GUI otherwise. Feel free to reject but this was my thoughts