### PR TITLE
Fix: Limbo Timer Showing Elsewhere

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/LimboTimeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/LimboTimeTracker.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.time.Duration.Companion.seconds
 
 class LimboTimeTracker {
     private val config get() = SkyHanniMod.feature.misc
@@ -28,11 +27,7 @@ class LimboTimeTracker {
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         if (!inLimbo) return
-
-        val passedSince = limboJoinTime.passedSince()
-        if (passedSince > 5.seconds) {
-            leaveLimbo()
-        }
+        leaveLimbo()
     }
 
     @SubscribeEvent


### PR DESCRIPTION
in my opinion, there does not need to be a time check here. I guess there could be another check each time it is displayed to see if we are in limbo or not but this should fix any issues with it