### PR TITLE
Fix: Title rendering layering

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
@@ -8,6 +8,7 @@ import io.github.moulberry.moulconfig.internal.TextRenderUtils
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.ScaledResolution
 import net.minecraft.client.renderer.GlStateManager
+import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -47,7 +48,7 @@ class TitleManager {
         endTime = SimpleTimeMark.farPast()
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (endTime.isInPast()) return
 


### PR DESCRIPTION
While fixing the item render layering i found (and used) this bug. The title is at the same layer as all other our guis, therefore it depends on the order in which the the event is called for the layering. So I set the priorty to lowest so the title renders allways on top of the rest, I would change the z offset of the Title, but any offset would render it on top of the chat.

## Example
![image](https://github.com/hannibal002/SkyHanni/assets/85900443/85cc268a-8736-4d6c-abaf-bacded32ff5d)
Ignore the weird item rendering it is fixed with #896 