### PR TITLE
Feature: Outline dropped items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -55,6 +55,7 @@ import at.hannibal2.skyhanni.features.misc.discordrpc.DiscordRPCManager
 import at.hannibal2.skyhanni.features.misc.ghostcounter.GhostCounter
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.features.misc.items.EstimatedWardrobePrice
+import at.hannibal2.skyhanni.features.misc.items.GlowingDroppedItems
 import at.hannibal2.skyhanni.features.misc.massconfiguration.DefaultConfigFeatures
 import at.hannibal2.skyhanni.features.misc.powdertracker.PowderTracker
 import at.hannibal2.skyhanni.features.misc.tabcomplete.PlayerTabComplete
@@ -394,6 +395,7 @@ class SkyHanniMod {
         loadModule(CosmeticFollowingLine())
         loadModule(SuperpairsClicksAlert())
         loadModule(PowderTracker())
+        loadModule(GlowingDroppedItems())
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/MiscConfig.java
@@ -923,22 +923,22 @@ public class MiscConfig {
 
 
     @Expose
-    @ConfigOption(name = "Items", desc = "")
+    @ConfigOption(name = "Glowing Dropped Items", desc = "")
     @Accordion
-    public ItemConfig itemConfig = new ItemConfig();
+    public GlowingDroppedItems glowingDroppedItems = new GlowingDroppedItems();
 
-    public static class ItemConfig {
+    public static class GlowingDroppedItems {
 
         @Expose
-        @ConfigOption(name = "Highlight Dropped Items", desc = "Draws a glowing outline around all dropped items on the ground.")
+        @ConfigOption(name = "Enabled", desc = "Draws a glowing outline around all dropped items on the ground.")
         @ConfigEditorBoolean
         @FeatureToggle
-        public boolean highlightDroppedItems = false;
+        public boolean enabled = false;
 
         @Expose
         @ConfigOption(name = "Highlight Showcase Items", desc = "Draws a glowing outline around showcase items.")
         @ConfigEditorBoolean
-        public boolean highlightShowcaseItems = false;
+        public boolean highlightShowcase = false;
 
         @Expose
         @ConfigOption(name = "Highlight Fishing Bait", desc = "Draws a glowing outline around fishing bait.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/MiscConfig.java
@@ -930,21 +930,19 @@ public class MiscConfig {
     public static class ItemConfig {
 
         @Expose
-        @ConfigOption(name = "Highlight Dropped Items", desc = "Draws a glowing outline around all dropped items on the ground")
+        @ConfigOption(name = "Highlight Dropped Items", desc = "Draws a glowing outline around all dropped items on the ground.")
         @ConfigEditorBoolean
         @FeatureToggle
         public boolean highlightDroppedItems = false;
 
         @Expose
-        @ConfigOption(name = "Highlight Showcase Items", desc = "Draws a glowing outline around showcase items")
+        @ConfigOption(name = "Highlight Showcase Items", desc = "Draws a glowing outline around showcase items.")
         @ConfigEditorBoolean
-        @FeatureToggle
         public boolean highlightShowcaseItems = false;
 
         @Expose
-        @ConfigOption(name = "Highlight Fishing Bait", desc = "Draws a glowing outline around fishing bait")
+        @ConfigOption(name = "Highlight Fishing Bait", desc = "Draws a glowing outline around fishing bait.")
         @ConfigEditorBoolean
-        @FeatureToggle
         public boolean highlightFishingBait = false;
 
     }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/MiscConfig.java
@@ -921,6 +921,34 @@ public class MiscConfig {
         }
     }
 
+
+    @Expose
+    @ConfigOption(name = "Items", desc = "")
+    @Accordion
+    public ItemConfig itemConfig = new ItemConfig();
+
+    public static class ItemConfig {
+
+        @Expose
+        @ConfigOption(name = "Highlight Dropped Items", desc = "Draws a glowing outline around all dropped items on the ground")
+        @ConfigEditorBoolean
+        @FeatureToggle
+        public boolean highlightDroppedItems = false;
+
+        @Expose
+        @ConfigOption(name = "Highlight Showcase Items", desc = "Draws a glowing outline around showcase items")
+        @ConfigEditorBoolean
+        @FeatureToggle
+        public boolean highlightShowcaseItems = false;
+
+        @Expose
+        @ConfigOption(name = "Highlight Fishing Bait", desc = "Draws a glowing outline around fishing bait")
+        @ConfigEditorBoolean
+        @FeatureToggle
+        public boolean highlightFishingBait = false;
+
+    }
+
     @Expose
     @ConfigOption(name = "Exp Bottles", desc = "Hides all the experience orbs lying on the ground.")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FortuneUpgrades.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FortuneUpgrades.kt
@@ -254,7 +254,7 @@ object FortuneUpgrades {
         } ?: return
 
         FarmingFortuneDisplay.loadFortuneLineData(item, 0.0)
-        val increase = reforge[item.getItemRarity() + 1, FarmingFortuneDisplay.reforgeFortune] ?: return
+        val increase = reforge[item.getItemRarity().id + 1, FarmingFortuneDisplay.reforgeFortune] ?: return
         list.add(
             FortuneUpgrade("§7Recombobulate your ${item.displayName}", null, "RECOMBOBULATOR_3000", 1, increase)
         )
@@ -267,7 +267,7 @@ object FortuneUpgrades {
         copperPrice: Int? = null
     ) {
         FarmingFortuneDisplay.loadFortuneLineData(item, 0.0)
-        val increase = reforge[item.getItemRarity(), FarmingFortuneDisplay.reforgeFortune] ?: return
+        val increase = reforge[item.getItemRarity().id, FarmingFortuneDisplay.reforgeFortune] ?: return
         list.add(
             FortuneUpgrade(
                 "§7Reforge your ${item.displayName} §7to ${reforge.reforgeName}",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
@@ -1,0 +1,59 @@
+package at.hannibal2.skyhanni.features.misc.items
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarity
+import at.hannibal2.skyhanni.utils.ItemUtils.name
+import at.hannibal2.skyhanni.utils.LorenzRarity
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraft.entity.Entity
+import net.minecraft.entity.item.EntityArmorStand
+import net.minecraft.entity.item.EntityItem
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class GlowingDroppedItems {
+
+    private val config get() = SkyHanniMod.feature.misc
+
+    /**
+     * List of skyblock locations where we might see items in showcases
+     */
+    private val showcaseItemLocations = listOf(
+            "The End",
+            "Jerry's Workshop"
+            ).toSet()
+
+    @SubscribeEvent
+    fun onRenderEntityOutlines(event: RenderEntityOutlineEvent) {
+        if (isEnabled() && event.type === RenderEntityOutlineEvent.Type.XRAY) {
+            event.queueEntitiesToOutline(getEntityOutlineColor)
+        }
+    }
+
+    private fun isEnabled() = LorenzUtils.inSkyBlock &&  config.itemConfig.highlightDroppedItems
+
+    private val getEntityOutlineColor: (entity: Entity) -> Int? = { entity ->
+        if (EntityItem::class.java.isInstance(entity) && !shouldHideShowcaseItem(entity as EntityItem)) {
+            val rarity = entity.entityItem.getItemRarity()
+
+            if (rarity != LorenzRarity.UNKNOWN && (config.itemConfig.highlightFishingBait || entity.entityItem.name?.endsWith(" Bait") != true)) {
+                rarity.color.toColor().rgb
+            } else null
+        } else null
+    }
+
+    private fun isShowcaseArea() = showcaseItemLocations.contains(LorenzUtils.skyBlockArea) || LorenzUtils.inIsland(IslandType.HUB) || LorenzUtils.inIsland(IslandType.PRIVATE_ISLAND) || LorenzUtils.inIsland(IslandType.PRIVATE_ISLAND_GUEST)
+
+    private fun shouldHideShowcaseItem(entity: EntityItem): Boolean {
+        if (!isShowcaseArea() || config.itemConfig.highlightShowcaseItems) return false;
+
+        for (entityArmorStand in entity.worldObj.getEntitiesWithinAABB(EntityArmorStand::class.java, entity.entityBoundingBox)) {
+            if (entityArmorStand.isInvisible) {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
@@ -34,7 +34,7 @@ class GlowingDroppedItems {
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
 
     private val getEntityOutlineColor: (entity: Entity) -> Int? = { entity ->
-        if (EntityItem::class.java.isInstance(entity) && !shouldHideShowcaseItem(entity as EntityItem)) {
+        if (entity is EntityItem && !shouldHideShowcaseItem(entity)) {
             val rarity = entity.entityItem.getItemRarityOrNull()
 
             if (config.highlightFishingBait || entity.entityItem.name?.endsWith(" Bait") != true) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
@@ -3,10 +3,10 @@ package at.hannibal2.skyhanni.features.misc.items
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
-import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarity
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.name
-import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.equalsOneOf
 import net.minecraft.entity.Entity
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.item.EntityItem
@@ -14,15 +14,15 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class GlowingDroppedItems {
 
-    private val config get() = SkyHanniMod.feature.misc
+    private val config get() = SkyHanniMod.feature.misc.itemConfig
 
     /**
      * List of skyblock locations where we might see items in showcases
      */
-    private val showcaseItemLocations = listOf(
-            "The End",
-            "Jerry's Workshop"
-            ).toSet()
+    private val showcaseItemLocations = setOf(
+        "The End",
+        "Jerry's Workshop"
+    )
 
     @SubscribeEvent
     fun onRenderEntityOutlines(event: RenderEntityOutlineEvent) {
@@ -31,24 +31,33 @@ class GlowingDroppedItems {
         }
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock &&  config.itemConfig.highlightDroppedItems
+    private fun isEnabled() = LorenzUtils.inSkyBlock && config.highlightDroppedItems
 
     private val getEntityOutlineColor: (entity: Entity) -> Int? = { entity ->
         if (EntityItem::class.java.isInstance(entity) && !shouldHideShowcaseItem(entity as EntityItem)) {
-            val rarity = entity.entityItem.getItemRarity()
+            val rarity = entity.entityItem.getItemRarityOrNull()
 
-            if (rarity != LorenzRarity.UNKNOWN && (config.itemConfig.highlightFishingBait || entity.entityItem.name?.endsWith(" Bait") != true)) {
-                rarity.color.toColor().rgb
+            if (config.highlightFishingBait || entity.entityItem.name?.endsWith(" Bait") != true) {
+                rarity?.color?.toColor()?.rgb
             } else null
         } else null
     }
 
-    private fun isShowcaseArea() = showcaseItemLocations.contains(LorenzUtils.skyBlockArea) || LorenzUtils.inIsland(IslandType.HUB) || LorenzUtils.inIsland(IslandType.PRIVATE_ISLAND) || LorenzUtils.inIsland(IslandType.PRIVATE_ISLAND_GUEST)
+    private fun isShowcaseArea() =
+        showcaseItemLocations.contains(LorenzUtils.skyBlockArea) ||
+                LorenzUtils.skyBlockIsland.equalsOneOf(
+                    IslandType.HUB,
+                    IslandType.PRIVATE_ISLAND,
+                    IslandType.PRIVATE_ISLAND_GUEST
+                )
 
     private fun shouldHideShowcaseItem(entity: EntityItem): Boolean {
-        if (!isShowcaseArea() || config.itemConfig.highlightShowcaseItems) return false;
+        if (!isShowcaseArea() || config.highlightShowcaseItems) return false
 
-        for (entityArmorStand in entity.worldObj.getEntitiesWithinAABB(EntityArmorStand::class.java, entity.entityBoundingBox)) {
+        for (entityArmorStand in entity.worldObj.getEntitiesWithinAABB(
+            EntityArmorStand::class.java,
+            entity.entityBoundingBox
+        )) {
             if (entityArmorStand.isInvisible) {
                 return true
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class GlowingDroppedItems {
 
-    private val config get() = SkyHanniMod.feature.misc.itemConfig
+    private val config get() = SkyHanniMod.feature.misc.glowingDroppedItems
 
     /**
      * List of skyblock locations where we might see items in showcases
@@ -31,7 +31,7 @@ class GlowingDroppedItems {
         }
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.highlightDroppedItems
+    private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
 
     private val getEntityOutlineColor: (entity: Entity) -> Int? = { entity ->
         if (EntityItem::class.java.isInstance(entity) && !shouldHideShowcaseItem(entity as EntityItem)) {
@@ -52,7 +52,7 @@ class GlowingDroppedItems {
                 )
 
     private fun shouldHideShowcaseItem(entity: EntityItem): Boolean {
-        if (!isShowcaseArea() || config.highlightShowcaseItems) return false
+        if (!isShowcaseArea() || config.highlightShowcase) return false
 
         for (entityArmorStand in entity.worldObj.getEntitiesWithinAABB(
             EntityArmorStand::class.java,

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
@@ -266,6 +266,7 @@ object EntityOutlineRenderer {
     // Add new features that need the entity outline logic here
     private fun isEnabled(): Boolean {
         if (SkyHanniMod.feature.fishing.rareSeaCreatureHighlight) return true
+        if (SkyHanniMod.feature.misc.glowingDroppedItems.enabled) return true
 
         return false
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -152,7 +152,7 @@ object ItemUtils {
         return nbt.getCompoundTag("SkullOwner").getString("Id")
     }
 
-    fun ItemStack.getItemRarity() = getItemRarityOrNull() ?: error("item rarity not detected for ")
+    fun ItemStack.getItemRarity() = getItemRarityOrNull() ?: error("item rarity not detected for item '$name'")
 
     fun ItemStack.getItemRarityOrNull(): LorenzRarity? {
         return when (this.getLore().lastOrNull()?.take(4)) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -152,8 +152,9 @@ object ItemUtils {
         return nbt.getCompoundTag("SkullOwner").getString("Id")
     }
 
-    fun ItemStack.getItemRarity(): LorenzRarity {
-        //todo make into an enum in future
+    fun ItemStack.getItemRarity() = getItemRarityOrNull() ?: error("item rarity not detected for ")
+
+    fun ItemStack.getItemRarityOrNull(): LorenzRarity? {
         return when (this.getLore().lastOrNull()?.take(4)) {
             "§f§l" -> LorenzRarity.COMMON
             "§a§l" -> LorenzRarity.UNCOMMON
@@ -164,7 +165,7 @@ object ItemUtils {
             "§b§l" -> LorenzRarity.DIVINE
             "§4§l" -> LorenzRarity.SUPREME
             "§c§l" -> LorenzRarity.SPECIAL
-            else -> LorenzRarity.UNKNOWN
+            else -> null
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -152,19 +152,19 @@ object ItemUtils {
         return nbt.getCompoundTag("SkullOwner").getString("Id")
     }
 
-    fun ItemStack.getItemRarity(): Int {
+    fun ItemStack.getItemRarity(): LorenzRarity {
         //todo make into an enum in future
         return when (this.getLore().lastOrNull()?.take(4)) {
-            "§f§l" -> 0     // common
-            "§a§l" -> 1     // uncommon
-            "§9§l" -> 2     // rare
-            "§5§l" -> 3     // epic
-            "§6§l" -> 4     // legendary
-            "§d§l" -> 5     // mythic
-            "§b§l" -> 6     // divine
-            "§4§l" -> 7     // supreme
-            "§c§l" -> 8     // special/very special
-            else -> -1      // unknown
+            "§f§l" -> LorenzRarity.COMMON
+            "§a§l" -> LorenzRarity.UNCOMMON
+            "§9§l" -> LorenzRarity.RARE
+            "§5§l" -> LorenzRarity.EPIC
+            "§6§l" -> LorenzRarity.LEGENDARY
+            "§d§l" -> LorenzRarity.MYTHIC
+            "§b§l" -> LorenzRarity.DIVINE
+            "§4§l" -> LorenzRarity.SUPREME
+            "§c§l" -> LorenzRarity.SPECIAL
+            else -> LorenzRarity.UNKNOWN
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzRarity.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzRarity.kt
@@ -1,0 +1,17 @@
+package at.hannibal2.skyhanni.utils
+
+
+enum class LorenzRarity(public val color: LorenzColor, public val id: Int) {
+    COMMON(LorenzColor.WHITE, 0),
+    UNCOMMON(LorenzColor.GREEN, 1),
+    RARE(LorenzColor.BLUE, 2),
+    EPIC(LorenzColor.DARK_PURPLE, 3),
+    LEGENDARY(LorenzColor.GOLD, 4),
+    MYTHIC(LorenzColor.LIGHT_PURPLE, 5),
+    DIVINE(LorenzColor.AQUA, 6),
+    SUPREME(LorenzColor.DARK_RED, 7),
+    SPECIAL(LorenzColor.RED, 8),
+    UNKNOWN(LorenzColor.BLACK, -1)
+    ;
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzRarity.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzRarity.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.utils
 
 
-enum class LorenzRarity(public val color: LorenzColor, public val id: Int) {
+enum class LorenzRarity(val color: LorenzColor, val id: Int) {
     COMMON(LorenzColor.WHITE, 0),
     UNCOMMON(LorenzColor.GREEN, 1),
     RARE(LorenzColor.BLUE, 2),
@@ -11,7 +11,6 @@ enum class LorenzRarity(public val color: LorenzColor, public val id: Int) {
     DIVINE(LorenzColor.AQUA, 6),
     SUPREME(LorenzColor.DARK_RED, 7),
     SPECIAL(LorenzColor.RED, 8),
-    UNKNOWN(LorenzColor.BLACK, -1)
     ;
 
 }


### PR DESCRIPTION
This is pretty much a copy of the feature from SBA, with a couple additional toggles, and a small fix to the showcase logic to work with the museum, shen's auction, museum, etc.

I also took a stab at changing the item rarity code to an enum so I could reuse the code.

Potato quality screenshot:

![javaw_2023-09-07_19-51-29](https://github.com/hannibal002/SkyHanni/assets/629141/abe5c4aa-394f-4ca9-8a64-2986f1f4d028)
