### PR TITLE
Fix typo with Not Clickable Items in Composter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -240,7 +240,7 @@ class HideNotClickableItems {
             return false
         }
 
-        hideReason = "Only sell the selected items!"
+        hideReason = "Only insert the selected items!"
         return true
     }
 


### PR DESCRIPTION
Changed "Only sell" to "Only insert" for items in the Composter. I was torn between using "insert" or "add" (Hypixel uses both in the Composter) so feel free to change.