### PR TITLE
Fix: Rare sea creature detection 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/damageindicator/MobFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/damageindicator/MobFinder.kt
@@ -205,11 +205,11 @@ class MobFinder {
 
                 if (entity.name == "Bloodfiend ") {
                     when {
-                        entity.hasMaxHealth(625) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_1)
-                        entity.hasMaxHealth(1_100) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_2)
-                        entity.hasMaxHealth(1_800) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_3)
-                        entity.hasMaxHealth(2_400) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_4)
-                        entity.hasMaxHealth(3_000) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_5)
+                        entity.hasMaxHealth(625, true) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_1)
+                        entity.hasMaxHealth(1_100, true) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_2)
+                        entity.hasMaxHealth(1_800, true) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_3)
+                        entity.hasMaxHealth(2_400, true) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_4)
+                        entity.hasMaxHealth(3_000, true) -> return EntityResult(bossType = BossType.SLAYER_BLOODFIEND_5)
                     }
                 }
             }
@@ -222,7 +222,7 @@ class MobFinder {
             if (entity is EntityBlaze) {
                 if (entity.name != "Dinnerbone") {
                     if (entity.hasNameTagWith(2, "§e﴾ §8[§7Lv200§8] §l§8§lAshfang§r ")) {
-                        if (entity.hasMaxHealth(50_000_000)) {
+                        if (entity.hasMaxHealth(50_000_000, true)) {
                             return EntityResult(bossType = BossType.NETHER_ASHFANG)
                         }
                     }
@@ -251,10 +251,10 @@ class MobFinder {
             if (entity is EntityEnderman) {
                 if (entity.hasNameTagWith(3, "§c☠ §bVoidgloom Seraph ")) {
                     when {
-                        entity.hasMaxHealth(300_000) -> return EntityResult(bossType = BossType.SLAYER_ENDERMAN_1)
-                        entity.hasMaxHealth(12_000_000) -> return EntityResult(bossType = BossType.SLAYER_ENDERMAN_2)
-                        entity.hasMaxHealth(50_000_000) -> return EntityResult(bossType = BossType.SLAYER_ENDERMAN_3)
-                        entity.hasMaxHealth(210_000_000) -> return EntityResult(bossType = BossType.SLAYER_ENDERMAN_4)
+                        entity.hasMaxHealth(300_000, true) -> return EntityResult(bossType = BossType.SLAYER_ENDERMAN_1)
+                        entity.hasMaxHealth(12_000_000, true -> return EntityResult(bossType = BossType.SLAYER_ENDERMAN_2)
+                        entity.hasMaxHealth(50_000_000, true) -> return EntityResult(bossType = BossType.SLAYER_ENDERMAN_3)
+                        entity.hasMaxHealth(210_000_000, true) -> return EntityResult(bossType = BossType.SLAYER_ENDERMAN_4)
                     }
                 }
             }
@@ -274,14 +274,14 @@ class MobFinder {
             if (entity is EntityZombie) {
                 if (entity.hasNameTagWith(2, "§c☠ §bRevenant Horror")) {
                     when {
-                        entity.hasMaxHealth(500) -> return EntityResult(bossType = BossType.SLAYER_ZOMBIE_1)
-                        entity.hasMaxHealth(20_000) -> return EntityResult(bossType = BossType.SLAYER_ZOMBIE_2)
-                        entity.hasMaxHealth(400_000) -> return EntityResult(bossType = BossType.SLAYER_ZOMBIE_3)
-                        entity.hasMaxHealth(1_500_000) -> return EntityResult(bossType = BossType.SLAYER_ZOMBIE_4)
+                        entity.hasMaxHealth(500, true) -> return EntityResult(bossType = BossType.SLAYER_ZOMBIE_1)
+                        entity.hasMaxHealth(20_000, true) -> return EntityResult(bossType = BossType.SLAYER_ZOMBIE_2)
+                        entity.hasMaxHealth(400_000, true) -> return EntityResult(bossType = BossType.SLAYER_ZOMBIE_3)
+                        entity.hasMaxHealth(1_500_000, true) -> return EntityResult(bossType = BossType.SLAYER_ZOMBIE_4)
                     }
                 }
                 if (entity.hasNameTagWith(2, "§c☠ §fAtoned Horror ")) {
-                    if (entity.hasMaxHealth(10_000_000)) {
+                    if (entity.hasMaxHealth(10_000_000, true)) {
                         return EntityResult(bossType = BossType.SLAYER_ZOMBIE_5)
                     }
                 }
@@ -293,14 +293,14 @@ class MobFinder {
             }
             if (entity is EntityMagmaCube) {
                 if (entity.hasNameTagWith(15, "§e﴾ §8[§7Lv500§8] §l§4§lMagma Boss§r ")) {
-                    if (entity.hasMaxHealth(200_000_000)) {
+                    if (entity.hasMaxHealth(200_000_000, true)) {
                         return EntityResult(bossType = BossType.NETHER_MAGMA_BOSS, ignoreBlocks = true)
                     }
                 }
             }
             if (entity is EntityHorse) {
                 if (entity.hasNameTagWith(15, "§8[§7Lv100§8] §c§6Headless Horseman§r ")) {
-                    if (entity.hasMaxHealth(3_000_000)) {
+                    if (entity.hasMaxHealth(3_000_000, true)) {
                         return EntityResult(bossType = BossType.HUB_HEADLESS_HORSEMAN)
                     }
                 }
@@ -333,10 +333,10 @@ class MobFinder {
             if (entity is EntitySpider) {
                 if (entity.hasNameTagWith(1, "§5☠ §4Tarantula Broodfather ")) {
                     when {
-                        entity.hasMaxHealth(740) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_1)
-                        entity.hasMaxHealth(30_000) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_2)
-                        entity.hasMaxHealth(900_000) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_3)
-                        entity.hasMaxHealth(2_400_000) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_4)
+                        entity.hasMaxHealth(740, true) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_1)
+                        entity.hasMaxHealth(30_000, true) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_2)
+                        entity.hasMaxHealth(900_000, true) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_3)
+                        entity.hasMaxHealth(2_400_000, true) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_4)
                     }
                 }
                 checkArachne(entity)?.let { return it }
@@ -344,10 +344,10 @@ class MobFinder {
             if (entity is EntityWolf) {
                 if (entity.hasNameTagWith(1, "§c☠ §fSven Packmaster ")) {
                     when {
-                        entity.hasMaxHealth(2_000) -> return EntityResult(bossType = BossType.SLAYER_WOLF_1)
-                        entity.hasMaxHealth(40_000) -> return EntityResult(bossType = BossType.SLAYER_WOLF_2)
-                        entity.hasMaxHealth(750_000) -> return EntityResult(bossType = BossType.SLAYER_WOLF_3)
-                        entity.hasMaxHealth(2_000_000) -> return EntityResult(bossType = BossType.SLAYER_WOLF_4)
+                        entity.hasMaxHealth(2_000, true) -> return EntityResult(bossType = BossType.SLAYER_WOLF_1)
+                        entity.hasMaxHealth(40_000, true) -> return EntityResult(bossType = BossType.SLAYER_WOLF_2)
+                        entity.hasMaxHealth(750_000, true) -> return EntityResult(bossType = BossType.SLAYER_WOLF_3)
+                        entity.hasMaxHealth(2_000_000, true) -> return EntityResult(bossType = BossType.SLAYER_WOLF_4)
                     }
                 }
             }
@@ -555,12 +555,12 @@ class MobFinder {
 
         for (entity in EntityUtils.getEntities<EntityGuardian>()) {
             //F3
-            if (entity.hasMaxHealth(1_000_000) || entity.hasMaxHealth(1_200_000)) {
+            if (entity.hasMaxHealth(1_000_000, true) || entity.hasMaxHealth(1_200_000, true)) {
                 guardians.add(entity)
             }
 
             //M3
-            if (entity.hasMaxHealth(120_000_000) || entity.hasMaxHealth(240_000_000)) {
+            if (entity.hasMaxHealth(120_000_000, true) || entity.hasMaxHealth(240_000_000, true)) {
                 guardians.add(entity)
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.damageindicator.DamageIndicatorManager
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.EntityUtils.hasMaxHealth
+import at.hannibal2.skyhanni.utils.EntityUtils.hasNameTagWith
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -34,10 +35,7 @@ class SeaCreatureFeatures {
         for (creatureType in RareSeaCreatureType.entries) {
             if (!creatureType.health.any { entity.hasMaxHealth(it, false, maxHealth) }) continue
             if (!creatureType.clazz.isInstance(entity)) continue
-
-            if (creatureType.nametag.isNotBlank() && EntityPlayer::class.java.isInstance(entity) && (entity as EntityPlayer).name != creatureType.nametag) {
-                continue
-            }
+            if (!entity.hasNameTagWith(3, creatureType.nametag)) continue
 
             rareSeaCreatures = rareSeaCreatures.editCopy { add(entity) }
             RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.RED.toColor().withAlpha(50))
@@ -71,14 +69,14 @@ class SeaCreatureFeatures {
         val nametag: String,
         vararg val health: Int
     ) {
-        WATER_HYDRA(EntityZombie::class.java, "Water Hydra", 500_000, 1_500_000),
-        SEA_EMPEROR(EntityGuardian::class.java, "The Sea Emperors", 750_000, 800_000, 2_250_000, 2_400_000),
-        ZOMBIE_MINER(EntityPlayer::class.java, "", 2_000_000, 6_000_000),
-        PHANTOM_FISHERMAN(EntityPlayer::class.java, "Phantom Fisher", 1_000_000, 3_000_000),
-        GRIM_REAPER(EntityPlayer::class.java, "Grim Reaper", 3_000_000, 9_000_000),
-        YETI(EntityPlayer::class.java, "", 2_000_000, 6_000_000),
-        NUTCRACKER(EntityPlayer::class.java, "", 4_000_000, 12_000_000),
-        GREAT_WHITE_SHARK(EntityPlayer::class.java, "GWS ", 1_500_000, 4_500_000),
+        WATER_HYDRA(EntityZombie::class.java, "Water Hydra", 500_000),
+        SEA_EMPEROR(EntityGuardian::class.java, "Sea Emperor", 750_000, 800_000),
+        ZOMBIE_MINER(EntityPlayer::class.java, "Zombie Miner", 2_000_000),
+        PHANTOM_FISHERMAN(EntityPlayer::class.java, "Phantom Fisher", 1_000_000),
+        GRIM_REAPER(EntityPlayer::class.java, "Grim Reaper", 3_000_000),
+        YETI(EntityPlayer::class.java, "Yeti", 2_000_000),
+        NUTCRACKER(EntityZombie::class.java, "Nutcracker", 4_000_000),
+        GREAT_WHITE_SHARK(EntityPlayer::class.java, "Great White Shark", 1_500_000),
         ;
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
@@ -35,7 +35,7 @@ class SlayerMiniBossFeatures {
 
         val maxHealth = event.maxHealth
         for (bossType in SlayerMiniBossType.entries) {
-            if (!bossType.health.any { entity.hasMaxHealth(it, false, maxHealth) }) continue
+            if (!bossType.health.any { entity.hasMaxHealth(it, true, maxHealth) }) continue
             if (!bossType.clazz.isInstance(entity)) continue
 
             miniBosses = miniBosses.editCopy { add(entity) }

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -100,22 +100,16 @@ object EntityUtils {
 
     //TODO remove baseMaxHealth
     fun EntityLivingBase.hasMaxHealth(health: Int, boss: Boolean = false, maxHealth: Int = baseMaxHealth): Boolean {
-        if (maxHealth == health) return true
+        val derpyMultiplier = if (LorenzUtils.isDerpy) 2 else 1
+        if (maxHealth == health * derpyMultiplier) return true
 
-        if (LorenzUtils.isDerpy) {
-            if (maxHealth == health * 2) return true
-        }
-
-        // TODO runic support
-
-        if (!boss) {
+        if (!boss && !LorenzUtils.inDungeons) {
             //Corrupted
-            if (maxHealth == health * 3) return true
-
-            //Derpy + Corrupted
-            if (LorenzUtils.isDerpy) {
-                if (maxHealth == health * 2 * 3) return true
-            }
+            if (maxHealth == health * 3 * derpyMultiplier) return true
+            // Runic
+            if (maxHealth == health * 4 * derpyMultiplier) return true
+            // Corrupted+Runic
+            if (maxHealth == health * 12 * derpyMultiplier) return true
         }
 
         return false


### PR DESCRIPTION
Use nametag detection for rare sea creatures to ensure no false positives (Water Hydras and T4 Revs both have 1.5m health and inherit from EntityZombie). Also added runic support to EntityLivingBase.hasMaxHealth as well as corrupted runic mobs.