### PR TITLE
Profit Tracker global solution

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/Storage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/Storage.java
@@ -328,10 +328,11 @@ public class Storage {
         @Expose
         public Map<String, SlayerProfitList> slayerProfitData = new HashMap<>();
 
+
         public static class SlayerProfitList {
 
             @Expose
-            public Map<NEUInternalName, SlayerItemProfit> items = new HashMap<>();
+            public Map<NEUInternalName, ProfitTrackerItem> items = new HashMap<>();
 
             @Expose
             public long mobKillCoins = 0;
@@ -342,7 +343,7 @@ public class Storage {
             @Expose
             public int slayerCompletedCount = 0;
 
-            public static class SlayerItemProfit {
+            public static class ProfitTrackerItem {
                 @Expose
                 public NEUInternalName internalName;
                 @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerItemProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerItemProfitTracker.kt
@@ -11,25 +11,16 @@ import at.hannibal2.skyhanni.events.PurseChangeCause
 import at.hannibal2.skyhanni.events.PurseChangeEvent
 import at.hannibal2.skyhanni.events.SlayerChangeEvent
 import at.hannibal2.skyhanni.events.SlayerQuestCompleteEvent
-import at.hannibal2.skyhanni.features.bazaar.BazaarApi.Companion.getBazaarData
-import at.hannibal2.skyhanni.features.bazaar.BazaarData
-import at.hannibal2.skyhanni.test.PriceSource
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.addAsSingletonList
-import at.hannibal2.skyhanni.utils.LorenzUtils.addSelector
-import at.hannibal2.skyhanni.utils.LorenzUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.NEUInternalName
-import at.hannibal2.skyhanni.utils.NEUItems.getNpcPrice
-import at.hannibal2.skyhanni.utils.NEUItems.getPrice
-import at.hannibal2.skyhanni.utils.NumberUtil
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.ProfitListWrapper
+import at.hannibal2.skyhanni.utils.ProfitTracker
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
-import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.renderables.Renderable
 import com.google.common.cache.CacheBuilder
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiInventory
@@ -47,9 +38,6 @@ object SlayerItemProfitTracker {
     private var itemLogCategory = ""
     private var display = emptyList<List<Any>>()
     private val logger = LorenzLogger("slayer/item_profit_tracker")
-    private var inventoryOpen = false
-    private var lastClickDelay = 0L
-    private var currentDisplayMode = DisplayMode.TOTAL
     private var currentSessionData = mutableMapOf<String, SlayerProfitList>()
 
     private fun addSlayerCosts(price: Int) {
@@ -57,7 +45,7 @@ object SlayerItemProfitTracker {
         itemLog.modify {
             it.slayerSpawnCost += price
         }
-        update()
+        updateDisplay()
     }
 
     @SubscribeEvent
@@ -80,7 +68,7 @@ object SlayerItemProfitTracker {
     fun onSlayerChange(event: SlayerChangeEvent) {
         val newSlayer = event.newSlayer
         itemLogCategory = newSlayer.removeColor()
-        update()
+        updateDisplay()
     }
 
     private fun addMobKillCoins(coins: Int) {
@@ -89,31 +77,54 @@ object SlayerItemProfitTracker {
         itemLog.modify {
             it.mobKillCoins += coins
         }
-        update()
+        updateDisplay()
     }
 
     private fun addItemPickup(internalName: NEUInternalName, stackSize: Int) {
         val itemLog = currentLog() ?: return
 
         itemLog.modify {
-            val slayerItemProfit = it.items.getOrPut(internalName) { SlayerProfitList.SlayerItemProfit() }
+            val slayerItemProfit = it.items.getOrPut(internalName) { SlayerProfitList.ProfitTrackerItem() }
 
             slayerItemProfit.timesDropped++
             slayerItemProfit.totalAmount += stackSize
         }
 
-        update()
+        updateDisplay()
     }
+
+    class SlayerWrapper<T : SlayerProfitList>(val list: T) : ProfitListWrapper<T>() {
+        override fun reset() {
+            list.items.clear()
+            list.mobKillCoins = 0
+            list.slayerSpawnCost = 0
+            list.slayerCompletedCount = 0
+        }
+
+        override fun getList(): Map<NEUInternalName, SlayerProfitList.ProfitTrackerItem> {
+            return list.items
+        }
+
+        override fun getType(): T = list
+
+    }
+
+    class AbstractSlayerProfitList(
+        total: SlayerWrapper<SlayerProfitList>,
+        currentSession: SlayerWrapper<SlayerProfitList>,
+        update: () -> Unit,
+    ) : ProfitTracker.AbstractProfitList<SlayerProfitList>(total, currentSession, update)
 
     private fun currentLog(): AbstractSlayerProfitList? {
         if (itemLogCategory == "") return null
 
         val profileSpecific = ProfileStorageData.profileSpecific ?: return null
 
-        return AbstractSlayerProfitList(
-            profileSpecific.slayerProfitData.getOrPut(itemLogCategory) { SlayerProfitList() },
-            currentSessionData.getOrPut(itemLogCategory) { SlayerProfitList() }
-        )
+        val a = profileSpecific.slayerProfitData.getOrPut(itemLogCategory) { SlayerProfitList() }
+        val b = currentSessionData.getOrPut(itemLogCategory) { SlayerProfitList() }
+        val update = { updateDisplay() }
+
+        return AbstractSlayerProfitList(SlayerWrapper(a), SlayerWrapper(b), update)
     }
 
     @SubscribeEvent
@@ -124,7 +135,7 @@ object SlayerItemProfitTracker {
             it.slayerCompletedCount++
         }
 
-        update()
+        updateDisplay()
     }
 
     @SubscribeEvent(priority = EventPriority.LOW, receiveCanceled = true)
@@ -163,160 +174,9 @@ object SlayerItemProfitTracker {
         }
     }
 
-    fun update() {
-        display = drawDisplay()
-    }
-
-    private fun drawDisplay() = buildList<List<Any>> {
-        val both = currentLog() ?: return@buildList
-        val itemLog = both.get(currentDisplayMode)
-
-        addAsSingletonList("§e§l$itemLogCategory Profit Tracker")
-        if (inventoryOpen) {
-            addSelector<DisplayMode>(
-                "§7Display Mode: ",
-                getName = { type -> type.displayName },
-                isCurrent = { it == currentDisplayMode },
-                onChange = {
-                    currentDisplayMode = it
-                    update()
-                }
-            )
-        }
-
-        var profit = 0.0
-        val map = mutableMapOf<Renderable, Long>()
-        for ((internalName, itemProfit) in itemLog.items) {
-            val amount = itemProfit.totalAmount
-
-            val price = (getPrice(internalName) * amount).toLong()
-
-            val cleanName = SlayerAPI.getNameWithEnchantmentFor(internalName)
-            var name = cleanName
-            val priceFormat = NumberUtil.format(price)
-            val hidden = itemProfit.hidden
-            if (hidden) {
-                while (name.startsWith("§f")) {
-                    name = name.substring(2)
-                }
-                name = StringUtils.addFormat(name, "§m")
-            }
-            val text = " §7${amount.addSeparators()}x $name§7: §6$priceFormat"
-
-            val timesDropped = itemProfit.timesDropped
-            val percentage = timesDropped.toDouble() / itemLog.slayerCompletedCount
-            val perBoss = LorenzUtils.formatPercentage(percentage.coerceAtMost(1.0))
-
-            val renderable = if (inventoryOpen) Renderable.clickAndHover(
-                text, listOf(
-                    "§7Dropped §e${timesDropped.addSeparators()} §7times.",
-                    "§7Your drop rate: §c$perBoss",
-                    "",
-                    "§eClick to " + (if (hidden) "show" else "hide") + "!",
-                    "§eControl + Click to remove this item!",
-                )
-            ) {
-                if (System.currentTimeMillis() > lastClickDelay + 150) {
-
-                    if (LorenzUtils.isControlKeyDown()) {
-                        itemLog.items.remove(internalName)
-                        LorenzUtils.chat("§e[SkyHanni] Removed $cleanName §efrom slayer profit display.")
-                        lastClickDelay = System.currentTimeMillis() + 500
-                    } else {
-                        itemProfit.hidden = !hidden
-                        lastClickDelay = System.currentTimeMillis()
-                    }
-                    update()
-                }
-            } else Renderable.string(text)
-            if (inventoryOpen || !hidden) {
-                map[renderable] = price
-            }
-            profit += price
-        }
-        val mobKillCoins = itemLog.mobKillCoins
-        if (mobKillCoins != 0L) {
-            val mobKillCoinsFormat = NumberUtil.format(mobKillCoins)
-            map[Renderable.hoverTips(
-                " §7Mob kill coins: §6$mobKillCoinsFormat",
-                listOf(
-                    "§7Killing mobs gives you coins (more with scavenger)",
-                    "§7You got §e$mobKillCoinsFormat §7coins in total this way"
-                )
-            )] = mobKillCoins
-            profit += mobKillCoins
-        }
-        val slayerSpawnCost = itemLog.slayerSpawnCost
-        if (slayerSpawnCost != 0L) {
-            val mobKillCoinsFormat = NumberUtil.format(slayerSpawnCost)
-            map[Renderable.hoverTips(
-                " §7Slayer Spawn Costs: §c$mobKillCoinsFormat",
-                listOf("§7You paid §c$mobKillCoinsFormat §7in total", "§7for starting the slayer quests.")
-            )] = slayerSpawnCost
-            profit += slayerSpawnCost
-        }
-
-        for (text in map.sortedDesc().keys) {
-            addAsSingletonList(text)
-        }
-
-        val slayerCompletedCount = itemLog.slayerCompletedCount
-        addAsSingletonList(
-            Renderable.hoverTips(
-                "§7Bosses killed: §e${slayerCompletedCount.addSeparators()}",
-                listOf("§7You killed the $itemLogCategory boss", "§e${slayerCompletedCount.addSeparators()} §7times.")
-            )
-        )
-
-        val profitFormat = NumberUtil.format(profit)
-        val profitPrefix = if (profit < 0) "§c" else "§6"
-
-        val profitPerBoss = profit / itemLog.slayerCompletedCount
-        val profitPerBossFormat = NumberUtil.format(profitPerBoss)
-
-        val text = "§eTotal Profit: $profitPrefix$profitFormat"
-        addAsSingletonList(Renderable.hoverTips(text, listOf("§7Profit per boss: $profitPrefix$profitPerBossFormat")))
-
-        if (inventoryOpen) {
-            addSelector<PriceSource>(
-                "",
-                getName = { type -> type.displayName },
-                isCurrent = { it.ordinal == config.priceFrom },
-                onChange = {
-                    config.priceFrom = it.ordinal
-                    update()
-                }
-            )
-        }
-        if (inventoryOpen && currentDisplayMode == DisplayMode.CURRENT) {
-            addAsSingletonList(
-                Renderable.clickAndHover(
-                    "§cReset session!",
-                    listOf("§cThis will reset your", "§ccurrent session for", "§c$itemLogCategory"),
-                ) {
-                    resetData(DisplayMode.CURRENT)
-                    update()
-                })
-        }
-    }
-
-    private fun resetData(displayMode: DisplayMode) {
+    fun updateDisplay() {
         val currentLog = currentLog() ?: return
-        val list = currentLog.get(displayMode)
-        list.items.clear()
-        list.mobKillCoins = 0
-        list.slayerSpawnCost = 0
-        list.slayerCompletedCount = 0
-    }
-
-    private fun getPrice(internalName: NEUInternalName) =
-        internalName.getBazaarData()?.let { getPrice(internalName, it) } ?: internalName.getPrice()
-
-    private fun getPrice(internalName: NEUInternalName, bazaarData: BazaarData) = when (config.priceFrom) {
-        0 -> bazaarData.sellPrice
-        1 -> bazaarData.buyPrice
-
-        else -> internalName.getNpcPrice()
+        display = currentLog.drawDisplay("§e§l${itemLogCategory} Profit Tracker")
     }
 
     @SubscribeEvent
@@ -327,33 +187,11 @@ object SlayerItemProfitTracker {
         val currentlyOpen = Minecraft.getMinecraft().currentScreen is GuiInventory
         if (inventoryOpen != currentlyOpen) {
             inventoryOpen = currentlyOpen
-            update()
+            updateDisplay()
         }
 
 
         config.pos.renderStringsAndItems(display, posLabel = "Slayer Item Profit Tracker")
-    }
-
-    enum class DisplayMode(val displayName: String) {
-        TOTAL("Total"),
-        CURRENT("This Session"),
-        ;
-    }
-
-    class AbstractSlayerProfitList(
-        private val total: SlayerProfitList,
-        private val currentSession: SlayerProfitList,
-    ) {
-
-        fun modify(modifyFunction: (SlayerProfitList) -> Unit) {
-            modifyFunction(total)
-            modifyFunction(currentSession)
-        }
-
-        fun get(displayMode: DisplayMode) = when (displayMode) {
-            DisplayMode.TOTAL -> total
-            DisplayMode.CURRENT -> currentSession
-        }
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
@@ -361,8 +199,8 @@ object SlayerItemProfitTracker {
     fun clearProfitCommand(args: Array<String>) {
         if (itemLogCategory == "") {
             LorenzUtils.chat(
-                "§c[SkyHanni] No current slayer data found. " +
-                        "Go to a slayer area and start the specific slayer type you want to reset the data of."
+                    "§c[SkyHanni] No current slayer data found. " +
+                    "Go to a slayer area and start the specific slayer type you want to reset the data of."
             )
             return
         }
@@ -370,15 +208,15 @@ object SlayerItemProfitTracker {
         if (args.size == 1) {
             if (args[0].lowercase() == "confirm") {
                 resetData(DisplayMode.TOTAL)
-                update()
+                updateDisplay()
                 LorenzUtils.chat("§e[SkyHanni] You reset your $itemLogCategory slayer data!")
                 return
             }
         }
 
         LorenzUtils.clickableChat(
-            "§e[SkyHanni] Are you sure you want to reset all your $itemLogCategory slayer data? Click here to confirm.",
-            "shclearslayerprofits confirm"
+                "§e[SkyHanni] Are you sure you want to reset all your $itemLogCategory slayer data? Click here to confirm.",
+                "shclearslayerprofits confirm"
         )
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ProfitTracker.kt
@@ -1,0 +1,203 @@
+package at.hannibal2.skyhanni.utils
+
+import at.hannibal2.skyhanni.config.Storage.ProfileSpecific.SlayerProfitList.ProfitTrackerItem
+import at.hannibal2.skyhanni.data.SlayerAPI
+import at.hannibal2.skyhanni.features.bazaar.BazaarApi.Companion.getBazaarData
+import at.hannibal2.skyhanni.features.bazaar.BazaarData
+import at.hannibal2.skyhanni.features.slayer.SlayerItemProfitTracker
+import at.hannibal2.skyhanni.test.PriceSource
+import at.hannibal2.skyhanni.utils.LorenzUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.LorenzUtils.addSelector
+import at.hannibal2.skyhanni.utils.LorenzUtils.sortedDesc
+import at.hannibal2.skyhanni.utils.NEUItems.getNpcPrice
+import at.hannibal2.skyhanni.utils.NEUItems.getPrice
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+
+class ProfitTracker {
+
+    enum class DisplayMode(val displayName: String) {
+        TOTAL("Total"),
+        CURRENT("This Session"),
+        ;
+    }
+
+    open class AbstractProfitList<ListData>(
+        private val total: ProfitListWrapper<ListData>,
+        private val currentSession: ProfitListWrapper<ListData>,
+        private val update: () -> Unit,
+    ) {
+        var inventoryOpen = false
+        var lastClickDelay = 0L
+        private var currentDisplayMode = DisplayMode.TOTAL
+
+        fun modify(modifyFunction: (ListData) -> Unit) {
+            modifyFunction(total.getType())
+            modifyFunction(currentSession.getType())
+        }
+
+        fun get(displayMode: DisplayMode) = when (displayMode) {
+            DisplayMode.TOTAL -> total
+            DisplayMode.CURRENT -> currentSession
+        }
+
+        private fun resetData(displayMode: DisplayMode) {
+            val list = get(displayMode)
+            list.reset()
+        }
+
+        fun drawDisplay(title: String) = buildList<List<Any>> {
+//            val both = currentLog() ?: return@buildList
+            val itemLog = get(currentDisplayMode)
+
+            addAsSingletonList(title)
+            if (inventoryOpen) {
+                addSelector<DisplayMode>(
+                        "§7Display Mode: ",
+                        getName = { type -> type.displayName },
+                        isCurrent = { it == currentDisplayMode },
+                        onChange = {
+                            currentDisplayMode = it
+                            update()
+                        }
+                )
+            }
+
+            var profit = 0.0
+            val map = mutableMapOf<Renderable, Long>()
+
+//            for ((internalName, itemProfit) in itemLog.items) {
+            for ((internalName, itemProfit) in itemLog.getList()) {
+                val amount = itemProfit.totalAmount
+
+                val price = (getPrice(internalName) * amount).toLong()
+
+                val cleanName = SlayerAPI.getNameWithEnchantmentFor(internalName)
+                var name = cleanName
+                val priceFormat = NumberUtil.format(price)
+                val hidden = itemProfit.hidden
+                if (hidden) {
+                    while (name.startsWith("§f")) {
+                        name = name.substring(2)
+                    }
+                    name = StringUtils.addFormat(name, "§m")
+                }
+                val text = " §7${amount.addSeparators()}x $name§7: §6$priceFormat"
+
+                val timesDropped = itemProfit.timesDropped
+                val percentage = timesDropped.toDouble() / itemLog.slayerCompletedCount
+                val perBoss = LorenzUtils.formatPercentage(percentage.coerceAtMost(1.0))
+
+                val renderable = if (inventoryOpen) Renderable.clickAndHover(
+                        text, listOf(
+                        "§7Dropped §e${timesDropped.addSeparators()} §7times.",
+                        "§7Your drop rate: §c$perBoss",
+                        "",
+                        "§eClick to " + (if (hidden) "show" else "hide") + "!",
+                        "§eControl + Click to remove this item!",
+                )
+                ) {
+                    if (System.currentTimeMillis() > lastClickDelay + 150) {
+
+                        if (LorenzUtils.isControlKeyDown()) {
+                            itemLog.getList().remove(internalName)
+//                            itemLog.items.remove(internalName)
+                            LorenzUtils.chat("§e[SkyHanni] Removed $cleanName §efrom slayer profit display.")
+                            lastClickDelay = System.currentTimeMillis() + 500
+                        } else {
+                            itemProfit.hidden = !hidden
+                            lastClickDelay = System.currentTimeMillis()
+                        }
+                        update()
+                    }
+                } else Renderable.string(text)
+                if (inventoryOpen || !hidden) {
+                    map[renderable] = price
+                }
+                profit += price
+            }
+            val mobKillCoins = itemLog.mobKillCoins
+            if (mobKillCoins != 0L) {
+                val mobKillCoinsFormat = NumberUtil.format(mobKillCoins)
+                map[Renderable.hoverTips(
+                        " §7Mob kill coins: §6$mobKillCoinsFormat",
+                        listOf(
+                                "§7Killing mobs gives you coins (more with scavenger)",
+                                "§7You got §e$mobKillCoinsFormat §7coins in total this way"
+                        )
+                )] = mobKillCoins
+                profit += mobKillCoins
+            }
+            val slayerSpawnCost = itemLog.slayerSpawnCost
+            if (slayerSpawnCost != 0L) {
+                val mobKillCoinsFormat = NumberUtil.format(slayerSpawnCost)
+                map[Renderable.hoverTips(
+                        " §7Slayer Spawn Costs: §c$mobKillCoinsFormat",
+                        listOf("§7You paid §c$mobKillCoinsFormat §7in total", "§7for starting the slayer quests.")
+                )] = slayerSpawnCost
+                profit += slayerSpawnCost
+            }
+
+            for (text in map.sortedDesc().keys) {
+                addAsSingletonList(text)
+            }
+
+            val slayerCompletedCount = itemLog.slayerCompletedCount
+            addAsSingletonList(
+                    Renderable.hoverTips(
+                            "§7Bosses killed: §e${slayerCompletedCount.addSeparators()}",
+                            listOf("§7You killed the ${itemLogCategory} boss", "§e${slayerCompletedCount.addSeparators()} §7times.")
+                    )
+            )
+
+            val profitFormat = NumberUtil.format(profit)
+            val profitPrefix = if (profit < 0) "§c" else "§6"
+
+            val profitPerBoss = profit / itemLog.slayerCompletedCount
+            val profitPerBossFormat = NumberUtil.format(profitPerBoss)
+
+            val text = "§eTotal Profit: $profitPrefix$profitFormat"
+            addAsSingletonList(Renderable.hoverTips(text, listOf("§7Profit per boss: $profitPrefix$profitPerBossFormat")))
+
+            if (inventoryOpen) {
+                addSelector<PriceSource>(
+                        "",
+                        getName = { type -> type.displayName },
+                        isCurrent = { it.ordinal == config.priceFrom },
+                        onChange = {
+                            config.priceFrom = it.ordinal
+                            update()
+                        }
+                )
+            }
+            if (inventoryOpen && currentDisplayMode == DisplayMode.CURRENT) {
+                addAsSingletonList(
+                        Renderable.clickAndHover(
+                                "§cReset session!",
+                                listOf("§cThis will reset your", "§ccurrent session of", title),
+                        ) {
+                            resetData(DisplayMode.CURRENT)
+                            update()
+                        })
+            }
+        }
+
+        fun getPrice(internalName: NEUInternalName) =
+                internalName.getBazaarData()?.let { getPrice(internalName, it) } ?: internalName.getPrice()
+
+        fun getPrice(internalName: NEUInternalName, bazaarData: BazaarData) = when (SlayerItemProfitTracker.config.priceFrom) {
+            0 -> bazaarData.sellPrice
+            1 -> bazaarData.buyPrice
+
+            else -> internalName.getNpcPrice()
+        }
+    }
+}
+
+abstract class ProfitListWrapper<T> {
+    abstract fun reset()
+
+    abstract fun getList(): MutableMap<NEUInternalName, ProfitTrackerItem>
+
+    abstract fun getType(): T
+}


### PR DESCRIPTION
I have tried/started to extract the slayer profit tracker solution into a global abstract data structure.
Allows for easy working with "click to hide", "show session/total stats" or change price format from bazaar buy order/sell offer or lowest bin/average ah or NPC price, and prevents a ton of code duplication.
Useful for all tracker features, also for stuff like armor drops and dicer drops.

This code will currently not compile and needs a way better base design.
Lines like 

```kt
class AbstractSlayerProfitList(
    total: SlayerWrapper<SlayerProfitList>,
    currentSession: SlayerWrapper<SlayerProfitList>,
    update: () -> Unit,
) : ProfitTracker.AbstractProfitList<SlayerProfitList>(total, currentSession, update)
```
cant be the final result.