### PR TITLE
Feature: Hide useless Booster Cookie message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -264,6 +264,7 @@ class ChatFilter {
         "§bNew day! §r§eYour §r§2Sky Mall §r§ebuff changed!",
         "§8§oYou can disable this messaging by toggling Sky Mall in your /hotm!",
         "§e[NPC] Jacob§f: §rMy contest has started!",
+        "§eObtain a §r§6Booster Cookie §r§efrom the community shop in the hub!",
     )
 
     private val anitaFortunePattern by RepoPattern.pattern(


### PR DESCRIPTION
This is the second line that shows up when you try to use a command that requires Cookie Buff:

```
You need the Cookie Buff to use this feature!
Obtain a Booster Cookie from the community shop in the hub!
```

## Changelog Improvements
+ Added Booster Cookie purchase reminder to chat filter category others. - alexia