### PR TITLE
Fix: Add mixin safety checks to new EntityOutlineRenderer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.utils.EntityUtils.hasMaxHealth
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.LorenzUtils.editCopy
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
@@ -33,16 +32,8 @@ class SeaCreatureFeatures {
 
         val maxHealth = event.maxHealth
         for (creatureType in RareSeaCreatureType.entries) {
-            if (EntityGuardian::class.java.isInstance(entity) && entity.baseMaxHealth > 1000) {
-                LorenzUtils.consoleLog("FISHING CREATURE NAME: ${entity.baseMaxHealth} ${(entity as EntityGuardian).customNameTag}")
-            }
-
             if (!creatureType.health.any { entity.hasMaxHealth(it, false, maxHealth) }) continue
             if (!creatureType.clazz.isInstance(entity)) continue
-
-            if (EntityPlayer::class.java.isInstance(entity)) {
-                LorenzUtils.consoleLog("FISHING CREATURE NAME: ${(entity as EntityPlayer).customNameTag}")
-            }
 
             if (creatureType.nametag.isNotBlank() && EntityPlayer::class.java.isInstance(entity) && (entity as EntityPlayer).name != creatureType.nametag) {
                 continue

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
@@ -44,6 +44,9 @@ object EntityOutlineRenderer {
     private val mc get() = Minecraft.getMinecraft()
     private val BUF_FLOAT_4: java.nio.FloatBuffer = org.lwjgl.BufferUtils.createFloatBuffer(4)
 
+    private val CustomRenderGlobal.frameBuffer get() = entityOutlineFramebuffer_skyhanni
+    private val CustomRenderGlobal.shader get() = entityOutlineShader_skyhanni
+
     /**
      * @return a new framebuffer with the size of the main framebuffer
      */
@@ -61,11 +64,11 @@ object EntityOutlineRenderer {
         if (swapBuffer.framebufferWidth != width || swapBuffer.framebufferHeight != height) {
             swapBuffer.createBindFramebuffer(width, height)
         }
-        val rg = mc.renderGlobal as CustomRenderGlobal
-        val outlineBuffer = rg.entityOutlineFramebuffer_skyhanni
+        val renderGlobal = mc.renderGlobal as CustomRenderGlobal
+        val outlineBuffer = renderGlobal.frameBuffer
         if (outlineBuffer.framebufferWidth != width || outlineBuffer.framebufferHeight != height) {
             outlineBuffer.createBindFramebuffer(width, height)
-            rg.entityOutlineShader_skyhanni.createBindFramebuffers(width, height)
+            renderGlobal.shader.createBindFramebuffers(width, height)
         }
     }
 
@@ -92,8 +95,8 @@ object EntityOutlineRenderer {
         updateFramebufferSize()
 
         // Clear and bind the outline framebuffer
-        renderGlobal.entityOutlineFramebuffer_skyhanni.framebufferClear()
-        renderGlobal.entityOutlineFramebuffer_skyhanni.bindFramebuffer(false)
+        renderGlobal.frameBuffer.framebufferClear()
+        renderGlobal.frameBuffer.bindFramebuffer(false)
 
         // Vanilla options
         RenderHelper.disableStandardItemLighting()
@@ -149,10 +152,10 @@ object EntityOutlineRenderer {
                 }
 
                 // Copy the entire depth buffer of everything that might occlude outline to outline framebuffer
-                copyBuffers(swapBuffer, renderGlobal.entityOutlineFramebuffer_skyhanni, GL11.GL_DEPTH_BUFFER_BIT)
-                renderGlobal.entityOutlineFramebuffer_skyhanni.bindFramebuffer(false)
+                copyBuffers(swapBuffer, renderGlobal.frameBuffer, GL11.GL_DEPTH_BUFFER_BIT)
+                renderGlobal.frameBuffer.bindFramebuffer(false)
             } else {
-                copyBuffers(mc.framebuffer, renderGlobal.entityOutlineFramebuffer_skyhanni, GL11.GL_DEPTH_BUFFER_BIT)
+                copyBuffers(mc.framebuffer, renderGlobal.frameBuffer, GL11.GL_DEPTH_BUFFER_BIT)
             }
 
             // Xray disabled by re-enabling traditional depth testing
@@ -169,13 +172,15 @@ object EntityOutlineRenderer {
         }
 
         // Disable outline mode
-        GL11.glTexEnvi(GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_MODE, GL11.GL_MODULATE);
-        GL11.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_COMBINE_RGB, GL11.GL_MODULATE);
-        GL11.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_SOURCE0_RGB, GL11.GL_TEXTURE);
-        GL11.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND0_RGB, GL11.GL_SRC_COLOR);
-        GL11.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_COMBINE_ALPHA, GL11.GL_MODULATE);
-        GL11.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_SOURCE0_ALPHA, GL11.GL_TEXTURE);
-        GL11.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND0_ALPHA, GL11.GL_SRC_ALPHA);
+        with(GL11.GL_TEXTURE_ENV) {
+            GL11.glTexEnvi(this, GL11.GL_TEXTURE_ENV_MODE, GL11.GL_MODULATE)
+            GL11.glTexEnvi(this, GL13.GL_COMBINE_RGB, GL11.GL_MODULATE)
+            GL11.glTexEnvi(this, GL13.GL_SOURCE0_RGB, GL11.GL_TEXTURE)
+            GL11.glTexEnvi(this, GL13.GL_OPERAND0_RGB, GL11.GL_SRC_COLOR)
+            GL11.glTexEnvi(this, GL13.GL_COMBINE_ALPHA, GL11.GL_MODULATE)
+            GL11.glTexEnvi(this, GL13.GL_SOURCE0_ALPHA, GL11.GL_TEXTURE)
+            GL11.glTexEnvi(this, GL13.GL_OPERAND0_ALPHA, GL11.GL_SRC_ALPHA)
+        }
 
         // Vanilla options
         RenderHelper.enableStandardItemLighting()
