### PR TITLE
Added clickable fake garden level up message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenLevelDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenLevelDisplay.kt
@@ -50,9 +50,10 @@ class GardenLevelDisplay {
         if (newLevel == oldLevel + 1) {
             if (newLevel > 15) {
                 LorenzUtils.runDelayed(50.milliseconds) {
-                    LorenzUtils.chat(
+                    LorenzUtils.clickableChat(
                         " \n§b§lGARDEN LEVEL UP §8$oldLevel ➜ §b$newLevel\n" +
-                                " §8+§aRespect from Elite Farmers and SkyHanni members :)\n "
+                                " §8+§aRespect from Elite Farmers and SkyHanni members :)\n ",
+                        "/gardenlevels"
                     )
                 }
             }


### PR DESCRIPTION
Makes this fake garden level up message clickable, to open /gardenlevels, like all the other level up messages 
![image](https://github.com/hannibal002/SkyHanni/assets/45315647/9aa7f2d7-b004-4a51-a966-b0093ca06dc9)

dont ask, feels more natural like this