### PR TITLE
Fix: Visitor spam temporarily

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
@@ -151,7 +151,7 @@ object VisitorAPI {
             }
             if (!found) continue
 
-            if (line.isEmpty() || line.contains("Account Info")) {
+            if (line.isEmpty() || line.contains("Account Info") || line.contains("Next Visitor")) {
                 found = false
                 continue
             }


### PR DESCRIPTION
## What
Stop visitor spam, doesnt make any other visitor features work but at least your chat wont get 10000 messages.


## Changelog Fixes
+ Stop SkyHanni from saying that Next Visitor is visiting your garden. - CalMWolfs
