### PR TITLE
Fix: shupdaterepo

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import com.google.gson.JsonObject
 import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -22,12 +23,14 @@ import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.minutes
 
 class RepoManager(private val configLocation: File) {
     private val gson get() = ConfigManager.gson
     private var latestRepoCommit: String? = null
     private val repoLocation: File = File(configLocation, "repo")
     private var error = false
+    private var lastUpdate = SimpleTimeMark.farPast()
 
     companion object {
         val successfulConstants = mutableListOf<String>()
@@ -82,7 +85,7 @@ class RepoManager(private val configLocation: File) {
                 val file = File(configLocation, "repo")
                 if (file.exists() && currentCommitJSON != null && currentCommitJSON["sha"].asString == latestRepoCommit
                 ) {
-                    if (unsuccessfulConstants.isEmpty()) {
+                    if (unsuccessfulConstants.isEmpty() || (command && lastUpdate.passedSince() < 1.minutes)) {
 
                         if (command) {
                             LorenzUtils.chat("§7The repo is already up to date!")
@@ -91,6 +94,7 @@ class RepoManager(private val configLocation: File) {
                         return@supplyAsync false
                     }
                 }
+                lastUpdate = SimpleTimeMark.now()
                 RepoUtils.recursiveDelete(repoLocation)
                 repoLocation.mkdirs()
                 val itemsZip = File(repoLocation, "sh-repo-main.zip")
@@ -214,19 +218,20 @@ class RepoManager(private val configLocation: File) {
             return
         }
         if (unsuccessfulConstants.isEmpty() && successfulConstants.isNotEmpty()) {
-            LorenzUtils.chat("Repo working fine!", prefixColor = "§a")
+            LorenzUtils.chat("Repo working fine! Commit hash: $latestRepoCommit", prefixColor = "§a")
             return
         }
+        LorenzUtils.chat("Repo has errors! Commit has: ${latestRepoCommit ?: "null"}", prefixColor = "§c")
         if (successfulConstants.isNotEmpty()) LorenzUtils.chat(
             "Successful Constants §7(${successfulConstants.size}):",
             prefixColor = "§a"
         )
         for (constant in successfulConstants) {
-            LorenzUtils.chat("   §a- §7$constant")
+            LorenzUtils.chat("   §a- §7$constant", false)
         }
         LorenzUtils.chat("Unsuccessful Constants §7(${unsuccessfulConstants.size}):")
         for (constant in unsuccessfulConstants) {
-            LorenzUtils.chat("   §e- §7$constant")
+            LorenzUtils.chat("   §e- §7$constant", false)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -30,7 +30,7 @@ class RepoManager(private val configLocation: File) {
     private var latestRepoCommit: String? = null
     private val repoLocation: File = File(configLocation, "repo")
     private var error = false
-    private var lastUpdate = SimpleTimeMark.farPast()
+    private var lastRepoUpdate = SimpleTimeMark.farPast()
 
     companion object {
         val successfulConstants = mutableListOf<String>()
@@ -85,8 +85,7 @@ class RepoManager(private val configLocation: File) {
                 val file = File(configLocation, "repo")
                 if (file.exists() && currentCommitJSON != null && currentCommitJSON["sha"].asString == latestRepoCommit
                 ) {
-                    if (unsuccessfulConstants.isEmpty() || (command && lastUpdate.passedSince() < 1.minutes)) {
-
+                    if (unsuccessfulConstants.isEmpty() && lastRepoUpdate.passedSince() < 1.minutes) {
                         if (command) {
                             LorenzUtils.chat("§7The repo is already up to date!")
                             atomicShouldManuallyReload.set(false)
@@ -94,7 +93,7 @@ class RepoManager(private val configLocation: File) {
                         return@supplyAsync false
                     }
                 }
-                lastUpdate = SimpleTimeMark.now()
+                lastRepoUpdate = SimpleTimeMark.now()
                 RepoUtils.recursiveDelete(repoLocation)
                 repoLocation.mkdirs()
                 val itemsZip = File(repoLocation, "sh-repo-main.zip")


### PR DESCRIPTION
adds commit has to repo status, cleans up the output from that a bit and fixes certain cases of you not being able to run `/shupdaterepo` when the mod thinks you have an up to date repo but you dont e.g. you modified your local repo and you want to revert back to the official repo