### PR TITLE
Fix: fixed hypixel update: splitting SkyMart into three categories

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/SkyMartCopperPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/SkyMartCopperPrice.kt
@@ -60,7 +60,7 @@ class SkyMartCopperPrice {
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
-        if (event.inventoryName != "SkyMart") return
+        if (!event.inventoryName.startsWith("SkyMart ")) return
 
         inInventory = true
         val table = mutableListOf<DisplayTableEntry>()


### PR DESCRIPTION
## What
fixed hypixel update: splitting SkyMart into three categories

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/c9116ccc-a27f-4fd4-b2e7-2f1fe2934610)

</details>

## Changelog Fixes
+ Fixed coins per copper display not working with new sub categories of SkyMart. - hannibal2