### PR TITLE
Fix: Wrong Slayer message triggers incorrectly

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
@@ -39,6 +39,7 @@ class SlayerQuestWarning {
         }
         if (message == "  §r§5§lSLAYER QUEST STARTED!") {
             needSlayerQuest = false
+            dirtySidebar = true
         }
 
         //no auto slayer


### PR DESCRIPTION
Easier steps to reproduce:

1. Start rev slayer t1 (autoslayer disabled)
2. Kill rev
3. Restart game client
4. Load back into the hub, talk to Maddox, claim your rev slayer 1 and start a sven slayer 1
5. Go to the castle and get a warning that you have the Wrong Slayer

There are potentially other ways of fixing this but the entire feature needs some code cleanup so I just went with a simple fix for now.