### PR TITLE
Improvement: Hide TNT Run Tournament lobby messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -51,6 +51,7 @@ class ChatFilter {
         // hypixel tournament notifications
         "§r§e§6§lHYPIXEL§e is hosting a §b§lBED WARS DOUBLES§e tournament!",
         "§r§e§6§lHYPIXEL BED WARS DOUBLES§e tournament is live!",
+        "§r§e§6§lHYPIXEL§e is hosting a §b§lTNT RUN§e tournament!",
 
         // other
         "§aYou are still radiating with §bGenerosity§r§a!"


### PR DESCRIPTION
## What
Hide TNT Run Tournament advertisement message in main lobby.

<!-- remove unused parts below -->
## Changelog Improvements
+ Hide the TNT Run Tournament advertisement message in the main lobby. - Alexia