### PR TITLE
Improvement: Add 4 more empty lines to custom scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -223,6 +223,26 @@ enum class ScoreboardElement(
         { true },
         ""
     ),
+    EMPTY_LINE7(
+        ::getEmptyLineDisplayPair,
+        { true },
+        ""
+    ),
+    EMPTY_LINE8(
+        ::getEmptyLineDisplayPair,
+        { true },
+        ""
+    ),
+    EMPTY_LINE9(
+        ::getEmptyLineDisplayPair,
+        { true },
+        ""
+    ),
+    EMPTY_LINE10(
+        ::getEmptyLineDisplayPair,
+        { true },
+        ""
+    ),
     ;
 
     override fun toString(): String {


### PR DESCRIPTION
## What
This Pull request bumps the number of empty lines from 6 to 10 in the custom scoreboard.
There has to be a better way to do this


## Changelog Improvements
+ Add 4 more empty lines into custom scoreboard. - j10a1n15

