### PR TITLE
Watchdog hider improvement

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -13,9 +13,7 @@ import at.hannibal2.skyhanni.features.bazaar.BazaarBestSellMethod
 import at.hannibal2.skyhanni.features.bazaar.BazaarCancelledBuyOrderClipboard
 import at.hannibal2.skyhanni.features.bazaar.BazaarOrderHelper
 import at.hannibal2.skyhanni.features.bingo.*
-import at.hannibal2.skyhanni.features.chat.ArachneChatMessageHider
-import at.hannibal2.skyhanni.features.chat.ChatFilter
-import at.hannibal2.skyhanni.features.chat.PlayerDeathMessages
+import at.hannibal2.skyhanni.features.chat.*
 import at.hannibal2.skyhanni.features.chat.playerchat.PlayerChatFilter
 import at.hannibal2.skyhanni.features.chat.playerchat.PlayerChatModifier
 import at.hannibal2.skyhanni.features.commands.PartyTransferCommand
@@ -363,6 +361,7 @@ class SkyHanniMod {
         loadModule(RiftWiltedBerberisHelper())
         loadModule(RiftHorsezookaHider())
         loadModule(GriffinPetWarning())
+        loadModule(PatternHiderManager(this))
         //
 
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -12,7 +12,7 @@ class ChatFilter {
     @SubscribeEvent
     fun onChatMessage(event: LorenzChatEvent) {
         if (!LorenzUtils.onHypixel) return
-
+        if (event.blockedReason != "") return
         val blockReason = block(event.message)
         if (blockReason != "") {
             event.blockedReason = blockReason
@@ -27,9 +27,7 @@ class ChatFilter {
         isGuildExp(message) && config.guildExp -> "guild_exp"
         friendJoin(message) && config.friendJoinLeft -> "friend_join"
         killCombo(message) && config.killCombo -> "kill_combo"
-        watchdogAnnouncement(message) && config.watchDog -> "watchdog"
         profileJoin(message) && config.profileJoin -> "profile_join"
-
         bazaarAndAHMiniMessages(message) && config.others -> "bz_ah_minis"
         slayer(message) && config.others -> "slayer"
         slayerDrop(message) && config.others -> "slayer_drop"
@@ -40,7 +38,6 @@ class ChatFilter {
         winterIsland(message) && config.others -> "winter_island"
         uselessWarning(message) && config.others -> "useless_warning"
         annoyingSpam(message) && config.others -> "annoying_spam"
-
         isWinterGift(message) && config.winterGift -> "winter_gift"
         isPowderMining(message) && config.powderMining -> "powder_mining"
 
@@ -219,13 +216,7 @@ class ChatFilter {
         return false
     }
 
-    private fun watchdogAnnouncement(message: String) = when {
-        message == "§4[WATCHDOG ANNOUNCEMENT]" -> true
-        message.matchRegex("§fWatchdog has banned §r§c§l(.*)§r§f players in the last 7 days.") -> true
-        message.matchRegex("§fStaff have banned an additional §r§c§l(.*)§r§f in the last 7 days.") -> true
-        message == "§cBlacklisted modifications are a bannable offense!" -> true
-        else -> false
-    }
+
 
     private fun profileJoin(message: String) = when {
         message.startsWith("§aYou are playing on profile: §e") -> true

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PatternHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PatternHider.kt
@@ -1,0 +1,52 @@
+package at.hannibal2.skyhanni.features.chat
+
+import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.StringUtils.matchRegex
+import net.minecraft.client.Minecraft
+import net.minecraft.util.IChatComponent
+import net.minecraftforge.client.event.ClientChatReceivedEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class PatternHider(val name: String, val pattern: List<Regex>, val isEnabled: () -> Boolean) {
+    private val chat = mutableListOf<IChatComponent>()
+    private var iterator = pattern.iterator()
+
+    private var ticks = 0
+    private val blockedReason = "${name}_pattern_match"
+
+    @SubscribeEvent
+    fun onTick(ignored: LorenzTickEvent) {
+        if (!isEnabled()) return
+        if (chat.isNotEmpty() && ticks <= 0) {
+            reset(iterator.hasNext())
+        }
+        ticks--
+    }
+
+    @SubscribeEvent
+    fun onChatMessage(event: LorenzChatEvent) {
+        if (!isEnabled()) return
+        if (iterator.hasNext()) {
+            val pattern = iterator.next()
+            if (pattern.matches(event.message)) {
+                ticks = 2
+                chat.add(event.chatComponent)
+                event.blockedReason = blockedReason
+            } else {
+                reset(true)
+            }
+        } else {
+            reset(false)
+        }
+    }
+
+    private fun reset(restoreBlockedChat: Boolean) {
+        if (chat.isNotEmpty() && restoreBlockedChat) {
+            chat.forEach { Minecraft.getMinecraft().thePlayer.addChatMessage(it) }
+        }
+        iterator = pattern.iterator()
+        chat.clear()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PatternHiderManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PatternHiderManager.kt
@@ -1,0 +1,25 @@
+package at.hannibal2.skyhanni.features.chat
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.utils.LorenzUtils
+
+class PatternHiderManager(skyHanniMod: SkyHanniMod) {
+    private val watchdogHider = PatternHider("watchdog", watchdogPattern) {
+        LorenzUtils.onHypixel && SkyHanniMod.feature.chat.watchDog
+    }
+
+    init {
+        skyHanniMod.loadModule(watchdogHider)
+    }
+
+    companion object {
+        val watchdogPattern = listOf(
+            Regex("§f"),
+            Regex("§4\\[WATCHDOG ANNOUNCEMENT]"),
+            Regex("§fWatchdog has banned §r§c§l(.*)§r§f players in the last 7 days."),
+            Regex("§fStaff have banned an additional §r§c§l(.*)§r§f in the last 7 days."),
+            Regex("§cBlacklisted modifications are a bannable offense!"),
+            Regex("§c")
+        )
+    }
+}


### PR DESCRIPTION
Attempts to hide watchdog messages by matching the watchdog message to a multi-line template including the empty lines around it. 

This is intended to resolve the issue where the Watchdog hider leaves two extra blank lines in chat. The empty line hider is a current work-around, but messes with other chat elements.

I am not sure why it doesn't properly hide the empty lines currently, as they seem to be properly filtered in logs.