### PR TITLE
Removed outdated description in custom keybind

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/GardenConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/GardenConfig.java
@@ -551,7 +551,7 @@ public class GardenConfig {
     public boolean keybind = false;
 
     @Expose
-    @ConfigOption(name = "Enabled", desc = "Use custom keybinds while holding a farming tool or daedalus axe in the hand. §cOnly updates after scrolling in the hotbar.")
+    @ConfigOption(name = "Enabled", desc = "Use custom keybinds while holding a farming tool or daedalus axe in the hand.")
     @ConfigEditorBoolean
     @ConfigAccordionId(id = 8)
     @FeatureToggle


### PR DESCRIPTION
Removed the description saying `Only updates after scrolling in the hotbar.` as that's no longer the case.