### PR TITLE
Fix: Showing Dwarven specific events in Crystal Hollows/Mineshaft.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventDisplay.kt
@@ -70,7 +70,8 @@ object MiningEventDisplay {
 
     fun updateData(eventData: MiningEventData) {
         eventData.runningEvents.forEach { (islandType, events) ->
-            val sorted = events.sortedBy { it.endsAt - it.event.defaultLength.inWholeMilliseconds }
+            val sorted = events.filter { islandType == IslandType.DWARVEN_MINES || !it.event.dwarvenSpecific }
+                .sortedBy { it.endsAt - it.event.defaultLength.inWholeMilliseconds }
 
             val oldData = islandEventData[islandType]
             if (oldData == null) {


### PR DESCRIPTION
## What
Fix: Showing Dwarven specific events in Crystal Hollows/Mineshaft. Still not sure how they are getting sent but i believe it is due to Hypixel sending wrong bossbar and people are on old version that doesnt check for dwarven specfic.

## Changelog Fixes
+ Further fixed Showing Dwarven specific events in Crystal Hollows/Mineshaft section of mining event display. - CalMWolfs
