### PR TITLE
Internal Change: ConfigMigrator Variable Names

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -124,7 +124,7 @@ class ConfigManager {
         if (::features.isInitialized) {
             logger.log("Loading config despite config being already loaded?")
         }
-        configDirectory.mkdir()
+        configDirectory.mkdirs()
 
         configFile = File(configDirectory, "config.json")
         sackFile = File(configDirectory, "sacks.json")


### PR DESCRIPTION
Refactor config migrator variable names to be more readable.
Change mkdir to mkdirs