### PR TITLE
Fix Poisoned Candy patterns

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactSplashPotionMessage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactSplashPotionMessage.kt
@@ -18,9 +18,9 @@ class CompactSplashPotionMessage {
 
         // Fix for Hypixel having a different message for Poisoned Candy.
         // Did not make the first pattern optional to prevent conflicts with Dungeon Buffs/other things
-        "§a§lBUFF! §fYou have gained §r(?<effectName>§2Poisoned Candy I)§r§f!§r".toPattern(),
-        "§a§lBUFF! §fYou splashed yourself with §r(?<effectName>§2Poisoned Candy I)§r§f!§r".toPattern(),
-        "§a§lBUFF! §fYou were splashed by (?<playerName>.*) §fwith §r(?<effectName>§2Poisoned Candy I)§r§f!§r".toPattern()
+        "§a§lBUFF! §fYou have gained §r(?<effectName>§2Poisoned Candy I)§r§f!".toPattern(),
+        "§a§lBUFF! §fYou splashed yourself with §r(?<effectName>§2Poisoned Candy I)§r§f!".toPattern(),
+        "§a§lBUFF! §fYou were splashed by (?<playerName>.*) §fwith §r(?<effectName>§2Poisoned Candy I)§r§f!".toPattern()
     )
 
     @SubscribeEvent


### PR DESCRIPTION
Fixes this:

![Screenshot showing Poisoned Candy message not being compacted unlike other potions](https://github.com/hannibal002/SkyHanni/assets/148620615/4df994a6-f7fe-4f90-8961-a50d9f400fbc)
