### PR TITLE
Improvement: Consistent enhanced backspace

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/BetterSignEditing.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/BetterSignEditing.kt
@@ -6,20 +6,18 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.mixins.transformers.AccessorGuiEditSign
 import at.hannibal2.skyhanni.utils.ClipboardUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager
-import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.OSUtils
 import kotlinx.coroutines.launch
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiScreen
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import org.lwjgl.input.Keyboard
 
 class BetterSignEditing {
 
     private var pasteLastClicked = false
     private var copyLastClicked = false
-    private var deleteWordLastClicked = false
+    private var deleteLastClicked = false
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
@@ -33,18 +31,20 @@ class BetterSignEditing {
     }
 
     private fun checkDeleting(gui: GuiScreen?) {
-        val deleteWordClicked = Keyboard.KEY_BACK.isKeyHeld() && KeyboardManager.isModifierKeyDown()
-        if (!deleteWordLastClicked && deleteWordClicked && gui is AccessorGuiEditSign) {
+        val deleteClicked = KeyboardManager.isDeleteWordDown() || KeyboardManager.isDeleteLineDown()
+        if (!deleteLastClicked && deleteClicked && gui is AccessorGuiEditSign) {
             SkyHanniMod.coroutineScope.launch {
-                val newLine = if (KeyboardManager.isShiftKeyDown()) "" else {
+                val newLine = if (KeyboardManager.isDeleteLineDown()) ""
+                else if (KeyboardManager.isDeleteWordDown()) {
                     val currentLine = gui.tileSign.signText[gui.editLine].unformattedText
+
                     val lastSpaceIndex = currentLine.lastIndexOf(' ')
                     if (lastSpaceIndex >= 0) currentLine.substring(0, lastSpaceIndex + 1) else ""
-                }
+                } else return@launch
                 LorenzUtils.setTextIntoSign(newLine, gui.editLine)
             }
         }
-        deleteWordLastClicked = deleteWordClicked
+        deleteLastClicked = deleteClicked
     }
 
     private fun checkCopying(gui: GuiScreen?) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/BetterSignEditing.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/BetterSignEditing.kt
@@ -38,8 +38,8 @@ class BetterSignEditing {
                 else if (KeyboardManager.isDeleteWordDown()) {
                     val currentLine = gui.tileSign.signText[gui.editLine].unformattedText
 
-                    val lastSpaceIndex = currentLine.lastIndexOf(' ')
-                    if (lastSpaceIndex >= 0) currentLine.substring(0, lastSpaceIndex + 1) else ""
+                    val lastSpaceIndex = currentLine.trimEnd().lastIndexOf(' ')
+                    if (lastSpaceIndex >= 0) currentLine.substring(0, lastSpaceIndex + 2) else ""
                 } else return@launch
                 LorenzUtils.setTextIntoSign(newLine, gui.editLine)
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
@@ -488,8 +488,8 @@ open class VisualWordGui : GuiScreen() {
             if (currentText.isNotEmpty()) {
                 currentText = if (KeyboardManager.isDeleteLineDown()) ""
                 else if (KeyboardManager.isDeleteWordDown()) {
-                    val lastSpaceIndex = currentText.lastIndexOf(' ')
-                    if (lastSpaceIndex >= 0) currentText.substring(0, lastSpaceIndex) else ""
+                    val lastSpaceIndex = currentText.trimEnd().removeSuffix(" ").lastIndexOf(' ')
+                    if (lastSpaceIndex >= 0) currentText.substring(0, lastSpaceIndex + 1) else ""
                 }
                 else {
                     currentText.substring(0, currentText.length - 1)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
@@ -486,16 +486,12 @@ open class VisualWordGui : GuiScreen() {
 
         if (keyCode == Keyboard.KEY_BACK) {
             if (currentText.isNotEmpty()) {
-                currentText = if (KeyboardManager.isModifierKeyDown()) {
-                    ""
-                } else if (KeyboardManager.isShiftKeyDown()) {
+                currentText = if (KeyboardManager.isDeleteLineDown()) ""
+                else if (KeyboardManager.isDeleteWordDown()) {
                     val lastSpaceIndex = currentText.lastIndexOf(' ')
-                    if (lastSpaceIndex >= 0) {
-                        currentText.substring(0, lastSpaceIndex)
-                    } else {
-                        ""
-                    }
-                } else {
+                    if (lastSpaceIndex >= 0) currentText.substring(0, lastSpaceIndex) else ""
+                }
+                else {
                     currentText.substring(0, currentText.length - 1)
                 }
                 saveTextChanges()

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -19,7 +19,16 @@ object KeyboardManager {
 
     // A mac-only key, represents Windows key on windows (but different key code)
     private fun isCommandKeyDown() = Keyboard.KEY_LMETA.isKeyHeld() || Keyboard.KEY_RMETA.isKeyHeld()
+
+    // Windows: Alt key Mac: Option key
+    private fun isMenuKeyDown() = Keyboard.KEY_LMENU.isKeyHeld() || Keyboard.KEY_RMENU.isKeyHeld()
+
     private fun isControlKeyDown() = Keyboard.KEY_LCONTROL.isKeyHeld() || Keyboard.KEY_RCONTROL.isKeyHeld()
+
+    fun isDeleteWordDown() = Keyboard.KEY_BACK.isKeyHeld() && if (SystemUtils.IS_OS_MAC) isMenuKeyDown() else isControlKeyDown()
+
+    fun isDeleteLineDown() = Keyboard.KEY_BACK.isKeyHeld() && if (SystemUtils.IS_OS_MAC) isCommandKeyDown() else isControlKeyDown() && isShiftKeyDown()
+
     fun isShiftKeyDown() = Keyboard.KEY_LSHIFT.isKeyHeld() || Keyboard.KEY_RSHIFT.isKeyHeld()
 
     fun isPastingKeysDown() = isModifierKeyDown() && Keyboard.KEY_V.isKeyHeld()


### PR DESCRIPTION
## What
Makes enhanced backspace (delete whole word/line) consistent across sh and other programs.
(`Win: Ctrl+Backspace for word Ctrl+Shift+Backspace for line` `Mac: Option+Back delete for word Cmd+Back delete for line`)
Also adds keyboard manager functions for detecting when these keys are pressed.

## Changelog Improvements
+ Improved delete word/line functionality for text boxes/signs. - Obsidian
    * It's now consistent with Discord's.