### PR TITLE
Show available/missing classes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/PartyFinderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/PartyFinderConfig.java
@@ -47,4 +47,11 @@ public class PartyFinderConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean markMissingClass = true;
+
+    @Expose
+    @ConfigOption(name = "Show Missing Classes", desc = "Show missing classes in a party in the tooltip.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean showMissingClasses = true;
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -156,7 +156,7 @@ class DungeonFinderFeatures {
 
         val stack = event.itemStack
 
-        val classNames = mutableListOf("Healer", "Mage", "Berserker", "Archer", "Tank")
+        val classNames = mutableListOf("Healer", "Mage", "Berserk", "Archer", "Tank")
 
         for ((index, line) in stack.getLore().withIndex()) {
             classLevelPattern.matchMatcher(line) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -156,6 +156,8 @@ class DungeonFinderFeatures {
 
         val stack = event.itemStack
 
+        val classNames = mutableListOf("Healer", "Mage", "Berserker", "Archer", "Tank")
+
         for ((index, line) in stack.getLore().withIndex()) {
             classLevelPattern.matchMatcher(line) {
                 val playerName = group("playerName")
@@ -163,8 +165,11 @@ class DungeonFinderFeatures {
                 val level = group("level").toInt()
                 val color = getColor(level)
                 event.toolTip[index + 1] = " §b$playerName§f: §e$className $color$level"
+                if(classNames.contains(className)) classNames.remove(className)
             }
         }
+        if(classNames.contains(selectedClass)) classNames[classNames.indexOf(selectedClass)] = "§a${selectedClass}§7"
+        if(config.showMissingClasses) event.toolTip.add("§eMissing: §7" + classNames.joinToString(", "))
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Added showing the available classes for each party in the tooltip (https://discord.com/channels/997079228510117908/1213127210156687400), highlighting your selected class in green if it's available.

https://conutik.catto.pics/124abe31 (If selected class is available)
https://conutik.catto.pics/b8fee201 (If selected class isn't available)

## Changelog New Features
+ Added available classes in the tooltip. - Conutik
    * Highlights your selected class in green if it's available
