### PR TITLE
Feature: Fish Bait Warnings

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -102,6 +102,7 @@ import at.hannibal2.skyhanni.features.event.jerry.HighlightJerries
 import at.hannibal2.skyhanni.features.event.jerry.frozentreasure.FrozenTreasureTracker
 import at.hannibal2.skyhanni.features.fame.AccountUpgradeReminder
 import at.hannibal2.skyhanni.features.fame.CityProjectFeatures
+import at.hannibal2.skyhanni.features.fishing.BaitChangeWarning
 import at.hannibal2.skyhanni.features.fishing.ChumBucketHider
 import at.hannibal2.skyhanni.features.fishing.FishingHookDisplay
 import at.hannibal2.skyhanni.features.fishing.FishingTimer
@@ -610,6 +611,7 @@ class SkyHanniMod {
         loadModule(ShiftClickEquipment())
         loadModule(LockMouseLook)
         loadModule(DungeonFinderFeatures())
+        loadModule(BaitChangeWarning());
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/FishingConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/FishingConfig.java
@@ -234,6 +234,25 @@ public class FishingConfig {
     }
 
     @Expose
+    @ConfigOption(name = "Bait Warnings", desc = "")
+    @Accordion
+    public FishingBaitWarningsConfig fishingBaitWarning = new FishingBaitWarningsConfig();
+
+    public static class FishingBaitWarningsConfig {
+        @Expose
+        @ConfigOption(name = "Bait Change Warning", desc = "Show warning when fishing bait is changed")
+        @ConfigEditorBoolean
+        @FeatureToggle
+        public boolean baitChangeWarning = false;
+
+        @Expose
+        @ConfigOption(name = "No Bait Warning", desc = "Show warning when no bait is used")
+        @ConfigEditorBoolean
+        @FeatureToggle
+        public boolean noBaitWarning = false;
+    }
+
+    @Expose
     @ConfigOption(name = "Rare Sea Creatures", desc = "")
     @Accordion
     public RareCatches rareCatches = new RareCatches();

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/BaitChangeWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/BaitChangeWarning.kt
@@ -1,0 +1,89 @@
+package at.hannibal2.skyhanni.features.fishing
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
+import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.name
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.getLorenzVec
+import at.hannibal2.skyhanni.utils.toLorenzVec
+import net.minecraft.client.Minecraft
+import net.minecraft.entity.item.EntityItem
+import net.minecraft.entity.projectile.EntityFishHook
+import net.minecraftforge.event.entity.EntityJoinWorldEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.seconds
+
+class BaitChangeWarning {
+    private val config get() = SkyHanniMod.feature.fishing.fishingBaitWarning
+    private var bobber: EntityFishHook? = null
+    private var lastBait: String? = null
+    private var timeLastCast: Long = 0L
+    private var isUsingBait: Boolean = false
+
+    @SubscribeEvent
+    fun onJoinWorld(event: EntityJoinWorldEvent){
+        if(!isEnabled()) return
+        val entity = event.entity ?: return
+        if(entity !is EntityFishHook) return
+        if(entity.angler != Minecraft.getMinecraft().thePlayer) return
+
+        bobber = entity;
+        timeLastCast = System.currentTimeMillis()
+        isUsingBait = false
+    }
+
+    @SubscribeEvent
+    fun onTick(event: LorenzTickEvent){
+        if(!isEnabled() || bobber == null) return
+        //Is there a way to get event sent time to be more accurate?
+        if(System.currentTimeMillis() - timeLastCast < 1000L) return
+
+        if(!isUsingBait && config.noBaitWarning) showNoBaitWarning()
+        reset()
+    }
+
+    fun reset(){
+        bobber = null
+        isUsingBait = false
+    }
+
+    @SubscribeEvent
+    fun onRenderWorld(event: LorenzRenderWorldEvent){
+        if(!isEnabled() || !config.baitChangeWarning) return
+        if(bobber == null) return
+        for(entityItem in EntityUtils.getEntitiesNearby<EntityItem>(bobber!!.getLorenzVec(), 1.5)){
+            val itemStack = entityItem.entityItem
+            var name = itemStack.name ?: continue
+            name = name.removeColor()
+
+            if((!name.endsWith(" Bait") && !name.startsWith("Obfuscated"))
+                || itemStack.stackSize != 1) continue
+
+            isUsingBait = true
+            if(lastBait == null){
+                lastBait = name.removeColor()
+                continue
+            }
+            if(name.removeColor() == lastBait) continue
+            showBaitChangeWarning(lastBait!!, name.removeColor())
+            lastBait = name.removeColor()
+        }
+    }
+
+    fun showBaitChangeWarning(before: String, after: String){
+        SoundUtils.playClickSound()
+        LorenzUtils.sendTitle("§eBait changed!", 2.seconds)
+        LorenzUtils.chat("§e" + before + " -> " + after)
+    }
+
+    fun showNoBaitWarning(){
+        SoundUtils.playErrorSound()
+        LorenzUtils.sendTitle("§cNo bait is used!", 2.seconds)
+    }
+
+    private fun isEnabled() = LorenzUtils.inSkyBlock && FishingAPI.hasFishingRodInHand()
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/ShowFishingItemName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/ShowFishingItemName.kt
@@ -55,7 +55,8 @@ class ShowFishingItemName {
                 if (name.removeColor() == "Stone") continue
 
                 val size = itemStack.stackSize
-                val isBait = name.endsWith(" Bait") && size == 1
+                val isBait = (name.removeColor().startsWith("Obfuscated")
+                    || name.endsWith(" Bait")) && size == 1
                 val prefix = if (!isBait) {
                     "§a§l+"
                 } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
@@ -27,8 +27,7 @@ class FireVeilWandParticles {
         if (!LorenzUtils.inSkyBlock) return
         if (config.display == 0) return
         if (System.currentTimeMillis() > lastClick + 5_500) return
-
-        if (event.type == EnumParticleTypes.FLAME && event.count == 1 && event.speed == 0f && event.offset.isZero()) {
+        if (event.type == EnumParticleTypes.FLAME && event.speed == 0.55f) {
             event.isCanceled = true
         }
     }


### PR DESCRIPTION
# What
- Add option to warn when used bait is changed
- Add option to warn when no bait is used
- Show obfuscated fish as bait instead of caught item

# Related to
[Suggestion on discord](https://discord.com/channels/997079228510117908/1166473391021228032)