### PR TITLE
Improvement + Fix: Various limbo stats related fixes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -289,7 +289,7 @@ object Commands {
         )
         registerCommand(
             "shlimbostats",
-            "Prints your Limbo Stats!"
+            "Prints your Limbo Stats.\n §7This includes your Personal Best, Playtime, and §aSkyHanni User Luck§7!"
         ) { LimboTimeTracker.printStats() }
         registerCommand(
             "shlimbo",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -31,7 +31,7 @@ class LimboPlaytime {
         "§5§o§b([\\d.,]+) hours.+\$"
     )
 
-    private var wholeMinutes: Long = 0
+    private var wholeMinutes = 0
     private var hoursString: String = ""
 
     private val storage get() = ProfileStorageData.playerSpecific?.limbo
@@ -51,13 +51,30 @@ class LimboPlaytime {
 
         if (lastCreateCooldown.passedSince() > 3.seconds) {
             lastCreateCooldown = SimpleTimeMark.now()
-            limboItem = if (wholeMinutes >= 60) Utils.createItemStack(
-                itemID.getItemStack().item,
-                itemName,
-                "§7Playtime: §a${wholeMinutes.addSeparators()} minutes",
-                "§7Or: §b$hoursString hours"
-            )
-            else Utils.createItemStack(itemID.getItemStack().item, itemName, "§7Playtime: §a$wholeMinutes minutes")
+            limboItem = when {
+                wholeMinutes >= 60 -> {
+                    Utils.createItemStack(
+                        itemID.getItemStack().item,
+                        itemName,
+                        "§7Playtime: §a${wholeMinutes.addSeparators()} minutes",
+                        "§7Or: §b$hoursString hours"
+                    )
+                }
+                wholeMinutes == 1 -> {
+                    Utils.createItemStack(
+                        itemID.getItemStack().item,
+                        itemName,
+                        "§7Playtime: §a$wholeMinutes minute"
+                    )
+                }
+                else -> {
+                    Utils.createItemStack(
+                        itemID.getItemStack().item,
+                        itemName,
+                        "§7Playtime: §a$wholeMinutes minutes"
+                    )
+                }
+            }
         }
         event.replaceWith(limboItem)
     }
@@ -85,7 +102,7 @@ class LimboPlaytime {
         if (storedPlaytime < 60) return
         val playtime = storedPlaytime.seconds
         val wholeHours = playtime.inWholeHours
-        wholeMinutes = playtime.inWholeMinutes
+        wholeMinutes = playtime.inWholeMinutes.toInt()
         if ((wholeMinutes % 60).toInt() == 0) {
             hoursString = "$wholeHours"
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -103,13 +103,14 @@ class LimboPlaytime {
         val playtime = storedPlaytime.seconds
         val wholeHours = playtime.inWholeHours
         wholeMinutes = playtime.inWholeMinutes.toInt()
-        if ((wholeMinutes % 60).toInt() == 0) {
+        if ((wholeMinutes % 60) == 0) {
             hoursString = "$wholeHours"
         } else {
             val minutes: Float = ((wholeMinutes - wholeHours * 60).toFloat() / 60).round(1)
             hoursString = wholeHours.addSeparators()
             if (findFloatDecimalPlace(minutes) != 0) {
-                hoursString += minutes.toString()
+                val minutesString = minutes.toString()
+                hoursString += minutesString.substring(minutesString.indexOf("."))
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -66,7 +66,8 @@ class LimboPlaytime {
         if (!LorenzUtils.inSkyBlock) return
         if (!event.slot.inventory.displayName.unformattedText.startsWith("Detailed /playtime")) return
         if (event.slot.slotIndex != 4) return
-        if (storage?.playtime == 0) return
+        val playtime = storage?.playtime ?: 0
+        if (playtime <= 60) return
 
         val lore = event.toolTip
         println("------")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -68,7 +68,7 @@ class LimboPlaytime {
         if (!event.slot.inventory.displayName.unformattedText.startsWith("Detailed /playtime")) return
         if (event.slot.slotIndex != 4) return
         val playtime = storage?.playtime ?: 0
-        if (playtime <= 60) return
+        if (playtime <= 120) return
 
         val lore = event.toolTip
         val hoursList = lore.filter { hoursPattern.matches(it) }.toMutableList()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -89,7 +89,7 @@ class LimboPlaytime {
             hoursString = "$wholeHours"
         } else {
             val minutes: Float = ((wholeMinutes - wholeHours * 60).toFloat() / 60).round(1)
-            hoursString = wholeHours.addSeparators() //+ minutes.round(1).toString()
+            hoursString = wholeHours.addSeparators()
             if (findFloatDecimalPlace(minutes) != 0) {
                 hoursString += minutes.toString()
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -46,7 +46,8 @@ class LimboPlaytime {
         if (event.inventory !is ContainerLocalMenu) return
         if (event.inventory.displayName.unformattedText != "Detailed /playtime") return
         if (event.slotNumber != 43) return
-        if (storage?.playtime == 0) return
+        val playtime = storage?.playtime ?: 0
+        if (playtime < 60) return
 
         if (lastCreateCooldown.passedSince() > 3.seconds) {
             lastCreateCooldown = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -70,9 +70,6 @@ class LimboPlaytime {
         if (playtime <= 60) return
 
         val lore = event.toolTip
-        println("------")
-        lore.forEach{ println(it) }
-        println("------")
         val hoursList = lore.filter { hoursPattern.matches(it) }.toMutableList()
         val minutesList = lore.filter { minutesPattern.matches(it) }.toMutableList()
 
@@ -91,19 +88,19 @@ class LimboPlaytime {
         if ((wholeMinutes % 60).toInt() == 0) {
             hoursString = "$wholeHours"
         } else {
-            val minutes: Float = ((wholeMinutes - wholeHours * 60).toFloat() / 60)
-            hoursString = wholeHours.addSeparators() + minutes.round(1).toString().replace("0", "")
+            val minutes: Float = ((wholeMinutes - wholeHours * 60).toFloat() / 60).round(1)
+            hoursString = wholeHours.addSeparators() //+ minutes.round(1).toString()
+            if (findFloatDecimalPlace(minutes) != 0) {
+                hoursString += minutes.toString()
+            }
         }
     }
 
     private fun addLimbo(hoursList: MutableList<String>, minutesList: MutableList<String>) {
         val storedPlaytime = storage?.playtime ?: 0
         if (wholeMinutes >= 60) {
-            val hours = storedPlaytime.seconds.inWholeHours
-            val minutes = (storedPlaytime.seconds.inWholeMinutes - (hours * 60).toFloat() / 6).toInt()
             modifiedList = hoursList
-            if (minutes == 0) modifiedList.add("§5§o§b$hours hours §7on Limbo")
-            else modifiedList.add("§5§o§b$hoursString hours §7on Limbo")
+            modifiedList.add("§5§o§b$hoursString hours §7on Limbo")
             modifiedList = modifiedList.sortedByDescending {
                 val matcher = hoursPattern.matcher(it)
                 if (matcher.find()) {
@@ -142,5 +139,11 @@ class LimboPlaytime {
             toolTip.addAll(modifiedList)
         }
         toolTip.add(totalPlaytime)
+    }
+
+    private fun findFloatDecimalPlace(input: Float): Int {
+        val string = input.toString()
+        val dotIndex = string.indexOf(".")
+        return (string[dotIndex+1].toString().toInt())
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -69,6 +69,9 @@ class LimboPlaytime {
         if (storage?.playtime == 0) return
 
         val lore = event.toolTip
+        println("------")
+        lore.forEach{ println(it) }
+        println("------")
         val hoursList = lore.filter { hoursPattern.matches(it) }.toMutableList()
         val minutesList = lore.filter { minutesPattern.matches(it) }.toMutableList()
 
@@ -110,9 +113,12 @@ class LimboPlaytime {
         } else {
             val minutes = storedPlaytime.seconds.inWholeMinutes
             modifiedList = minutesList
-            modifiedList.add("§a$minutes minutes §7on Limbo")
+            modifiedList.add("§5§o§a$minutes minutes §7on Limbo")
             modifiedList = modifiedList.sortedByDescending {
-                it.substringAfter("§a").substringBefore(" minutes").toDoubleOrNull()
+                val matcher = minutesPattern.matcher(it)
+                if (matcher.find()) {
+                    matcher.group(1).toDoubleOrNull() ?: 0.0
+                } else 0.0
             }.toMutableList()
             setMinutes = true
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
@@ -147,7 +147,7 @@ object LimboTimeTracker {
             val currentPB = storage?.personalBest ?: 0
             val userLuck = storage?.userLuck ?: 0f
             val limboPB: Int = if (currentPB < timeInLimbo) timeInLimbo else currentPB
-            ChatUtils.chat("§fYour current PB is §e${limboPB.seconds}§f, granting you §a+${userLuck.round(2)}✴ §fSkyHanni User Luck!")
+            ChatUtils.chat("§fYour current PB is §e${limboPB.seconds}§f, granting you §a+${userLuck.round(2)}✴ SkyHanni User Luck§f!")
             ChatUtils.chat("§fYou have §e${playtime.seconds} §fof playtime!")
         }
     }


### PR DESCRIPTION
## What
- Fixes playtimes x.0 displaying incorrectly
https://discord.com/channels/997079228510117908/1196872092579274872/1221201110585577472
- Fixes the limbo item in `/playtimedetailed` being displayed when below 1 minute
- Fixes playtime being displayed in the `/playtimedetailed` tooltip when below 2 minutes (lol)
https://discord.com/channels/997079228510117908/1196872092579274872/1217261171728584704
- Fixes "1 minutes" being pluralized
- Adds keywords to `/shlimbostats`'s description for better discoverability
https://discord.com/channels/997079228510117908/997079229302837269/1221252532769394749
- Fixes coloring in `/shlimbostats`

## Changelog Improvements
+ Various additions to `/playtimedetailed`'s Limbo to be more consistent with Hypixel. - martimavocado
    * The item is now hidden when playtime is lower than 1 minute.
    * The tooltip is now hidden when playtime is lower than 2 minutes.
    * Fixes 1 minute being pluralized.
+ Adds a few keywords to `/shlimbostats` for better discoverability. - martimavocado

## Changelog Fixes
+ Fixed `/playtimedetailed`'s Limbo displaying incorrectly for x.0 playtimes. - martimavocado
+ Fixed inconsistent coloring in `/shlimbostats`. - martimavocado