### PR TITLE
Wrong/broken Changelog: Mana bar

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -27,6 +27,7 @@ import at.hannibal2.skyhanni.data.ItemClickData
 import at.hannibal2.skyhanni.data.ItemRenderBackground
 import at.hannibal2.skyhanni.data.ItemTipHelper
 import at.hannibal2.skyhanni.data.LocationFixData
+import at.hannibal2.skyhanni.data.ManaAPI
 import at.hannibal2.skyhanni.data.MayorElection
 import at.hannibal2.skyhanni.data.MinecraftData
 import at.hannibal2.skyhanni.data.OtherInventoryData
@@ -225,6 +226,7 @@ import at.hannibal2.skyhanni.features.inventory.tiarelay.TiaRelayHelper
 import at.hannibal2.skyhanni.features.inventory.tiarelay.TiaRelayWaypoints
 import at.hannibal2.skyhanni.features.itemabilities.ChickenHeadTimer
 import at.hannibal2.skyhanni.features.itemabilities.FireVeilWandParticles
+import at.hannibal2.skyhanni.features.itemabilities.ManaDisplay
 import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbilityCooldown
 import at.hannibal2.skyhanni.features.mining.DeepCavernsParkour
 import at.hannibal2.skyhanni.features.mining.HighlightMiningCommissionMobs
