### PR TITLE
Fix: Add Burningsoul Demon to line to miniboss

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
@@ -76,7 +76,7 @@ class SlayerMiniBossFeatures {
         TARANTULA(EntitySpider::class.java, 54_000, 144_000, 576_000),
         SVEN(EntityWolf::class.java, 45_000, 120_000, 480_000),
         VOIDLING(EntityEnderman::class.java, 8_400_000, 17_500_000, 52_500_000),
-        INFERNAL(EntityBlaze::class.java, 12_000_000, 25_000_000),
+        INFERNAL(EntityBlaze::class.java, 12_000_000, 25_000_000, 75_000_000),
         ;
     }
 }


### PR DESCRIPTION
<!-- remove all unused parts -->
## What
Adds Burningsoul Demon (the 75M HP blaze slayer miniboss) to the "line to slayer" and "highlight miniboss" features.
Have not been able to test this ingame because for some reason I cant get one to spawn.

https://ptb.discord.com/channels/997079228510117908/1216453491619532871/1216453491619532871

## Changelog Fixes
+ Added Burningsoul Demon (75M HP miniboss) to line to miniboss and highlight slayer minibosses. - Empa