### PR TITLE
Backend: Add open in regex101.com intention

### DIFF
--- a/.live-plugins/regexr/plugin.kts
+++ b/.live-plugins/regexr/plugin.kts
@@ -1,0 +1,109 @@
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.findParentOfType
+import liveplugin.openInBrowser
+import liveplugin.registerIntention
+import liveplugin.show
+import org.intellij.markdown.html.urlEncode
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.psi.*
+
+// depends-on-plugin org.jetbrains.kotlin
+
+registerIntention(RenameKotlinFunctionToUseCamelCaseIntention())
+if (!isIdeStartup) show("Reloaded Regex intentions")
+val logger =
+    Logger.getInstance("SkyHanni")
+
+val regexTestPrefix = "REGEX-TEST: "
+
+class RegexInfo(
+    val regex: KtValueArgument,
+    val comment: KDoc?,
+) {
+    fun getRegexText(): String? {
+        val templateExpr = regex.getArgumentExpression() as? KtStringTemplateExpression ?: return null
+        val sb = StringBuilder()
+        for (x in templateExpr.entries) {
+            when (x) {
+                is KtEscapeStringTemplateEntry -> sb.append(x.unescapedValue)
+                is KtLiteralStringTemplateEntry -> sb.append(x.text)
+                else -> return null
+            }
+        }
+        return sb.toString()
+    }
+
+    val commentText by lazy {
+        comment?.text
+            ?.replace("/*", "")
+            ?.replace("*/", "")
+            ?.lines()
+            ?.map {
+                it.trim().trimStart('*').trim()
+            }
+    }
+
+    fun getExamples(): List<String> {
+        val examples = commentText?.filter { it.startsWith(regexTestPrefix) }
+            ?.map { it.substring(regexTestPrefix.length) }
+        if (examples == null) return listOf()
+        return examples
+    }
+}
+
+inner class RenameKotlinFunctionToUseCamelCaseIntention : PsiElementBaseIntentionAction() {
+    override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+        return findRegexInfo(element) != null
+    }
+
+    fun findRegexInfo(element: PsiElement): RegexInfo? {
+        val call = element.findParentOfType<KtCallExpression>() ?: return null
+        if (call.valueArguments.size != 2) return null
+        val methodName = call.calleeExpression as? KtSimpleNameExpression ?: return null
+        if (methodName.getReferencedName() != "pattern") return null
+        val field = call.findParentOfType<KtProperty>() ?: return null
+        val regex = call.valueArguments[1] ?: return null
+        val comment = field.docComment
+        return RegexInfo(regex, comment)
+    }
+
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        val info = findRegexInfo(element) ?: return
+        val regex = info.getRegexText()
+        if (regex == null) {
+            show("Regex needs to be a bare string literal in order to open it in the browser!")
+            return
+        }
+        openInBrowser(
+            "https://regex101.com/?regex=${urlEncode(regex)}&testString=${
+                urlEncode(
+                    info.getExamples().joinToString("\n")
+                )
+            }"
+        )
+    }
+
+    override fun generatePreview(project: Project, editor: Editor, file: PsiFile): IntentionPreviewInfo {
+        val element = getElement(editor, file) ?: return IntentionPreviewInfo.EMPTY
+        val info = findRegexInfo(element) ?: return IntentionPreviewInfo.EMPTY
+        val exampleCount = info.getExamples().size
+        return IntentionPreviewInfo.Html(
+            """
+            Opens this regex on regex101.com with $exampleCount example${s(exampleCount)}.
+            """
+        )
+    }
+
+    override fun getText() = "Open regex101.com"
+    override fun getFamilyName() = "OpenRegexExplorerIntention"
+}
+
+fun s(count: Int): String {
+    return if (count == 1) "" else "s"
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -271,6 +271,9 @@ class ChatFilter {
         "§eObtain a §r§6Booster Cookie §r§efrom the community shop in the hub!",
     )
 
+    /**
+     * REGEX-TEST: §e[NPC] Jacob§f: §rYour §9Anita's Talisman §fis giving you §6+25☘ Carrot Fortune §fduring the contest!
+     */
     private val anitaFortunePattern by RepoPattern.pattern(
         "chat.jacobevent.accessory",
         "§e\\[NPC] Jacob§f: §rYour §9Anita's \\w+ §fis giving you §6\\+\\d{1,2}☘ .+ Fortune §fduring the contest!"

--- a/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPattern.kt
@@ -84,6 +84,11 @@ interface RepoPattern : ReadOnlyProperty<Any?, Pattern> {
         /**
          * Obtain a reference to a [Pattern] backed by either a local regex, or a remote regex.
          * Check the documentation of [RepoPattern] for more information.
+         *
+         * This method supports "Open regex101.com" using [LivePlugin](https://plugins.jetbrains.com/plugin/7282-liveplugin).
+         * To use it, install LivePlugin, enable "Run plugins on IDE start" and "Run project specific plugins".
+         * Now you can use ALT+ENTER while hovering over a [pattern] call using your text cursor to access the "Open in regex101.com" intention.
+         * Add a KDoc comment to the associated variable containing lines starting with `REGEX-TEST: ` to pre-fill examples.
          */
         fun pattern(key: String, @Language("RegExp") fallback: String): RepoPattern {
             return RepoPatternManager.of(key, fallback)


### PR DESCRIPTION
<!-- remove all unused parts -->

## Dependencies


## What
Adds a intellij intention to open a repopattern in regex101.com

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/20768569/f6ea608f-74ae-446a-b5dd-8fdc9acd4b75)
![image](https://github.com/hannibal002/SkyHanni/assets/20768569/4b2a5040-3322-4c4f-9618-95c1494645f2)

<!-- drop images here -->

</details>

## Changelog New Features


## Changelog Improvements


## Changelog Fixes


## Changelog Technical Details
+ Add "open in regex101.com" IntelliJ intention. - !nea
    * Press ALT+ENTER while hovering over a RepoPattern.pattern call with your text cursor to select the "Open regex101.com" option
    * Add a Kotlin doc comment with `REGEX-TEST: someString` lines to add test cases

## Changelog Removed Features


