### PR TITLE
Feature: Outline dungeon teammates

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -396,6 +396,7 @@ class SkyHanniMod {
         loadModule(SuperpairsClicksAlert())
         loadModule(PowderTracker())
         loadModule(GlowingDroppedItems())
+        loadModule(DungeonTeammateOutlines())
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/DungeonConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/DungeonConfig.java
@@ -65,6 +65,13 @@ public class DungeonConfig {
     @FeatureToggle
     public boolean highlightDeathmites = true;
 
+    @Expose
+    @ConfigOption(name = "Highlight Teammates", desc = "Highlight teammates with a glowing outline")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean highlightTeammates = true;
+
+
     @ConfigOption(name = "Object Hider", desc = "Hide various things in dungeons.")
     @ConfigEditorAccordion(id = 3)
     public boolean objectHider = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTeammateOutlines.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTeammateOutlines.kt
@@ -1,0 +1,39 @@
+package at.hannibal2.skyhanni.features.dungeon
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraft.client.Minecraft
+import net.minecraft.client.entity.EntityOtherPlayerMP
+import net.minecraft.client.gui.FontRenderer
+import net.minecraft.entity.Entity
+import net.minecraft.scoreboard.ScorePlayerTeam
+import net.minecraft.scoreboard.Team
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class DungeonTeammateOutlines {
+    private val config get() = SkyHanniMod.feature.dungeon
+
+    @SubscribeEvent
+    fun onRenderEntityOutlines(event: RenderEntityOutlineEvent) {
+        if (isEnabled() && event.type === RenderEntityOutlineEvent.Type.XRAY) {
+            event.queueEntitiesToOutline { entity -> getEntityOutlineColor(entity) }
+        }
+    }
+
+    private fun isEnabled() = LorenzUtils.inSkyBlock && LorenzUtils.inDungeons && config.highlightTeammates
+
+    private fun getEntityOutlineColor(entity: Entity): Int? {
+        if (entity !is EntityOtherPlayerMP || entity.team == null) return null
+
+        // Must be visible on the scoreboard
+        val team = entity.team as ScorePlayerTeam
+        if (team.nameTagVisibility == Team.EnumVisible.NEVER) return null
+
+        val colorFormat = FontRenderer.getFormatFromString(team.colorPrefix)
+        return if (colorFormat.length >= 2)
+            Minecraft.getMinecraft().fontRendererObj.getColorCode(colorFormat[1]);
+        else null
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
@@ -273,6 +273,7 @@ object EntityOutlineRenderer {
         if (isMissingMixin) return false
         if (SkyHanniMod.feature.fishing.rareSeaCreatureHighlight) return true
         if (SkyHanniMod.feature.misc.glowingDroppedItems.enabled) return true
+        if (SkyHanniMod.feature.dungeon.highlightTeammates) return true
 
         return false
     }


### PR DESCRIPTION
Thus completes porting the entity outline features from SBA. May want to alter this in the future to change the colors by class or health or something, but for now i just went with the team color logic that SBA used.

![java_2023-09-08_17-34-22](https://github.com/hannibal002/SkyHanni/assets/629141/728a0d75-658f-4b97-a9a7-78db458d9680)

![java_2023-09-08_17-32-59](https://github.com/hannibal002/SkyHanni/assets/629141/92b37cc4-a082-4e49-b045-11912532073c)
