### PR TITLE
Backend: /shtestmessage upgrade

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
@@ -1,9 +1,11 @@
 package at.hannibal2.skyhanni.test.command
 
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.OSUtils
+import kotlinx.coroutines.launch
 import net.minecraft.util.ChatComponentText
-import net.minecraftforge.client.event.ClientChatReceivedEvent
-import net.minecraftforge.common.MinecraftForge
 
 object TestChatCommand {
 
@@ -13,12 +15,36 @@ object TestChatCommand {
             return
         }
 
-        val hidden = args.last() == "-s"
+        val last = args.last()
+        if (last == "-clipboard") {
+            SkyHanniMod.coroutineScope.launch {
+                OSUtils.readFromClipboard()?.let {
+                    test(it)
+                } ?: run {
+                    ChatUtils.userError("Clipboard does not contain a string!")
+                }
+            }
+            return
+        }
+        val hidden = last == "-s"
         var rawMessage = args.toList().joinToString(" ")
         if (!hidden) ChatUtils.chat("Testing message: §7$rawMessage", prefixColor = "§a")
         if (hidden) rawMessage = rawMessage.replace(" -s", "")
-        val formattedMessage = rawMessage.replace("&", "§")
-        ChatUtils.chat(formattedMessage, false)
-        MinecraftForge.EVENT_BUS.post(ClientChatReceivedEvent(0, ChatComponentText(formattedMessage)))
+        test(rawMessage.replace("&", "§"))
+    }
+
+    private fun test(message: String) {
+        val event = LorenzChatEvent(message, ChatComponentText(message))
+        event.postAndCatch()
+
+        if (event.blockedReason != "") {
+            ChatUtils.chat("§cChat blocked: ${event.blockedReason}")
+        } else {
+            val finalMessage = event.chatComponent.formattedText
+            if (finalMessage != message) {
+                ChatUtils.chat("§eChat modified!")
+            }
+            ChatUtils.chat(finalMessage, false)
+        }
     }
 }


### PR DESCRIPTION

## What
/shtestmessage now also supports `-clipboard` as parameter, copying the clipboard. also, it now supports blocked or modified chat messages.

## Changelog Technical Details
+ More features for /shtestmessage - hannibal2
    * Supports -clipboard parameter, uses the clipboard as text.
    * Supports blocked or modified chat events.