### PR TITLE
Feature: Add a reversed version of /shcroptime

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -25,6 +25,7 @@ import at.hannibal2.skyhanni.features.fishing.tracker.FishingProfitTracker
 import at.hannibal2.skyhanni.features.fishing.tracker.SeaCreatureTracker
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.garden.GardenCropTimeCommand
+import at.hannibal2.skyhanni.features.garden.GardenCropsInCommand
 import at.hannibal2.skyhanni.features.garden.GardenNextJacobContest
 import at.hannibal2.skyhanni.features.garden.composter.ComposterOverlay
 import at.hannibal2.skyhanni.features.garden.farming.ArmorDropTracker
@@ -152,6 +153,10 @@ object Commands {
             "shcroptime",
             "Calculates with your current crop per second speed how long you need to farm a crop to collect this amount of items"
         ) { GardenCropTimeCommand.onCommand(it) }
+        registerCommand(
+            "shcropsin",
+            "Calculates with your current crop per second how many items you can collect in this amount of time"
+        ) { GardenCropsInCommand.onCommand(it) }
         registerCommand(
             "shrpcstart",
             "Manually starts the Discord Rich Presence feature"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropTimeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropTimeCommand.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.sorted
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatNumber
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils
 
@@ -26,7 +27,7 @@ object GardenCropTimeCommand {
 
         val rawAmount = args[0]
         val amount = try {
-            rawAmount.toInt()
+            rawAmount.formatNumber().toInt()
         } catch (e: NumberFormatException) {
             LorenzUtils.userError("Not a valid number: '$rawAmount'")
             return
@@ -63,7 +64,7 @@ object GardenCropTimeCommand {
         }
 
         if (map.isEmpty()) {
-            LorenzUtils.error("No crop item found for '$rawSearchName'.")
+            LorenzUtils.userError("No crop item found for '$rawSearchName'.")
             return
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropsInCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropsInCommand.kt
@@ -1,0 +1,71 @@
+package at.hannibal2.skyhanni.features.garden
+
+import at.hannibal2.skyhanni.features.garden.farming.CropMoneyDisplay
+import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed.getSpeed
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemName
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.sorted
+import at.hannibal2.skyhanni.utils.NEUItems
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.TimeUtils
+
+/*
+ * What I need ot do,
+ *  - get the crop rate / h
+ *  - find some time standard to use
+ */
+
+object GardenCropsInCommand {
+    private val config get() = GardenAPI.config.moneyPerHours
+
+    fun onCommand(args: Array<String>) {
+        if (!config.display) {
+            LorenzUtils.userError("shcroptime requires 'Show money per Hour' feature to be enabled to work!")
+            return
+        }
+
+        if (args.size < 2) {
+            LorenzUtils.userError("Usage: /shcropsin <time> <item>")
+            return
+        }
+
+        val rawTime = args[0]
+        val seconds = try {
+            TimeUtils.getDuration(rawTime).inWholeSeconds
+        } catch (e: NumberFormatException) {
+            LorenzUtils.userError("Not a valid time: '$rawTime'")
+            return
+        }
+
+        val rawSearchName = args.toMutableList().drop(1).joinToString(" ")
+        val searchName = rawSearchName.lowercase()
+
+        val map = mutableMapOf<String, Long>()
+        for (entry in CropMoneyDisplay.multipliers) {
+            val internalName = entry.key
+            val itemName = internalName.getItemName()
+            if (itemName.removeColor().lowercase().contains(searchName)) {
+                val (baseId, baseAmount) = NEUItems.getMultiplier(internalName)
+                val baseName = baseId.getItemName()
+                val crop = CropType.getByName(baseName.removeColor())
+
+                val speed = crop.getSpeed()
+
+                if (speed == null){
+                    map["$itemName §cNo speed data!"] = -1
+                } else {
+                    val fullAmount = seconds * speed / baseAmount
+                    map["$itemName §b${fullAmount.addSeparators()}x"] = fullAmount
+                }
+            }
+        }
+
+        if (map.isEmpty()) {
+            LorenzUtils.userError("No crops found for '$rawSearchName'")
+            return
+        }
+
+        LorenzUtils.chat("Crops farmed in $rawTime:\n" + map.sorted().keys.joinToString("\n"))
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropsInCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropsInCommand.kt
@@ -16,7 +16,7 @@ object GardenCropsInCommand {
 
     fun onCommand(args: Array<String>) {
         if (!config.display) {
-            LorenzUtils.userError("shcroptime requires 'Show money per Hour' feature to be enabled to work!")
+            LorenzUtils.userError("shcropsin requires 'Show money per Hour' feature to be enabled to work!")
             return
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropsInCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropsInCommand.kt
@@ -10,11 +10,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils
 
-/*
- * What I need ot do,
- *  - get the crop rate / h
- *  - find some time standard to use
- */
 
 object GardenCropsInCommand {
     private val config get() = GardenAPI.config.moneyPerHours


### PR DESCRIPTION
Adds the command `/shcropsin <time> <item>`, described in "Reversed /shcroptime #202". Given a duration and crop it will calculate how many crops you would farm.

P.S This is my first actual pull request so I apologize if I messed something up.