### PR TITLE
Improvement: Thaumaturgy Tuning in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
@@ -103,6 +103,16 @@ public class DisplayConfig {
     public boolean colorArrowAmount = false;
 
     @Expose
+    @ConfigOption(name = "Compact Tuning", desc = "Show tuning stats compact")
+    @ConfigEditorBoolean
+    public boolean compactTuning = false;
+
+    @Expose
+    @ConfigOption(name = "Tuning Amount", desc = "Only show the first # tunings.\n§cDoes not work with Compact Tuning.")
+    @ConfigEditorSlider(minValue = 1, maxValue = 8, minStep = 1)
+    public int tuningAmount = 2;
+
+    @Expose
     @ConfigOption(name = "Line Spacing", desc = "The amount of space between each line.")
     @ConfigEditorSlider(minValue = 0, maxValue = 20, minStep = 1)
     public int lineSpacing = 10;

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.storage;
 
 import at.hannibal2.skyhanni.api.SkillAPI;
+import at.hannibal2.skyhanni.data.MaxwellAPI;
 import at.hannibal2.skyhanni.data.model.ComposterUpgrade;
 import at.hannibal2.skyhanni.features.combat.endernodetracker.EnderNodeTracker;
 import at.hannibal2.skyhanni.features.combat.ghostcounter.GhostData;
@@ -54,7 +55,7 @@ public class ProfileSpecificStorage {
         public int magicalPower = -1;
 
         @Expose
-        public Map<String, String> tunings = new HashMap<>();
+        public List<MaxwellAPI.Tuning> tunings = new ArrayList<>();
     }
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -54,7 +54,7 @@ public class ProfileSpecificStorage {
         public int magicalPower = -1;
 
         @Expose
-        public Map<String, Integer> tunings = new HashMap<>();
+        public Map<String, String> tunings = new HashMap<>();
     }
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -55,7 +55,7 @@ public class ProfileSpecificStorage {
         public int magicalPower = -1;
 
         @Expose
-        public List<MaxwellAPI.Tuning> tunings = new ArrayList<>();
+        public List<MaxwellAPI.ThaumaturgyPowerTuning> tunings = new ArrayList<>();
     }
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -52,6 +52,9 @@ public class ProfileSpecificStorage {
 
         @Expose
         public int magicalPower = -1;
+
+        @Expose
+        public Map<String, Integer> tunings = new HashMap<>();
     }
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -112,7 +112,8 @@ object MaxwellAPI {
         if (!isEnabled()) return
 
         if (isThaumaturgyInventory(event.inventoryName)) {
-            loadThaumaturgyGui(event.inventoryItems)
+            loadThaumaturgyCurrentPower(event.inventoryItems)
+            loadThaumaturgyTunings(event.inventoryItems)
         }
 
         if (yourBagsGuiPattern.matches(event.inventoryName)) {
@@ -122,7 +123,7 @@ object MaxwellAPI {
         }
     }
 
-    private fun loadCurrentPower(inventoryItems: Map<Int, ItemStack>) {
+    private fun loadThaumaturgyCurrentPower(inventoryItems: Map<Int, ItemStack>) {
         val selectedPowerStack =
             inventoryItems.values.find {
                 powerSelectedPattern.matches(it.getLore().lastOrNull())
@@ -139,12 +140,7 @@ object MaxwellAPI {
             )
     }
 
-    private fun loadThaumaturgyGui(inventoryItems: Map<Int, ItemStack>) {
-        loadCurrentPower(inventoryItems)
-        loadTunings(inventoryItems)
-    }
-
-    private fun loadTunings(inventoryItems: Map<Int, ItemStack>) {
+    private fun loadThaumaturgyTunings(inventoryItems: Map<Int, ItemStack>) {
         val item = inventoryItems[51] ?: return
         var active = false
         val map = mutableMapOf<String, Int>()

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -42,7 +42,7 @@ object MaxwellAPI {
             storage?.maxwell?.magicalPower = value ?: return
         }
 
-    var tunings: List<Tuning>?
+    var tunings: List<ThaumaturgyPowerTuning>?
         get() = storage?.maxwell?.tunings
         set(value) {
             storage?.maxwell?.tunings = value ?: return
@@ -152,7 +152,7 @@ object MaxwellAPI {
     }
 
     private fun loadThaumaturgyTuningsFromTuning(inventoryItems: Map<Int, ItemStack>) {
-        val map = mutableListOf<Tuning>()
+        val map = mutableListOf<ThaumaturgyPowerTuning>()
         for (stack in inventoryItems.values) {
             for (line in stack.getLore()) {
                 statsTuningDataPattern.readTuningFromLine(line)?.let {
@@ -170,13 +170,13 @@ object MaxwellAPI {
         tunings = map
     }
 
-    private fun Pattern.readTuningFromLine(line: String): Tuning? {
+    private fun Pattern.readTuningFromLine(line: String): ThaumaturgyPowerTuning? {
         return matchMatcher(line) {
             val color = "§" + group("color")
             val icon = group("icon")
             val name = groupOrNull("name") ?: "<missing>"
             val value = group("amount")
-            Tuning(value, color, name, icon)
+            ThaumaturgyPowerTuning(value, color, name, icon)
         }
     }
 
@@ -205,7 +205,7 @@ object MaxwellAPI {
 
         val item = inventoryItems[51] ?: return
         var active = false
-        val map = mutableListOf<Tuning>()
+        val map = mutableListOf<ThaumaturgyPowerTuning>()
         for (line in item.getLore()) {
             if (thaumaturgyStartPattern.matches(line)) {
                 active = true
@@ -266,7 +266,7 @@ object MaxwellAPI {
 
     class UnknownMaxwellPower(message: String) : Exception(message)
 
-    class Tuning(
+    class ThaumaturgyPowerTuning(
         @Expose val value: String,
         @Expose val color: String,
         @Expose var name: String,

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
 import at.hannibal2.skyhanni.utils.StringUtils.trimWhiteSpace
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import com.google.gson.annotations.Expose
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -37,7 +38,7 @@ object MaxwellAPI {
             storage?.maxwell?.magicalPower = value ?: return
         }
 
-    var tunings: Map<String, String>?
+    var tunings: List<Tuning>?
         get() = storage?.maxwell?.tunings
         set(value) {
             storage?.maxwell?.tunings = value ?: return
@@ -135,7 +136,7 @@ object MaxwellAPI {
     }
 
     private fun loadThaumaturgyTuningsFromTuning(inventoryItems: Map<Int, ItemStack>) {
-        val map = mutableMapOf<String, String>()
+        val map = mutableListOf<Tuning>()
         for (stack in inventoryItems.values) {
             for (line in stack.getLore()) {
                 map.readTuningFromLine(statsTuningDataPattern, line)
@@ -144,13 +145,13 @@ object MaxwellAPI {
         tunings = map
     }
 
-    private fun MutableMap<String, String>.readTuningFromLine(pattern: Pattern, line: String) {
+    private fun MutableList<Tuning>.readTuningFromLine(pattern: Pattern, line: String) {
         pattern.matchMatcher(line) {
-            val color = group("color")
+            val color = "§" + group("color")
             val icon = group("icon")
-            val name = "§$color$icon"
-            val amount = group("amount")
-            put(name, amount)
+            val name = "<name>"
+            val value = group("amount")
+            add(Tuning(value, color, name, icon))
         }
     }
 
@@ -179,7 +180,7 @@ object MaxwellAPI {
 
         val item = inventoryItems[51] ?: return
         var active = false
-        val map = mutableMapOf<String, String>()
+        val map = mutableListOf<Tuning>()
         for (line in item.getLore()) {
             if (thaumaturgyStartPattern.matches(line)) {
                 active = true
@@ -237,4 +238,11 @@ object MaxwellAPI {
     }
 
     class UnknownMaxwellPower(message: String) : Exception(message)
+
+    class Tuning(
+        @Expose val value: String,
+        @Expose val color: String,
+        @Expose val name: String,
+        @Expose val icon: String,
+    )
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -139,7 +139,7 @@ object MaxwellAPI {
         var active = false
         val map = mutableMapOf<String, Int>()
         for (line in item.getLore()) {
-            if (line == "§7Your tuning:") {
+            if (startPattern.matches(line)) {
                 active = true
                 continue
             }
@@ -147,7 +147,7 @@ object MaxwellAPI {
                 if (line.isEmpty()) {
                     break
                 }
-                "§(?<color>.)\\+(?<amount>\\d+)(?<icon>.) .+".toPattern().matchMatcher(line) {
+                dataPattern.matchMatcher(line) {
                     val color = group("color")
                     val icon = group("icon")
                     val name = "§$color$icon"
@@ -156,7 +156,7 @@ object MaxwellAPI {
                 }
             }
         }
-        tunings = map.sortedDesc().toList().take(3).toMap()
+        tunings = map.sortedDesc()
     }
 
     private fun processStack(stack: ItemStack) {

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -4,6 +4,8 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.MaxwellPowersJson
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard
+import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardElement
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -81,6 +83,10 @@ object MaxwellAPI {
         "thaumaturgy.statstuning",
         "§7You have: .+ §7\\+ §(?<color>.)(?<amount>[^ ]+) (?<icon>.)"
     )
+    private val tuningAutoAssignedPattern by group.pattern(
+        "tuningpoints.chat.autoassigned",
+        "§aYour §r§eTuning Points §r§awere auto-assigned as convenience!"
+    )
     private val yourBagsGuiPattern by group.pattern(
         "gui.yourbags",
         "Your Bags"
@@ -114,6 +120,14 @@ object MaxwellAPI {
                     "power" to power,
                     "message" to message
                 )
+        }
+        tuningAutoAssignedPattern.matchMatcher(event.message) {
+            if (tunings?.isNotEmpty() == true) {
+                val tuningsInScoreboard = ScoreboardElement.TUNING in CustomScoreboard.config.scoreboardEntries
+                if (tuningsInScoreboard) {
+                    ChatUtils.chat("Talk to Maxwell again to update the tuning data in scoreboard.")
+                }
+            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -167,7 +167,7 @@ class DungeonFinderFeatures {
         if (stack.getLore().firstOrNull()?.removeColor()?.startsWith("Dungeon:") == false) return
         if (classNames.contains(selectedClass)) selectedClass = "§a${selectedClass}§7"
         event.toolTip.add("")
-        event.toolTip.add("§cMissing: §7" + createCommaSeparatedList(classNames))
+        event.toolTip.add("§cMissing: §7" + classNames.createCommaSeparatedList())
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayDisplay.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.name
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.plots
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
-import at.hannibal2.skyhanni.utils.StringUtils
+import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.timerColor
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -61,7 +61,7 @@ class SprayDisplay {
 
         expiredPlots.forEach { it.markExpiredSprayAsNotified() }
         val wasAwayString = if (wasAway) "§7While you were away, your" else "§7Your"
-        val plotString = StringUtils.createCommaSeparatedList(expiredPlots.map { "§b${it.name}" }, "§7")
+        val plotString = expiredPlots.map { "§b${it.name}" }.createCommaSeparatedList("§7")
         val sprayString = if (expiredPlots.size > 1) "sprays" else "spray"
         val out = "$wasAwayString $sprayString on §aPlot §7- $plotString §7expired."
         ChatUtils.chat(out)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -28,6 +28,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.inDungeons
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.percentageColor
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
+import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.TabListData
@@ -42,7 +43,7 @@ internal var amountOfUnknownLines = 0
 enum class ScoreboardElement(
     private val displayPair: Supplier<List<ScoreboardElementType>>,
     val showWhen: () -> Boolean,
-    private val configLine: String
+    private val configLine: String,
 ) {
     TITLE(
         ::getTitleDisplayPair,
@@ -137,6 +138,11 @@ enum class ScoreboardElement(
         ::getPowerDisplayPair,
         ::getPowerShowWhen,
         "Power: §aSighted §7(§61.263§7)"
+    ),
+    TUNING(
+        ::getTuningDisplayPair,
+        { MaxwellAPI.tunings?.isNotEmpty() ?: false },
+        "Tuning: §c❁34§7, §e⚔20§7, and §9☣7"
     ),
     COOKIE(
         ::getCookieDisplayPair,
@@ -233,7 +239,6 @@ enum class ScoreboardElement(
         return showWhen()
     }
 }
-
 
 private fun getTitleDisplayPair() = if (displayConfig.titleAndFooter.useHypixelTitleAnimation) {
     listOf(ScoreboardData.objectiveTitle to displayConfig.titleAndFooter.alignTitleAndFooter)
@@ -428,7 +433,6 @@ private fun getDateDisplayPair() =
         SkyBlockTime.now().formatted(yearElement = false, hoursAndMinutesElement = false) to HorizontalAlignment.LEFT
     )
 
-
 private fun getTimeDisplayPair(): List<ScoreboardElementType> {
     var symbol = getGroupFromPattern(ScoreboardData.sidebarLinesFormatted, ScoreboardPattern.timePattern, "symbol")
     if (symbol == "0") symbol = ""
@@ -460,6 +464,17 @@ private fun getPowerDisplayPair() = listOf(
         }
     }
         ?: "§cOpen \"Your Bags\"!") to HorizontalAlignment.LEFT
+)
+
+private fun getTuningDisplayPair() = listOf(
+    (MaxwellAPI.tunings?.let {
+        val tuning = it.toList()
+            .take(3)
+            .map { (key, value) -> key + value }
+            .createCommaSeparatedList("§7")
+        "Tuning: $tuning"
+    }
+        ?: "§cTalk to \"Maxwell\"!") to HorizontalAlignment.LEFT
 )
 
 private fun getPowerShowWhen() = !inAnyIsland(IslandType.THE_RIFT)
@@ -507,7 +522,6 @@ private fun getObjectiveDisplayPair() = buildList {
 private fun getObjectiveShowWhen(): Boolean =
     !inAnyIsland(IslandType.KUUDRA_ARENA)
         && ScoreboardData.sidebarLinesFormatted.none { ScoreboardPattern.objectivePattern.matches(it) }
-
 
 private fun getSlayerDisplayPair(): List<ScoreboardElementType> = listOf(
     (if (SlayerAPI.hasActiveSlayerQuest()) "Slayer Quest" else "<hidden>") to HorizontalAlignment.LEFT,

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -493,7 +493,7 @@ private fun getTuningDisplayPair(): List<Pair<String, HorizontalAlignment>> {
         )
     } else {
         val tuning = tunings
-            .take(displayConfig.tuningAmount)
+            .take(displayConfig.tuningAmount.coerceAtLeast(1))
             .map { tuning ->
                 with(tuning) {
                     " §7- §f" + if (displayConfig.displayNumbersFirst) {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -28,6 +28,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.inDungeons
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.percentageColor
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
+import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.TabListData
@@ -467,25 +468,27 @@ private fun getPowerDisplayPair() = listOf(
 
 private fun getTuningDisplayPair(): List<Pair<String, HorizontalAlignment>> {
     val tunings = MaxwellAPI.tunings ?: return listOf("§cTalk to \"Maxwell\"!" to HorizontalAlignment.LEFT)
+    if (tunings.isEmpty()) return listOf("§cNo Maxwell Tunings :(" to HorizontalAlignment.LEFT)
 
+    val title = StringUtils.pluralize(tunings.size, "Tuning", "Tunings")
     return if (displayConfig.compactTuning) {
         val tuning = tunings
             .take(3)
             .joinToString("§7, ") { tuning ->
                 with(tuning) {
                     if (displayConfig.displayNumbersFirst) {
-                        "$color$value $icon"
+                        "$color$value$icon"
                     } else {
-                        "$color$icon $value"
+                        "$color$icon$value"
                     }
                 }
 
             }
         listOf(
             if (displayConfig.displayNumbersFirst) {
-                "$tuning §fTuning"
+                "$tuning §f$title"
             } else {
-                "Tuning: $tuning"
+                "$title: $tuning"
             } to HorizontalAlignment.LEFT
         )
     } else {
@@ -501,7 +504,7 @@ private fun getTuningDisplayPair(): List<Pair<String, HorizontalAlignment>> {
                 }
 
             }.toTypedArray()
-        listOf("Tuning:", *tuning).map { it to HorizontalAlignment.LEFT }
+        listOf("$title:", *tuning).map { it to HorizontalAlignment.LEFT }
     }
 }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -497,7 +497,7 @@ private fun getTuningDisplayPair(): List<Pair<String, HorizontalAlignment>> {
             .map { tuning ->
                 with(tuning) {
                     " §7- §f" + if (displayConfig.displayNumbersFirst) {
-                        "$color$value$icon $name"
+                        "$color$value $icon $name"
                     } else {
                         "$name: $color$value$icon"
                     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
@@ -71,9 +71,8 @@ class StatsTuning {
         if (stack.name != "§aStats Tuning") return false
         val tunings = MaxwellAPI.tunings ?: return false
 
-        event.stackTip = tunings.toList()
-            .take(3)
-            .map { it.first + it.second }
+        event.stackTip = tunings
+            .map { it.key + it.value }
             .createCommaSeparatedList("§7")
         event.offsetX = 3
         event.offsetY = -5

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
@@ -34,7 +34,11 @@ class StatsTuning {
         val stack = event.stack
 
         if (config.templateStats && inventoryName == "Stats Tuning") if (templateStats(stack, event)) return
-        if (config.selectedStats && MaxwellAPI.isThaumaturgyInventory(inventoryName) && renderTunings(stack, event)) return
+        if (config.selectedStats && MaxwellAPI.isThaumaturgyInventory(inventoryName) && renderTunings(
+                stack,
+                event
+            )
+        ) return
         if (config.points && inventoryName == "Stats Tuning") points(stack, event)
     }
 
@@ -71,7 +75,11 @@ class StatsTuning {
         val tunings = MaxwellAPI.tunings ?: return false
 
         event.stackTip = tunings
-            .map { it.key + it.value }
+            .map { tuning ->
+                with(tuning) {
+                    "$color$value$icon"
+                }
+            }
             .createCommaSeparatedList("§7")
         event.offsetX = 3
         event.offsetY = -5

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -35,7 +34,7 @@ class StatsTuning {
         val stack = event.stack
 
         if (config.templateStats && inventoryName == "Stats Tuning") if (templateStats(stack, event)) return
-        if (config.selectedStats && MaxwellAPI.thaumaturgyGuiPattern.matches(inventoryName) && renderTunings(stack, event)) return
+        if (config.selectedStats && MaxwellAPI.isThaumaturgyInventory(inventoryName) && renderTunings(stack, event)) return
         if (config.points && inventoryName == "Stats Tuning") points(stack, event)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.MaxwellAPI
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -10,7 +11,9 @@ import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
+import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -32,7 +35,7 @@ class StatsTuning {
         val stack = event.stack
 
         if (config.templateStats && inventoryName == "Stats Tuning") if (templateStats(stack, event)) return
-        if (config.selectedStats && inventoryName == "Accessory Bag Thaumaturgy" && selectedStats(stack, event)) return
+        if (config.selectedStats && MaxwellAPI.thaumaturgyGuiPattern.matches(inventoryName) && renderTunings(stack, event)) return
         if (config.points && inventoryName == "Stats Tuning") points(stack, event)
     }
 
@@ -64,26 +67,14 @@ class StatsTuning {
         return true
     }
 
-    private fun selectedStats(stack: ItemStack, event: RenderInventoryItemTipEvent): Boolean {
+    private fun renderTunings(stack: ItemStack, event: RenderInventoryItemTipEvent): Boolean {
         if (stack.name != "§aStats Tuning") return false
+        val tunings = MaxwellAPI.tunings ?: return false
 
-        var grab = false
-        val list = mutableListOf<String>()
-        for (line in stack.getLore()) {
-            if (line == "§7Your tuning:") {
-                grab = true
-                continue
-            }
-            if (!grab) continue
-            if (line == "") {
-                grab = false
-                continue
-            }
-            val text = line.split(":")[0].split(" ")[0] + "§7"
-            list.add(text)
-        }
-        if (list.isEmpty()) return false
-        event.stackTip = list.joinToString(" + ")
+        event.stackTip = tunings.toList()
+            .take(3)
+            .map { it.first + it.second }
+            .createCommaSeparatedList("§7")
         event.offsetX = 3
         event.offsetY = -5
         event.alignLeft = false

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -189,11 +189,6 @@ object StringUtils {
         return "$allButLast$delimiterColor, and ${this[lastIndex]}"
     }
 
-    @Deprecated("outdated", ReplaceWith("list.createCommaSeparatedList(delimiterColor)"))
-    fun createCommaSeparatedList(list: List<String>, delimiterColor: String = ""): String {
-        return list.createCommaSeparatedList(delimiterColor)
-    }
-
     fun pluralize(number: Int, singular: String, plural: String? = null, withNumber: Boolean = false): String {
         val pluralForm = plural ?: "${singular}s"
         var str = if (number == 1) singular else pluralForm

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -95,7 +95,6 @@ object StringUtils {
         return toString().replace("-", "")
     }
 
-
     inline fun <T> Pattern.matchMatcher(text: String, consumer: Matcher.() -> T) =
         matcher(text).let { if (it.matches()) consumer(it) else null }
 
@@ -181,13 +180,18 @@ object StringUtils {
      * @param delimiterColor - the color code of the delimiter, inserted before each delimiter (commas and "and").
      * @return a string representing the list joined with the Oxford comma and the word "and".
      */
+    fun List<String>.createCommaSeparatedList(delimiterColor: String = ""): String {
+        if (this.isEmpty()) return ""
+        if (this.size == 1) return this[0]
+        if (this.size == 2) return "${this[0]}$delimiterColor and ${this[1]}"
+        val lastIndex = this.size - 1
+        val allButLast = this.subList(0, lastIndex).joinToString("$delimiterColor, ")
+        return "$allButLast$delimiterColor, and ${this[lastIndex]}"
+    }
+
+    @Deprecated("outdated", ReplaceWith("list.createCommaSeparatedList(delimiterColor)"))
     fun createCommaSeparatedList(list: List<String>, delimiterColor: String = ""): String {
-        if (list.isEmpty()) return ""
-        if (list.size == 1) return list[0]
-        if (list.size == 2) return "${list[0]}$delimiterColor and ${list[1]}"
-        val lastIndex = list.size - 1
-        val allButLast = list.subList(0, lastIndex).joinToString("$delimiterColor, ")
-        return "$allButLast$delimiterColor, and ${list[lastIndex]}"
+        return list.createCommaSeparatedList(delimiterColor)
     }
 
     fun pluralize(number: Int, singular: String, plural: String? = null, withNumber: Boolean = false): String {


### PR DESCRIPTION
## What
Show Thaumaturgy tuning points stats in scoreboard, and moving the detection into the API class & into config.

statsTuningDataPattern: https://regex101.com/r/2o2Ddp/1
thaumaturgyDataPattern: https://regex101.com/r/m7qOe2/1

Idea on Discord: https://discord.com/channels/997079228510117908/1218840613596954655

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/15637c90-b37c-4ebf-9754-519994c46ae1)
![image](https://github.com/hannibal002/SkyHanni/assets/24389977/fae212fe-5ed0-423b-9703-0d3cd6a0e8a7)


</details>

## Changelog Improvements
+ Show Thaumaturgy Tuning in Custom Scoreboard. - hannibal2
    * Option to show in compact mode.
    * Supports "Values First" option.
    * Change the number of tunings shown.

## Changelog Technical Details
+ Moved Thaumaturgy Tuning Points detection into MaxwellAPI, and saving it in the profile-specific config. - hannibal2