### PR TITLE
Removed Feature: Colored Visitor Name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.java
@@ -78,12 +78,6 @@ public class VisitorConfig {
     }
 
     @Expose
-    @ConfigOption(name = "Colored Name", desc = "Show the visitor name in the color of the rarity.")
-    @ConfigEditorBoolean
-    @FeatureToggle
-    public boolean coloredName = true;
-
-    @Expose
     @ConfigOption(name = "Hypixel Message", desc = "Hide the chat message from Hypixel that a new visitor has arrived at your garden.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorColorNames.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorColorNames.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.garden.visitor
 
 import at.hannibal2.skyhanni.data.jsonobjects.repo.GardenJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -24,8 +23,6 @@ object GardenVisitorColorNames {
     }
 
     fun getColoredName(name: String): String {
-        if (!GardenAPI.config.visitors.coloredName) return name
-
         val cleanName = name.removeColor()
         val color = visitorColours[cleanName] ?: return name
         return color + cleanName

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -592,18 +592,6 @@ class GardenVisitorFeatures {
         return false
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGH)
-    fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityLivingBase>) {
-        if (!config.coloredName) return
-        val entity = event.entity
-        val entityId = entity.entityId
-        for (visitor in VisitorAPI.getVisitors()) {
-            if (visitor.nameTagEntityId == entityId) {
-                entity.customNameTag = GardenVisitorColorNames.getColoredName(entity.name)
-            }
-        }
-    }
-
     @SubscribeEvent
     fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Garden Visitor Stats")


### PR DESCRIPTION
## What
Removed the Colored Name option for Garden visitors, as Hypixel has added this feature themselves.

<details>
<summary>Images</summary>

This is vanilla Minecraft 1.8.9.

![Screenshot showing Garden visitors with colored names in a vanilla Minecraft instance](https://github.com/hannibal002/SkyHanni/assets/148620615/ad999374-07e8-4604-8c7f-1b50cde34d95)

</details>

## Changelog Removed Features
+ Removed colored name tag option for Garden visitors. - Alexia Luna
    * Hypixel has added this feature themselves.

