### PR TITLE
Fix: Fix bad skyblock locations in the end, howling cave, and dreadfarm

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/DevConfig.java
@@ -121,6 +121,9 @@ public class DevConfig {
     public Position debugPos = new Position(10, 10, false, true);
 
     @Expose
+    public Position debugLocationPos = new Position(1, 160, false, true);
+
+    @Expose
     @ConfigOption(name = "Minecraft Console", desc = "")
     @ConfigEditorAccordion(id = 1)
     public boolean minecraftConsole = false;

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -1,17 +1,25 @@
 package at.hannibal2.skyhanni.data
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.*
+import at.hannibal2.skyhanni.utils.LocationUtils.isPlayerInside
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TabListData
 import net.minecraft.client.Minecraft
+import net.minecraft.util.AxisAlignedBB
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.network.FMLNetworkEvent
 
 class HypixelData {
+    private val config get() = SkyHanniMod.feature.dev
     private val tabListProfilePattern = "§e§lProfile: §r§a(?<profile>.*)".toPattern()
+    private val westVillageFarmArea = AxisAlignedBB(-54.0, 69.0, -115.0, -40.0, 75.0, -127.0)
+    private val howlingCaveArea = AxisAlignedBB(-401.0, 50.0, -104.0, -337.0, 90.0, 36.0)
+    private val zealotBruiserHideoutFixArea = AxisAlignedBB(-520.0, 66.0, -332.0, -558.0, 85.0, -280.0)
 
     companion object {
         var hypixelLive = false
@@ -66,6 +74,13 @@ class HypixelData {
     }
 
     @SubscribeEvent
+    fun onRenderOverlay(event: GuiRenderEvent.GameOverlayRenderEvent) {
+        if (LorenzUtils.inSkyBlock && Minecraft.getMinecraft().gameSettings.showDebugInfo) {
+            config.debugLocationPos.renderString("Current Area: $skyBlockArea", posLabel = "SkyBlock Area (Debug)")
+        }
+    }
+
+    @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
         if (event.isMod(2)) {
             if (LorenzUtils.inSkyBlock) {
@@ -73,6 +88,11 @@ class HypixelData {
                     .firstOrNull { it.startsWith(" §7⏣ ") || it.startsWith(" §5ф ") }
                     ?.substring(5)?.removeColor()
                     ?: "?"
+
+                if (skyBlockIsland == IslandType.THE_RIFT && westVillageFarmArea.isPlayerInside()) skyBlockArea = "Dreadfarm"
+                if (skyBlockIsland == IslandType.THE_PARK && howlingCaveArea.isPlayerInside()) skyBlockArea = "Howling Cave"
+                if (skyBlockIsland == IslandType.THE_END && zealotBruiserHideoutFixArea.isPlayerInside()) skyBlockArea = "The End"
+
                 checkProfileName()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/EnderNodeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/EnderNodeTracker.kt
@@ -146,8 +146,7 @@ class EnderNodeTracker {
         display = formatDisplay(drawDisplay())
     }
 
-    private fun isInTheEnd() = LorenzUtils.inIsland(IslandType.THE_END)
-            && ScoreboardData.sidebarLines.any { it.contains("The End") }
+    private fun isInTheEnd() = LorenzUtils.skyBlockArea == "The End"
 
     private fun isEnderArmor(displayName: String?) = when (displayName) {
         "§5Ender Helmet",


### PR DESCRIPTION
Fixes locations in the dreadfarm, howling cave, and the end that appear as the wrong location and cause certain features to work incorrectly (slayer detection, wiltered berberis helper, and end node profit tracker). 

![java_2023-09-08_10-32-49](https://github.com/hannibal002/SkyHanni/assets/629141/655c094d-5a08-49a1-8e6b-5383daff100f)

![java_2023-09-08_12-14-31](https://github.com/hannibal002/SkyHanni/assets/629141/d5b35b88-a880-40ca-bf26-564399460dfb)

![java_2023-09-08_12-15-34](https://github.com/hannibal002/SkyHanni/assets/629141/2c2f0c81-11d6-4b9c-b982-e337779369a9)
