### PR TITLE
Fix: Typo in Deep Caverns Parkour message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/DeepCavernsParkour.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/DeepCavernsParkour.kt
@@ -94,7 +94,7 @@ class DeepCavernsParkour {
             if (it.displayName != "§aObsidian Sanctuary") {
                 if (!show) {
                     start()
-                    ChatUtils.chat("Automatically enabling Deep Caverns Parkour, helping you find the way to the bottom of Deep Caverns and the path to Ryst.")
+                    ChatUtils.chat("Automatically enabling Deep Caverns Parkour, helping you find the way to the bottom of Deep Caverns and the path to Rhys.")
                 }
             }
         }


### PR DESCRIPTION
Ryst -> Rhys