### PR TITLE
Fix: Entity Render Event

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -180,7 +180,9 @@ class SummoningMobManager {
         if (!entity.hasCustomName()) return
         if (entity.isDead) return
 
-        event.isCanceled = entity in summoningMobNametags
+        if (entity in summoningMobNametags) {
+            event.cancel()
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -16,6 +16,7 @@ import net.minecraft.item.ItemStack
 import net.minecraft.potion.Potion
 import net.minecraft.util.AxisAlignedBB
 import net.minecraftforge.client.event.RenderLivingEvent
+import net.minecraftforge.fml.common.eventhandler.Event
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 object EntityUtils {
@@ -163,26 +164,45 @@ object EntityUtils {
 
     @SubscribeEvent
     fun onEntityRender(event: RenderLivingEvent<*>) {
-        SkyHanniRenderEntityEvent(event.entity, event.renderer, event.x, event.y, event.z).postAndCatch()
+        val shEvent = SkyHanniRenderEntityEvent(event.entity, event.renderer, event.x, event.y, event.z)
+        if (shEvent.postAndCatch()) {
+            event.cancel()
+        }
     }
 
     @SubscribeEvent
     fun onEntityRenderPre(event: RenderLivingEvent.Pre<*>) {
-        SkyHanniRenderEntityEvent.Pre(event.entity, event.renderer, event.x, event.y, event.z).postAndCatch()
+        val shEvent = SkyHanniRenderEntityEvent.Pre(event.entity, event.renderer, event.x, event.y, event.z)
+        if (shEvent.postAndCatch()) {
+            event.cancel()
+        }
     }
 
     @SubscribeEvent
     fun onEntityRenderPost(event: RenderLivingEvent.Post<*>) {
-        SkyHanniRenderEntityEvent.Post(event.entity, event.renderer, event.x, event.y, event.z).postAndCatch()
+        val shEvent = SkyHanniRenderEntityEvent.Post(event.entity, event.renderer, event.x, event.y, event.z)
+        if (shEvent.postAndCatch()) {
+            event.cancel()
+        }
     }
 
     @SubscribeEvent
     fun onEntityRenderSpecialsPre(event: RenderLivingEvent.Specials.Pre<*>) {
-        SkyHanniRenderEntityEvent.Specials.Pre(event.entity, event.renderer, event.x, event.y, event.z).postAndCatch()
+        val shEvent = SkyHanniRenderEntityEvent.Specials.Pre(event.entity, event.renderer, event.x, event.y, event.z)
+        if (shEvent.postAndCatch()) {
+            event.cancel()
+        }
     }
 
     @SubscribeEvent
     fun onEntityRenderSpecialsPost(event: RenderLivingEvent.Specials.Post<*>) {
-        SkyHanniRenderEntityEvent.Specials.Post(event.entity, event.renderer, event.x, event.y, event.z).postAndCatch()
+        val shEvent = SkyHanniRenderEntityEvent.Specials.Post(event.entity, event.renderer, event.x, event.y, event.z)
+        if (shEvent.postAndCatch()) {
+            event.cancel()
+        }
     }
+}
+
+private fun Event.cancel() {
+    isCanceled = true
 }


### PR DESCRIPTION
## What
Fixed entity render event not hiding on cancel.
This caused the damage indicator to no longer block vanilla names nearby.
This also breaks other features like terracotta hider, ashfang minis hider, teleport pad name hider, and every other feature that uses `SkyHanniRenderEntityEvent` to hide entities.

## Changelog Fixes
+ Fixed Damage Indicator not hiding vanilla names. - hannibal2