### PR TITLE
Fix: Fixed Cookie Time with Effect Widget in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -13,6 +13,8 @@
 //  - color options in the purse etc lines
 //  - choose the amount of decimal places in shorten nums
 //  - more anchor points (alignment enums in renderutils)
+//  - 24h instead of 12h for skyblock time
+//  - only alert for lines that exist longer than 1s
 //
 
 package at.hannibal2.skyhanni.features.gui.customscoreboard

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -30,6 +30,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.percentageColor
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
+import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -529,16 +530,32 @@ private fun getTuningDisplayPair(): List<Pair<String, HorizontalAlignment>> {
 
 private fun getPowerShowWhen() = !inAnyIsland(IslandType.THE_RIFT)
 
+private fun getCookieTime(): String? {
+    return CustomScoreboardUtils.getTablistFooter().split("\n")
+        .nextAfter("§d§lCookie Buff")
+        ?: run {
+            for (line in TabListData.getTabList()) {
+                ScoreboardPattern.boosterCookieEffectsWidgetPattern.matchMatcher(line) {
+                    return group("time")
+                }
+            }
+            null
+        }
+}
+
 private fun getCookieDisplayPair(): List<ScoreboardElementType> {
-    val timeLine = CustomScoreboardUtils.getTablistFooter().split("\n")
-        .nextAfter("§d§lCookie Buff") ?: "<hidden>"
+    val timeLine: String = getCookieTime()
+        ?: return listOf(
+            "§d§lCookie Buff" to HorizontalAlignment.LEFT,
+            " §7- §cNot active" to HorizontalAlignment.LEFT
+        )
 
     return listOf(
         "§d§lCookie Buff" to HorizontalAlignment.LEFT,
-        if (timeLine.contains("Not active"))
+        if (ScoreboardPattern.cookieNotActivePattern.matches(timeLine))
             " §7- §cNot active" to HorizontalAlignment.LEFT
         else
-            " §7- §e${timeLine.substringAfter("§d§lCookie Buff").trim()}" to HorizontalAlignment.LEFT
+            " §7- §f${timeLine}" to HorizontalAlignment.LEFT
     )
 }
 
@@ -546,10 +563,7 @@ private fun getCookieShowWhen(): Boolean {
     if (HypixelData.bingo) return false
 
     return if (informationFilteringConfig.hideEmptyLines) {
-        CustomScoreboardUtils.getTablistFooter().split("\n").any {
-            CustomScoreboardUtils.getTablistFooter().split("\n").nextAfter("§d§lCookie Buff")?.contains(it)
-                ?: false
-        }
+        getCookieTime() != null
     } else {
         true
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -415,4 +415,12 @@ object ScoreboardPattern {
         "eventtime",
         "^\\s+Ends In: §r§e(?<time>.*)$"
     )
+    val boosterCookieEffectsWidgetPattern by tablistGroup.pattern(
+        "boostereffects",
+        "\\s*(?:§.)*Cookie Buff(?:§.)*: (?:§r)*(?<time>.*)"
+    )
+    val cookieNotActivePattern by tablistGroup.pattern(
+        "cookienotactive",
+        "Not active|§c§lINACTIVE"
+    )
 }


### PR DESCRIPTION
## What
This Pull Request fixes the booster cookie time in custom scoreboard, when the Effects widget is enabled

## Changelog Fixes
+ Fixed Cookie time with in custom scoreboard when effects widget is enabled. - j10a1n15

