### PR TITLE
Feature: Add spawn timer support for Arachne quickspawns

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mobs/SpawnTimers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mobs/SpawnTimers.kt
@@ -3,14 +3,17 @@ package at.hannibal2.skyhanni.features.mobs
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.LorenzChatEvent
-import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
+import at.hannibal2.skyhanni.events.PacketEvent
+import at.hannibal2.skyhanni.utils.*
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
-import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import net.minecraft.network.play.server.S2APacketParticles
+import net.minecraft.util.EnumParticleTypes
 import net.minecraftforge.client.event.RenderWorldLastEvent
+import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
@@ -21,6 +24,19 @@ class SpawnTimers {
     private var arachneSpawnTime = SimpleTimeMark.farPast()
     private val arachneFragmentMessage = "^☄ [a-z0-9_]{2,22} placed an arachne's calling! something is awakening! \\(4/4\\)\$".toRegex()
     private val arachneCrystalMessage = "^☄ [a-z0-9_]{2,22} placed an arachne crystal! something is awakening!$".toRegex()
+    private var saveNextTickParticles = false
+    private var particleCounter = 0
+    private var tickTime: Long = 0
+    private var searchTime: Long = 0
+
+    @SubscribeEvent
+    fun onWorldChange(event: LorenzWorldChangeEvent) {
+        searchTime = 0
+        tickTime = 0
+        particleCounter = 0
+        saveNextTickParticles = false
+        arachneSpawnTime = SimpleTimeMark.farPast()
+    }
 
     @SubscribeEvent
     fun onRenderWorld(event: RenderWorldLastEvent) {
@@ -38,10 +54,40 @@ class SpawnTimers {
         val message = event.message.removeColor().lowercase()
 
         if (arachneFragmentMessage.matches(message) || arachneCrystalMessage.matches(message)) {
-            arachneSpawnTime = if (arachneCrystalMessage.matches(message))
-                SimpleTimeMark.now() + 24.seconds
-            else
-                SimpleTimeMark.now() + 19.seconds
+            if (arachneCrystalMessage.matches(message)) {
+                saveNextTickParticles = true
+                searchTime = System.currentTimeMillis()
+                particleCounter = 0
+                tickTime = 0L
+            } else arachneSpawnTime = SimpleTimeMark.now() + 19.seconds
+        }
+    }
+
+    // All this to detect "quickspawn" vs regular arachne spawn
+    @SubscribeEvent(priority = EventPriority.LOW, receiveCanceled = true)
+    fun onChatPacket(event: PacketEvent.ReceiveEvent) {
+        if (!saveNextTickParticles) return
+        if (System.currentTimeMillis() <= searchTime + 3000) return
+
+        if (particleCounter == 0 && tickTime == 0L) tickTime = System.currentTimeMillis()
+
+        if (System.currentTimeMillis() > tickTime + 60) {
+            arachneSpawnTime = if (particleCounter <= 20)  {
+                SimpleTimeMark.now() + 21.seconds
+            } else {
+                SimpleTimeMark.now() + 37.seconds
+            }
+            saveNextTickParticles = false
+            return
+        }
+
+        val packet = event.packet
+        if (packet is S2APacketParticles) {
+            val location = packet.toLorenzVec().round(2)
+            if (arachneAltarLocation.distance(location) > 30) return
+            if (packet.particleType == EnumParticleTypes.REDSTONE && packet.particleSpeed == 1.0f) {
+                particleCounter += 1
+            }
         }
     }
 


### PR DESCRIPTION
This cost me so much precious enchanted string to test 😭 😭 😭 

In all my tests, quickspawning only ever had particles once, most of the time it had zero. Regular spawning always had 60+, so these margins should be fairly safe. Same with the offset from the chat message. I did about 15 tests with a mix of regular vs quickspawns to confirm. Tests that consumed enchanted string I needed for rev viscera 😭 