### PR TITLE
Backend: Less fixed rate timer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,13 +53,14 @@ format like "- #821" to illustrate the dependency.
   and [Java](https://www.oracle.com/java/technologies/javase/codeconventions-contents.html).
 - Do not copy features from other mods. Exceptions:
     - Mods that are paid to use.
-    - Mods that have reached their end of life. (Rip SBA, Dulkir and Soopy)
+  - Mods that have reached their end of life. (Rip SBA, Dulkir and Soopy).
     - The mod has, according to Hypixel rules, illegal features ("cheat mod/client").
     - If you can improve the existing feature in a meaningful way.
 - All new classes should be written in Kotlin, with a few exceptions:
     - Config files in `at.hannibal2.skyhanni.config.features`
     - Mixin classes in `at.hannibal2.skyhanni.mixins.transformers`
-  - Java classes that represent JSON data objects in `at.hannibal2.skyhanni.data.jsonobjects`
+- Future JSON data objects should be made in kotlin and placed in the directory `at.hannibal2.skyhanni.data.jsonobjects`
+    - Config files should still be made in Java.
 - Please use the existing event system, or expand on it. Do not use Forge events.
     - (We inject the calls with Mixin)
 - Please use existing utils methods.
@@ -70,7 +71,7 @@ format like "- #821" to illustrate the dependency.
 - Please try to avoid using `System.currentTimeMillis()`. Use our own class `SimpleTimeMark` instead.
     - See [this commit](https://github.com/hannibal002/SkyHanni/commit/3d748cb79f3a1afa7f1a9b7d0561e5d7bb284a9b)
       as an example.
-- Try to avoid using kotlin's `!!` (catch if not null) feature.
+- Try to avoid using Kotlin's `!!` (catch if not null) feature.
     - Replace it with `?:` (if null return this).
     - This will most likely not be possible to avoid when working with objects from java.
 - Don't forget to add `@FeatureToggle` to new standalone features (not options to that feature) in the config.
@@ -81,6 +82,8 @@ format like "- #821" to illustrate the dependency.
 for more information and usages.
     - The pattern variables are named in the scheme `variableNamePattern`
 - Please use Regex instead of String comparison when it is likely Hypixel will change the message in the future.
+- Do not use `fixedRateTimer` when possible and instead use `SecondPassedEvent` to safely execute the repeating event on
+  the main thread.
 
 ## Software Used in SkyHanni
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ format like "- #821" to illustrate the dependency.
 - All new classes should be written in Kotlin, with a few exceptions:
     - Config files in `at.hannibal2.skyhanni.config.features`
     - Mixin classes in `at.hannibal2.skyhanni.mixins.transformers`
-  - Java classes that represent JSON data objects in `at.hannibal2.skyhanni.data.jsonobjects`
+- Future JSON data objects should be made in kotlin and placed in the directory `at.hannibal2.skyhanni.data.jsonobjects`
 - Please use the existing event system, or expand on it. Do not use Forge events.
     - (We inject the calls with Mixin)
 - Please use existing utils methods.
@@ -70,7 +70,7 @@ format like "- #821" to illustrate the dependency.
 - Please try to avoid using `System.currentTimeMillis()`. Use our own class `SimpleTimeMark` instead.
     - See [this commit](https://github.com/hannibal002/SkyHanni/commit/3d748cb79f3a1afa7f1a9b7d0561e5d7bb284a9b)
       as an example.
-- Try to avoid using kotlin's `!!` (catch if not null) feature.
+- Try to avoid using Kotlin's `!!` (catch if not null) feature.
     - Replace it with `?:` (if null return this).
     - This will most likely not be possible to avoid when working with objects from java.
 - Don't forget to add `@FeatureToggle` to new standalone features (not options to that feature) in the config.
@@ -81,6 +81,8 @@ format like "- #821" to illustrate the dependency.
 for more information and usages.
     - The pattern variables are named in the scheme `variableNamePattern`
 - Please use Regex instead of String comparison when it is likely Hypixel will change the message in the future.
+- Do not use `fixedRateTimer` when possible and instead use `SecondPassedEvent` to safely execute the repeating event on
+  the main thread.
 
 ## Software Used in SkyHanni
 

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.data.CropAccessoryData
 import at.hannibal2.skyhanni.data.EntityData
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.FameRanks
+import at.hannibal2.skyhanni.data.FixedRateTimerManager
 import at.hannibal2.skyhanni.data.FriendAPI
 import at.hannibal2.skyhanni.data.GardenComposterUpgradesData
 import at.hannibal2.skyhanni.data.GardenCropMilestones
@@ -485,6 +486,7 @@ class SkyHanniMod {
         loadModule(BossbarData)
         loadModule(EntityUtils)
         loadModule(ChatUtils)
+        loadModule(FixedRateTimerManager())
 
         // APIs
         loadModule(BazaarApi())

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.events.ActionBarUpdateEvent
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.SkillOverflowLevelupEvent
 import at.hannibal2.skyhanni.features.skillprogress.SkillProgress
 import at.hannibal2.skyhanni.features.skillprogress.SkillType
@@ -38,7 +39,6 @@ import net.minecraft.command.CommandBase
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.LinkedList
 import java.util.regex.Matcher
-import kotlin.concurrent.fixedRateTimer
 import kotlin.time.Duration.Companion.seconds
 
 object SkillAPI {
@@ -81,13 +81,8 @@ object SkillAPI {
     var showDisplay = false
     var lastUpdate = SimpleTimeMark.farPast()
 
-    init {
-        fixedRateTimer(name = "skyhanni-skillprogress-timer", initialDelay = 1_000L, period = 1_000L) {
-            tickSkill()
-        }
-    }
-
-    private fun tickSkill() {
+    @SubscribeEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
         val activeSkill = activeSkill ?: return
         val info = skillXPInfoMap[activeSkill] ?: return
         if (!info.sessionTimerActive) return

--- a/src/main/java/at/hannibal2/skyhanni/data/FixedRateTimerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/FixedRateTimerManager.kt
@@ -1,0 +1,20 @@
+package at.hannibal2.skyhanni.data
+
+import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraft.client.Minecraft
+import kotlin.concurrent.fixedRateTimer
+
+class FixedRateTimerManager {
+    private var totalSeconds = 0
+
+    init {
+        fixedRateTimer(name = "skyhanni-fixed-rate-timer-manager", period = 1000L) {
+            Minecraft.getMinecraft().addScheduledTask {
+                if (!LorenzUtils.onHypixel) return@addScheduledTask
+                SecondPassedEvent(totalSeconds).postAndCatch()
+                totalSeconds++
+            }
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/events/SecondPassedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/SecondPassedEvent.kt
@@ -1,0 +1,5 @@
+package at.hannibal2.skyhanni.events
+
+class SecondPassedEvent(private val totalSeconds: Int) : LorenzEvent() {
+    fun repeatSeconds(i: Int) = i % totalSeconds
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMilestonesDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMilestonesDisplay.kt
@@ -4,12 +4,12 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.DungeonStartEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.concurrent.fixedRateTimer
 
 class DungeonMilestonesDisplay {
 
@@ -33,22 +33,16 @@ class DungeonMilestonesDisplay {
         fun isMilestoneMessage(message: String): Boolean = milestonePatternList.any { it.matches(message) }
     }
 
-    init {
-        fixedRateTimer(name = "skyhanni-dungeon-milestone-display", period = 200) {
-            if (isEnabled()) {
-                checkVisibility()
-            }
-        }
-    }
-
-    private fun checkVisibility() {
+    @SubscribeEvent
+    fun onTick(event: LorenzTickEvent) {
+        if (!event.isMod(5)) return
         if (currentMilestone >= 3 && System.currentTimeMillis() > timeReached + 3_000 && display != "") {
             display = display.substring(1)
         }
     }
 
     @SubscribeEvent(receiveCanceled = true)
-    fun onChatPacket(event: LorenzChatEvent) {
+    fun onChat(event: LorenzChatEvent) {
         if (!isEnabled()) return
 
         if (isMilestoneMessage(event.message)) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/jerry/frozentreasure/FrozenTreasureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/jerry/frozentreasure/FrozenTreasureTracker.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.ConfigUtils
@@ -23,7 +24,6 @@ import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.concurrent.fixedRateTimer
 
 object FrozenTreasureTracker {
 
@@ -44,11 +44,6 @@ object FrozenTreasureTracker {
 
     init {
         FrozenTreasure.entries.forEach { it.chatPattern }
-
-        fixedRateTimer(name = "skyhanni-frozen-treasure-tracker", period = 1000) {
-            if (!onJerryWorkshop()) return@fixedRateTimer
-            calculateIcePerHour()
-        }
     }
 
     class Data : TrackerData() {
@@ -77,12 +72,14 @@ object FrozenTreasureTracker {
         tracker.update()
     }
 
-    private fun calculateIcePerHour() {
+    @SubscribeEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
+        if (!onJerryWorkshop()) return
+
         val difference = estimatedIce - lastEstimatedIce
         lastEstimatedIce = estimatedIce
 
         if (difference == estimatedIce) return
-
 
         if (difference == 0L) {
             if (icePerSecond.isEmpty()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
-import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.concurrent.fixedRateTimer
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -27,16 +26,6 @@ class JyrreTimer {
     )
     private var display = emptyList<Any>()
     private var duration = 0.seconds
-
-    init {
-        fixedRateTimer(name = "skyhanni-update-jyrre-display", period = 1000L) {
-            try {
-                updateJyrreDisplay()
-            } catch (error: Throwable) {
-                ErrorManager.logErrorWithData(error, "Error Updating Jyrre Timer")
-            }
-        }
-    }
 
     @SubscribeEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
@@ -60,7 +49,8 @@ class JyrreTimer {
         config.pos.renderSingleLineWithItems(display, posLabel = "Refined Jyrre Timer")
     }
 
-    private fun updateJyrreDisplay() {
+    @SubscribeEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
 
         if (display.isNotEmpty() && !config.showInactive && duration <= 0.seconds) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorAcceptEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -221,6 +222,12 @@ object GardenVisitorDropStatistics {
         if (amount is Int) return amount.addSeparators()
         if (amount is Long) return NumberUtil.format(amount)
         return "$amount"
+    }
+
+    //todo this should just save when changed not once a second
+    @SubscribeEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
+        saveAndUpdate()
     }
 
     fun saveAndUpdate() {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.events.CropClickEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorArrivalEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -20,7 +21,6 @@ import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.concurrent.fixedRateTimer
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -65,20 +65,6 @@ class GardenVisitorTimer {
         visitorJustArrived = true
     }
 
-    init {
-        fixedRateTimer(name = "skyhanni-update-visitor-display", period = 1000L) {
-            try {
-                updateVisitorDisplay()
-            } catch (error: Throwable) {
-                ErrorManager.logErrorWithData(error, "Encountered an error when updating visitor display")
-            }
-            try {
-                GardenVisitorDropStatistics.saveAndUpdate()
-            } catch (_: Throwable) {
-            } // no config yet
-        }
-    }
-
     @SubscribeEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
         display = ""
@@ -88,7 +74,8 @@ class GardenVisitorTimer {
         sixthVisitorReady = false
     }
 
-    private fun updateVisitorDisplay() {
+    @SubscribeEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
 
         var visitorsAmount = VisitorAPI.visitorsInTabList(TabListData.getTabList()).size

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConfigUtils
@@ -25,7 +26,6 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonNull
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.concurrent.fixedRateTimer
 
 object PowderTracker {
 
@@ -73,15 +73,16 @@ object PowderTracker {
 
     init {
         PowderChestReward.entries.forEach { it.chatPattern }
+    }
 
-        fixedRateTimer(name = "skyhanni-powder-tracker", period = 1000) {
-            if (!isEnabled()) return@fixedRateTimer
-            calculateResourceHour(gemstoneInfo)
-            calculateResourceHour(mithrilInfo)
-            calculateResourceHour(diamondEssenceInfo)
-            calculateResourceHour(goldEssenceInfo)
-            calculateResourceHour(chestInfo)
-        }
+    @SubscribeEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
+        if (!isEnabled()) return
+        calculateResourceHour(gemstoneInfo)
+        calculateResourceHour(mithrilInfo)
+        calculateResourceHour(diamondEssenceInfo)
+        calculateResourceHour(goldEssenceInfo)
+        calculateResourceHour(chestInfo)
     }
 
     private val tracker = SkyHanniTracker("Powder Tracker", { Data() }, { it.powderTracker })

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -11,10 +11,10 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzKeyPressEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.ConfigUtils
@@ -42,7 +42,6 @@ import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.concurrent.fixedRateTimer
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -101,21 +100,14 @@ object TrevorFeatures {
 
     private val config get() = SkyHanniMod.feature.misc.trevorTheTrapper
 
-    init {
-        fixedRateTimer(name = "skyhanni-update-trapper", period = 1000L) {
-            if (onFarmingIsland() && config.trapperSolver) {
-                Minecraft.getMinecraft().addScheduledTask {
-                    try {
-                        updateTrapper()
-                        TrevorTracker.update()
-                        TrevorTracker.calculatePeltsPerHour()
-                        if (questActive) TrevorSolver.findMob()
-                    } catch (error: Throwable) {
-                        ErrorManager.logErrorWithData(error, "Encountered an error when updating the trapper solver")
-                    }
-                }
-            }
-        }
+    @SubscribeEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
+        if (!onFarmingIsland()) return
+        if (!config.trapperSolver) return
+        updateTrapper()
+        TrevorTracker.update()
+        TrevorTracker.calculatePeltsPerHour()
+        if (questActive) TrevorSolver.findMob()
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Remove a lot of fixed rate timers because they do not execute on the main thread and replaced them with SecondPassedEvent.
- This event is still called exactly once a second so it is more accurate than LorenzTickEvent.repeatSeconds(i)
-  Did not replace all occurances of it as these two cases (tps and bps) rely on very accurate timings. These replaced features just need to occur exactly once per second not once every 20 ticks

Also updated the contributing guide a bit to include this and fix a few small things

## Changelog Technical Details
+ Remove a lot of usage of fixed rate timers and replace with a new event. - CalMWolfs
    * This makes these events that need to repeat about every second execute on the main thread.

