### PR TITLE
Fix: Reducing sensitivity after locking doesn't keep the mouse locked

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/SensitivityReducer.kt
@@ -139,11 +139,11 @@ object SensitivityReducer {
 
         if (!LockMouseLook.lockedMouse) {
             storage.savedMouseloweredSensitivity = gameSettings.mouseSensitivity
+            val newSens = doTheMath(storage.savedMouseloweredSensitivity)
+            gameSettings?.mouseSensitivity = newSens
         } else {
             storage.savedMouseloweredSensitivity = storage.savedMouselockedSensitivity
         }
-        val newSens = doTheMath(storage.savedMouseloweredSensitivity)
-        gameSettings?.mouseSensitivity = newSens
         if (showMessage) ChatUtils.chat("§bMouse sensitivity is now lowered. Type /shsensreduce to restore your sensitivity.")
     }
 


### PR DESCRIPTION
## What
fixes "lock -> lower" not keeping the mouse locked
https://canary.discord.com/channels/997079228510117908/1221572382855270566

## Changelog Fixes
+ Fixed mouse locking not always working. - martimavocado