### PR TITLE
Improvement + Fix: Custom Scoreboard Fixes Part 4

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -125,13 +125,13 @@ object MaxwellAPI {
             if (tunings?.isNotEmpty() == true) {
                 val tuningsInScoreboard = ScoreboardElement.TUNING in CustomScoreboard.config.scoreboardEntries
                 if (tuningsInScoreboard) {
-                    ChatUtils.chat("Talk to Maxwell again to update the tuning data in scoreboard.")
+                    ChatUtils.chat("Talk to Maxwell and open the Tuning Page again to update the tuning data in scoreboard.")
                 }
             }
         }
     }
 
-    // load earler, so that other features can already use the api in this event
+    // load earlier, so that other features can already use the api in this event
     @SubscribeEvent(priority = EventPriority.HIGH)
     fun onInventoryFullyLoaded(event: InventoryOpenEvent) {
         if (!isEnabled()) return
@@ -200,7 +200,7 @@ object MaxwellAPI {
     private fun loadThaumaturgyTunings(inventoryItems: Map<Int, ItemStack>) {
         val tunings = tunings ?: return
 
-        // Only load those rounded values if we dont have any valurs at all
+        // Only load those rounded values if we dont have any values at all
         if (tunings.isNotEmpty()) return
 
         val item = inventoryItems[51] ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -9,11 +9,9 @@
 //  - countdown events like fishing festival + fiesta when its not on tablist
 //  - CookieAPI https://discord.com/channels/997079228510117908/1162844830360146080/1195695210433351821
 //  - Rng meter display
-//  - shorten time till next mayor https://discord.com/channels/997079228510117908/1162844830360146080/1216440046320746596
 //  - option to hide coins earned
 //  - color options in the purse etc lines
 //  - choose the amount of decimal places in shorten nums
-//  - ~~very important bug fix: duplex is weird :(~~ will be fixed with empas quiverapi overhaul
 //  - more anchor points (alignment enums in renderutils)
 //
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -99,28 +99,29 @@ class CustomScoreboard {
 
     private fun createLines() = buildList<ScoreboardElementType> {
         for (element in config.scoreboardEntries) {
-            val line = element.getVisiblePair()
+            val lines = element.getVisiblePair()
+            if (lines.isEmpty()) continue
 
             // Hide consecutive empty lines
             if (
                 informationFilteringConfig.hideConsecutiveEmptyLines &&
-                line.isNotEmpty() && line[0].first == "<empty>" && lastOrNull()?.first?.isEmpty() == true
+                lines.isNotEmpty() && lines[0].first == "<empty>" && lastOrNull()?.first?.isEmpty() == true
             ) {
                 continue
             }
 
             // Adds empty lines
-            if (line[0].first == "<empty>") {
+            if (lines[0].first == "<empty>") {
                 add("" to HorizontalAlignment.LEFT)
                 continue
             }
 
             // Does not display this line
-            if (line.any { it.first == "<hidden>" }) {
+            if (lines.any { it.first == "<hidden>" }) {
                 continue
             }
 
-            addAll(line)
+            addAll(lines)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -92,10 +92,6 @@ enum class ScoreboardEvents(private val displayLine: Supplier<List<String>>, pri
         ::getBroodmotherLines,
         ::getBroodmotherShowWhen
     ),
-    NEW_YEAR(
-        ::getNewYearLines,
-        ::getNewYearShowWhen
-    ),
     ORINGO(
         ::getOringoLines,
         ::getOringoShowWhen
@@ -368,14 +364,6 @@ private fun getBroodmotherLines(): List<String> {
 
 private fun getBroodmotherShowWhen(): Boolean {
     return getSbLines().any { SbPattern.broodmotherPattern.matches(it) }
-}
-
-private fun getNewYearLines(): List<String> {
-    return listOf(getSbLines().first { SbPattern.newYearPattern.matches(it) })
-}
-
-private fun getNewYearShowWhen(): Boolean {
-    return getSbLines().any { SbPattern.newYearPattern.matches(it) }
 }
 
 private fun getOringoLines(): List<String> {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -283,7 +283,7 @@ object ScoreboardPattern {
     )
     val brokenRedstonePattern by miscSb.pattern(
         "brokenredstone",
-        "\\s*e: §e§b\\d{1,3}%$"
+        "\\s*(?:(?:§.)*⚡ (§.)*Redston|e: (?:§.)*\\d+%)\\s*"
     )
     val redstonePattern by miscSb.pattern(
         "redstone",

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -248,7 +248,7 @@ object ScoreboardPattern {
     )
     val reformingPattern by combatSb.pattern(
         "magmareforming",
-        "^§cThe boss is reforming!$"
+        "^§cThe boss is (?:re)?forming!$"
     )
     val bossHealthPattern by combatSb.pattern(
         "magmabosshealth",

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -14,7 +14,10 @@ object UnknownLinesHandler {
     fun handleUnknownLines() {
         val sidebarLines = ScoreboardData.sidebarLinesFormatted
 
-        unknownLines = sidebarLines.toMutableList().map { it.removeResets() }.filter { it.isNotBlank() }
+        unknownLines = sidebarLines
+            .map { it.removeResets() }
+            .filter { it.isNotBlank() }
+            .filter { it.trim().length > 3 }
 
         /*
          * remove with pattern

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -41,6 +41,7 @@ object UnknownLinesHandler {
             SbPattern.autoClosingPattern,
             SbPattern.startingInPattern,
             SbPattern.timeElapsedPattern,
+            SbPattern.instanceShutdownPattern,
             SbPattern.keysPattern,
             SbPattern.clearedPattern,
             SbPattern.soloPattern,


### PR DESCRIPTION
## What
This Pull Request fixes the IndexOutOfBoundsException (not confirmed, switched Islands like 20 times without the error appearing), adjusting the auto-adjust-tuning point line and more.

## Changelog Improvements
+ Improved the stats tuning message when Hypixel auto-adjusts your tuning points. - j10a1n15

## Changelog Fixes
+ Custom Scoreboard Fixes. - j10a1n15
    * Fixed IndexOutOfBoundException.
    * Fixed Instance Shutdown Line not being hidden.
    * Fixed a broken Hypixel Scoreboard Line.
    * Fixed New Year Line appearing twice.