### PR TITLE
Highlight items in inventory if they are not in your neu repo

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -319,6 +319,7 @@ class SkyHanniMod {
         loadModule(PacketTest())
         loadModule(TestBingo)
         loadModule(TestCopyRngMeterValues)
+        loadModule(HighlightMissingRepoItems())
     }
 
     @Mod.EventHandler

--- a/src/main/java/at/hannibal2/skyhanni/config/features/DevData.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/DevData.java
@@ -48,6 +48,12 @@ public class DevData {
     public boolean showInternalName = false;
 
     @Expose
+    @ConfigOption(name = "Show empty internal names", desc = "Shows internal name even if it is blank.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 0)
+    public boolean showEmptyNames = false;
+
+    @Expose
     @ConfigOption(name = "Show item UUID", desc = "Show the Unique Identifier of items. in the lore.")
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 0)
@@ -58,6 +64,12 @@ public class DevData {
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 0)
     public boolean copyRngMeter = false;
+
+    @Expose
+    @ConfigOption(name = "Highlight Missing Repo Items", desc = "Highlights each item in the current inventory that is not in your current NEU repo.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 0)
+    public boolean highlightMissingRepo = false;
 
     @Expose
     public Position debugPos = new Position(10, 10, false, true);

--- a/src/main/java/at/hannibal2/skyhanni/test/HighlightMissingRepoItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/HighlightMissingRepoItems.kt
@@ -1,0 +1,57 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NEUItems
+import at.hannibal2.skyhanni.utils.RenderUtils.highlight
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.inventory.GuiChest
+import net.minecraft.client.gui.inventory.GuiInventory
+import net.minecraft.inventory.Slot
+import net.minecraftforge.event.world.WorldEvent
+import net.minecraftforge.fml.common.eventhandler.EventPriority
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class HighlightMissingRepoItems {
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+        if (!SkyHanniMod.feature.dev.highlightMissingRepo) return
+
+        val gui = event.gui
+
+        if (gui is GuiChest) {
+            highlightItems(gui.inventorySlots.inventorySlots)
+        } else if (gui is GuiInventory) {
+            val player = Minecraft.getMinecraft().thePlayer
+            highlightItems(player.inventoryContainer.inventorySlots)
+        }
+    }
+
+    private fun highlightItems(slots: Iterable<Slot>) {
+        for (slot in slots) {
+            if (!slot.hasStack) continue
+            val internalName = slot.stack.getInternalName()
+            if (internalName == "") continue
+            if (!NEUItems.allItemsCache.containsValue(internalName)) {
+                slot highlight LorenzColor.RED
+            }
+        }
+    }
+
+    @SubscribeEvent
+    fun onWorldLoad(event: WorldEvent.Load) {
+        if (NEUItems.allItemsCache.isEmpty()) {
+            NEUItems.allItemsCache = NEUItems.readAllNeuItems()
+        }
+    }
+
+    @SubscribeEvent
+    fun onRepoReload(event: io.github.moulberry.notenoughupdates.events.RepositoryReloadEvent) {
+        NEUItems.allItemsCache = NEUItems.readAllNeuItems()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/HighlightMissingRepoItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/HighlightMissingRepoItems.kt
@@ -11,7 +11,6 @@ import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiInventory
 import net.minecraft.inventory.Slot
-import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -33,20 +32,14 @@ class HighlightMissingRepoItems {
     }
 
     private fun highlightItems(slots: Iterable<Slot>) {
+        if (NEUItems.allInternalNames.isEmpty()) return
         for (slot in slots) {
             if (!slot.hasStack) continue
             val internalName = slot.stack.getInternalName()
             if (internalName == "") continue
-            if (!NEUItems.allItemsCache.containsValue(internalName)) {
+            if (!NEUItems.allInternalNames.contains(internalName)) {
                 slot highlight LorenzColor.RED
             }
-        }
-    }
-
-    @SubscribeEvent
-    fun onWorldLoad(event: WorldEvent.Load) {
-        if (NEUItems.allItemsCache.isEmpty()) {
-            NEUItems.allItemsCache = NEUItems.readAllNeuItems()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniTestCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniTestCommand.kt
@@ -167,6 +167,7 @@ class SkyHanniTestCommand {
         val itemStack = event.itemStack
         if (itemStack != null) {
             val internalName = itemStack.getInternalName()
+            if (internalName == "" && !SkyHanniMod.feature.dev.showEmptyNames) return
             event.toolTip.add("Internal Name: '$internalName'")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -30,7 +30,7 @@ object NEUItems {
     private val multiplierCache = mutableMapOf<String, Pair<String, Int>>()
     private val recipesCache = mutableMapOf<String, Set<NeuRecipe>>()
     private val enchantmentNamePattern = Pattern.compile("^(?<format>(?:§.)+)(?<name>[^§]+) (?<level>[IVXL]+)$")
-    private var allItemsCache = mapOf<String, String>() // item name -> internal name
+    var allItemsCache = mapOf<String, String>() // item name -> internal name
 
     fun getInternalName(itemName: String): String {
         return getInternalNameOrNull(itemName) ?: throw Error("getInternalName is null for '$itemName'")
@@ -53,7 +53,7 @@ object NEUItems {
         return null
     }
 
-    private fun readAllNeuItems(): Map<String, String> {
+    fun readAllNeuItems(): Map<String, String> {
         val map = mutableMapOf<String, String>()
         for (internalName in manager.itemInformation.keys) {
             val name = manager.createItem(internalName).displayName.removeColor().lowercase()

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -31,6 +31,7 @@ object NEUItems {
     private val recipesCache = mutableMapOf<String, Set<NeuRecipe>>()
     private val enchantmentNamePattern = Pattern.compile("^(?<format>(?:§.)+)(?<name>[^§]+) (?<level>[IVXL]+)$")
     var allItemsCache = mapOf<String, String>() // item name -> internal name
+    var allInternalNames = mutableListOf<String>()
 
     fun getInternalName(itemName: String): String {
         return getInternalNameOrNull(itemName) ?: throw Error("getInternalName is null for '$itemName'")
@@ -54,10 +55,12 @@ object NEUItems {
     }
 
     fun readAllNeuItems(): Map<String, String> {
+        allInternalNames.clear()
         val map = mutableMapOf<String, String>()
         for (internalName in manager.itemInformation.keys) {
             val name = manager.createItem(internalName).displayName.removeColor().lowercase()
             map[name] = internalName
+            allInternalNames.add(internalName)
         }
         return map
     }


### PR DESCRIPTION
When in an inventory, any item not in the player's loaded NEU repo will be highlighted red. This is useful for when new items come out, or if a bug is occurring ring around a certain item.
Off by default
example:
![image](https://github.com/hannibal002/SkyHanni/assets/94038482/6f52a386-275c-481d-ac6b-23185a2939f9)
