### PR TITLE
fix(UnitTests): double registration of blocks/items

### DIFF
--- a/src/test/java/at/hannibal2/skyhanni/test/BootstrapHook.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/BootstrapHook.kt
@@ -14,15 +14,20 @@ import java.util.concurrent.locks.ReentrantLock
 class BootstrapHook : BeforeAllCallback, Extension {
     companion object {
         private val LOCK: Lock = ReentrantLock()
+        private var bootstrapped = false
     }
 
     override fun beforeAll(p0: ExtensionContext?) {
         LOCK.lock()
         try {
-            Bootstrap::class.java.getDeclaredField("alreadyRegistered").makeAccessible().set(null, true)
-            Block.registerBlocks()
-            BlockFire.init()
-            Item.registerItems()
+            if (!bootstrapped) {
+                bootstrapped = true
+
+                Bootstrap::class.java.getDeclaredField("alreadyRegistered").makeAccessible().set(null, true)
+                Block.registerBlocks()
+                BlockFire.init()
+                Item.registerItems()
+            }
         } finally {
             LOCK.unlock()
         }

--- a/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
@@ -1,0 +1,34 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.utils.ItemUtils
+import org.junit.jupiter.api.Test
+
+class ItemUtilsTest {
+
+    val items: MutableMap<String, Pair<String, Int>> = mutableMapOf(
+            "§5Hoe of Greatest Tilling" to Pair("§5Hoe of Greatest Tilling", 1),
+            "§fSilver medal §8x2" to Pair("§fSilver medal", 2),
+            "§aJacob's Ticket §8x32" to Pair("§aJacob's Ticket", 32),
+            "§9Delicate V" to Pair("§9Delicate V", 1),
+            "  §81x §9Enchanted Sugar Cane" to Pair("§9Enchanted Sugar Cane", 1),
+            "§6Gold medal" to Pair("§6Gold medal", 1),
+            " §8+§319k §7Farming XP" to Pair("§7Farming XP", 19_000),
+            " §8+§215 §7Garden Experience" to Pair("§7Garden Experience", 15),
+            " §8+§c21 Copper" to Pair("Copper", 21),
+            " §8+§b10 Bits" to Pair("Bits", 10),
+            " §8+§37.2k §7Farming XP" to Pair("§7Farming XP", 7_200),
+    )
+
+    @Test
+    fun testReadItemAmount() {
+        for ((itemString, expected) in items) {
+            val results = ItemUtils.readItemAmount(itemString)
+            assert(results != null) {
+                "Could not read item '$itemString'"
+            }
+            assert(results?.equals(expected) == true) {
+                "'${results.toString()}' does not match '$expected'"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This reverts commit 202759b.

And add the fix to run all unit tests in multiple test class files

![image](https://github.com/hannibal002/SkyHanni/assets/720645/43d87465-b646-4714-9cb7-e0d13ab79fcb)


This closes this PR as well #575

Since we can keep the tests how they are