### PR TITLE
Improvement: Events Priority in Custom Scoreboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ at [DiscordRPCManager.kt](https://github.com/hannibal002/SkyHanni/blob/beta/src/
 
 We use the [auto update library](https://github.com/nea89o/libautoupdate) from nea89.
 
-## Additional Useful Developement Tools
+## Additional Useful Development Tools
 
 ### DevAuth
 

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -11,7 +11,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 27
+    const val CONFIG_VERSION = 28
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/CustomScoreboardConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/CustomScoreboardConfig.java
@@ -36,11 +36,6 @@ public class CustomScoreboardConfig {
     public DisplayConfig displayConfig = new DisplayConfig();
 
     @Expose
-    @ConfigOption(name = "Information Filtering", desc = "")
-    @Accordion
-    public InformationFilteringConfig informationFilteringConfig = new InformationFilteringConfig();
-
-    @Expose
     @ConfigOption(name = "Background Options", desc = "")
     @Accordion
     public BackgroundConfig backgroundConfig = new BackgroundConfig();
@@ -54,6 +49,12 @@ public class CustomScoreboardConfig {
     @ConfigOption(name = "Mayor Options", desc = "")
     @Accordion
     public MayorConfig mayorConfig = new MayorConfig();
+
+    @Expose
+    @ConfigOption(name = "Information Filtering", desc = "")
+    @Accordion
+    public InformationFilteringConfig informationFilteringConfig = new InformationFilteringConfig();
+
 
     @Expose
     @ConfigOption(name = "Unknown Lines warning", desc = "Gives a chat warning when unknown lines are found in the scoreboard.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/CustomScoreboardConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/CustomScoreboardConfig.java
@@ -28,7 +28,7 @@ public class CustomScoreboardConfig {
         desc = "Drag text to change the appearance of the advanced scoreboard." // supporting both custom & advanced search
     )
     @ConfigEditorDraggableList()
-    public List<ScoreboardElement> scoreboardEntries = new ArrayList<>(ScoreboardElement.getEntries());
+    public List<ScoreboardElement> scoreboardEntries = new ArrayList<>(ScoreboardElement.defaultOption);
 
     @Expose
     @ConfigOption(name = "Display Options", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
@@ -21,6 +21,11 @@ public class DisplayConfig {
     public TitleAndFooterConfig titleAndFooter = new TitleAndFooterConfig();
 
     @Expose
+    @ConfigOption(name = "Events Options", desc = "")
+    @Accordion
+    public EventsConfig eventsConfig = new EventsConfig();
+
+    @Expose
     @ConfigOption(name = "Hide Vanilla Scoreboard", desc = "Hide the vanilla scoreboard." +
         "\n§cUsing mods that add their own scoreboard will not be affected by this setting!")
     @ConfigEditorBoolean
@@ -37,12 +42,6 @@ public class DisplayConfig {
     @ConfigOption(name = "Show unclaimed bits", desc = "Show the amount of available Bits that can still be claimed.")
     @ConfigEditorBoolean
     public boolean showUnclaimedBits = false;
-
-    @Expose
-    @ConfigOption(name = "Show all active events", desc = "Show all active events in the scoreboard instead of one.")
-    @ConfigEditorBoolean
-    public boolean showAllActiveEvents = false;
-
 
     @Expose
     @ConfigOption(name = "Show Magical Power", desc = "Show your amount of Magical Power in the scoreboard.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/EventsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/EventsConfig.java
@@ -19,9 +19,8 @@ public class EventsConfig {
     @ConfigEditorDraggableList()
     public List<ScoreboardEvents> eventEntries = new ArrayList<>(ScoreboardEvents.defaultOption);
 
-
     @Expose
-    @ConfigOption(name = "Show all active events", desc = "Show all active events in the scoreboard instead of one.")
+    @ConfigOption(name = "Show all active events", desc = "Show all active events in the scoreboard instead of the one with the highest priority.")
     @ConfigEditorBoolean
     public boolean showAllActiveEvents = false;
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/EventsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/EventsConfig.java
@@ -1,10 +1,24 @@
 package at.hannibal2.skyhanni.config.features.gui.customscoreboard;
 
+import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardEvents;
 import com.google.gson.annotations.Expose;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorDraggableList;
 import io.github.moulberry.moulconfig.annotations.ConfigOption;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class EventsConfig {
+
+    @Expose
+    @ConfigOption(
+        name = "Events Priority",
+        desc = "Drag your list to select the priority of each event."
+    )
+    @ConfigEditorDraggableList()
+    public List<ScoreboardEvents> eventEntries = new ArrayList<>(ScoreboardEvents.getEntries());
+
 
     @Expose
     @ConfigOption(name = "Show all active events", desc = "Show all active events in the scoreboard instead of one.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/EventsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/EventsConfig.java
@@ -1,0 +1,14 @@
+package at.hannibal2.skyhanni.config.features.gui.customscoreboard;
+
+import com.google.gson.annotations.Expose;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.moulberry.moulconfig.annotations.ConfigOption;
+
+public class EventsConfig {
+
+    @Expose
+    @ConfigOption(name = "Show all active events", desc = "Show all active events in the scoreboard instead of one.")
+    @ConfigEditorBoolean
+    public boolean showAllActiveEvents = false;
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/EventsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/EventsConfig.java
@@ -17,7 +17,7 @@ public class EventsConfig {
         desc = "Drag your list to select the priority of each event."
     )
     @ConfigEditorDraggableList()
-    public List<ScoreboardEvents> eventEntries = new ArrayList<>(ScoreboardEvents.getEntries());
+    public List<ScoreboardEvents> eventEntries = new ArrayList<>(ScoreboardEvents.defaultOption);
 
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -18,6 +18,7 @@
 package at.hannibal2.skyhanni.features.gui.customscoreboard
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiPositionMovedEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -91,6 +92,7 @@ class CustomScoreboard {
     companion object {
         internal val config get() = SkyHanniMod.feature.gui.customScoreboard
         internal val displayConfig get() = config.displayConfig
+        internal val eventsConfig get() = displayConfig.eventsConfig
         internal val informationFilteringConfig get() = config.informationFilteringConfig
         internal val backgroundConfig get() = config.backgroundConfig
     }
@@ -160,4 +162,9 @@ class CustomScoreboard {
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
     private fun isHideVanillaScoreboardEnabled() = isEnabled() && config.displayConfig.hideVanillaScoreboard
+
+    @SubscribeEvent
+    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+        event.move(28, "gui.customscoreboard.displayConfig.showAllActiveEvents", "gui.customscoreboard.displayConfig.eventsConfig.showAllActiveEvents")
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -257,6 +257,7 @@ enum class ScoreboardElement(
             COPPER,
             NORTH_STARS,
             HEAT,
+            COLD,
             EMPTY_LINE,
             ISLAND,
             LOCATION,

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -238,6 +238,43 @@ enum class ScoreboardElement(
         if (!informationFilteringConfig.hideIrrelevantLines) return true
         return showWhen()
     }
+
+    companion object {
+        // I don't know why, but this field is needed for it to work
+        @kotlin.jvm.JvmField
+        val defaultOption = listOf(
+            TITLE,
+            PROFILE,
+            PURSE,
+            BANK,
+            MOTES,
+            BITS,
+            COPPER,
+            NORTH_STARS,
+            HEAT,
+            EMPTY_LINE,
+            ISLAND,
+            LOCATION,
+            LOBBY_CODE,
+            PLAYER_AMOUNT,
+            VISITING,
+            EMPTY_LINE2,
+            DATE,
+            TIME,
+            EVENTS,
+            OBJECTIVE,
+            EMPTY_LINE3,
+            QUIVER,
+            POWER,
+            TUNING,
+            EMPTY_LINE4,
+            POWDER,
+            MAYOR,
+            PARTY,
+            FOOTER,
+            EXTRA
+        )
+    }
 }
 
 private fun getTitleDisplayPair() = if (displayConfig.titleAndFooter.useHypixelTitleAnimation) {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -263,6 +263,7 @@ enum class ScoreboardElement(
             TIME,
             EVENTS,
             OBJECTIVE,
+            COOKIE,
             EMPTY_LINE3,
             QUIVER,
             POWER,

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -631,6 +631,7 @@ private fun getPowderShowWhen() = inAdvancedMiningIsland()
 
 private fun getEventsDisplayPair(): List<ScoreboardElementType> {
     return ScoreboardEvents.getEvent()
+        .filterNotNull()
         .flatMap { it.getLines().map { i -> i to HorizontalAlignment.LEFT } }
         .takeIf { it.isNotEmpty() } ?: listOf("<hidden>" to HorizontalAlignment.LEFT)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -183,7 +183,29 @@ enum class ScoreboardEvents(
 
         // I don't know why, but this field is needed for it to work
         @kotlin.jvm.JvmField
-        val defaultOption = listOf(VOTING, SERVER_CLOSE, DUNGEONS, KUUDRA, DOJO, DARK_AUCTION, JACOB_CONTEST, JACOB_MEDALS, TRAPPER, GARDEN_CLEAN_UP, GARDEN_PASTING, FLIGHT_DURATION, WINTER, SPOOKY, BROODMOTHER, MINING_EVENTS, DAMAGE, MAGMA_BOSS, ESSENCE, EFFIGIES, ACTIVE_TABLIST_EVENTS)
+        val defaultOption = listOf(
+            VOTING,
+            SERVER_CLOSE,
+            DUNGEONS,
+            KUUDRA,
+            DOJO,
+            DARK_AUCTION,
+            JACOB_CONTEST,
+            JACOB_MEDALS,
+            TRAPPER,
+            GARDEN_CLEAN_UP,
+            GARDEN_PASTING,
+            FLIGHT_DURATION,
+            WINTER,
+            SPOOKY,
+            BROODMOTHER,
+            MINING_EVENTS,
+            DAMAGE,
+            MAGMA_BOSS,
+            ESSENCE,
+            EFFIGIES,
+            ACTIVE_TABLIST_EVENTS
+        )
     }
 }
 
@@ -271,8 +293,7 @@ private fun getDarkAuctionLines() = buildList {
     getSbLines().firstOrNull { SbPattern.startingInPattern.matches(it) }?.let { add(it) }
     getSbLines().firstOrNull { SbPattern.timeLeftPattern.matches(it) }?.let { add(it) }
 
-    val darkAuctionCurrentItemLine =
-        getSbLines().firstOrNull { SbPattern.darkAuctionCurrentItemPattern.matches(it) }
+    val darkAuctionCurrentItemLine = getSbLines().firstOrNull { SbPattern.darkAuctionCurrentItemPattern.matches(it) }
 
     if (darkAuctionCurrentItemLine != null) {
         add(darkAuctionCurrentItemLine)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -32,104 +32,143 @@ private fun getSbLines(): List<String> {
     return ScoreboardData.sidebarLinesFormatted
 }
 
-enum class ScoreboardEvents(private val displayLine: Supplier<List<String>>, private val showWhen: () -> Boolean) {
+enum class ScoreboardEvents(
+    private val displayLine: Supplier<List<String>>,
+    private val showWhen: () -> Boolean,
+    private val configLine: String
+) {
     VOTING(
         ::getVotingLines,
-        ::getVotingShowWhen
+        ::getVotingShowWhen,
+        "§7(All Voting Lines)"
     ),
     SERVER_CLOSE(
         ::getServerCloseLines,
-        ::getServerCloseShowWhen
+        ::getServerCloseShowWhen,
+        "§cServer closing soon!"
     ),
     DUNGEONS(
         ::getDungeonsLines,
-        ::getDungeonsShowWhen
+        ::getDungeonsShowWhen,
+        "§7(All Dungeons Lines)"
     ),
     KUUDRA(
         ::getKuudraLines,
-        ::getKuudraShowWhen
+        ::getKuudraShowWhen,
+        "§7(All Kuudra Lines)"
     ),
     DOJO(
         ::getDojoLines,
-        ::getDojoShowWhen
+        ::getDojoShowWhen,
+        "§7(ALl Dojo Lines)"
     ),
     DARK_AUCTION(
         ::getDarkAuctionLines,
-        ::getDarkAuctionShowWhen
+        ::getDarkAuctionShowWhen,
+        "Time Left: §b11\n" +
+            "Current Item:\n" +
+            " §5Travel Scroll to Sirius"
     ),
     JACOB_CONTEST(
         ::getJacobContestLines,
-        ::getJacobContestShowWhen
+        ::getJacobContestShowWhen,
+        "§eJacob's Contest\n" +
+            "§e○ §fCarrot §a18m17s\n" +
+            " Collected §e8,264"
     ),
     JACOB_MEDALS(
         ::getJacobMedalsLines,
-        ::getJacobMedalsShowWhen
+        ::getJacobMedalsShowWhen,
+        "§6§lGOLD §fmedals: §613\n" +
+            "§f§lSILVER §fmedals: §f3\n" +
+            "§c§lBRONZE §fmedals: §c4"
     ),
     TRAPPER(
         ::getTrapperLines,
-        ::getTrapperShowWhen
+        ::getTrapperShowWhen,
+        "Pelts: §5711\n" +
+            "Tracker Mob Location:\n" +
+            "§bMushroom Gorge"
     ),
     GARDEN_CLEAN_UP(
         ::getGardenCleanUpLines,
-        ::getGardenCleanUpShowWhen
+        ::getGardenCleanUpShowWhen,
+        "Cleanup: §c12.6%"
     ),
     GARDEN_PASTING(
         ::getGardenPastingLines,
-        ::getGardenPastingShowWhen
+        ::getGardenPastingShowWhen,
+        "§fBarn Pasting§7: §e12.3%"
     ),
     FLIGHT_DURATION(
         ::getFlightDurationLines,
-        ::getFlightDurationShowWhen
+        ::getFlightDurationShowWhen,
+        "Flight Duration: §a10m 0s"
     ),
     WINTER(
         ::getWinterLines,
-        ::getWinterShowWhen
+        ::getWinterShowWhen,
+        "§7(All Winter Event Lines)"
     ),
     SPOOKY(
         ::getSpookyLines,
-        ::getSpookyShowWhen
+        ::getSpookyShowWhen,
+        "§7(All Spooky Event Lines)"
     ),
     BROODMOTHER(
         ::getBroodmotherLines,
-        ::getBroodmotherShowWhen
-    ),
-    ORINGO(
-        ::getOringoLines,
-        ::getOringoShowWhen
+        ::getBroodmotherShowWhen,
+        "§4Broodmother§7: §eDormant"
     ),
     MINING_EVENTS(
         ::getMiningEventsLines,
-        ::getMiningEventsShowWhen
+        ::getMiningEventsShowWhen,
+        "§7(All Mining Event Lines)"
     ),
     DAMAGE(
         ::getDamageLines,
-        ::getDamageShowWhen
+        ::getDamageShowWhen,
+        "Dragon HP: §a6,180,925 §c❤\n" +
+            "Your Damage: §c375,298.5"
     ),
     MAGMA_BOSS(
         ::getMagmaBossLines,
-        ::getMagmaBossShowWhen
+        ::getMagmaBossShowWhen,
+        "§7(All Magma Boss Lines)\n" +
+            "§7Boss: §c0%\n" +
+            "§7Damage Soaked:\n" +
+            "§e▎▎▎▎▎▎▎▎▎▎▎▎▎▎▎▎▎▎▎▎§7▎▎▎▎▎"
     ),
     ESSENCE(
         ::getEssenceLines,
-        ::getEssenceShowWhen
+        ::getEssenceShowWhen,
+        "Dragon Essence: §d1,285"
     ),
     EFFIGIES(
         ::getEffigiesLines,
-        ::getEffigiesShowWhen
+        ::getEffigiesShowWhen,
+        "Effigies: §c⧯§c⧯⧯§7⧯§c⧯§c⧯"
     ),
     ACTIVE_TABLIST_EVENTS(
         ::getActiveEventLine,
-        ::getActiveEventShowWhen
+        ::getActiveEventShowWhen,
+        "§7(All Active Tablist Events)"
     ),
     REDSTONE(
         ::getRedstoneLines,
-        ::getRedstoneShowWhen
+        ::getRedstoneShowWhen,
+        "§e§l⚡ §cRedstone: §e§b7%"
     ),
 
     NONE(
         ::getNoneLines,
-        { false }
+        { false },
+        "§cNo Events."
     );
+
+    override fun toString(): String {
+        return configLine
+    }
 
     fun getLines(): List<String> {
         return displayLine.get()

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.gui.customscoreboard
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ScoreboardData
-import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.config
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.eventsConfig
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardEvents.VOTING
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
@@ -60,7 +59,7 @@ enum class ScoreboardEvents(
     DOJO(
         ::getDojoLines,
         ::getDojoShowWhen,
-        "§7(ALl Dojo Lines)"
+        "§7(All Dojo Lines)"
     ),
     DARK_AUCTION(
         ::getDarkAuctionLines,
@@ -159,12 +158,7 @@ enum class ScoreboardEvents(
         ::getRedstoneShowWhen,
         "§e§l⚡ §cRedstone: §e§b7%"
     ),
-
-    NONE(
-        ::getNoneLines,
-        { false },
-        "§cNo Events."
-    );
+    ;
 
     override fun toString(): String {
         return configLine
@@ -175,11 +169,16 @@ enum class ScoreboardEvents(
     }
 
     companion object {
-        fun getEvent(): List<ScoreboardEvents> {
+        fun getEvent() = buildList<ScoreboardEvents?> {
             if (eventsConfig.showAllActiveEvents) {
-                return entries.filter { it.showWhen() }
+                for (event in eventsConfig.eventEntries) {
+                    if (event.showWhen()) {
+                        add(event)
+                    }
+                }
+            } else {
+                add(eventsConfig.eventEntries.firstOrNull { it.showWhen() })
             }
-            return listOf(entries.firstOrNull { it.showWhen() } ?: NONE)
         }
     }
 }
@@ -514,11 +513,4 @@ private fun getRedstoneLines(): List<String> {
 
 private fun getRedstoneShowWhen(): Boolean {
     return SbPattern.redstonePattern.anyMatches(getSbLines())
-}
-
-private fun getNoneLines(): List<String> {
-    return when {
-        config.informationFilteringConfig.hideEmptyLines -> listOf("<hidden>")
-        else -> listOf("§cNo Event")
-    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.config
+import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.eventsConfig
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardEvents.VOTING
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
 import at.hannibal2.skyhanni.features.misc.ServerRestartTitle
@@ -136,7 +137,7 @@ enum class ScoreboardEvents(private val displayLine: Supplier<List<String>>, pri
 
     companion object {
         fun getEvent(): List<ScoreboardEvents> {
-            if (config.displayConfig.showAllActiveEvents) {
+            if (eventsConfig.showAllActiveEvents) {
                 return entries.filter { it.showWhen() }
             }
             return listOf(entries.firstOrNull { it.showWhen() } ?: NONE)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -180,6 +180,10 @@ enum class ScoreboardEvents(
                 add(eventsConfig.eventEntries.firstOrNull { it.showWhen() })
             }
         }
+
+        // I don't know why, but this field is needed for it to work
+        @kotlin.jvm.JvmField
+        val defaultOption = listOf(VOTING, SERVER_CLOSE, DUNGEONS, KUUDRA, DOJO, DARK_AUCTION, JACOB_CONTEST, JACOB_MEDALS, TRAPPER, GARDEN_CLEAN_UP, GARDEN_PASTING, FLIGHT_DURATION, WINTER, SPOOKY, BROODMOTHER, MINING_EVENTS, DAMAGE, MAGMA_BOSS, ESSENCE, EFFIGIES, ACTIVE_TABLIST_EVENTS)
     }
 }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -307,7 +307,7 @@ object ScoreboardPattern {
     )
     val dojoPointsPattern by miscSb.pattern(
         "dojopoints",
-        "^(§.)*Points: (§.)*[\\w.]+( §7\\(§.*§7\\))?$"
+        "^(§.)*Points: (§.)*[\\w.]+ ?(§7\\(§.*§7\\))?\$"
     )
     val dojoTimePattern by miscSb.pattern(
         "dojotime",


### PR DESCRIPTION
## What
Describe what this pull request does, including technical details, screenshots, links to discord, etc.


## Changelog Improvements
+ Added customisable Events Priority in Custom Scoreboard. - j10a1n15
    * Using a draggable list, you can fully customise, what events will be shown which what priority.
+ Updated default Scoreboard Elements config option. - j10a1n15