### PR TITLE
Fix: Anita Accessory Chat Filter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -269,7 +269,7 @@ class ChatFilter {
 
     private val anitaFortunePattern by RepoPattern.pattern(
         "chat.jacobevent.accessory",
-        "§e\\[NPC] Jacob§f: Your §9Anita's (\\w+) §fis giving you §6\\+(\\d{1,2})☘ (\\w+) Fortune §fduring the contest!"
+        "§e\\[NPC] Jacob§f: §rYour §9Anita's (\\w+) §fis giving you §6\\+(\\d{1,2})☘ (\\w+) Fortune §fduring the contest!"
     )
 
     private val skymallPerkPattern by RepoPattern.pattern(


### PR DESCRIPTION
## What
Fixed Hide Anita Accessories' fortune bonus messages not getting hidden outside the Garden

## Changelog Fixes
+ Fixed Hide Anita Accessories' fortune bonus chat message not getting hidden in the chat filter. - alexia