### PR TITLE
Wrong/broken Changelog: Sort of fixed aotj not having cooldown.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
@@ -46,6 +46,7 @@ enum class ItemAbility(
     VOODOO_DOLL_WILTED(3),
     FIRE_FURY_STAFF(20),
     SHADOW_FURY(15, "STARRED_SHADOW_FURY"),
+    ASPECT_OF_THE_JERRY(5,"ASPECT_OF_THE_JERRY_SIGNATURE"),
 
     // doesn't have a sound
     ENDER_BOW("Ender Warp", 30, "Ender Bow"),

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -153,6 +153,15 @@ class ItemAbilityCooldown {
             event.soundName == "random.drink" && event.pitch.round(1) == 1.8f && event.volume == 1.0f -> {
                 ItemAbility.HOLY_ICE.sound()
             }
+            // Aspect of the Jerry
+            event.soundName == "mob.villager.idle" && event.pitch == 1f && event.volume == 1.0f -> {
+                ItemAbility.ASPECT_OF_THE_JERRY.sound()
+            }
+            // Jerry's Aspect of the Jerry (reforge)
+            // TODO fix this sharing cooldown with normal aotj and aotj signature
+            event.soundName == "mob.villager.death" && event.pitch == 0.6507937f && event.volume == 1.0f -> {
+                ItemAbility.ASPECT_OF_THE_JERRY.sound()
+            }
         }
     }
 


### PR DESCRIPTION
When an aotj is reforged with jerry stone, it gets a new ability, and the cooldown of it isn't shared with normal aotj.
Couldn't figure out how to make this work, so in this pr, all 3 share the same cooldown text.