### PR TITLE
Fix: GFS tab complete sending the wrong command

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/GetFromSacksTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/GetFromSacksTabComplete.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.jsonobjects.repo.SacksJson
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -37,7 +38,7 @@ object GetFromSacksTabComplete {
         if (realName == rawName) return
         if (realName !in sackList) return
         event.isCanceled = true
-        LorenzUtils.sendCommandToServer(message.replace(rawName, realName))
+        ChatUtils.sendMessageToServer(message.replace(rawName, realName))
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.gfsSack


### PR DESCRIPTION
fixes sending `//gfs` instead of `/gfs`