### PR TITLE
Fix: GhostCounter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ghostcounter/GhostFormatting.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ghostcounter/GhostFormatting.kt
@@ -160,7 +160,7 @@ object GhostFormatting {
                 base = "  &6Bestiary %currentLevel%->%nextLevel%: &b%value%"
                 openMenu = "§cOpen Bestiary Menu !"
                 maxed = "%currentKill% (&c&lMaxed!)"
-                showMax_progress = "%currentKill%/3M (%percentNumber%%)"
+                showMax_progress = "%currentKill%/250k (%percentNumber%%)"
                 progress = "%currentKill%/%killNeeded%"
             }
             with(killHourFormatting) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ghostcounter/GhostUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ghostcounter/GhostUtil.kt
@@ -123,6 +123,6 @@ object GhostUtil {
     }
 
     private fun percent(number: Double): String {
-        return "${((number / 250_000) * 100).roundToPrecision(4)}"
+        return 100.0.coerceAtMost(((number / 250_000) * 100).roundToPrecision(4)).toString()
     }
 }


### PR DESCRIPTION
- Fixed max kills still using old bestiary data when resetting config
- Fixed percentage going above 100% for bestiary progress