### PR TITLE
Removed Feature: Removed max pet xp tooltip

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/pets/PetExperienceToolTipConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/pets/PetExperienceToolTipConfig.java
@@ -8,11 +8,10 @@ import io.github.moulberry.moulconfig.annotations.ConfigOption;
 public class PetExperienceToolTipConfig {
 
     @Expose
-    @ConfigOption(name = "Enabled", desc = "Show the full pet exp and the progress to level 100 (ignoring rarity) when hovering over a pet while pressing shift key.")
+    @ConfigOption(name = "Enabled", desc = "Show the progress to level 100 (ignoring rarity) when hovering over a pet while pressing shift key.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean petDisplay = true;
-
 
     @Expose
     @ConfigOption(name = "Show Always", desc = "Show this info always, even if not pressing shift key.")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PetExpTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PetExpTooltip.kt
@@ -45,10 +45,8 @@ class PetExpTooltip {
             val percentage = petExperience / maxXp
             val percentageFormat = LorenzUtils.formatPercentage(percentage)
 
-            event.toolTip.add(index, " ")
-            if (percentage >= 1) {
-                event.toolTip.add(index, "§7Total experience: §e${NumberUtil.format(petExperience)}")
-            } else {
+            if (percentage < 1) {
+                event.toolTip.add(index, " ")
                 val progressBar = StringUtils.progressBar(percentage)
                 val isBelowLegendary = itemStack.getItemRarityOrNull()?.let { it < LorenzRarity.LEGENDARY } ?: false
                 val addLegendaryColor = if (isBelowLegendary) "§6" else ""


### PR DESCRIPTION
## What
Removes SH's total pet xp tooltip for maxed pets because Hypixel added one.

## Changelog Removed Features
+ Removed max pet XP tooltip because Hypixel added it. - Obsidian

