### PR TITLE
Fix: ShiftClickNPCSell empty invenotry

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNPCSell.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNPCSell.kt
@@ -29,9 +29,10 @@ object ShiftClickNPCSell {
     @SubscribeEvent
     fun onOpen(event: InventoryFullyOpenedEvent) {
         if (!LorenzUtils.inSkyBlock) return
-        val item = event.inventoryItems[event.inventoryItems.keys.last() + sellSlot]
+        if (event.inventoryItems.isEmpty()) return
+        val item = event.inventoryItems[event.inventoryItems.keys.last() + sellSlot] ?: return
 
-        inInventory = lastLoreLineOfSellPattern.matches(item?.getLore()?.lastOrNull())
+        inInventory = lastLoreLineOfSellPattern.matches(item.getLore().lastOrNull())
     }
 
     @SubscribeEvent


### PR DESCRIPTION
fixes the NoSuchElementException when opening an empty chest