### PR TITLE
Fix names of Crystal Hollows mining areas

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsNamesInCore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsNamesInCore.kt
@@ -14,10 +14,10 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 class CrystalHollowsNamesInCore {
     private val config get() = SkyHanniMod.feature.mining
     private val coreLocations = mapOf(
-        LorenzVec(550, 116, 550) to "§8Precursor City",
+        LorenzVec(550, 116, 550) to "§8Precursor Remnants",
         LorenzVec(552, 116, 474) to "§bMithril Deposits",
         LorenzVec(477, 116, 476) to "§aJungle",
-        LorenzVec(474, 116, 554) to "§6Goblin Hideout"
+        LorenzVec(474, 116, 554) to "§6Goblin Holdout"
     )
 
     private var showWaypoints = false


### PR DESCRIPTION
- It's Goblin Holdout, not Hideout.
- (Lost) Precursor City is a place within, the big area itself is Precursor Remnants.