### PR TITLE
Backend: Double text in tablist

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -173,7 +173,8 @@ object TabListRenderer {
                     middleX += 8 + 2
                 }
 
-                val text = if (AdvancedPlayerList.ignoreCustomTabList()) tabLine.text else tabLine.customName
+                var text = if (AdvancedPlayerList.ignoreCustomTabList()) tabLine.text else tabLine.customName
+                if (text.contains("§l")) text = "§r$text"
                 if (tabLine.type == TabStringType.TITLE) {
                     minecraft.fontRendererObj.drawStringWithShadow(
                         text,
@@ -215,7 +216,7 @@ object TabListRenderer {
     )
 
     @SubscribeEvent
-    fun hideFireFromTheTabListBecauseWhoWantsThose(event: SkipTabListLineEvent) {
+    fun onSkipTablistLine(event: SkipTabListLineEvent) {
         if (config.hideFiresales && event.lastSubTitle != null && fireSalePattern.matches(event.lastSubTitle.text)) {
             event.cancel()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabStringType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabStringType.kt
@@ -11,11 +11,11 @@ enum class TabStringType {
     companion object {
 
         fun fromLine(line: String): TabStringType {
-            val strippedLine: String = line.removeColor()
-            if (strippedLine.startsWith(" ")) {
+            val unformattedLine: String = line.removeColor()
+            if (unformattedLine.startsWith(" ")) {
                 return TEXT
             }
-            return if (TabListReader.usernamePattern.matcher(strippedLine).find()) {
+            return if (TabListReader.usernamePattern.matcher(unformattedLine).find()) {
                 PLAYER
             } else {
                 SUB_TITLE


### PR DESCRIPTION
## What
Fixes an issue on alpha which makes any text that is bold half way through have a full bold shadow. This seems to be a minecraft issue but my attempts with my limited knowledge of mixins were unsuccessful to fix the issue.

## Changelog Technical Details
+ Fixes minecraft bug where bold text can render weirdly. - CalMWolfs

