### PR TITLE
Fix: Black Hotbar Slots

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
@@ -47,10 +47,18 @@ class GuiEditManager {
         openGuiPositionEditor(hotkeyReminder = false)
     }
 
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    fun e(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        GlStateManager.translate(0f, 0f, 0f)
+    }
+
     @SubscribeEvent(priority = EventPriority.LOWEST)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         latestPositions = currentPositions.toMap()
         currentPositions.clear()
+        GlStateManager.color(1f, 1f, 1f, 1f)
+        GlStateManager.enableBlend()
+        GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0)
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
@@ -47,11 +47,6 @@ class GuiEditManager {
         openGuiPositionEditor(hotkeyReminder = false)
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
-    fun e(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        GlStateManager.translate(0f, 0f, 0f)
-    }
-
     @SubscribeEvent(priority = EventPriority.LOWEST)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         latestPositions = currentPositions.toMap()


### PR DESCRIPTION
## What
Fixed the issue with the black hotbar slots for good, be "reseting" the state as a last thing for the GuiOverlayRenderEvent event. It could make issue if the inistial state where diffrent, but can't fix that because it's hard to get the state out of the GlStateManger since everything is private and there are no geters only setters.

## Changelog Fixes
+ Fixed Hotbar loosing its transparency. - Thunderblade73
    * This was the case if the skill progress none textured bar was rendered.