### PR TITLE
Fix double rendering of item tooltips with chat triggers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
@@ -54,8 +54,9 @@ public abstract class MixinGuiContainer extends GuiScreen {
     @Inject(method = "drawScreen",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/client/renderer/GlStateManager;popMatrix()V",
-                    shift = At.Shift.AFTER
+                    target = "Lnet/minecraft/entity/player/InventoryPlayer;getItemStack()Lnet/minecraft/item/ItemStack;",
+                    shift = At.Shift.BEFORE,
+                    ordinal = 1
             )
     )
     public void drawScreen_after(int mouseX, int mouseY, float partialTicks, CallbackInfo ci) {


### PR DESCRIPTION
The root cause here is
https://github.com/ChatTriggers/ChatTriggers/blob/master/src/main/kotlin/com/chattriggers/ctjs/launch/plugin/guiContainer.kt not separating their code into its own method, so the original injection point would find their popMatrix attribute as well as the vanilla one. I changed this to now use a different injection point which is not being used by chattriggers. The real fix would be to just move the chattriggers code into a hook method.