### PR TITLE
Fix: Send coords being command instead of a message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/SendCoordinatedCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/SendCoordinatedCommand.kt
@@ -12,11 +12,11 @@ class SendCoordinatedCommand {
         val message = event.message
         if (message == "/sendcoords") {
             event.isCanceled = true
-            ChatUtils.sendCommandToServer(getCoordinates())
+            ChatUtils.sendMessageToServer(getCoordinates())
         } else if (message.startsWith("/sendcoords ")) {
             event.isCanceled = true
             val description = message.split(" ").drop(1).joinToString(" ")
-            ChatUtils.sendCommandToServer("${getCoordinates()} $description")
+            ChatUtils.sendMessageToServer("${getCoordinates()} $description")
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
@@ -14,11 +14,11 @@ object ViewRecipeCommand {
     fun onMessageSendToServer(event: MessageSendToServerEvent) {
         if (!config.viewRecipeLowerCase) return
         val message = event.message
+        if (!message.startsWith("/viewrecipe ", ignoreCase = true)) return
+
         if (message == message.uppercase()) return
-        if (message.startsWith("/viewrecipe ", ignoreCase = true)) {
-            event.isCanceled = true
-            ChatUtils.sendCommandToServer(message.uppercase())
-        }
+        event.isCanceled = true
+        ChatUtils.sendCommandToServer(message.uppercase().drop(1))
     }
 
     val list by lazy {


### PR DESCRIPTION
- Send coords as a command instead of as text
- View recipe command containing an extra "/"