### PR TITLE
Trying to fix patcher coord preview

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/EntityRendererHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/EntityRendererHook.kt
@@ -1,0 +1,15 @@
+package at.hannibal2.skyhanni.mixins.hooks
+
+import net.minecraft.client.Minecraft
+
+class EntityRendererHook {
+    companion object {
+
+        @JvmStatic
+        fun onTranslateCamera(x: Float, y: Float, z: Float) {
+            if (Minecraft.getMinecraft().thePlayer.isSneaking()) {
+                println("z: $z")
+            }
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityRenderer.java
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.data.GuiEditManager;
+import at.hannibal2.skyhanni.mixins.hooks.EntityRendererHook;
 import net.minecraft.client.renderer.EntityRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,5 +14,14 @@ public class MixinEntityRenderer {
     @Inject(method = "updateCameraAndRender", at = @At("TAIL"))
     private void onLastRender(float partialTicks, long nanoTime, CallbackInfo ci) {
         GuiEditManager.renderLast();
+    }
+
+
+    // Our target is to get the line 'GlStateManager.translate(0.0F, 0.0F, (float)(-d3));'
+    // This line is in class EntityRenderer on line 615
+
+    @Inject(method = "orientCamera", at = @At(value = "Lnet/minecraft/client/GlStateManager;translate(FFF)V", ordinal = 2))
+    private void onTranslateCamera(float x, float y, float z, CallbackInfo ci) {
+        EntityRendererHook.onTranslateCamera(x, y, z);
     }
 }


### PR DESCRIPTION
Trying to fix this bug:
![image](https://github.com/hannibal002/SkyHanni/assets/24389977/70998ad3-e02e-4f1b-973e-f1f045fd6db9)

The goal is to grab the camera position and calculate the render point from there instead of from the eye position.