### PR TITLE
Fix: Fixed Powder color in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -676,32 +676,40 @@ private fun getQuiverShowWhen(): Boolean {
 }
 
 private fun getPowderDisplayPair() = buildList {
-    val powderTypes = listOf(
-        "§2Mithril" to getGroupFromPattern(
+    val powderTypes: List<Triple<String, String, String>> = listOf(
+        Triple("Mithril", "§2", getGroupFromPattern(
             TabListData.getTabList(),
             ScoreboardPattern.mithrilPowderPattern,
             "mithrilpowder"
-        ).formatNum(),
-        "§dGemstone" to getGroupFromPattern(
+        ).formatNum()),
+        Triple("Gemstone", "§d", getGroupFromPattern(
             TabListData.getTabList(),
             ScoreboardPattern.gemstonePowderPattern,
             "gemstonepowder"
-        ).formatNum(),
-        "§bGlacite" to getGroupFromPattern(
+        ).formatNum()),
+        Triple("Glacite", "§b", getGroupFromPattern(
             TabListData.getTabList(),
             ScoreboardPattern.glacitePowderPattern,
             "glacitepowder"
-        ).formatNum(),
+        ).formatNum())
     )
 
-    if (informationFilteringConfig.hideEmptyLines && powderTypes.all { it.second == "0" }) {
+    if (informationFilteringConfig.hideEmptyLines && powderTypes.all { it.third == "0" }) {
         add("<hidden>" to HorizontalAlignment.LEFT)
     } else {
         add("§9§lPowder" to HorizontalAlignment.LEFT)
 
-        for ((type, value) in powderTypes) {
-            if (value != "0") {
-                add(" §7- §f$type: $value" to HorizontalAlignment.LEFT)
+        if (displayConfig.displayNumbersFirst) {
+            for ((type, color, value) in powderTypes) {
+                if (value != "0") {
+                    add(" §7- $color$value $type" to HorizontalAlignment.LEFT)
+                }
+            }
+        } else {
+            for ((type, color, value) in powderTypes) {
+                if (value != "0") {
+                    add(" §7- §f$type: $color$value" to HorizontalAlignment.LEFT)
+                }
             }
         }
     }


### PR DESCRIPTION
## What
This Pull Request fixes the powder display always showing the color first, instead of only when "numbers first" is enabled.

<details>
<summary>Images</summary>

unintended
![image](https://github.com/hannibal002/SkyHanni/assets/45315647/8ef07ee3-1054-41d4-a896-beb19d111289)
intended
![image](https://github.com/hannibal002/SkyHanni/assets/45315647/d7141242-dfcb-43fd-a22e-32620b21f1e8)

</details>

## Changelog Fixes
+ Fixed powder display always displaying the color first in Custom Scoreboard. - j10a1n15

