### PR TITLE
Fix: Pest Tracker Waypoint Color

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -86,8 +86,6 @@ class PestParticleWaypoint {
             else -> return
         }
 
-        val (r, g, b) = event.offset.toDoubleArray().map { it.toFloat() }
-        color = Color(r, g, b)
         val location = event.location
 
         if (config.hideParticles) event.cancel()
@@ -97,6 +95,8 @@ class PestParticleWaypoint {
         if (firstParticlePoint == null) {
             if (playerLocation().distance(location) > 5) return
             firstParticlePoint = location
+            val (r, g, b) = event.offset.toDoubleArray().map { it.toFloat() }
+            color = Color(r, g, b)
         } else if (secondParticlePoint == null) {
             secondParticlePoint = location
             lastParticlePoint = location


### PR DESCRIPTION
## What
Fixes pest tracker waypoint color sometimes rapidly changing between colors.

## Changelog Fixes
+ Fixed Pest Waypoint color flickering. - Empa