### PR TITLE
Only show vacuum bag on your own vacuums

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -204,6 +204,12 @@ object ItemDisplayOverlayFeatures {
 
         if (VACUUM_GARDEN.isSelected() && item.getInternalNameOrNull() in PestAPI.vacuumVariants) {
             for (line in lore) {
+                if (line.contains("Click to trade!") || line.contains("Starting bid:") || line.contains("Buy it now:")) {
+                    return ""
+                }
+            }
+
+            for (line in lore) {
                 gardenVacuumPatterm.matchMatcher(line) {
                     val pests = group("amount").formatNumber()
                     return if (config.vacuumBagCap) {


### PR DESCRIPTION
This prevents the vacuum bag from showing as item stack size in SkyMart and the Auction House, as it can be confusing.