### PR TITLE
Fix: Party Finder "Mark Missing Class" highlighting too much

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -149,6 +149,8 @@ class DungeonFinderFeatures {
 
         val chestName = InventoryUtils.openInventoryName()
         if (chestName != "Party Finder") return
+        val allowedSlots = (10..34).filter { it !in listOf(17, 18, 26, 27) }
+        if (event.slot.slotNumber !in allowedSlots) return
 
         val stack = event.itemStack
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -167,9 +167,14 @@ class DungeonFinderFeatures {
         }
         if (!config.showMissingClasses) return
         if (stack.getLore().firstOrNull()?.removeColor()?.startsWith("Dungeon:") == false) return
-        if (classNames.contains(selectedClass)) selectedClass = "§a${selectedClass}§7"
+        var uncoloredSelectedClass = ""
+        if (classNames.contains(selectedClass)) {
+            uncoloredSelectedClass = selectedClass
+            selectedClass = "§a${selectedClass}§7"
+        }
         event.toolTip.add("")
         event.toolTip.add("§cMissing: §7" + classNames.createCommaSeparatedList())
+        if (uncoloredSelectedClass.isNotEmpty()) selectedClass = uncoloredSelectedClass
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
fixes "mark missing class" marking every party after hovering over one that was marked as green.
also adds a whitelist for the slot numbers where the missing classes can be shown in the lore, so this isn't shown in some menu items like the close button.

## Changelog Fixes
+ Fixed "Mark Missing Class" highlighting every party. - martimavocado
