### PR TITLE
Deprecate string functions where InternalName functions should be used

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -117,6 +117,7 @@ object ItemUtils {
     }
 
     // TODO remove
+    @Deprecated("Use NEUInternalName rather than String", ReplaceWith("getInternalName()"))
     fun ItemStack.getInternalName_old() = getInternalName().asString()
 
     fun ItemStack.getInternalName() = getInternalNameOrNull() ?: NEUInternalName.NONE

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -47,6 +47,7 @@ object NEUItems {
     }
 
     // TODO remove
+    @Deprecated("Use NEUInternalName rather than String", ReplaceWith("getInternalNameFromItemName()"))
     fun getRawInternalName(itemName: String): String {
         return getInternalNameFromItemName(itemName).asString()
     }
@@ -172,6 +173,7 @@ object NEUItems {
     fun getItemStackOrNull(internalName: String) = internalName.asInternalName().getItemStackOrNull()
 
     // TODO remove
+    @Deprecated("Use NEUInternalName rather than String", ReplaceWith("getItemStack()"))
     fun getItemStack(internalName: String, definite: Boolean = false): ItemStack =
         internalName.asInternalName().getItemStack(definite)
 


### PR DESCRIPTION
Makes it harder for new contributions with these to get missed while these are in the process of being removed