### PR TITLE
Fix: Revert shader version for Mac compatibility

### DIFF
--- a/src/main/resources/assets/skyhanni/shaders/rounded_rect.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_rect.fsh
@@ -1,4 +1,4 @@
-#version 130
+#version 120
 
 uniform float scaleFactor;
 uniform float radius;
@@ -6,7 +6,7 @@ uniform float smoothness;
 uniform vec2 halfSize;
 uniform vec2 centerPos;
 
-in vec4 color;
+varying vec4 color;
 
 // From https://www.shadertoy.com/view/WtdSDs
 float roundedRectSDF(vec2 center, vec2 halfSize, float radius) {

--- a/src/main/resources/assets/skyhanni/shaders/rounded_rect.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_rect.vsh
@@ -1,6 +1,6 @@
-#version 130
+#version 120
 
-out vec4 color;
+varying vec4 color;
 
 void main() {
     gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;

--- a/src/main/resources/assets/skyhanni/shaders/standard_chroma.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/standard_chroma.fsh
@@ -1,14 +1,14 @@
 // Chroma Fragment Shader
 // (Same as textured_chroma.fsh but isn't restricted to textured elements)
 
-#version 130
+#version 120
 
 uniform float chromaSize;
 uniform float timeOffset;
 uniform float saturation;
 uniform bool forwardDirection;
 
-in vec4 originalColor;
+varying vec4 originalColor;
 
 float rgb2b(vec3 rgb) {
     return max(max(rgb.r, rgb.g), rgb.b);

--- a/src/main/resources/assets/skyhanni/shaders/standard_chroma.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/standard_chroma.vsh
@@ -1,9 +1,9 @@
 // Chroma Vertex Shader
 // (Same as textured_chroma.vsh but isn't restricted to only texture elements)
 
-#version 130
+#version 120
 
-out vec4 originalColor;
+varying vec4 originalColor;
 
 void main() {
     gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;

--- a/src/main/resources/assets/skyhanni/shaders/textured_chroma.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/textured_chroma.fsh
@@ -2,7 +2,7 @@
 // Modified from SkyblockAddons
 // Credit: https://github.com/BiscuitDevelopment/SkyblockAddons/blob/main/src/main/resources/assets/skyblockaddons/shaders/program/chroma_screen_textured.fsh
 
-#version 130
+#version 120
 
 uniform float chromaSize;
 uniform float timeOffset;
@@ -11,8 +11,8 @@ uniform bool forwardDirection;
 
 uniform sampler2D outTexture;
 
-in vec2 outTextureCoords;
-in vec4 outColor;
+varying vec2 outTextureCoords;
+varying vec4 outColor;
 
 float rgb2b(vec3 rgb) {
     return max(max(rgb.r, rgb.g), rgb.b);

--- a/src/main/resources/assets/skyhanni/shaders/textured_chroma.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/textured_chroma.vsh
@@ -1,10 +1,10 @@
 // Textured Chroma Vertex Shader
 // Credit: https://github.com/BiscuitDevelopment/SkyblockAddons/blob/main/src/main/resources/assets/skyblockaddons/shaders/program/chroma_screen_textured.vsh
 
-#version 130
+#version 120
 
-out vec2 outTextureCoords;
-out vec4 outColor;
+varying vec2 outTextureCoords;
+varying vec4 outColor;
 
 void main() {
     gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;


### PR DESCRIPTION
## What
Reverts shader versions back to 120 since on Mac, LWJGL uses the legacy profile for the OpenGL context by default, which only supports up to GLSL version 1.20

## Changelog Technical Details
+ Revert shader version for Mac compatibility. - Vixid

