### PR TITLE
Internal Change: Replace void with unit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -117,8 +117,8 @@ class RepoManager(private val configLocation: File) {
         }
     }
 
-    private fun reloadRepository(answerMessage: String = ""): CompletableFuture<Void?> {
-        val comp = CompletableFuture<Void?>()
+    private fun reloadRepository(answerMessage: String = ""): CompletableFuture<Unit?> {
+        val comp = CompletableFuture<Unit?>()
         if (!atomicShouldManuallyReload.get()) return comp
         Minecraft.getMinecraft().addScheduledTask {
             try {


### PR DESCRIPTION
Void is not equivalent to Java void but java.lang.Void.