### PR TITLE
Fix: Support Badlion sendcoords format and only show inquisitor waypoints in the hub

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzKeyPressEvent
@@ -216,7 +217,7 @@ object InquisitorWaypointShare {
 
     @SubscribeEvent(priority = EventPriority.LOW, receiveCanceled = true)
     fun onFirstChatEvent(event: PacketEvent.ReceiveEvent) {
-        if (!isEnabled()) return
+        if (!isEnabled() || LorenzUtils.skyBlockIsland != IslandType.HUB) return
         val packet = event.packet
         if (packet !is S02PacketChat) return
         val messageComponent = packet.chatComponent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherSendCoordinates.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherSendCoordinates.kt
@@ -23,7 +23,7 @@ class PatcherSendCoordinates {
     private val logger = LorenzLogger("misc/patchercoords")
 
     // TODO USE SH-REPO
-    private val pattern = "(?<playerName>.*): x: (?<x>.*), y: (?<y>.*), z: (?<z>.*)".toPattern()
+    private val pattern = "(?<playerName>.*): [xX]: (?<x>[0-9.-]+),? [yY]: (?<y>[0-9.-]+),? [zZ]: (?<z>.*)".toPattern()
 
     @SubscribeEvent
     fun onPatcherCoordinates(event: LorenzChatEvent) {
@@ -32,8 +32,8 @@ class PatcherSendCoordinates {
         val message = event.message.removeColor()
         pattern.matchMatcher(message) {
             var description = group("playerName").split(" ").last()
-            val x = group("x").toInt()
-            val y = group("y").toInt()
+            val x = group("x").toFloat()
+            val y = group("y").toFloat()
 
             val end = group("z")
             val z = if (end.contains(" ")) {
@@ -41,8 +41,8 @@ class PatcherSendCoordinates {
                 val extra = split.drop(1).joinToString(" ")
                 description += " " + extra
 
-                split.first().toInt()
-            } else end.toInt()
+                split.first().toFloat()
+            } else end.toFloat()
             patcherBeacon.add(PatcherBeacon(LorenzVec(x, y, z), description, System.currentTimeMillis() / 1000))
             logger.log("got patcher coords and username")
         }


### PR DESCRIPTION
Seen a lot of false reports from Skyhanni users this week when ppl share coords in Crystal Hollows. Also adding support for Badlion coords of the format `X: 123.45 Y: 456.78 Z: 100.00`