### PR TITLE
Update MinionCraftHelper Slayer Exclusions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
@@ -150,6 +150,8 @@ class MinionCraftHelper {
                 if (internalId == "REVENANT_GENERATOR_1") continue
                 if (internalId == "TARANTULA_GENERATOR_1") continue
                 if (internalId == "VOIDLING_GENERATOR_1") continue
+                if (internalId == "INFERNO_GENERATOR_1") continue
+                if (internalId == "VAMPIRE_GENERATOR_1") continue
                 tierOneMinions.add(internalId)
             }
 


### PR DESCRIPTION
Add Blaze Slayer and Vampire Slayer Minions to MinionCraftHelper tier 1 exclusions