### PR TITLE
Fix: hypixel update showing `new` next to garden visitors in tab list

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
@@ -168,8 +168,10 @@ object VisitorAPI {
                 logger.log("Ignore wrong own name: '$name'")
                 continue
             }
-
-            visitorsInTab.add(name)
+            val finalName = if (name.endsWith(" §b§lNEW!")) {
+                name.split(" §b§lNEW!")[0]
+            } else name
+            visitorsInTab.add(finalName)
         }
         return visitorsInTab
     }


### PR DESCRIPTION
## What
fixed Hypixel update: showing `new` next to garden visitors in tab list

## Changelog Fixes
+ Fixed tab list visitor name detection breaking when tab list said "new" - hannibal2