### PR TITLE
Add NBT Copy Keybind

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/DevConfig.java
@@ -82,7 +82,13 @@ public class DevConfig {
     public boolean showItemUuid = false;
 
     @Expose
-    @ConfigOption(name = "Copy NBT Data", desc = "Copies compressed NBT data on key press in a GUI")
+    @ConfigOption(name = "Copy NBT Data", desc = "Copies NBT data on key press in a GUI")
+    @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
+    @ConfigAccordionId(id = 0)
+    public int copyNBTData = Keyboard.KEY_NONE;
+
+    @Expose
+    @ConfigOption(name = "Copy Compressed NBT Data", desc = "Copies compressed NBT data on key press in a GUI")
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     @ConfigAccordionId(id = 0)
     public int copyNBTDataCompressed = Keyboard.KEY_NONE;

--- a/src/main/java/at/hannibal2/skyhanni/test/TestExportTools.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestExportTools.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.test
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.test.command.CopyItemCommand.copyItemToClipboard
 import at.hannibal2.skyhanni.utils.ItemStackTypeAdapterFactory
 import at.hannibal2.skyhanni.utils.KSerializable
 import at.hannibal2.skyhanni.utils.KotlinTypeAdapterFactory
@@ -19,6 +20,8 @@ import java.io.InputStreamReader
 import java.io.Reader
 
 object TestExportTools {
+    private val config get() = SkyHanniMod.feature.dev
+
     val gson = GsonBuilder()
         .registerTypeAdapterFactory(KotlinTypeAdapterFactory())
         .registerTypeAdapter(NBTTagCompound::class.java, NBTTypeAdapter)
@@ -47,13 +50,18 @@ object TestExportTools {
 
     @SubscribeEvent
     fun onKeybind(event: GuiScreenEvent.KeyboardInputEvent.Post) {
-        if (!OSUtils.isKeyHeld(SkyHanniMod.feature.dev.copyNBTDataCompressed)) return
+
+        if (!OSUtils.isKeyHeld(config.copyNBTDataCompressed) && !OSUtils.isKeyHeld(config.copyNBTData)) return
         val gui = event.gui as? GuiContainer ?: return
         val focussedSlot = gui.slotUnderMouse ?: return
         val stack = focussedSlot.stack ?: return
+        if (OSUtils.isKeyHeld(config.copyNBTData)) {
+            copyItemToClipboard(stack)
+            return
+        }
         val json = toJson(Item, stack)
         OSUtils.copyToClipboard(json)
-        LorenzUtils.chat("Copied test importable to clipbooard")
+        LorenzUtils.chat("Copied test importable to clipboard")
     }
 
 

--- a/src/main/java/at/hannibal2/skyhanni/test/TestExportTools.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestExportTools.kt
@@ -51,7 +51,7 @@ object TestExportTools {
 
     @SubscribeEvent
     fun onKeybind(event: GuiScreenEvent.KeyboardInputEvent.Post) {
-        if (config.copyNBTDataCompressed.isKeyHeld() && config.copyNBTData.isKeyHeld()) return
+        if (!config.copyNBTDataCompressed.isKeyHeld() && !config.copyNBTData.isKeyHeld()) return
         val gui = event.gui as? GuiContainer ?: return
         val focussedSlot = gui.slotUnderMouse ?: return
         val stack = focussedSlot.stack ?: return

--- a/src/main/java/at/hannibal2/skyhanni/test/TestExportTools.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestExportTools.kt
@@ -51,11 +51,11 @@ object TestExportTools {
 
     @SubscribeEvent
     fun onKeybind(event: GuiScreenEvent.KeyboardInputEvent.Post) {
-        if (!OSUtils.isKeyHeld(config.copyNBTDataCompressed) && !OSUtils.isKeyHeld(config.copyNBTData)) return
+        if (config.copyNBTDataCompressed.isKeyHeld() && config.copyNBTData.isKeyHeld()) return
         val gui = event.gui as? GuiContainer ?: return
         val focussedSlot = gui.slotUnderMouse ?: return
         val stack = focussedSlot.stack ?: return
-        if (OSUtils.isKeyHeld(config.copyNBTData)) {
+        if (config.copyNBTData.isKeyHeld()) {
             copyItemToClipboard(stack)
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
@@ -6,33 +6,15 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getMinecraftId
+import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 
 object CopyItemCommand {
 
     fun command() {
         try {
-            val resultList = mutableListOf<String>()
-            val itemStack = InventoryUtils.getItemInHand() ?: return
-            resultList.add("ITEM LORE")
-            resultList.add("display name: '" + itemStack.displayName.toString() + "'")
-            val itemID = itemStack.getInternalName_old()
-            resultList.add("internalName: '$itemID'")
-            resultList.add("minecraft id: '" + itemStack.getMinecraftId() + "'")
-            resultList.add("lore:")
-            for (line in itemStack.getLore()) {
-                resultList.add(" '$line'")
-            }
-            resultList.add("")
-            resultList.add("getTagCompound")
-            if (itemStack.hasTagCompound()) {
-                val tagCompound = itemStack.tagCompound
-                recurseTag(tagCompound, "  ", resultList)
-            }
-
-            val string = resultList.joinToString("\n")
-            OSUtils.copyToClipboard(string)
-            LorenzUtils.chat("§e[SkyHanni] Item info copied into the clipboard!")
+            val itemStack = InventoryUtils.getItemInHand() ?: throw Exception()
+            copyItemToClipboard(itemStack)
         } catch (_: Throwable) {
             LorenzUtils.chat("§c[SkyHanni] No item in hand!")
         }
@@ -53,4 +35,26 @@ object CopyItemCommand {
         }
     }
 
+    fun copyItemToClipboard(itemStack: ItemStack){
+        val resultList = mutableListOf<String>()
+        resultList.add("ITEM LORE")
+        resultList.add("display name: '" + itemStack.displayName.toString() + "'")
+        val itemID = itemStack.getInternalName_old()
+        resultList.add("internalName: '$itemID'")
+        resultList.add("minecraft id: '" + itemStack.getMinecraftId() + "'")
+        resultList.add("lore:")
+        for (line in itemStack.getLore()) {
+            resultList.add(" '$line'")
+        }
+        resultList.add("")
+        resultList.add("getTagCompound")
+        if (itemStack.hasTagCompound()) {
+            val tagCompound = itemStack.tagCompound
+            recurseTag(tagCompound, "  ", resultList)
+        }
+
+        val string = resultList.joinToString("\n")
+        OSUtils.copyToClipboard(string)
+        LorenzUtils.chat("§e[SkyHanni] Item info copied into the clipboard!")
+    }
 }


### PR DESCRIPTION
Add NBT Copy Config
Refactor copy item functionality code to be in separate function
Change compressed nbt config name to "Copy Compressed NBT Data"
Fix typo in word "clipboard"
Fix bug where "no item in hand message" was not sending

This is revised based on feedback in #558 