### PR TITLE
Fix: getting slayer spawn cost from bank

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.data.SlayerAPI
 import at.hannibal2.skyhanni.data.jsonobjects.repo.SlayerProfitTrackerItemsJson
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
+import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.PurseChangeCause
 import at.hannibal2.skyhanni.events.PurseChangeEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
@@ -18,8 +19,11 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
+import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import com.google.gson.JsonObject
@@ -34,6 +38,14 @@ object SlayerProfitTracker {
     private var itemLogCategory = ""
     private var baseSlayerType = ""
     private val trackers = mutableMapOf<String, SkyHanniItemTracker<Data>>()
+
+    /**
+     * REGEX-TEST: §7Took 1.9k coins from your bank for auto-slayer...
+     */
+    private val autoSlayerBankPattern by RepoPattern.pattern(
+        "slayer.autoslayer.bank.chat",
+        "§7Took (?<coins>.+) coins from your bank for auto-slayer\\.\\.\\."
+    )
 
     class Data : ItemTrackerData() {
 
@@ -71,9 +83,9 @@ object SlayerProfitTracker {
 
     private val ItemTrackerData.TrackedItem.timesDropped get() = timesGained
 
-    private fun addSlayerCosts(price: Int) {
+    private fun addSlayerCosts(price: Double) {
         getTracker()?.modify {
-            it.slayerSpawnCost += price
+            it.slayerSpawnCost += price.toInt()
         }
     }
 
@@ -92,7 +104,15 @@ object SlayerProfitTracker {
             getTracker()?.addCoins(coins.toInt())
         }
         if (event.reason == PurseChangeCause.LOSE_SLAYER_QUEST_STARTED) {
-            addSlayerCosts(coins.toInt())
+            addSlayerCosts(coins)
+        }
+    }
+
+    @SubscribeEvent
+    fun onChat(event: LorenzChatEvent) {
+        if (!isEnabled()) return
+        autoSlayerBankPattern.matchMatcher(event.message) {
+            addSlayerCosts(group("coins").formatDouble())
         }
     }
 


### PR DESCRIPTION
## What
Previously, we grabbed the slayer spawn cost for the slayer profit tracker from the change of purse in the scoreboard.
But what if your purse is empty?
Hypixel grabs the coins from the bank, but we had no way to accurately detect the change since the bank value in the tab list is rounded (20m - 50k = 20m)
We also thought about using the static price per slayer type and tier (since we detect this correctly), but there is a % reduction in slayer price on different scenarios. So I decided against showing wrong information and instead don't show any information.

But recently, Hypixel had added a chat message telling us how much coins you just spent on slayer quests using the bank:
`§7Took 1.9k coins from your bank for auto-slayer...`
This PR uses this chat line to accurately calculate the slayer spawn cost when all money is in the bank.

Suggestion on Discord: https://discord.com/channels/997079228510117908/1219560956380577853

## Changelog Fixes
+ Fixed Slayer Profit Tracker not detecting the slayer spawn cost when taking money from the bank. - hannibal2