### PR TITLE
Fix: Fixed Custom Scoreboard Dungeon Problems

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -387,12 +387,11 @@ private fun getIslandDisplayPair() =
     listOf("§7㋖ §a" + HypixelData.skyBlockIsland.displayName to HorizontalAlignment.LEFT)
 
 private fun getLocationDisplayPair() = buildList {
-    add(
-        getGroupFromPattern(
-            ScoreboardData.sidebarLinesFormatted,
-            ScoreboardPattern.locationPattern,
-            "location"
-        ).trim() to HorizontalAlignment.LEFT)
+    val location =
+        getGroupFromPattern(ScoreboardData.sidebarLinesFormatted, ScoreboardPattern.locationPattern, "location").trim()
+    if (location == "0") return@buildList
+
+    add(location to HorizontalAlignment.LEFT)
 
     val plotLine = ScoreboardData.sidebarLinesFormatted.firstOrNull { ScoreboardPattern.plotPattern.matches(it) }
     if (plotLine != null) add(plotLine to HorizontalAlignment.LEFT)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -191,7 +191,7 @@ private fun getDungeonsLines() = listOf(
     SbPattern.floor3GuardiansPattern
 ).let { patterns ->
     // BetterMap adds a random §r at the start, making it go black
-    getSbLines().filter { line -> patterns.any { it.matches(line.replace("§r", "")) } }
+    getSbLines().filter { line -> patterns.any { it.matches(line) } }.map { it.removePrefix("§r") }
 }
 
 private fun getDungeonsShowWhen(): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -43,6 +43,7 @@ object UnknownLinesHandler {
             SbPattern.soloPattern,
             SbPattern.teammatesPattern,
             SbPattern.floor3GuardiansPattern,
+            SbPattern.m7dragonsPattern,
             SbPattern.wavePattern,
             SbPattern.tokensPattern,
             SbPattern.submergesPattern,


### PR DESCRIPTION
## What
This Pull Request fixes several issues, which occur during a dungeon run. Most of them are M7 problems, since Hypixel in quirky in there. The last issue is a BetterMaps moment, which was fixed in here.

## Changelog Fixes
+ Fixed Custom Scoreboard errors inside the dungeon. - j10a1n15
    * Fixed dragon's line not being properly removed.
    * Fixed a line randomly showing "0" sometimes.
    * Fixed "Cleared..." line sometimes being black.

