### PR TITLE
Internal: Updated editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,7 @@ max_line_length = 120
 # Java files should not use wildcard imports
 ij_java_names_count_to_use_import_on_demand = 999
 ij_java_class_count_to_use_import_on_demand = 999
+ij_java_packages_to_use_import_on_demand =
 
 [*.kt]
 # Kotlin files should not use wildcard imports

--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,4 @@ ij_java_class_count_to_use_import_on_demand = 999
 # Kotlin files should not use wildcard imports
 ij_kotlin_name_count_to_use_star_import = 999
 ij_kotlin_name_count_to_use_star_import_for_members = 999
+ij_kotlin_packages_to_use_import_on_demand =


### PR DESCRIPTION
Added one line that overrides the "Packages to Use Import with `*`"
Which has as default 3 things in it.