### PR TITLE
Mark carrot/pumpkin fortune as completed when giving to Carrolyn after already done

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
@@ -256,5 +256,13 @@ class CaptureFarmingGear {
         if (msg == "PUMPKINS EXPORTATION COMPLETE!") {
             storage.pumpkinFortune = true
         }
+        if (msg == "[NPC] Carrolyn: Thank you for the carrots.") {
+            storage.carrotFortune = true
+            LorenzUtils.chat("§aYou have already given Carrolyn enough Exportable Carrots. Marked carrot fortune as completed.")
+        }
+        if (msg == "[NPC] Carrolyn: Thank you for the pumpkins.") {
+            storage.pumpkinFortune = true
+            LorenzUtils.chat("§aYou have already given Carrolyn enough Expired Pumpkin. Marked pumpkin fortune as completed.")
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
@@ -262,7 +262,7 @@ class CaptureFarmingGear {
         }
         if (msg == "[NPC] Carrolyn: Thank you for the pumpkins.") {
             storage.pumpkinFortune = true
-            LorenzUtils.chat("§aYou have already given Carrolyn enough Expired Pumpkin.")
+            LorenzUtils.chat("§aYou have already given Carrolyn enough Expired Pumpkins.")
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
@@ -258,11 +258,11 @@ class CaptureFarmingGear {
         }
         if (msg == "[NPC] Carrolyn: Thank you for the carrots.") {
             storage.carrotFortune = true
-            LorenzUtils.chat("§aYou have already given Carrolyn enough Exportable Carrots. Marked carrot fortune as completed.")
+            LorenzUtils.chat("§aYou have already given Carrolyn enough Exportable Carrots.")
         }
         if (msg == "[NPC] Carrolyn: Thank you for the pumpkins.") {
             storage.pumpkinFortune = true
-            LorenzUtils.chat("§aYou have already given Carrolyn enough Expired Pumpkin. Marked pumpkin fortune as completed.")
+            LorenzUtils.chat("§aYou have already given Carrolyn enough Expired Pumpkin.")
         }
     }
 }


### PR DESCRIPTION
The meaning of these messages is not obvious at a glance, but they only appear when trying to give more exportable carrots/expired pumpkin to Carrolyn beyond 3,000.

<img width="653" alt="Screenshot of the feature in action" src="https://github.com/hannibal002/SkyHanni/assets/148620615/b2c3bf68-f551-4fd5-a31f-de99329ade1e">
