### PR TITLE
Improvement: Add Curse of Greed to non-God Potion effects

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
@@ -68,6 +68,8 @@ class NonGodPotEffectDisplay {
 
         PEST_REPELLENT("§6Pest Repellent I§r"),
         PEST_REPELLENT_MAX("§6Pest Repellent II"),
+
+        CURSE_OF_GREED("§4Curse of Greed I"),
         ;
     }
 


### PR DESCRIPTION
## What
Added Curse of Greed to non-God Potion effect display.

Doesn't really work perfectly, as there is no chat message when it activates or expires, but that can be fixed outside the scope of this PR later by updating durations from the tab list more frequently.

## Changelog Improvements
+ Added "Curse of Greed" to non-God Potion effect display. - Alexia Luna