### PR TITLE
Fix next visitor time while farming

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -160,8 +160,7 @@ class GardenVisitorTimer {
         }
 
         val extraSpeed = if (diff in 2.seconds..10.seconds) {
-            val factor = diff.inWholeSeconds.toDouble()
-            val duration = millis / factor
+            val duration = millis / 3
             "§7/§$formatColor" + duration.format()
         } else ""
         if (config.newVisitorPing && millis < 10.seconds) {


### PR DESCRIPTION
The speed factor should be exactly 3, trying to determine it dynamically causes inaccuracies due to lag / rounding.