### PR TITLE
Fix: Lane Switch Warning (part 5)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -42,7 +42,7 @@ object FarmingLaneFeatures {
     private var movementState = MovementState.CALCULATING
 
     enum class MovementState(val label: String) {
-        NOT_MOVING("§eMove to update!"),
+        NOT_MOVING("§ePaused"),
         TOO_SLOW("§cToo slow!"),
         CALCULATING("§aCalculating.."),
         NORMAL(""),
@@ -167,18 +167,22 @@ object FarmingLaneFeatures {
     }
 
     private fun calculateMovementState(speed: Double): MovementState {
-        if (speed == 0.0) return MovementState.NOT_MOVING
+        if (lastSpeed != speed) {
+            lastSpeed = speed
+            sameSpeedCounter = 0
+        }
+        sameSpeedCounter++
+
+        if (speed == 0.0 && sameSpeedCounter > 1) {
+            return MovementState.NOT_MOVING
+        }
         val speedTooSlow = speed < 1
-        if (speedTooSlow) return MovementState.TOO_SLOW
+        if (speedTooSlow && sameSpeedCounter > 5) {
+            return MovementState.TOO_SLOW
+        }
         // only calculate the time if the speed has not changed
         if (!MovementSpeedDisplay.usingSoulsandSpeed) {
-            if (lastSpeed != speed) {
-                lastSpeed = speed
-                sameSpeedCounter = 0
-                return MovementState.CALCULATING
-            }
-            sameSpeedCounter++
-            if (sameSpeedCounter < 5) {
+            if (sameSpeedCounter < 6) {
                 return MovementState.CALCULATING
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -85,7 +85,7 @@ object FarmingLaneFeatures {
                 } else ""
                 add("§7Time remaining: $color$format$suffix")
                 if (MovementSpeedDisplay.usingSoulsandSpeed) {
-                    add("§7Using inaccurate soulsand speed!")
+                    add("§7Using inaccurate soul sand speed!")
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MovementSpeedDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MovementSpeedDisplay.kt
@@ -3,11 +3,14 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.enums.OutsideSbFeature
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
+import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.round
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import net.minecraft.client.Minecraft
+import net.minecraft.init.Blocks
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.concurrent.fixedRateTimer
 
@@ -16,9 +19,11 @@ class MovementSpeedDisplay {
     private val config get() = SkyHanniMod.feature.misc
 
     private var display = ""
+    private val soulsandSpeeds = mutableListOf<Double>()
 
     companion object {
-        var speedInLastTick = 0.0
+        var speed = 0.0
+        var usingSoulsandSpeed = false
     }
 
     init {
@@ -30,15 +35,26 @@ class MovementSpeedDisplay {
     private fun checkSpeed() {
         if (!LorenzUtils.onHypixel) return
 
-        speedInLastTick = with(Minecraft.getMinecraft().thePlayer) {
+        speed = with(Minecraft.getMinecraft().thePlayer) {
             val oldPos = LorenzVec(prevPosX, prevPosY, prevPosZ)
             val newPos = LorenzVec(posX, posY, posZ)
 
             // Distance from previous tick, multiplied by TPS
             oldPos.distance(newPos) * 20
         }
+        val movingOnSoulsand = LocationUtils.playerLocation().getBlockAt() == Blocks.soul_sand && speed > 0.0
+        if (movingOnSoulsand) {
+            soulsandSpeeds.add(speed)
+            if (soulsandSpeeds.size > 6) {
+                speed = soulsandSpeeds.average()
+                soulsandSpeeds.removeAt(0)
+            }
+        } else {
+            soulsandSpeeds.clear()
+        }
+        usingSoulsandSpeed = movingOnSoulsand && soulsandSpeeds.size == 6
         if (isEnabled()) {
-            display = "Movement Speed: ${speedInLastTick.round(2)}"
+            display = "Movement Speed: ${speed.round(2)}"
         }
     }
 


### PR DESCRIPTION
## What
added a workaround for minecraft bug that broke soul sand walking speed calculation
supports soul sand farming, showing state of speed

## Changelog Fixes
+ Lane Switch warning and remaining time ETA now supports soul sand farming and shows the current state of movement. - hannibal2