### PR TITLE
Fix: Chat symbols showing twice

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PlayerChatSymbols.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PlayerChatSymbols.kt
@@ -31,7 +31,7 @@ class PlayerChatSymbols {
     )
     private val symbolPattern by patternGroup.pattern(
         "symbol",
-        "((?:§\\w)+\\S)"
+        "(?:§.)+(\\S)"
     )
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -249,8 +249,9 @@ object StringUtils {
         modifyFirstChatComponent(chatComponent) { component ->
             if (component is ChatComponentText) {
                 component as AccessorChatComponentText
-                if (component.text_skyhanni().contains(toReplace)) {
-                    component.setText_skyhanni(component.text_skyhanni().replace(toReplace, replacement))
+                val componentText = component.text_skyhanni()
+                if (componentText.contains(toReplace)) {
+                    component.setText_skyhanni(componentText.replace(toReplace, replacement))
                     return@modifyFirstChatComponent true
                 }
                 return@modifyFirstChatComponent false


### PR DESCRIPTION
## What
Fix chat symbols showing twice because hypixel decided to remove formatting from chat components 💀 


## Changelog Fixes
+ Fixed some chat symbols showing twice in chat due to a Hypixel change. - CalMWolfs