### PR TITLE
Improvement: Auto Disable Collection Highlight

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SkyblockGuideConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SkyblockGuideConfig.java
@@ -19,7 +19,7 @@ public class SkyblockGuideConfig {
         desc = "Highlights missing collections.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean collectionGuide = true;
+    public boolean collectionGuide = false;
 
     @Expose
     @ConfigOption(name = "Abiphone Highlight",


### PR DESCRIPTION
## What
Currently, the SkyBlock level guide highlights missing items feature also highlights collections per default. This pull request changes the default value to false.

Discord message: https://discord.com/channels/997079228510117908/1000669238035497022/1222503545366909050

## Changelog Improvements
+ Changed SkyBlock Level Guide Highlighting Collections to no longer being default enabled. - hannibal2