### PR TITLE
Fix: RenderEntityLiving performance fix

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/markedplayer/MarkedPlayerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/markedplayer/MarkedPlayerConfig.java
@@ -32,6 +32,6 @@ public class MarkedPlayerConfig {
     @ConfigOption(name = "Marked Entity Color", desc = "The color of the marked player in the world. §cDoes not yet support chroma.")
     @Expose
     @ConfigEditorDropdown
-    public LorenzColor entityColor = LorenzColor.YELLOW;
+    public Property<LorenzColor> entityColor = Property.of(LorenzColor.YELLOW);
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/RenderMobColoredEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RenderMobColoredEvent.kt
@@ -1,7 +1,0 @@
-package at.hannibal2.skyhanni.events
-
-import net.minecraft.entity.EntityLivingBase
-
-// TODO remove
-@Deprecated("use RenderLivingHelper .setEntityColor && .removeEntityColor")
-class RenderMobColoredEvent(val entity: EntityLivingBase, var color: Int) : LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/RenderMobColoredEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RenderMobColoredEvent.kt
@@ -3,4 +3,5 @@ package at.hannibal2.skyhanni.events
 import net.minecraft.entity.EntityLivingBase
 
 // TODO remove
+@Deprecated("use RenderLivingHelper .setEntityColor && .removeEntityColor")
 class RenderMobColoredEvent(val entity: EntityLivingBase, var color: Int) : LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/ResetEntityHurtEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/ResetEntityHurtEvent.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.events
 import net.minecraft.entity.EntityLivingBase
 import java.awt.Color
 
-// TODO remove
+@Deprecated("use RenderLivingHelper .setNoHurtTime && .removeNoHurtTime")
 class ResetEntityHurtEvent(val entity: EntityLivingBase, var shouldReset: Boolean) : LorenzEvent()
 
 fun Color.withAlpha(alpha: Int): Int = (alpha.coerceIn(0, 255) shl 24) or (this.rgb and 0x00ffffff)

--- a/src/main/java/at/hannibal2/skyhanni/events/ResetEntityHurtEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/ResetEntityHurtEvent.kt
@@ -1,7 +1,0 @@
-package at.hannibal2.skyhanni.events
-
-import net.minecraft.entity.EntityLivingBase
-
-@Deprecated("use RenderLivingHelper .setNoHurtTime && .removeNoHurtTime")
-class ResetEntityHurtEvent(val entity: EntityLivingBase, var shouldReset: Boolean) : LorenzEvent()
-

--- a/src/main/java/at/hannibal2/skyhanni/events/ResetEntityHurtEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/ResetEntityHurtEvent.kt
@@ -1,9 +1,7 @@
 package at.hannibal2.skyhanni.events
 
 import net.minecraft.entity.EntityLivingBase
-import java.awt.Color
 
 @Deprecated("use RenderLivingHelper .setNoHurtTime && .removeNoHurtTime")
 class ResetEntityHurtEvent(val entity: EntityLivingBase, var shouldReset: Boolean) : LorenzEvent()
 
-fun Color.withAlpha(alpha: Int): Int = (alpha.coerceIn(0, 255) shl 24) or (this.rgb and 0x00ffffff)

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AreaMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AreaMiniBossFeatures.kt
@@ -52,9 +52,8 @@ class AreaMiniBossFeatures {
 
             if (config.areaBossHighlight) {
                 val color = bossType.color.toColor().withAlpha(bossType.colorOpacity)
-                RenderLivingEntityHelper.setEntityColor(entity, color)
+                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, color)
                 { config.areaBossHighlight && SlayerAPI.isInAnyArea }
-                RenderLivingEntityHelper.setNoHurtTime(entity) { config.areaBossHighlight && SlayerAPI.isInAnyArea }
             }
 
             // TODO add sound

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AreaMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AreaMiniBossFeatures.kt
@@ -5,8 +5,8 @@ import at.hannibal2.skyhanni.data.SlayerAPI
 import at.hannibal2.skyhanni.events.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.hasMaxHealth
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzColor

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -3,8 +3,8 @@ package at.hannibal2.skyhanni.features.combat.mobs
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.events.EntityMaxHealthUpdateEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.hasNameTagWith
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -28,9 +28,11 @@ class MobHighlight {
         val entity = event.entity
         val baseMaxHealth = entity.baseMaxHealth
         if (config.corruptedMobHighlight && event.health == baseMaxHealth * 3) {
-            RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.DARK_PURPLE.toColor().withAlpha(127))
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                entity,
+                LorenzColor.DARK_PURPLE.toColor().withAlpha(127)
+            )
             { config.corruptedMobHighlight }
-            RenderLivingEntityHelper.setNoHurtTime(entity) { config.corruptedMobHighlight }
         }
     }
 
@@ -41,15 +43,19 @@ class MobHighlight {
         val entity = event.entity
         val maxHealth = event.maxHealth
         if (config.arachneKeeperHighlight && (maxHealth == 3_000 || maxHealth == 12_000) && entity is EntityCaveSpider) {
-            RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.DARK_BLUE.toColor().withAlpha(127))
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                entity,
+                LorenzColor.DARK_BLUE.toColor().withAlpha(127)
+            )
             { config.arachneKeeperHighlight }
-            RenderLivingEntityHelper.setNoHurtTime(entity) { config.arachneKeeperHighlight }
         }
 
         if (config.corleoneHighlighter && maxHealth == 1_000_000 && entity is EntityOtherPlayerMP && entity.name == "Team Treasurite") {
-            RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.DARK_PURPLE.toColor().withAlpha(127))
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                entity,
+                LorenzColor.DARK_PURPLE.toColor().withAlpha(127)
+            )
             { config.corleoneHighlighter }
-            RenderLivingEntityHelper.setNoHurtTime(entity) { config.corleoneHighlighter }
         }
 
         if (entity is EntityEnderman) {
@@ -57,17 +63,21 @@ class MobHighlight {
                 val isZealot = maxHealth == 13_000 || maxHealth == 13_000 * 4 // runic
                 val isBruiser = maxHealth == 65_000 || maxHealth == 65_000 * 4 // runic
                 if (isZealot || isBruiser) {
-                    RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.DARK_AQUA.toColor().withAlpha(127))
+                    RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                        entity,
+                        LorenzColor.DARK_AQUA.toColor().withAlpha(127)
+                    )
                     { config.zealotBruiserHighlighter }
-                    RenderLivingEntityHelper.setNoHurtTime(entity) { config.zealotBruiserHighlighter }
                 }
             }
 
             // Special Zealots are not impacted by derpy
             if (config.specialZealotHighlighter && maxHealth.ignoreDerpy() == 2_000) {
-                RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.DARK_RED.toColor().withAlpha(50))
+                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                    entity,
+                    LorenzColor.DARK_RED.toColor().withAlpha(50)
+                )
                 { config.specialZealotHighlighter }
