### PR TITLE
Feature: /shclearcontestdata

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -216,7 +216,11 @@ object Commands {
         registerCommand(
             "shwhereami",
             "Print current island in chat"
-        ) { SkyHanniDebugsAndTests.whereami() }
+        ) { SkyHanniDebugsAndTests.whereAmI() }
+        registerCommand(
+            "shclearcontestdata",
+            "Resets Jacob's Contest Data"
+        ) { SkyHanniDebugsAndTests.clearContestData() }
         registerCommand(
             "shconfig",
             "Search or reset config elements §c(warning, dangerous!)"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -46,7 +46,7 @@ object GardenNextJacobContest {
     private var dispatcher = Dispatchers.IO
     private var display = emptyList<Any>()
     private var simpleDisplay = emptyList<String>()
-    private var contests = mutableMapOf<SimpleTimeMark, FarmingContest>()
+    var contests = mutableMapOf<SimpleTimeMark, FarmingContest>()
     private var inCalendar = false
 
     private val patternDay = "§aDay (?<day>.*)".toPattern()
@@ -61,9 +61,9 @@ object GardenNextJacobContest {
     private var loadedContestsYear = -1
     private var nextContestsAvailableAt = -1L
 
-    private var lastFetchAttempted = 0L
-    private var isFetchingContests = false
-    private var fetchedFromElite = false
+    var lastFetchAttempted = 0L
+    var isFetchingContests = false
+    var fetchedFromElite = false
     private var isSendingContests = false
 
     @SubscribeEvent
@@ -455,7 +455,7 @@ object GardenNextJacobContest {
     private fun askToSendContests() =
         config.shareAutomatically == 0 // 0 = Ask, 1 = Send (Only call if isSendEnabled())
 
-    private fun fetchContestsIfAble() {
+    fun fetchContestsIfAble() {
         if (isFetchingContests || contests.size == maxContestsPerYear || !isFetchEnabled()) return
         // Allows retries every 10 minutes when it's after 1 day into the new year
         val currentMills = System.currentTimeMillis()
@@ -470,7 +470,7 @@ object GardenNextJacobContest {
         }
     }
 
-    private suspend fun fetchUpcomingContests() {
+    suspend fun fetchUpcomingContests() {
         try {
             val url = "https://api.elitebot.dev/contests/at/now"
             val result = withContext(dispatcher) { APIUtil.getJSONResponse(url) }.asJsonObject

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -455,7 +455,7 @@ object GardenNextJacobContest {
     private fun askToSendContests() =
         config.shareAutomatically == 0 // 0 = Ask, 1 = Send (Only call if isSendEnabled())
 
-    fun fetchContestsIfAble() {
+    private fun fetchContestsIfAble() {
         if (isFetchingContests || contests.size == maxContestsPerYear || !isFetchEnabled()) return
         // Allows retries every 10 minutes when it's after 1 day into the new year
         val currentMills = System.currentTimeMillis()

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
+import at.hannibal2.skyhanni.features.garden.GardenNextJacobContest
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorColorNames
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -38,6 +39,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
 import at.hannibal2.skyhanni.utils.SoundUtils
+import kotlinx.coroutines.launch
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.nbt.NBTTagCompound
@@ -250,12 +252,23 @@ class SkyHanniDebugsAndTests {
             LorenzUtils.chat("stopped ${modules.size} listener classes.")
         }
 
-        fun whereami() {
+        fun whereAmI() {
             if (LorenzUtils.inSkyBlock) {
                 LorenzUtils.chat("§eYou are currently in ${LorenzUtils.skyBlockIsland}.")
                 return
             }
             LorenzUtils.chat("§eYou are not in Skyblock.")
+        }
+
+        fun clearContestData() {
+            GardenNextJacobContest.contests.clear()
+            GardenNextJacobContest.fetchedFromElite = false
+            GardenNextJacobContest.isFetchingContests = true
+            SkyHanniMod.coroutineScope.launch {
+                GardenNextJacobContest.fetchUpcomingContests()
+                GardenNextJacobContest.lastFetchAttempted = System.currentTimeMillis()
+                GardenNextJacobContest.isFetchingContests = false
+            }
         }
 
         fun copyLocation(args: Array<String>) {


### PR DESCRIPTION
Adds /shclearcontestdata which clears the stored jacob's contests and fetches new ones from elitebot, done to provide a cleaner  solution than faq 7