### PR TITLE
Backend: error manager only for beta users

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -804,16 +804,19 @@ private fun getFooterDisplayPair() = listOf(
 private fun getExtraDisplayPair(): List<ScoreboardElementType> {
     if (unknownLines.isEmpty()) return listOf("<hidden>" to HorizontalAlignment.LEFT)
 
-    if (amountOfUnknownLines != unknownLines.size && config.unknownLinesWarning) {
+    val size = unknownLines.size
+    if (amountOfUnknownLines != size && config.unknownLinesWarning) {
+        val message = "CustomScoreboard detected $size unknown line${if (size > 1) "s" else ""}"
         ErrorManager.logErrorWithData(
-            CustomScoreboardUtils.UndetectedScoreboardLines("CustomScoreboard detected ${unknownLines.size} unknown line${if (unknownLines.size > 1) "s" else ""}"),
-            "CustomScoreboard detected ${unknownLines.size} unknown line${if (unknownLines.size > 1) "s" else ""}",
+            CustomScoreboardUtils.UndetectedScoreboardLines(message),
+            message,
             "Unknown Lines" to unknownLines,
             "Island" to HypixelData.skyBlockIsland,
             "Area" to HypixelData.skyBlockArea,
-            noStackTrace = true
+            noStackTrace = true,
+            betaOnly = true,
         )
-        amountOfUnknownLines = unknownLines.size
+        amountOfUnknownLines = size
     }
 
     return listOf("§cUndetected Lines:" to HorizontalAlignment.LEFT) + unknownLines.map { it to HorizontalAlignment.LEFT }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -810,10 +810,10 @@ private fun getExtraDisplayPair(): List<ScoreboardElementType> {
 
     val size = unknownLines.size
     if (amountOfUnknownLines != size && devConfig.unknownLinesWarning) {
-        val message = "CustomScoreboard detected $size unknown line${if (size > 1) "s" else ""}"
+        val message = "CustomScoreboard detected ${pluralize(unknownLines.size, "unknown line", withNumber = true)}"
         ErrorManager.logErrorWithData(
-            CustomScoreboardUtils.UndetectedScoreboardLines("CustomScoreboard detected ${pluralize(unknownLines.size, "unknown line", withNumber = true)}"),
-            "CustomScoreboard detected ${pluralize(unknownLines.size, "unknown line", withNumber = true)}",
+            CustomScoreboardUtils.UndetectedScoreboardLines(message),
+            message,
             "Unknown Lines" to unknownLines,
             "Island" to HypixelData.skyBlockIsland,
             "Area" to HypixelData.skyBlockArea,

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -814,7 +814,6 @@ private fun getExtraDisplayPair(): List<ScoreboardElementType> {
             "Island" to HypixelData.skyBlockIsland,
             "Area" to HypixelData.skyBlockArea,
             noStackTrace = true,
-            betaOnly = true,
         )
         amountOfUnknownLines = size
     }

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.test.command
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -87,8 +88,9 @@ object ErrorManager {
         vararg extraData: Pair<String, Any?>,
         ignoreErrorCache: Boolean = false,
         noStackTrace: Boolean = false,
+        betaOnly: Boolean = false,
     ) {
-        logError(IllegalStateException(internalMessage), userMessage, ignoreErrorCache, noStackTrace, *extraData)
+        logError(IllegalStateException(internalMessage), userMessage, ignoreErrorCache, noStackTrace, *extraData, betaOnly = betaOnly)
     }
 
     @Deprecated("Use data as well", ReplaceWith("ErrorManager.logErrorWithData(throwable, message)"))
@@ -102,8 +104,9 @@ object ErrorManager {
         vararg extraData: Pair<String, Any?>,
         ignoreErrorCache: Boolean = false,
         noStackTrace: Boolean = false,
+        betaOnly: Boolean = false,
     ) {
-        logError(throwable, message, ignoreErrorCache, noStackTrace, *extraData)
+        logError(throwable, message, ignoreErrorCache, noStackTrace, *extraData, betaOnly = betaOnly)
     }
 
     private fun logError(
@@ -112,7 +115,9 @@ object ErrorManager {
         ignoreErrorCache: Boolean,
         noStackTrace: Boolean,
         vararg extraData: Pair<String, Any?>,
+        betaOnly: Boolean = false,
     ) {
+        if (betaOnly && !LorenzUtils.isBetaVersion()) return
         if (!ignoreErrorCache) {
             val pair = if (throwable.stackTrace.isNotEmpty()) {
                 throwable.stackTrace[0].let { (it.fileName ?: "<unknown>") to it.lineNumber }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
+import at.hannibal2.skyhanni.features.misc.update.UpdateManager
 import at.hannibal2.skyhanni.mixins.transformers.AccessorGuiEditSign
 import at.hannibal2.skyhanni.test.TestBingo
 import at.hannibal2.skyhanni.utils.ChatUtils.lastButtonClicked
@@ -372,4 +373,6 @@ object LorenzUtils {
 
     fun inMiningIsland() = IslandType.GOLD_MINES.isInIsland() || IslandType.DEEP_CAVERNS.isInIsland()
         || inAdvancedMiningIsland()
+
+    fun isBetaVersion() = UpdateManager.isCurrentlyBeta()
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -7,8 +7,8 @@ import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
-import at.hannibal2.skyhanni.features.misc.visualwords.ModifyVisualWords
 import at.hannibal2.skyhanni.features.misc.update.UpdateManager
+import at.hannibal2.skyhanni.features.misc.visualwords.ModifyVisualWords
 import at.hannibal2.skyhanni.mixins.transformers.AccessorGuiEditSign
 import at.hannibal2.skyhanni.test.TestBingo
 import at.hannibal2.skyhanni.utils.ChatUtils.lastButtonClicked


### PR DESCRIPTION
## What
Error Manager now has a parameter to only show for beta users.

Instead of putting this behind a toggle in the settings, this is now a form of differentiating between beta users and full version users. Beta users are meant to see more "behind the scenes" stuff or the mod, and also more error messages so we can easier fix bugs.
At the same time, we don't want too many duplicate bug reports from many more full version users and don't want to bother them with error messages as much.

## Changelog Technical Details
+ Error Manager now has a parameter to only show for beta users. - hannibal2
    * Less spam for full version users, still enough reports from beat users.