### PR TITLE
Fix: Remove bugged hypixel entities

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -331,6 +331,7 @@ import at.hannibal2.skyhanni.test.HighlightMissingRepoItems
 import at.hannibal2.skyhanni.test.HotSwapDetection
 import at.hannibal2.skyhanni.test.PacketTest
 import at.hannibal2.skyhanni.test.ParkourWaypointSaver
+import at.hannibal2.skyhanni.test.RemoveBuggedHypixelEntities
 import at.hannibal2.skyhanni.test.ShowItemUuid
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.test.TestBingo
@@ -710,6 +711,7 @@ class SkyHanniMod {
 
         // test stuff
         loadModule(SkyHanniDebugsAndTests())
+        loadModule(RemoveBuggedHypixelEntities)
         loadModule(CopyNearbyParticlesCommand)
         loadModule(ButtonOnPause())
         loadModule(PacketTest())

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/AccessorWorldClient.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/AccessorWorldClient.java
@@ -1,0 +1,15 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Set;
+
+@Mixin(WorldClient.class)
+public interface AccessorWorldClient {
+
+    @Accessor("entityList")
+    Set<Entity> getEntityList_skyhanni();
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.test
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.PacketEvent
+import at.hannibal2.skyhanni.mixins.transformers.AccessorWorldClient
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -10,7 +11,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.makeAccessible
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.equalsIgnoreColor
 import net.minecraft.client.Minecraft
-import net.minecraft.client.multiplayer.WorldClient
 import net.minecraft.entity.Entity
 import net.minecraft.network.Packet
 import net.minecraft.network.play.server.S13PacketDestroyEntities
@@ -153,9 +153,8 @@ object RemoveBuggedHypixelEntities {
             val worldClient = Minecraft.getMinecraft().theWorld
             val inLoadedEntityList = entity in worldClient.loadedEntityList
             val inDestroyedEntities = entityId in destroyedEntities
-            val client = worldClient as WorldClient
-            val entityList: Set<Entity> =
-                client.javaClass.getDeclaredField("entityList").makeAccessible().get(client) as Set<Entity>
+            val client = worldClient as AccessorWorldClient
+            val entityList: Set<Entity> = client.getEntityList_skyhanni()
             val inEntityList = entity in entityList
 
             val name = entity.name

--- a/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
@@ -21,6 +21,8 @@ import kotlin.time.Duration.Companion.seconds
 
 object RemoveBuggedHypixelEntities {
 
+    private val neverUpdatedTime = (-1).seconds
+
     private var lastCheckTime = SimpleTimeMark.farPast()
 
     private var foundEntities = mutableListOf<Int>()
@@ -91,14 +93,9 @@ object RemoveBuggedHypixelEntities {
         }
     }
 
-    val neverUpdatedTime = (-1).seconds
-
     private fun checkNearby() {
         if (!Minecraft.getMinecraft().thePlayer.isSneaking()) return
-
-        if (lastCheckTime.passedSince() < 500.milliseconds) {
-            return
-        }
+        if (lastCheckTime.passedSince() < 500.milliseconds) return
 
         lastCheckTime = SimpleTimeMark.now()
 
@@ -148,8 +145,13 @@ object RemoveBuggedHypixelEntities {
             val inEntityList = entity in entityList
 
             val name = entity.name
-            val text = "'" + name + "' | " + lastUpdateTime + " | $ticksExisted ticks | npc:$npc |" +
-                " inLoadedEntityList:$inLoadedEntityList | inEntityList:$inEntityList | inDestroyedEntities:$inDestroyedEntities"
+            val text = "'$name' | " +
+                lastUpdateTime + " | " +
+                "$ticksExisted ticks | " +
+                "npc:$npc | " +
+                "inLoadedEntityList:$inLoadedEntityList | " +
+                "inEntityList:$inEntityList | " +
+                "inDestroyedEntities:$inDestroyedEntities"
             result.add(text)
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
@@ -104,8 +104,14 @@ object RemoveBuggedHypixelEntities {
 
         collectFound()
 
-        val entities = EntityUtils.getEntitiesNextToPlayer<Entity>(5.0).filter { it != Minecraft.getMinecraft().thePlayer }
+        val entities =
+            EntityUtils.getEntitiesNextToPlayer<Entity>(5.0).filter { it != Minecraft.getMinecraft().thePlayer }
 
+        filterInvalidEntities(entities)
+        debug(entities)
+    }
+
+    private fun filterInvalidEntities(entities: Sequence<Entity>) {
         for (entity in entities) {
             val entityId = entity.entityId
             val lastUpdateTime = lastFoundTime[entityId]?.passedSince() ?: neverUpdatedTime
@@ -124,8 +130,6 @@ object RemoveBuggedHypixelEntities {
                 }
             }
         }
-
-        debug(entities)
     }
 
     private fun debug(list: Sequence<Entity>) {
@@ -145,7 +149,7 @@ object RemoveBuggedHypixelEntities {
 
             val name = entity.name
             val text = "'" + name + "' | " + lastUpdateTime + " | $ticksExisted ticks | npc:$npc |" +
-                    " inLoadedEntityList:$inLoadedEntityList | inEntityList:$inEntityList | inDestroyedEntities:$inDestroyedEntities"
+                " inLoadedEntityList:$inLoadedEntityList | inEntityList:$inEntityList | inDestroyedEntities:$inDestroyedEntities"
             result.add(text)
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
@@ -1,0 +1,161 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
+import at.hannibal2.skyhanni.events.PacketEvent
+import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.makeAccessible
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.StringUtils.equalsIgnoreColor
+import net.minecraft.client.Minecraft
+import net.minecraft.client.multiplayer.WorldClient
+import net.minecraft.entity.Entity
+import net.minecraft.network.Packet
+import net.minecraft.network.play.server.S13PacketDestroyEntities
+import net.minecraft.network.play.server.S14PacketEntity
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+object RemoveBuggedHypixelEntities {
+
+    private var lastCheckTime = SimpleTimeMark.farPast()
+
+    @SubscribeEvent
+    fun onTick(event: LorenzTickEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+
+        checkNearby()
+
+        if (event.repeatSeconds(1)) {
+            collectFound()
+        }
+    }
+
+    private fun collectFound() {
+        val helpList = foundEntities.toList()
+        foundEntities.clear()
+
+        val lastFound = lastFoundTime.toMutableMap()
+        val now = SimpleTimeMark.now()
+        for (id in helpList) {
+            lastFound[id] = now
+        }
+        lastFoundTime = lastFound
+    }
+
+    @SubscribeEvent
+    fun onWorldChange(event: LorenzWorldChangeEvent) {
+        foundEntities.clear()
+        lastFoundTime = emptyMap()
+        destroyedEntities.clear()
+    }
+
+    private var foundEntities = mutableListOf<Int>()
+    private var lastFoundTime = mapOf<Int, SimpleTimeMark>()
+    private var destroyedEntities = mutableListOf<Int>()
+
+    @SubscribeEvent
+    fun onReceiveCurrentShield(event: PacketEvent.ReceiveEvent) {
+        val packet = event.packet
+
+        if (packet is S13PacketDestroyEntities) {
+            for (entityID in packet.entityIDs) {
+                destroyedEntities.add(entityID)
+            }
+            return
+        }
+
+        detectEntityUpdate(packet)
+    }
+
+    private fun detectEntityUpdate(packet: Packet<*>) {
+        val clazz = packet.javaClass
+        if (!clazz.simpleName.contains("entity", ignoreCase = true)) return
+        if (packet is S14PacketEntity) {
+            tryToAdd(packet, S14PacketEntity::class.java)
+        } else {
+            tryToAdd(packet, clazz)
+        }
+    }
+
+    private fun tryToAdd(packet: Packet<*>, clazz: Class<*>) {
+        for (field in clazz.declaredFields) {
+            val name = field.name
+            if (name.equalsIgnoreColor("entityId")) {
+                val id = field.makeAccessible().get(packet) as Int
+                addEntityId(id)
+            }
+        }
+    }
+
+    private fun addEntityId(entityId: Int) {
+        foundEntities.add(entityId)
+    }
+
+    private fun checkNearby() {
+        if (!Minecraft.getMinecraft().thePlayer.isSneaking()) return
+
+        if (lastCheckTime.passedSince() < 500.milliseconds) {
+            return
+        }
+
+        lastCheckTime = SimpleTimeMark.now()
+
+        collectFound()
+
+        val list = EntityUtils.getEntitiesNextToPlayer<Entity>(5.0)
+
+        val neverUpdatedTime = (-1).seconds
+        val result = mutableListOf<String>()
+        for (entity in list) {
+            if (entity == Minecraft.getMinecraft().thePlayer) continue
+            val entityId = entity.entityId
+            val lastUpdateTime = lastFoundTime[entityId]?.passedSince() ?: neverUpdatedTime
+            val ticksExisted = entity.ticksExisted
+            val npc = entity.isNPC()
+            val worldClient = Minecraft.getMinecraft().theWorld
+            val inLoadedEntityList = entity in worldClient.loadedEntityList
+            val inDestroyedEntities = entityId in destroyedEntities
+            val client = worldClient as WorldClient
+            val entityList: Set<Entity> =
+                client.javaClass.getDeclaredField("entityList").makeAccessible().get(client) as Set<Entity>
+            val inEntityList = entity in entityList
+
+            val name = entity.name
+            val text = "'" + name + "' | " + lastUpdateTime + " | $ticksExisted ticks | npc:$npc |" +
+                " inLoadedEntityList:$inLoadedEntityList | inEntityList:$inEntityList | inDestroyedEntities:$inDestroyedEntities"
+
+            if (name == "§c☣ §fBleeds: §8-") {
+                if (ticksExisted > 20 * 4) {
+                    removeInvalidEntity(entityId, "Minotaur ability name")
+                }
+            }
+
+            result.add(text)
+            if (lastUpdateTime == neverUpdatedTime) {
+                if (ticksExisted > 20) {
+                    removeInvalidEntity(entityId, "Mob never updated")
+                }
+            }
+        }
+
+        if (result.isEmpty()) {
+            println("check (nothing)")
+            return
+        }
+
+        println(" ")
+        println("check:")
+        for (s in result) {
+            println(" $s")
+        }
+    }
+
+    private fun removeInvalidEntity(entityId: Int, reason: String) {
+        Minecraft.getMinecraft().theWorld.removeEntityFromWorld(entityId)
+        LorenzUtils.chat("Manually removing a broken Hypixel entity: $reason")
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/RemoveBuggedHypixelEntities.kt
@@ -98,11 +98,10 @@ object RemoveBuggedHypixelEntities {
         if (lastCheckTime.passedSince() < 500.milliseconds) return
 
         lastCheckTime = SimpleTimeMark.now()
-
         collectFound()
 
-        val entities =
-            EntityUtils.getEntitiesNextToPlayer<Entity>(5.0).filter { it != Minecraft.getMinecraft().thePlayer }
+        val entities = EntityUtils.getEntitiesNextToPlayer<Entity>(5.0)
+                .filter { it != Minecraft.getMinecraft().thePlayer }
 
         filterInvalidEntities(entities)
         debug(entities)
@@ -130,6 +129,21 @@ object RemoveBuggedHypixelEntities {
     }
 
     private fun debug(list: Sequence<Entity>) {
+        val result = calculateEntities(list)
+
+        if (result.isEmpty()) {
+            println("check (nothing)")
+            return
+        }
+
+        println(" ")
+        println("check:")
+        for (s in result) {
+            println(" $s")
+        }
+    }
+
+    private fun calculateEntities(list: Sequence<Entity>): MutableList<String> {
         val result = mutableListOf<String>()
         for (entity in list) {
             val entityId = entity.entityId
@@ -146,25 +160,15 @@ object RemoveBuggedHypixelEntities {
 
             val name = entity.name
             val text = "'$name' | " +
-                lastUpdateTime + " | " +
-                "$ticksExisted ticks | " +
-                "npc:$npc | " +
-                "inLoadedEntityList:$inLoadedEntityList | " +
-                "inEntityList:$inEntityList | " +
-                "inDestroyedEntities:$inDestroyedEntities"
+                    lastUpdateTime + " | " +
+                    "$ticksExisted ticks | " +
+                    "npc:$npc | " +
+                    "inLoadedEntityList:$inLoadedEntityList | " +
+                    "inEntityList:$inEntityList | " +
+                    "inDestroyedEntities:$inDestroyedEntities"
             result.add(text)
         }
-
-        if (result.isEmpty()) {
-            println("check (nothing)")
-            return
-        }
-
-        println(" ")
-        println("check:")
-        for (s in result) {
-            println(" $s")
-        }
+        return result
     }
 
     private fun removeInvalidEntity(entityId: Int, reason: String) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -139,7 +139,7 @@ object EntityUtils {
         return inventory.any { it != null && it.getSkullTexture() == skin }
     }
 
-    fun EntityPlayer.isNPC() = uniqueID == null || uniqueID.version() != 4
+    fun Entity.isNPC() = this is EntityPlayer && (uniqueID == null || uniqueID.version() != 4)
 
     fun EntityLivingBase.hasPotionEffect(potion: Potion) = getActivePotionEffect(potion) != null
 
@@ -150,9 +150,13 @@ object EntityUtils {
 
     inline fun <reified R : Entity> getEntities(): Sequence<R> = getAllEntities().filterIsInstance<R>()
 
-    fun getAllEntities(): Sequence<Entity> = Minecraft.getMinecraft()?.theWorld?.loadedEntityList?.let {
-        if (Minecraft.getMinecraft().isCallingFromMinecraftThread) it else it.toMutableList()
-    }?.asSequence()?.filterNotNull() ?: emptySequence()
+    fun getAllEntities(): Sequence<Entity> {
+        val result = Minecraft.getMinecraft()?.theWorld?.loadedEntityList?.let {
+            if (Minecraft.getMinecraft().isCallingFromMinecraftThread) it else it.toMutableList()
+        }?.asSequence()?.filterNotNull() ?: emptySequence()
+
+        return result
+    }
 
     fun Entity.canBeSeen(radius: Double = 150.0) = getLorenzVec().add(y = 0.5).canBeSeen(radius)
 


### PR DESCRIPTION
Remove bugged Hypixel entities that are close with sneaking

TODO:
option to disable
option to toggle the extra debug thing
option to show a moving nametag at this spot
option to count removed entities per world
option to show a chat message