### PR TITLE
Improvement: Show Town Board with accepted Rescue Mission quest

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -176,7 +176,10 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
     }
 
     private fun renderTownBoard(event: LorenzRenderWorldEvent) {
-        if (quests.any { it.state == QuestState.READY_TO_COLLECT || it.state == QuestState.NOT_ACCEPTED }) {
+        if (quests.any {
+                it.state == QuestState.READY_TO_COLLECT ||
+                it.state == QuestState.NOT_ACCEPTED ||
+                (it is RescueMissionQuest && it.state == QuestState.ACCEPTED) }) {
             val location = when (reputationHelper.factionType) {
                 FactionType.BARBARIAN -> townBoardBarbarian
                 FactionType.MAGE -> townBoardMage


### PR DESCRIPTION
## What
Show Town Board when there is an accepted Rescue Mission quest, since you need to talk to an NPC at the Town Board before starting the rescue.

## Changelog Improvements
+ Show Town Board waypoint when there is an accepted Rescue Mission quest. - Alexia