### PR TITLE
fix(fire-veil): hide particles from new fire veil animation

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
@@ -27,8 +27,7 @@ class FireVeilWandParticles {
         if (!LorenzUtils.inSkyBlock) return
         if (config.display == 0) return
         if (System.currentTimeMillis() > lastClick + 5_500) return
-
-        if (event.type == EnumParticleTypes.FLAME && event.count == 1 && event.speed == 0f && event.offset.isZero()) {
+        if (event.type == EnumParticleTypes.FLAME && event.speed == 0.55f) {
             event.isCanceled = true
         }
     }


### PR DESCRIPTION
# Why
- new fire veil wand animation breaks hide particle logic 

# Related to
- [discord thread](https://discord.com/channels/997079228510117908/1166396815369838714)