### PR TITLE
Improvement: Added wireframe as Totem of Corruption outline

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/TotemOfCorruptionConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/TotemOfCorruptionConfig.java
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.core.config.Position;
 import com.google.gson.annotations.Expose;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorColour;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorSlider;
 import io.github.moulberry.moulconfig.annotations.ConfigOption;
 
@@ -32,8 +33,26 @@ public class TotemOfCorruptionConfig {
 
     @Expose
     @ConfigOption(name = "Show Effective Area", desc = "Show the effective area (16 blocks) of the Totem of Corruption.")
-    @ConfigEditorBoolean
-    public boolean showEffectiveArea = true;
+    @ConfigEditorDropdown()
+    public OutlineType outlineType = OutlineType.FILLED;
+
+    public enum OutlineType {
+        NONE("No Outline"),
+        FILLED("Filled"),
+        WIREFRAME("Wireframe"),
+        ;
+
+        private final String str;
+
+        OutlineType(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public String toString() {
+            return str;
+        }
+    }
 
     @Expose
     @ConfigOption(name = "Color of the area", desc = "The color of the area of the Totem of Corruption.")

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.sendTitle
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.RenderUtils.drawSphereInWorld
+import at.hannibal2.skyhanni.utils.RenderUtils.drawSphereWireframeInWorld
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.SoundUtils.playPlingSound
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
@@ -82,7 +82,7 @@ class TotemOfCorruption {
         val color = config.color.toChromaColor()
         for (totem in totems) {
             // The center of the totem is the upper part
-            event.drawSphereInWorld(color, totem.location.add(y = 1), 16f)
+            event.drawSphereWireframeInWorld(color, totem.location.add(y = 1), 16f)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.fishing
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.features.fishing.TotemOfCorruptionConfig.OutlineType
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
@@ -11,6 +12,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.sendTitle
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.RenderUtils.drawSphereInWorld
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSphereWireframeInWorld
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.SoundUtils.playPlingSound
@@ -81,8 +83,18 @@ class TotemOfCorruption {
 
         val color = config.color.toChromaColor()
         for (totem in totems) {
-            // The center of the totem is the upper part
-            event.drawSphereWireframeInWorld(color, totem.location.add(y = 1), 16f)
+            // The center of the totem is the upper part of the armor stand
+            when (config.outlineType) {
+                OutlineType.FILLED -> {
+                    event.drawSphereInWorld(color, totem.location.add(y = 1), 16f)
+                }
+
+                OutlineType.WIREFRAME -> {
+                    event.drawSphereWireframeInWorld(color, totem.location.add(y = 1), 16f)
+                }
+
+                else -> return
+            }
         }
     }
 
@@ -132,7 +144,7 @@ class TotemOfCorruption {
 
     private fun isOverlayEnabled() = LorenzUtils.inSkyBlock && config.showOverlay
     private fun isHideParticlesEnabled() = LorenzUtils.inSkyBlock && config.hideParticles
-    private fun isEffectiveAreaEnabled() = LorenzUtils.inSkyBlock && config.showEffectiveArea
+    private fun isEffectiveAreaEnabled() = LorenzUtils.inSkyBlock && config.outlineType != OutlineType.NONE
 }
 
 class Totem(

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -785,6 +785,87 @@ object RenderUtils {
         GlStateManager.popMatrix()
     }
 
+    fun LorenzRenderWorldEvent.drawSphereWireframeInWorld(
+        color: Color,
+        location: LorenzVec,
+        radius: Float,
+    ) {
+        drawSphereWireframeInWorld(color, location.x, location.y, location.z, radius)
+    }
+
+    fun LorenzRenderWorldEvent.drawSphereWireframeInWorld(
+        color: Color,
+        x: Double,
+        y: Double,
+        z: Double,
+        radius: Float,
+    ) {
+        GlStateManager.pushMatrix()
+        GL11.glNormal3f(0.0f, 1.0f, 0.0f)
+
+        GlStateManager.disableTexture2D()
+        color.bindColor()
+
+        var x1 = x
+        var y1 = y
+        var z1 = z
+        val renderViewEntity = Minecraft.getMinecraft().renderViewEntity
+        val viewX =
+            renderViewEntity.prevPosX + (renderViewEntity.posX - renderViewEntity.prevPosX) * partialTicks.toDouble()
+        val viewY =
+            renderViewEntity.prevPosY + (renderViewEntity.posY - renderViewEntity.prevPosY) * partialTicks.toDouble()
+        val viewZ =
+            renderViewEntity.prevPosZ + (renderViewEntity.posZ - renderViewEntity.prevPosZ) * partialTicks.toDouble()
+        x1 -= viewX
+        y1 -= viewY
+        z1 -= viewZ
+
+        val tessellator = Tessellator.getInstance()
+        val worldrenderer = tessellator.worldRenderer
+        worldrenderer.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION)
+
+        val segments = 32
+
+        for (phi in 0 until segments) {
+            for (theta in 0 until segments * 2) {
+                val x2 = x1 + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
+                val y2 = y1 + radius * cos(Math.PI * phi / segments)
+                val z2 = z1 + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
+
+                val x3 = x1 + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
+                val y3 = y1 + radius * cos(Math.PI * (phi + 1) / segments)
+                val z3 = z1 + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
+
+                val x4 = x1 + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
+                val y4 = y1 + radius * cos(Math.PI * (phi + 1) / segments)
+                val z4 = z1 + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
+
+                val x5 = x1 + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
+                val y5 = y1 + radius * cos(Math.PI * phi / segments)
+                val z5 = z1 + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
+
+
+                worldrenderer.pos(x2, y2, z2).endVertex()
+                worldrenderer.pos(x3, y3, z3).endVertex()
+
+                worldrenderer.pos(x3, y3, z3).endVertex()
+                worldrenderer.pos(x4, y4, z4).endVertex()
+
+                worldrenderer.pos(x4, y4, z4).endVertex()
+                worldrenderer.pos(x5, y5, z5).endVertex()
+
+                worldrenderer.pos(x5, y5, z5).endVertex()
+                worldrenderer.pos(x2, y2, z2).endVertex()
+            }
+        }
+
+        tessellator.draw()
+
+        GlStateManager.enableTexture2D()
+        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f)
+        GlStateManager.popMatrix()
+    }
+
     private fun Color.bindColor() =
         GlStateManager.color(this.red / 255f, this.green / 255f, this.blue / 255f, this.alpha / 255f)
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -664,20 +664,8 @@ object RenderUtils {
         GlStateManager.enableAlpha()
         GlStateManager.disableTexture2D()
         color.bindColor()
+        bindCamera()
 
-        var x1 = x
-        var y1 = y
-        var z1 = z
-        val renderViewEntity = Minecraft.getMinecraft().renderViewEntity
-        val viewX =
-            renderViewEntity.prevPosX + (renderViewEntity.posX - renderViewEntity.prevPosX) * partialTicks.toDouble()
-        val viewY =
-            renderViewEntity.prevPosY + (renderViewEntity.posY - renderViewEntity.prevPosY) * partialTicks.toDouble()
-        val viewZ =
-            renderViewEntity.prevPosZ + (renderViewEntity.posZ - renderViewEntity.prevPosZ) * partialTicks.toDouble()
-        x1 -= viewX
-        y1 -= viewY
-        z1 -= viewZ
         val tessellator = Tessellator.getInstance()
         val worldrenderer = tessellator.worldRenderer
         worldrenderer.begin(GL11.GL_QUAD_STRIP, DefaultVertexFormats.POSITION)
@@ -686,12 +674,12 @@ object RenderUtils {
         while (currentAngle < 2 * Math.PI) {
             val xOffset = radius * cos(currentAngle.toDouble()).toFloat()
             val zOffset = radius * sin(currentAngle.toDouble()).toFloat()
-            worldrenderer.pos(x1 + xOffset, y1 + height, z1 + zOffset).endVertex()
-            worldrenderer.pos(x1 + xOffset, y1 + 0, z1 + zOffset).endVertex()
+            worldrenderer.pos(x + xOffset, y + height, z + zOffset).endVertex()
+            worldrenderer.pos(x + xOffset, y + 0, z + zOffset).endVertex()
             currentAngle += angleStep
         }
-        worldrenderer.pos(x1 + radius, y1 + height, z1).endVertex()
-        worldrenderer.pos(x1 + radius, y1 + 0.0, z1).endVertex()
+        worldrenderer.pos(x + radius, y + height, z).endVertex()
+        worldrenderer.pos(x + radius, y + 0.0, z).endVertex()
         tessellator.draw()
 
         GlStateManager.enableCull()
@@ -728,20 +716,7 @@ object RenderUtils {
         GlStateManager.enableAlpha()
         GlStateManager.disableTexture2D()
         color.bindColor()
-
-        var x1 = x
-        var y1 = y
-        var z1 = z
-        val renderViewEntity = Minecraft.getMinecraft().renderViewEntity
-        val viewX =
-            renderViewEntity.prevPosX + (renderViewEntity.posX - renderViewEntity.prevPosX) * partialTicks.toDouble()
-        val viewY =
-            renderViewEntity.prevPosY + (renderViewEntity.posY - renderViewEntity.prevPosY) * partialTicks.toDouble()
-        val viewZ =
-            renderViewEntity.prevPosZ + (renderViewEntity.posZ - renderViewEntity.prevPosZ) * partialTicks.toDouble()
-        x1 -= viewX
-        y1 -= viewY
-        z1 -= viewZ
+        bindCamera()
 
         val tessellator = Tessellator.getInstance()
         val worldrenderer = tessellator.worldRenderer
@@ -751,27 +726,27 @@ object RenderUtils {
 
         for (phi in 0 until segments) {
             for (theta in 0 until segments * 2) {
-                val x2 = x1 + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
-                val y2 = y1 + radius * cos(Math.PI * phi / segments)
-                val z2 = z1 + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
+                val x1 = x + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
+                val y1 = y + radius * cos(Math.PI * phi / segments)
+                val z1 = z + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
 
-                val x3 = x1 + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
-                val y3 = y1 + radius * cos(Math.PI * (phi + 1) / segments)
-                val z3 = z1 + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
+                val x2 = x + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
+                val y2 = y + radius * cos(Math.PI * (phi + 1) / segments)
+                val z2 = z + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
 
+                worldrenderer.pos(x1, y1, z1).endVertex()
                 worldrenderer.pos(x2, y2, z2).endVertex()
+
+                val x3 = x + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
+                val y3 = y + radius * cos(Math.PI * (phi + 1) / segments)
+                val z3 = z + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
+
+                val x4 = x + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
+                val y4 = y + radius * cos(Math.PI * phi / segments)
+                val z4 = z + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
+
                 worldrenderer.pos(x3, y3, z3).endVertex()
-
-                val x4 = x1 + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
-                val y4 = y1 + radius * cos(Math.PI * (phi + 1) / segments)
-                val z4 = z1 + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
-
-                val x5 = x1 + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
-                val y5 = y1 + radius * cos(Math.PI * phi / segments)
-                val z5 = z1 + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
-
                 worldrenderer.pos(x4, y4, z4).endVertex()
-                worldrenderer.pos(x5, y5, z5).endVertex()
             }
         }
 
@@ -805,20 +780,7 @@ object RenderUtils {
 
         GlStateManager.disableTexture2D()
         color.bindColor()
-
-        var x1 = x
-        var y1 = y
-        var z1 = z
-        val renderViewEntity = Minecraft.getMinecraft().renderViewEntity
-        val viewX =
-            renderViewEntity.prevPosX + (renderViewEntity.posX - renderViewEntity.prevPosX) * partialTicks.toDouble()
-        val viewY =
-            renderViewEntity.prevPosY + (renderViewEntity.posY - renderViewEntity.prevPosY) * partialTicks.toDouble()
-        val viewZ =
-            renderViewEntity.prevPosZ + (renderViewEntity.posZ - renderViewEntity.prevPosZ) * partialTicks.toDouble()
-        x1 -= viewX
-        y1 -= viewY
-        z1 -= viewZ
+        bindCamera()
 
         val tessellator = Tessellator.getInstance()
         val worldrenderer = tessellator.worldRenderer
@@ -828,22 +790,25 @@ object RenderUtils {
 
         for (phi in 0 until segments) {
             for (theta in 0 until segments * 2) {
-                val x2 = x1 + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
-                val y2 = y1 + radius * cos(Math.PI * phi / segments)
-                val z2 = z1 + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
+                val x1 = x + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
+                val y1 = y + radius * cos(Math.PI * phi / segments)
+                val z1 = z + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
 
-                val x3 = x1 + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
-                val y3 = y1 + radius * cos(Math.PI * (phi + 1) / segments)
-                val z3 = z1 + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
+                val x2 = x + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * theta / (segments * 2))
+                val y2 = y + radius * cos(Math.PI * (phi + 1) / segments)
+                val z2 = z + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * theta / (segments * 2))
 
-                val x4 = x1 + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
-                val y4 = y1 + radius * cos(Math.PI * (phi + 1) / segments)
-                val z4 = z1 + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
+                val x3 = x + radius * sin(Math.PI * (phi + 1) / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
+                val y3 = y + radius * cos(Math.PI * (phi + 1) / segments)
+                val z3 = z + radius * sin(Math.PI * (phi + 1) / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
 
-                val x5 = x1 + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
-                val y5 = y1 + radius * cos(Math.PI * phi / segments)
-                val z5 = z1 + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
+                val x4 = x + radius * sin(Math.PI * phi / segments) * cos(2.0 * Math.PI * (theta + 1) / (segments * 2))
+                val y4 = y + radius * cos(Math.PI * phi / segments)
+                val z4 = z + radius * sin(Math.PI * phi / segments) * sin(2.0 * Math.PI * (theta + 1) / (segments * 2))
 
+
+                worldrenderer.pos(x1, y1, z1).endVertex()
+                worldrenderer.pos(x2, y2, z2).endVertex()
 
                 worldrenderer.pos(x2, y2, z2).endVertex()
                 worldrenderer.pos(x3, y3, z3).endVertex()
@@ -852,10 +817,7 @@ object RenderUtils {
                 worldrenderer.pos(x4, y4, z4).endVertex()
 
                 worldrenderer.pos(x4, y4, z4).endVertex()
-                worldrenderer.pos(x5, y5, z5).endVertex()
-
-                worldrenderer.pos(x5, y5, z5).endVertex()
-                worldrenderer.pos(x2, y2, z2).endVertex()
+                worldrenderer.pos(x1, y1, z1).endVertex()
             }
         }
 
@@ -868,6 +830,14 @@ object RenderUtils {
 
     private fun Color.bindColor() =
         GlStateManager.color(this.red / 255f, this.green / 255f, this.blue / 255f, this.alpha / 255f)
+
+    private fun bindCamera() {
+        val renderManager = Minecraft.getMinecraft().renderManager
+        val viewer = renderManager.viewerPosX
+        val viewY = renderManager.viewerPosY
+        val viewZ = renderManager.viewerPosZ
+        GlStateManager.translate(-viewer, -viewY, -viewZ)
+    }
 
     fun drawStringScaledMaxWidth(
         str: String?,


### PR DESCRIPTION
## What
This Pull Request updates the Totem of Corruption feature to add a dropdown, where you can select different types of outlines.
Reason for this is the new addition of the wireframe.

<details>
<summary>Images</summary>


Wireframe

https://github.com/hannibal002/SkyHanni/assets/45315647/8bc1a2cb-716b-42d9-84b9-5671064a6a2e

<!-- drop images here -->

</details>

## Changelog Improvements
+ Added wireframe as a valid Totem of Corruption outline. - j10a1n15

## Changelog Technical Details
+ Added bindCamera() method and started using it. - j10a1n15
