### PR TITLE
Fix: Fixed In-game Time in Scoreboard displaying 0 instead of 12

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -135,7 +135,7 @@ object TimeUtils {
         yearElement: Boolean = true,
         hoursAndMinutesElement: Boolean = true
     ): String {
-        val hour = if (this.hour > 12) this.hour - 12 else this.hour
+        val hour = (this.hour + 11) % 12 + 1
         val timeOfDay = if (this.hour > 11) "pm" else "am"
         val minute = this.minute.toString().padStart(2, '0')
         val month = SkyBlockTime.monthName(this.month)


### PR DESCRIPTION
## What
This Pull Request fixes the scoreboard time showing 0 instead of 12, this is **not** tested ingame, I only tested it [here (Kotlin Playground)](https://pl.kotl.in/E-WnTDe9P).


## Changelog Fixes
+ Fixed time in Custom Scoreboard displaying 0 instead of 12. - j10a1n15
