### PR TITLE
Fix: Dungeon Floor Number

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -311,7 +311,9 @@ class DungeonFinderFeatures {
     fun onRenderItemTip(event: RenderInventoryItemTipEvent) {
         if (!isEnabled()) return
         if (!config.floorAsStackSize) return
-        event.stackTip = (floorStackSize[event.slot.slotIndex]
+        val slot = event.slot
+        if (slot.slotNumber != slot.slotIndex) return
+        event.stackTip = (floorStackSize[slot.slotIndex]
             ?.takeIf { it.isNotEmpty() } ?: return)
     }
 


### PR DESCRIPTION
## What
fix dungeon floor number in inventory
Discord bug report: https://discord.com/channels/997079228510117908/1222561686976987259

## Changelog Fixes
+ Fixed showing the Dungeon Floor numbers in your inventory as well while inside the Catacombs Gate menu. - hannibal2