### PR TITLE
Improvement: Allow teleporting when in an infested plot

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestFinderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestFinderConfig.java
@@ -53,4 +53,9 @@ public class PestFinderConfig {
     @ConfigOption(name = "Teleport Hotkey", desc = "Press this key to warp to the nearest plot with pests on it.")
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     public int teleportHotkey = Keyboard.KEY_NONE;
+
+    @Expose
+    @ConfigOption(name = "Always Teleport", desc = "Allow teleporting with the Teleport Hotkey even when you're already in an infested plot.")
+    @ConfigEditorBoolean
+    public boolean alwaysTp = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -243,7 +243,7 @@ class PestFinder {
             return
         }
 
-        if (plot.isPlayerInside()) {
+        if (plot.isPlayerInside() && !config.alwaysTp) {
             ChatUtils.userError("You're already in an infested plot!")
             return
         }


### PR DESCRIPTION
## What
Adds a toggle to allow teleporting with the pest teleport hotkey while already in an infested plot.

## Changelog Improvements
+ Allow using the teleport hotkey when in an infested plot. - Obsidian