### PR TITLE
Add ability to get unique visitors served without Green Thumb

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -139,6 +139,12 @@ class FarmingFortuneDisplay {
         if (upgradeFortune == null) {
             updatedDisplay.addAsSingletonList("§cOpen §e/cropupgrades§c for more exact data!")
         }
+
+        val uniqueVisitors = GardenAPI.storage?.uniqueVisitors?.toDouble() ?: 0.0
+        if (uniqueVisitors == 0.0) {
+            updatedDisplay.addAsSingletonList("§cOpen §e/visitormilestones§c for more exact data!")
+        }
+
         if (accessoryFortune == null) {
             updatedDisplay.addAsSingletonList("§cOpen Accessory Bag for more exact data!")
             if (CropAccessoryData.isLoadingAccessories) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TabListData
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.math.round
 import kotlin.time.Duration.Companion.days
@@ -37,8 +38,8 @@ class CaptureFarmingGear {
 
     private val cakePattern = "(?:Big )?Yum! You (?:gain|refresh) [+]5☘ Farming Fortune for 48 hours!".toPattern()
 
-    private val tierPattern = "§7Progress to Tier (?<nextTier>\\d+):.*".toPattern()
-    private val tierProgressPattern = ".* §e(?<having>.*)§6/(?<total>.*)".toPattern()
+    private val tierPattern by RepoPattern.pattern("garden.uniqueVisitors.tier", "§7Progress to Tier (?<nextTier>\\d+):.*")
+    private val tierProgressPattern by RepoPattern.pattern("garden.uniqueVisitors.tierProgress", ".* §e(?<having>.*)§6/(?<total>.*)")
 
     companion object {
         private val strengthPattern = " Strength: §r§c❁(?<strength>.*)".toPattern()
@@ -94,14 +95,14 @@ class CaptureFarmingGear {
             LorenzUtils.chat("Toggled expired pumpkin fortune to: ${storage.pumpkinFortune}")
         }
 
-        private fun getUniqueVisitorsForTier(tier: Int, progress: Int): Int {
+        private fun getUniqueVisitorsForTier(tier: Int): Int {
             return when {
                 tier == 0 -> 0
                 tier == 1 -> 1
                 tier == 2 -> 5
                 tier >= 3 -> 10 * (tier - 2)
                 else -> throw IllegalStateException("Unexpected unique visitors tier: $tier")
-            } + progress
+            }
         }
     }
 
@@ -229,20 +230,20 @@ class CaptureFarmingGear {
         }
         if (event.inventoryName.contains("Visitor Milestones")) {
             for ((_, item) in event.inventoryItems) {
-                if (item.displayName == "§aUnique Visitors Served") {
-                    var tier = -1
-                    var tierProgress = -1
-                    for (line in item.getLore()) {
-                        tierPattern.matchMatcher(line) {
-                            tier = group("nextTier").toInt() - 1
-                        }
-                        tierProgressPattern.matchMatcher(line) {
-                            tierProgress = group("having").toInt()
-                        }
+                if (item.displayName != "§aUnique Visitors Served") continue
+
+                var tier = -1
+                var tierProgress = -1
+                for (line in item.getLore()) {
+                    tierPattern.matchMatcher(line) {
+                        tier = group("nextTier").toInt() - 1
                     }
-                    if (tier > -1 && tierProgress > -1) {
-                        GardenAPI.storage?.uniqueVisitors = getUniqueVisitorsForTier(tier, tierProgress)
+                    tierProgressPattern.matchMatcher(line) {
+                        tierProgress = group("having").toInt()
                     }
+                }
+                if (tier > -1 && tierProgress > -1) {
+                    GardenAPI.storage?.uniqueVisitors = getUniqueVisitorsForTier(tier) + tierProgress
                 }
             }
         }


### PR DESCRIPTION
This won't automatically update when you serve a new unique visitor, but I think it didn't do that with Green Thumb either unless you manually opened `/eq`, so this is a good start to be able to at least suggest Green Thumb to people who don't have it at all yet.