### PR TITLE
Fix: Party Leader detection when name ends with an S

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/PartyAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PartyAPI.kt
@@ -18,7 +18,7 @@ object PartyAPI {
     private val patternGroup = RepoPattern.group("data.party")
     private val youJoinedPartyPattern by patternGroup.pattern(
         "you.joined",
-        "§eYou have joined (?<name>.*)'s §eparty!"
+        "§eYou have joined (?<name>.*)'s? §eparty!"
     )
     private val othersJoinedPartyPattern by patternGroup.pattern(
         "others.joined",


### PR DESCRIPTION
## What
Fixed detection of Party Leader when their username ends with an `s`.

## Changelog Fixes
+ Fixed detection of Party Leader when their username ends with an `s`. - Alexia Luna