### PR TITLE
Fix weight leaderboard showing new position as -1 sometimes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -385,7 +385,9 @@ class FarmingWeightDisplay {
         private fun checkOffScreenLeaderboardChanges() {
             val profileSpecific = ProfileStorageData.profileSpecific ?: return
             val oldPosition = profileSpecific.garden.farmingWeight.lastFarmingWeightLeaderboard
-            if (oldPosition == -1) return
+
+            if (oldPosition <= 0) return
+            if (leaderboardPosition <= 0) return
 
             val diff = leaderboardPosition - oldPosition
             if (diff == 0) return


### PR DESCRIPTION
Also changed the old position check to exclude 0 as well just in case.