### PR TITLE
Don't hide messages from Jacob

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.java
@@ -60,7 +60,7 @@ public class VisitorConfig {
     public boolean hypixelArrivedMessage = true;
 
     @Expose
-    @ConfigOption(name = "Hide Chat", desc = "Hide chat messages from the visitors in garden. (Except Beth and Spaceman)")
+    @ConfigOption(name = "Hide Chat", desc = "Hide chat messages from the visitors in garden. (Except Beth, Jacob and Spaceman)")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean hideChat = true;

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -436,6 +436,7 @@ class GardenVisitorFeatures {
 
     private fun hideVisitorMessage(message: String) = visitorChatMessagePattern.matchMatcher(message) {
         val name = group("name")
+        if (name == "Jacob") return false
         if (name == "Spaceman") return false
         if (name == "Beth") return false
 


### PR DESCRIPTION
If Jacob is a visitor on your garden, SkyHanni was also hiding messages relating to Jacob's Farming Contest. As a hotfix for now, let's just not hide any messages from Jacob at all.