### PR TITLE
Fix: SkillProgess display size without bar

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -53,7 +53,7 @@ object SkillProgress {
     private var allDisplay = emptyList<Renderable>()
     private var etaDisplay = emptyList<Renderable>()
     private var lastGainUpdate = SimpleTimeMark.farPast()
-    private var maxWidth = 0
+    private var maxWidth = 182
     var hideInActionBar = listOf<String>()
 
     @SubscribeEvent


### PR DESCRIPTION
The gui editor breaks for the skill Progress display if the bar is disabled. Since the size of the gui element is always 0 since the correct value only gets set in the bar logic.
## Discord
https://discord.com/channels/997079228510117908/1163373629204086894/1211052740407726101