### PR TITLE
Fix boosted crop not being highlighted during contest participation

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -349,7 +349,7 @@ object GardenNextJacobContest {
             val lineStripped = line.removeColor().trim()
             if (!lineStripped.startsWith("☘ ")) continue
             for (crop in nextContest.crops) {
-                if (line.removeColor().trim() == "☘ ${crop.cropName}") {
+                if (line.removeColor().trim().startsWith("☘ ${crop.cropName}")) {
                     return crop
                 }
             }


### PR DESCRIPTION
If you are participating in that contest there is additional text after the crop name.