### PR TITLE
Internal Changes: add support for compacted numbers parsing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -195,7 +195,7 @@ object ItemUtils {
 
     fun isSkyBlockMenuItem(stack: ItemStack?): Boolean = stack?.getInternalName_old() == "SKYBLOCK_MENU"
 
-    private val patternInFront = "(?: *§8(\\+§[\\d\\w])?(?<amount>[\\dkm,]+)(x )?)?(?<name>.*)".toPattern()
+    private val patternInFront = "(?: *§8(\\+§[\\d\\w])?(?<amount>[\\d\\.km,]+)(x )?)?(?<name>.*)".toPattern()
     private val patternBehind = "(?<name>(?:['\\w-]+ ?)+)(?:§8x(?<amount>[\\d,]+))?".toPattern()
 
     private val itemAmountCache = mutableMapOf<String, Pair<String, Int>>()

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.cachedData
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRecombobulated
 import at.hannibal2.skyhanni.utils.StringUtils.matchRegex
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.NumberUtil.formatNumber
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 import net.minecraft.client.Minecraft
@@ -15,6 +16,7 @@ import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
 import net.minecraftforge.common.util.Constants
 import java.util.LinkedList
+import java.util.regex.Matcher
 import kotlin.time.Duration.Companion.seconds
 
 object ItemUtils {
@@ -193,7 +195,7 @@ object ItemUtils {
 
     fun isSkyBlockMenuItem(stack: ItemStack?): Boolean = stack?.getInternalName_old() == "SKYBLOCK_MENU"
 
-    private val patternInFront = "(?: *§8(?<amount>[\\d,]+)x )?(?<name>.*)".toPattern()
+    private val patternInFront = "(?: *§8(\\+§[\\d\\w])?(?<amount>[\\dkm,]+)(x )?)?(?<name>.*)".toPattern()
     private val patternBehind = "(?<name>(?:['\\w-]+ ?)+)(?:§8x(?<amount>[\\d,]+))?".toPattern()
 
     private val itemAmountCache = mutableMapOf<String, Pair<String, Int>>()
@@ -212,10 +214,7 @@ object ItemUtils {
         if (matcher.matches()) {
             val itemName = matcher.group("name")
             if (!itemName.contains("§8x")) {
-                val amount = matcher.group("amount")?.replace(",", "")?.toInt() ?: 1
-                val pair = Pair(itemName.trim(), amount)
-                itemAmountCache[input] = pair
-                return pair
+                return makePair(input, itemName.trim(), matcher)
             }
         }
 
@@ -231,7 +230,12 @@ object ItemUtils {
         }
 
         val itemName = color + matcher.group("name").trim()
-        val amount = matcher.group("amount")?.replace(",", "")?.toInt() ?: 1
+        return makePair(input, itemName, matcher)
+    }
+
+    private fun makePair(input: String, itemName: String, matcher: Matcher): Pair<String, Int> {
+        val matcherAmount = matcher.group("amount")
+        val amount = matcherAmount?.formatNumber()?.toInt() ?: 1;
         val pair = Pair(itemName, amount)
         itemAmountCache[input] = pair
         return pair

--- a/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
@@ -1,0 +1,41 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.isEnchanted
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHotPotatoCount
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getItemUuid
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeName
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.hasArtOfPeace
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRecombobulated
+import org.junit.jupiter.api.Test
+import kotlin.math.exp
+
+class ItemUtilsTest {
+
+    val items: MutableMap<String, Pair<String, Int>> = mutableMapOf(
+            "§5Hoe of Greatest Tilling" to Pair("§5Hoe of Greatest Tilling", 1),
+            "§fSilver medal §8x2" to Pair("§fSilver medal", 2),
+            "§aJacob's Ticket §8x32" to Pair("§aJacob's Ticket", 32),
+            "§9Delicate V" to Pair("§9Delicate V", 1),
+            "  §81x §9Enchanted Sugar Cane" to Pair("§9Enchanted Sugar Cane", 1),
+            "§6Gold medal" to Pair("§6Gold medal", 1),
+            " §8+§319k §7Farming XP" to Pair("§7Farming XP", 19_000),
+            " §8+§215 §7Garden Experience" to Pair("§7Garden Experience", 15),
+            " §8+§c21 Copper" to Pair("Copper", 21),
+            " §8+§b10 Bits" to Pair("Bits", 10),
+    )
+
+    @Test
+    fun testReadItemAmount() {
+        for ((itemString, expected) in items) {
+            val results = ItemUtils.readItemAmount(itemString)
+            assert(results != null) {
+                "Could not read item '$itemString'"
+            }
+            assert(results?.equals(expected) == true) {
+                "'${results.toString()}' does not match '$expected'"
+            }
+        }
+    }
+}

--- a/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
@@ -16,6 +16,7 @@ class ItemUtilsTest {
             " §8+§215 §7Garden Experience" to Pair("§7Garden Experience", 15),
             " §8+§c21 Copper" to Pair("Copper", 21),
             " §8+§b10 Bits" to Pair("Bits", 10),
+            " §8+§37.2k §7Farming XP" to Pair("§7Farming XP", 7_200),
     )
 
     @Test

--- a/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
@@ -1,15 +1,7 @@
 package at.hannibal2.skyhanni.test
 
 import at.hannibal2.skyhanni.utils.ItemUtils
-import at.hannibal2.skyhanni.utils.ItemUtils.isEnchanted
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHotPotatoCount
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getItemUuid
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeName
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.hasArtOfPeace
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRecombobulated
 import org.junit.jupiter.api.Test
-import kotlin.math.exp
 
 class ItemUtilsTest {
 


### PR DESCRIPTION
This PR does add support for item amounts with compacted numbers

e.g.

`10k` `1m`

This also adds support for another amount prefix from the garden visitor rewards
e.g.
```
 §8+§319k §7Farming XP
 §8+§215 §7Garden Experience
 §8+§c21 Copper
 §8+§b10 Bits
```

Additionally i pulled log of items that did get pushed through this by visiting anita, the composter, and the garden plot configuration

```
§5Basket of Seeds
§5Hoe of Greatest Tilling
§6Gold medal
§9Delicate V
§9Nether Wart Pouch
§aJacob's Ticket
§aJacob's Ticket §8x20
§aJacob's Ticket §8x30
§aJacob's Ticket §8x32
§cBronze medal
§fSilver medal
§fSilver medal §8x2
  §81x §9Enchanted Sugar Cane
```

Tested on the places i could find of the usage from it

I am not 100% sure if i got all the places it gets used, if i missed something, let me know, i ll go ahead and add those test cases.