-                RenderLivingEntityHelper.setNoHurtTime(entity) { config.specialZealotHighlighter }
             }
         }
 
@@ -91,14 +101,12 @@ class MobHighlight {
     }
 
     private fun markArachneMinis(entity: EntityLivingBase) {
-        RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.GOLD.toColor().withAlpha(50))
+        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, LorenzColor.GOLD.toColor().withAlpha(50))
         { config.arachneBossHighlighter }
-        RenderLivingEntityHelper.setNoHurtTime(entity) { config.arachneBossHighlighter }
     }
 
     private fun markArachne(entity: EntityLivingBase) {
-        RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.RED.toColor().withAlpha(50))
+        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, LorenzColor.RED.toColor().withAlpha(50))
         { config.arachneBossHighlighter }
-        RenderLivingEntityHelper.setNoHurtTime(entity) { config.arachneBossHighlighter }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
@@ -193,11 +193,7 @@ class DungeonHideItems {
 
         if (isSkeletonSkull(entity)) {
             movingSkeletonSkulls[entity] = System.currentTimeMillis()
-            RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.GOLD.toColor().withAlpha(60))
-            {
-                shouldColorMovingSkull(entity)
-            }
-            RenderLivingEntityHelper.setNoHurtTime(entity)
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, LorenzColor.GOLD.toColor().withAlpha(60))
             {
                 shouldColorMovingSkull(entity)
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
@@ -7,8 +7,8 @@ import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.EntityMoveEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LorenzColor

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
@@ -200,6 +200,7 @@ class DungeonHideItems {
     fun onRenderMobColored(event: RenderMobColoredEvent) {
         if (!LorenzUtils.inDungeons) return
         if (!SkyHanniMod.feature.dungeon.highlightSkeletonSkull) return
+
         val entity = event.entity
         if (entity is EntityArmorStand && isSkeletonSkull(entity)) {
             val lastMove = movingSkeletonSkulls.getOrDefault(entity, 0)
@@ -213,6 +214,7 @@ class DungeonHideItems {
     fun onResetEntityHurtTime(event: ResetEntityHurtEvent) {
         if (!LorenzUtils.inDungeons) return
         if (!SkyHanniMod.feature.dungeon.highlightSkeletonSkull) return
+
         val entity = event.entity
         if (entity is EntityArmorStand && isSkeletonSkull(entity)) {
             val lastMove = movingSkeletonSkulls.getOrDefault(entity, 0)

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
@@ -7,14 +7,14 @@ import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.EntityMoveEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
-import at.hannibal2.skyhanni.events.RenderMobColoredEvent
-import at.hannibal2.skyhanni.events.ResetEntityHurtEvent
 import at.hannibal2.skyhanni.events.withAlpha
+import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.getLorenzVec
+import net.minecraft.entity.Entity
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.item.EntityItem
 import net.minecraft.util.EnumParticleTypes
@@ -193,36 +193,19 @@ class DungeonHideItems {
 
         if (isSkeletonSkull(entity)) {
             movingSkeletonSkulls[entity] = System.currentTimeMillis()
-        }
-    }
-
-    @SubscribeEvent
-    fun onRenderMobColored(event: RenderMobColoredEvent) {
-        if (!LorenzUtils.inDungeons) return
-        if (!SkyHanniMod.feature.dungeon.highlightSkeletonSkull) return
-
-        val entity = event.entity
-        if (entity is EntityArmorStand && isSkeletonSkull(entity)) {
-            val lastMove = movingSkeletonSkulls.getOrDefault(entity, 0)
-            if (lastMove + 200 > System.currentTimeMillis()) {
-                event.color = LorenzColor.GOLD.toColor().withAlpha(60)
+            RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.GOLD.toColor().withAlpha(60))
+            {
+                shouldColorMovingSkull(entity)
+            }
+            RenderLivingEntityHelper.setNoHurtTime(entity)
+            {
+                shouldColorMovingSkull(entity)
             }
         }
     }
 
-    @SubscribeEvent
-    fun onResetEntityHurtTime(event: ResetEntityHurtEvent) {
-        if (!LorenzUtils.inDungeons) return
-        if (!SkyHanniMod.feature.dungeon.highlightSkeletonSkull) return
-
-        val entity = event.entity
-        if (entity is EntityArmorStand && isSkeletonSkull(entity)) {
-            val lastMove = movingSkeletonSkulls.getOrDefault(entity, 0)
-            if (lastMove + 200 > System.currentTimeMillis()) {
-                event.shouldReset = true
-            }
-        }
-    }
+    private fun shouldColorMovingSkull(entity: Entity) =
+        SkyHanniMod.feature.dungeon.highlightSkeletonSkull && movingSkeletonSkulls[entity]?.let { it + 200 > System.currentTimeMillis() } ?: false
 
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
@@ -77,8 +77,10 @@ object DungeonLividFinder {
         if (!newLivid.name.contains("Livid")) return
 
         lividEntity = newLivid
-        RenderLivingEntityHelper.setEntityColor(newLivid, color.toColor().withAlpha(30)) { shouldHighlight() }
-        RenderLivingEntityHelper.setNoHurtTime(newLivid) { shouldHighlight() }
+        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+            newLivid,
+            color.toColor().withAlpha(30)
+        ) { shouldHighlight() }
     }
 
     private fun shouldHighlight() = getLividAlive() != null && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
@@ -5,10 +5,10 @@ import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/HighlightDungeonDeathmite.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/HighlightDungeonDeathmite.kt
@@ -20,9 +20,8 @@ class HighlightDungeonDeathmite {
         val maxHealth = event.maxHealth
 
         if (entity is EntitySilverfish && maxHealth == 1_000_000_000) {
-            RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.DARK_RED.toColor().withAlpha(20))
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, LorenzColor.DARK_RED.toColor().withAlpha(20))
             { SkyHanniMod.feature.dungeon.highlightDeathmites }
-            RenderLivingEntityHelper.setNoHurtTime(entity) { SkyHanniMod.feature.dungeon.highlightDeathmites }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/HighlightDungeonDeathmite.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/HighlightDungeonDeathmite.kt
@@ -2,8 +2,8 @@ package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.EntityMaxHealthUpdateEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.monster.EntitySilverfish

--- a/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
@@ -7,9 +7,9 @@ import at.hannibal2.skyhanni.events.EntityCustomNameUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.RenderMobColoredEvent
 import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.event.winter.UniqueGiftCounter
+import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.entity.EntityPlayerSP
+import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.player.EntityPlayer
@@ -73,20 +73,20 @@ object UniqueGiftingOpportunitiesFeatures {
 
     @SubscribeEvent
     fun onEntityJoinWorldEvent(event: EntityJoinWorldEvent) {
+        playerColor(event)
         val entity = event.entity as? EntityArmorStand ?: return
         analyzeArmorStand(entity)
     }
 
-    @SubscribeEvent
-    fun onRenderMobColored(event: RenderMobColoredEvent) {
-        if (!isEnabled()) return
+    private fun playerColor(event: EntityJoinWorldEvent) {
+        if (event.entity is EntityOtherPlayerMP) {
+            val entity = event.entity as EntityOtherPlayerMP
+            if (entity.isNPC() || isIronman(entity) || isBingo(entity)) return
 
-        val entity = event.entity
-        if (entity is EntityPlayerSP) return
-        if (entity is EntityPlayer && !entity.isNPC() && !isIronman(entity) && !isBingo(entity) &&
-            !hasGiftedPlayer(entity)
-        ) {
-            event.color = LorenzColor.DARK_GREEN.toColor().withAlpha(127)
+            RenderLivingEntityHelper.setEntityColor(
+                entity,
+                LorenzColor.DARK_GREEN.toColor().withAlpha(127)
+            ) { isEnabled() && !hasGiftedPlayer(entity) }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
@@ -80,6 +80,7 @@ object UniqueGiftingOpportunitiesFeatures {
     @SubscribeEvent
     fun onRenderMobColored(event: RenderMobColoredEvent) {
         if (!isEnabled()) return
+
         val entity = event.entity
         if (entity is EntityPlayerSP) return
         if (entity is EntityPlayer && !entity.isNPC() && !isIronman(entity) && !isBingo(entity) &&

--- a/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
@@ -7,9 +7,9 @@ import at.hannibal2.skyhanni.events.EntityCustomNameUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.event.winter.UniqueGiftCounter
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
 import at.hannibal2.skyhanni.utils.InventoryUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/HighlightInquisitors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/HighlightInquisitors.kt
@@ -1,8 +1,8 @@
 package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.player.EntityPlayer

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/HighlightInquisitors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/HighlightInquisitors.kt
@@ -22,8 +22,7 @@ class HighlightInquisitors {
 
         if (entity is EntityPlayer && entity.name == "Minos Inquisitor") {
             val color = LorenzColor.AQUA.toColor().withAlpha(127)
-            RenderLivingEntityHelper.setEntityColor(entity, color) { config.highlightInquisitors }
-            RenderLivingEntityHelper.setNoHurtTime(entity) { config.highlightInquisitors }
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, color) { config.highlightInquisitors }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
@@ -35,7 +35,7 @@ class HighlightJerries {
 
         if (entity is EntityVillager && maxHealth in 3..6) {
             val color = listOfLorenzColors[maxHealth].toColor().withAlpha(20)
-            RenderLivingEntityHelper.setEntityColor(entity, color) { config.highlightJerries }
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, color) { config.highlightJerries }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
@@ -2,8 +2,8 @@ package at.hannibal2.skyhanni.features.event.jerry
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.EntityMaxHealthUpdateEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.passive.EntityVillager

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -6,10 +6,10 @@ import at.hannibal2.skyhanni.events.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
 import at.hannibal2.skyhanni.events.SeaCreatureFishEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.hasMaxHealth
 import at.hannibal2.skyhanni.utils.EntityUtils.hasNameTagWith
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -50,9 +50,8 @@ class SeaCreatureFeatures {
             if (!entity.hasNameTagWith(3, creatureType.nametag)) continue
 
             rareSeaCreatures = rareSeaCreatures.editCopy { add(entity) }
-            RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.RED.toColor().withAlpha(50))
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, LorenzColor.RED.toColor().withAlpha(50))
             { config.highlight }
-            RenderLivingEntityHelper.setNoHurtTime(entity) { config.highlight }
 
             // Water hydra splitting in two
             if (creatureType == RareSeaCreatureType.WATER_HYDRA && entity.health == (entity.baseMaxHealth.toFloat() / 2)) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/HighlightVisitorsOutsideOfGarden.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/HighlightVisitorsOutsideOfGarden.kt
@@ -5,10 +5,10 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.GardenJson
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.getSkinTexture
 import at.hannibal2.skyhanni.utils.LorenzColor

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
@@ -4,11 +4,11 @@ import at.hannibal2.skyhanni.events.garden.visitor.VisitorAcceptedEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorArrivalEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorLeftEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorRefusedEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzLogger

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -6,8 +6,8 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.hasMaxHealth
 import at.hannibal2.skyhanni.utils.LorenzColor

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -54,7 +54,10 @@ class HighlightMiningCommissionMobs {
         val entities = EntityUtils.getEntities<EntityLivingBase>()
         for ((type, entity) in active.flatMap { type -> entities.map { type to it } }) {
             if (type.isMob(entity)) {
-                RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.YELLOW.toColor().withAlpha(127))
+                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                    entity,
+                    LorenzColor.YELLOW.toColor().withAlpha(127)
+                )
                 { isEnabled() && type in active }
             }
         }
@@ -82,7 +85,10 @@ class HighlightMiningCommissionMobs {
         val entity = event.entity
         for (type in active) {
             if (type.isMob(entity)) {
-                RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.YELLOW.toColor().withAlpha(127))
+                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                    entity,
+                    LorenzColor.YELLOW.toColor().withAlpha(127)
+                )
                 { isEnabled() && type in active }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -99,7 +99,6 @@ class MarkedPlayerManager {
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         if (Minecraft.getMinecraft().thePlayer == null) return
 
-        markedPlayers.forEach { RenderLivingEntityHelper.removeCustomRender(it.value) }
         markedPlayers.clear()
         if (config.markOwnName.get()) {
             val name = LorenzUtils.getPlayerName()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -5,9 +5,9 @@ import at.hannibal2.skyhanni.config.enums.OutsideSbFeature
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.client.Minecraft

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -56,8 +56,7 @@ class MarkedPlayerManager {
                 val name = entity.name.lowercase()
                 if (name in playerNamesToMark) {
                     markedPlayers[name] = entity
-                    RenderLivingEntityHelper.setNoHurtTime(entity, ::isEnabled)
-                    RenderLivingEntityHelper.setEntityColor(
+                    RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                         entity,
                         config.entityColor.toColor().withAlpha(127),
                         ::isEnabled

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.client.Minecraft
@@ -56,13 +57,22 @@ class MarkedPlayerManager {
                 val name = entity.name.lowercase()
                 if (name in playerNamesToMark) {
                     markedPlayers[name] = entity
-                    RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
-                        entity,
-                        config.entityColor.toColor().withAlpha(127),
-                        ::isEnabled
-                    )
+                    entity.setColor()
                 }
             }
+        }
+
+        private fun refreshColours() =
+            markedPlayers.forEach {
+                it.value.setColor()
+            }
+
+        private fun EntityOtherPlayerMP.setColor() {
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                this,
+                config.entityColor.get().toColor().withAlpha(127),
+                ::isEnabled
+            )
         }
 
         fun isMarkedPlayer(player: String): Boolean = player.lowercase() in playerNamesToMark
@@ -83,6 +93,7 @@ class MarkedPlayerManager {
                 playerNamesToMark.remove(name)
             }
         }
+        config.entityColor.onToggle(::refreshColours)
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -6,8 +6,8 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.RenderMobColoredEvent
-import at.hannibal2.skyhanni.events.ResetEntityHurtEvent
 import at.hannibal2.skyhanni.events.withAlpha
+import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -16,9 +16,9 @@ import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class MarkedPlayerManager {
-    private val config get() = SkyHanniMod.feature.markedPlayers
-
     companion object {
+
+        private val config get() = SkyHanniMod.feature.markedPlayers
 
         val playerNamesToMark = mutableListOf<String>()
         private val markedPlayers = mutableMapOf<String, EntityOtherPlayerMP>()
@@ -44,6 +44,7 @@ class MarkedPlayerManager {
                 ChatUtils.chat("§aMarked §eplayer §b$displayName§e!")
             } else {
                 playerNamesToMark.remove(name)
+                markedPlayers[name]?.let { RenderLivingEntityHelper.removeNoHurtTime(it) }
                 markedPlayers.remove(name)
                 ChatUtils.chat("§cUnmarked §eplayer §b$displayName§e!")
             }
@@ -56,11 +57,15 @@ class MarkedPlayerManager {
                 val name = entity.name.lowercase()
                 if (name in playerNamesToMark) {
                     markedPlayers[name] = entity
+                    RenderLivingEntityHelper.setNoHurtTime(entity, ::isEnabled)
                 }
             }
         }
 
         fun isMarkedPlayer(player: String): Boolean = player.lowercase() in playerNamesToMark
+
+        private fun isEnabled() = (LorenzUtils.inSkyBlock || OutsideSbFeature.MARKED_PLAYERS.isSelected())
+            && config.highlightInWorld
     }
 
     @SubscribeEvent
@@ -97,22 +102,10 @@ class MarkedPlayerManager {
     }
 
     @SubscribeEvent
-    fun onResetEntityHurtTime(event: ResetEntityHurtEvent) {
-        if (!isEnabled()) return
-
-        val entity = event.entity
-        if (entity in markedPlayers.values) {
-            event.shouldReset = true
-        }
-    }
-
-    private fun isEnabled() = (LorenzUtils.inSkyBlock || OutsideSbFeature.MARKED_PLAYERS.isSelected())
-        && config.highlightInWorld
-
-    @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         if (Minecraft.getMinecraft().thePlayer == null) return
 
+        markedPlayers.forEach { RenderLivingEntityHelper.removeNoHurtTime(it.value) }
         markedPlayers.clear()
         if (config.markOwnName.get()) {
             val name = LorenzUtils.getPlayerName()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.config.enums.OutsideSbFeature
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.RenderMobColoredEvent
 import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -44,7 +43,7 @@ class MarkedPlayerManager {
                 ChatUtils.chat("§aMarked §eplayer §b$displayName§e!")
             } else {
                 playerNamesToMark.remove(name)
-                markedPlayers[name]?.let { RenderLivingEntityHelper.removeNoHurtTime(it) }
+                markedPlayers[name]?.let { RenderLivingEntityHelper.removeCustomRender(it) }
                 markedPlayers.remove(name)
                 ChatUtils.chat("§cUnmarked §eplayer §b$displayName§e!")
             }
@@ -58,6 +57,11 @@ class MarkedPlayerManager {
                 if (name in playerNamesToMark) {
                     markedPlayers[name] = entity
                     RenderLivingEntityHelper.setNoHurtTime(entity, ::isEnabled)
+                    RenderLivingEntityHelper.setEntityColor(
+                        entity,
+                        config.entityColor.toColor().withAlpha(127),
+                        ::isEnabled
+                    )
                 }
             }
         }
@@ -92,20 +96,10 @@ class MarkedPlayerManager {
     }
 
     @SubscribeEvent
-    fun onRenderMobColored(event: RenderMobColoredEvent) {
-        if (!isEnabled()) return
-
-        val entity = event.entity
-        if (entity in markedPlayers.values) {
-            event.color = config.entityColor.toColor().withAlpha(127)
-        }
-    }
-
-    @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         if (Minecraft.getMinecraft().thePlayer == null) return
 
-        markedPlayers.forEach { RenderLivingEntityHelper.removeNoHurtTime(it.value) }
+        markedPlayers.forEach { RenderLivingEntityHelper.removeCustomRender(it.value) }
         markedPlayers.clear()
         if (config.markOwnName.get()) {
             val name = LorenzUtils.getPlayerName()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -11,12 +11,12 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzKeyPressEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -236,7 +236,7 @@ object TrevorFeatures {
         var entityTrapper = EntityUtils.getEntityByID(trapperID)
         if (entityTrapper !is EntityLivingBase) entityTrapper = EntityUtils.getEntityByID(backupTrapperID)
         if (entityTrapper is EntityLivingBase && config.trapperTalkCooldown) {
-            RenderLivingEntityHelper.setEntityColor(entityTrapper, currentStatus.color)
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entityTrapper, currentStatus.color)
             { config.trapperTalkCooldown }
             entityTrapper.getLorenzVec().let {
                 if (it.distanceToPlayer() < 15) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangBlazes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangBlazes.kt
@@ -2,20 +2,20 @@ package at.hannibal2.skyhanni.features.nether.ashfang
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.RenderMobColoredEvent
-import at.hannibal2.skyhanni.events.ResetEntityHurtEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.combat.damageindicator.BossType
 import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
+import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.getAllNameTagsWith
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.monster.EntityBlaze
@@ -59,7 +59,7 @@ class AshfangBlazes {
                     blazeArmorStand = blazeArmorStand.editCopy {
                         this[entity] = armorStand
                     }
-                    blazeColor[entity] = color
+                    entity setBlazeColor color
                 }
             }
         }
@@ -83,24 +83,6 @@ class AshfangBlazes {
         nearAshfang = EntityUtils.getEntities<EntityArmorStand>().any { it.name.contains("Ashfang") }
     }
 
-    @SubscribeEvent
-    fun onRenderMobColored(event: RenderMobColoredEvent) {
-        if (!isEnabled()) return
-        if (!config.highlightBlazes) return
-        val entity = event.entity
-        event.color = blazeColor[entity]?.toColor()?.withAlpha(40) ?: 0
-    }
-
-    @SubscribeEvent
-    fun onResetEntityHurtTime(event: ResetEntityHurtEvent) {
-        if (!isEnabled()) return
-        if (!config.highlightBlazes) return
-        val entity = event.entity
-        if (entity in blazeColor) {
-            event.shouldReset = true
-        }
-    }
-
     @SubscribeEvent(priority = EventPriority.HIGH)
     fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityLivingBase>) {
         if (!isEnabled()) return
@@ -117,6 +99,9 @@ class AshfangBlazes {
 
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
+        blazeColor.forEach {
+            RenderLivingEntityHelper.removeCustomRender(it.key)
+        }
         blazeColor.clear()
         blazeArmorStand = emptyMap()
     }
@@ -129,6 +114,15 @@ class AshfangBlazes {
     }
 
     private fun isEnabled(): Boolean {
-        return LorenzUtils.inSkyBlock && DamageIndicatorManager.isBossSpawned(BossType.NETHER_ASHFANG)
+        return IslandType.CRIMSON_ISLE.isInIsland() && DamageIndicatorManager.isBossSpawned(BossType.NETHER_ASHFANG)
+    }
+
+    private infix fun EntityBlaze.setBlazeColor(color: LorenzColor) {
+        blazeColor[this] = color
+        RenderLivingEntityHelper.setNoHurtTime(this) { isEnabled() && config.highlightBlazes }
+        RenderLivingEntityHelper.setEntityColor(
+            this,
+            color.toColor().withAlpha(40),
+        ) { isEnabled() && config.highlightBlazes }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangBlazes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangBlazes.kt
@@ -99,9 +99,6 @@ class AshfangBlazes {
 
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
-        blazeColor.forEach {
-            RenderLivingEntityHelper.removeCustomRender(it.key)
-        }
         blazeColor.clear()
         blazeArmorStand = emptyMap()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangBlazes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangBlazes.kt
@@ -116,8 +116,7 @@ class AshfangBlazes {
 
     private infix fun EntityBlaze.setBlazeColor(color: LorenzColor) {
         blazeColor[this] = color
-        RenderLivingEntityHelper.setNoHurtTime(this) { isEnabled() && config.highlightBlazes }
-        RenderLivingEntityHelper.setEntityColor(
+        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
             this,
             color.toColor().withAlpha(40),
         ) { isEnabled() && config.highlightBlazes }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangBlazes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangBlazes.kt
@@ -7,11 +7,11 @@ import at.hannibal2.skyhanni.events.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.combat.damageindicator.BossType
 import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.getAllNameTagsWith
 import at.hannibal2.skyhanni.utils.LorenzColor

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BlobbercystsHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BlobbercystsHighlight.kt
@@ -4,9 +4,9 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.client.entity.EntityOtherPlayerMP

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BlobbercystsHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BlobbercystsHighlight.kt
@@ -26,8 +26,7 @@ class BlobbercystsHighlight {
         if (!event.isMod(5)) return
         EntityUtils.getEntities<EntityOtherPlayerMP>().forEach {
             if (it.name == blobberName) {
-                RenderLivingEntityHelper.setEntityColor(it, Color.RED.withAlpha(80)) { isEnabled() }
-                RenderLivingEntityHelper.setNoHurtTime(it) { isEnabled() }
+                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(it, Color.RED.withAlpha(80)) { isEnabled() }
                 entityList.add(it)
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
@@ -53,7 +53,7 @@ class VoltHighlighter {
             if (state == VoltState.NO_VOLT) continue
 
             if (config.voltMoodMeter)
-                RenderLivingEntityHelper.setEntityColor(
+                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                     entity, when (state) {
                         VoltState.FRIENDLY -> 0x8000FF00.toInt()
                         VoltState.DOING_LIGHTNING -> 0x800000FF.toInt()

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
@@ -5,12 +5,12 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isAtFullHealth
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
@@ -115,7 +115,7 @@ class LivingCaveDefenseBlocks {
             val entity = getNearestMovingDefenseBlock(location)?.entity ?: return
             staticBlocks = staticBlocks.editCopy {
                 add(DefenseBlock(entity, location))
-                RenderLivingEntityHelper.setEntityColor(
+                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                     entity,
                     color.withAlpha(50)
                 ) { isEnabled() && staticBlocks.any { it.entity == entity } }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftLarva.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftLarva.kt
@@ -1,10 +1,10 @@
 package at.hannibal2.skyhanni.features.rift.area.wyldwoods
 
 import at.hannibal2.skyhanni.events.LorenzTickEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.getEntities
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
 import at.hannibal2.skyhanni.utils.InventoryUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftOdonata.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftOdonata.kt
@@ -1,10 +1,10 @@
 package at.hannibal2.skyhanni.features.rift.area.wyldwoods
 
 import at.hannibal2.skyhanni.events.LorenzTickEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.getEntities
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
 import at.hannibal2.skyhanni.utils.InventoryUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
@@ -40,9 +40,8 @@ class SlayerMiniBossFeatures {
             if (bossType.clazz != entity.javaClass) continue
 
             miniBosses = miniBosses.editCopy { add(entity) }
-            RenderLivingEntityHelper.setEntityColor(entity, LorenzColor.AQUA.toColor().withAlpha(127))
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, LorenzColor.AQUA.toColor().withAlpha(127))
             { config.slayerMinibossHighlight }
-            RenderLivingEntityHelper.setNoHurtTime(entity) { config.slayerMinibossHighlight }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
@@ -4,10 +4,10 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.hasMaxHealth
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -198,8 +198,7 @@ object VampireSlayerFeatures {
             }
 
             if (shouldRender) {
-                RenderLivingEntityHelper.setEntityColor(this, color) { isEnabled() }
-                RenderLivingEntityHelper.setNoHurtTime(this) { isEnabled() }
+                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(this, color) { isEnabled() }
                 entityList.add(this)
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -9,12 +9,12 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
@@ -2,8 +2,8 @@ package at.hannibal2.skyhanni.features.slayer.blaze
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.EntityLiving
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
@@ -24,14 +24,12 @@ class HellionShieldHelper {
 fun EntityLiving.setHellionShield(shield: HellionShield?) {
     if (shield != null) {
         HellionShieldHelper.hellionShieldMobs[this] = shield
-        RenderLivingEntityHelper.setNoHurtTime(this) { LorenzUtils.inSkyBlock && SkyHanniMod.feature.slayer.blazes.hellion.coloredMobs }
-        RenderLivingEntityHelper.setEntityColor(
+        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
             this,
             shield.color.toColor().withAlpha(80)
         ) { LorenzUtils.inSkyBlock && SkyHanniMod.feature.slayer.blazes.hellion.coloredMobs }
     } else {
         HellionShieldHelper.hellionShieldMobs.remove(this)
-        RenderLivingEntityHelper.removeNoHurtTime(this)
-        RenderLivingEntityHelper.removeEntityColor(this)
+        RenderLivingEntityHelper.removeCustomRender(this)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
@@ -2,9 +2,8 @@ package at.hannibal2.skyhanni.features.slayer.blaze
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.RenderMobColoredEvent
-import at.hannibal2.skyhanni.events.ResetEntityHurtEvent
 import at.hannibal2.skyhanni.events.withAlpha
+import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.EntityLiving
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -17,24 +16,6 @@ class HellionShieldHelper {
     }
 
     @SubscribeEvent
-    fun onRenderMobColored(event: RenderMobColoredEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-        if (!SkyHanniMod.feature.slayer.blazes.hellion.coloredMobs) return
-
-        val shield = hellionShieldMobs.getOrDefault(event.entity, null) ?: return
-        event.color = shield.color.toColor().withAlpha(80)
-    }
-
-    @SubscribeEvent
-    fun onResetEntityHurtTime(event: ResetEntityHurtEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-        if (!SkyHanniMod.feature.slayer.blazes.hellion.coloredMobs) return
-
-        hellionShieldMobs.getOrDefault(event.entity, null) ?: return
-        event.shouldReset = true
-    }
-
-    @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "slayer.blazeColoredMobs", "slayer.blazes.hellion.coloredMobs")
     }
@@ -43,7 +24,14 @@ class HellionShieldHelper {
 fun EntityLiving.setHellionShield(shield: HellionShield?) {
     if (shield != null) {
         HellionShieldHelper.hellionShieldMobs[this] = shield
+        RenderLivingEntityHelper.setNoHurtTime(this) { LorenzUtils.inSkyBlock && SkyHanniMod.feature.slayer.blazes.hellion.coloredMobs }
+        RenderLivingEntityHelper.setEntityColor(
+            this,
+            shield.color.toColor().withAlpha(80)
+        ) { LorenzUtils.inSkyBlock && SkyHanniMod.feature.slayer.blazes.hellion.coloredMobs }
     } else {
         HellionShieldHelper.hellionShieldMobs.remove(this)
+        RenderLivingEntityHelper.removeNoHurtTime(this)
+        RenderLivingEntityHelper.removeEntityColor(this)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -8,11 +8,11 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -213,13 +213,7 @@ class EndermanSlayerFeatures {
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         endermenWithBeacons.clear()
-        flyingBeacons.forEach {
-            RenderLivingEntityHelper.removeEntityColor(it)
-        }
         flyingBeacons.clear()
-        nukekubiSkulls.forEach {
-            RenderLivingEntityHelper.removeEntityColor(it)
-        }
         nukekubiSkulls.clear()
         sittingBeacon = emptyMap()
         logger.log("Reset everything (world change)")

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -7,9 +7,9 @@ import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.RenderMobColoredEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.withAlpha
+import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
@@ -43,8 +43,8 @@ class EndermanSlayerFeatures {
     private val config get() = SkyHanniMod.feature.slayer.endermen
     private val beaconConfig get() = config.beacon
     private val endermenWithBeacons = mutableListOf<EntityEnderman>()
-    private var flyingBeacons = listOf<EntityArmorStand>()
-    private val nukekubiSkulls = mutableListOf<EntityArmorStand>()
+    private val flyingBeacons = mutableSetOf<EntityArmorStand>()
+    private val nukekubiSkulls = mutableSetOf<EntityArmorStand>()
     private var sittingBeacon = mapOf<LorenzVec, SimpleTimeMark>()
     private val logger = LorenzLogger("slayer/enderman")
     private val nukekubiSkulTexture =
@@ -65,8 +65,12 @@ class EndermanSlayerFeatures {
             if (showBeacon()) {
                 val stack = entity.inventory[4] ?: return
                 if (stack.name == "Beacon" && entity.canBeSeen(15.0)) {
-                    flyingBeacons = flyingBeacons.editCopy {
-                        add(entity)
+                    flyingBeacons.add(entity)
+                    RenderLivingEntityHelper.setEntityColor(
+                        entity,
+                        beaconConfig.beaconColor.toChromaColor().withAlpha(1)
+                    ) {
+                        beaconConfig.highlightBeacon
                     }
                     if (beaconConfig.showWarning) {
                         LorenzUtils.sendTitle("§4Beacon", 2.seconds)
@@ -77,6 +81,10 @@ class EndermanSlayerFeatures {
 
             if (config.highlightNukekebi && entity.inventory.any { it?.getSkullTexture() == nukekubiSkulTexture } && entity !in nukekubiSkulls) {
                 nukekubiSkulls.add(entity)
+                RenderLivingEntityHelper.setEntityColor(
+                    entity,
+                    LorenzColor.GOLD.toColor().withAlpha(1)
+                ) { config.highlightNukekebi }
                 logger.log("Added Nukekubi skulls at ${entity.getLorenzVec()}")
             }
         }
@@ -87,19 +95,6 @@ class EndermanSlayerFeatures {
     private fun canSee(b: LorenzVec) = b.canBeSeen(15.0)
 
     private fun showBeacon() = beaconConfig.highlightBeacon || beaconConfig.showWarning || beaconConfig.showLine
-
-    @SubscribeEvent
-    fun onRenderMobColored(event: RenderMobColoredEvent) {
-        if (!IslandType.THE_END.isInIsland()) return
-
-        if (beaconConfig.highlightBeacon && event.entity in flyingBeacons) {
-            event.color = beaconConfig.beaconColor.toChromaColor().withAlpha(1)
-        }
-
-        if (config.highlightNukekebi && event.entity in nukekubiSkulls) {
-            event.color = LorenzColor.GOLD.toColor().withAlpha(1)
-        }
-    }
 
     @SubscribeEvent
     fun onWorldRender(event: LorenzRenderWorldEvent) {
@@ -170,11 +165,17 @@ class EndermanSlayerFeatures {
         if (!IslandType.THE_END.isInIsland()) return
         if (!event.repeatSeconds(1)) return
 
-        nukekubiSkulls.also { skulls -> skulls.removeAll { it.isDead } }
-        if (flyingBeacons.any { it.isDead }) {
-            flyingBeacons = flyingBeacons.editCopy {
-                removeAll { it.isDead }
+        nukekubiSkulls.removeAll {
+            if (it.isDead) {
+                RenderLivingEntityHelper.removeEntityColor(it)
             }
+            it.isDead
+        }
+        flyingBeacons.removeAll {
+            if (it.isDead) {
+                RenderLivingEntityHelper.removeEntityColor(it)
+            }
+            it.isDead
         }
 
         // Removing the beacon if It's still there after 7 sesconds.
@@ -196,9 +197,8 @@ class EndermanSlayerFeatures {
         if (event.new == "beacon") {
             val armorStand = flyingBeacons.find { location.distance(it.getLorenzVec()) < 3 }
             if (armorStand != null) {
-                flyingBeacons = flyingBeacons.editCopy {
-                    remove(armorStand)
-                }
+                flyingBeacons.remove(armorStand)
+                RenderLivingEntityHelper.removeEntityColor(armorStand)
                 sittingBeacon = sittingBeacon.editCopy { this[location] = SimpleTimeMark.now() }
                 logger.log("Replaced flying beacon with sitting beacon at $location")
             }
@@ -213,7 +213,13 @@ class EndermanSlayerFeatures {
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         endermenWithBeacons.clear()
-        flyingBeacons = emptyList()
+        flyingBeacons.forEach {
+            RenderLivingEntityHelper.removeEntityColor(it)
+        }
+        flyingBeacons.clear()
+        nukekubiSkulls.forEach {
+            RenderLivingEntityHelper.removeEntityColor(it)
+        }
         nukekubiSkulls.clear()
         sittingBeacon = emptyMap()
         logger.log("Reset everything (world change)")

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -208,8 +208,7 @@ class SummoningMobManager {
 
     private infix fun EntityLivingBase.setColor(color: LorenzColor?) {
         if (color != null) {
-            RenderLivingEntityHelper.setNoHurtTime(this) { isEnabled() && config.summoningMobColored }
-            RenderLivingEntityHelper.setEntityColor(
+            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                 this,
                 color.toColor().withAlpha(127),
             ) { isEnabled() && config.summoningMobColored }

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -6,10 +6,9 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.RenderMobColoredEvent
-import at.hannibal2.skyhanni.events.ResetEntityHurtEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.events.withAlpha
+import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils
@@ -114,6 +113,7 @@ class SummoningMobManager {
                     .distance(playerLocation) < 10 && it.ticksExisted < 2
             }.forEach {
                 summoningMobs[it] = SummoningMob(System.currentTimeMillis(), name = "Mob")
+                it.setColor(LorenzColor.GREEN)
                 updateData()
                 if (summoningMobs.size == summoningsSpawned) {
                     searchMobs = false
@@ -133,6 +133,7 @@ class SummoningMobManager {
             val name = summoningMob.name
             if (currentHealth == 0) {
                 summoningMobs.remove(entityLiving)
+                entityLiving.setColor(null)
                 ChatUtils.chat("Your Summoning Mob just §cdied!")
                 continue
             }
@@ -183,29 +184,14 @@ class SummoningMobManager {
     }
 
     @SubscribeEvent
-    fun onRenderMobColored(event: RenderMobColoredEvent) {
-        if (config.summoningMobColored) {
-            val entity = event.entity
-            if (entity is EntityLiving && entity in summoningMobs.keys) {
-                event.color = LorenzColor.GREEN.toColor().withAlpha(127)
-            }
-        }
-    }
-
-    @SubscribeEvent
-    fun onResetEntityHurtTime(event: ResetEntityHurtEvent) {
-        val entity = event.entity
-        if (config.summoningMobColored && entity in summoningMobs.keys) {
-            event.shouldReset = true
-        }
-    }
-
-    @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "summonings", "combat.summonings")
     }
 
     private fun despawned() {
+        summoningMobs.forEach {
+            RenderLivingEntityHelper.removeCustomRender(it.key)
+        }
         summoningMobs.clear()
         summoningMobNametags.clear()
         summoningsSpawned = 0
@@ -222,4 +208,16 @@ class SummoningMobManager {
         var name: String = "",
         var lastDisplayName: String = "",
     )
+
+    private infix fun EntityLivingBase.setColor(color: LorenzColor?) {
+        if (color != null) {
+            RenderLivingEntityHelper.setNoHurtTime(this) { isEnabled() && config.summoningMobColored }
+            RenderLivingEntityHelper.setEntityColor(
+                this,
+                color.toColor().withAlpha(127),
+            ) { isEnabled() && config.summoningMobColored }
+        } else {
+            RenderLivingEntityHelper.removeCustomRender(this)
+        }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -7,9 +7,9 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzColor

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -189,9 +189,6 @@ class SummoningMobManager {
     }
 
     private fun despawned() {
-        summoningMobs.forEach {
-            RenderLivingEntityHelper.removeCustomRender(it.key)
-        }
         summoningMobs.clear()
         summoningMobNametags.clear()
         summoningsSpawned = 0

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -57,14 +57,13 @@ class RenderLivingEntityHelper {
             }
 
             // TODO remove event
-            if (!SkyHanniDebugsAndTests.globalRender) return 0
             val event = RenderMobColoredEvent(entity, 0)
             event.postAndCatch()
             return event.color
         }
 
         fun <T : EntityLivingBase> changeHurtTime(entity: T): Int {
-            if (!SkyHanniDebugsAndTests.globalRender) return 0
+            if (!SkyHanniDebugsAndTests.globalRender) return entity.hurtTime
             run {
                 val condition = entityNoHurTimeCondition[entity] ?: return@run
                 if (condition.invoke()) {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -14,7 +14,6 @@ class RenderLivingEntityHelper {
         entityColorMap.clear()
         entityColorCondition.clear()
 
-        entityNoHurTime.clear()
         entityNoHurTimeCondition.clear()
     }
 
@@ -23,7 +22,6 @@ class RenderLivingEntityHelper {
         private val entityColorMap = mutableMapOf<EntityLivingBase, Int>()
         private val entityColorCondition = mutableMapOf<EntityLivingBase, () -> Boolean>()
 
-        private val entityNoHurTime = mutableListOf<EntityLivingBase>()
         private val entityNoHurTimeCondition = mutableMapOf<EntityLivingBase, () -> Boolean>()
 
         fun <T : EntityLivingBase> removeEntityColor(entity: T) {
@@ -37,8 +35,11 @@ class RenderLivingEntityHelper {
         }
 
         fun <T : EntityLivingBase> setNoHurtTime(entity: T, condition: () -> Boolean) {
-            entityNoHurTime.add(entity)
             entityNoHurTimeCondition[entity] = condition
+        }
+
+        fun <T : EntityLivingBase> removeNoHurtTime(entity: T) {
+            entityNoHurTimeCondition.remove(entity)
         }
 
         fun <T : EntityLivingBase> setColorMultiplier(entity: T): Int {
@@ -59,8 +60,8 @@ class RenderLivingEntityHelper {
 
         fun <T : EntityLivingBase> changeHurtTime(entity: T): Int {
             if (!SkyHanniDebugsAndTests.globalRender) return 0
-            if (entityNoHurTime.contains(entity)) {
-                val condition = entityNoHurTimeCondition[entity]!!
+            run {
+                val condition = entityNoHurTimeCondition[entity] ?: return@run
                 if (condition.invoke()) {
                     return 0
                 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -1,8 +1,6 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.RenderMobColoredEvent
-import at.hannibal2.skyhanni.events.ResetEntityHurtEvent
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import net.minecraft.entity.EntityLivingBase
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -55,11 +53,7 @@ class RenderLivingEntityHelper {
                     return entityColorMap[entity]!!
                 }
             }
-
-            // TODO remove event
-            val event = RenderMobColoredEvent(entity, 0)
-            event.postAndCatch()
-            return event.color
+            return 0
         }
 
         fun <T : EntityLivingBase> changeHurtTime(entity: T): Int {
@@ -70,11 +64,7 @@ class RenderLivingEntityHelper {
                     return 0
                 }
             }
-
-            // TODO remove event
-            val event = ResetEntityHurtEvent(entity, false)
-            event.postAndCatch()
-            return if (event.shouldReset) 0 else entity.hurtTime
+            return entity.hurtTime
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -42,6 +42,11 @@ class RenderLivingEntityHelper {
             entityNoHurTimeCondition.remove(entity)
         }
 
+        fun <T : EntityLivingBase> removeCustomRender(entity: T) {
+            removeEntityColor(entity)
+            removeNoHurtTime(entity)
+        }
+
         fun <T : EntityLivingBase> setColorMultiplier(entity: T): Int {
             if (!SkyHanniDebugsAndTests.globalRender) return 0
             if (entityColorMap.containsKey(entity)) {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -36,6 +36,11 @@ class RenderLivingEntityHelper {
             entityNoHurTimeCondition[entity] = condition
         }
 
+        fun <T : EntityLivingBase> setEntityColorWithNoHurtTime(entity: T, color: Int, condition: () -> Boolean) {
+            setEntityColor(entity, color, condition)
+            setNoHurtTime(entity, condition)
+        }
+
         fun <T : EntityLivingBase> removeNoHurtTime(entity: T) {
             entityNoHurTimeCondition.remove(entity)
         }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -45,7 +45,7 @@ class RenderLivingEntityHelper {
             removeNoHurtTime(entity)
         }
 
-        fun <T : EntityLivingBase> setColorMultiplier(entity: T): Int {
+        fun <T : EntityLivingBase> internalSetColorMultiplier(entity: T): Int {
             if (!SkyHanniDebugsAndTests.globalRender) return 0
             if (entityColorMap.containsKey(entity)) {
                 val condition = entityColorCondition[entity]!!
@@ -56,7 +56,7 @@ class RenderLivingEntityHelper {
             return 0
         }
 
-        fun <T : EntityLivingBase> changeHurtTime(entity: T): Int {
+        fun <T : EntityLivingBase> internalChangeHurtTime(entity: T): Int {
             if (!SkyHanniDebugsAndTests.globalRender) return entity.hurtTime
             run {
                 val condition = entityNoHurTimeCondition[entity] ?: return@run

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinRendererLivingEntity.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinRendererLivingEntity.java
@@ -21,11 +21,11 @@ public abstract class MixinRendererLivingEntity<T extends EntityLivingBase> exte
 
     @Inject(method = "getColorMultiplier", at = @At("HEAD"), cancellable = true)
     private void setColorMultiplier(T entity, float lightBrightness, float partialTickTime, CallbackInfoReturnable<Integer> cir) {
-        cir.setReturnValue(RenderLivingEntityHelper.Companion.setColorMultiplier(entity));
+        cir.setReturnValue(RenderLivingEntityHelper.Companion.internalSetColorMultiplier(entity));
     }
 
     @Redirect(method = "setBrightness", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/EntityLivingBase;hurtTime:I", opcode = Opcodes.GETFIELD))
     private int changeHurtTime(EntityLivingBase entity) {
-        return RenderLivingEntityHelper.Companion.changeHurtTime(entity);
+        return RenderLivingEntityHelper.Companion.internalChangeHurtTime(entity);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/test/WorldEdit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/WorldEdit.kt
@@ -5,9 +5,9 @@ import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.withAlpha
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ClipboardUtils
+import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.expandBlock

--- a/src/main/java/at/hannibal2/skyhanni/utils/ColorUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ColorUtils.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.utils
 import java.awt.Color
 import kotlin.math.max
 
-
 object ColorUtils {
 
     /** transfer string colors from the config to java.awt.Color */
@@ -30,4 +29,8 @@ object ColorUtils {
             alpha
         )
     }
+
+    fun Color.withAlpha(alpha: Int): Int = (alpha.coerceIn(0, 255) shl 24) or (this.rgb and 0x00ffffff)
 }
+
+


### PR DESCRIPTION
## What
Removed RenderMobColoredEvent & ResetEntityHurtEvent since they are very resource hungry

<!-- remove unused parts below -->
## Changelog Fixes
+ Improved performance of custom colored mobs. - Thunderblade73

## Changelog Technical Details
+ Removed the RenderMobColoredEvent & ResetEntityHurtEvent. - Thunderblade73