### PR TITLE
Add persian SkyHanni support

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/Features.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/Features.java
@@ -18,10 +18,13 @@ import at.hannibal2.skyhanni.config.features.rift.RiftConfig;
 import at.hannibal2.skyhanni.config.features.skillprogress.SkillProgressConfig;
 import at.hannibal2.skyhanni.config.features.slayer.SlayerConfig;
 import at.hannibal2.skyhanni.config.storage.Storage;
+import at.hannibal2.skyhanni.utils.LorenzUtils;
 import com.google.gson.annotations.Expose;
 import io.github.moulberry.moulconfig.Config;
 import io.github.moulberry.moulconfig.Social;
 import io.github.moulberry.moulconfig.annotations.Category;
+import io.github.moulberry.moulconfig.gui.HorizontalAlign;
+import io.github.moulberry.moulconfig.processor.ProcessedCategory;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.Arrays;
@@ -36,6 +39,13 @@ public class Features extends Config {
     @Override
     public boolean shouldAutoFocusSearchbar() {
         return true;
+    }
+
+    @Override
+    public HorizontalAlign alignCategory(ProcessedCategory category, boolean isSelected) {
+        if (LorenzUtils.INSTANCE.isAprilFoolsDay())
+            return HorizontalAlign.RIGHT;
+        return super.alignCategory(category, isSelected);
     }
 
     @Override
@@ -54,7 +64,11 @@ public class Features extends Config {
 
     @Override
     public String getTitle() {
-        return "SkyHanni " + SkyHanniMod.getVersion() + " by §channibal2§r, config by §5Moulberry §rand §5nea89";
+        String modName = "SkyHanni";
+        if (LorenzUtils.INSTANCE.isAprilFoolsDay())
+            modName = new StringBuilder().append("اسکای هانی").reverse().toString(); // Minecraft does not render RTL strings very nicely, so we reverse the string here. Not authentic, but close enough.
+
+        return modName + " " + SkyHanniMod.getVersion() + " by §channibal2§r, config by §5Moulberry §rand §5nea89";
     }
 
     /*

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.java
@@ -114,5 +114,10 @@ public class DebugConfig {
     public boolean currentAreaDebug = true;
 
     @Expose
+    @ConfigOption(name = "Always April Fools", desc = "Always show april fools jokes.")
+    @ConfigEditorBoolean
+    public boolean alwaysFunnyTime = false;
+
+    @Expose
     public Position trackSoundPosition = new Position(0, 0);
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -28,6 +28,8 @@ import net.minecraft.util.ChatComponentText
 import net.minecraftforge.fml.common.FMLCommonHandler
 import java.text.DecimalFormat
 import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.Month
 import java.util.Timer
 import java.util.TimerTask
 import java.util.regex.Matcher
@@ -66,6 +68,11 @@ object LorenzUtils {
     val isIronmanProfile get() = inSkyBlock && HypixelData.ironman
 
     val lastWorldSwitch get() = HypixelData.joinedWorld
+
+    val isAprilFoolsDay: Boolean
+        get() = SkyHanniMod.feature.dev.debug.alwaysFunnyTime || LocalDate.now().let {
+            it.month == Month.APRIL && it.dayOfMonth == 1
+        }
 
     fun SimpleDateFormat.formatCurrentTime(): String = this.format(System.currentTimeMillis())
 


### PR DESCRIPTION
## What

Added near eastern inspired config elements

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/20768569/2afd88d1-8884-495b-9a49-2ab68f69fa39)

</details>

## Changelog New Features
+ Added an April Fools joke - !nea
    * Adds a persian/farsi transliteration of the name "SkyHanni"
    * Adds right aligned category names to the config

exclude_from_changelog