### PR TITLE
Performance improvements for the damage indicator

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MayorElection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorElection.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.utils.APIUtil
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.put
 import at.hannibal2.skyhanni.utils.jsonobjects.MayorJson
 import io.github.moulberry.notenoughupdates.util.SkyBlockTime
 import kotlinx.coroutines.Dispatchers
@@ -74,8 +75,4 @@ class MayorElection {
     private fun MayorJson.Election.getPairs() = year + 1 to candidates.bestCandidate()
 
     private fun List<MayorJson.Candidate>.bestCandidate() = maxBy { it.votes }
-
-    private infix fun <K, V> MutableMap<K, V>.put(pairs: Pair<K, V>) {
-        this[pairs.first] = pairs.second
-    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/damageindicator/DamageIndicatorManager.kt
@@ -300,7 +300,7 @@ class DamageIndicatorManager {
     fun onTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
         data = data.editCopy {
-            EntityUtils.getEntitiesSequence<EntityLivingBase>().mapNotNull(::checkEntity).forEach { this put it }
+            EntityUtils.getEntities<EntityLivingBase>().mapNotNull(::checkEntity).forEach { this put it }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/damageindicator/DamageIndicatorManager.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.LorenzUtils.between
 import at.hannibal2.skyhanni.utils.LorenzUtils.editCopy
+import at.hannibal2.skyhanni.utils.LorenzUtils.put
 import at.hannibal2.skyhanni.utils.LorenzUtils.round
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
@@ -299,10 +300,7 @@ class DamageIndicatorManager {
     fun onTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
         data = data.editCopy {
-            EntityUtils.getEntitiesSequence<EntityLivingBase>().mapNotNull(::checkEntity)
-                .forEach { (uuid, entityData) ->
-                    this[uuid] = entityData
-                }
+            EntityUtils.getEntitiesSequence<EntityLivingBase>().mapNotNull(::checkEntity).forEach { this put it }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerHideParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerHideParticles.kt
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class EndermanSlayerHideParticles {
 
-    private var endermanLocations = listOf<LorenzVec>()
+    private var endermanLocations = sequenceOf<LorenzVec>()
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -157,6 +157,7 @@ object EntityUtils {
     fun EntityEnderman.getBlockInHand(): IBlockState? = heldBlockState
 
     inline fun <reified R : Entity> getEntities(): List<R> = getAllEntities().filterIsInstance<R>()
+    inline fun <reified R : Entity> getEntitiesSequence(): Sequence<R> = Minecraft.getMinecraft()?.theWorld?.loadedEntityList?.asSequence()?.filterIsInstance<R>() ?: emptySequence()
 
     inline fun <reified R : Entity> getEntitiesOrNull(): List<R>? = getAllEntitiesOrNull()?.filterIsInstance<R>()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -126,10 +126,10 @@ object EntityUtils {
             ?.value
     }
 
-    inline fun <reified T : Entity> getEntitiesNextToPlayer(radius: Double): List<T> =
+    inline fun <reified T : Entity> getEntitiesNextToPlayer(radius: Double): Sequence<T> =
         getEntitiesNearby<T>(LocationUtils.playerLocation(), radius)
 
-    inline fun <reified T : Entity> getEntitiesNearby(location: LorenzVec, radius: Double): List<T> =
+    inline fun <reified T : Entity> getEntitiesNearby(location: LorenzVec, radius: Double): Sequence<T> =
         getEntities<T>().filter { it.distanceTo(location) < radius }
 
     fun EntityLivingBase.isAtFullHealth() = baseMaxHealth == health.toInt()
@@ -156,12 +156,11 @@ object EntityUtils {
 
     fun EntityEnderman.getBlockInHand(): IBlockState? = heldBlockState
 
-    inline fun <reified R : Entity> getEntities(): List<R> = getAllEntities().filterIsInstance<R>()
-    inline fun <reified R : Entity> getEntitiesSequence(): Sequence<R> = Minecraft.getMinecraft()?.theWorld?.loadedEntityList?.asSequence()?.filterIsInstance<R>() ?: emptySequence()
+    inline fun <reified R : Entity> getEntities(): Sequence<R> = getAllEntities().filterIsInstance<R>()
 
-    inline fun <reified R : Entity> getEntitiesOrNull(): List<R>? = getAllEntitiesOrNull()?.filterIsInstance<R>()
+    inline fun <reified R : Entity> getEntitiesOrNull(): Sequence<R>? = getAllEntitiesOrNull()?.filterIsInstance<R>()
 
-    fun getAllEntities(): List<Entity> = getAllEntitiesOrNull() ?: error("minecraft.world.loadedEntityList is null.")
+    fun getAllEntities(): Sequence<Entity> = getAllEntitiesOrNull() ?: emptySequence()
 
-    fun getAllEntitiesOrNull(): List<Entity>? = Minecraft.getMinecraft()?.theWorld?.loadedEntityList?.toMutableList()
+    fun getAllEntitiesOrNull(): Sequence<Entity>? = Minecraft.getMinecraft()?.theWorld?.loadedEntityList?.asSequence()
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -422,4 +422,8 @@ object LorenzUtils {
         }
         return false
     }
+
+    infix fun <K, V> MutableMap<K, V>.put(pairs: Pair<K, V>) {
+        this[pairs.first] = pairs.second
+    }
 }


### PR DESCRIPTION
I dont know why, but this feature was pulling about 5% of my frametimes because it did not disable itself while turned off (also because iterating over all entities instead of just keeping a list of relevant boss entities using entity world add and entity world remove events is kinda weird, but i didnt want to bother fixing that for a feature i dont use).