### PR TITLE
Fix for Players with Ranks in CompactTab

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -24,7 +24,7 @@ object AdvancedPlayerList {
     private val config get() = SkyHanniMod.feature.misc.compactTabList.advancedPlayerList
 
     // TODO USE SH-REPO
-    private val pattern = ".*\\[(?<level>.*)] (?<name>.*)".toPattern()
+    private val pattern = ".*\\[(?<level>.*)] §r(?<name>.*)".toPattern()
 
     private var playerDatas = mutableMapOf<String, PlayerData>()
 
@@ -59,14 +59,21 @@ object AdvancedPlayerList {
                     val playerData = PlayerData(removeColor.toInt())
                     currentData[line] = playerData
 
+                    var index = 0
                     val fullName = group("name")
+                    if (fullName.contains("[")) index++
                     val name = fullName.split(" ")
-                    val coloredName = name[0]
-                    playerData.coloredName = coloredName
+                    val coloredName = name[index]
+                    if (index == 1) {
+                        playerData.coloredName = name[0] + coloredName
+                    } else {
+                        playerData.coloredName = coloredName
+                    }
                     playerData.name = coloredName.removeColor()
                     playerData.levelText = levelText
-                    if (name.size > 1) {
-                        val nameSuffix = name.drop(1).joinToString(" ")
+                    index++
+                    if (name.size > index) {
+                        val nameSuffix = name.drop(index).joinToString(" ")
                         playerData.nameSuffix = nameSuffix
                         if (nameSuffix.contains("♲")) {
                             playerData.ironman = true
@@ -161,7 +168,7 @@ object AdvancedPlayerList {
             suffix += " " + getSocialScoreIcon(score)
         }
         if (config.markSkyHanniContributors && data.name in contributors) {
-            suffix += " §c:O"
+            suffix += "§c:O"
         }
 
         if (IslandType.CRIMSON_ISLE.isInIsland() && !config.hideFactions) {


### PR DESCRIPTION
Fix frivolous space for developer marker
Fix Regex to capture better
Change logic to hopefully put name and rank in scoreboard for users with rank. 