### PR TITLE
Fix: Ghost Entities Fix

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
@@ -55,5 +55,5 @@ object FixGhostEntities {
         }
     }
 
-    fun isEnabled() = LorenzUtils.connectedToHypixel && config.fixGhostEntities
+    fun isEnabled() = LorenzUtils.inSkyBlock && config.fixGhostEntities
 }


### PR DESCRIPTION
## What
Fix "Ghost Entities" feature breaking outside SkyBlock game modes on Hypixel

## Changelog Fixes
+ Fix "Ghost Entities" feature breaking outside SkyBlock game modes on Hypixel. - hannibal2