### PR TITLE
Fix: Serverid error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -95,7 +95,7 @@ class HypixelData {
         var bingo = false
 
         var profileName = ""
-        var joinedWorld = 0L
+        var joinedWorld = SimpleTimeMark.farPast()
 
         var skyBlockArea = "?"
 
@@ -119,6 +119,7 @@ class HypixelData {
 
         fun checkCurrentServerId() {
             if (!LorenzUtils.inSkyBlock) return
+            if (LorenzUtils.lastWorldSwitch.passedSince() < 1.seconds) return
 
             ScoreboardData.sidebarLinesFormatted.forEach {
                 serverIdScoreboardPattern.matchMatcher(it) {
@@ -213,7 +214,7 @@ class HypixelData {
         inLimbo = false
         inLobby = false
         locraw.forEach { locraw[it.key] = "" }
-        joinedWorld = System.currentTimeMillis()
+        joinedWorld = SimpleTimeMark.now()
         serverId = null
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
@@ -25,6 +25,7 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class OwnInventoryData {
 
@@ -133,12 +134,10 @@ class OwnInventoryData {
     class IgnoredItem(val condition: (NEUInternalName) -> Boolean, val blockedUntil: SimpleTimeMark)
 
     private fun addItem(internalName: NEUInternalName, add: Int) {
-        val diffWorld = System.currentTimeMillis() - LorenzUtils.lastWorldSwitch
-        if (diffWorld < 3_000) return
+        if (LorenzUtils.lastWorldSwitch.passedSince() < 3.seconds) return
 
         ignoredItemsUntil.removeIf { it.blockedUntil.isInPast() }
         if (ignoredItemsUntil.any { it.condition(internalName) }) {
-//             println("ignored: $internalName")
             return
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SackDataUpdateEvent
-import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorAcceptEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorAcceptedEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorArrivalEvent
@@ -437,8 +436,9 @@ class GardenVisitorFeatures {
         update()
 
         logger.log("New visitor detected: '$name'")
+        val recentWorldSwitch = LorenzUtils.lastWorldSwitch.passedSince() < 2.seconds
 
-        if (config.notificationTitle && System.currentTimeMillis() > LorenzUtils.lastWorldSwitch + 2_000) {
+        if (config.notificationTitle && !recentWorldSwitch) {
             LorenzUtils.sendTitle("§eNew Visitor", 5.seconds)
         }
         if (config.notificationChat) {
@@ -446,7 +446,7 @@ class GardenVisitorFeatures {
             ChatUtils.chat("$displayName §eis visiting your garden!")
         }
 
-        if (System.currentTimeMillis() > LorenzUtils.lastWorldSwitch + 2_000) {
+        if (!recentWorldSwitch) {
             if (name.removeColor().contains("Jerry")) {
                 logger.log("Jerry!")
                 ItemBlink.setBlink(NEUItems.getItemStackOrNull("JERRY;4"), 5_000)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
@@ -33,6 +33,7 @@ import net.minecraftforge.event.entity.player.ItemTooltipEvent
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.lwjgl.input.Keyboard
+import kotlin.time.Duration.Companion.seconds
 
 class VisitorListener {
 
@@ -71,13 +72,14 @@ class VisitorListener {
         if (!GardenAPI.inGarden()) return
         val visitorsInTab = VisitorAPI.visitorsInTabList(event.tabList)
 
-        VisitorAPI.getVisitors().forEach {
-            val name = it.visitorName
-            val time = System.currentTimeMillis() - LorenzUtils.lastWorldSwitch
-            val removed = name !in visitorsInTab && time > 2_000
-            if (removed) {
-                logger.log("Removed old visitor: '$name'")
-                VisitorAPI.removeVisitor(name)
+        if (LorenzUtils.lastWorldSwitch.passedSince() > 2.seconds) {
+            VisitorAPI.getVisitors().forEach {
+                val name = it.visitorName
+                val removed = name !in visitorsInTab
+                if (removed) {
+                    logger.log("Removed old visitor: '$name'")
+                    VisitorAPI.removeVisitor(name)
+                }
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -47,7 +47,6 @@ class MiningEventTracker {
 
     private val defaultCooldown = 1.minutes
 
-    private var lastWorldSwitch = SimpleTimeMark.farPast()
     private var eventEndTime = SimpleTimeMark.farPast()
     private var lastSentEvent: MiningEventType? = null
 
@@ -55,7 +54,6 @@ class MiningEventTracker {
 
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
-        lastWorldSwitch = SimpleTimeMark.farPast()
         eventEndTime = SimpleTimeMark.farPast()
         lastSentEvent = null
     }
@@ -63,7 +61,7 @@ class MiningEventTracker {
     @SubscribeEvent
     fun onBossbarChange(event: BossbarUpdateEvent) {
         if (!LorenzUtils.inAdvancedMiningIsland()) return
-        if (lastWorldSwitch.passedSince() < 5.seconds) return
+        if (LorenzUtils.lastWorldSwitch.passedSince() < 5.seconds) return
         if (!eventEndTime.isInPast()) {
             return
         }

--- a/src/test/java/at/hannibal2/skyhanni/test/garden/VisitorListenerTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/garden/VisitorListenerTest.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorAPI
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorListener
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -70,7 +71,7 @@ class VisitorListenerTest {
             mockk { every { visitorName } returns "§fJacob" },
         )
 
-        every { LorenzUtils.lastWorldSwitch } returns System.currentTimeMillis()
+        every { LorenzUtils.lastWorldSwitch } returns SimpleTimeMark.now()
 
         listener.onTabListUpdate(
             TabListUpdateEvent(


### PR DESCRIPTION
## What
 - Fixed serverid error popping up in chat.
 - Made `LorenzUtils.lastWorldSwitch` use `SimpleTimeMark` instead of `currentTimeMillis`.

## Changelog Fixes
+ Fixed server ID error appearing in chat. - CalMWolfs

## Changelog Technical Details
+ Made LorenzUtils.lastWorldSwitch use SimpleTimeMark instead of currentTimeMillis. - CalMWolfs
