### PR TITLE
Fix: Improve performance for tooltips and item ability cooldown feature (fixes item cooldown flickering)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -9,10 +9,13 @@ import at.hannibal2.skyhanni.events.*
 import at.hannibal2.skyhanni.features.garden.CropType.Companion.getTurboCrop
 import at.hannibal2.skyhanni.features.garden.GardenAPI.addCropIcon
 import at.hannibal2.skyhanni.features.garden.GardenAPI.getCropType
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName_old
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
@@ -157,14 +160,15 @@ class FarmingFortuneDisplay {
         var itemBaseFortune = 0.0
         var greenThumbFortune = 0.0
 
-        fun getToolFortune(tool: ItemStack?): Double {
-            val internalName = tool?.getInternalName_old() ?: return 0.0
-            if (internalName == "THEORETICAL_HOE") {
+        fun getToolFortune(tool: ItemStack?): Double = getToolFortune(tool?.getInternalName())
+        fun getToolFortune(internalName: NEUInternalName?): Double {
+            if (internalName == null) return 0.0
+            if (internalName.equals("THEORETICAL_HOE")) {
                 return 0.0
             }
             return if (internalName.startsWith("THEORETICAL_HOE")) {
-                listOf(10.0, 25.0, 50.0)[internalName.last().digitToInt() - 1]
-            } else when (internalName) {
+                listOf(10.0, 25.0, 50.0)[internalName.toString().last().digitToInt() - 1]
+            } else when (internalName.toString()) {
                 "FUNGI_CUTTER" -> 30.0
                 "COCO_CHOPPER" -> 20.0
                 else -> 0.0
@@ -208,12 +212,18 @@ class FarmingFortuneDisplay {
         fun getCultivatingFortune(tool: ItemStack?): Double { return (tool?.getEnchantments()?.get("cultivating") ?: 0) * 2.0}
 
         fun getAbilityFortune(item: ItemStack?):  Double  {
+            if (item == null) return 0.0
+            return getAbilityFortune(item.getInternalName(), item.getLore())
+        }
+
+        fun getAbilityFortune(internalName: NEUInternalName, lore: List<String>):  Double  {
             val lotusAbilityPattern = "§7Piece Bonus: §6+(?<bonus>.*)☘".toPattern()
             // todo make it work on Melon and Cropie armor
             val armorAbilityFortune = "§7.*§7Grants §6(?<bonus>.*)☘.*".toPattern()
             var pieces = 0
-            for (line in item?.getLore()!!) {
-                if (item.getInternalName_old().contains("LOTUS")) {
+
+            lore.forEach { line ->
+                if (internalName.contains("LOTUS")) {
                     lotusAbilityPattern.matchMatcher(line) {
                         return group("bonus").toDouble()
                     }
@@ -226,6 +236,7 @@ class FarmingFortuneDisplay {
                     return if (pieces < 2) 0.0 else group("bonus").toDouble() / pieces
                 }
             }
+
             return 0.0
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.features.garden.FarmingFortuneDisplay.Companion.get
 import at.hannibal2.skyhanni.features.garden.GardenAPI.getCropType
 import at.hannibal2.skyhanni.features.garden.fortuneguide.FFGuideGUI
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getFarmingForDummiesCount
@@ -32,8 +33,10 @@ class ToolTooltipTweaks {
         if (!LorenzUtils.inSkyBlock) return
 
         val itemStack = event.itemStack
+        val itemLore = itemStack.getLore()
+        val internalName = itemStack.getInternalName()
         val crop = itemStack.getCropType()
-        val toolFortune = FarmingFortuneDisplay.getToolFortune(itemStack)
+        val toolFortune = FarmingFortuneDisplay.getToolFortune(internalName)
         val counterFortune = FarmingFortuneDisplay.getCounterFortune(itemStack)
         val collectionFortune = FarmingFortuneDisplay.getCollectionFortune(itemStack)
         val turboCropFortune = FarmingFortuneDisplay.getTurboCropFortune(itemStack, crop)
@@ -44,7 +47,7 @@ class ToolTooltipTweaks {
         val sunderFortune = FarmingFortuneDisplay.getSunderFortune(itemStack)
         val harvestingFortune = FarmingFortuneDisplay.getHarvestingFortune(itemStack)
         val cultivatingFortune = FarmingFortuneDisplay.getCultivatingFortune(itemStack)
-        val abilityFortune = getAbilityFortune(itemStack)
+        val abilityFortune = getAbilityFortune(internalName, itemLore)
 
         val ffdFortune = itemStack.getFarmingForDummiesCount() ?: 0
         val hiddenFortune =
@@ -137,7 +140,7 @@ class ToolTooltipTweaks {
         }
 
         // Fixing a hypixel bug. TODO remove once hypixel fixes it. use disabled features repo maybe?
-        if (itemStack.getInternalName().contains("LOTUS")) {
+        if (internalName.contains("LOTUS")) {
             event.toolTip.replaceAll { it.replace("Kills:", "Visitors:") }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -148,7 +148,7 @@ class ItemDisplayOverlayFeatures {
         }
 
         if (SkyHanniMod.feature.inventory.itemNumberAsStackSize.contains(12)) {
-            if (item.getInternalName_old() == "LARVA_HOOK") {
+            if (itemName.contains("Larva Hook")) {
                 for (line in item.getLore()) {
                     "§7§7You may harvest §6(?<amount>.).*".toPattern().matchMatcher(line) {
                         val amount = group("amount").toInt()
@@ -163,7 +163,7 @@ class ItemDisplayOverlayFeatures {
         }
 
         if (SkyHanniMod.feature.inventory.itemNumberAsStackSize.contains(13)) {
-            if (item.getInternalName_old() == "POTION") {
+            if (itemName.startsWith("Dungeon ") && itemName.contains(" Potion")) {
                 item.name?.let {
                     "Dungeon (?<level>.*) Potion".toPattern().matchMatcher(it.removeColor()) {
                         return when (val level = group("level").romanToDecimal()) {


### PR DESCRIPTION
Reduce calls to NEU's getInternalName as it's a very costly function that we're calling quite often (replaced one occurrence of it being called for each line in item lore). Optimize item ability cooldown to reduce the CPU overhead as well as fix the item cooldown text "flickering" every other frame.

Profiling with Spark indicated a roughly 30% CPU usage reduction for normal walking around with items in my hotbar, and significant improvements to tooltips (specifically the RNG meter tooltips which were the slowest).