### PR TITLE
FF guide additions and fixes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -65,6 +65,7 @@ object Commands {
         registerCommand("shcropstartlocation") { GardenStartLocation.setLocationCommand() }
         registerCommand("shstopcityprojectreminder") { CityProjectFeatures.disable() }
         registerCommand("shclearslayerprofits") { SlayerItemProfitTracker.clearProfitCommand(it) }
+        registerCommand("shclearfarmingitems") { clearFarmingItems() }
 
         // for users - fix bugs
         registerCommand("shupdaterepo") { SkyHanniMod.repo.updateRepo() }
@@ -107,6 +108,13 @@ object Commands {
             CaptureFarmingGear.captureFarmingGear()
             SkyHanniMod.screenToOpen = FFGuideGUI()
         }
+    }
+
+    private fun clearFarmingItems() {
+        val config = GardenAPI.config?.fortune ?: return
+        LorenzUtils.chat("§e[SkyHanni] clearing farming items")
+        config.farmingItems.clear()
+        config.outdatedItems.clear()
     }
 
     private fun registerCommand(name: String, function: (Array<String>) -> Unit) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FarmingReforges.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FarmingReforges.kt
@@ -9,13 +9,16 @@ enum class FarmingReforges(
     val epic: Int,
     val legendary: Int,
     val mythic: Int
-) {
+) { // if reforge item is an empty string it means it will never be called, just for upgrading and recomb stats
     BLESSED("Blessed", "BLESSED_FRUIT", 5, 7, 9, 13, 16, 20),
     BOUNTIFUL("Bountiful", "GOLDEN_BALL", 1, 2, 3, 5, 7, 10),
     BLOOMING("Blooming", "FLOWERING_BOUQUET", 1, 2, 3, 4, 5, 6),
     ROOTED("Rooted", "BURROWING_SPORES", 4, 6, 8, 10, 12, 14),
     BUSTLING("Bustling", "SKYMART_BROCHURE", 1, 2, 4, 6, 8, 10),
-    MOSSY("Mossy", "OVERGROWN_GRASS", 5, 10, 15, 20, 25, 30)
+    MOSSY("Mossy", "OVERGROWN_GRASS", 5, 10, 15, 20, 25, 30),
+    ROBUST("Robust", "", 2, 3, 4, 6, 8, 10),
+    EARTHLY("Earthly", "LARGE_WALNUT", 1, 4, 6, 8, 10, 12),
+    GREEN_THUMB("Green Thumb", "", 1, 2, 3, 4, 5, 6)
 }
 
 operator fun FarmingReforges.get(index: Int, current: Double = 0.0): Double? {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FortuneUpgrades.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FortuneUpgrades.kt
@@ -196,7 +196,10 @@ object FortuneUpgrades {
 
     private fun recombobulateItem(item: ItemStack, list: MutableList<FortuneUpgrade>) {
         if (item.isRecombobulated()) return
-        val reforge = item.getReforgeName()?.let { FarmingReforges.valueOf(it.uppercase()) } ?: return
+        val reforge = item.getReforgeName()?.let {
+            FarmingReforges.values().find { enumValue -> enumValue.name == it.uppercase()
+            }
+        } ?: return
 
         FarmingFortuneDisplay.loadFortuneLineData(item, 0.0)
         val increase = reforge[item.getItemRarity() + 1, FarmingFortuneDisplay.reforgeFortune] ?: return
@@ -206,7 +209,6 @@ object FortuneUpgrades {
 
     private fun reforgeItem(item: ItemStack, reforge: FarmingReforges, list: MutableList<FortuneUpgrade>,copperPrice: Int? = null) {
         FarmingFortuneDisplay.loadFortuneLineData(item, 0.0)
-
         val increase = reforge[item.getItemRarity(), FarmingFortuneDisplay.reforgeFortune] ?: return
         list.add(FortuneUpgrade("§7Reforge your ${item.displayName} §7to ${reforge.reforgeName}",
             copperPrice, reforge.reforgeItem, 1, increase))


### PR DESCRIPTION
I'll just put it as a changelog:
```diff
Farming fortune guide changes (Contributed by CalMWolfs)
= Fixed error that stopped you from opening the guide
+ Added a few more uncommon farming reforges
+ Added /shclearfarmingitems to reset the saved items
```
