### PR TITLE
Fix: Add support for Service Files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -188,7 +188,7 @@ tasks.shadowJar {
         }
     }
     exclude("META-INF/versions/**")
-
+    mergeServiceFiles()
     relocate("io.github.moulberry.moulconfig", "at.hannibal2.skyhanni.deps.moulconfig")
     relocate("moe.nea.libautoupdate", "at.hannibal2.skyhanni.deps.libautoupdate")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 libautoupdate = "1.0.3"
-moulconfig = "2.4.0"
+moulconfig = "2.4.3"
 
 [libraries]
 moulconfig = { module = "org.notenoughupdates.moulconfig:legacy", version.ref = "moulconfig" }


### PR DESCRIPTION
Add support for Service Files
Bump version to 2.4.3 to resolve search and line bugs.

This resolves crashing if SkyHanni is used outside of devEnv :)