### PR TITLE
Fix: Profile name on alpha

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -449,6 +449,8 @@ class FarmingWeightDisplay {
             val url = "https://api.elitebot.dev/weight/$uuid"
             val apiResponse = APIUtil.getJSONResponse(url)
 
+            var error: Throwable? = null
+
             try {
                 val apiData = ConfigManager.gson.fromJson<EliteWeightJson>(apiResponse)
 
@@ -469,6 +471,7 @@ class FarmingWeightDisplay {
                 }
 
             } catch (e: Exception) {
+                error = e
                 ErrorManager.logErrorWithData(
                     e, "Error loading user farming weight",
                     "url" to url,
@@ -477,10 +480,16 @@ class FarmingWeightDisplay {
                 )
             }
             apiError = true
-            ErrorManager.skyHanniError(
-                "Loading the farming weight data from elitebot.dev failed!\n"
-                    + "§eYou can re-enter the garden to try to fix the problem.\n" +
-                    "§cIf this message repeats, please report it on Discord!",
+
+            ErrorManager.logErrorWithData(
+                error ?: IllegalStateException("Error loading user farming weight"),
+                "Error loading user farming weight\n" +
+                    "§eLoading the farming weight data from elitebot.dev failed!\n" +
+                    "§eYou can re-enter the garden to try to fix the problem.\n" +
+                    "§cIf this message repeats, please report it on Discord!\n",
+                "url" to url,
+                "apiResponse" to apiResponse,
+                "localProfile" to localProfile
             )
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -472,12 +472,6 @@ class FarmingWeightDisplay {
 
             } catch (e: Exception) {
                 error = e
-                ErrorManager.logErrorWithData(
-                    e, "Error loading user farming weight",
-                    "url" to url,
-                    "apiResponse" to apiResponse,
-                    "localProfile" to localProfile
-                )
             }
             apiError = true
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -86,6 +86,6 @@ object UtilsPatterns {
 
     val tabListProfilePattern by patternGroup.pattern(
         "tablist.profile",
-        "(?:§.)+Profile: §r§a(?<profile>.*)"
+        "(?:§.)+Profile: §r§a(?<profile>\\S+).*"
     )
 }


### PR DESCRIPTION
## What
Fixes getting the profile name with alpha's new tablist system for ironman, stranded and bingo? players

## Changelog Fixes
+ Fixed getting profile name from tab list on alpha for special profiles. - CalMWolfs
    * Fixes for any Ironman, Stranded and maybe Bingo players.

## Changelog Technical Details
+ Added more error logging to getting farming weight. - CalMWolfs

