### PR TITLE
Fix: Fixed Mining Events Priority in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -177,7 +177,7 @@ enum class ScoreboardEvents(
                     }
                 }
             } else {
-                add(eventsConfig.eventEntries.firstOrNull { it.showWhen() })
+                add(eventsConfig.eventEntries.firstOrNull { it.showWhen() && it.getLines().isNotEmpty() })
             }
         }
 


### PR DESCRIPTION
## What
This Pull Request fixes mining events priority.


## Changelog Fixes
+ Fixed Mining Events Priority in Custom Scoreboard. - j10a1n15

