### PR TITLE
Fix: Anita's Accessory Chat Filter not working with multi-word crops

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -269,7 +269,7 @@ class ChatFilter {
 
     private val anitaFortunePattern by RepoPattern.pattern(
         "chat.jacobevent.accessory",
-        "§e\\[NPC] Jacob§f: §rYour §9Anita's (\\w+) §fis giving you §6\\+(\\d{1,2})☘ (\\w+) Fortune §fduring the contest!"
+        "§e\\[NPC] Jacob§f: §rYour §9Anita's \\w+ §fis giving you §6\\+\\d{1,2}☘ .+ Fortune §fduring the contest!"
     )
 
     private val skymallPerkPattern by RepoPattern.pattern(


### PR DESCRIPTION
## What
Fixed Anita's Accessory chat filter not working with multi-word crops (Cocoa Beans, Nether Wart, Sugar Cane).

## Changelog Fixes
+ Fixed Anita's Accessory chat filter not working with multi-word crops (Cocoa Beans, Nether Wart, Sugar Cane). - Alexia

## Changelog Technical Details
+ Removed unnecessary capturing groups from the Anita's Accessory chat filter regex. - Alexia
