### PR TITLE
Fix: Duplicate chat prefix in pv loading

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ChatClickActionManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatClickActionManager.kt
@@ -14,7 +14,7 @@ object ChatClickActionManager {
     }
 
     private fun ClickableAction.sendToChat() {
-        ChatUtils.clickableChat(message, "shaction $token")
+        ChatUtils.clickableChat(message, "shaction $token", prefix = false)
     }
 
     fun onCommand(args: Array<String>) {


### PR DESCRIPTION
## What
Fix duplicate chat prefix when using ChatClickActionManager
report on discord: https://discord.com/channels/997079228510117908/1220890375573733397

## Changelog Fixes
+ Fixed duplicate chat prefix when updating trophy fishing data from NEU PV. - hannibal2