### PR TITLE
Fix Regex in Ghost Counter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/GhostCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/GhostCounter.kt
@@ -54,7 +54,7 @@ object GhostCounter {
     val hidden get() = ProfileStorageData.profileSpecific?.ghostCounter
     private var display = listOf<List<Any>>()
     private var ghostCounterV3File = File("." + File.separator + "config" + File.separator + "ChatTriggers" + File.separator + "modules" + File.separator + "GhostCounterV3" + File.separator + ".persistantData.json")
-    private val skillXPPattern = ".*§3\\+(?<gained>.*).*\\((?<total>.*)\\/(?<current>.*)\\).*".toPattern()
+    private val skillXPPattern = ".*§3\\+(?<gained>.*)( Combat)? \\((?<total>.*)\\/(?<current>.*)\\).*".toPattern()
     private val killComboExpiredPattern = "§cYour Kill Combo has expired! You reached a (?<combo>.*) Kill Combo!".toPattern()
     private val ghostXPPattern = "(?<current>\\d+(?:\\.\\d+)?(?:,\\d+)?[kK]?)\\/(?<total>\\d+(?:\\.\\d+)?(?:,\\d+)?[kKmM]?)".toPattern()
     private val bestiaryPattern = "BESTIARY Ghost .*➜(?<newLevel>.*)".toPattern()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/GhostCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/GhostCounter.kt
@@ -54,7 +54,7 @@ object GhostCounter {
     val hidden get() = ProfileStorageData.profileSpecific?.ghostCounter
     private var display = listOf<List<Any>>()
     private var ghostCounterV3File = File("." + File.separator + "config" + File.separator + "ChatTriggers" + File.separator + "modules" + File.separator + "GhostCounterV3" + File.separator + ".persistantData.json")
-    private val skillXPPattern = ".*§3\\+(?<gained>.*)( Combat)? \\((?<total>.*)\\/(?<current>.*)\\).*".toPattern()
+    private val skillXPPattern = ".*§3\\+(?<gained>.*)( .* | )\\((?<total>.*)\\/(?<current>.*)\\).*".toPattern()
     private val killComboExpiredPattern = "§cYour Kill Combo has expired! You reached a (?<combo>.*) Kill Combo!".toPattern()
     private val ghostXPPattern = "(?<current>\\d+(?:\\.\\d+)?(?:,\\d+)?[kK]?)\\/(?<total>\\d+(?:\\.\\d+)?(?:,\\d+)?[kKmM]?)".toPattern()
     private val bestiaryPattern = "BESTIARY Ghost .*➜(?<newLevel>.*)".toPattern()


### PR DESCRIPTION
Fixes some regex that I think I broke and is causing the errors.
Still does not fix ghost counter for people that have their skill exp display in the format of:
+128.8 Combat (27.42%) but it may fix it for a few people.
I don't understand the calculations done enough to be able to switch it over to work for percentages as well