### PR TITLE
Fix: Fixed Server Player Amount not being affected by "display numbers first"

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -496,7 +496,10 @@ fun getPlayerAmountDisplayPair() = buildList {
     } else {
         ""
     }
-    add("§7Players: §a${getPlayersOnCurrentServer()}$max" to HorizontalAlignment.LEFT)
+    if (displayConfig.displayNumbersFirst)
+        add("§a${getPlayersOnCurrentServer()}$max Players" to HorizontalAlignment.LEFT)
+    else
+        add("§7Players: §a${getPlayersOnCurrentServer()}$max" to HorizontalAlignment.LEFT)
 }
 
 private fun getVisitDisplayPair() =
@@ -689,21 +692,27 @@ private fun getQuiverShowWhen(): Boolean {
 
 private fun getPowderDisplayPair() = buildList {
     val powderTypes: List<Triple<String, String, String>> = listOf(
-        Triple("Mithril", "§2", getGroupFromPattern(
-            TabListData.getTabList(),
-            ScoreboardPattern.mithrilPowderPattern,
-            "mithrilpowder"
-        ).formatNum()),
-        Triple("Gemstone", "§d", getGroupFromPattern(
-            TabListData.getTabList(),
-            ScoreboardPattern.gemstonePowderPattern,
-            "gemstonepowder"
-        ).formatNum()),
-        Triple("Glacite", "§b", getGroupFromPattern(
-            TabListData.getTabList(),
-            ScoreboardPattern.glacitePowderPattern,
-            "glacitepowder"
-        ).formatNum())
+        Triple(
+            "Mithril", "§2", getGroupFromPattern(
+                TabListData.getTabList(),
+                ScoreboardPattern.mithrilPowderPattern,
+                "mithrilpowder"
+            ).formatNum()
+        ),
+        Triple(
+            "Gemstone", "§d", getGroupFromPattern(
+                TabListData.getTabList(),
+                ScoreboardPattern.gemstonePowderPattern,
+                "gemstonepowder"
+            ).formatNum()
+        ),
+        Triple(
+            "Glacite", "§b", getGroupFromPattern(
+                TabListData.getTabList(),
+                ScoreboardPattern.glacitePowderPattern,
+                "glacitepowder"
+            ).formatNum()
+        )
     )
 
     if (informationFilteringConfig.hideEmptyLines && powderTypes.all { it.third == "0" }) {


### PR DESCRIPTION
## What
This Pull Request fixes the option "Display Numbers first" not affecting the server player amount (thank you empa).

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/45315647/cdc08c1e-b8f2-4d76-bb69-43fd1dbd7420)

</details>

## Changelog Fixes
+ Fixed Server Player Amount not being affected by "display numbers first". - j10a1n15
