### PR TITLE
Fix: OneConfig listing SkyHanni twice in their modlist

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiForgeInterop.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiForgeInterop.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config
 
+import cc.polyfrost.oneconfig.utils.IgnoredGuiFactory
 import io.github.moulberry.moulconfig.gui.GuiScreenElementWrapper
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiScreen
@@ -10,8 +11,7 @@ import org.lwjgl.input.Keyboard
 import java.io.IOException
 
 @Suppress("unused")
-class ConfigGuiForgeInterop : IModGuiFactory {
-
+class ConfigGuiForgeInterop : IModGuiFactory, IgnoredGuiFactory {
     override fun initialize(minecraft: Minecraft) {}
     override fun mainConfigGuiClass() = WrappedSkyHanniConfig::class.java
 

--- a/src/main/java/cc/polyfrost/oneconfig/utils/IgnoredGuiFactory.kt
+++ b/src/main/java/cc/polyfrost/oneconfig/utils/IgnoredGuiFactory.kt
@@ -1,0 +1,4 @@
+package cc.polyfrost.oneconfig.utils
+
+interface IgnoredGuiFactory {
+}


### PR DESCRIPTION
## What
fixes oneconfig showing skyhanni twice
![image](https://github.com/hannibal002/SkyHanni/assets/39881008/f6fbe29d-0542-4bd8-b121-45f2883f1d55)
still doesn't show the logo but that's an issue on their end

## Changelog Fixes
+ Fixes OneConfig listing SkyHanni twice. - martimavocado
