### PR TITLE
Fix: Crash in /ff

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/pages/OverviewPage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/pages/OverviewPage.kt
@@ -26,14 +26,14 @@ class OverviewPage : FFGuideGUI.FFGuidePage() {
             FFGuideGUI.guiLeft + 15, FFGuideGUI.guiTop + 5, 90, mouseX, mouseY, FFGuideGUI.tooltipToDisplay
         )
 
-        var line = if (FFStats.baseFF[FFTypes.ANITA]!! < 0.0) "§cAnita buff not saved\n§eVisit Anita to set it!"
+        var line = if (FFTypes.ANITA.notSaved()) "§cAnita buff not saved\n§eVisit Anita to set it!"
         else "§7§2Fortune for levelling your Anita extra crops\n§2You get 4☘ per buff level"
         GuiRenderUtils.drawFarmingBar(
             "§2Anita Buff", line, FFStats.baseFF[FFTypes.ANITA] ?: 0.0, 60, FFGuideGUI.guiLeft + 15,
             FFGuideGUI.guiTop + 30, 90, mouseX, mouseY, FFGuideGUI.tooltipToDisplay
         )
 
-        line = if (FFStats.baseFF[FFTypes.FARMING_LVL]!! < 0.0) "§cFarming level not saved\n§eOpen /skills to set it!"
+        line = if (FFTypes.FARMING_LVL.notSaved()) "§cFarming level not saved\n§eOpen /skills to set it!"
         else "§7§2Fortune for levelling your farming skill\n§2You get 4☘ per farming level"
         GuiRenderUtils.drawFarmingBar(
             "§2Farming Level", line, FFStats.baseFF[FFTypes.FARMING_LVL] ?: 0.0, 240, FFGuideGUI.guiLeft + 15,
@@ -41,7 +41,7 @@ class OverviewPage : FFGuideGUI.FFGuidePage() {
         )
 
         line =
-            if (FFStats.baseFF[FFTypes.COMMUNITY_SHOP]!! < 0.0) "§cCommunity upgrade level not saved\n§eVisit Elizabeth to set it!"
+            if (FFTypes.COMMUNITY_SHOP.notSaved()) "§cCommunity upgrade level not saved\n§eVisit Elizabeth to set it!"
             else "§7§2Fortune for community shop upgrades\n§2You get 4☘ per upgrade tier"
         GuiRenderUtils.drawFarmingBar(
             "§2Community upgrades", line, FFStats.baseFF[FFTypes.COMMUNITY_SHOP] ?: 0.0,
@@ -49,7 +49,7 @@ class OverviewPage : FFGuideGUI.FFGuidePage() {
         )
 
         line =
-            if (FFStats.baseFF[FFTypes.PLOTS]!! < 0.0) "§cUnlocked plot count not saved\n§eOpen /desk and view your plots to set it!"
+            if (FFTypes.PLOTS.notSaved()) "§cUnlocked plot count not saved\n§eOpen /desk and view your plots to set it!"
             else "§7§2Fortune for unlocking garden plots\n§2You get 3☘ per plot unlocked"
         GuiRenderUtils.drawFarmingBar(
             "§2Garden Plots", line, FFStats.baseFF[FFTypes.PLOTS] ?: 0.0, 72, FFGuideGUI.guiLeft + 15,
@@ -263,4 +263,8 @@ class OverviewPage : FFGuideGUI.FFGuidePage() {
             FFGuideGUI.guiLeft + 255, FFGuideGUI.guiTop + 130, 90, mouseX, mouseY, FFGuideGUI.tooltipToDisplay
         )
     }
+
+    private fun FFTypes.notSaved(): Boolean = FFStats.baseFF[this]?.let {
+        it < 0.0
+    } ?: true
 }


### PR DESCRIPTION
## What
Removing `!!` usages in `OverviewPage`
Created and using `FFTypes.notSaved()`

This fixes this NPE crash:
<details>
<summary>Stack Trace</summary>

> java.lang.NullPointerException: Rendering screen
> at at.hannibal2.skyhanni.features.garden.fortuneguide.pages.OverviewPage.drawPage(OverviewPage.kt:29)
> at at.hannibal2.skyhanni.features.garden.fortuneguide.FFGuideGUI.func_73863_a(FFGuideGUI.kt:226)
> at net.minecraftforge.client.ForgeHooksClient.drawScreen(ForgeHooksClient.java:311)
> at net.minecraft.client.renderer.EntityRenderer.func_181560_a(EntityRenderer.java:1104)
> at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1051)
> at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:349)
> at net.minecraft.client.main.Main.main(SourceFile:124)
> at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
> at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> at java.lang.reflect.Method.invoke(Method.java:497)
> at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
> at net.minecraft.launchwrapper.Launch.main(Launch.java:28)

</details>

## Changelog Fixes
+ Fixed rare crash in /ff display. - hannibal2