### PR TITLE
Improvement + Fix: Sensitivity Reducer + Mouse Lock incompatbility

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/SensitivityReducer.kt
@@ -106,6 +106,7 @@ object SensitivityReducer {
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!(isToggled || isManualToggle)) return
         if (!config.showGUI) return
+        if (LockMouseLook.lockedMouse) return
         config.position.renderString("§eSensitivity Lowered", posLabel = "Sensitivity Lowered")
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/SensitivityReducer.kt
@@ -136,7 +136,11 @@ object SensitivityReducer {
         val divisor = config.reducingFactor.get()
         ChatUtils.debug("dividing by $divisor")
 
-        storage.savedMouseloweredSensitivity = gameSettings.mouseSensitivity
+        if (!LockMouseLook.lockedMouse) {
+            storage.savedMouseloweredSensitivity = gameSettings.mouseSensitivity
+        } else {
+            storage.savedMouseloweredSensitivity = storage.savedMouselockedSensitivity
+        }
         val newSens = doTheMath(storage.savedMouseloweredSensitivity)
         gameSettings?.mouseSensitivity = newSens
         if (showMessage) ChatUtils.chat("§bMouse sensitivity is now lowered. Type /shsensreduce to restore your sensitivity.")


### PR DESCRIPTION
## What
- Fixes "lock -> lower -> unlock -> unlower" keeping the mouse locked
https://canary.discord.com/channels/997079228510117908/1216111642681675796
- Hide the gui overlay when mouse is locked

## Changelog Improvements
+ Hide the Sensitivity Reducer overlay when the mouse is locked. - martimavocado

## Changelog Fixes
+ Fixed another Sensitivity Reducer + Mouse Lock incompatibility. - martimavocado


