### PR TITLE
Fix: bestiary milestone notification

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactBestiaryChatMessage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactBestiaryChatMessage.kt
@@ -58,7 +58,7 @@ class CompactBestiaryChatMessage {
         } else if (inBestiary) {
             event.blockedReason = "bestiary"
             blockedLines++
-            if (blockedLines > 10) {
+            if (blockedLines > 12) {
                 blockedLines = 0
                 inBestiary = false
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactBestiaryChatMessage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactBestiaryChatMessage.kt
@@ -58,7 +58,7 @@ class CompactBestiaryChatMessage {
         } else if (inBestiary) {
             event.blockedReason = "bestiary"
             blockedLines++
-            if (blockedLines > 12) {
+            if (blockedLines > 15) {
                 blockedLines = 0
                 inBestiary = false
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactBestiaryChatMessage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactBestiaryChatMessage.kt
@@ -23,6 +23,8 @@ class CompactBestiaryChatMessage {
 
     var milestoneMessage: String? = null
 
+    val milestonePattern = "^.+(§8\\d{1,3}➡§e\\d{1,3})$".toRegex()
+
     @SubscribeEvent
     fun onChatMessage(event: LorenzChatEvent) {
         if (!LorenzUtils.inSkyBlock) return
@@ -70,9 +72,9 @@ class CompactBestiaryChatMessage {
                     LorenzUtils.chat("§6§lBESTIARY MILESTONE $it")
                     milestoneMessage = null
                 }
-                if (message.endsWith("§6§lBESTIARY MILESTONE")) {
+                milestonePattern.matchEntire(message)?.let {
                     acceptMoreDescription = false
-                    milestoneMessage = message
+                    milestoneMessage = it.groups[1]!!.value
                 }
                 if (acceptMoreDescription) {
                     bestiaryDescription.add(message.trim())


### PR DESCRIPTION
Fix the compact bestiary milestone message to show milestone level:
<img width="336" alt="Screenshot 2023-08-03 at 9 32 17 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/5faa7cfa-0adc-4804-8ceb-a18056ab5c37">
Before this change, it looked like:
<img width="627" alt="Screenshot 2023-08-03 at 9 34 49 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/6a71ee59-0687-4cd9-9243-6337595d31ae">


