### PR TITLE
Minor fix: modify instead of block trophy fishing and sea creature messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.features.chat.ChatFilterGui
 import at.hannibal2.skyhanni.utils.IdentityCharacteristics
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.chat
 import at.hannibal2.skyhanni.utils.LorenzUtils.makeAccessible
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.ChatLine
@@ -120,6 +121,14 @@ object ChatManager {
             messageHistory[key] = MessageFilteringResult(original, ActionKind.MODIFIED, null, modified)
         } else {
             messageHistory[key] = MessageFilteringResult(original, ActionKind.ALLOWED, null, null)
+        }
+
+        // TODO: Handle this with ChatManager.retractMessage or some other way for logging and /shchathistory purposes?
+        if (chatEvent.chatLineId != 0) {
+            event.isCanceled = true
+            Minecraft.getMinecraft().ingameGUI.chatGUI.printChatMessageWithOptionalDeletion(
+                event.message, chatEvent.chatLineId
+            )
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/events/LorenzChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/LorenzChatEvent.kt
@@ -5,5 +5,6 @@ import net.minecraft.util.IChatComponent
 class LorenzChatEvent(
     var message: String,
     var chatComponent: IChatComponent,
-    var blockedReason: String = ""
+    var blockedReason: String = "",
+    var chatLineId: Int = 0
 ) : LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureMessageShortener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureMessageShortener.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.SeaCreatureFishEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.util.ChatComponentText
-import net.minecraft.util.IChatComponent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class SeaCreatureMessageShortener {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureMessageShortener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureMessageShortener.kt
@@ -3,6 +3,8 @@ package at.hannibal2.skyhanni.features.fishing
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.SeaCreatureFishEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraft.util.ChatComponentText
+import net.minecraft.util.IChatComponent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class SeaCreatureMessageShortener {
@@ -11,18 +13,19 @@ class SeaCreatureMessageShortener {
     @SubscribeEvent
     fun onSeaCreatureFish(event: SeaCreatureFishEvent) {
         if (!LorenzUtils.inSkyBlock) return
-        if (!config.shortenFishingMessage && !config.compactDoubleHook) return
-        val seaCreature = event.seaCreature
-        event.chatEvent.blockedReason = "sea_creature_caught"
 
-        val doubleHookPrefix = if (config.compactDoubleHook && event.doubleHook) "§e§lDOUBLE HOOK! " else ""
-        val message = doubleHookPrefix + if (config.shortenFishingMessage) {
-            "§9You caught a ${seaCreature.displayName}§9!"
-        } else event.chatEvent.message
-        LorenzUtils.chat(message, false)
+        val original = event.chatEvent.chatComponent.formattedText
+        var edited = original
 
-        if (seaCreature.fishingExperience == 0) {
-            LorenzUtils.debug("no fishing exp set for " + seaCreature.name)
+        if (config.shortenFishingMessage) {
+            edited = "§9You caught a ${event.seaCreature.displayName}§9!"
         }
+
+        if (config.compactDoubleHook && event.doubleHook) {
+            edited = "§e§lDOUBLE HOOK! $edited"
+        }
+
+        if (original == edited) return
+        event.chatEvent.chatComponent = ChatComponentText(edited)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.ordinal
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import net.minecraft.client.Minecraft
 import net.minecraft.util.ChatComponentText
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -42,40 +41,45 @@ class TrophyFishMessages {
         val trophyFishes = fishes ?: return
         val trophyFishCounts = trophyFishes.getOrPut(internalName) { mutableMapOf() }
         val amount = trophyFishCounts.addOrPut(rarity, 1)
-        event.blockedReason = "trophy_fish"
 
-        if (config.enabled && config.design == DesignFormat.STYLE_1 && amount == 1) {
-            LorenzUtils.chat("§6§lTROPHY FISH! §c§lFIRST §r$displayRarity $displayName", prefix = false)
+        if (shouldBlockTrophyFish(rarity, amount)) {
+            event.blockedReason = "low_trophy_fish"
             return
         }
 
-        if (config.bronzeHider && rarity == TrophyRarity.BRONZE && amount != 1) return
-        if (config.silverHider && rarity == TrophyRarity.SILVER && amount != 1) return
-        val totalText = if (config.totalAmount) {
-            val total = trophyFishCounts.sumAllValues()
-            " §7(${total.addSeparators()}. total)"
-        } else ""
+        val original = event.chatComponent
+        var edited = original
 
-        val component = ChatComponentText(
-            if (config.enabled) {
-                "§6§lTROPHY FISH! " + when (config.design) {
-                    DesignFormat.STYLE_1 -> "§7$amount. §r$displayRarity $displayName$totalText"
-                    DesignFormat.STYLE_2 -> "§bYou caught a $displayName $displayRarity§b. §7(${amount.addSeparators()})$totalText"
-                    else -> "§bYou caught your ${amount.addSeparators()}${amount.ordinal()} $displayRarity $displayName§b.$totalText"
-                }
-            } else event.message
-        )
+        if (config.enabled) {
+            edited = ChatComponentText("§6§lTROPHY FISH! " + when (config.design) {
+                DesignFormat.STYLE_1 -> if (amount == 1) "§c§lFIRST §r$displayRarity $displayName"
+                     else "§7$amount. §r$displayRarity $displayName"
+                DesignFormat.STYLE_2 -> "§bYou caught a $displayName $displayRarity§b. §7(${amount.addSeparators()})"
+                else -> "§bYou caught your ${amount.addSeparators()}${amount.ordinal()} $displayRarity $displayName§b."
+            })
+        }
+
+        if (config.totalAmount) {
+            val total = trophyFishCounts.sumAllValues()
+            edited.appendSibling(ChatComponentText(" §7(${total.addSeparators()}. total)"))
+        }
 
         if (config.tooltip) {
             TrophyFishManager.getInfo(internalName)?.let {
-                component.chatStyle = it.getTooltip(trophyFishCounts)
+                edited.chatStyle = it.getTooltip(trophyFishCounts)
             }
         }
 
-        Minecraft.getMinecraft().ingameGUI.chatGUI.printChatMessageWithOptionalDeletion(
-            component, if (config.duplicateHider) (internalName + rarity).hashCode() else 0
-        )
+        event.chatComponent = edited
+
+        if (config.duplicateHider) {
+            event.chatLineId = (internalName + rarity).hashCode()
+        }
     }
+
+    private fun shouldBlockTrophyFish(rarity: TrophyRarity, amount: Int) =
+        config.bronzeHider && rarity == TrophyRarity.BRONZE && amount != 1
+                || config.silverHider && rarity == TrophyRarity.SILVER && amount != 1
 
     @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {


### PR DESCRIPTION
Fixes https://discord.com/channels/997079228510117908/1187222863141408909

- Modify messages in SeaCreatureMessageShortener instead of blocking and resending
- Modify messages in TrophyFishMessages instead of blocking and resending
- Minor cleanup of some confusing logic in above classes
- Added chatLineId (default 0) to LorenzChatEvent, which uses printChatMessageWithOptionalDeletion to allow retracting a family of previous messages
