### PR TITLE
Fix: Translator changing colors and hiding messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/Translator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/Translator.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.chat
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.SkyHanniMod.Companion.consoleLog
 import at.hannibal2.skyhanni.test.command.CopyErrorCommand
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.OSUtils
@@ -38,7 +37,6 @@ class Translator {
         val chatComponent = e.message
         val message = chatComponent.unformattedText
         if (!messageContentRegex.matches(message.removeColor())) return
-        consoleLog(chatComponent.toString())
         if (!chatComponent.isFromAHuman()) return // some messages are considered "player-sent" by hypixel when they actually aren't
         val theChatComponentWeCareAbout =
             if (chatComponent.siblings.isNotEmpty()) chatComponent.siblings.last() else chatComponent


### PR DESCRIPTION
- Uses the existing chat style instead of creating a new one so that messages don't become white
- Added detection for if a message is by a human instead of just using a regex for if it contains a colon (not perfect because hypixel dislikes me)

Please test this. The chat components that my dev env received were different than the ones that my prod env received, so I expect there are more situations that I need to account for.