### PR TITLE
Fix: Lane Switch again

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MovementSpeedDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MovementSpeedDisplay.kt
@@ -28,7 +28,7 @@ class MovementSpeedDisplay {
     }
 
     private fun checkSpeed() {
-        if (!isEnabled()) return
+        if (!LorenzUtils.onHypixel) return
 
         speedInLastTick = with(Minecraft.getMinecraft().thePlayer) {
             val oldPos = LorenzVec(prevPosX, prevPosY, prevPosZ)
@@ -37,7 +37,9 @@ class MovementSpeedDisplay {
             // Distance from previous tick, multiplied by TPS
             oldPos.distance(newPos) * 20
         }
-        display = "Movement Speed: ${speedInLastTick.round(2)}"
+        if (isEnabled()) {
+            display = "Movement Speed: ${speedInLastTick.round(2)}"
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Lane switch now uses `MovementSpeedDisplay.speedInLastTick`. But this only gets updated when the feature `Movement Speed` is enabled. This pull request changes that this data gets updated all the time.

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fixed Lane Detection warning and time remaining not working when movement speed feature is disabled. - hannibal2