### PR TITLE
Improvement: Hide visitor Jacob messages without hiding real Jacob ones

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -545,7 +545,7 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
   is empty when fully filled and show a preview how these stats change when hovering over an upgrade
 + Hide crop money display, crop milestone display and garden visitor list while inside anita show, SkyMart or the
   composter inventory
-+ Hide chat messages from the visitors in the garden. (Except Beth, Jacob and Spaceman)
++ Hide chat messages from the visitors in the garden. (Except Beth and Spaceman)
 + Show the average crop milestone in the crop milestone inventory.
 + **FF for Contest** - Show the minimum needed Farming Fortune for reaching a medal in the Jacob's Farming Contest
   inventory.

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.java
@@ -84,7 +84,7 @@ public class VisitorConfig {
     public boolean hypixelArrivedMessage = true;
 
     @Expose
-    @ConfigOption(name = "Hide Chat", desc = "Hide chat messages from the visitors in the garden. (Except Beth, Jacob and Spaceman)")
+    @ConfigOption(name = "Hide Chat", desc = "Hide chat messages from the visitors in the garden. (Except Beth and Spaceman)")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean hideChat = true;

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -89,7 +89,7 @@ class GardenVisitorFeatures {
     )
     private val visitorChatMessagePattern by patternGroup.pattern(
         "visitorchat",
-        "§e\\[NPC] (§.)?(?<name>.*)§f: §r.*"
+        "§e\\[NPC] (?<color>§.)?(?<name>.*)§f: §r.*"
     )
     private val partialAcceptedPattern by patternGroup.pattern(
         "partialaccepted",
@@ -476,8 +476,10 @@ class GardenVisitorFeatures {
     }
 
     private fun hideVisitorMessage(message: String) = visitorChatMessagePattern.matchMatcher(message) {
+        val color = group("color")
+        if (color == "§e") return false // Non-visitor NPC, probably Jacob
+
         val name = group("name")
-        if (name == "Jacob") return false
         if (name == "Spaceman") return false
         if (name == "Beth") return false
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -477,7 +477,7 @@ class GardenVisitorFeatures {
 
     private fun hideVisitorMessage(message: String) = visitorChatMessagePattern.matchMatcher(message) {
         val color = group("color")
-        if (color == "§e") return false // Non-visitor NPC, probably Jacob
+        if (color == null || color == "§e") return false // Non-visitor NPC, probably Jacob
 
         val name = group("name")
         if (name == "Spaceman") return false


### PR DESCRIPTION
## What
Hide visitor Jacob messages without hiding real Jacob ones.

This has now been made easy as Hypixel added rarity colors to visitor chat messages.

## Changelog Improvements
+ Hide visitor Jacob messages without hiding real Jacob ones. - Alexia Luna
    * Previously, we made the Jacob visitor messages not hidden to avoid hiding real Jacob messages.