### PR TITLE
Fix mushroom counter when farming sugar cane/cactus with Mooshroom Cow

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
@@ -42,7 +42,7 @@ object GardenCropSpeed {
         fixedRateTimer(name = "skyhanni-crop-milestone-speed", period = 1000L) {
             if (isEnabled()) {
                 if (GardenAPI.mushroomCowPet) {
-                    CropType.MUSHROOM.setCounter(CropType.MUSHROOM.getCounter() + blocksBroken)
+                    CropType.MUSHROOM.setCounter(CropType.MUSHROOM.getCounter() + blocksBroken * (lastBrokenCrop?.multiplier ?: 1))
                 }
                 checkSpeed()
                 update()


### PR DESCRIPTION
These crops have double mushroom drops because two blocks break at once. It's already handled for e.g. money per hour in the code, but wasn't accounted for here.