### PR TITLE
Neu version change

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUVersionCheck.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUVersionCheck.kt
@@ -20,9 +20,8 @@ object NEUVersionCheck {
             neuWarning(
                 "NotEnoughUpdates is missing!\n" +
                     "SkyHanni requires the latest version of NotEnoughUpdates to work.\n" +
-                    "You currently need NEU version 2.1.1-Pre-4 or later.\n\n" +
-                    "NEU 2.1 is NOT the latest version.\n\n" +
-                    "NEU 2.1.1 is NOT on the NEU GitHub.\n\n" +
+                    "You currently need NEU version 2.1.1-Pre-4 or later.\n" +
+                    "NEU 2.1 is NOT the latest version.\n" +
                     "Use these links to download the latest version:"
             )
             return
@@ -38,9 +37,8 @@ object NEUVersionCheck {
         }
         neuWarning(
             "NotEnoughUpdates is outdated!\n" +
-                "You currently need NEU version 2.1.1-Pre-4 or later.\n\n" +
-                "NEU 2.1 is NOT the latest version.\n\n" +
-                "NEU 2.1.1 is NOT on the NEU GitHub.\n\n" +
+                "You currently need NEU version 2.1.1-Pre-4 or later.\n" +
+                "NEU 2.1 is NOT the latest version.\n" +
                 "Use these links to download the latest version:"
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUVersionCheck.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUVersionCheck.kt
@@ -19,12 +19,11 @@ object NEUVersionCheck {
         } catch (e: Throwable) {
             neuWarning(
                 "NotEnoughUpdates is missing!\n" +
-                        "SkyHanni requires the latest version of NotEnoughUpdates to work.\n" +
-                        "You currently need NEU version 2.1.1-Alpha-19 or later.\n" +
-                        "NEU 2.1 is NOT the latest version.\n" +
-                        "It is ONLY in the #neu-alphas channel in the NEU discord\n" +
-                        "Or in the #neu-updates channel in the SkyHanni discord\n" +
-                        "Use these links to download the latest version:"
+                    "SkyHanni requires the latest version of NotEnoughUpdates to work.\n" +
+                    "You currently need NEU version 2.1.1-Pre-4 or later.\n\n" +
+                    "NEU 2.1 is NOT the latest version.\n\n" +
+                    "NEU 2.1.1 is NOT on the NEU GitHub.\n\n" +
+                    "Use these links to download the latest version:"
             )
             return
         }
@@ -39,12 +38,10 @@ object NEUVersionCheck {
         }
         neuWarning(
             "NotEnoughUpdates is outdated!\n" +
-                    "You currently need NEU version 2.1.1-Alpha-19 or later.\n\n" +
-                    "NEU 2.1 is NOT the latest version.\n\n" +
-                    "NEU 2.1.1 is NOT on the NEU GitHub.\n\n" +
-                    "It is ONLY in the #neu-alphas channel in the NEU discord\n" +
-                    "Or in the #neu-updates channel in the SkyHanni discord\n" +
-                    "Use these links to download the latest version:"
+                "You currently need NEU version 2.1.1-Pre-4 or later.\n\n" +
+                "NEU 2.1 is NOT the latest version.\n\n" +
+                "NEU 2.1.1 is NOT on the NEU GitHub.\n\n" +
+                "Use these links to download the latest version:"
         )
     }
 
@@ -54,6 +51,7 @@ object NEUVersionCheck {
             Pair("Join SkyHanni Discord", "https://discord.com/invite/skyhanni-997079228510117908"),
             Pair("Open SkyHanni GitHub", "https://github.com/hannibal002/SkyHanni"),
             Pair("Join NEU Discord", "https://discord.gg/moulberry"),
+            Pair("Download Pre-4", "https://github.com/NotEnoughUpdates/NotEnoughUpdates/releases/tag/v2.1.1-pre4"),
         )
         closeMinecraft()
     }


### PR DESCRIPTION
update to pre 4.
as this neu version fixes stuff like api and has the download that doesn't need discord it also makes it the best option until neu has autoupdate