### PR TITLE
 Fix sixth visitor warning title showing when disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -129,9 +129,11 @@ class GardenVisitorTimer {
             if (isSixthVisitorEnabled() && millis.isNegative()) {
                 visitorsAmount++
                 if (!sixthVisitorReady) {
-                    LorenzUtils.sendTitle("§a6th Visitor Ready", 5.seconds)
                     sixthVisitorReady = true
-                    if (isSixthVisitorWarningEnabled()) SoundUtils.playBeepSound()
+                    if (isSixthVisitorWarningEnabled()) {
+                        LorenzUtils.sendTitle("§a6th Visitor Ready", 5.seconds)
+                        SoundUtils.playBeepSound()
+                    }
                 }
             }
         }


### PR DESCRIPTION
It would previously show the title even if only "Sixth Visitor Estimate" was enabled and "Sixth Visitor Warning" was not.