### PR TITLE
Improvement: fixed hypixel update: tab widget allow to disable profile name 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.UtilsPatterns
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -66,10 +67,18 @@ object ProfileStorageData {
 
         if (noTabListTime.passedSince() > 3.seconds) {
             noTabListTime = SimpleTimeMark.now()
-            ChatUtils.chat(
-                "Extra Information from Tab list not found! " +
-                    "Enable it: SkyBlock Menu ➜ Settings ➜ Personal ➜ User Interface ➜ Player List Info"
-            )
+            val foundSkyBlockTabList = TabListData.getTabList().any { it.contains("§b§lArea:") }
+            if (foundSkyBlockTabList) {
+                ChatUtils.clickableChat(
+                    "§cCan not read profile name from tab list! Open /widget and enable Profile Widget",
+                    command = "widget"
+                )
+            } else {
+                ChatUtils.chat(
+                    "§cExtra Information from Tab list not found! " +
+                        "Enable it: SkyBlock Menu ➜ Settings ➜ Personal ➜ User Interface ➜ Player List Info"
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## What
fixed Hypixel update: tab widget allows to disable profile name 

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/ef6ab3a1-f90b-4034-a1c9-db210b61f1b2)

</details>

## Changelog Improvements
+ Better chat error when profile name is disabled via Hypixel widgets. - hannibal2