### PR TITLE
Fix: Slayer cost from bank counting wrong

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -84,6 +84,7 @@ object SlayerProfitTracker {
     private val ItemTrackerData.TrackedItem.timesDropped get() = timesGained
 
     private fun addSlayerCosts(price: Double) {
+        require(price < 0) {"slayer costs can not be positve"}
         getTracker()?.modify {
             it.slayerSpawnCost += price.toInt()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -112,7 +112,7 @@ object SlayerProfitTracker {
     fun onChat(event: LorenzChatEvent) {
         if (!isEnabled()) return
         autoSlayerBankPattern.matchMatcher(event.message) {
-            addSlayerCosts(group("coins").formatDouble())
+            addSlayerCosts(-group("coins").formatDouble())
         }
     }
 
@@ -180,7 +180,7 @@ object SlayerProfitTracker {
                     listOf("§7You paid §c$mobKillCoinsFormat §7in total", "§7for starting the slayer quests.")
                 )
             )
-            profit += slayerSpawnCost
+            profit -= slayerSpawnCost
         }
 
         val slayerCompletedCount = itemLog.slayerCompletedCount

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -181,7 +181,7 @@ object SlayerProfitTracker {
                     listOf("§7You paid §c$mobKillCoinsFormat §7in total", "§7for starting the slayer quests.")
                 )
             )
-            profit -= slayerSpawnCost
+            profit += slayerSpawnCost
         }
 
         val slayerCompletedCount = itemLog.slayerCompletedCount


### PR DESCRIPTION
## What
Fixed slayer cost from bank counting plus instead of minus profit.
Coins in PurseChangeEvent are negative. I forgot in #https://github.com/hannibal002/SkyHanni/pull/1218 to subtract the value of auto slayer bank chat message. addSlayerCosts requires a negative value.

## Changelog Fixes
+ Fixed slayer cost from bank counting plus instead of minus profit. - hannibal2