### PR TITLE
Fix: /playtimedetailed tooltip generation, limbostats with negative luck

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -137,10 +137,22 @@ class LimboPlaytime {
         minutesList: MutableList<String>,
         hoursList: MutableList<String>,
     ) {
-        val firstLine = toolTip.first()
-        val totalPlaytime = toolTip.last()
+        val firstList = mutableListOf<String>()
+        val lastList = mutableListOf<String>()
+        var hasPassed = false
+        toolTip.forEach {
+            if (!(hoursPattern.matches(it) || minutesPattern.matches(it)) && !hasPassed) {
+                firstList.add(it)
+            } else hasPassed = true
+        }
+        hasPassed = false
+        toolTip.forEach {
+            if (!(hoursPattern.matches(it) || minutesPattern.matches(it)) && hasPassed) {
+                lastList.add(it)
+            } else hasPassed = true
+        }
         toolTip.clear()
-        toolTip.add(firstLine)
+        toolTip.addAll(firstList)
         if (!setMinutes) {
             toolTip.addAll(modifiedList)
             toolTip.addAll(minutesList)
@@ -148,7 +160,7 @@ class LimboPlaytime {
             toolTip.addAll(hoursList)
             toolTip.addAll(modifiedList)
         }
-        toolTip.add(totalPlaytime)
+        toolTip.addAll(lastList)
     }
 
     private fun findFloatDecimalPlace(input: Float): Int {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
@@ -146,7 +146,6 @@ object LimboTimeTracker {
         } else {
             val currentPB = storage?.personalBest ?: 0
             val userLuck = storage?.userLuck ?: 0f
-            storage?.userLuck = Float.NEGATIVE_INFINITY
             val limboPB: Int = if (currentPB < timeInLimbo) timeInLimbo else currentPB
             var luckString = tryTruncateFloat(userLuck.round(2))
             if (userLuck > 0) luckString = "+$luckString"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
@@ -146,9 +146,15 @@ object LimboTimeTracker {
         } else {
             val currentPB = storage?.personalBest ?: 0
             val userLuck = storage?.userLuck ?: 0f
+            storage?.userLuck = Float.NEGATIVE_INFINITY
             val limboPB: Int = if (currentPB < timeInLimbo) timeInLimbo else currentPB
-            ChatUtils.chat("§fYour current PB is §e${limboPB.seconds}§f, granting you §a+${userLuck.round(2)}✴ SkyHanni User Luck§f!")
-            ChatUtils.chat("§fYou have §e${playtime.seconds} §fof playtime!")
+            var luckString = tryTruncateFloat(userLuck.round(2))
+            if (userLuck > 0) luckString = "+$luckString"
+            var firstMessage = "§fYour current PB is §e${limboPB.seconds}§f, granting you §a$luckString✴ SkyHanni User Luck§f!"
+            val secondMessage = "§fYou have §e${playtime.seconds} §fof playtime!"
+            if ((userLuck == Float.POSITIVE_INFINITY) || (userLuck == Float.NEGATIVE_INFINITY)) firstMessage = "$firstMessage §Zwhat"
+            ChatUtils.chat(firstMessage)
+            ChatUtils.chat(secondMessage)
         }
     }
 
@@ -189,4 +195,10 @@ object LimboTimeTracker {
     }
 
     fun isEnabled() = config.showTimeInLimbo
+
+    private fun tryTruncateFloat(input: Float): String {
+        val string = input.toString()
+        return if (string.endsWith(".0")) return string.dropLast(2)
+        else string
+    }
 }


### PR DESCRIPTION
## What
- Fixes `/shlimbostats` not supporting negative luck values.
https://discord.com/channels/997079228510117908/997079229302837269/1223021717962621008
- Fixes tooltip generation in `/playtimedetailed`, previously additional lines such as the ones from `/sh dev` or `F3 + H` would break this
![image](https://github.com/hannibal002/SkyHanni/assets/39881008/18b27654-d649-435e-b243-9970e7635477)
https://discord.com/channels/997079228510117908/1117409804382642296/1222752922425888859

i want to move tryTruncateFloat somewhere else, is the better place for this StringUtils or NumberUtils? it might also need a better name

## Changelog Fixes
+ Fixed /shlimbostats not displaying negative SkyHanni User Luck correctly. - martimavocado
+ Fixed /playtimedetailed not always correctly displaying the tooltip. - martimavocado
