### PR TITLE
Improvement: Custom fishing hook alert text

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingHookDisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingHookDisplayConfig.java
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;
 import com.google.gson.annotations.Expose;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorText;
 import io.github.moulberry.moulconfig.annotations.ConfigOption;
 
 public class FishingHookDisplayConfig {
@@ -16,6 +17,15 @@ public class FishingHookDisplayConfig {
 
     @Expose
     @ConfigOption(
+        name = "Custom Alert",
+        desc = "Replaces the default §c§l!!!§r Hypixel\n" +
+            "§7alert with your own custom one."
+    )
+    @ConfigEditorText
+    public String customAlertText = "&c&l!!!";
+
+    @Expose
+    @ConfigOption(
         name = "Hide Armor Stand",
         desc = "Hide the original armor stand from Hypixel when the SkyHanni display is enabled."
     )
@@ -23,5 +33,5 @@ public class FishingHookDisplayConfig {
     public boolean hideArmorStand = true;
 
     @Expose
-    public Position position = new Position(460, -240, 3.4f);
+    public Position position = new Position(-475, -240, 3.4f, true);
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -75,8 +75,9 @@ class FishingHookDisplay {
             return
         }
         if (!armorStand.hasCustomName()) return
+        val alertText = if (armorStand.name == "§c§l!!!") config.customAlertText.replace("&", "§") else armorStand.name
 
-        config.position.renderString(armorStand.name, posLabel = "Fishing Hook Display")
+        config.position.renderString(alertText, posLabel = "Fishing Hook Display")
     }
 
     private fun EntityArmorStand.hasCorrectName(): Boolean {


### PR DESCRIPTION
## What
Adds the ability to customize the fishing hook alert text, replacing the default "!!!" hypixel shows. Also makes the text be centered

<details>
<summary>Images</summary>

<!-- drop images here -->
![image](https://github.com/hannibal002/SkyHanni/assets/42304516/aa47b1b3-4a27-41dd-a425-e7599a55d01e)
</details>

## Changelog Improvements
+ Fishing Hook Alert text changes. - Empa
    * Added custom text when ready to pull.
    * The text is now aligned to the center of the GUI element.