### PR TITLE
Fix: Fixed typos

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestFinderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestFinderConfig.java
@@ -23,7 +23,7 @@ public class PestFinderConfig {
     @Expose
     @ConfigOption(
         name = "Show Plot in World",
-        desc = "Mark infected plot names and world border in the world."
+        desc = "Mark infested plot names and world border in the world."
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -179,7 +179,7 @@ class FarmingWeightDisplay {
             val list = mutableListOf<Renderable>()
             list.add(Renderable.clickAndHover(
                 "§6Farming Weight§7: $weight$leaderboard",
-                listOf("§eClick to open the Farming Profile of you.")
+                listOf("§eClick to open your Farming Profile.")
             ) {
                 openWebsite(LorenzUtils.getPlayerName())
             })

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -179,11 +179,11 @@ class PestFinder {
         }
     }
 
-    private fun getNearestInfectedPest() = getPlotsWithPests().minByOrNull { it.middle.distanceSqToPlayer() }
+    private fun getNearestInfestedPest() = getPlotsWithPests().minByOrNull { it.middle.distanceSqToPlayer() }
 
     private fun removeNearestPest() {
-        val plot = getNearestInfectedPest() ?: run {
-            ChatUtils.error("Can not remove nearest pest: No infected plots detected.")
+        val plot = getNearestInfestedPest() ?: run {
+            ChatUtils.error("Can not remove nearest pest: No infested plots detected.")
             return
         }
         plot.pests--
@@ -238,13 +238,13 @@ class PestFinder {
         if (lastKeyPress.passedSince() < 2.seconds) return
         lastKeyPress = SimpleTimeMark.now()
 
-        val plot = getNearestInfectedPest() ?: run {
-            ChatUtils.userError("No infected plots detected to warp to!")
+        val plot = getNearestInfestedPest() ?: run {
+            ChatUtils.userError("No infested plots detected to warp to!")
             return
         }
 
         if (plot.isPlayerInside()) {
-            ChatUtils.userError("You stand already on the infected plot!")
+            ChatUtils.userError("You're already in an infested plot!")
             return
         }
 


### PR DESCRIPTION
## What
Fixes typos.
Pests: Infected -> infested,
You stand already on the infected plot! -> You're already in an infested plot!
Farming weight display: Click to open the farming profile of you. -> Click to open your farming profile.

## Changelog Fixes
+ Fixed typos/grammar. - Obsidian
    * Typos in pest features.
    * Grammar in Farming Weight Display