### PR TITLE
Double hooks in shark fishing counter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -142,14 +142,6 @@ object ChatManager {
         return false
     }
 
-    @SubscribeEvent
-    fun onChatMessage(chatEvent: LorenzChatEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-
-        val seaCreature = SeaCreatureManager.getSeaCreature(chatEvent.message) ?: return
-        SeaCreatureFishEvent(seaCreature, chatEvent).postAndCatch()
-    }
-
     fun openChatFilterGUI() {
         SkyHanniMod.screenToOpen = ChatFilterGui(getRecentMessageHistory())
     }

--- a/src/main/java/at/hannibal2/skyhanni/events/SeaCreatureFishEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/SeaCreatureFishEvent.kt
@@ -2,4 +2,8 @@ package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.features.fishing.SeaCreature
 
-class SeaCreatureFishEvent(val seaCreature: SeaCreature, val chatEvent: LorenzChatEvent) : LorenzEvent()
+class SeaCreatureFishEvent(
+    val seaCreature: SeaCreature,
+    val chatEvent: LorenzChatEvent,
+    val doubleHook: Boolean
+) : LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -1,10 +1,32 @@
 package at.hannibal2.skyhanni.features.fishing
 
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.SeaCreatureFishEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class SeaCreatureManager {
+
+    private var doubleHook = false
+
+    @SubscribeEvent
+    fun onChatMessage(event: LorenzChatEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+        if (doubleHookMessages.contains(event.message)) {
+            if (SkyHanniMod.feature.fishing.compactDoubleHook) {
+                event.blockedReason = "double_hook"
+            }
+            doubleHook = true
+        } else {
+            val seaCreature = getSeaCreature(event.message)
+            if (seaCreature != null) {
+                SeaCreatureFishEvent(seaCreature, event, doubleHook).postAndCatch()
+            }
+            doubleHook = false
+        }
+    }
 
     @SubscribeEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
@@ -43,6 +65,11 @@ class SeaCreatureManager {
     companion object {
         private val seaCreatureMap = mutableMapOf<String, SeaCreature>()
         var allFishingMobNames = emptyList<String>()
+
+        private val doubleHookMessages = setOf(
+            "§eIt's a §r§aDouble Hook§r§e! Woot woot!",
+            "§eIt's a §r§aDouble Hook§r§e!"
+        )
 
         fun getSeaCreature(message: String): SeaCreature? {
             return seaCreatureMap.getOrDefault(message, null)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureMessageShortener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureMessageShortener.kt
@@ -8,19 +8,7 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class SeaCreatureMessageShortener {
-    private var nextIsDoubleHook: Boolean = false
-
     private val config get() = SkyHanniMod.feature.fishing
-
-    @SubscribeEvent(priority = EventPriority.LOW)
-    fun onChatMessage(event: LorenzChatEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-        if (!config.shortenFishingMessage && !config.compactDoubleHook) return
-        if (doubleHookMessages.contains(event.message)) {
-            event.blockedReason = "double_hook"
-            nextIsDoubleHook = true
-        }
-    }
 
     @SubscribeEvent
     fun onSeaCreatureFish(event: SeaCreatureFishEvent) {
@@ -33,8 +21,7 @@ class SeaCreatureMessageShortener {
             "§9You caught a $seaCreature§9!"
         } else event.chatEvent.message
 
-        if (config.compactDoubleHook && nextIsDoubleHook) {
-            nextIsDoubleHook = false
+        if (config.compactDoubleHook && event.doubleHook) {
             message = "§e§lDOUBLE HOOK! $message"
         }
         LorenzUtils.chat(message)
@@ -42,12 +29,5 @@ class SeaCreatureMessageShortener {
         if (seaCreature.fishingExperience == 0) {
             LorenzUtils.debug("no fishing exp set for " + seaCreature.displayName)
         }
-    }
-
-    companion object {
-        private val doubleHookMessages = setOf(
-            "§eIt's a §r§aDouble Hook§r§e! Woot woot!",
-            "§eIt's a §r§aDouble Hook§r§e!"
-        )
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SharkFishCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SharkFishCounter.kt
@@ -24,7 +24,7 @@ class SharkFishCounter {
 
         val displayName = event.seaCreature.displayName
         if (displayName.contains("Shark")) {
-            counter++
+            counter += if (event.doubleHook) 2 else 1
             display = "§7Sharks caught: §e${counter.addSeparators()}"
         }
     }


### PR DESCRIPTION
This PR adds a double hook flag to a SeaCreatureFishEvent (moving the event logic into SeaCreatureManager). This flag is used for the shark fishing counter to support double hooks, and for the compact double hook message. 

(in the future this may be used for a more general sea creature counter or other features)