### PR TITLE
Split storage into more files plus code cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni
 
 import at.hannibal2.skyhanni.api.CollectionAPI
+import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.Features
 import at.hannibal2.skyhanni.config.SackData
@@ -304,6 +305,7 @@ import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.MinecraftConsoleFilter.Companion.initLogging
 import at.hannibal2.skyhanni.utils.NEUVersionCheck.checkIfNeuIsLoaded
 import at.hannibal2.skyhanni.utils.TabListData
+import at.hannibal2.skyhanni.utils.jsonobjects.FriendsJson
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -381,7 +383,7 @@ class SkyHanniMod {
         loadModule(GardenAPI)
         loadModule(CollectionAPI())
         loadModule(FarmingContestAPI)
-        loadModule(FriendAPI())
+        loadModule(FriendAPI)
         loadModule(PartyAPI)
         loadModule(GuildAPI)
         loadModule(SlayerAPI)
@@ -647,7 +649,7 @@ class SkyHanniMod {
         configManager.firstLoad()
         initLogging()
         Runtime.getRuntime().addShutdownHook(Thread {
-            configManager.saveConfig("shutdown-hook")
+            configManager.saveConfig(ConfigFileType.FEATURES, "shutdown-hook")
         })
         repo = RepoManager(configManager.configDirectory)
         try {
@@ -684,6 +686,8 @@ class SkyHanniMod {
         @JvmStatic
         val feature: Features get() = configManager.features
         val sackData: SackData get() = configManager.sackData
+        val friendsData: FriendsJson get() = configManager.friendsData
+
         lateinit var repo: RepoManager
         lateinit var configManager: ConfigManager
         val logger: Logger = LogManager.getLogger("SkyHanni")

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -231,6 +231,7 @@ import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.features.misc.items.EstimatedWardrobePrice
 import at.hannibal2.skyhanni.features.misc.items.GlowingDroppedItems
 import at.hannibal2.skyhanni.features.misc.massconfiguration.DefaultConfigFeatures
+import at.hannibal2.skyhanni.features.misc.massconfiguration.KnownFeaturesJson
 import at.hannibal2.skyhanni.features.misc.teleportpad.TeleportPadCompactName
 import at.hannibal2.skyhanni.features.misc.teleportpad.TeleportPadInventoryNumber
 import at.hannibal2.skyhanni.features.misc.trevor.TrevorFeatures
@@ -687,6 +688,7 @@ class SkyHanniMod {
         val feature: Features get() = configManager.features
         val sackData: SackData get() = configManager.sackData
         val friendsData: FriendsJson get() = configManager.friendsData
+        val knownFeaturesData: KnownFeaturesJson get() = configManager.knownFeaturesData
 
         lateinit var repo: RepoManager
         lateinit var configManager: ConfigManager

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -306,6 +306,7 @@ import at.hannibal2.skyhanni.utils.MinecraftConsoleFilter.Companion.initLogging
 import at.hannibal2.skyhanni.utils.NEUVersionCheck.checkIfNeuIsLoaded
 import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.jsonobjects.FriendsJson
+import at.hannibal2.skyhanni.utils.jsonobjects.JacobContestsJson
 import at.hannibal2.skyhanni.utils.jsonobjects.KnownFeaturesJson
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -689,6 +690,7 @@ class SkyHanniMod {
         val sackData: SackData get() = configManager.sackData
         val friendsData: FriendsJson get() = configManager.friendsData
         val knownFeaturesData: KnownFeaturesJson get() = configManager.knownFeaturesData
+        val jacobContestsData: JacobContestsJson get() = configManager.jacobContestData
 
         lateinit var repo: RepoManager
         lateinit var configManager: ConfigManager

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -231,7 +231,6 @@ import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.features.misc.items.EstimatedWardrobePrice
 import at.hannibal2.skyhanni.features.misc.items.GlowingDroppedItems
 import at.hannibal2.skyhanni.features.misc.massconfiguration.DefaultConfigFeatures
-import at.hannibal2.skyhanni.features.misc.massconfiguration.KnownFeaturesJson
 import at.hannibal2.skyhanni.features.misc.teleportpad.TeleportPadCompactName
 import at.hannibal2.skyhanni.features.misc.teleportpad.TeleportPadInventoryNumber
 import at.hannibal2.skyhanni.features.misc.trevor.TrevorFeatures
@@ -307,6 +306,7 @@ import at.hannibal2.skyhanni.utils.MinecraftConsoleFilter.Companion.initLogging
 import at.hannibal2.skyhanni.utils.NEUVersionCheck.checkIfNeuIsLoaded
 import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.jsonobjects.FriendsJson
+import at.hannibal2.skyhanni.utils.jsonobjects.KnownFeaturesJson
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.jsonobjects.FriendsJson
+import at.hannibal2.skyhanni.utils.jsonobjects.JacobContestsJson
 import at.hannibal2.skyhanni.utils.jsonobjects.KnownFeaturesJson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
@@ -109,6 +110,8 @@ class ConfigManager {
         private set
     lateinit var knownFeaturesData: KnownFeaturesJson
         private set
+    lateinit var jacobContestData: JacobContestsJson
+        private set
 
     private val logger = LorenzLogger("config_manager")
 
@@ -118,6 +121,7 @@ class ConfigManager {
     private var sackFile: File? = null
     private var friendsFile: File? = null
     private var knowFeaturesFile: File? = null
+    private var jacobContestsFile: File? = null
 
     lateinit var processor: MoulConfigProcessor<Features>
     private var disableSaving = false
@@ -132,12 +136,13 @@ class ConfigManager {
         sackFile = File(configDirectory, "sacks.json")
         friendsFile = File(configDirectory, "friends.json")
         knowFeaturesFile = File(configDirectory, "known_features.json")
+        jacobContestsFile = File(configDirectory, "jacob_contests.json")
 
         features = firstLoadFile(configFile, ConfigFileType.FEATURES, Features(), true)
         sackData = firstLoadFile(sackFile, ConfigFileType.SACKS, SackData(), false)
         friendsData = firstLoadFile(friendsFile, ConfigFileType.FRIENDS, FriendsJson(), false)
-        knownFeaturesData = firstLoadFile(knowFeaturesFile, ConfigFileType.KNOWN_FEATURES,
-            KnownFeaturesJson(), false)
+        knownFeaturesData = firstLoadFile(knowFeaturesFile, ConfigFileType.KNOWN_FEATURES, KnownFeaturesJson(), false)
+        jacobContestData = firstLoadFile(jacobContestsFile, ConfigFileType.JACOB_CONTESTS, JacobContestsJson(), false)
 
         fixedRateTimer(name = "skyhanni-config-auto-save", period = 60_000L, initialDelay = 60_000L) {
             saveConfig(ConfigFileType.FEATURES, "auto-save-60s")
@@ -202,6 +207,7 @@ class ConfigManager {
             ConfigFileType.SACKS -> saveFile(sackFile, fileType.fileName, SkyHanniMod.sackData, reason)
             ConfigFileType.FRIENDS -> saveFile(friendsFile, fileType.fileName, SkyHanniMod.friendsData, reason)
             ConfigFileType.KNOWN_FEATURES -> saveFile(knowFeaturesFile, fileType.fileName, SkyHanniMod.knownFeaturesData, reason)
+            ConfigFileType.JACOB_CONTESTS -> saveFile(jacobContestsFile, fileType.fileName, SkyHanniMod.jacobContestsData, reason)
         }
     }
 
@@ -240,5 +246,6 @@ enum class ConfigFileType(val fileName: String) {
     SACKS("sacks"),
     FRIENDS("friends"),
     KNOWN_FEATURES("known_features"),
+    JACOB_CONTESTS("jacob_contests"),
     ;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.config
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
-import at.hannibal2.skyhanni.features.misc.massconfiguration.KnownFeaturesJson
 import at.hannibal2.skyhanni.features.misc.update.UpdateManager
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzRarity
@@ -11,6 +10,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.jsonobjects.FriendsJson
+import at.hannibal2.skyhanni.utils.jsonobjects.KnownFeaturesJson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 import com.google.gson.TypeAdapter
@@ -136,7 +136,8 @@ class ConfigManager {
         features = firstLoadFile(configFile, ConfigFileType.FEATURES, Features(), true)
         sackData = firstLoadFile(sackFile, ConfigFileType.SACKS, SackData(), false)
         friendsData = firstLoadFile(friendsFile, ConfigFileType.FRIENDS, FriendsJson(), false)
-        knownFeaturesData = firstLoadFile(knowFeaturesFile, ConfigFileType.KNOWN_FEATURES, KnownFeaturesJson(), false)
+        knownFeaturesData = firstLoadFile(knowFeaturesFile, ConfigFileType.KNOWN_FEATURES,
+            KnownFeaturesJson(), false)
 
         fixedRateTimer(name = "skyhanni-config-auto-save", period = 60_000L, initialDelay = 60_000L) {
             saveConfig(ConfigFileType.FEATURES, "auto-save-60s")

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -192,17 +192,24 @@ class ConfigManager {
     }
 
     fun saveConfig(reason: String) {
+        saveFile(configFile, "config", SkyHanniMod.feature, reason)
+    }
+
+    fun saveSackData(reason: String) {
+        saveFile(sackFile, "sacks", SkyHanniMod.sackData, reason)
+    }
+
+    private fun saveFile(file: File?, fileName: String, data: Any, reason: String) {
         if (disableSaving) return
         logger.log("saveConfig: $reason")
-        val file = configFile ?: throw Error("Can not save config, configFile is null!")
+        if (file == null) throw Error("Can not save $fileName, ${fileName}File is null!")
         try {
-            logger.log("Saving config file")
+            logger.log("Saving $fileName file")
             file.parentFile.mkdirs()
-            val unit = file.parentFile.resolve("config.json.write")
+            val unit = file.parentFile.resolve("$fileName.json.write")
             unit.createNewFile()
             BufferedWriter(OutputStreamWriter(FileOutputStream(unit), StandardCharsets.UTF_8)).use { writer ->
-                // TODO remove old "hidden" area
-                writer.write(gson.toJson(SkyHanniMod.feature))
+                writer.write(gson.toJson(data))
             }
             // Perform move — which is atomic, unlike writing — after writing is done.
             Files.move(
@@ -212,24 +219,7 @@ class ConfigManager {
                 StandardCopyOption.ATOMIC_MOVE
             )
         } catch (e: IOException) {
-            logger.log("Could not save config file to $file")
-            e.printStackTrace()
-        }
-    }
-
-    fun saveSackData(reason: String) {
-        if (disableSaving) return
-        logger.log("saveSackData: $reason")
-        val file = sackFile ?: throw Error("Can not save sacks, sackFile is null!")
-        try {
-            logger.log("Saving sack file")
-            file.parentFile.mkdirs()
-            file.createNewFile()
-            BufferedWriter(OutputStreamWriter(FileOutputStream(file), StandardCharsets.UTF_8)).use { writer ->
-                writer.write(gson.toJson(SkyHanniMod.sackData))
-            }
-        } catch (e: IOException) {
-            logger.log("Could not save sacks file to $file")
+            logger.log("Could not save $fileName file to $file")
             e.printStackTrace()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.config
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
+import at.hannibal2.skyhanni.features.misc.massconfiguration.KnownFeaturesJson
 import at.hannibal2.skyhanni.features.misc.update.UpdateManager
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzRarity
@@ -106,6 +107,8 @@ class ConfigManager {
         private set
     lateinit var friendsData: FriendsJson
         private set
+    lateinit var knownFeaturesData: KnownFeaturesJson
+        private set
 
     private val logger = LorenzLogger("config_manager")
 
@@ -114,6 +117,7 @@ class ConfigManager {
     private var configFile: File? = null
     private var sackFile: File? = null
     private var friendsFile: File? = null
+    private var knowFeaturesFile: File? = null
 
     lateinit var processor: MoulConfigProcessor<Features>
     private var disableSaving = false
@@ -127,10 +131,12 @@ class ConfigManager {
         configFile = File(configDirectory, "config.json")
         sackFile = File(configDirectory, "sacks.json")
         friendsFile = File(configDirectory, "friends.json")
+        knowFeaturesFile = File(configDirectory, "known_features.json")
 
         features = firstLoadFile(configFile, ConfigFileType.FEATURES, Features(), true)
         sackData = firstLoadFile(sackFile, ConfigFileType.SACKS, SackData(), false)
         friendsData = firstLoadFile(friendsFile, ConfigFileType.FRIENDS, FriendsJson(), false)
+        knownFeaturesData = firstLoadFile(knowFeaturesFile, ConfigFileType.KNOWN_FEATURES, KnownFeaturesJson(), false)
 
         fixedRateTimer(name = "skyhanni-config-auto-save", period = 60_000L, initialDelay = 60_000L) {
             saveConfig(ConfigFileType.FEATURES, "auto-save-60s")
@@ -194,6 +200,7 @@ class ConfigManager {
             ConfigFileType.FEATURES -> saveFile(configFile, fileType.fileName, SkyHanniMod.feature, reason)
             ConfigFileType.SACKS -> saveFile(sackFile, fileType.fileName, SkyHanniMod.sackData, reason)
             ConfigFileType.FRIENDS -> saveFile(friendsFile, fileType.fileName, SkyHanniMod.friendsData, reason)
+            ConfigFileType.KNOWN_FEATURES -> saveFile(knowFeaturesFile, fileType.fileName, SkyHanniMod.knownFeaturesData, reason)
         }
     }
 
@@ -231,5 +238,6 @@ enum class ConfigFileType(val fileName: String) {
     FEATURES("config"),
     SACKS("sacks"),
     FRIENDS("friends"),
+    KNOWN_FEATURES("known_features"),
     ;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -199,7 +199,7 @@ class ConfigManager {
         saveFile(sackFile, "sacks", SkyHanniMod.sackData, reason)
     }
 
-    private fun saveFile(file: File?, fileName: String, data: Any, reason: String) {
+    fun saveFile(file: File?, fileName: String, data: Any, reason: String) {
         if (disableSaving) return
         logger.log("saveConfig: $reason")
         if (file == null) throw Error("Can not save $fileName, ${fileName}File is null!")

--- a/src/main/java/at/hannibal2/skyhanni/config/Features.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/Features.java
@@ -51,7 +51,7 @@ public class Features extends Config {
 
     @Override
     public void saveNow() {
-        SkyHanniMod.configManager.saveConfig("close-gui");
+        SkyHanniMod.configManager.saveConfig(ConfigFileType.FEATURES, "close-gui");
     }
 
     @Override

--- a/src/main/java/at/hannibal2/skyhanni/config/Storage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/Storage.java
@@ -38,9 +38,6 @@ public class Storage {
     public Map<String, List<String>> knownFeatureToggles = new HashMap<>();
 
     @Expose
-    public Map<Long, List<CropType>> gardenJacobFarmingContestTimes = new HashMap<>();
-
-    @Expose
     public List<VisualWord> modifiedWords = new ArrayList<>();
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.commands
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.ConfigGuiManager
 import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.data.GuiEditManager
@@ -241,7 +242,7 @@ object Commands {
         registerCommand(
             "shconfigsave",
             "Manually saving the config"
-        ) { SkyHanniMod.configManager.saveConfig("manual-command") }
+        ) { SkyHanniMod.configManager.saveConfig(ConfigFileType.FEATURES, "manual-command") }
     }
 
     private fun developersCodingHelp() {

--- a/src/main/java/at/hannibal2/skyhanni/data/FriendAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/FriendAPI.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.data
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.events.HypixelJoinEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
@@ -60,7 +61,8 @@ class FriendAPI {
     }
 
     fun saveConfig() {
-        file.writeText(ConfigManager.gson.toJson(friendsJson))
+        val friendsJsonCopy = friendsJson ?: return
+        SkyHanniMod.configManager.saveFile(file, "friends", friendsJsonCopy, "Save file")
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
@@ -301,7 +302,7 @@ object SackAPI {
 
     private fun saveSackData() {
         ProfileStorageData.sackProfiles?.sackContents = sackData
-        SkyHanniMod.configManager.saveSackData("saving-data")
+        SkyHanniMod.configManager.saveConfig(ConfigFileType.SACKS, "saving-data")
     }
 
     data class SackGemstone(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.garden
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -182,7 +183,7 @@ object GardenNextJacobContest {
     }
 
     private fun saveConfig() {
-        val map = SkyHanniMod.feature.storage.gardenJacobFarmingContestTimes
+        val map = SkyHanniMod.jacobContestsData.contestTimes
         map.clear()
 
         val currentYear = SkyBlockTime.now().year
@@ -193,11 +194,12 @@ object GardenNextJacobContest {
 
             map[contest.endTime] = contest.crops
         }
+        SkyHanniMod.configManager.saveConfig(ConfigFileType.JACOB_CONTESTS, "Save contests")
     }
 
     @SubscribeEvent
     fun onConfigLoad(event: ConfigLoadEvent) {
-        val savedContests = SkyHanniMod.feature.storage.gardenJacobFarmingContestTimes
+        val savedContests = SkyHanniMod.jacobContestsData.contestTimes
         val year = savedContests.firstNotNullOfOrNull {
             val endTime = it.key
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigFeatures.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.misc.massconfiguration
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import io.github.moulberry.moulconfig.processor.ConfigProcessorDriver
@@ -22,7 +23,7 @@ object DefaultConfigFeatures {
         val processor = FeatureToggleProcessor()
         ConfigProcessorDriver.processConfig(SkyHanniMod.feature.javaClass, SkyHanniMod.feature, processor)
         knownToggles[SkyHanniMod.version] = processor.allOptions.map { it.path }
-        SkyHanniMod.configManager.saveConfig("Updated known feature flags")
+        SkyHanniMod.configManager.saveConfig(ConfigFileType.FEATURES, "Updated known feature flags")
         if (!SkyHanniMod.feature.storage.hasPlayedBefore) {
             SkyHanniMod.feature.storage.hasPlayedBefore = true
             LorenzUtils.clickableChat(

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigFeatures.kt
@@ -18,12 +18,18 @@ object DefaultConfigFeatures {
         Minecraft.getMinecraft().thePlayer ?: return
         didNotifyOnce = true
 
-        val knownToggles = SkyHanniMod.feature.storage.knownFeatureToggles
+        val oldToggles = SkyHanniMod.feature.storage.knownFeatureToggles
+        if (oldToggles.isNotEmpty()) {
+            SkyHanniMod.knownFeaturesData.knownFeatures = oldToggles
+            SkyHanniMod.feature.storage.knownFeatureToggles = emptyMap()
+        }
+
+        val knownToggles = SkyHanniMod.knownFeaturesData.knownFeatures
         val updated = SkyHanniMod.version !in knownToggles
         val processor = FeatureToggleProcessor()
         ConfigProcessorDriver.processConfig(SkyHanniMod.feature.javaClass, SkyHanniMod.feature, processor)
         knownToggles[SkyHanniMod.version] = processor.allOptions.map { it.path }
-        SkyHanniMod.configManager.saveConfig(ConfigFileType.FEATURES, "Updated known feature flags")
+        SkyHanniMod.configManager.saveConfig(ConfigFileType.KNOWN_FEATURES, "Updated known feature flags")
         if (!SkyHanniMod.feature.storage.hasPlayedBefore) {
             SkyHanniMod.feature.storage.hasPlayedBefore = true
             LorenzUtils.clickableChat(
@@ -47,7 +53,7 @@ object DefaultConfigFeatures {
         val processor = FeatureToggleProcessor()
         ConfigProcessorDriver.processConfig(SkyHanniMod.feature.javaClass, SkyHanniMod.feature, processor)
         var optionList = processor.orderedOptions
-        val knownToggles = SkyHanniMod.feature.storage.knownFeatureToggles
+        val knownToggles = SkyHanniMod.knownFeaturesData.knownFeatures
         val togglesInNewVersion = knownToggles[new]
         if (new != "null" && togglesInNewVersion == null) {
             LorenzUtils.chat("§e[SkyHanni] Unknown version $new")
@@ -93,7 +99,7 @@ object DefaultConfigFeatures {
         if (strings.size <= 2)
             return CommandBase.getListOfStringsMatchingLastWord(
                 strings,
-                SkyHanniMod.feature.storage.knownFeatureToggles.keys + listOf("null")
+                SkyHanniMod.knownFeaturesData.knownFeatures.keys + listOf("null")
             )
         return listOf()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/KnownFeaturesJson.java
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/KnownFeaturesJson.java
@@ -1,0 +1,12 @@
+package at.hannibal2.skyhanni.features.misc.massconfiguration;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KnownFeaturesJson {
+    @Expose
+    public Map<String, List<String>> knownFeatures = new HashMap<>();
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.test
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.ConfigGuiManager
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
@@ -117,8 +118,8 @@ class SkyHanniDebugsAndTests {
             // TODO make it so that it does not reset the config
 
             // saving old config state
-            SkyHanniMod.configManager.saveConfig("reload config manager")
-            SkyHanniMod.configManager.saveSackData("reload config manager")
+            SkyHanniMod.configManager.saveConfig(ConfigFileType.FEATURES, "reload config manager")
+            SkyHanniMod.configManager.saveConfig(ConfigFileType.SACKS,"reload config manager")
             Thread {
                 Thread.sleep(500)
                 SkyHanniMod.configManager.disableSaving()

--- a/src/main/java/at/hannibal2/skyhanni/utils/jsonobjects/JacobContestsJson.java
+++ b/src/main/java/at/hannibal2/skyhanni/utils/jsonobjects/JacobContestsJson.java
@@ -1,0 +1,13 @@
+package at.hannibal2.skyhanni.utils.jsonobjects;
+
+import at.hannibal2.skyhanni.features.garden.CropType;
+import com.google.gson.annotations.Expose;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JacobContestsJson {
+    @Expose
+    public Map<Long, List<CropType>> contestTimes = new HashMap<>();
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/jsonobjects/KnownFeaturesJson.java
+++ b/src/main/java/at/hannibal2/skyhanni/utils/jsonobjects/KnownFeaturesJson.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.features.misc.massconfiguration;
+package at.hannibal2.skyhanni.utils.jsonobjects;
 
 import com.google.gson.annotations.Expose;
 


### PR DESCRIPTION
moves gardenJacobFarmingContestTimes and knownFeatureToggles to new files. Will wipe jacobs contests as these can be prefetched easily
should preserve known feature toggles

make everything use same config system.
the main config will still undergo the config fix
everything now gets backups if broken.
The new blank file is not written to until it is said to save (mostly because you crash if it was different, does not affect anything)
reduced a lot of code duplication

closes 
https://github.com/hannibal002/SkyHanni/issues/170 and https://github.com/hannibal002/SkyHanni/pull/165