### PR TITLE
Account upgrade complete reminder

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -23,6 +23,8 @@ import at.hannibal2.skyhanni.features.commands.WikiCommand
 import at.hannibal2.skyhanni.features.damageindicator.DamageIndicatorManager
 import at.hannibal2.skyhanni.features.dungeon.*
 import at.hannibal2.skyhanni.features.event.diana.*
+import at.hannibal2.skyhanni.features.fame.AccountUpgradeReminder
+import at.hannibal2.skyhanni.features.fame.CityProjectFeatures
 import at.hannibal2.skyhanni.features.fishing.*
 import at.hannibal2.skyhanni.features.fishing.trophy.OdgerWaypoint
 import at.hannibal2.skyhanni.features.fishing.trophy.TrophyFishFillet
@@ -378,6 +380,7 @@ class SkyHanniMod {
         loadModule(EnderNodeTracker())
         loadModule(CompactBestiaryChatMessage())
         loadModule(WatchdogHider())
+        loadModule(AccountUpgradeReminder())
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/Storage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/Storage.java
@@ -39,6 +39,12 @@ public class Storage {
 
         @Expose
         public long nextCityProjectParticipationTime = 0L;
+
+        @Expose
+        public String currentAccountUpgrade = null;
+
+        @Expose
+        public long nextAccountUpgradeCompletionTime = -1L;
     }
 
     public static class ProfileSpecific {

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.features.bingo.BingoCardDisplay
 import at.hannibal2.skyhanni.features.bingo.BingoNextStepHelper
 import at.hannibal2.skyhanni.features.event.diana.BurrowWarpHelper
 import at.hannibal2.skyhanni.features.event.diana.InquisitorWaypointShare
+import at.hannibal2.skyhanni.features.fame.AccountUpgradeReminder
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.garden.GardenCropTimeCommand
 import at.hannibal2.skyhanni.features.garden.composter.ComposterOverlay
@@ -19,7 +20,7 @@ import at.hannibal2.skyhanni.features.garden.farming.GardenStartLocation
 import at.hannibal2.skyhanni.features.garden.fortuneguide.CaptureFarmingGear
 import at.hannibal2.skyhanni.features.garden.fortuneguide.FFGuideGUI
 import at.hannibal2.skyhanni.features.minion.MinionFeatures
-import at.hannibal2.skyhanni.features.misc.CityProjectFeatures
+import at.hannibal2.skyhanni.features.fame.CityProjectFeatures
 import at.hannibal2.skyhanni.features.misc.CollectionTracker
 import at.hannibal2.skyhanni.features.misc.MarkedPlayerManager
 import at.hannibal2.skyhanni.features.misc.discordrpc.DiscordRPCManager
@@ -229,6 +230,8 @@ object Commands {
         registerCommand("shshareinquis", "") { InquisitorWaypointShare.sendInquisitor() }
         registerCommand("shcopyerror", "") { CopyErrorCommand.command(it) }
         registerCommand("shstopcityprojectreminder", "") { CityProjectFeatures.disable() }
+        registerCommand("shstopaccountupgradereminder", "") { AccountUpgradeReminder.disable() }
+
     }
 
     private fun commandHelp(args: Array<String>) {

--- a/src/main/java/at/hannibal2/skyhanni/config/features/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/MiscConfig.java
@@ -809,6 +809,11 @@ public class MiscConfig {
     public boolean harpNumbers = false;
 
     @Expose
+    @ConfigOption(name = "Account Upgrade Reminder", desc = "Remind you to claim account upgrades when complete.")
+    @ConfigEditorBoolean
+    public boolean accountUpgradeReminder = true;
+
+    @Expose
     @ConfigOption(name = "Config Button", desc = "Add a button to the pause menu to configure SkyHanni.")
     @ConfigEditorBoolean
     public boolean configButtonOnPause = true;

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/AccountUpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/AccountUpgradeReminder.kt
@@ -75,7 +75,7 @@ class AccountUpgradeReminder {
         if (durationDays == -1) return
         val playerSpecific = ProfileStorageData.playerSpecific ?: return
         playerSpecific.currentAccountUpgrade = upgrade
-        playerSpecific.nextAccountUpgradeCompletionTime = System.currentTimeMillis() + durationDays * MILLIS_IN_DAY
+        playerSpecific.nextAccountUpgradeCompletionTime = System.currentTimeMillis() + durationDays.toLong() * MILLIS_IN_DAY
     }
 
     private fun clearUpgrade() {
@@ -88,7 +88,7 @@ class AccountUpgradeReminder {
         private val durationRegex = "§8Duration: (\\d{1,3})d".toRegex()
         private val startedRegex = "§eYou started the §r§a(.+) §r§eupgrade!".toRegex()
         private val claimedRegex = "§eYou claimed the §r§a.+ §r§eupgrade!".toRegex()
-        private const val MILLIS_IN_DAY = 1000 * 60 * 60 * 24
+        private const val MILLIS_IN_DAY = 1000 * 60 * 60 * 24L
 
         private fun isEnabled() = SkyHanniMod.feature.misc.accountUpgradeReminder
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/AccountUpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/AccountUpgradeReminder.kt
@@ -1,0 +1,99 @@
+package at.hannibal2.skyhanni.features.fame
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.events.*
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class AccountUpgradeReminder {
+    private var inInventory = false
+    private var durationDays = -1
+    private var lastReminderSend = 0L
+
+    @SubscribeEvent
+    fun onTick(event: LorenzTickEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+        if (event.repeatSeconds(1)) {
+            checkReminder()
+        }
+    }
+
+    // TODO: Merge this logic with CityProjectFeatures reminder to reduce duplication
+    private fun checkReminder() {
+        if (!isEnabled()) return
+        val playerSpecific = ProfileStorageData.playerSpecific ?: return
+        if (ReminderUtils.isBusy()) return
+        if (LorenzUtils.skyBlockArea == "Community Center") return
+
+        val upgrade = playerSpecific.currentAccountUpgrade ?: return
+        if (System.currentTimeMillis() <= playerSpecific.nextAccountUpgradeCompletionTime ) return
+
+        if (lastReminderSend + 30_000 > System.currentTimeMillis()) return
+        lastReminderSend = System.currentTimeMillis()
+
+        LorenzUtils.clickableChat(
+            "§e[SkyHanni] The §a$upgrade §eupgrade has completed! Go to the Community Center to claim.",
+            "shstopaccountupgradereminder"
+        )
+    }
+
+    @SubscribeEvent
+    fun onInventoryLoad(event: InventoryFullyOpenedEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+        inInventory = event.inventoryName == "Community Shop"
+    }
+
+    @SubscribeEvent
+    @Suppress("UNUSED_PARAMETER")
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        inInventory = false
+    }
+
+    @SubscribeEvent
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!inInventory) return
+        val clickedItemLore = event.slot?.stack?.getLore() ?: return
+        if (clickedItemLore.getOrNull(0) != "§8Account Upgrade") return
+        durationDays = clickedItemLore.firstNotNullOf {
+            durationRegex.matchEntire(it)
+        }.groups[1]!!.value.toInt()
+    }
+
+    @SubscribeEvent
+    fun onUpgradeStarted(event: LorenzChatEvent) {
+        if (claimedRegex.matches(event.message)) {
+            clearUpgrade()
+        } else {
+            val upgrade = startedRegex.matchEntire(event.message)?.groups?.get(1)?.value ?: return
+            startUpgrade(upgrade)
+        }
+    }
+
+    private fun startUpgrade(upgrade: String) {
+        if (durationDays == -1) return
+        val playerSpecific = ProfileStorageData.playerSpecific ?: return
+        playerSpecific.currentAccountUpgrade = upgrade
+        playerSpecific.nextAccountUpgradeCompletionTime = System.currentTimeMillis() + durationDays * MILLIS_IN_DAY
+    }
+
+    private fun clearUpgrade() {
+        val playerSpecific = ProfileStorageData.playerSpecific ?: return
+        playerSpecific.currentAccountUpgrade = null
+        playerSpecific.nextAccountUpgradeCompletionTime = -1L
+    }
+
+    companion object {
+        private val durationRegex = "§8Duration: (\\d{1,3})d".toRegex()
+        private val startedRegex = "§eYou started the §r§a(.+) §r§eupgrade!".toRegex()
+        private val claimedRegex = "§eYou claimed the §r§a.+ §r§eupgrade!".toRegex()
+        private const val MILLIS_IN_DAY = 1000 * 60 * 60 * 24
+
+        private fun isEnabled() = SkyHanniMod.feature.misc.accountUpgradeReminder
+
+        fun disable() {
+            SkyHanniMod.feature.misc.accountUpgradeReminder = false
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/AccountUpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/AccountUpgradeReminder.kt
@@ -34,7 +34,7 @@ class AccountUpgradeReminder {
         lastReminderSend = System.currentTimeMillis()
 
         LorenzUtils.clickableChat(
-            "§e[SkyHanni] The §a$upgrade §eupgrade has completed! Go to the Community Center to claim.",
+            "§e[SkyHanni] The §a$upgrade §eupgrade has completed! §c(Click to disable these reminders)",
             "shstopaccountupgradereminder"
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.features.misc
+package at.hannibal2.skyhanni.features.fame
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.ProfileStorageData
@@ -46,9 +46,7 @@ class CityProjectFeatures {
     private fun checkDailyReminder() {
         if (!config.dailyReminder) return
         val playerSpecific = ProfileStorageData.playerSpecific ?: return
-        if (LorenzUtils.inDungeons) return
-        if (LorenzUtils.inKuudraFight) return
-        if (FarmingContestAPI.inContest) return
+        if (ReminderUtils.isBusy()) return
 
         if (LorenzUtils.skyBlockArea == "Community Center") return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/ReminderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/ReminderUtils.kt
@@ -1,0 +1,9 @@
+package at.hannibal2.skyhanni.features.fame
+
+import at.hannibal2.skyhanni.features.garden.contest.FarmingContestAPI
+import at.hannibal2.skyhanni.utils.LorenzUtils
+
+object ReminderUtils {
+    fun isBusy(): Boolean =
+        LorenzUtils.inDungeons || LorenzUtils.inKuudraFight || FarmingContestAPI.inContest
+}


### PR DESCRIPTION
This pull request adds a simple reminder when an account upgrade is completed, modeled heavily on city project reminders. Enabled by default; can be disabled in settings or by clicking.

TODO is to merge the city project reminder logic with this and potentially other reminders, as it's definitely a bit duplicated currently.