### PR TITLE
Use New Elite API

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/EliteFarmingWeight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/EliteFarmingWeight.kt
@@ -233,7 +233,7 @@ class EliteFarmingWeight {
         }
 
         private fun getExactWeight(): Double {
-            val values = calculateCollectionWeight(false).values
+            val values = calculateCollectionWeight().values
             return if (values.isNotEmpty()) {
                 values.sum()
             } else 0.0
@@ -298,14 +298,13 @@ class EliteFarmingWeight {
             LorenzUtils.chat("§eYou can re-enter the garden to try to fix the problem. If this message repeats itself, please report it on Discord!")
         }
 
-        private fun calculateCollectionWeight(round: Boolean = true): MutableMap<CropType, Double> {
+        private fun calculateCollectionWeight(): MutableMap<CropType, Double> {
             val weightPerCrop = mutableMapOf<CropType, Double>()
             var totalWeight = 0.0
             for (crop in CropType.values()) {
                 val weight = crop.getLocalCounter() / crop.getFactor()
-                val roundedWeight = weight.let { if (round) it.round(2) else it }
-                weightPerCrop[crop] = roundedWeight
-                totalWeight += roundedWeight
+                weightPerCrop[crop] = weight
+                totalWeight += weight
             }
             if (totalWeight > 0) {
                 weightPerCrop[CropType.MUSHROOM] = specialMushroomWeight(weightPerCrop, totalWeight)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/EliteFarmingWeight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/EliteFarmingWeight.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed.getSpeed
 import at.hannibal2.skyhanni.utils.APIUtil
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.round
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.TimeUtils
 import kotlinx.coroutines.Dispatchers
@@ -170,11 +169,11 @@ class EliteFarmingWeight {
         private fun getETA(): String {
             if (weight < 0) return ""
 
-            var next = nextPlayer ?: return ""
-            var nextName = if (leaderboardPosition == -1) "#10000" else next.ign
+            var nextPlayer = nextPlayer ?: return ""
+            var nextName = if (leaderboardPosition == -1) "#10000" else nextPlayer.name
 
             val totalWeight = (localWeight + weight)
-            var weightUntilOvertake = next.amount - totalWeight
+            var weightUntilOvertake = nextPlayer.weight - totalWeight
 
             if (weightUntilOvertake < 0) {
                 if (weightPerSecond > 0) {
@@ -193,13 +192,13 @@ class EliteFarmingWeight {
                 nextPlayers.removeFirst()
 
                 // Display waiting message if nextPlayers list is empty
-                next = nextPlayer ?: return "§cWaiting for leaderboard update..."
+                nextPlayer = this.nextPlayer ?: return "§cWaiting for leaderboard update..."
                 // Update values to next player
-                nextName = next.ign
-                weightUntilOvertake = next.amount - totalWeight
+                nextName = nextPlayer.name
+                weightUntilOvertake = nextPlayer.weight - totalWeight
             }
 
-            if (next.amount == 0.0) {
+            if (nextPlayer.weight == 0.0) {
                 return "§cRejoin the garden to show ETA!"
             }
 
@@ -342,6 +341,6 @@ class EliteFarmingWeight {
             )
         }
 
-        data class UpcomingPlayer(val ign: String, val amount: Double)
+        data class UpcomingPlayer(val name: String, val weight: Double)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/EliteFarmingWeight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/EliteFarmingWeight.kt
@@ -319,12 +319,12 @@ class EliteFarmingWeight {
         private val factorPerCrop by lazy {
             mapOf(
                 CropType.WHEAT to 100_000.0,
-                CropType.CARROT to 300_000.0,
+                CropType.CARROT to 302_061.86,
                 CropType.POTATO to 300_000.0,
                 CropType.SUGAR_CANE to 200_000.0,
                 CropType.NETHER_WART to 250_000.0,
-                CropType.PUMPKIN to 90_066.27,
-                CropType.MELON to 450_324.6,
+                CropType.PUMPKIN to 98_284.71,
+                CropType.MELON to 485_308.47,
                 CropType.MUSHROOM to 90_178.06,
                 CropType.COCOA_BEANS to 267_174.04,
                 CropType.CACTUS to 177_254.45,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/EliteFarmingWeight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/EliteFarmingWeight.kt
@@ -132,8 +132,8 @@ class EliteFarmingWeight {
         private fun getLeaderboard(): String {
             if (!config.eliteFarmingWeightLeaderboard) return ""
 
-            // Fetching new leaderboard position every 10 minutes
-            if (System.currentTimeMillis() > lastLeaderboardUpdate + 600_000) {
+            // Fetching new leaderboard position every 10.5 minutes
+            if (System.currentTimeMillis() > lastLeaderboardUpdate + 630_000) {
                 if (!isLoadingLeaderboard) {
                     isLoadingLeaderboard = true
                     SkyHanniMod.coroutineScope.launch {


### PR DESCRIPTION
- Updates the old `elitebot.dev/api` references to instead use the new `api.elitebot.dev` endpoints 
- Makes the upcoming players for the ETA display into a list, which allows the next player to instantly be displayed when passing someone on the leaderboard
- Changes the crop farming weight values to the updated ones
- Removes rounding from the middle of the weight calculation, as it's no longer done that way