### PR TITLE
Inventory name detection fix

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ChestValue.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
@@ -26,7 +27,7 @@ class ChestValue {
     private val config get() = SkyHanniMod.feature.inventory.chestValueConfig
     private var display = emptyList<List<Any>>()
     private val chestItems = mutableMapOf<NEUInternalName, Item>()
-    private val inInventory get() = InventoryUtils.openInventoryName().isValidStorage()
+    private val inInventory get() = InventoryUtils.openInventoryName().removeColor().isValidStorage()
 
     @SubscribeEvent
     fun onBackgroundDraw(event: GuiRenderEvent.ChestBackgroundRenderEvent) {


### PR DESCRIPTION
Inventory name detection break if using a resourcepack that change the lang file.

I can fix if using custom color, but not if the text is completely modified.

Example pack that break the feature (and maybe others): https://www.curseforge.com/minecraft/texture-packs/default-dark-mode