### PR TITLE
Add check for SkyHanni Repository ID in publish

### DIFF
--- a/.github/workflows/generate-constants.yaml
+++ b/.github/workflows/generate-constants.yaml
@@ -37,7 +37,8 @@ jobs:
         runs-on: ubuntu-latest
         needs: regexes
         name: "Publish regexes"
-        if: ${{ 'push' == github.event_name && 'beta' == github.ref_name }}
+        # 511310721 is the Repository ID for SkyHanni
+        if: ${{ 'push' == github.event_name && 'beta' == github.ref_name && '511310721' == github.repository_id }}
         steps:
             -   uses: actions/checkout@v3
                 with:


### PR DESCRIPTION
This prevents an attempt to publish to the repo from forks, which is not desired (and would fail without permissions)

`github.repository_id` is used instead of `github.repository` (which would return `hannibal002/SkyHanni`) to prevent the need to revise this if any of the other aspects change (e.g. renaming the repo, hannibal002 changing username, transferring to an org, etc.)