### PR TITLE
Improvement: Show Foxy's extra event in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.put
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.asTimeMark
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import io.github.moulberry.notenoughupdates.util.SkyBlockTime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -20,6 +21,12 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 object MayorAPI {
+
+    val foxyExtraEventPattern by RepoPattern.pattern(
+        "mayorapi.foxy.extraevent",
+        "Schedules an extra §.(?<event>Mining Fiesta) §.event during the year\\."
+    )
+
     var lastUpdate = SimpleTimeMark.farPast()
     private var dispatcher = Dispatchers.IO
 

--- a/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
@@ -24,7 +24,7 @@ object MayorAPI {
 
     val foxyExtraEventPattern by RepoPattern.pattern(
         "mayorapi.foxy.extraevent",
-        "Schedules an extra §.(?<event>Mining Fiesta) §.event during the year\\."
+        "Schedules an extra §.(?<event>.*) §.event during the year\\."
     )
 
     var lastUpdate = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
@@ -14,7 +14,7 @@ enum class Mayor(
     DIANA("Diana", "§2", Perk.LUCKY, Perk.MYTHOLOGICAL_RITUAL, Perk.PET_XP_BUFF),
     DIAZ("Diaz", "§6", Perk.BARRIER_STREET, Perk.SHOPPING_SPREE),
     FINNEGAN("Finnegan", "§c", Perk.FARMING_SIMULATOR, Perk.PELT_POCALYPSE, Perk.GOATED),
-    FOXY("Foxy", "§d", Perk.SWEET_TOOTH, Perk.BENEVOLENCE, Perk.EXTRA_EVENT_M, Perk.EXTRA_EVENT_F, Perk.EXTRA_EVENT_S),
+    FOXY("Foxy", "§d", Perk.SWEET_TOOTH, Perk.BENEVOLENCE, Perk.EXTRA_EVENT_MINING, Perk.EXTRA_EVENT_FISHING, Perk.EXTRA_EVENT_SPOOKY),
     MARINA("Marina", "§b", Perk.FISHING_XP_BUFF, Perk.LUCK_OF_THE_SEA, Perk.FISHING_FESTIVAL),
     PAUL("Paul", "§c", Perk.MARAUDER, Perk.EZPZ, Perk.BENEDICTION),
 
@@ -87,9 +87,9 @@ enum class Perk(val perkName: String) {
     // Foxy
     SWEET_TOOTH("Sweet Tooth"),
     BENEVOLENCE("Benevolence"),
-    EXTRA_EVENT_M("Extra Event (Mining)"),
-    EXTRA_EVENT_F("Extra Event (Fishing)"),
-    EXTRA_EVENT_S("Extra Event (Spooky)"),
+    EXTRA_EVENT_MINING("Extra Event (Mining)"),
+    EXTRA_EVENT_FISHING("Extra Event (Fishing)"),
+    EXTRA_EVENT_SPOOKY("Extra Event (Spooky)"),
 
     // Marina
     FISHING_XP_BUFF("Fishing XP Buff"),

--- a/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
@@ -35,7 +35,7 @@ enum class Mayor(
 
             mayor.perks.forEach { it.isActive = false }
             mayor.activePerks.clear()
-            perks.mapNotNull { perk -> Perk.entries.firstOrNull { it.perkName == perk.tryAndGetExtraFoxyEvent() } }
+            perks.mapNotNull { perk -> Perk.entries.firstOrNull { it.perkName == perk.renameIfFoxyExtraEventPerkFound() } }
                 .filter { mayor.perks.contains(it) }.forEach {
                     it.isActive = true
                     mayor.activePerks.add(it)
@@ -44,7 +44,7 @@ enum class Mayor(
             return mayor
         }
 
-        private fun MayorJson.Perk.tryAndGetExtraFoxyEvent(): String? {
+        private fun MayorJson.Perk.renameIfFoxyExtraEventPerkFound(): String? {
             val foxyExtraEventPairs = mapOf(
                 "Spooky Festival" to "Extra Event (Spooky)",
                 "Mining Fiesta" to "Extra Event (Mining)",

--- a/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.data
 
+import at.hannibal2.skyhanni.data.MayorAPI.foxyExtraEventPattern
 import at.hannibal2.skyhanni.data.jsonobjects.local.MayorJson
+import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 
 enum class Mayor(
     val mayorName: String,
@@ -12,7 +14,7 @@ enum class Mayor(
     DIANA("Diana", "§2", Perk.LUCKY, Perk.MYTHOLOGICAL_RITUAL, Perk.PET_XP_BUFF),
     DIAZ("Diaz", "§6", Perk.BARRIER_STREET, Perk.SHOPPING_SPREE),
     FINNEGAN("Finnegan", "§c", Perk.FARMING_SIMULATOR, Perk.PELT_POCALYPSE, Perk.GOATED),
-    FOXY("Foxy", "§d", Perk.SWEET_TOOTH, Perk.BENEVOLENCE, Perk.EXTRA_EVENT),
+    FOXY("Foxy", "§d", Perk.SWEET_TOOTH, Perk.BENEVOLENCE, Perk.EXTRA_EVENT_M, Perk.EXTRA_EVENT_F, Perk.EXTRA_EVENT_S),
     MARINA("Marina", "§b", Perk.FISHING_XP_BUFF, Perk.LUCK_OF_THE_SEA, Perk.FISHING_FESTIVAL),
     PAUL("Paul", "§c", Perk.MARAUDER, Perk.EZPZ, Perk.BENEDICTION),
 
@@ -33,13 +35,26 @@ enum class Mayor(
 
             mayor.perks.forEach { it.isActive = false }
             mayor.activePerks.clear()
-            perks.mapNotNull { perk -> Perk.entries.firstOrNull { it.perkName == perk.name } }
+            perks.mapNotNull { perk -> Perk.entries.firstOrNull { it.perkName == perk.tryAndGetExtraFoxyEvent() } }
                 .filter { mayor.perks.contains(it) }.forEach {
                     it.isActive = true
                     mayor.activePerks.add(it)
                 }
 
             return mayor
+        }
+
+        private fun MayorJson.Perk.tryAndGetExtraFoxyEvent(): String? {
+            val foxyExtraEventPairs = mapOf(
+                "Spooky Festival" to "Extra Event (Spooky)",
+                "Mining Fiesta" to "Extra Event (Mining)",
+                "Fishing Festival" to "Extra Event (Fishing)"
+            )
+
+            foxyExtraEventPattern.matchMatcher(this.description) {
+                return foxyExtraEventPairs.entries.firstOrNull { it.key == group("event") }?.value
+            }
+            return this.name
         }
     }
 }
@@ -72,7 +87,9 @@ enum class Perk(val perkName: String) {
     // Foxy
     SWEET_TOOTH("Sweet Tooth"),
     BENEVOLENCE("Benevolence"),
-    EXTRA_EVENT("Extra Event"),
+    EXTRA_EVENT_M("Extra Event (Mining)"),
+    EXTRA_EVENT_F("Extra Event (Fishing)"),
+    EXTRA_EVENT_S("Extra Event (Spooky)"),
 
     // Marina
     FISHING_XP_BUFF("Fishing XP Buff"),


### PR DESCRIPTION
## What
This Pull Request shows what the current extra event from Foxy is.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/45315647/37bcd87f-d10c-4b92-942e-98072d182c06)

</details>

## Changelog Improvements
+ Added feature to showcase foxy's extra in Custom Scoreboard. - j10a1n15
