### PR TITLE
Replaced Npc with NPC (typos)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SackDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SackDisplay.kt
@@ -227,7 +227,7 @@ object SackDisplay {
 
     enum class PriceFrom(val displayName: String) {
         BAZAAR("Bazaar Price"),
-        NPC("Npc Price"),
+        NPC("NPC Price"),
         ;
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/PriceSource.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/PriceSource.kt
@@ -3,6 +3,6 @@ package at.hannibal2.skyhanni.test
 enum class PriceSource(val displayName: String) {
     BAZAAR_INSTANT_SELL("Instant Sell"),
     BAZAAR_SELL_OFFER("Sell Offer"),
-    NPC("Npc Price"),
+    NPC("NPC Price"),
     ;
 }

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -420,7 +420,7 @@ class SkyHanniDebugsAndTests {
         val internalName = event.itemStack.getInternalNameOrNull() ?: return
 
         val npcPrice = internalName.getNpcPriceOrNull() ?: return
-        event.toolTip.add("§7Npc price: §6${npcPrice.addSeparators()}")
+        event.toolTip.add("§7NPC price: §6${npcPrice.addSeparators()}")
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Fixed a few situations where "Npc" would be used instead of "NPC". Should now be consistent throughout the mod.