### PR TITLE
Fix: Typo in Fishing "Contest"

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SharkFishCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SharkFishCounter.kt
@@ -58,7 +58,7 @@ class SharkFishCounter {
         val g = counter[3] // Great White
         val total = count.addSeparators()
         val funnyComment = funnyComment(count)
-        ChatUtils.chat("You caught $total §f(§a$n §9$b §5$t §6$g§f) §esharks during this fishing contest. $funnyComment")
+        ChatUtils.chat("You caught $total §f(§a$n §9$b §5$t §6$g§f) §esharks during this fishing festival. $funnyComment")
         counter = mutableListOf(0, 0, 0, 0)
         display = ""
     }


### PR DESCRIPTION
## What
Changes the text displayed after a Fishing Festival from "fishing contest" to "fishing festival".

## Changelog Fixes
+ Renamed "fishing contest" to "fishing festival". - Empa