### PR TITLE
Fix: Fixed Booster Cookie time when its not active

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -421,6 +421,6 @@ object ScoreboardPattern {
     )
     val cookieNotActivePattern by tablistGroup.pattern(
         "cookienotactive",
-        "Not active|§c§lINACTIVE"
+        "((?:§.)*Not active.*)|(§c§lINACTIVE)"
     )
 }


### PR DESCRIPTION
## What
This Pull Request fixes the cookie time when a cookie is not active.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/45315647/978ae89e-6c64-4d05-9b92-6c4936fe9c4c)

</details>

exclude_from_changelog