### PR TITLE
Internal change: Remove malware false positive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ folder for how to properly do this. You also may have to disable repo auto updat
 ### Discord IPC
 
 DiscordIPC is a service that SkyHanni uses to send information from SkyBlock to Discord in Rich Presence. <br>
-Specifically, we use [TirelessTraveler's Fork](https://github.com/ILikePlayingGames/DiscordIPC) of a fork of a fork of
+Specifically, we use [NetheriteMiner's Fork](https://github.com/NetheriteMiner/DiscordIPC) of a fork of a fork of a fork of
 the [original](https://github.com/jagrosh/DiscordIPC).
 For info on usage, look
 at [DiscordRPCManager.kt](https://github.com/hannibal002/SkyHanni/blob/beta/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
     forge("net.minecraftforge:forge:1.8.9-11.15.1.2318-1.8.9")
 
     // Discord RPC client
-    shadowImpl("com.github.ILikePlayingGames:DiscordIPC:f91ed4b") {
+    shadowImpl("com.github.NetheriteMiner:DiscordIPC:3106be5") {
         exclude(module = "log4j")
         because("Different version conflicts with Minecraft's Log4J")
         exclude(module = "gson")


### PR DESCRIPTION
This changes the fork of DiscordIPC that we use to one hosted on my GitHub instead of TirelessTraveler's in which the version of JUnixSocket is updated to remove any potential vulnerabilities. I have tested this with VirusTotal and it has stopped complaining, at least for now.