### PR TITLE
Feat: Choose Farming Weight ETA Goal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/
 run/
 build/
+bin/
 
 # gradle
 build

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Garden.java
@@ -763,6 +763,12 @@ public class Garden {
     public boolean eliteFarmingWeightOvertakeETAAlways = true;
 
     @Expose
+    @ConfigOption(name = "ETA Goal", desc = "Override the Overtake ETA to show when you'll reach the specified rank (if not there yet). (Default: \"10000\")")
+    @ConfigEditorText
+    @ConfigAccordionId(id = 11)
+    public String eliteFarmingWeightETAGoalRank = "10000";
+
+    @Expose
     @ConfigOption(name = "Dicer Counter", desc = "")
     @ConfigEditorAccordion(id = 12)
     public boolean dicerCounter = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -48,6 +48,8 @@ class FarmingWeightDisplay {
         lastLeaderboardUpdate = 0
 
         nextPlayers.clear()
+        rankGoal = -1
+
         localCounter.clear()
     }
 
@@ -56,7 +58,9 @@ class FarmingWeightDisplay {
         display = emptyList()
         profileId = ""
         weight = -2.0
+
         nextPlayers.clear()
+        rankGoal = -1
     }
 
     var tick = 0
@@ -83,6 +87,7 @@ class FarmingWeightDisplay {
         private var dirtyCropWeight = false
         private var isLoadingWeight = false
         private var isLoadingLeaderboard = false
+        private var rankGoal = -1
 
         private var nextPlayers = mutableListOf<UpcomingPlayer>()
         private val nextPlayer get() = nextPlayers.firstOrNull()
@@ -123,6 +128,8 @@ class FarmingWeightDisplay {
             }
 
             val weight = getWeight()
+
+            if (rankGoal == -1) rankGoal = getRankGoal()
             val leaderboard = getLeaderboard()
 
             val list = mutableListOf<String>()
@@ -139,14 +146,7 @@ class FarmingWeightDisplay {
 
             // Fetching new leaderboard position every 10.5 minutes
             if (System.currentTimeMillis() > lastLeaderboardUpdate + 630_000) {
-                if (!isLoadingLeaderboard) {
-                    isLoadingLeaderboard = true
-                    SkyHanniMod.coroutineScope.launch {
-                        leaderboardPosition = loadLeaderboardPosition()
-                        lastLeaderboardUpdate = System.currentTimeMillis()
-                        isLoadingLeaderboard = false
-                    }
-                }
+                loadLeaderboardIfAble()
             }
 
             return if (leaderboardPosition != -1) {
@@ -172,11 +172,33 @@ class FarmingWeightDisplay {
             return "§e" + LorenzUtils.formatDouble(totalWeight, 2)
         }
 
+        private fun getRankGoal(): Int {
+            val value = config.eliteFarmingWeightETAGoalRank
+            var goal = 10000
+
+            // Check that the provided string is valid
+            val parsed = value.toIntOrNull() ?: 0
+            if (parsed < 1 || parsed > goal) {
+                LorenzUtils.error("[SkyHanni] Invalid Farming Weight Overtake Goal!")
+                LorenzUtils.chat("§eEdit the Overtake Goal config value with a valid number [1-10000] to use this feature!")
+                config.eliteFarmingWeightETAGoalRank = goal.toString()
+            } else {
+                goal = parsed
+            }
+
+            // Fetch the positions again if the goal was changed
+            if (rankGoal != goal) {
+                loadLeaderboardIfAble()
+            }
+
+            return goal
+        }
+
         private fun getETA(): String {
             if (weight < 0) return ""
 
             var nextPlayer = nextPlayer ?: return ""
-            var nextName = if (leaderboardPosition == -1) "#10000" else nextPlayer.name
+            var nextName = if (leaderboardPosition == -1 || leaderboardPosition > rankGoal) "#$rankGoal" else nextPlayer.name
 
             val totalWeight = (localWeight + weight)
             var weightUntilOvertake = nextPlayer.weight - totalWeight
@@ -244,10 +266,25 @@ class FarmingWeightDisplay {
             } else 0.0
         }
 
+        private fun loadLeaderboardIfAble() {
+            if (isLoadingLeaderboard) return
+            isLoadingLeaderboard = true
+
+            SkyHanniMod.coroutineScope.launch {
+                leaderboardPosition = loadLeaderboardPosition()
+                lastLeaderboardUpdate = System.currentTimeMillis()
+                isLoadingLeaderboard = false
+            }
+        }
+
         private suspend fun loadLeaderboardPosition() = try {
             val uuid = LorenzUtils.getPlayerUuid()
+
             val includeUpcoming = if (isEtaEnabled()) "?includeUpcoming=true" else ""
-            val url = "https://api.elitebot.dev/leaderboard/rank/farmingweight/$uuid/$profileId$includeUpcoming"
+            val goalRank = getRankGoal() + 1 // API returns upcoming players as if you were at this rank already
+            val atRank = if (isEtaEnabled() && goalRank != 10001) "&atRank=$goalRank" else ""
+
+            val url = "https://api.elitebot.dev/leaderboard/rank/farmingweight/$uuid/$profileId$includeUpcoming$atRank"
             val result = withContext(Dispatchers.IO) { APIUtil.getJSONResponse(url) }.asJsonObject
 
             if (isEtaEnabled()) {


### PR DESCRIPTION
Adds a config option to select what spot in the farming weight leaderboard you're aiming for.

![image](https://github.com/hannibal002/SkyHanni/assets/24925519/5f533318-5b7d-4ea9-ab43-0db3854fbf5d)

Reverts back to showing the next player once you've passed the goal, and sends a chat message if you entered an invalid number. Only updates on garden load or leaderboard pull, this could be changed, but it shouldn't update for every single character update when typing.