### PR TITLE
Fix progress to maxed milestone appearing twice on milestone 20

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenCropMilestoneInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenCropMilestoneInventory.kt
@@ -58,7 +58,7 @@ class GardenCropMilestoneInventory {
 
         val crop = GardenCropMilestones.getCropTypeByLore(event.itemStack) ?: return
         val tier = GardenCropMilestones.getTierForCropCount(crop.getCounter(), crop)
-        if (tier > 20) return
+        if (tier >= 20) return
 
         val maxTier = GardenCropMilestones.getMaxTier()
         val maxCounter = GardenCropMilestones.getCropsForTier(maxTier, crop)


### PR DESCRIPTION
Hypixel and skyhanni were both showing progress to max milestone on milestone 20, when skyhanni should only show it on milestones below 20 (20 not included)