### PR TITLE
Fix: Overlay Rendering Layer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
@@ -24,7 +24,9 @@ class RenderData {
         if (!SkyHanniDebugsAndTests.globalRender) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
 
+        GlStateManager.translate(0f,0f,-3f)
         GuiRenderEvent.GuiOverlayRenderEvent().postAndCatch()
+        GlStateManager.translate(0f,0f,3f)
     }
 
     @SubscribeEvent
@@ -38,7 +40,9 @@ class RenderData {
         GlStateManager.enableDepth()
 
         if (GuiEditManager.isInGui()) {
+            GlStateManager.translate(0f,0f,-3f)
             GuiRenderEvent.GuiOverlayRenderEvent().postAndCatch()
+            GlStateManager.translate(0f,0f,3f)
         }
 
         GuiRenderEvent.ChestGuiOverlayRenderEvent().postAndCatch()

--- a/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
@@ -8,7 +8,6 @@ import io.github.moulberry.moulconfig.internal.TextRenderUtils
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.ScaledResolution
 import net.minecraft.client.renderer.GlStateManager
-import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -57,7 +56,7 @@ class TitleManager {
         endTime = SimpleTimeMark.farPast()
     }
 
-    @SubscribeEvent(priority = EventPriority.LOWEST)
+    @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (endTime.isInPast()) return
 
@@ -70,7 +69,7 @@ class TitleManager {
         val renderer = Minecraft.getMinecraft().fontRendererObj
 
         GlStateManager.pushMatrix()
-        GlStateManager.translate((width / 2).toFloat(), (height / heightModifier).toFloat(), 0.0f)
+        GlStateManager.translate((width / 2).toFloat(), (height / heightModifier).toFloat(), 3.0f)
         GlStateManager.scale(fontSizeModifier, fontSizeModifier, fontSizeModifier)
         TextRenderUtils.drawStringCenteredScaledMaxWidth(display, renderer, 0f, 0f, true, 75, 0)
         GlStateManager.popMatrix()

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -8,7 +8,6 @@ import io.github.moulberry.moulconfig.gui.GuiScreenElementWrapper
 import io.github.moulberry.notenoughupdates.util.Utils
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
-import net.minecraft.client.gui.GuiChat
 import net.minecraft.client.gui.inventory.GuiEditSign
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.item.ItemStack
@@ -233,8 +232,6 @@ interface Renderable {
 
             override fun render(posX: Int, posY: Int) {
                 GlStateManager.pushMatrix()
-                if (Minecraft.getMinecraft().currentScreen is GuiChat)
-                    GlStateManager.translate(0F, 0F, -3F)
                 any.renderOnScreen(0F, 0F, scaleMultiplier = scale)
                 GlStateManager.popMatrix()
             }


### PR DESCRIPTION
moved GuiOverlayRenderEvent 3 units in z back to fix rendering items in front of the chat. 
With this changes the layer of the Title can be fixed since we can keep it at the same rendering layer as before but there is no conflict anymore since everything else is moved back. 
This won't have any unexcpeted consequences 🤞.