### PR TITLE
Fix: translator incorrectly modifying vanilla colors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/Translator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/Translator.kt
@@ -38,7 +38,7 @@ class Translator {
         if (!messageContentRegex.matches(message.removeColor())) return
 
         val clickStyle = createClickStyle(message)
-        chatComponent.setChatStyle(clickStyle)
+        chatComponent.siblings.last().setChatStyle(clickStyle)
     }
 
     private fun createClickStyle(message: String): ChatStyle {


### PR DESCRIPTION
Skytils' chat tabs depended on those colors being correct, which was why the two symptoms appeared together