### PR TITLE
Fix: NEUInternalName is null for item name 'Mushroom'

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/CollectionAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/CollectionAPI.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.NEUInternalName
+import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
@@ -35,13 +36,17 @@ object CollectionAPI {
 
     val collectionValue = mutableMapOf<NEUInternalName, Long>()
 
+    private val incorrectCollectionNames = mapOf(
+        "Mushroom" to "RED_MUSHROOM".asInternalName()
+    )
+
     @SubscribeEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
         collectionValue.clear()
     }
 
     @SubscribeEvent
-    fun onTick(event: InventoryFullyOpenedEvent) {
+    fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         val inventoryName = event.inventoryName
         if (inventoryName.endsWith(" Collection")) {
             val stack = event.inventoryItems[4] ?: return
@@ -49,7 +54,8 @@ object CollectionAPI {
                 singleCounterPattern.matchMatcher(line) {
                     val counter = group("amount").formatLong()
                     val name = inventoryName.split(" ").dropLast(1).joinToString(" ")
-                    collectionValue[NEUInternalName.fromItemName(name)] = counter
+                    val internalName = incorrectCollectionNames[name] ?: NEUInternalName.fromItemName(name)
+                    collectionValue[internalName] = counter
                 }
             }
             CollectionUpdateEvent().postAndCatch()
@@ -69,10 +75,11 @@ object CollectionAPI {
                     name = name.split(" ").dropLast(1).joinToString(" ")
                 }
 
+                val internalName = incorrectCollectionNames[name] ?: NEUInternalName.fromItemName(name)
                 loop@ for (line in lore) {
                     counterPattern.matchMatcher(line) {
                         val counter = group("amount").formatLong()
-                        collectionValue[NEUInternalName.fromItemName(name)] = counter
+                        collectionValue[internalName] = counter
                     }
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -28,7 +28,7 @@ object DebugCommand {
                 if (search.equalsIgnoreColor("all")) {
                     "search for everything:"
                 } else "search '$search':"
-            } else "search is not specified, show only interesting stuff:"
+            } else "no search specified, only showing interesting stuff:"
         )
 
         val event = DebugDataCollectEvent(list, search)

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
@@ -1,5 +1,7 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.test.command.ErrorManager
+
 class NEUInternalName private constructor(private val internalName: String) {
 
     companion object {
@@ -20,7 +22,10 @@ class NEUInternalName private constructor(private val internalName: String) {
         fun fromItemNameOrNull(itemName: String): NEUInternalName? = ItemNameResolver.getInternalNameOrNull(itemName)
 
         fun fromItemName(itemName: String): NEUInternalName =
-            fromItemNameOrNull(itemName) ?: throw Error("NEUInternalName is null for item name '$itemName'")
+            fromItemNameOrNull(itemName) ?: ErrorManager.skyHanniError(
+                "NEUInternalName is null for item name: '$itemName'",
+                "inventoryName" to InventoryUtils.openInventoryName()
+            )
     }
 
     fun asString() = internalName


### PR DESCRIPTION
## What
Added more debug to show current inventory name when getting internal name from item name fails which helps to debug a few different cases. Also fixed the error where item name 'Mushroom' has no internal name. It is currently just mapped to RED_MUSHROOM but all features that use this list don't support mushroom anyways.
- Also reworded something in shdebug because it sounded weird

## Changelog Fixes
+ Fixed NEUInternalName is null for item name 'Mushroom'. - CalMWolfs

## Changelog Technical Details
+ Added more debug when internal name from item name is null. - CalMWolfs

