### PR TITLE
Backend: Add Dark Auction as IslandType and fix IslandType detection for dungeons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -27,7 +27,7 @@ import kotlin.concurrent.thread
 
 class HypixelData {
     private val group = RepoPattern.group("data.hypixeldata")
-    private val tabListProfilePattern by group.pattern("tabListprofile", "§e§lProfile: §r§a(?<profile>.*)")
+    private val tabListProfilePattern by group.pattern("tablistprofile", "§e§lProfile: §r§a(?<profile>.*)")
     private val lobbyTypePattern by group.pattern("lobbytype", "(?<lobbyType>.*lobby)\\d+")
     private val islandNamePattern by group.pattern("islandname", "§b§l(Area|Dungeon): §r§7(?<island>.*)")
 

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -214,9 +214,6 @@ class HypixelData {
             islandNamePattern.matchMatcher(line) {
                 newIsland = group("island")
             }
-            /*if (line.startsWith("§b§lArea: ") || line.startsWith("§b§lDungeon: ")) {
-                newIsland = line.split(": ")[1].removeColor()
-            }*/
             if (line == " Status: §r§9Guest") {
                 guesting = true
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TabListData
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonObject
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates
 import net.minecraft.client.Minecraft
@@ -25,9 +26,10 @@ import net.minecraftforge.fml.common.network.FMLNetworkEvent
 import kotlin.concurrent.thread
 
 class HypixelData {
-    // TODO USE SH-REPO
-    private val tabListProfilePattern = "§e§lProfile: §r§a(?<profile>.*)".toPattern()
-    private val lobbyTypePattern = "(?<lobbyType>.*lobby)\\d+".toPattern()
+    private val group = RepoPattern.group("data.hypixeldata")
+    private val tabListProfilePattern by group.pattern("tabListProfilePattern", "§e§lProfile: §r§a(?<profile>.*)")
+    private val lobbyTypePattern by group.pattern("lobbyTypePattern", "(?<lobbyType>.*lobby)\\d+")
+    private val islandNamePattern by group.pattern("islandNamePattern", "§b§l(Area|Dungeon): §r§7(?<island>.*)")
 
     private var lastLocRaw = 0L
 
@@ -209,9 +211,12 @@ class HypixelData {
         var newIsland = ""
         var guesting = false
         for (line in TabListData.getTabList()) {
-            if (line.startsWith("§b§lArea: ") || line.startsWith("§b§lDungeon: ")) {
-                newIsland = line.split(": ")[1].removeColor()
+            islandNamePattern.matchMatcher(line) {
+                newIsland = group("island")
             }
+            /*if (line.startsWith("§b§lArea: ") || line.startsWith("§b§lDungeon: ")) {
+                newIsland = line.split(": ")[1].removeColor()
+            }*/
             if (line == " Status: §r§9Guest") {
                 guesting = true
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -27,9 +27,9 @@ import kotlin.concurrent.thread
 
 class HypixelData {
     private val group = RepoPattern.group("data.hypixeldata")
-    private val tabListProfilePattern by group.pattern("tabListProfilePattern", "§e§lProfile: §r§a(?<profile>.*)")
-    private val lobbyTypePattern by group.pattern("lobbyTypePattern", "(?<lobbyType>.*lobby)\\d+")
-    private val islandNamePattern by group.pattern("islandNamePattern", "§b§l(Area|Dungeon): §r§7(?<island>.*)")
+    private val tabListProfilePattern by group.pattern("tabListprofile", "§e§lProfile: §r§a(?<profile>.*)")
+    private val lobbyTypePattern by group.pattern("lobbytype", "(?<lobbyType>.*lobby)\\d+")
+    private val islandNamePattern by group.pattern("islandname", "§b§l(Area|Dungeon): §r§7(?<island>.*)")
 
     private var lastLocRaw = 0L
 

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -209,7 +209,7 @@ class HypixelData {
         var newIsland = ""
         var guesting = false
         for (line in TabListData.getTabList()) {
-            if (line.startsWith("§b§lArea: ")) {
+            if (line.startsWith("§b§lArea: ") || line.startsWith("§b§lDungeon: ")) {
                 newIsland = line.split(": ")[1].removeColor()
             }
             if (line == " Status: §r§9Guest") {

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -12,6 +12,7 @@ enum class IslandType(val displayName: String, val modeName: String = "null") {
     CATACOMBS("Catacombs", "dungeon"),
 
     HUB("Hub", "village"),
+    DARK_AUCTION("Dark Auction"),
     THE_FARMING_ISLANDS("The Farming Islands"),
     CRYSTAL_HOLLOWS("Crystal Hollows"),
     THE_PARK("The Park", "floating_islands_1"),
@@ -20,7 +21,7 @@ enum class IslandType(val displayName: String, val modeName: String = "null") {
     GARDEN("Garden"),
     GARDEN_GUEST("Garden Guest"),
     SPIDER_DEN("Spider's Den"),
-    WINTER("Jerry's Workshop"), //todo confirm
+    WINTER("Jerry's Workshop"),
     THE_RIFT("The Rift"),
 
     NONE(""),

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -525,7 +525,7 @@ object LorenzUtils {
             && tileSign.signText[3].unformattedText.removeColor() == "speed cap!")
     }
 
-    fun IslandType.isInIsland() = inSkyBlock && (skyBlockIsland == this || this == IslandType.CATACOMBS && inDungeons)
+    fun IslandType.isInIsland() = inSkyBlock && skyBlockIsland == this
 
     fun <K> MutableMap<K, Int>.addOrPut(key: K, number: Int): Int {
         val currentValue = this[key] ?: 0


### PR DESCRIPTION
This adds the Dark Auction as a new IslandType and fixes the IslandType detection for dungeons.