### PR TITLE
Fix: Garden plot borders continously toggling

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotBorders.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotBorders.kt
@@ -6,15 +6,18 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DLine
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.lwjgl.input.Keyboard
 import java.awt.Color
 import kotlin.math.floor
+import kotlin.time.Duration.Companion.milliseconds
 
 class GardenPlotBorders {
 
     private val config get() = SkyHanniMod.feature.garden.plotBorders
+    private var timeLastSaved = SimpleTimeMark.farPast()
     private var showBorders = false
     private val LINE_COLOR = LorenzColor.YELLOW.toColor()
 
@@ -25,12 +28,16 @@ class GardenPlotBorders {
     @SubscribeEvent
     fun onKeyClick(event: LorenzKeyPressEvent) {
         if (!isEnabled()) return
+        if (timeLastSaved.passedSince() < 250.milliseconds) return
+
         if (event.keyCode == Keyboard.KEY_G && Keyboard.isKeyDown(Keyboard.KEY_F3)) {
             showBorders = !showBorders
         }
         if (event.keyCode == Keyboard.KEY_F3 && Keyboard.isKeyDown(Keyboard.KEY_G)) {
             showBorders = !showBorders
         }
+
+        timeLastSaved = SimpleTimeMark.now()
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Plot borders were hard to toggle on and off due to them being toggled continously if the keys were held down for more than a tick, so added a delay so they don't do that.