### PR TITLE
Backend: Disable Diana when not Diana

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/EventConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/EventConfig.java
@@ -195,6 +195,11 @@ public class EventConfig {
         @ConfigEditorBoolean
         @FeatureToggle
         public boolean petWarning = true;
+
+        @Expose
+        @ConfigOption(name = "Always Diana", desc = "Forcefully set the Diana event to be active. This is useful if the auto mayor detection fails.")
+        @ConfigEditorBoolean
+        public boolean alwaysDiana = false;
     }
 
     @ConfigOption(name = "Winter Season on Jerry's Island", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzKeyPressEvent
 import at.hannibal2.skyhanni.utils.LocationUtils
@@ -19,8 +18,7 @@ class BurrowWarpHelper {
 
     @SubscribeEvent
     fun onKeyClick(event: LorenzKeyPressEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-        if (LorenzUtils.skyBlockIsland != IslandType.HUB) return
+        if (!DianaAPI.featuresEnabled()) return
         if (!config.burrowNearestWarp) return
 
         if (event.keyCode != config.keyBindWarp) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaAPI.kt
@@ -1,14 +1,19 @@
 package at.hannibal2.skyhanni.features.event.diana
 
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.MayorElection
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 
 object DianaAPI {
     fun hasSpadeInHand() = InventoryUtils.itemInHandId.equals("ANCESTRAL_SPADE")
 
-    fun isRitualActive() = MayorElection.isPerkActive("Diana", "Mythological Ritual") ||
-            MayorElection.isPerkActive("Jerry", "Perkpocalypse")
+    private fun isRitualActive() = MayorElection.isPerkActive("Diana", "Mythological Ritual") ||
+            MayorElection.isPerkActive("Jerry", "Perkpocalypse") || SkyHanniMod.feature.event.diana.alwaysDiana
 
     fun hasGriffinPet() = ProfileStorageData.profileSpecific?.currentPet?.contains("Griffin") ?: false
+
+    fun featuresEnabled() = isRitualActive() && IslandType.HUB.isInIsland()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -96,6 +96,7 @@ object GriffinBurrowHelper {
 
     @SubscribeEvent
     fun onPlayerMove(event: EntityMoveEvent) {
+        if (!DianaAPI.featuresEnabled()) return
         if (event.distance > 10 && event.entity == Minecraft.getMinecraft().thePlayer) {
             teleportedLocation = event.newLocation
         }
@@ -103,6 +104,7 @@ object GriffinBurrowHelper {
 
     @SubscribeEvent
     fun onChatMessage(event: LorenzChatEvent) {
+        if (!DianaAPI.featuresEnabled()) return
         if (event.message.startsWith("§c ☠ §r§7You were killed by §r")) {
             particleBurrows = particleBurrows.editCopy { keys.removeIf { this[it] == BurrowType.MOB } }
         }
@@ -142,6 +144,7 @@ object GriffinBurrowHelper {
 
     @SubscribeEvent
     fun onRenderWorld(event: LorenzRenderWorldEvent) {
+        if (!DianaAPI.featuresEnabled()) return
         sendTip(event)
 
         val playerLocation = LocationUtils.playerLocation()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.BurrowDetectEvent
 import at.hannibal2.skyhanni.events.BurrowDugEvent
@@ -9,12 +8,9 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
-import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName_old
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.init.Blocks
-import net.minecraft.item.ItemStack
 import net.minecraft.network.play.server.S2APacketParticles
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -28,9 +24,8 @@ class GriffinBurrowParticleFinder {
 
     @SubscribeEvent(priority = EventPriority.LOW, receiveCanceled = true)
     fun onChatPacket(event: PacketEvent.ReceiveEvent) {
-        if (!LorenzUtils.inSkyBlock) return
+        if (!DianaAPI.featuresEnabled()) return
         if (!config.burrowsSoopyGuess) return
-        if (LorenzUtils.skyBlockIsland != IslandType.HUB) return
         val packet = event.packet
 
         if (packet is S2APacketParticles) {
@@ -101,7 +96,7 @@ class GriffinBurrowParticleFinder {
     @SubscribeEvent
     fun onChatMessage(event: LorenzChatEvent) {
         if (!config.burrowsSoopyGuess) return
-        if (LorenzUtils.skyBlockIsland != IslandType.HUB) return
+        if (!DianaAPI.featuresEnabled()) return
         val message = event.message
         if (message.startsWith("§eYou dug out a Griffin Burrow!") ||
             message == "§eYou finished the Griffin burrow chain! §r§7(4/4)"
@@ -121,20 +116,16 @@ class GriffinBurrowParticleFinder {
 
     @SubscribeEvent
     fun onBlockClick(event: BlockClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
+        if (!DianaAPI.featuresEnabled()) return
         if (!config.burrowsSoopyGuess) return
-        if (LorenzUtils.skyBlockIsland != IslandType.HUB) return
 
         val pos = event.position
-        if (event.itemInHand?.isSpade != true || pos.getBlockAt() !== Blocks.grass) return
+        if (!DianaAPI.hasSpadeInHand() || pos.getBlockAt() !== Blocks.grass) return
 
         if (burrows.containsKey(pos)) {
             lastDugParticleBurrow = pos
         }
     }
-
-    private val ItemStack.isSpade
-        get() = getInternalName_old() == "ANCESTRAL_SPADE"
 
     class Burrow(
         var location: LorenzVec,

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -8,9 +8,11 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName_old
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.init.Blocks
+import net.minecraft.item.ItemStack
 import net.minecraft.network.play.server.S2APacketParticles
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -120,12 +122,15 @@ class GriffinBurrowParticleFinder {
         if (!config.burrowsSoopyGuess) return
 
         val pos = event.position
-        if (!DianaAPI.hasSpadeInHand() || pos.getBlockAt() !== Blocks.grass) return
+        if (event.itemInHand?.isSpade != true || pos.getBlockAt() !== Blocks.grass) return
 
         if (burrows.containsKey(pos)) {
             lastDugParticleBurrow = pos
         }
     }
+
+    private val ItemStack.isSpade
+        get() = getInternalName_old() == "ANCESTRAL_SPADE"
 
     class Burrow(
         var location: LorenzVec,

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinPetWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinPetWarning.kt
@@ -1,10 +1,8 @@
 package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
@@ -15,9 +13,8 @@ class GriffinPetWarning {
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
         if (!event.isMod(20)) return
-        if (!IslandType.HUB.isInIsland()) return
         if (!SkyHanniMod.feature.event.diana.petWarning) return
-        if (!DianaAPI.isRitualActive()) return
+        if (!DianaAPI.featuresEnabled()) return
         if (!DianaAPI.hasSpadeInHand()) return
 
         if (!DianaAPI.hasGriffinPet() && lastWarnTime.passedSince() > 30.seconds) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.event.diana
 
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzKeyPressEvent
@@ -249,7 +248,7 @@ object InquisitorWaypointShare {
         }
     }
 
-    fun isEnabled() = LorenzUtils.inSkyBlock && LorenzUtils.skyBlockIsland == IslandType.HUB && config.enabled
+    fun isEnabled() = DianaAPI.featuresEnabled() && config.enabled
 
     fun maybeRemove(playerName: String) {
         if (inquisitorsNearby.isEmpty()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/SoopyGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/SoopyGuessBurrow.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
@@ -282,6 +281,6 @@ class SoopyGuessBurrow {
     }
 
     private fun isEnabled(): Boolean {
-        return LorenzUtils.inSkyBlock && LorenzUtils.skyBlockIsland == IslandType.HUB && SkyHanniMod.feature.event.diana.burrowsSoopyGuess
+        return DianaAPI.featuresEnabled() && SkyHanniMod.feature.event.diana.burrowsSoopyGuess
     }
 }


### PR DESCRIPTION
Stops some stuff from happening when its not Diana which should slightly increase performance
Adds force Diana option in case mayor detection fails