### PR TITLE
Fix: minion hopper profit and /shdefaultoptions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/minion/MinionsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/minion/MinionsConfig.java
@@ -33,6 +33,7 @@ public class MinionsConfig {
     @Expose
     @ConfigOption(name = "Hopper Profit Display", desc = "Use the hopper's held coins and the last empty time to calculate the coins per day.")
     @ConfigEditorBoolean
+    @FeatureToggle
     public boolean hopperProfitDisplay = true;
 
     @Expose


### PR DESCRIPTION
## What
Fixed minion hopper profit display feature not getting changed by /shdefaultoptions
https://discord.com/channels/997079228510117908/1216132393274970112

## Changelog Fixes
+ Fixed minion hopper profit display feature not getting changed by /shdefaultoptions. - hannibal2