### PR TITLE
Change: Changed description of Dungeon Filter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.java
@@ -32,7 +32,7 @@ public class ChatConfig {
     public ChatSymbols chatSymbols = new ChatSymbols();
 
     @Expose
-    @ConfigOption(name = "Dungeon Filter", desc = "Hide annoying messages in Dungeons.")
+    @ConfigOption(name = "Dungeon Filter", desc = "Hides pickup, reminder, buff, damage, ability, puzzle and end messages in Dungeons.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean dungeonMessages = true;


### PR DESCRIPTION
People don't know what exactly "annoying messages" are and some don't know that it also removes blessing messages.
Gives clarity to users.

Maybe: Add a Multi-Dropdown/Menu to select types of messages in the future