### PR TITLE
Fix: PestAPI tablist formatting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -75,7 +75,7 @@ object PestAPI {
         "§4§lൠ §cThis plot has §6(?<amount>\\d) Pests?§c!"
     )
     /**
-     * REGEX-TEST:  Infested Plots: §r§b4§r§f, §r§b12§r§f, §r§b13§r§f, §r§b18§r§f, §r§b20
+     * REGEX-TEST:  Plots: §r§b4§r§f, §r§b12§r§f, §r§b13§r§f, §r§b18§r§f, §r§b20
      */
     private val infectedPlotsTablistPattern by patternGroup.pattern(
         "tablist.infectedplots",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -79,7 +79,7 @@ object PestAPI {
      */
     private val infectedPlotsTablistPattern by patternGroup.pattern(
         "tablist.infectedplots",
-        "\\sInfested Plots: (?<plots>.*)"
+        "\\sPlots: (?<plots>.*)"
     )
 
     private fun fixPests() {


### PR DESCRIPTION
## What
Fixes the repo pattern for getting infected plots from tablist because hypixel changed formatting again (yay)

## Changelog Fixes
+ Fixed not detecting infected plots from tab list. - Empa