### PR TITLE
Fix: Fixed "Hide Empty Numbers" not hiding empty coop banks (Custom Scoreboard)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -361,7 +361,7 @@ private fun getBankDisplayPair(): List<ScoreboardElementType> {
 
     return listOf(
         when {
-            informationFilteringConfig.hideEmptyLines && bank == "0" -> "<hidden>"
+            informationFilteringConfig.hideEmptyLines && (bank == "0" || bank == "0§7 / §60") -> "<hidden>"
             displayConfig.displayNumbersFirst -> "§6$bank Bank"
             else -> "Bank: §6$bank"
         } to HorizontalAlignment.LEFT


### PR DESCRIPTION
## What
This Pull Request fixes coop banks not being affected by "hide empty numbers". This is a bit of an hacky solution for now, till someone or I finally code the BankAPI/include the bank into PurseAPI.


## Changelog Fixes
+ Fixed coop banks not being affected by "hide empty numbers" in Custom Scoreboard. - j10a1n15

