### PR TITLE
Improvement + Fix: Lane Detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/LaneSwitchSoundSettings.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/LaneSwitchSoundSettings.java
@@ -24,7 +24,10 @@ public class LaneSwitchSoundSettings {
     public Runnable testSound = FarmingLaneFeatures::playUserSound;
 
     @Expose
-    @ConfigOption(name = "Repeat Duration", desc = "Change in how many ticks the sound will repeat. Change to 20 for only once per second.")
+    @ConfigOption(
+        name = "Repeat Duration",
+        desc = "Change how often the sound should be repeated in ticks. Change to 20 for only once per second."
+    )
     @ConfigEditorSlider(minValue = 1, maxValue = 20, minStep = 1)
     public int repeatDuration = 20;
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/LaneSwitchSoundSettings.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/LaneSwitchSoundSettings.java
@@ -23,6 +23,11 @@ public class LaneSwitchSoundSettings {
     @ConfigEditorButton(buttonText = "Test")
     public Runnable testSound = FarmingLaneFeatures::playUserSound;
 
+    @Expose
+    @ConfigOption(name = "Repeat Duration", desc = "Change in how many ticks the sound will repeat. Change to 20 for only once per second.")
+    @ConfigEditorSlider(minValue = 1, maxValue = 20, minStep = 1)
+    public int repeatDuration = 20;
+
     @ConfigOption(name = "List of Sounds", desc = "A list of available sounds.")
     @ConfigEditorButton(buttonText = "Open")
     public Runnable listOfSounds = () -> OSUtils.openBrowser("https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/mapping-and-modding-tutorials/2213619-1-8-all-playsound-sound-arguments");

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -143,7 +143,12 @@ object GardenAPI {
 
     fun inGarden() = IslandType.GARDEN.isInIsland()
 
-    fun isCurrentlyFarming() = inGarden() && GardenCropSpeed.averageBlocksPerSecond > 0.0
+    fun isCurrentlyFarming() = inGarden() && GardenCropSpeed.averageBlocksPerSecond > 0.0 && hasFarmingToolInHand()
+
+    fun hasFarmingToolInHand() = InventoryUtils.getItemInHand()?.let {
+        val crop = it.getCropType()
+        getToolInHand(it, crop) != null
+    } ?: false
 
     fun ItemStack.getCropType(): CropType? {
         val internalName = getInternalName()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneAPI.kt
@@ -17,21 +17,15 @@ object FarmingLaneAPI {
     val lanes get() = GardenAPI.storage?.farmingLanes
     var currentLane: FarmingLane? = null
     private var lastNoLaneWarning = SimpleTimeMark.farPast()
-    private var lastCrop: CropType? = null
 
     @SubscribeEvent
     fun onGardenToolChange(event: GardenToolChangeEvent) {
-        handleLaneSwitch(event.crop)
+        currentLane = null
     }
 
     @SubscribeEvent
     fun onCropClick(event: CropClickEvent) {
-        handleLaneSwitch(event.crop)
-    }
-
-    private fun handleLaneSwitch(crop: CropType?) {
-        if (crop == lastCrop) return
-        lastCrop = crop
+        val crop = event.crop
 
         val lanes = lanes ?: return
         val lane = lanes[crop]
@@ -46,6 +40,8 @@ object FarmingLaneAPI {
 
     private fun warnNoLane(crop: CropType?) {
         if (crop == null || currentLane != null) return
+        if (!GardenAPI.isCurrentlyFarming()) return
+        if (FarmingLaneCreator.detection) return
         if (!config.distanceDisplay && !config.laneSwitchNotification.enabled) return
 
         if (lastNoLaneWarning.passedSince() < 30.seconds) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneCreator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneCreator.kt
@@ -54,7 +54,7 @@ object FarmingLaneCreator {
             reset()
             return
         }
-        if (lastLocation.distance(location) < 1) return
+        if (lastLocation.distance(location) < 0.5) return
 
         this.lastLocation = location
         val start = start ?: error("start can not be null")
@@ -67,7 +67,7 @@ object FarmingLaneCreator {
                 potentialEnd = location
                 return
             }
-            if (potentialEnd.distance(location) > 5) {
+            if (potentialEnd.distance(location) > 2) {
                 val crop = crop ?: error("crop can not be null")
                 saveLane(start, potentialEnd, crop)
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneCreator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneCreator.kt
@@ -19,7 +19,7 @@ import kotlin.math.min
 object FarmingLaneCreator {
     val config get() = FarmingLaneAPI.config
 
-    private var detection = false
+    var detection = false
     private var start: LorenzVec? = null
     private var lastLocation: LorenzVec? = null
     private var potentialEnd: LorenzVec? = null

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.farming.lane
 
+import at.hannibal2.skyhanni.events.GardenToolChangeEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
@@ -39,6 +40,11 @@ object FarmingLaneFeatures {
 
     @SubscribeEvent
     fun onFarmingLaneSwitch(event: FarmingLaneSwitchEvent) {
+        display = emptyList()
+    }
+
+    @SubscribeEvent
+    fun onGardenToolChange(event: GardenToolChangeEvent) {
         display = emptyList()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.TimeUtils.ticks
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.math.absoluteValue
 import kotlin.time.Duration
@@ -37,6 +38,7 @@ object FarmingLaneFeatures {
     private var lastSpeed = 0.0
     private var validSpeed = false
     private var lastTimeFarming = SimpleTimeMark.farPast()
+    private var lastPlaySound = SimpleTimeMark.farPast()
     private var lastDirection = 0
 
     @SubscribeEvent
@@ -121,7 +123,10 @@ object FarmingLaneFeatures {
         with(config.laneSwitchNotification) {
             if (enabled) {
                 LorenzUtils.sendTitle(text.replace("&", "§"), 2.seconds)
-                playUserSound()
+                if (lastPlaySound.passedSince() >= sound.repeatDuration.ticks) {
+                    lastPlaySound = SimpleTimeMark.now()
+                    playUserSound()
+                }
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.farming.FarmingLaneSwitchEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.garden.farming.lane.FarmingLaneAPI.getValue
 import at.hannibal2.skyhanni.features.garden.farming.lane.FarmingLaneAPI.setValue
+import at.hannibal2.skyhanni.features.misc.MovementSpeedDisplay
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -126,7 +127,7 @@ object FarmingLaneFeatures {
     }
 
     private fun calculateSpeed(): Boolean {
-        val speedPerSecond = LocationUtils.distanceFromPreviousTick().round(2)
+        val speedPerSecond = MovementSpeedDisplay.speedInLastTick.round(2)
         if (speedPerSecond == 0.0) return false
         val speedTooSlow = speedPerSecond < 1
         if (speedTooSlow) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MovementSpeedDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MovementSpeedDisplay.kt
@@ -3,20 +3,48 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.enums.OutsideSbFeature
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.round
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
+import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.concurrent.fixedRateTimer
 
 class MovementSpeedDisplay {
 
     private val config get() = SkyHanniMod.feature.misc
 
+    private var display = ""
+
+    companion object {
+        var speedInLastTick = 0.0
+    }
+
+    init {
+        fixedRateTimer(name = "skyhanni-movement-speed-display", period = 250, initialDelay = 1_000) {
+            checkSpeed()
+        }
+    }
+
+    private fun checkSpeed() {
+        if (!isEnabled()) return
+
+        speedInLastTick = with(Minecraft.getMinecraft().thePlayer) {
+            val oldPos = LorenzVec(prevPosX, prevPosY, prevPosZ)
+            val newPos = LorenzVec(posX, posY, posZ)
+
+            // Distance from previous tick, multiplied by TPS
+            oldPos.distance(newPos) * 20
+        }
+        display = "Movement Speed: ${speedInLastTick.round(2)}"
+    }
+
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
 
-        config.playerMovementSpeedPos.renderString("Movement Speed: ${LocationUtils.distanceFromPreviousTick()}", posLabel = "Movement Speed")
+        config.playerMovementSpeedPos.renderString(display, posLabel = "Movement Speed")
     }
 
     fun isEnabled() = LorenzUtils.onHypixel &&

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.utils
 
-import at.hannibal2.skyhanni.utils.LorenzUtils.round
 import net.minecraft.client.Minecraft
 import net.minecraft.entity.Entity
 import net.minecraft.util.AxisAlignedBB
@@ -11,13 +10,6 @@ object LocationUtils {
         Minecraft.getMinecraft().theWorld.rayTraceBlocks(a.toVec3(), b.toVec3(), false, true, false) == null
 
     fun playerLocation() = Minecraft.getMinecraft().thePlayer.getLorenzVec()
-
-    fun distanceFromPreviousTick(): Double = with(Minecraft.getMinecraft().thePlayer) {
-        val oldPos = LorenzVec(prevPosX, prevPosY, prevPosZ)
-        val newPos = LorenzVec(posX, posY, posZ)
-
-        (oldPos.distance(newPos) * 20).round(2)
-    }
 
     fun LorenzVec.distanceToPlayer() = distance(playerLocation())
 


### PR DESCRIPTION
## What
fix lane corners showing while not farming and code cleanup

## Changelog Improvements
+ Lane detection works faster now. - hannibal2
+ Added option to change how often the Lane Switch sound should play. - hannibal2

## Changelog Fixes
+ Fix lane corners showing while not farming. - hannibal2
+ Fix Movement Speed display while on soulsand. - hannibal2
+ Fix Farming Lane time remaining display while on soulsand. - hannibal2

## Changelog Technical Details
+ Removed distanceFromPreviousTick as it is not accurate while on soulsand. - hannibal2