### PR TITLE
Fix: Typo in not clickable items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -273,7 +273,7 @@ class HideNotClickableItems {
         }
 
         if (ItemUtils.isSkyBlockMenuItem(stack)) {
-            hideReason = "The SkyBlock Menu cannot be put into the potion bag!"
+            hideReason = "The SkyBlock Menu cannot be put into your equipment!"
             return true
         }
 


### PR DESCRIPTION
## What
Fixes a typo in the Not Clickable Items feature, when hovering over the SkyBlock Menu while in the `/equipment` menu.

## Changelog Fixes
+ Fix a typo in Not Clickable Items in the /equipment menu. - martimavocado

