### PR TITLE
Fix: SuperBoom TNT wrong itemNameQuery

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -23,15 +23,20 @@ object ItemNameResolver {
             return itemNameCache.getOrPut(lowercase) { fixEnchantmentName(it) }
         }
 
-        val internalName = ItemResolutionQuery.findInternalNameByDisplayName(itemName, true)?.let {
+        val internalName = when (itemName) {
+            "SUPERBOOM TNT" -> "SUPERBOOM_TNT".asInternalName()
+            else -> {
+                ItemResolutionQuery.findInternalNameByDisplayName(itemName, true)?.let {
 
-            // This fixes a NEU bug with §9Hay Bale (cosmetic item)
-            // TODO remove workaround when this is fixed in neu
-            val rawInternalName = if (it == "HAY_BALE") "HAY_BLOCK" else it
-            rawInternalName.asInternalName()
-        } ?: run {
-            getInternalNameOrNullIgnoreCase(itemName)
-        } ?: return null
+                    // This fixes a NEU bug with §9Hay Bale (cosmetic item)
+                    // TODO remove workaround when this is fixed in neu
+                    val rawInternalName = if (it == "HAY_BALE") "HAY_BLOCK" else it
+                    rawInternalName.asInternalName()
+                } ?: run {
+                    getInternalNameOrNullIgnoreCase(itemName)
+                } ?: return null
+            }
+        }
 
         itemNameCache[lowercase] = internalName
         return internalName


### PR DESCRIPTION
## What
Solve the wrong item query of "SUPERBOOM TNT" (btw. "Superboom TNT" would work).
The issue is on NEUs side but I wouldn't know a solution, since the mangelnd logic is fundamental wrong as for this specific case

## Discord
https://discord.com/channels/997079228510117908/1218607214135083180

## Changelog Fixes
+ Fixed Superboom TNT not working with Queued GFS. - Thunderblade73