### PR TITLE
Backend: Banned Classes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.config.SackData
 import at.hannibal2.skyhanni.config.commands.Commands.init
 import at.hannibal2.skyhanni.data.ActionBarData
 import at.hannibal2.skyhanni.data.ActionBarStatsData
+import at.hannibal2.skyhanni.data.BannedClasses
 import at.hannibal2.skyhanni.data.BitsAPI
 import at.hannibal2.skyhanni.data.BlockData
 import at.hannibal2.skyhanni.data.BossbarData
@@ -429,6 +430,7 @@ class SkyHanniMod {
 
         // data
         loadModule(this)
+        loadModule(BannedClasses)
         loadModule(ChatManager)
         loadModule(HypixelData())
         loadModule(LocationFixData)

--- a/src/main/java/at/hannibal2/skyhanni/data/BannedClasses.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BannedClasses.kt
@@ -14,8 +14,7 @@ object BannedClasses {
         list = event.getConstant<BannedClassesJson>("BannedClasses").bannedClasses[SkyHanniMod.version] ?: emptyList()
     }
 
-    fun isBanned(provider: () -> Class<*>?): Boolean =
-        list.isNotEmpty() && isBanned(provider())
+    fun isBanned(provider: () -> Class<*>?): Boolean = list.isNotEmpty() && isBanned(provider())
 
     fun isBanned(javaClass: Class<*>?): Boolean = javaClass?.name?.let(list::contains) ?: false
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/BannedClasses.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BannedClasses.kt
@@ -14,5 +14,8 @@ object BannedClasses {
         list = event.getConstant<BannedClassesJson>("BannedClasses").bannedClasses[SkyHanniMod.version] ?: emptyList()
     }
 
-    fun isBanned(javaClass: Class<*>): Boolean = list.contains(javaClass.name)
+    fun isBanned(provider: () -> Class<*>?): Boolean =
+        list.isNotEmpty() && isBanned(provider())
+
+    fun isBanned(javaClass: Class<*>?): Boolean = javaClass?.name?.let(list::contains) ?: false
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/BannedClasses.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BannedClasses.kt
@@ -1,0 +1,18 @@
+package at.hannibal2.skyhanni.data
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.jsonobjects.repo.BannedClassesJson
+import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+object BannedClasses {
+
+    private var list = listOf<String>()
+
+    @SubscribeEvent
+    fun onRepoReload(event: RepositoryReloadEvent) {
+        list = event.getConstant<BannedClassesJson>("BannedClasses").bannedClasses[SkyHanniMod.version] ?: emptyList()
+    }
+
+    fun isBanned(javaClass: Class<*>): Boolean = list.contains(javaClass.name)
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/EventCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EventCounter.kt
@@ -36,7 +36,8 @@ object EventCounter {
         println("")
         var total = 0
         for ((name, amount) in map.entries.sortedBy { it.value }) {
-            println("$name (${amount.addSeparators()} times)")
+            val displayName =  name.replace("at.hannibal2.skyhanni.events", "events")
+            println("$displayName (${amount.addSeparators()} times)")
             total += amount
         }
         println("")

--- a/src/main/java/at/hannibal2/skyhanni/data/QuiverAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/QuiverAPI.kt
@@ -238,7 +238,6 @@ object QuiverAPI {
 
     fun isEnabled() = LorenzUtils.inSkyBlock && storage != null
 
-
     // Load arrows from repo
     @SubscribeEvent
     fun onRepoReload(event: RepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/BannedClassesJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/BannedClassesJson.kt
@@ -1,0 +1,9 @@
+package at.hannibal2.skyhanni.data.jsonobjects.repo
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+
+data class BannedClassesJson(
+    @Expose
+    @SerializedName("banned_classes") val bannedClasses: Map<String, List<String>>,
+)

--- a/src/main/java/at/hannibal2/skyhanni/events/LorenzEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/LorenzEvent.kt
@@ -36,8 +36,7 @@ abstract class LorenzEvent : Event() {
         ignoreErrorCache: Boolean = false,
         onError: (Throwable) -> Unit,
     ): Boolean {
-        // TODO remove comment
-//         if (BannedClasses.isBanned(this.javaClass)) return false
+        if (BannedClasses.isBanned(this.javaClass)) return false
 
         EventCounter.count(eventName)
         val visibleErrors = 3
@@ -45,15 +44,14 @@ abstract class LorenzEvent : Event() {
         eventHandlerDepth++
         for (listener in getListeners()) {
             val shListener = (listener as? ASMEventHandlerExt)?.target_skyhanni
-            shListener?.let {
-                if (BannedClasses.isBanned(it.javaClass)) continue
+            if (BannedClasses.isBanned(shListener?.javaClass)) {
+                continue
             }
             try {
                 listener.invoke(this)
             } catch (throwable: Throwable) {
                 errors++
                 if (printError && errors <= visibleErrors) {
-//                     val callerName = listener.toString().split(" ")[1].split("@")[0].split(".").last()
                     val callerName = shListener?.javaClass?.name ?: "<caller is null>"
                     val errorName = throwable::class.simpleName ?: "error"
                     val message = "Caught an $errorName at $eventName in $callerName: ${throwable.message}"

--- a/src/main/java/at/hannibal2/skyhanni/events/LorenzEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/LorenzEvent.kt
@@ -36,6 +36,7 @@ abstract class LorenzEvent : Event() {
         ignoreErrorCache: Boolean = false,
         onError: (Throwable) -> Unit,
     ): Boolean {
+        // Stop banned event classes from getting fired
         if (BannedClasses.isBanned(this.javaClass)) return false
 
         EventCounter.count(eventName)
@@ -44,6 +45,7 @@ abstract class LorenzEvent : Event() {
         eventHandlerDepth++
         for (listener in getListeners()) {
             val shListener = (listener as? ASMEventHandlerExt)?.target_skyhanni
+            // Stop banned listener classes from accepting events
             if (BannedClasses.isBanned(shListener?.javaClass)) {
                 continue
             }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/ASMEventHandlerExt.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/ASMEventHandlerExt.java
@@ -1,0 +1,5 @@
+package at.hannibal2.skyhanni.mixins.hooks;
+
+public interface ASMEventHandlerExt {
+    Object getTarget_skyhanni();
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/RememberEventHandlerTarget.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/RememberEventHandlerTarget.java
@@ -7,6 +7,7 @@ import net.minecraftforge.fml.common.eventhandler.ASMEventHandler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.lang.reflect.Method;
 
@@ -15,8 +16,8 @@ import java.lang.reflect.Method;
 public class RememberEventHandlerTarget implements ASMEventHandlerExt {
     private Object skyhanni_target;
 
-    @Inject(method = "<init>", at = @At("TAIL"))
-    private void onInject(Object target, Method method, ModContainer owner) {
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onInject(Object target, Method method, ModContainer owner, CallbackInfo ci) {
         skyhanni_target = target;
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/RememberEventHandlerTarget.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/RememberEventHandlerTarget.java
@@ -1,0 +1,27 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.mixins.hooks.ASMEventHandlerExt;
+import jline.internal.Nullable;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.eventhandler.ASMEventHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+
+import java.lang.reflect.Method;
+
+
+@Mixin(ASMEventHandler.class)
+public class RememberEventHandlerTarget implements ASMEventHandlerExt {
+    private Object skyhanni_target;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void onInject(Object target, Method method, ModContainer owner) {
+        skyhanni_target = target;
+    }
+
+    @Override
+    public @Nullable Object getTarget_skyhanni() {
+        return skyhanni_target;
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils.round
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.isInt
-import at.hannibal2.skyhanni.utils.ReflectionUtils.makeAccessible
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.Minecraft
@@ -248,8 +247,8 @@ object PacketTest {
         is S0CPacketSpawnPlayer -> entityID
         is S0FPacketSpawnMob -> entityID
         is S0EPacketSpawnObject -> entityID
-        is S19PacketEntityHeadLook -> javaClass.getDeclaredField("entityId").makeAccessible().get(this) as Int
-        is S19PacketEntityStatus -> javaClass.getDeclaredField("entityId").makeAccessible().get(this) as Int
+//         is S19PacketEntityHeadLook -> javaClass.getDeclaredField("entityId").makeAccessible().get(this) as Int
+//         is S19PacketEntityStatus -> javaClass.getDeclaredField("entityId").makeAccessible().get(this) as Int
         /* is S14PacketEntity.S15PacketEntityRelMove -> packet.javaClass.getDeclaredField("entityId").makeAccessible().get(packet) as Int
         is S14PacketEntity.S16PacketEntityLook -> packet.javaClass.getDeclaredField("entityId").makeAccessible().get(packet) as Int
         is S14PacketEntity.S17PacketEntityLookMove -> packet.javaClass.getDeclaredField("entityId").makeAccessible().get(packet) as Int */


### PR DESCRIPTION
## What
Added a list of banned classes per mod versions in the repo that either hide events or listener classes.
Useful for hot fixing bugs, illegal features, or other Hypixel things.

## How to test

<details>
<summary>Test Tutorial</summary>

Create the repo file BannedClasses.json, and write this inside:
```
{
    "banned_classes": {
        "0.24.Beta.20": [
            "at.hannibal2.skyhanni.features.garden.composter.ComposterDisplay",
            "at.hannibal2.skyhanni.events.LorenzChatEvent"
        ]
    }
}
```
Notice how both all chat filters no longer work, and the composter display does no longer show.

</details>


## Changelog Technical Details
+ Added banned classes. - hannibal2
    * Stop banned event classes from getting fired.
    * Stop banned listener classes from accepting events.