### PR TITLE
Fix: Item cooldown for fire fury staff and jinxed voodoo doll

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
@@ -41,6 +41,7 @@ enum class ItemAbility(
     WITHER_CLOAK(10),
     HOLY_ICE(4),
     VOODOO_DOLL_WILTED(3),
+    FIRE_FURY_STAFF(20),
     SHADOW_FURY(15, "STARRED_SHADOW_FURY"),
 
     // doesn't have a sound
@@ -48,7 +49,6 @@ enum class ItemAbility(
     LIVID_DAGGER("Throw", 5, "Livid Dagger"),
     FIRE_VEIL("Fire Veil", 5, "Fire Veil Wand"),
     INK_WAND("Ink Bomb", 30, "Ink Wand"),
-    FIRE_FURY_STAFF("Firestorm", 20, "Fire Fury Staff"),
 
     // doesn't have a consistent sound
     ECHO("Echo", 3, "Ancestral Spade");

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -25,6 +25,7 @@ class ItemAbilityCooldown {
     private val youAlignedOthersPattern = "§eYou aligned §r§a.* §r§eother player(s)?!".toPattern()
     private val WEIRD_TUBA = "WEIRD_TUBA".asInternalName()
     private val WEIRDER_TUBA = "WEIRDER_TUBA".asInternalName()
+    private val VOODOO_DOLL_WILTED = "VOODOO_DOLL_WILTED".asInternalName()
 
     @SubscribeEvent
     fun onSoundEvent(event: PlaySoundEvent) {
@@ -34,6 +35,11 @@ class ItemAbilityCooldown {
                 if (abilityScrolls.size != 3) return
 
                 ItemAbility.HYPERION.sound()
+            }
+        }
+        if (event.soundName == "liquid.lavapop") {
+            if (event.pitch == 1.0f && event.volume == 1f) {
+                ItemAbility.FIRE_FURY_STAFF.sound()
             }
         }
         if (event.soundName == "mob.enderdragon.growl") {
@@ -86,9 +92,17 @@ class ItemAbilityCooldown {
                 ItemAbility.VOODOO_DOLL.sound()
             }
         }
-        if (event.soundName == "random.successful_hit") {
+        if (event.soundName == "random.successful_hit") { // Jinxed Voodoo Doll Hit
             if (event.volume == 1.0f && event.pitch == 0.7936508f) {
                 ItemAbility.VOODOO_DOLL_WILTED.sound()
+            }
+        }
+        if (event.soundName == "mob.ghast.scream") { // Jinxed Voodoo Doll Miss
+            if (event.volume == 1.0f && event.pitch >= 1.6 && event.pitch <= 1.7) {
+                val recentItems = InventoryUtils.recentItemsInHand.values
+                if (VOODOO_DOLL_WILTED in recentItems) {
+                    ItemAbility.VOODOO_DOLL_WILTED.sound()
+                }
             }
         }
         if (event.soundName == "random.explode") {


### PR DESCRIPTION
Fixed a bug where fire fury staff cooldown detection didn't work if rapidly changing weapons while using the ability of another weapon (e.g. using Frozen Scythe, swapping to fire fury staff for one tick to use it, and swapping back). Also fixed Jinxed Voodoo Doll not going on cooldown if you miss (it should).