### PR TITLE
Feature: Highlighted Motes Orbs Size

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/RiftConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/RiftConfig.java
@@ -694,6 +694,11 @@ public class RiftConfig {
         public boolean enabled = true;
 
         @Expose
+        @ConfigOption(name = "Highlight Size", desc = "Set render size for highlighted Motes Orbs.")
+        @ConfigEditorSlider(minStep = 1, minValue = 1, maxValue = 5)
+        public int size = 5;
+
+        @Expose
         @ConfigOption(name = "Hide Particles", desc = "Hide normal Motes Orbs particles.")
         @ConfigEditorBoolean
         @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/RiftMotesOrb.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/RiftMotesOrb.kt
@@ -79,12 +79,15 @@ class RiftMotesOrb {
 
             val location = orb.location
 
+            val sizeOffset = (5 - config.size) * -0.1
             if (orb.pickedUp) {
-                event.drawDynamicText(location.add(0.0, 0.5, 0.0), "§7Motes Orb", 1.5, ignoreBlocks = false)
-                event.drawWaypointFilled(location, LorenzColor.GRAY.toColor())
+                event.drawDynamicText(location.add(0.0, 0.5, 0.0), "§7Motes Orb", 1.5 + sizeOffset, ignoreBlocks =
+                false)
+                event.drawWaypointFilled(location, LorenzColor.GRAY.toColor(), extraSize = -sizeOffset)
             } else {
-                event.drawDynamicText(location.add(0.0, 0.5, 0.0), "§dMotes Orb", 1.5, ignoreBlocks = false)
-                event.drawWaypointFilled(location, LorenzColor.LIGHT_PURPLE.toColor())
+                event.drawDynamicText(location.add(0.0, 0.5, 0.0), "§dMotes Orb", 1.5 + sizeOffset, ignoreBlocks =
+                false)
+                event.drawWaypointFilled(location, LorenzColor.LIGHT_PURPLE.toColor(), extraSize = sizeOffset)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/RiftMotesOrb.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/RiftMotesOrb.kt
@@ -83,7 +83,7 @@ class RiftMotesOrb {
             if (orb.pickedUp) {
                 event.drawDynamicText(location.add(0.0, 0.5, 0.0), "§7Motes Orb", 1.5 + sizeOffset, ignoreBlocks =
                 false)
-                event.drawWaypointFilled(location, LorenzColor.GRAY.toColor(), extraSize = -sizeOffset)
+                event.drawWaypointFilled(location, LorenzColor.GRAY.toColor(), extraSize = sizeOffset)
             } else {
                 event.drawDynamicText(location.add(0.0, 0.5, 0.0), "§dMotes Orb", 1.5 + sizeOffset, ignoreBlocks =
                 false)


### PR DESCRIPTION
# What
- Add configuration to set the size of highlighted motes orbs.

# Why
- Default size is too obstructing the view imo.