@@ -183,7 +188,7 @@ object EntityOutlineRenderer {
 
         // Load the outline shader
         GlStateManager.depthMask(false)
-        renderGlobal.entityOutlineShader_skyhanni.loadShaderGroup(partialTicks)
+        renderGlobal.shader.loadShaderGroup(partialTicks)
         GlStateManager.depthMask(true)
 
         // Reset GL/framebuffers for next render layers
@@ -227,7 +232,7 @@ object EntityOutlineRenderer {
 
         // Vanilla Conditions
         val renderGlobal = mc.renderGlobal as CustomRenderGlobal
-        if (renderGlobal.entityOutlineFramebuffer_skyhanni == null || renderGlobal.entityOutlineShader_skyhanni == null || mc.thePlayer == null) return false
+        if (renderGlobal.frameBuffer == null || renderGlobal.shader == null || mc.thePlayer == null) return false
 
         // Optifine Conditions
         if (!stopLookingForOptifine && isFastRender == null) {
@@ -355,10 +360,8 @@ object EntityOutlineRenderer {
     fun onTick(event: LorenzTickEvent) {
         if (!(event.phase == EventPriority.NORMAL && isEnabled())) return;
 
-        val rg: CustomRenderGlobal?
-
-        try {
-            rg = mc.renderGlobal as CustomRenderGlobal
+        val renderGlobal = try {
+            mc.renderGlobal as CustomRenderGlobal
         } catch (e: NoClassDefFoundError) {
             CopyErrorCommand.logError(e, "Unable to enable entity outlines, the required mixin is not loaded")
             isMissingMixin = true
@@ -382,17 +385,15 @@ object EntityOutlineRenderer {
             entityRenderCache.noOutlineCache = noxrayOutlineEvent.entitiesToChooseFrom
             emptyLastTick = if (isCacheEmpty()) {
                 if (!emptyLastTick) {
-                    rg.entityOutlineFramebuffer_skyhanni.framebufferClear()
+                    renderGlobal.frameBuffer.framebufferClear()
                 }
                 true
-            } else {
-                false
-            }
+            } else false
         } else if (!emptyLastTick) {
             entityRenderCache.xrayCache = null
             entityRenderCache.noXrayCache = null
             entityRenderCache.noOutlineCache = null
-            if (rg.entityOutlineFramebuffer_skyhanni != null) rg.entityOutlineFramebuffer_skyhanni.framebufferClear()
+            if (renderGlobal.frameBuffer != null) renderGlobal.frameBuffer.framebufferClear()
             emptyLastTick = true
         }
     }


### PR DESCRIPTION
Minor code cleanup, added extra isEnabled() checks where required, and disable the feature if the mixin isn't loaded for some reason