### PR TITLE
Improvement: Allow translate commands w/o feature on

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -216,7 +216,7 @@ object Commands {
         ) { FarmingWeightDisplay.lookUpCommand(it) }
         registerCommand(
             "shcopytranslation",
-            "Translates a message in English to another language via clipboard.\n" +
+            "Copy the English translation of a message in another language to the clipboard.\n" +
                 "Uses a 2 letter language code that can be found at the end of a translation message."
         ) { Translator.fromEnglish(it) }
         registerCommand(

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -216,11 +216,13 @@ object Commands {
         ) { FarmingWeightDisplay.lookUpCommand(it) }
         registerCommand(
             "shcopytranslation",
-            "<language code (2 letters)> <messsage to translate>\n" +
-                "Requires the Chat > Translator feature to be enabled.\n" +
-                "Copies the translation for a given message to your clipboard. " +
-                "Language codes are at the end of the translation when you click on a message."
+            "Translates a message in English to another language via clipboard.\n" +
+                "Uses a 2 letter language code that can be found at the end of a translation message."
         ) { Translator.fromEnglish(it) }
+        registerCommand(
+            "shtranslate",
+            "Translate a message in another language to English."
+        ) { Translator.toEnglish(it) }
         registerCommand(
             "shmouselock",
             "Lock/Unlock the mouse so it will no longer rotate the player (for farming)"
@@ -482,10 +484,6 @@ object Commands {
         registerCommand("shsendcontests", "") { GardenNextJacobContest.shareContestConfirmed(it) }
         registerCommand("shwords", "Opens the config list for modifying visual words") { openVisualWords() }
         registerCommand("shstopaccountupgradereminder", "") { AccountUpgradeReminder.disable() }
-        registerCommand(
-            "shsendtranslation",
-            "Respond with a translation of the message that the user clicks"
-        ) { Translator.toEnglish(it) }
     }
 
     private fun shortenedCommands() {

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.java
@@ -111,8 +111,8 @@ public class ChatConfig {
     @Expose
     @ConfigOption(
         name = "Translator",
-        desc = "Click on a message to translate it into English. " +
-            "Use §e/shcopytranslation§7 to get the translation from English. " +
+        desc = "Click on a message to translate it to English. " +
+            "Use §e/shcopytranslation§7 to translate from English. " +
             "§cTranslation is not guaranteed to be 100% accurate."
     )
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/Translator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/Translator.kt
@@ -43,7 +43,7 @@ class Translator {
         style.setChatClickEvent(
             ClickEvent(
                 ClickEvent.Action.RUN_COMMAND,
-                "/shsendtranslation ${messageContentRegex.find(message)!!.groupValues[1]}"
+                "/shtranslate ${messageContentRegex.find(message)!!.groupValues[1]}"
             )
         )
         style.setChatHoverEvent(
@@ -82,10 +82,8 @@ class Translator {
 
         private fun getTranslationToEnglish(message: String): String {
             val url =
-                "https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=en&dt=t&q=" + URLEncoder.encode(
-                    message,
-                    "UTF-8"
-                )
+                "https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=en&dt=t&q=" +
+                    URLEncoder.encode(message, "UTF-8")
 
             var messageToSend = ""
             val layer1 = getJSONResponse(url).asJsonArray
@@ -114,10 +112,8 @@ class Translator {
 
         private fun getTranslationFromEnglish(message: String, lang: String): String {
             val url =
-                "https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=$lang&dt=t&q=" + URLEncoder.encode(
-                    message,
-                    "UTF-8"
-                )
+                "https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=$lang&dt=t&q=" +
+                    URLEncoder.encode(message, "UTF-8")
 
             val layer1 = getJSONResponse(url).asJsonArray
             if (layer1.size() < 1) return "Error!"
@@ -137,11 +133,7 @@ class Translator {
         }
 
         fun toEnglish(args: Array<String>) {
-            if (!isEnabled()) return
-            var message = ""
-            for (i in args) {
-                message = "$message$i "
-            }
+            val message = args.joinToString(" ")
 
             coroutineScope.launch {
                 val translation = getTranslationToEnglish(message)
@@ -151,20 +143,16 @@ class Translator {
         }
 
         fun fromEnglish(args: Array<String>) {
-            if (!isEnabled()) return
             if (args.size < 2 || args[0].length != 2) { // args[0] is the language code
                 ChatUtils.userError("Usage: /shcopytranslation <two letter language code (at the end of a translation)> <message>")
                 return
             }
             val language = args[0]
-            var message = ""
-            for (i in 1..<args.size) {
-                message = "$message${args[i]} "
-            }
+            val message = args.drop(1).joinToString(" ")
 
             coroutineScope.launch {
                 val translation = getTranslationFromEnglish(message, language)
-                ChatUtils.chat("Copied translation to clipboard: $translation")
+                ChatUtils.chat("Copied translation to clipboard: §f$translation")
                 OSUtils.copyToClipboard(translation)
             }
         }


### PR DESCRIPTION
## What
Allows using the translate commands (`/shtranslate` and `/shcopytranslation`) without the Translator feature (which modifies most chat messages) being turned on.
Also renamed `/shsendtranslation` to `/shtranslate` and moved it out of internal commands, made some descriptions more concise, and slight code cleanup.

## Changelog Improvements
+ Allow using translate commands without the feature turned on. - Obsidian
    * Changed /shsendtranslation to /shtranslate and moved it from internal commands.