### PR TITLE
Improvement + Fix: Pest Tracker Waypoint trigerring with some other particles

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -75,9 +75,13 @@ class PestParticleWaypoint {
         if (!isEnabled()) return
         if (event.type != EnumParticleTypes.REDSTONE || event.speed != 1f) return
 
-        isPointingToPest = when (event.offset) {
-            LorenzVec(0.8, 0.0, 0.0) -> false
-            LorenzVec(0.8, 0.4, 0.0) -> true
+        val darkYellow = LorenzVec(0.0, 0.8, 0.0)
+        val yellow = LorenzVec(0.8, 0.8, 0.0)
+        val redPest = LorenzVec(0.8, 0.4, 0.0)
+        val redPlot = LorenzVec(0.8, 0.0, 0.0)
+        isPointingToPest = when (event.offset.round(5)) {
+            redPlot -> false
+            redPest, yellow, darkYellow -> true
             else -> return
         }
         val location = event.location

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
+import at.hannibal2.skyhanni.events.garden.pests.PestUpdateEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayerIgnoreY
@@ -150,6 +151,11 @@ class PestParticleWaypoint {
         if (guessPoint.distanceToPlayerIgnoreY() > 8) return
         if (isPointingToPest && lastPestTrackerUse.passedSince() !in 1.seconds..config.showForSeconds.seconds) return
         reset()
+    }
+
+    @SubscribeEvent
+    fun onPestUpdate(event: PestUpdateEvent) {
+        if (PestAPI.scoreboardPests == 0) reset()
     }
 
     private fun calculateWaypoint(list: MutableList<LorenzVec>): LorenzVec? {


### PR DESCRIPTION
## What
Fixes pest tracker not working when using certain pets with visibility on using armors with specific runes, or others, and improves the detection of whether its pointing to a pest or to the center of a plot using the particle offset.

## Changelog Improvements
+ Better pest tracker waypoint detection for pest or center of plot. - Empa
+ Immediately hide waypoints when there are no pests left. - Empa

## Changelog Fixes
+ Fixed some particles triggering the pest tracker waypoint. - Empa