### PR TITLE
Fix: Composter Upgrades not loaded

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -162,6 +162,13 @@ object ComposterOverlay {
     }
 
     private fun update() {
+        val composterUpgrades = ComposterAPI.composterUpgrades ?: return
+        if (composterUpgrades.isEmpty()) {
+            val list = Collections.singletonList(listOf("§cOpen Composter Upgrades!"))
+            organicMatterDisplay = list
+            fuelExtraDisplay = list
+            return
+        }
         if (organicMatterFactors.isEmpty()) {
             organicMatterDisplay =
                 Collections.singletonList(


### PR DESCRIPTION
## What
Request opening the composter upgrades inventory when no upgrades are loaded

<details>
<summary>Image</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/ee3ac79f-d6ac-4fe0-abfd-755177640e11)

</details>


## Changelog Fixes
+ Show warning in Composter Overlay when composter upgrades are not found. - hannibal2