### PR TITLE
Skip unavailable experiments for number of clicks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SuperpairsClicksAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SuperpairsClicksAlert.kt
@@ -29,6 +29,7 @@ class SuperpairsClicksAlert {
                 roundsNeeded = -1
                 break
             }
+            if (lore.any { it.contains("Enchanting level too low!") || it.contains("Not enough experience!") }) continue
             val match = lore.asReversed().firstNotNullOfOrNull { roundsNeededRegex.find(it.removeColor()) } ?: continue
             roundsNeeded = match.groups[1]!!.value.toInt()
             break


### PR DESCRIPTION
This isn't a perfect fix, as the player could still choose a lower tier experiment for some reason, but it's a start.