### PR TITLE
trying to fix lock mouse lock

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
@@ -2,12 +2,11 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 object LockMouseLook {
-    private var lockedMouse = false
-    private var oldSensitivity = 0F
+    var lockedMouse = false
+//    private var oldSensitivity = 0F
 
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
@@ -17,13 +16,13 @@ object LockMouseLook {
     fun toggleLock() {
         lockedMouse = !lockedMouse
 
-        val gameSettings = Minecraft.getMinecraft().gameSettings
+//        val gameSettings = Minecraft.getMinecraft().gameSettings
         if (lockedMouse) {
-            oldSensitivity = gameSettings.mouseSensitivity
-            gameSettings.mouseSensitivity = -1F / 3F
+//            oldSensitivity = gameSettings.mouseSensitivity
+//            gameSettings.mouseSensitivity = -1F / 3F
             LorenzUtils.chat("§e[SkyHanni] §bMouse rotation is now locked. Type /shmouselock to unlock your rotation")
         } else {
-            gameSettings.mouseSensitivity = oldSensitivity
+//            gameSettings.mouseSensitivity = oldSensitivity
             LorenzUtils.chat("§e[SkyHanni] §bMouse rotation is now unlocked.")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/neu/CustomItemEffectsHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/neu/CustomItemEffectsHook.kt
@@ -1,0 +1,17 @@
+package at.hannibal2.skyhanni.mixins.hooks.neu
+
+import at.hannibal2.skyhanni.features.misc.LockMouseLook
+import net.minecraft.client.Minecraft
+
+object CustomItemEffectsHook {
+
+    @JvmStatic
+    fun getSensMultiplier(): Float {
+        return if (LockMouseLook.lockedMouse) {
+            //        -1F / 3F
+            0f
+        } else {
+            Minecraft.getMinecraft().gameSettings.mouseSensitivity
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/neu/MixinCustomItemEffects.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/neu/MixinCustomItemEffects.java
@@ -1,0 +1,16 @@
+package at.hannibal2.skyhanni.mixins.transformers.neu;
+
+import at.hannibal2.skyhanni.mixins.hooks.neu.CustomItemEffectsHook;
+import io.github.moulberry.notenoughupdates.miscfeatures.CustomItemEffects;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = CustomItemEffects.class, remap = false)
+public class MixinCustomItemEffects {
+
+    @Redirect(method = "getSensMultiplier", at = @At(value = "INVOKE"))
+    private float getSensMultiplier_skyhanni() {
+        return CustomItemEffectsHook.getSensMultiplier();
+    }
+}


### PR DESCRIPTION
Using mixins to mix into neu method that mixes into the part of the code where neu uses `Minecraft.getMinecraft().gameSettings.mouseSensitivity`.
This does not work at all right now.

Using the same mixin as neu doesn't work as this will cause conflicts with @redirect.
