### PR TITLE
Add annotations to MC classes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
     kotlin("jvm") version "1.9.0"
     id("com.bnorm.power.kotlin-power-assert") version "0.13.0"
+    id("moe.nea.shot") version "1.0.0"
 }
 
 group = "at.hannibal2.skyhanni"
@@ -68,6 +69,8 @@ val headlessLwjgl by configurations.creating {
     isVisible = false
 }
 
+val shot = shots.shot("minecraft", project.file("shots.txt"))
+
 dependencies {
     minecraft("com.mojang:minecraft:1.8.9")
     mappings("de.oceanlabs.mcp:mcp_stable:22-1.8.9")
@@ -116,6 +119,9 @@ dependencies {
     }
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     testImplementation("io.mockk:mockk:1.12.5")
+}
+configurations.getByName("minecraftNamed").dependencies.forEach {
+    shot.applyTo(it as HasConfigurableAttributes<*>)
 }
 
 tasks.withType(Test::class) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
         maven("https://maven.fabricmc.net")
         maven("https://maven.minecraftforge.net/")
         maven("https://repo.spongepowered.org/maven/")
+        maven("https://repo.nea.moe/releases")
         maven("https://repo.sk1er.club/repository/maven-releases/")
     }
     resolutionStrategy {

--- a/shots.txt
+++ b/shots.txt
@@ -1,0 +1,56 @@
+net.minecraft.client.entity.EntityPlayerSP:
+    sendQueue:
+        annotate org.jetbrains.annotations.NotNull
+net.minecraft.client.Minecraft:
+    renderEngine:
+        annotate org.jetbrains.annotations.NotNull
+    renderGlobal:
+        annotate org.jetbrains.annotations.NotNull
+    thePlayer:
+        annotate org.jetbrains.annotations.Nullable
+    pointedEntity:
+        annotate org.jetbrains.annotations.Nullable
+    effectRenderer:
+        annotate org.jetbrains.annotations.NotNull
+    fontRendererObj:
+        annotate org.jetbrains.annotations.NotNull
+    standardGalacticFontRenderer:
+        annotate org.jetbrains.annotations.NotNull
+    currentScreen:
+        annotate org.jetbrains.annotations.Nullable
+    entityRenderer:
+        annotate org.jetbrains.annotations.NotNull
+    guiAchievement:
+        annotate org.jetbrains.annotations.NotNull
+    ingameGUI:
+        annotate org.jetbrains.annotations.NotNull
+    objectMouseOver:
+        annotate org.jetbrains.annotations.Nullable
+    gameSettings:
+        annotate org.jetbrains.annotations.NotNull
+    mouseHelper:
+        annotate org.jetbrains.annotations.NotNull
+    mcDataDir:
+        annotate org.jetbrains.annotations.NotNull
+    frameTimer:
+        annotate org.jetbrains.annotations.NotNull
+    mcProfiler:
+        annotate org.jetbrains.annotations.NotNull
+    mcDefaultResourcePack:
+        annotate org.jetbrains.annotations.NotNull
+    theWorld:
+        annotate org.jetbrains.annotations.Nullable
+    <init>(net.minecraft.client.main.GameConfiguration):
+        annotateParameter 0 org.jetbrains.annotations.NotNull
+    getFrameBuffer():
+        annotate org.jetbrains.annotations.NotNull
+    getVersion():
+        annotate org.jetbrains.annotations.NotNull
+    drawSplashScreen(net.minecraft.client.renderer.texture.TextureManager):
+        annotate org.jetbrains.annotations.NotNull
+    getSaveLoader():
+        annotate org.jetbrains.annotations.NotNull
+    displayGuiScreen(net.minecraft.client.gui.GuiScreen):
+        annotateParameter 0 org.jetbrains.annotations.Nullable
+    getMusicTicker():
+        annotate org.jetbrains.annotations.NotNull


### PR DESCRIPTION
Adds nullability annotations to some MC classes. This prevents Kotlin from using platform types like `Player!`. This way nullability needs to be explicitly handled by Kotlin code.