### PR TITLE
Fix: Fix one wiltered berberis farm plot not working

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/RiftAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/RiftAPI.kt
@@ -4,11 +4,16 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.features.RiftConfig
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.LocationUtils.isPlayerInside
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import net.minecraft.item.ItemStack
+import net.minecraft.util.AxisAlignedBB
 
 object RiftAPI {
+
+    private val westVillageFarmArea = AxisAlignedBB(-54.0, 69.0, -115.0, -40.0, 75.0, -127.0)
+
     fun inRift() = LorenzUtils.inIsland(IslandType.THE_RIFT)
 
     val config: RiftConfig get() = SkyHanniMod.feature.rift
@@ -26,5 +31,5 @@ object RiftAPI {
     fun inLivingCave() = LorenzUtils.skyBlockArea == "Living Cave"
     fun inLivingStillness() = LorenzUtils.skyBlockArea == "Living Stillness"
     fun inStillgoreChateau() = LorenzUtils.skyBlockArea == "Stillgore Château" || LorenzUtils.skyBlockArea == "Oubliette"
-    fun inDreadfarm() = LorenzUtils.skyBlockArea == "Dreadfarm"
+    fun inDreadfarm() = LorenzUtils.skyBlockArea == "Dreadfarm" || (LorenzUtils.skyBlockArea == "West Village" && westVillageFarmArea.isPlayerInside())
 }


### PR DESCRIPTION
If player is in the West Village, check if they are in the bounding box of one of the farm plots that isn't in the "Dreadfarm" area.

![java_2023-09-08_10-32-49](https://github.com/hannibal002/SkyHanni/assets/629141/df3c6254-a143-4b80-aa33-6e4475f4c43e)

Resolves https://github.com/hannibal002/SkyHanni/issues/395