### PR TITLE
Improvement + Fix: Use custom https ssl context for auto updater

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-libautoupdate = "1.0.3"
+libautoupdate = "1.3.1"
 moulconfig = "2.5.0"
 headlessLwjgl = "1.7.2"
 jbAnnotations = "24.1.0"

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.java
@@ -98,6 +98,11 @@ public class DebugConfig {
     public boolean hotSwapDetection = false;
 
     @Expose
+    @ConfigOption(name = "Always Outdated", desc = "For the sake of the auto updater, act like you are always oudated.")
+    @ConfigEditorBoolean
+    public boolean alwaysOutdated = false;
+
+    @Expose
     @ConfigOption(name = "SkyHanni Event Counter", desc = "Count once per second how many skyhanni events gets triggered, " +
         "show the total amount in console output.")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.LorenzLogger
+import com.google.gson.JsonElement
 import io.github.moulberry.moulconfig.processor.MoulConfigProcessor
 import io.github.moulberry.notenoughupdates.util.ApiUtil
 import io.github.moulberry.notenoughupdates.util.MinecraftExecutor
@@ -132,7 +133,24 @@ object UpdateManager {
     private val context = UpdateContext(
         UpdateSource.githubUpdateSource("hannibal002", "SkyHanni"),
         UpdateTarget.deleteAndSaveInTheSameFolder(UpdateManager::class.java),
-        CurrentVersion.ofTag(SkyHanniMod.version),
+        object : CurrentVersion {
+            val normalDelegate = CurrentVersion.ofTag(SkyHanniMod.version)
+            override fun display(): String {
+                if (SkyHanniMod.feature.dev.debug.alwaysOutdated)
+                    return "Force Outdated"
+                return normalDelegate.display()
+            }
+
+            override fun isOlderThan(element: JsonElement): Boolean {
+                if (SkyHanniMod.feature.dev.debug.alwaysOutdated)
+                    return true
+                return normalDelegate.isOlderThan(element)
+            }
+
+            override fun toString(): String {
+                return "ForceOutdateDelegate($normalDelegate)"
+            }
+        },
         SkyHanniMod.MODID,
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -8,16 +8,19 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import io.github.moulberry.moulconfig.processor.MoulConfigProcessor
+import io.github.moulberry.notenoughupdates.util.ApiUtil
 import io.github.moulberry.notenoughupdates.util.MinecraftExecutor
 import moe.nea.libautoupdate.CurrentVersion
 import moe.nea.libautoupdate.PotentialUpdate
 import moe.nea.libautoupdate.UpdateContext
 import moe.nea.libautoupdate.UpdateSource
 import moe.nea.libautoupdate.UpdateTarget
+import moe.nea.libautoupdate.UpdateUtils
 import net.minecraft.client.Minecraft
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.concurrent.CompletableFuture
+import javax.net.ssl.HttpsURLConnection
 
 object UpdateManager {
 
@@ -135,6 +138,11 @@ object UpdateManager {
 
     init {
         context.cleanup()
+        UpdateUtils.patchConnection {
+            if (it is HttpsURLConnection) {
+                ApiUtil.patchHttpsRequest(it)
+            }
+        }
     }
 
     enum class UpdateState {


### PR DESCRIPTION
## Dependencies

## What

Adds a custom https ssl context for auto updater requests.

## Changelog New Features

## Changelog Improvements

## Changelog Fixes
+ Fixed auto updater getting stuck on "Downloading" - !nea
    * Most of those cases are caused by a missing SSL certificate. Let's hope NEU includes that certificate, since we now use NEUs cert store for updating.

## Changelog Technical Details
+ Bumped libautoupdate version - !nea
+ Added always outdated toggle - !nea
    * Force the autoupdater to auto update

## Changelog Removed Features
