### PR TITLE
fix crash with item rarity

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PetExpTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PetExpTooltip.kt
@@ -42,8 +42,8 @@ class PetExpTooltip {
             event.toolTip.add(index, "§7Total experience: §e${NumberUtil.format(petExperience)}")
         } else {
             val progressBar = StringUtils.progressBar(percentage)
-            val isBelowLEgendary = itemStack.getItemRarity() < LorenzRarity.LEGENDARY
-            val addLegendaryColor = if (isBelowLEgendary) "§6" else ""
+            val isBelowLegendary = itemStack.getItemRarity() < LorenzRarity.LEGENDARY
+            val addLegendaryColor = if (isBelowLegendary) "§6" else ""
             event.toolTip.add(index, "$progressBar §e${petExperience.addSeparators()}§6/§e${NumberUtil.format(maxXp)}")
             event.toolTip.add(index, "§7Progress to ${addLegendaryColor}Level $maxLevel: §e$percentageFormat")
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -152,13 +152,19 @@ object ItemUtils {
         return nbt.getCompoundTag("SkullOwner").getString("Id")
     }
 
-    fun ItemStack.getItemRarity() = getItemRarityOrNull() ?: error("item rarity not detected for item '$name'")
+    fun ItemStack.getItemRarity(): LorenzRarity {
+        var itemRarity = this.getItemRarityOrNull()
+        if (itemRarity == null) {
+            LorenzUtils.error("item rarity not detected for item '$name'")
+            itemRarity = LorenzRarity.COMMON
+        }
+        return itemRarity
+    }
 
     fun ItemStack.getItemRarityOrNull(): LorenzRarity? {
         if (isPet(cleanName())) {
             return getPetRarity(this)
         }
-
         return when (this.getLore().lastOrNull()?.take(4)) {
             "§f§l" -> LorenzRarity.COMMON
             "§a§l" -> LorenzRarity.UNCOMMON


### PR DESCRIPTION
- Converting all fails to common rarity may not be the best solution but it is better than the user crashing
- We should try as much as possible to not just crash the user when something is wrong and instead use LorenzUtils.error and then return some value that we can deal with
- This will not fix the initial problem that caused the item to have no rarity and I haven't looked into that

[bug report of the initial issue](https://discord.com/channels/997079228510117908/1149879403061461086)