@@ -448,6 +450,7 @@ class SkyHanniMod {
         loadModule(TrackerManager)
         loadModule(UtilsPatterns)
         loadModule(PetAPI)
+        loadModule(ManaAPI)
         loadModule(BossbarData)
         loadModule(ChatUtils)
 
@@ -740,6 +743,7 @@ class SkyHanniMod {
         loadModule(SulphurSkitterBox())
         loadModule(HighlightInquisitors())
         loadModule(VerminTracker)
+        loadModule(ManaDisplay)
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/itemability/ItemAbilityConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/itemability/ItemAbilityConfig.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.Expose;
 import io.github.moulberry.moulconfig.annotations.Accordion;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.moulberry.moulconfig.annotations.ConfigOption;
+import io.github.moulberry.moulconfig.observer.Property;
 
 public class ItemAbilityConfig {
 
@@ -23,7 +24,7 @@ public class ItemAbilityConfig {
     @Expose
     @ConfigOption(name = "Show When Ready", desc = "Show the R and background (if enabled) when the ability is ready.")
     @ConfigEditorBoolean
-    public boolean itemAbilityShowWhenReady = true;
+    public Property<Boolean> itemAbilityShowWhenReady = Property.of(true);
 
     @Expose
     @ConfigOption(name = "Fire Veil", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -17,6 +17,10 @@ public class MiscConfig {
     @Category(name = "Pets", desc = "Pets Settings")
     public PetConfig pets = new PetConfig();
 
+    @Expose
+    @Category(name = "Player Stats Displays", desc = "Show Player Stats")
+    public PlayerStatsDisplayConfig playerStatsDisplay = new PlayerStatsDisplayConfig();
+
     @ConfigOption(name = "Hide Armor", desc = "")
     @Accordion
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/PlayerStatsDisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/PlayerStatsDisplayConfig.java
@@ -1,0 +1,18 @@
+package at.hannibal2.skyhanni.config.features.misc;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import at.hannibal2.skyhanni.config.core.config.Position;
+import com.google.gson.annotations.Expose;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.moulberry.moulconfig.annotations.ConfigOption;
+
+public class PlayerStatsDisplayConfig {
+    @Expose
+    @ConfigOption(name = "Mana Display", desc = "Show the estimated mana and max mana as a display.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean mana = false;
+
+    @Expose
+    public Position manaPosition = new Position(-330, -15, false, true);
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/ActionBarStatsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ActionBarStatsData.kt
@@ -21,6 +21,10 @@ enum class ActionBarStatsData(@Language("RegExp") rawPattern: String) {
         // language=RegExp
         ".*§b(?<mana>[\\d,]+)/[\\d,]+✎.*"
     ),
+    MAX_MANA(
+        // language=RegExp
+        ".*§b[\\d,]+/(?<maxMana>[\\d,]+)✎.*"
+    ),
     RIFT_TIME(
         // language=RegExp
         "§[a7](?<riftTime>[\\dms ]+)ф.*"
@@ -46,16 +50,15 @@ enum class ActionBarStatsData(@Language("RegExp") rawPattern: String) {
         @SubscribeEvent
         fun onActionBar(event: LorenzActionBarEvent) {
             if (!LorenzUtils.inSkyBlock) return
-
-            entries.mapNotNull { data ->
+            for (data in entries) {
                 data.pattern.matchMatcher(event.message) {
                     val newValue = group(1)
                     if (data.value != newValue) {
                         data.value = newValue
-                        ActionBarValueUpdate(data)
-                    } else null
+                        ActionBarValueUpdate(data).postAndCatch()
+                    }
                 }
-            }.forEach { it.postAndCatch() }
+            }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemRenderBackground.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemRenderBackground.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.events.RenderRealOverlayEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.cachedData
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
 import net.minecraft.client.renderer.GlStateManager
@@ -10,31 +11,40 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class ItemRenderBackground {
 
+    class RenderBackgroundData {
+        var color = -1
+        var time = 0L
+        var lineColor = -1
+        var borderTime = 0L
+    }
+
     companion object {
 
-        private val backgroundColor = mutableMapOf<ItemStack, Int>()
-        private val backgroundTime = mutableMapOf<ItemStack, Long>()
-        private val borderLineColor = mutableMapOf<ItemStack, Int>()
-        private val borderTime = mutableMapOf<ItemStack, Long>()
+        private fun ItemStack.getData() = cachedData.renderBackground
 
         var ItemStack.background: Int
             get() {
-                if (System.currentTimeMillis() > backgroundTime.getOrDefault(this, 0) + 60) return -1
-                return backgroundColor.getOrDefault(this, -1)
+                val data = getData()
+                data.time
+                if (System.currentTimeMillis() > data.time + 60) return -1
+                return data.color
             }
             set(value) {
-                backgroundColor[this] = value
-                backgroundTime[this] = System.currentTimeMillis()
+                val data = getData()
+                data.color = value
+                data.time = System.currentTimeMillis()
             }
 
         var ItemStack.borderLine: Int
             get() {
-                if (System.currentTimeMillis() > borderTime.getOrDefault(this, 0) + 60) return -1
-                return borderLineColor.getOrDefault(this, -1)
+                val data = getData()
+                if (System.currentTimeMillis() > data.lineColor + 60) return -1
+                return data.lineColor
             }
             set(value) {
-                borderLineColor[this] = value
-                borderTime[this] = System.currentTimeMillis()
+                val data = getData()
+                data.lineColor = value
+                data.borderTime = System.currentTimeMillis()
             }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemRenderBackground.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemRenderBackground.kt
@@ -25,7 +25,6 @@ class ItemRenderBackground {
         var ItemStack.background: Int
             get() {
                 val data = getData()
-                data.time
                 if (System.currentTimeMillis() > data.time + 60) return -1
                 return data.color
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/ManaAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ManaAPI.kt
@@ -1,0 +1,138 @@
+package at.hannibal2.skyhanni.data
+
+import at.hannibal2.skyhanni.events.ActionBarValueUpdate
+import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.events.ManaChangeEvent
+import at.hannibal2.skyhanni.events.item.ItemAbilityCastEvent
+import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbilityType
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemName
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatNumber
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getManaDisintegrators
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import net.minecraft.item.ItemStack
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.math.abs
+import kotlin.time.Duration.Companion.seconds
+
+object ManaAPI {
+
+    var estimatedMana = -1.0
+    var maxMana = -1.0
+
+    private var lastHypixelMana = -1.0
+
+    var lastAbilityCastTime = SimpleTimeMark.farPast()
+    var lastAbilityCastText = ""
+
+    val regenPerTick get() = maxMana / 50.0
+
+    @SubscribeEvent
+    fun onActionBarValueUpdate(event: ActionBarValueUpdate) {
+        if (event.updated == ActionBarStatsData.MANA) {
+            val mana = event.updated.value.formatNumber().toDouble()
+            if (estimatedMana == -1.0) {
+                estimatedMana = mana
+            }
+            if (lastHypixelMana != mana) {
+                lastHypixelMana = mana
+                hypixelManaChange(lastHypixelMana, mana)
+            }
+        }
+        if (event.updated == ActionBarStatsData.MAX_MANA) {
+            maxMana = event.updated.value.formatNumber().toDouble()
+        }
+    }
+
+    @SubscribeEvent
+    fun onTick(event: LorenzTickEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+        val speedFactor = 4
+        if (event.isMod(40 / speedFactor)) {
+            val regenPerTick = (regenPerTick / speedFactor).toInt()
+//             println("regenPerTick: ${regenPerTick.addSeparators()} (maxMana=${maxMana.addSeparators()})")
+            estimatedMana += regenPerTick
+            update()
+        }
+    }
+
+    private fun update() {
+        if (estimatedMana < 0) {
+            estimatedMana = 0.0
+        }
+        if (estimatedMana > maxMana) {
+            estimatedMana = maxMana
+        }
+        ManaChangeEvent().postAndCatch()
+    }
+
+    @SubscribeEvent
+    fun onItemAbilityCast(event: ItemAbilityCastEvent) {
+        val itemStack = event.itemStack
+        val cost = manaCost(event.itemAbility, itemStack)
+        estimatedMana -= cost
+
+        val itemName = itemStack.getInternalName().getItemName().removeColor()
+
+//         lastAbilityCastText = "§c- ${diff.addSeparators()} §7(${event.itemAbility})"
+        lastAbilityCastText = "§c- ${cost.addSeparators()} §7(${itemName})"
+        lastAbilityCastTime = SimpleTimeMark.now()
+    }
+
+    private fun manaCost(itemAbility: ItemAbilityType, itemStack: ItemStack): Double {
+        val manaCostPercentage = itemAbility.manaCostPercentage
+        if (manaCostPercentage != 0.0) {
+            return maxMana * manaCostPercentage
+        }
+
+        val baseCost = if (IslandType.THE_RIFT.isInIsland()) {
+            itemAbility.riftManaCost
+        } else itemAbility.manaCost
+
+        var reduceFactor = 0.0
+        itemStack.getEnchantments()?.let {
+            val ultimateWiseLevel = it["ultimate_wise"] ?: 0
+            reduceFactor += ultimateWiseLevel * 0.1
+        }
+
+        itemStack.getManaDisintegrators()?.let {
+            reduceFactor += it * 0.01
+        }
+        return baseCost * (1 - reduceFactor)
+    }
+
+    private fun hypixelManaChange(old: Double, new: Double) {
+        println("hypixel mana change: ${old.addSeparators()} -> ${new.addSeparators()}")
+        if (lastAbilityCastTime.passedSince() > 2.seconds) {
+            val distance = abs(new - estimatedMana)
+            if (distance > regenPerTick * 2) {
+                // reset to known value
+                ChatUtils.debug("Fixed wrong estimated mana value")
+//                 ErrorManager.logErrorStateWithData(
+//                     "Fixed wrong estimated mana value",
+//                     "estimatedMana is wrong",
+//                     "estimatedMana" to estimatedMana,
+//                     "new" to new,
+//                     "distance" to distance,
+//                     "regenPerTick" to regenPerTick,
+//                     "old" to old,
+//                 )
+                estimatedMana = new
+            }
+        }
+    }
+
+    @SubscribeEvent
+    fun onIslandChange(event: IslandChangeEvent) {
+        estimatedMana = -1.0
+        lastHypixelMana = -1.0
+        maxMana = -1.0
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/events/ManaChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/ManaChangeEvent.kt
@@ -1,0 +1,3 @@
+package at.hannibal2.skyhanni.events
+
+class ManaChangeEvent : LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ItemAbilityCastEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ItemAbilityCastEvent.kt
@@ -1,8 +1,8 @@
 package at.hannibal2.skyhanni.events.item
 
 import at.hannibal2.skyhanni.events.LorenzEvent
-import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbility
+import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbilityType
 import net.minecraftforge.fml.common.eventhandler.Cancelable
 
 @Cancelable
-class ItemAbilityCastEvent(val itemAbility: ItemAbility): LorenzEvent()
+class ItemAbilityCastEvent(val itemAbility: ItemAbilityType): LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ItemAbilityCastEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ItemAbilityCastEvent.kt
@@ -2,7 +2,8 @@ package at.hannibal2.skyhanni.events.item
 
 import at.hannibal2.skyhanni.events.LorenzEvent
 import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbilityType
+import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.eventhandler.Cancelable
 
 @Cancelable
-class ItemAbilityCastEvent(val itemAbility: ItemAbilityType): LorenzEvent()
+class ItemAbilityCastEvent(val itemAbility: ItemAbilityType, val itemStack: ItemStack): LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ItemAbilityCastEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ItemAbilityCastEvent.kt
@@ -1,0 +1,8 @@
+package at.hannibal2.skyhanni.events.item
+
+import at.hannibal2.skyhanni.events.LorenzEvent
+import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbility
+import net.minecraftforge.fml.common.eventhandler.Cancelable
+
+@Cancelable
+class ItemAbilityCastEvent(val itemAbility: ItemAbility): LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
@@ -98,7 +98,7 @@ class DungeonAPI {
 
         fun getRoomID() = ScoreboardData.sidebarLines.firstOrNull()?.removeColor()?.split(" ")?.getOrNull(2)
 
-        fun isInF7Boss(): Boolean = LorenzUtils.inDungeons && getCurrentBoss() == DungeonFloor.F7 && inBossRoom
+        fun isInF7Boss(): Boolean = LorenzUtils.inDungeons && getCurrentBoss() == DungeonFloor.F7_NECRON && inBossRoom
     }
 
     @SubscribeEvent
@@ -242,14 +242,14 @@ class DungeonAPI {
     }
 
     enum class DungeonFloor(private val bossName: String) {
-        ENTRANCE("The Watcher"),
-        F1("Bonzo"),
-        F2("Scarf"),
-        F3("The Professor"),
-        F4("Thorn"),
-        F5("Livid"),
-        F6("Sadan"),
-        F7("Necron");
+        ENTRANCE_WATCHER("The Watcher"),
+        F1_BONZO("Bonzo"),
+        F2_SCARF("Scarf"),
+        F3_PROFESSOR("The Professor"),
+        F4_THORN("Thorn"),
+        F5_LIVID("Livid"),
+        F6_SADAN("Sadan"),
+        F7_NECRON("Necron");
 
         companion object {
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
@@ -90,12 +90,15 @@ class DungeonAPI {
             return ""
         }
 
+        // TODO add cache
         fun getCurrentBoss(): DungeonFloor? {
             val floor = dungeonFloor ?: return null
             return DungeonFloor.valueOf(floor.replace("M", "F"))
         }
 
         fun getRoomID() = ScoreboardData.sidebarLines.firstOrNull()?.removeColor()?.split(" ")?.getOrNull(2)
+
+        fun isInF7Boss(): Boolean = LorenzUtils.inDungeons && getCurrentBoss() == DungeonFloor.F7 && inBossRoom
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/TerracottaPhase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/TerracottaPhase.kt
@@ -45,6 +45,6 @@ class TerracottaPhase {
 
     private fun isActive() = isEnabled() && inTerracottaPhase
 
-    private fun isEnabled() =
-        LorenzUtils.inDungeons && DungeonAPI.inBossRoom && DungeonAPI.getCurrentBoss() == DungeonAPI.DungeonFloor.F6
+    private fun isEnabled() = LorenzUtils.inDungeons && DungeonAPI.inBossRoom &&
+            DungeonAPI.getCurrentBoss() == DungeonAPI.DungeonFloor.F6_SADAN
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaAPI.kt
@@ -16,7 +16,7 @@ object DianaAPI {
 
     fun hasSpadeInHand() = InventoryUtils.itemInHandId == spade
 
-    private fun isRitualActive() = MayorElection.isPerkActive("Diana", "Mythological Ritual") ||
+    fun isRitualActive() = MayorElection.isPerkActive("Diana", "Mythological Ritual") ||
         MayorElection.isPerkActive("Jerry", "Perkpocalypse") || SkyHanniMod.feature.event.diana.alwaysDiana
 
     fun hasGriffinPet() = PetAPI.isCurrentPet("Griffin")

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.config.features.itemability.FireVeilWandConfig.Disp
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.item.ItemAbilityCastEvent
-import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbility
+import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbilityType
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -35,7 +35,7 @@ class FireVeilWandParticles {
 
     @SubscribeEvent
     fun onItemAbilityCast(event: ItemAbilityCastEvent) {
-        if (event.itemAbility == ItemAbility.FIRE_VEIL_WAND) {
+        if (event.itemAbility == ItemAbilityType.FIRE_VEIL_WAND) {
             lastClick = SimpleTimeMark.now()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
@@ -3,16 +3,13 @@ package at.hannibal2.skyhanni.features.itemabilities
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.itemability.FireVeilWandConfig.DisplayEntry
-import at.hannibal2.skyhanni.data.ClickType
-import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
-import at.hannibal2.skyhanni.features.nether.ashfang.AshfangFreezeCooldown
+import at.hannibal2.skyhanni.events.item.ItemAbilityCastEvent
+import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbility
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConfigUtils
-import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraft.client.Minecraft
@@ -23,7 +20,6 @@ import kotlin.time.Duration.Companion.seconds
 class FireVeilWandParticles {
 
     private val config get() = SkyHanniMod.feature.itemAbilities.fireVeilWands
-    private val item by lazy { "FIRE_VEIL_WAND".asInternalName() }
 
     private var lastClick = SimpleTimeMark.farPast()
 
@@ -38,14 +34,8 @@ class FireVeilWandParticles {
     }
 
     @SubscribeEvent
-    fun onItemClick(event: ItemClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-        if (event.clickType != ClickType.RIGHT_CLICK) return
-        val internalName = event.itemInHand?.getInternalName()
-
-        if (AshfangFreezeCooldown.iscurrentlyFrozen()) return
-
-        if (internalName == item) {
+    fun onItemAbilityCast(event: ItemAbilityCastEvent) {
+        if (event.itemAbility == ItemAbility.FIRE_VEIL_WAND) {
             lastClick = SimpleTimeMark.now()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/ManaDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/ManaDisplay.kt
@@ -1,0 +1,66 @@
+package at.hannibal2.skyhanni.features.itemabilities
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.ManaAPI
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.ManaChangeEvent
+import at.hannibal2.skyhanni.events.PreProfileSwitchEvent
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.seconds
+
+object ManaDisplay {
+    private val config get() = SkyHanniMod.feature.misc.playerStatsDisplay
+
+    var display = listOf<String>()
+
+    @SubscribeEvent
+    fun onManaChange(event: ManaChangeEvent) {
+        display = buildList {
+            add(firstLine())
+            add(getSecondLine())
+        }
+    }
+
+    private fun firstLine(): String {
+        val estimatedMana = ManaAPI.estimatedMana
+        val maxMana = ManaAPI.maxMana
+        if (maxMana == -1.0) {
+            return "§bLoading mana.."
+        }
+
+        return "§b${estimatedMana.addSeparators()}/${maxMana.addSeparators()}"
+    }
+
+    private fun getSecondLine(): String {
+        val estimatedMana = ManaAPI.estimatedMana
+        val maxMana = ManaAPI.maxMana
+        val secondLine = if (ManaAPI.lastAbilityCastTime.passedSince() < 1.5.seconds) {
+            ManaAPI.lastAbilityCastText
+        } else {
+            if (estimatedMana == maxMana) {
+                ""
+            } else {
+                val regenPerTick = ManaAPI.regenPerTick
+                "§a+ ${regenPerTick.addSeparators()}"
+            }
+        }
+        return secondLine
+    }
+
+    @SubscribeEvent
+    fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+
+        if (!config.mana) return
+
+        config.manaPosition.renderStrings(display, posLabel = "Mana Display")
+    }
+
+    @SubscribeEvent
+    fun onPreProfileSwitch(event: PreProfileSwitchEvent) {
+        display = emptyList()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ActiveAbility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ActiveAbility.kt
@@ -43,7 +43,7 @@ class ActiveAbility(
 
     fun onClick(clickType: ClickType) {
         if (lastItemClick.passedSince() < type.allowRecastAfter) return
-        if (!canCastAbility()) return
+        if (!isAllowed()) return
 
         // only allow left clicks on alternative position, only right clicks on others
         if (type.alternativePosition != (clickType == ClickType.LEFT_CLICK)) return
@@ -85,5 +85,5 @@ class ActiveAbility(
         return false
     }
 
-    private fun canCastAbility(): Boolean = type.isAllowed() && !allAbilitiesBlocked()
+    fun isAllowed(): Boolean = type.isAllowed() && !allAbilitiesBlocked()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ActiveAbility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ActiveAbility.kt
@@ -1,0 +1,89 @@
+package at.hannibal2.skyhanni.features.itemabilities.abilitycooldown
+
+import at.hannibal2.skyhanni.data.ClickType
+import at.hannibal2.skyhanni.events.item.ItemAbilityCastEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
+import at.hannibal2.skyhanni.features.nether.ashfang.AshfangFreezeCooldown
+import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.TimeUtils.format
+import kotlin.math.floor
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class ActiveAbility(
+    val type: ItemAbilityType,
+    var text: ItemText? = null,
+
+    private var lastActivation: SimpleTimeMark = SimpleTimeMark.farPast(),
+    var specialColor: LorenzColor? = null,
+    private var lastItemClick: SimpleTimeMark = SimpleTimeMark.farPast(),
+) {
+
+    fun activate(color: LorenzColor? = null, customCooldown: Duration = (type.cooldown)) {
+        specialColor = color
+        lastActivation = SimpleTimeMark.now() - (type.cooldown - customCooldown)
+    }
+
+    fun isOnCooldown(): Boolean = getDuration().isPositive()
+
+    private fun getCooldown(): Duration {
+        // Some items aren't really a cooldown but an effect over time, so don't apply cooldown multipliers
+        if (type == ItemAbilityType.WAND_OF_ATONEMENT || type == ItemAbilityType.RAGNAROCK_AXE) {
+            return type.cooldown
+        }
+
+        return type.cooldown * getMultiplier()
+    }
+
+    fun getDurationText(): String = getDuration().format(showMilliSeconds = getDuration() < 1.6.seconds).dropLast(1)
+
+    fun getDuration() = getCooldown() - lastActivation.passedSince()
+
+    fun onClick(clickType: ClickType) {
+        if (lastItemClick.passedSince() < type.allowRecastAfter) return
+        if (!canCastAbility()) return
+
+        // only allow left clicks on alternative position, only right clicks on others
+        if (type.alternativePosition != (clickType == ClickType.LEFT_CLICK)) return
+
+        startAbility()
+    }
+
+    private fun startAbility() {
+        if (ItemAbilityCastEvent(type).postAndCatch()) return
+
+        lastItemClick = SimpleTimeMark.now()
+        lastActivation = SimpleTimeMark.now()
+    }
+
+    fun getMultiplier(): Double = getMageCooldownReduction() ?: 1.0
+
+    private fun getMageCooldownReduction(): Double? {
+        if (type.ignoreMageCooldownReduction) return null
+        if (!LorenzUtils.inDungeons) return null
+        if (DungeonAPI.playerClass != DungeonAPI.DungeonClass.MAGE) return null
+
+        var abilityCooldownMultiplier = 1.0
+        abilityCooldownMultiplier -= if (DungeonAPI.isUniqueClass) {
+            0.5 // 50% base reduction at level 0
+        } else {
+            0.25 // 25% base reduction at level 0
+        }
+
+        // 1% ability reduction every other level
+        abilityCooldownMultiplier -= 0.01 * floor(DungeonAPI.playerClassLevel / 2f)
+
+        return abilityCooldownMultiplier
+    }
+
+    private fun allAbilitiesBlocked(): Boolean {
+        if (LorenzUtils.skyBlockArea == "Matriarch's Lair") return true
+        if (AshfangFreezeCooldown.iscurrentlyFrozen()) return true
+
+        return false
+    }
+
+    private fun canCastAbility(): Boolean = type.isAllowed() && !allAbilitiesBlocked()
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
@@ -131,7 +131,7 @@ enum class ItemAbility(
 
     fun setItemClick(clickType: ClickType) {
         if (lastItemClick.passedSince() < allowRecastAfter) return
-        if (!isAllowed()) return
+        if (!canCastAbility()) return
 
         // only allow left clicks on alternative position, only right clicks on others
         if (alternativePosition != (clickType == ClickType.LEFT_CLICK)) return
@@ -167,6 +167,10 @@ enum class ItemAbility(
         }
 
         private fun allAbilitiesBlocked(): Boolean {
+            if (LorenzUtils.skyBlockArea == "Matriarch's Lair") {
+                return true
+            }
+
             return false
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
@@ -1,83 +1,98 @@
 package at.hannibal2.skyhanni.features.itemabilities.abilitycooldown
 
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import kotlin.math.floor
 
 enum class ItemAbility(
-    val abilityName: String,
     private val cooldownInSeconds: Int,
-    vararg val itemNames: String,
-    val alternativePosition: Boolean = false,
+    val manaCost: Int,
+    vararg alternateInternalNames: String,
+
     var lastActivation: Long = 0L,
     var specialColor: LorenzColor? = null,
     var lastItemClick: Long = 0L,
-    val actionBarDetection: Boolean = true,
-    private val ignoreMageCooldownReduction: Boolean = false,
+
+    val alternativePosition: Boolean = false,
+    val ignoreMageCooldownReduction: Boolean = false,
+    val remainingMana: (Int) -> Int = { it - manaCost },
+    val riftManaCost: Int = manaCost,
+    val remainingManaRift: (Int) -> Int = { it - riftManaCost },
+    val allowRecastAfterSeconds: Int = cooldownInSeconds,
+    val isAllowed: (Unit) -> Boolean = { true },
 ) {
-    // TODO add into repo
 
-    HYPERION(5, "SCYLLA", "VALKYRIE", "ASTRAEA", ignoreMageCooldownReduction = true),
-    GYROKINETIC_WAND_LEFT(30, "GYROKINETIC_WAND", alternativePosition = true),
-    GYROKINETIC_WAND_RIGHT(10, "GYROKINETIC_WAND"),
-    GIANTS_SWORD(30),
-    ICE_SPRAY_WAND(5),
-    ATOMSPLIT_KATANA(4, "VORPAL_KATANA", "VOIDEDGE_KATANA", ignoreMageCooldownReduction = true),
-    RAGNAROCK_AXE(20),
-    WAND_OF_ATONEMENT(7, "WAND_OF_HEALING", "WAND_OF_MENDING", "WAND_OF_RESTORATION"),
+    HYPERION(5, 300, "SCYLLA", "VALKYRIE", "ASTRAEA", ignoreMageCooldownReduction = true),
+    GYROKINETIC_WAND_LEFT(30, 1200, "GYROKINETIC_WAND", alternativePosition = true),
+    GYROKINETIC_WAND_RIGHT(10, 220, "GYROKINETIC_WAND", isAllowed = {
+        LorenzUtils.inDungeons || LorenzUtils.inKuudraFight
+    }),
+    GIANTS_SWORD(30, 100),
+    ICE_SPRAY_WAND(5, 50),
+    ATOMSPLIT_KATANA(4, 200, "VORPAL_KATANA", "VOIDEDGE_KATANA", ignoreMageCooldownReduction = true),
+    RAGNAROCK_AXE(20, 500),
 
-    GOLEM_SWORD(3),
-    END_STONE_SWORD(5),
-    SOUL_ESOWARD(20),
-    PIGMAN_SWORD(5),
-    EMBER_ROD(30),
-    STAFF_OF_THE_VOLCANO(30),
-    STARLIGHT_WAND(2),
-    VOODOO_DOLL(5),
-    WEIRD_TUBA(20),
-    WEIRDER_TUBA(30),
-    FIRE_FREEZE_STAFF(10),
-    SWORD_OF_BAD_HEALTH(5),
-    WITHER_CLOAK(10),
-    HOLY_ICE(4),
-    VOODOO_DOLL_WILTED(3),
-    FIRE_FURY_STAFF(20),
-    SHADOW_FURY(15, "STARRED_SHADOW_FURY"),
+    // todo support for mana disintegrator
+    WAND_OF_ATONEMENT(7, 240, "WAND_OF_HEALING", "WAND_OF_MENDING", "WAND_OF_RESTORATION"),
+    GOLEM_SWORD(3, 70),
+    END_STONE_SWORD(5, 0, remainingMana = { 0 }, isAllowed = {
+        !LorenzUtils.inDungeons
+    }),
 
-    // doesn't have a sound
-    ENDER_BOW("Ender Warp", 30, "Ender Bow"),
-    LIVID_DAGGER("Throw", 5, "Livid Dagger"),
-    FIRE_VEIL("Fire Veil", 5, "Fire Veil Wand"),
-    INK_WAND("Ink Bomb", 30, "Ink Wand"),
-    ROGUE_SWORD("Speed Boost", 30, "Rogue Sword", ignoreMageCooldownReduction = true),
-    TALBOTS_THEODOLITE("Track", 10, "Talbot's Theodolite"),
+    // TODO show while the ability is running
+    SOUL_ESOWARD(20, 350),
 
-    // doesn't have a consistent sound
-    ECHO("Echo", 3, "Ancestral Spade");
+    PIGMAN_SWORD(5, 400),
+    EMBER_ROD(30, 150),
+    STAFF_OF_THE_VOLCANO(30, 100),
+    STARLIGHT_WAND(2, 120),
+    VOODOO_DOLL(5, 200),
+    WEIRD_TUBA(20, 150, riftManaCost = 60),
+    WEIRDER_TUBA(30, 120, riftManaCost = 60, allowRecastAfterSeconds = 20),
+    FIRE_FREEZE_STAFF(10, 500, allowRecastAfterSeconds = 0),
+    SWORD_OF_BAD_HEALTH(5, 0),
+    WITHER_CLOAK(10, 0),
+    HOLY_ICE(4, 20),
+    VOODOO_DOLL_WILTED(3, 180),
+    FIRE_FURY_STAFF(20, 1000, allowRecastAfterSeconds = 0),
+    SHADOW_FURY(15, 0, "STARRED_SHADOW_FURY"),
+    ENDER_BOW(30, 50),
+    LIVID_DAGGER(5, 150),
+    FIRE_VEIL_WAND(5, 300, allowRecastAfterSeconds = 0),
+    INK_WAND(30, 60),
+    ROGUE_SWORD(30, 50, ignoreMageCooldownReduction = true),
+    TALBOTS_THEODOLITE(10, 98),
+    ANCESTRAL_SPADE(3, 98, isAllowed = {
+//         IslandType.HUB.isInIsland() && DianaAPI.isRitualActive()
+        IslandType.HUB.isInIsland()
+    }),
+    MOODY_GRAPPLESHOT(1, 30),
+    FLOWER_OF_TRUTH(1, 0),
+    BOUQUET_OF_LIES(1, 0),
+    WAND_OF_VOLCANO(1, 0),
+    ASPECT_OF_THE_END(0, 50),
+    ASPECT_OF_THE_VOID(0, 45),
+    AURORA_STAFF(1, 0),
+
+    // TODO incoming damage reduction for 10s
+    ENRAGER(500, 20),
+    ;
 
     var newVariant = false
-    var internalNames = mutableListOf<NEUInternalName>()
+    val internalNames: List<NEUInternalName>
 
-    constructor(
-        cooldownInSeconds: Int,
-        vararg alternateInternalNames: String,
-        alternativePosition: Boolean = false,
-        ignoreMageCooldownReduction: Boolean = false,
-    ) : this(
-        "no name",
-        cooldownInSeconds,
-        actionBarDetection = false,
-        alternativePosition = alternativePosition,
-        ignoreMageCooldownReduction = ignoreMageCooldownReduction
-    ) {
-        newVariant = true
+    init {
+        val internalNames = mutableListOf<NEUInternalName>()
         alternateInternalNames.forEach {
             internalNames.add(it.asInternalName())
         }
         internalNames.add(name.asInternalName())
+        this.internalNames = internalNames
     }
 
     fun activate(color: LorenzColor? = null, customCooldown: Int = (cooldownInSeconds * 1000)) {
@@ -112,12 +127,13 @@ enum class ItemAbility(
 
     fun setItemClick() {
         lastItemClick = System.currentTimeMillis()
+        lastActivation = System.currentTimeMillis()
     }
 
     companion object {
 
         fun getByInternalName(internalName: NEUInternalName): ItemAbility? {
-            return entries.firstOrNull { it.newVariant && internalName in it.internalNames }
+            return entries.firstOrNull { internalName in it.internalNames }
         }
 
         fun ItemAbility.getMultiplier(): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.item.ItemAbilityCastEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
+import at.hannibal2.skyhanni.features.nether.ashfang.AshfangFreezeCooldown
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
@@ -167,9 +168,8 @@ enum class ItemAbility(
         }
 
         private fun allAbilitiesBlocked(): Boolean {
-            if (LorenzUtils.skyBlockArea == "Matriarch's Lair") {
-                return true
-            }
+            if (LorenzUtils.skyBlockArea == "Matriarch's Lair") return true
+            if (AshfangFreezeCooldown.iscurrentlyFrozen()) return true
 
             return false
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -7,22 +7,15 @@ import at.hannibal2.skyhanni.events.LorenzActionBarEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
 import at.hannibal2.skyhanni.events.RenderObject
 import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbility.Companion.getMultiplier
 import at.hannibal2.skyhanni.features.nether.ashfang.AshfangFreezeCooldown
-import at.hannibal2.skyhanni.utils.CollectionUtils.equalsOneOf
-import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils
-import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.between
-import at.hannibal2.skyhanni.utils.LorenzUtils.round
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAbilityScrolls
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getItemId
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getItemUuid
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
@@ -35,7 +28,7 @@ class ItemAbilityCooldown {
 
     private val config get() = SkyHanniMod.feature.itemAbilities
 
-    private var lastAbility = ""
+//     private var lastAbility = ""
     private var items = mapOf<ItemStack, List<ItemText>>()
     private var abilityItems = mapOf<ItemStack, MutableList<ItemAbility>>()
     private val youAlignedOthersPattern = "§eYou aligned §r§a.* §r§eother player(s)?!".toPattern()
@@ -44,121 +37,121 @@ class ItemAbilityCooldown {
     private val WEIRDER_TUBA = "WEIRDER_TUBA".asInternalName()
     private val VOODOO_DOLL_WILTED = "VOODOO_DOLL_WILTED".asInternalName()
 
-    @SubscribeEvent
-    fun onSoundEvent(event: PlaySoundEvent) {
-        when {
-            // Hyperion
-            event.soundName == "mob.zombie.remedy" && event.pitch == 0.6984127f && event.volume == 1f -> {
-                val abilityScrolls = InventoryUtils.getItemInHand()?.getAbilityScrolls() ?: return
-                if (abilityScrolls.size != 3) return
-
-                ItemAbility.HYPERION.sound()
-            }
-            // Fire Fury Staff
-            event.soundName == "liquid.lavapop" && event.pitch == 1.0f && event.volume == 1f -> {
-                ItemAbility.FIRE_FURY_STAFF.sound()
-            }
-            // Ice Spray Wand
-            event.soundName == "mob.enderdragon.growl" && event.pitch == 1f && event.volume == 1f -> {
-                ItemAbility.ICE_SPRAY_WAND.sound()
-            }
-            // Gyrokinetic Wand & Shadow Fury
-            event.soundName == "mob.endermen.portal" -> {
-                // Gryokinetic Wand
-                if (event.pitch == 0.61904764f && event.volume == 1f) {
-                    ItemAbility.GYROKINETIC_WAND_LEFT.sound()
-                }
-                // Shadow Fury
-                if (event.pitch == 1f && event.volume == 1f) {
-                    val internalName = InventoryUtils.getItemInHand()?.getInternalName() ?: return
-                    if (!internalName.equalsOneOf(
-                            "SHADOW_FURY".asInternalName(),
-                            "STARRED_SHADOW_FURY".asInternalName()
-                        )
-                    ) return
-
-                    ItemAbility.SHADOW_FURY.sound()
-                }
-            }
-            // Giant's Sword
-            event.soundName == "random.anvil_land" && event.pitch == 0.4920635f && event.volume == 1f -> {
-                ItemAbility.GIANTS_SWORD.sound()
-            }
-            // Atomsplit Katana
-            event.soundName == "mob.ghast.affectionate_scream" && event.pitch == 0.4920635f && event.volume == 0.15f -> {
-                ItemAbility.ATOMSPLIT_KATANA.sound()
-            }
-            // Wand of Atonement
-            event.soundName == "liquid.lavapop" && event.pitch == 0.7619048f && event.volume == 0.15f -> {
-                ItemAbility.WAND_OF_ATONEMENT.sound()
-            }
-            // Starlight Wand
-            event.soundName == "mob.bat.hurt" && event.volume == 0.1f -> {
-                ItemAbility.STARLIGHT_WAND.sound()
-            }
-            // Voodoo Doll
-            event.soundName == "mob.guardian.curse" && event.volume == 0.2f -> {
-                ItemAbility.VOODOO_DOLL.sound()
-            }
-            // Jinxed Voodoo Doll Hit
-            event.soundName == "random.successful_hit" && event.volume == 1.0f && event.pitch == 0.7936508f -> {
-                ItemAbility.VOODOO_DOLL_WILTED.sound()
-            }
-            // Jinxed Voodoo Doll Miss
-            event.soundName == "mob.ghast.scream" && event.volume == 1.0f && event.pitch >= 1.6 && event.pitch <= 1.7 -> {
-                val recentItems = InventoryUtils.recentItemsInHand.values
-                if (VOODOO_DOLL_WILTED in recentItems) {
-                    ItemAbility.VOODOO_DOLL_WILTED.sound()
-                }
-            }
-            // Golem Sword
-            event.soundName == "random.explode" && event.pitch == 4.047619f && event.volume == 0.2f -> {
-                ItemAbility.GOLEM_SWORD.sound()
-            }
-            // Weird Tuba & Weirder Tuba
-            event.soundName == "mob.wolf.howl" && event.volume == 0.5f -> {
-                val recentItems = InventoryUtils.recentItemsInHand.values
-                if (WEIRD_TUBA in recentItems) {
-                    ItemAbility.WEIRD_TUBA.sound()
-                }
-                if (WEIRDER_TUBA in recentItems) {
-                    ItemAbility.WEIRDER_TUBA.sound()
-                }
-            }
-            // End Stone Sword
-            event.soundName == "mob.zombie.unfect" && event.pitch == 2.0f && event.volume == 0.3f -> {
-                ItemAbility.END_STONE_SWORD.sound()
-            }
-            // Soul Esoward
-            event.soundName == "mob.wolf.panting" && event.pitch == 1.3968254f && event.volume == 0.4f -> {
-                ItemAbility.SOUL_ESOWARD.sound()
-            }
-            // Pigman Sword
-            event.soundName == "mob.zombiepig.zpigangry" && event.pitch == 2.0f && event.volume == 0.3f -> {
-                ItemAbility.PIGMAN_SWORD.sound()
-            }
-            // Ember Rod
-            event.soundName == "mob.ghast.fireball" && event.pitch == 1.0f && event.volume == 0.3f -> {
-                ItemAbility.EMBER_ROD.sound()
-            }
-            // Fire Freeze Staff
-            event.soundName == "mob.guardian.elder.idle" && event.pitch == 2.0f && event.volume == 0.2f -> {
-                ItemAbility.FIRE_FREEZE_STAFF.sound()
-            }
-            // Staff of the Volcano
-            event.soundName == "random.explode" && event.pitch == 0.4920635f && event.volume == 0.5f -> {
-                ItemAbility.STAFF_OF_THE_VOLCANO.sound()
-            }
-            // Staff of the Volcano
-            event.soundName == "random.eat" && event.pitch == 1.0f && event.volume == 1.0f -> {
-                ItemAbility.STAFF_OF_THE_VOLCANO.sound()
-            }
-            // Holy Ice
-            event.soundName == "random.drink" && event.pitch.round(1) == 1.8f && event.volume == 1.0f -> {
-                ItemAbility.HOLY_ICE.sound()
-            }
-        }
-    }
+//     @SubscribeEvent
+//     fun onSoundEvent(event: PlaySoundEvent) {
+//         when {
+//             // Hyperion
+//             event.soundName == "mob.zombie.remedy" && event.pitch == 0.6984127f && event.volume == 1f -> {
+//                 val abilityScrolls = InventoryUtils.getItemInHand()?.getAbilityScrolls() ?: return
+//                 if (abilityScrolls.size != 3) return
+//
+//                 ItemAbility.HYPERION.sound()
+//             }
+//             // Fire Fury Staff
+//             event.soundName == "liquid.lavapop" && event.pitch == 1.0f && event.volume == 1f -> {
+//                 ItemAbility.FIRE_FURY_STAFF.sound()
+//             }
+//             // Ice Spray Wand
+//             event.soundName == "mob.enderdragon.growl" && event.pitch == 1f && event.volume == 1f -> {
+//                 ItemAbility.ICE_SPRAY_WAND.sound()
+//             }
+//             // Gyrokinetic Wand & Shadow Fury
+//             event.soundName == "mob.endermen.portal" -> {
+//                 // Gryokinetic Wand
+//                 if (event.pitch == 0.61904764f && event.volume == 1f) {
+//                     ItemAbility.GYROKINETIC_WAND_LEFT.sound()
+//                 }
+//                 // Shadow Fury
+//                 if (event.pitch == 1f && event.volume == 1f) {
+//                     val internalName = InventoryUtils.getItemInHand()?.getInternalName() ?: return
+//                     if (!internalName.equalsOneOf(
+//                             "SHADOW_FURY".asInternalName(),
+//                             "STARRED_SHADOW_FURY".asInternalName()
+//                         )
+//                     ) return
+//
+//                     ItemAbility.SHADOW_FURY.sound()
+//                 }
+//             }
+//             // Giant's Sword
+//             event.soundName == "random.anvil_land" && event.pitch == 0.4920635f && event.volume == 1f -> {
+//                 ItemAbility.GIANTS_SWORD.sound()
+//             }
+//             // Atomsplit Katana
+//             event.soundName == "mob.ghast.affectionate_scream" && event.pitch == 0.4920635f && event.volume == 0.15f -> {
+//                 ItemAbility.ATOMSPLIT_KATANA.sound()
+//             }
+//             // Wand of Atonement
+//             event.soundName == "liquid.lavapop" && event.pitch == 0.7619048f && event.volume == 0.15f -> {
+//                 ItemAbility.WAND_OF_ATONEMENT.sound()
+//             }
+//             // Starlight Wand
+//             event.soundName == "mob.bat.hurt" && event.volume == 0.1f -> {
+//                 ItemAbility.STARLIGHT_WAND.sound()
+//             }
+//             // Voodoo Doll
+//             event.soundName == "mob.guardian.curse" && event.volume == 0.2f -> {
+//                 ItemAbility.VOODOO_DOLL.sound()
+//             }
+//             // Jinxed Voodoo Doll Hit
+//             event.soundName == "random.successful_hit" && event.volume == 1.0f && event.pitch == 0.7936508f -> {
+//                 ItemAbility.VOODOO_DOLL_WILTED.sound()
+//             }
+//             // Jinxed Voodoo Doll Miss
+//             event.soundName == "mob.ghast.scream" && event.volume == 1.0f && event.pitch >= 1.6 && event.pitch <= 1.7 -> {
+//                 val recentItems = InventoryUtils.recentItemsInHand.values
+//                 if (VOODOO_DOLL_WILTED in recentItems) {
+//                     ItemAbility.VOODOO_DOLL_WILTED.sound()
+//                 }
+//             }
+//             // Golem Sword
+//             event.soundName == "random.explode" && event.pitch == 4.047619f && event.volume == 0.2f -> {
+//                 ItemAbility.GOLEM_SWORD.sound()
+//             }
+//             // Weird Tuba & Weirder Tuba
+//             event.soundName == "mob.wolf.howl" && event.volume == 0.5f -> {
+//                 val recentItems = InventoryUtils.recentItemsInHand.values
+//                 if (WEIRD_TUBA in recentItems) {
+//                     ItemAbility.WEIRD_TUBA.sound()
+//                 }
+//                 if (WEIRDER_TUBA in recentItems) {
+//                     ItemAbility.WEIRDER_TUBA.sound()
+//                 }
+//             }
+//             // End Stone Sword
+//             event.soundName == "mob.zombie.unfect" && event.pitch == 2.0f && event.volume == 0.3f -> {
+//                 ItemAbility.END_STONE_SWORD.sound()
+//             }
+//             // Soul Esoward
+//             event.soundName == "mob.wolf.panting" && event.pitch == 1.3968254f && event.volume == 0.4f -> {
+//                 ItemAbility.SOUL_ESOWARD.sound()
+//             }
+//             // Pigman Sword
+//             event.soundName == "mob.zombiepig.zpigangry" && event.pitch == 2.0f && event.volume == 0.3f -> {
+//                 ItemAbility.PIGMAN_SWORD.sound()
+//             }
+//             // Ember Rod
+//             event.soundName == "mob.ghast.fireball" && event.pitch == 1.0f && event.volume == 0.3f -> {
+//                 ItemAbility.EMBER_ROD.sound()
+//             }
+//             // Fire Freeze Staff
+//             event.soundName == "mob.guardian.elder.idle" && event.pitch == 2.0f && event.volume == 0.2f -> {
+//                 ItemAbility.FIRE_FREEZE_STAFF.sound()
+//             }
+//             // Staff of the Volcano
+//             event.soundName == "random.explode" && event.pitch == 0.4920635f && event.volume == 0.5f -> {
+//                 ItemAbility.STAFF_OF_THE_VOLCANO.sound()
+//             }
+//             // Staff of the Volcano
+//             event.soundName == "random.eat" && event.pitch == 1.0f && event.volume == 1.0f -> {
+//                 ItemAbility.STAFF_OF_THE_VOLCANO.sound()
+//             }
+//             // Holy Ice
+//             event.soundName == "random.drink" && event.pitch.round(1) == 1.8f && event.volume == 1.0f -> {
+//                 ItemAbility.HOLY_ICE.sound()
+//             }
+//         }
+//     }
 
     @SubscribeEvent
     fun onItemClick(event: ItemClickEvent) {
@@ -177,6 +170,7 @@ class ItemAbilityCooldown {
     fun onIslandChange(event: LorenzWorldChangeEvent) {
         for (ability in ItemAbility.entries) {
             ability.lastActivation = 0L
+            ability.lastItemClick = 0L
             ability.specialColor = null
         }
     }
@@ -185,8 +179,8 @@ class ItemAbilityCooldown {
     fun onActionBar(event: LorenzActionBarEvent) {
         if (!isEnabled()) return
 
-        val message: String = event.message
-        handleOldAbilities(message)
+        val message = event.message
+//         handleOldAbilities(message)
 
         when {
             message.contains("§lCASTING IN ") -> {
@@ -207,30 +201,30 @@ class ItemAbilityCooldown {
         }
     }
 
-    private fun handleOldAbilities(message: String) {
-        // TODO use regex
-        if (message.contains(" (§6") && message.contains("§b) ")) {
-            val name: String = message.between(" (§6", "§b) ")
-            if (name == lastAbility) return
-            lastAbility = name
-            for (ability in ItemAbility.entries) {
-                if (ability.abilityName == name) {
-                    click(ability)
-                    return
-                }
-            }
-            return
-        }
-        lastAbility = ""
-    }
+//     private fun handleOldAbilities(message: String) {
+//         // TODO use regex
+//         if (message.contains(" (§6") && message.contains("§b) ")) {
+//             val name: String = message.between(" (§6", "§b) ")
+//             if (name == lastAbility) return
+//             lastAbility = name
+//             for (ability in ItemAbility.entries) {
+//                 if (ability.abilityName == name) {
+//                     click(ability)
+//                     return
+//                 }
+//             }
+//             return
+//         }
+//         lastAbility = ""
+//     }
 
     private fun isEnabled(): Boolean = LorenzUtils.inSkyBlock && config.itemAbilityCooldown
 
-    private fun click(ability: ItemAbility) {
-        if (ability.actionBarDetection) {
-            ability.activate()
-        }
-    }
+//     private fun click(ability: ItemAbility) {
+//         if (ability.actionBarDetection) {
+//             ability.activate()
+//         }
+//     }
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
@@ -340,32 +334,23 @@ class ItemAbilityCooldown {
     }
 
     private fun hasAbility(stack: ItemStack): MutableList<ItemAbility> {
-        val itemName: String = stack.cleanName()
         val internalName = stack.getInternalName()
 
         val list = mutableListOf<ItemAbility>()
         for (ability in ItemAbility.entries) {
-            if (ability.newVariant) {
-                if (ability.internalNames.contains(internalName)) {
-                    list.add(ability)
-                }
-            } else {
-                for (name in ability.itemNames) {
-                    if (itemName.contains(name)) {
-                        list.add(ability)
-                    }
-                }
+            if (ability.internalNames.contains(internalName)) {
+                list.add(ability)
             }
         }
         return list
     }
 
-    private fun ItemAbility.sound() {
-        val ping = System.currentTimeMillis() - lastItemClick
-        if (ping < 400) {
-            activate()
-        }
-    }
+//     private fun ItemAbility.sound() {
+//         val ping = System.currentTimeMillis() - lastItemClick
+//         if (ping < 400) {
+//             activate()
+//         }
+//     }
 
     class ItemText(
         val color: LorenzColor,

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -153,7 +153,7 @@ class ItemAbilityCooldown {
         val itemInHand = event.itemInHand ?: return
 
         for (ability in itemInHand.getActiveAbilities()) {
-            ability.onClick(event.clickType)
+            ability.onClick(itemInHand, event.clickType)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -344,6 +344,7 @@ class ItemAbilityCooldown {
 
         val list = mutableListOf<ItemAbility>()
         for (ability in ItemAbility.entries) {
+            if (!ability.canCastAbility()) continue
             if (ability.internalNames.contains(internalName)) {
                 list.add(ability)
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.itemabilities.abilitycooldown
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.ItemRenderBackground.Companion.background
 import at.hannibal2.skyhanni.events.ItemClickEvent
-import at.hannibal2.skyhanni.events.LorenzActionBarEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
@@ -174,14 +173,14 @@ class ItemAbilityCooldown {
         activeAbilities.clear()
     }
 
-    @SubscribeEvent
-    fun onActionBar(event: LorenzActionBarEvent) {
-        if (!isEnabled()) return
-
-        val message = event.message
+//     @SubscribeEvent
+//     fun onActionBar(event: LorenzActionBarEvent) {
+//         if (!isEnabled()) return
+//
+//         val message = event.message
 //         handleOldAbilities(message)
-
-        when {
+//
+//         when {
 //             message.contains("§lCASTING IN ") -> {
 //                 if (!ItemAbilityType.RAGNAROCK_AXE.isOnCooldown()) {
 //                     ItemAbilityType.RAGNAROCK_AXE.activate(LorenzColor.WHITE, 3.seconds)
@@ -197,8 +196,8 @@ class ItemAbilityCooldown {
 //             message.contains("§c§lCANCELLED") -> {
 //                 ItemAbilityType.RAGNAROCK_AXE.activate(null, 17.seconds)
 //             }
-        }
-    }
+//         }
+//     }
 
 //     private fun handleOldAbilities(message: String) {
 //         // TODO use regex

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -2,11 +2,13 @@ package at.hannibal2.skyhanni.features.itemabilities.abilitycooldown
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.ItemRenderBackground.Companion.background
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
 import at.hannibal2.skyhanni.events.RenderObject
+import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -26,6 +28,9 @@ class ItemAbilityCooldown {
     private val activeAbilities = mutableMapOf<ItemAbilityType, ActiveAbility>()
     private val youAlignedOthersPattern = "§eYou aligned §r§a.* §r§eother player(s)?!".toPattern()
     private val youBuffedYourselfPattern = "§aYou buffed yourself for §r§c\\+\\d+❁ Strength".toPattern()
+
+    private var readyText = ""
+
 //     private val WEIRD_TUBA = "WEIRD_TUBA".asInternalName()
 //     private val WEIRDER_TUBA = "WEIRDER_TUBA".asInternalName()
 //     private val VOODOO_DOLL_WILTED = "VOODOO_DOLL_WILTED".asInternalName()
@@ -227,9 +232,16 @@ class ItemAbilityCooldown {
         }
     }
 
+    @SubscribeEvent
+    fun onConfigInit(event: ConfigLoadEvent) {
+        readyText = if (config.itemAbilityShowWhenReady.get()) "R" else ""
+        config.itemAbilityShowWhenReady.afterChange {
+            readyText = if (this) "R" else ""
+        }
+    }
+
     private fun createItemText(ability: ActiveAbility): ItemText {
         val specialColor = ability.specialColor
-        val readyText = if (config.itemAbilityShowWhenReady) "R" else ""
         return if (ability.isOnCooldown()) {
             val color =
                 specialColor
@@ -284,7 +296,7 @@ class ItemAbilityCooldown {
                 var opacity = 130
                 if (color == LorenzColor.GREEN) {
                     opacity = 80
-                    if (!config.itemAbilityShowWhenReady) return
+                    if (!config.itemAbilityShowWhenReady.get()) return
                 }
                 stack.background = color.addOpacity(opacity).rgb
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.events.RenderItemTipEvent
 import at.hannibal2.skyhanni.events.RenderObject
 import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbility.Companion.getMultiplier
 import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ItemAbility.entries
-import at.hannibal2.skyhanni.features.nether.ashfang.AshfangFreezeCooldown
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -157,7 +156,6 @@ class ItemAbilityCooldown {
 
     @SubscribeEvent
     fun onItemClick(event: ItemClickEvent) {
-        if (AshfangFreezeCooldown.iscurrentlyFrozen()) return
         handleItemClick(event.itemInHand, event.clickType)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityType.kt
@@ -16,15 +16,16 @@ enum class ItemAbilityType(
 
     val alternativePosition: Boolean = false,
     val ignoreMageCooldownReduction: Boolean = false,
-    val remainingMana: (Int) -> Int = { it - manaCost },
+    val allowRecast: Boolean = false,
+    val manaCostPercentage: Double = 0.0,
     val riftManaCost: Int = manaCost,
     val remainingManaRift: (Int) -> Int = { it - riftManaCost },
     val cooldown: Duration = cooldownInSeconds.seconds,
-    val allowRecastAfter: Duration = cooldown,
+    val recastAfter: Duration = cooldown,
     val isAllowed: () -> Boolean = { true },
 ) {
 
-    HYPERION(5, 300, "SCYLLA", "VALKYRIE", "ASTRAEA", ignoreMageCooldownReduction = true),
+    HYPERION(5, 300, "SCYLLA", "VALKYRIE", "ASTRAEA", ignoreMageCooldownReduction = true, allowRecast = true),
     GYROKINETIC_WAND_LEFT(30, 1200, "GYROKINETIC_WAND", alternativePosition = true, isAllowed = {
         LorenzUtils.skyBlockArea != "Village"
     }),
@@ -40,7 +41,7 @@ enum class ItemAbilityType(
     // todo support for mana disintegrator
     WAND_OF_ATONEMENT(7, 240, "WAND_OF_HEALING", "WAND_OF_MENDING", "WAND_OF_RESTORATION"),
     GOLEM_SWORD(3, 70),
-    END_STONE_SWORD(5, 0, remainingMana = { 0 }, isAllowed = {
+    END_STONE_SWORD(5, 0, manaCostPercentage = 1.0, isAllowed = {
         !LorenzUtils.inDungeons
     }),
 
@@ -53,13 +54,13 @@ enum class ItemAbilityType(
     STARLIGHT_WAND(2, 120),
     VOODOO_DOLL(5, 200),
     WEIRD_TUBA(20, 150, riftManaCost = 60),
-    WEIRDER_TUBA(30, 120, riftManaCost = 60, allowRecastAfter = 20.seconds),
-    FIRE_FREEZE_STAFF(10, 500, allowRecastAfter = 0.seconds),
+    WEIRDER_TUBA(30, 120, riftManaCost = 60, recastAfter = 20.seconds),
+    FIRE_FREEZE_STAFF(10, 500, recastAfter = 0.seconds),
     SWORD_OF_BAD_HEALTH(5, 0),
     WITHER_CLOAK(10, 0),
     HOLY_ICE(4, 20),
     VOODOO_DOLL_WILTED(3, 180),
-    FIRE_FURY_STAFF(20, 1000, allowRecastAfter = 0.seconds),
+    FIRE_FURY_STAFF(20, 1000, recastAfter = 0.seconds),
     SHADOW_FURY(15, 0, "STARRED_SHADOW_FURY"),
     ENDER_BOW(30, 50),
     LIVID_DAGGER(5, 150),
@@ -72,10 +73,10 @@ enum class ItemAbilityType(
         IslandType.HUB.isInIsland()
     }),
     MOODY_GRAPPLESHOT(1, 30),
-    FLOWER_OF_TRUTH(1, 0),
-    BOUQUET_OF_LIES(1, 0),
+    FLOWER_OF_TRUTH(1, 0, manaCostPercentage = 0.1),
+    BOUQUET_OF_LIES(1, 0, manaCostPercentage = 0.1),
     WAND_OF_VOLCANO(1, 0),
-    ASPECT_OF_THE_END(0, 50, isAllowed =  {
+    ASPECT_OF_THE_END(0, 50, isAllowed = {
         !DungeonAPI.isInF7Boss()
     }),
 

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityType.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.itemabilities.abilitycooldown
 
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
+import at.hannibal2.skyhanni.features.event.diana.DianaAPI
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NEUInternalName
@@ -68,8 +69,7 @@ enum class ItemAbilityType(
     ROGUE_SWORD(30, 50, ignoreMageCooldownReduction = true),
     TALBOTS_THEODOLITE(10, 98),
     ANCESTRAL_SPADE(3, 98, isAllowed = {
-//         IslandType.HUB.isInIsland() && DianaAPI.isRitualActive()
-        IslandType.HUB.isInIsland()
+        IslandType.HUB.isInIsland() && DianaAPI.isRitualActive()
     }),
     MOODY_GRAPPLESHOT(1, 30),
     FLOWER_OF_TRUTH(1, 0),
@@ -84,6 +84,8 @@ enum class ItemAbilityType(
 
     // TODO incoming damage reduction for 10s
     ENRAGER(500, 20),
+
+    BONZO_STAFF(0, 90, "STARRED_BONZO_STAFF"),
     ;
 
     var newVariant = false

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemText.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemText.kt
@@ -1,0 +1,10 @@
+package at.hannibal2.skyhanni.features.itemabilities.abilitycooldown
+
+import at.hannibal2.skyhanni.utils.LorenzColor
+
+class ItemText(
+    val color: LorenzColor,
+    val text: String,
+    val onCooldown: Boolean,
+    val alternativePosition: Boolean,
+)

--- a/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
@@ -1,5 +1,7 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ActiveAbility
+
 data class CachedItemData(
     // -1 = not loaded
     var petCandies: Int? = -1,
@@ -23,4 +25,6 @@ data class CachedItemData(
     var itemRarity: LorenzRarity? = null,
 
     var itemCategory: ItemCategory? = null,
+
+    var itemAbilities: List<ActiveAbility> = listOf()
 )

--- a/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.data.ItemRenderBackground
 import at.hannibal2.skyhanni.features.itemabilities.abilitycooldown.ActiveAbility
 
 data class CachedItemData(
@@ -26,5 +27,7 @@ data class CachedItemData(
 
     var itemCategory: ItemCategory? = null,
 
-    var itemAbilities: List<ActiveAbility>? = null
+    var itemAbilities: List<ActiveAbility>? = null,
+
+    var renderBackground: ItemRenderBackground.RenderBackgroundData = ItemRenderBackground.RenderBackgroundData(),
 )

--- a/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
@@ -26,5 +26,5 @@ data class CachedItemData(
 
     var itemCategory: ItemCategory? = null,
 
-    var itemAbilities: List<ActiveAbility> = listOf()
+    var itemAbilities: List<ActiveAbility>? = null
 )

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -185,7 +185,7 @@ object SkyBlockItemModifierUtils {
 
     fun ItemStack.getEdition() = getAttributeInt("edition")
 
-    fun ItemStack.getEnchantments() = getExtraAttributes()?.takeIf { it.hasKey("enchantments") }?.run {
+    fun ItemStack.getEnchantments(): Map<String, Int>? = getExtraAttributes()?.takeIf { it.hasKey("enchantments") }?.run {
         val enchantments = this.getCompoundTag("enchantments")
         enchantments.keySet.associateWith { enchantments.getInteger(it) }
     }


### PR DESCRIPTION
## Dependencies
- #994


## Goal
Show if item abilities cant be used because of missing mana / time until enough mana is loaded
Also showing a mana bar that gets updated client side.

## Progress

- [ ] item ability possible check
- [ ] mana bar
- [ ] orb support (mana disintegrator)
- [ ] mana disintegrator for wands
- [ ] denied area heavy pearls
- [ ] denied area rescue mission
- [x] no tp during f7 boss
- [ ] Hyperion cooldown of  50ms or so?
- [ ] widra dragon armor
- [ ] overflow mana
- [ ] hyperion spam (50ms check?)
- [ ] aote/aotv sneak ability
- [ ] lesser orb of healing

power scroll? maybe out of scope


## Done Changelog 
+ nothing :(

![grafik](https://github.com/hannibal002/SkyHanni/assets/24389977/96a52588-8aa5-4358-b35f-e85d6eacbc4a)
