### PR TITLE
Feature: Dragon Priority in M7

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -105,6 +105,7 @@ import at.hannibal2.skyhanni.features.dungeon.DungeonChatFilter
 import at.hannibal2.skyhanni.features.dungeon.DungeonCleanEnd
 import at.hannibal2.skyhanni.features.dungeon.DungeonCopilot
 import at.hannibal2.skyhanni.features.dungeon.DungeonDeathCounter
+import at.hannibal2.skyhanni.features.dungeon.DungeonDragonPriority
 import at.hannibal2.skyhanni.features.dungeon.DungeonFinderFeatures
 import at.hannibal2.skyhanni.features.dungeon.DungeonHideItems
 import at.hannibal2.skyhanni.features.dungeon.DungeonHighlightClickedBlocks
@@ -806,6 +807,7 @@ class SkyHanniMod {
         loadModule(LimboPlaytime())
         loadModule(RareDropMessages())
         loadModule(CraftMaterialsFromBazaar())
+        loadModule(DungeonDragonPriority())
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
@@ -137,4 +137,28 @@ public class DragPrioConfig {
 
     @Expose
     public Position dragonSpawnedPosition = new Position(332, 220, 3.2f);
+
+
+    @Expose
+    @ConfigOption(name = "(debug) force class", desc = "forces the logic to think you are this class")
+    @ConfigEditorDropdown
+    public ForceClass forceClass = ForceClass.NONE;
+
+    public enum ForceClass {
+        ARCHER("Archer"),
+        BERSERK("Berserk"),
+        MAGE("Mage"),
+        TANK("Tank"),
+        HEALER("Healer"),
+        NONE("Disabled");
+
+        private final String str;
+
+        ForceClass(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public String toString() { return str; }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.features.dungeon;
 
+import at.hannibal2.skyhanni.config.core.config.Position;
 import com.google.gson.annotations.Expose;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorDropdown;
@@ -117,4 +118,16 @@ public class DragPrioConfig {
         @Override
         public String toString() { return str; }
     }
+
+    @Expose
+    @ConfigOption(name = "Title Duration", desc = "Sets for how long the title should be up.")
+    @ConfigEditorSlider(
+            minValue = 0f,
+            maxValue = 5f,
+            minStep = 0.1f
+    )
+    public float titleDuration = 2f;
+
+    @Expose
+    public Position dragonSpawnedPosition = new Position(332, 220, 3.2f);
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
@@ -1,0 +1,42 @@
+package at.hannibal2.skyhanni.config.features.dungeon;
+
+import com.google.gson.annotations.Expose;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorSlider;
+import io.github.moulberry.moulconfig.annotations.ConfigOption;
+
+public class DragPrioConfig {
+    @Expose
+    @ConfigOption(name = "Set Power", desc = "Set the power that you split on.")
+    @ConfigEditorSlider(
+            minValue = 0,
+            maxValue = 32,
+            minStep = 1
+    )
+    public int splitPower = 22;
+
+    @Expose
+    @ConfigOption(name = "Easy Power", desc = "Set the power that you split on for easy drags (O/P/G).")
+    @ConfigEditorSlider(
+            minValue = 0,
+            maxValue = 32,
+            minStep = 1
+    )
+    public int easyPower = 19;
+
+    @Expose
+    @ConfigOption(name = "Show Non-Split drags", desc = "Display \"X Dragon is spawning!\" on non-split drags.")
+    @ConfigEditorBoolean
+    public boolean showSingleDragons = true;
+
+    @Expose
+    @ConfigOption(name = "Send Split Message", desc = "Send the \"Bers Team: Arch Team:\" message.")
+    @ConfigEditorBoolean
+    public boolean sendMessage = false;
+
+
+    @Expose
+    @ConfigOption(name = "Say Split", desc = "Send \"Split\" when splitting.")
+    @ConfigEditorBoolean
+    public boolean saySplit = true;
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
@@ -9,6 +9,11 @@ import io.github.moulberry.moulconfig.annotations.ConfigOption;
 
 public class DragPrioConfig {
     @Expose
+    @ConfigOption(name = "Enabled", desc = "Enables the feature.")
+    @ConfigEditorBoolean
+    public boolean enabled = false;
+
+    @Expose
     @ConfigOption(name = "Set Power", desc = "Set the power that you split on.")
     @ConfigEditorSlider(
             minValue = 0,

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.config.features.dungeon;
 
 import com.google.gson.annotations.Expose;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorSlider;
 import io.github.moulberry.moulconfig.annotations.ConfigOption;
 
@@ -39,4 +40,81 @@ public class DragPrioConfig {
     @ConfigOption(name = "Say Split", desc = "Send \"Split\" when splitting.")
     @ConfigEditorBoolean
     public boolean saySplit = true;
+
+    @Expose
+    @ConfigOption(name = "Healer", desc = "Set the team the healer should be with")
+    @ConfigEditorDropdown
+    public HealerNormalValue healerNormal = HealerNormalValue.ARCHER;
+
+    public enum HealerNormalValue {
+        ARCHER("Archer Team"),
+        BERSERK("Berserk Team");
+
+        private final String str;
+
+        HealerNormalValue(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public String toString() { return str; }
+    }
+
+    @Expose
+    @ConfigOption(name = "Tank", desc = "Set the team the tank should be with")
+    @ConfigEditorDropdown
+    public TankNormalValue tankNormal = TankNormalValue.ARCHER;
+
+    public enum TankNormalValue {
+        ARCHER("Archer Team"),
+        BERSERK("Berserk Team");
+
+        private final String str;
+
+        TankNormalValue(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public String toString() { return str; }
+    }
+
+
+    @Expose
+    @ConfigOption(name = "Healer Purple", desc = "Set the team the healer should be with when purple")
+    @ConfigEditorDropdown
+    public HealerPurpleValue healerPurple = HealerPurpleValue.ARCHER;
+
+    public enum HealerPurpleValue {
+        ARCHER("Archer Team"),
+        BERSERK("Berserk Team");
+
+        private final String str;
+
+        HealerPurpleValue(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public String toString() { return str; }
+    }
+
+    @Expose
+    @ConfigOption(name = "Tank Purple", desc = "Set the team the tank should be with when purple")
+    @ConfigEditorDropdown
+    public TankPurpleValue tankPurple = TankPurpleValue.ARCHER;
+
+    public enum TankPurpleValue {
+        ARCHER("Archer Team"),
+        BERSERK("Berserk Team");
+
+        private final String str;
+
+        TankPurpleValue(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public String toString() { return str; }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
@@ -48,8 +48,8 @@ public class DragPrioConfig {
     public boolean saySplit = true;
 
     @Expose
-    @ConfigOption(name = "Healer", desc = "Set the team the healer should be with")
-    @ConfigEditorDropdown
+//    @ConfigOption(name = "Healer", desc = "Set the team the healer should be with")
+//    @ConfigEditorDropdown
     public HealerNormalValue healerNormal = HealerNormalValue.ARCHER;
 
     public enum HealerNormalValue {
@@ -67,8 +67,8 @@ public class DragPrioConfig {
     }
 
     @Expose
-    @ConfigOption(name = "Tank", desc = "Set the team the tank should be with")
-    @ConfigEditorDropdown
+//    @ConfigOption(name = "Tank", desc = "Set the team the tank should be with")
+//    @ConfigEditorDropdown
     public TankNormalValue tankNormal = TankNormalValue.ARCHER;
 
     public enum TankNormalValue {

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.features.dungeon;
 
+import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;
 import com.google.gson.annotations.Expose;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
@@ -10,6 +11,7 @@ import io.github.moulberry.moulconfig.annotations.ConfigOption;
 public class DragPrioConfig {
     @Expose
     @ConfigOption(name = "Enabled", desc = "Enables the feature.")
+    @FeatureToggle
     @ConfigEditorBoolean
     public boolean enabled = false;
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DragPrioConfig.java
@@ -5,8 +5,10 @@ import at.hannibal2.skyhanni.config.core.config.Position;
 import com.google.gson.annotations.Expose;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorDropdown;
+import io.github.moulberry.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.moulberry.moulconfig.annotations.ConfigEditorSlider;
 import io.github.moulberry.moulconfig.annotations.ConfigOption;
+import org.lwjgl.input.Keyboard;
 
 public class DragPrioConfig {
     @Expose
@@ -161,4 +163,10 @@ public class DragPrioConfig {
         @Override
         public String toString() { return str; }
     }
+
+    @Expose
+    @ConfigOption(name = "Toggle Hotkey", desc = "Press this key to quickly toggle between Normal and Split modes." +
+            "\n§eRequires the relevant above settings to be toggled")
+    @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
+    public int keyBindToggleModes = Keyboard.KEY_NONE;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.java
@@ -93,6 +93,11 @@ public class DungeonConfig {
     public TerracottaPhaseConfig terracottaPhase = new TerracottaPhaseConfig();
 
     @Expose
+    @ConfigOption(name = "Drag Prio", desc = "drag prio")
+    @Accordion
+    public DragPrioConfig dragPrio = new DragPrioConfig();
+
+    @Expose
     @ConfigOption(name = "Moving Skeleton Skulls", desc = "Highlight Skeleton Skulls when combining into an " +
         "orange Skeletor (not useful when combined with feature Hide Skeleton Skull).")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
@@ -62,7 +62,7 @@ object DungeonAPI {
         "§r§r§fBlessing of (?<type>\\w+) (?<amount>\\w+)§r"
     )
     private val noBlessingPattern by patternGroup.pattern(
-        "noBlessings",
+        "noblessings",
         "§r§r§7No Buffs active. Find them by exploring the Dungeon!§r"
     )
 
@@ -71,7 +71,13 @@ object DungeonAPI {
         POWER(0),
         STONE(0),
         WISDOM(0),
-        TIME(0)
+        TIME(0);
+
+        companion object {
+            fun reset() {
+                entries.forEach { it.power = 0 }
+            }
+        }
     }
 
     fun inDungeon() = dungeonFloor != null
@@ -169,9 +175,9 @@ object DungeonAPI {
         val tabData = TabListData.getPlayerTabOverlay()
         if (tabData.footer_skyhanni == null) return
         val tabList = tabData.footer_skyhanni.formattedText.split("\n")
-        tabList.forEach { it ->
+        tabList.forEach {
             if (noBlessingPattern.matches(it)) {
-                DungeonBlessings.entries.forEach { it.power = 0 }
+                DungeonBlessings.reset()
                 return
             }
             val matcher = blessingPattern.matcher(it)

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
@@ -20,6 +20,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -59,6 +60,10 @@ object DungeonAPI {
     private val blessingPattern by patternGroup.pattern(
         "blessings",
         "§r§r§fBlessing of (?<type>\\w+) (?<amount>\\w+)§r"
+    )
+    private val noBlessingPattern by patternGroup.pattern(
+        "noBlessings",
+        "§r§r§7No Buffs active. Find them by exploring the Dungeon!§r"
     )
 
     enum class DungeonBlessings(var power: Int) {
@@ -164,7 +169,11 @@ object DungeonAPI {
         val tabData = TabListData.getPlayerTabOverlay()
         if (tabData.footer_skyhanni == null) return
         val tabList = tabData.footer_skyhanni.formattedText.split("\n")
-        tabList.forEach {
+        tabList.forEach { it ->
+            if (noBlessingPattern.matches(it)) {
+                DungeonBlessings.entries.forEach { it.power = 0 }
+                return
+            }
             val matcher = blessingPattern.matcher(it)
             if (matcher.find()) {
                 val type = matcher.group("type") ?: return@forEach

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -2,6 +2,8 @@ package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.features.dungeon.DragPrioConfig
+import at.hannibal2.skyhanni.data.MayorAPI
+import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.DungeonCompleteEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -244,6 +246,9 @@ class DungeonDragonPriority {
         config.dragonSpawnedPosition.renderString(titleString, posLabel = "Dragon Priority Title")
     }
 
-    private fun getPower(): Double = DungeonAPI.DungeonBlessings.valueOf("POWER").power +
-            (DungeonAPI.DungeonBlessings.valueOf("TIME").power.toDouble() / 2)
+    private fun getPower(): Double {
+        val paulBoost = if (MayorAPI.currentMayor?.activePerks?.contains(Perk.BENEDICTION) == true) 1.25 else 1.0
+        return (DungeonAPI.DungeonBlessings.valueOf("POWER").power
+                + (DungeonAPI.DungeonBlessings.valueOf("TIME").power.toDouble() / 2)) * paulBoost
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -89,7 +89,7 @@ class DungeonDragonPriority {
     private fun startP5() {
         if (!config.saySplit) return
         val currentClass = DungeonAPI.playerClass
-        when (currentClass) {
+        if (config.forceClass == DragPrioConfig.ForceClass.NONE) when (currentClass) {
             DungeonAPI.DungeonClass.MAGE -> inBerserkTeam = true
             DungeonAPI.DungeonClass.BERSERK -> inBerserkTeam = true
             DungeonAPI.DungeonClass.ARCHER -> inArcherTeam = true
@@ -100,6 +100,18 @@ class DungeonDragonPriority {
 
             DungeonAPI.DungeonClass.HEALER -> isHealer = true
             else -> return
+        } else {
+            when (config.forceClass) {
+                DragPrioConfig.ForceClass.ARCHER -> inArcherTeam = true
+                DragPrioConfig.ForceClass.BERSERK -> inBerserkTeam = true
+                DragPrioConfig.ForceClass.MAGE -> inBerserkTeam = true
+                DragPrioConfig.ForceClass.TANK -> {
+                    inArcherTeam = true
+                    isTank = true
+                }
+                DragPrioConfig.ForceClass.HEALER -> isHealer = true
+                else -> return
+            }
         }
         DelayedRun.runDelayed(2000.milliseconds) {
             val currentPower = getPower()

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -1,0 +1,64 @@
+package at.hannibal2.skyhanni.features.dungeon
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.StringUtils.matches
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.milliseconds
+
+class DungeonDragonPriority {
+
+    private val config get() = SkyHanniMod.feature.dungeon.dragPrio
+
+    private val startPattern by RepoPattern.pattern(
+        "dungeons.startPhase5",
+        "(.+)§r§a picked the §r§cCorrupted Blue Relic§r§a!"
+    )
+
+    enum class DragonInfo(var hasSpawned: Boolean) {
+        POWER(false),
+        FLAME(false),
+        ICE(false),
+        SOUL(false),
+        APEX(false)
+    }
+
+    private var inBerserkTeam = false
+    private var inArcherTeam = false
+    private var isHealer = false
+
+    private val waitDuration = 2000.milliseconds
+
+    @SubscribeEvent
+    fun onChat(event: LorenzChatEvent) {
+        if (!DungeonAPI.inDungeon()) return
+        if (DungeonAPI.dungeonFloor != "M7") return
+        if (!startPattern.matches(event.message)) return
+        reset()
+        startP5()
+    }
+
+    private fun startP5() {
+        if (!config.saySplit) return
+        val currentClass = DungeonAPI.playerClass
+        when (currentClass) {
+            DungeonAPI.DungeonClass.MAGE -> inBerserkTeam = true
+            DungeonAPI.DungeonClass.BERSERK -> inBerserkTeam = true
+            DungeonAPI.DungeonClass.ARCHER -> inArcherTeam = true
+            DungeonAPI.DungeonClass.TANK -> inArcherTeam = true
+            DungeonAPI.DungeonClass.HEALER -> isHealer = true
+            else -> return //throw error
+        }
+        DelayedRun.runDelayed(waitDuration) {
+            val currentPower = 5//get power
+        }
+    }
+    private fun reset() {
+        DragonInfo.entries.forEach { it.hasSpawned = false }
+        inArcherTeam = false
+        inBerserkTeam = false
+        isHealer = false
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -126,12 +126,12 @@ class DungeonDragonPriority {
             if (!it.hasSpawned && (x in it.xRange && z in it.zRange)) {
                 ChatUtils.debug("try spawning ${it.name}")
                 it.hasSpawned = true
-                assignDrag(it)
+                assignDragon(it)
             }
         }
     }
 
-    private fun assignDrag(dragon: DragonInfo) {
+    private fun assignDragon(dragon: DragonInfo) {
         when (DragonInfo.NONE) {
             dragonOrder[0] -> {
                 ChatUtils.debug("${dragon.name} is now dragon0")
@@ -145,7 +145,6 @@ class DungeonDragonPriority {
             else -> {
                 ChatUtils.debug("dragonOrder was full")
                 if (config.showSingleDragons) sendTitle("§${dragon.colorCode}${dragon.color} is Spawning!")
-                return
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -1,10 +1,18 @@
 package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.features.dungeon.DragPrioConfig
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.DungeonCompleteEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.events.ReceiveParticleEvent
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.util.EnumParticleTypes
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -13,23 +21,27 @@ class DungeonDragonPriority {
     private val config get() = SkyHanniMod.feature.dungeon.dragPrio
 
     private val startPattern by RepoPattern.pattern(
-        "dungeons.startPhase5",
+        "dungeons.startphase5",
         "(.+)§r§a picked the §r§cCorrupted Blue Relic§r§a!"
     )
 
-    enum class DragonInfo(var hasSpawned: Boolean) {
-        POWER(false),
-        FLAME(false),
-        ICE(false),
-        SOUL(false),
-        APEX(false)
+    enum class DragonInfo(val color: String, var hasSpawned: Boolean, val isEasy: Boolean, val priority: IntArray) {
+        POWER("Red", false, false, intArrayOf(1, 3)),
+        FLAME("Orange", false, true, intArrayOf(2, 1)),
+        ICE("Blue", false, false, intArrayOf(3, 4)),
+        SOUL("Purple", false, true, intArrayOf(4, 5)),
+        APEX("Green", false, true, intArrayOf(5, 2)),
+        NONE("None", false, false, intArrayOf(0, 0))
     }
 
     private var inBerserkTeam = false
     private var inArcherTeam = false
     private var isHealer = false
+    private var isTank = false
 
-    private val waitDuration = 2000.milliseconds
+    private var isSearching = false
+
+    private var dragonOrder = arrayOf(DragonInfo.NONE, DragonInfo.NONE)
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
@@ -47,18 +59,179 @@ class DungeonDragonPriority {
             DungeonAPI.DungeonClass.MAGE -> inBerserkTeam = true
             DungeonAPI.DungeonClass.BERSERK -> inBerserkTeam = true
             DungeonAPI.DungeonClass.ARCHER -> inArcherTeam = true
-            DungeonAPI.DungeonClass.TANK -> inArcherTeam = true
+            DungeonAPI.DungeonClass.TANK -> {
+                inArcherTeam = true
+                isTank = true
+            }
+
             DungeonAPI.DungeonClass.HEALER -> isHealer = true
-            else -> return //throw error
+            else -> return
         }
-        DelayedRun.runDelayed(waitDuration) {
-            val currentPower = 5//get power
+        DelayedRun.runDelayed(2000.milliseconds) {
+            val currentPower = getPower()
+            when {
+                currentPower >= config.splitPower -> {
+                    ChatUtils.chat("power: $currentPower | split on all drags")
+                    return@runDelayed
+                }
+
+                currentPower >= config.easyPower -> {
+                    ChatUtils.chat("power: $currentPower | split on easy drags")
+                    return@runDelayed
+                }
+
+                else -> {
+                    ChatUtils.chat("power: $currentPower | no split")
+                    return@runDelayed
+                }
+            }
         }
+        isSearching = true
     }
+
     private fun reset() {
         DragonInfo.entries.forEach { it.hasSpawned = false }
+        dragonOrder = arrayOf(DragonInfo.NONE, DragonInfo.NONE)
         inArcherTeam = false
         inBerserkTeam = false
         isHealer = false
+        isTank = false
     }
+
+    private fun checkCoordinates(particle: LorenzVec) {
+        val x = particle.x.toInt()
+        val y = particle.y.toInt()
+        val z = particle.z.toInt()
+        if (y !in 14..19) return
+        when (x) {
+            in 27..32 -> {
+                when (z) {
+                    59 -> trySpawnDragon(DragonInfo.POWER)
+                    94 -> trySpawnDragon(DragonInfo.APEX)
+                }
+            }
+
+            in 79..85 -> {
+                when (z) {
+                    59 -> trySpawnDragon(DragonInfo.FLAME)
+                    94 -> trySpawnDragon(DragonInfo.ICE)
+                }
+            }
+
+            56 -> trySpawnDragon(DragonInfo.SOUL)
+        }
+    }
+
+    private fun trySpawnDragon(dragon: DragonInfo) {
+        if (dragon.hasSpawned) return
+        dragon.hasSpawned = true
+        assignDrag(dragon)
+        DelayedRun.runDelayed(8000.milliseconds) {
+            dragon.hasSpawned = false
+        }
+    }
+
+    private fun assignDrag(dragon: DragonInfo) {
+        when (DragonInfo.NONE) {
+            dragonOrder[0] -> dragonOrder[0] = dragon
+            dragonOrder[1] -> {
+                dragonOrder[1] = dragon
+                isSearching = false
+                determinePriority()
+            }
+
+            else -> return
+        }
+        if (config.showSingleDragons) {
+            ChatUtils.chat("${dragon.color} is spawning")
+        }
+    }
+
+    private fun determinePriority() {
+        val normalDrag = if (dragonOrder[0].priority[0] < dragonOrder[1].priority[0]) {
+            dragonOrder[0]
+        } else dragonOrder[1]
+        val power = getPower()
+        var split = 0
+        val isEasy: Boolean = dragonOrder[0].isEasy && dragonOrder[1].isEasy
+        when {
+            power >= config.splitPower -> split = 1
+            isEasy && power >= config.easyPower -> split = 1
+        }
+        val berserkDragon: DragonInfo
+        val archerDragon: DragonInfo
+        if (dragonOrder[0].priority[split] < dragonOrder[1].priority[split]) {
+            berserkDragon = dragonOrder[0]
+            archerDragon = dragonOrder[1]
+        } else {
+            berserkDragon = dragonOrder[1]
+            archerDragon = dragonOrder[0]
+        }
+        displayDragons(berserkDragon, archerDragon, normalDrag, split)
+    }
+
+    private fun displayDragons(
+        berserkDragon: DragonInfo,
+        archerDragon: DragonInfo,
+        normalDrag: DragonInfo,
+        split: Int
+    ) {
+        val purple = DragonInfo.SOUL in dragonOrder
+        if (config.sendMessage && split == 1) {
+            ChatUtils.chat("Berserk Team: ${berserkDragon.color}")
+            ChatUtils.chat("Archer Team: ${archerDragon.color}")
+        }
+        if (split == 0) {
+            ChatUtils.chat("${normalDrag.color} is spawning! (title)")
+        } else {
+            if (inBerserkTeam || (purple && (
+                        (isHealer && config.healerPurple == DragPrioConfig.HealerPurpleValue.BERSERK)
+                                || (isTank && config.tankPurple == DragPrioConfig.TankPurpleValue.BERSERK)))
+            ) {
+                ChatUtils.chat("$berserkDragon is Spawning!!")
+            } else {
+                ChatUtils.chat("$archerDragon is Spawning!!")
+            }
+        }
+    }
+
+    @SubscribeEvent
+    fun onDungeonEnd(event: DungeonCompleteEvent) {
+        isSearching = false
+    }
+
+    @SubscribeEvent
+    fun onParticle(event: ReceiveParticleEvent) {
+        if (!DungeonAPI.inDungeon()) return
+        if (!isSearching) return
+        if (event.type != EnumParticleTypes.ENCHANTMENT_TABLE) return
+        checkCoordinates(event.location)
+    }
+
+    @SubscribeEvent
+    fun onDebugCollect(event: DebugDataCollectEvent) {
+        event.title("DragPrio")
+        if (!LorenzUtils.inDungeons) {
+            event.addIrrelevant("not in dungeons")
+            return
+        }
+        if (DungeonAPI.dungeonFloor != "M7") {
+            event.addIrrelevant("not in m7")
+            return
+        }
+
+        event.addData {
+            add("Power: ${getPower()}")
+            add("inArchTeam: $inArcherTeam")
+            add("inBersTeam: $inBerserkTeam")
+            add("isHealer: $isHealer")
+            add("isTank: $isTank")
+            add("isSearching: $isSearching")
+            add("dragon0: ${dragonOrder[0].name}")
+            add("dragon1: ${dragonOrder[1].name}")
+        }
+    }
+
+    private fun getPower(): Double = DungeonAPI.DungeonBlessings.valueOf("POWER").power +
+            (DungeonAPI.DungeonBlessings.valueOf("TIME").power.toDouble() / 2)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.test.DebugCommand
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -71,6 +72,7 @@ class DungeonDragonPriority {
     private var isTank = false
 
     private var isSearching = false
+    private val particleList = mutableListOf<String>()
     private var titleString = ""
 
     private var dragonOrder = arrayOf(DragonInfo.NONE, DragonInfo.NONE)
@@ -131,6 +133,7 @@ class DungeonDragonPriority {
         inBerserkTeam = false
         isHealer = false
         isTank = false
+        particleList.clear()
     }
 
     private fun checkCoordinates(particle: Packet<*>) {
@@ -141,7 +144,10 @@ class DungeonDragonPriority {
         val z = vec.z.toInt()
         if (y !in 15..22) return
         DragonInfo.entries.forEach {
-            if (!it.isSpawning && (x in it.xRange && z in it.zRange)) assignDragon(it)
+            if (!it.isSpawning) {
+                if (x in it.xRange && z in it.zRange) assignDragon(it)
+                else particleList.add(vec.toString())
+            }
         }
     }
 
@@ -218,6 +224,12 @@ class DungeonDragonPriority {
 
     @SubscribeEvent
     fun onDungeonEnd(event: DungeonCompleteEvent) {
+        if (particleList.isNotEmpty()) {
+            val stringList = particleList.joinToString("\n")
+            particleList.clear()
+            ChatUtils.clickableChat("i want particles again sorry",
+                { OSUtils.copyToClipboard(stringList); ChatUtils.chat("copied") })
+        }
         if (!config.enabled) return
         if (!isSearching) return
         isSearching = false

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -166,14 +166,14 @@ class DungeonDragonPriority {
         displayDragons(berserkDragon, archerDragon, split)
     }
 
-    private fun displayDragons(
+    private fun displayDragons( //TODO: cleanup this
         berserkDragon: DragonInfo,
         archerDragon: DragonInfo,
         split: Int
     ) {
         val purple = DragonInfo.SOUL in dragonOrder
         ChatUtils.debug("berserkDragon: ${berserkDragon.name} | archerDragon: ${archerDragon.name}")
-        if (split == 1 && config.saySplit) {
+        if (split == 1 && config.sendMessage) {
             ChatUtils.chat("Berserk Team: ${berserkDragon.color} (send in pc)")
             ChatUtils.chat("Archer Team: ${archerDragon.color} (send in pc)")
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.data.MayorAPI
 import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.DungeonCompleteEvent
+import at.hannibal2.skyhanni.events.DungeonStartEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzKeyPressEvent
@@ -150,7 +151,8 @@ class DungeonDragonPriority {
         val y = vec.y.toInt()
         val z = vec.z.toInt()
         if (y !in 15..22) return
-        particleList.add("Position: $vec | Count: ${particle.particleCount} | Speed: ${particle.particleSpeed} | Offset: ${particle.xOffset} ${particle.yOffset} ${particle.zOffset} | LongDistance: ${particle.isLongDistance}")
+        particleList.add("Position: $vec | Type: ${particle.particleType} | Count: ${particle.particleCount} | Speed: ${particle.particleSpeed} | Offset: ${particle.xOffset} ${particle.yOffset} ${particle.zOffset} | LongDistance: ${particle.isLongDistance}")
+        if (particle.particleType != EnumParticleTypes.FLAME) return
         DragonInfo.entries.forEach {
             if (!it.isSpawning && (x in it.xRange && z in it.zRange)) {
                 particleList.add("matched ${it.name}")
@@ -224,8 +226,14 @@ class DungeonDragonPriority {
         if (DungeonAPI.dungeonFloor != "M7") return
         if (!isSearching) return
         if (event.packet !is S2APacketParticles) return
-        if (event.packet.particleType != EnumParticleTypes.FLAME) return
         checkCoordinates(event.packet)
+    }
+
+    @SubscribeEvent
+    fun onDungeonStart(event: DungeonStartEvent) {
+        if (DungeonAPI.dungeonFloor != "F1") return
+        if (isSearching) return
+        isSearching = true
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -49,6 +49,7 @@ class DungeonDragonPriority {
         if (DungeonAPI.dungeonFloor != "M7") return
         if (!startPattern.matches(event.message)) return
         reset()
+        ChatUtils.debug("starting p5")
         startP5()
     }
 
@@ -71,17 +72,17 @@ class DungeonDragonPriority {
             val currentPower = getPower()
             when {
                 currentPower >= config.splitPower -> {
-                    ChatUtils.chat("power: $currentPower | split on all drags")
+                    ChatUtils.chat("Power: $currentPower | Split on all drags!")
                     return@runDelayed
                 }
 
                 currentPower >= config.easyPower -> {
-                    ChatUtils.chat("power: $currentPower | split on easy drags")
+                    ChatUtils.chat("Power: $currentPower | Split on easy drags!")
                     return@runDelayed
                 }
 
                 else -> {
-                    ChatUtils.chat("power: $currentPower | no split")
+                    ChatUtils.chat("Power: $currentPower | No split!")
                     return@runDelayed
                 }
             }
@@ -125,6 +126,7 @@ class DungeonDragonPriority {
     private fun trySpawnDragon(dragon: DragonInfo) {
         if (dragon.hasSpawned) return
         dragon.hasSpawned = true
+        ChatUtils.chat("${dragon.name} spawning")
         assignDrag(dragon)
         DelayedRun.runDelayed(8000.milliseconds) {
             dragon.hasSpawned = false
@@ -133,13 +135,16 @@ class DungeonDragonPriority {
 
     private fun assignDrag(dragon: DragonInfo) {
         when (DragonInfo.NONE) {
-            dragonOrder[0] -> dragonOrder[0] = dragon
+            dragonOrder[0] -> {
+                ChatUtils.chat("${dragon.name} is now dragon0")
+                dragonOrder[0] = dragon
+            }
             dragonOrder[1] -> {
+                ChatUtils.chat("${dragon.name} is now dragon1")
                 dragonOrder[1] = dragon
                 isSearching = false
                 determinePriority()
             }
-
             else -> return
         }
         if (config.showSingleDragons) {
@@ -154,6 +159,7 @@ class DungeonDragonPriority {
         val power = getPower()
         var split = 0
         val isEasy: Boolean = dragonOrder[0].isEasy && dragonOrder[1].isEasy
+        ChatUtils.chat("isEasy: $isEasy, ${dragonOrder[0].isEasy}, ${dragonOrder[1].isEasy}")
         when {
             power >= config.splitPower -> split = 1
             isEasy && power >= config.easyPower -> split = 1
@@ -168,6 +174,7 @@ class DungeonDragonPriority {
             archerDragon = dragonOrder[0]
         }
         displayDragons(berserkDragon, archerDragon, normalDrag, split)
+        ChatUtils.chat("${berserkDragon.name}, ${archerDragon.name}, ${normalDrag.name}, $split") //remove later
     }
 
     private fun displayDragons(

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -52,9 +52,10 @@ class DungeonDragonPriority {
             fun clearSpawned() {
                 entries.forEach { it.hasSpawned = false }
             }
+
             fun getSpawnedAmount(): Int {
                 var spawned = 0
-                entries.forEach{ if (it.hasSpawned) spawned += 1}
+                entries.forEach { if (it.hasSpawned) spawned += 1 }
                 return spawned
             }
         }
@@ -98,7 +99,7 @@ class DungeonDragonPriority {
         DelayedRun.runDelayed(2000.milliseconds) {
             val currentPower = getPower()
             when {
-                currentPower >= config.splitPower ->  ChatUtils.chat("Power: $currentPower | Split on all drags!")
+                currentPower >= config.splitPower -> ChatUtils.chat("Power: $currentPower | Split on all drags!")
                 currentPower >= config.easyPower -> ChatUtils.chat("Power: $currentPower | Split on easy drags!")
                 else -> ChatUtils.chat("Power: $currentPower | No split!")
             }
@@ -122,7 +123,7 @@ class DungeonDragonPriority {
         val y = vec.y.toInt()
         val z = vec.z.toInt()
         if (y !in 15..22) return
-        DragonInfo.entries.forEach{
+        DragonInfo.entries.forEach {
             if (!it.hasSpawned && (x in it.xRange && z in it.zRange)) {
                 ChatUtils.debug("try spawning ${it.name}")
                 it.hasSpawned = true
@@ -137,11 +138,13 @@ class DungeonDragonPriority {
                 ChatUtils.debug("${dragon.name} is now dragon0")
                 dragonOrder[0] = dragon
             }
+
             dragonOrder[1] -> {
                 ChatUtils.debug("${dragon.name} is now dragon1")
                 dragonOrder[1] = dragon
                 determinePriority()
             }
+
             else -> {
                 ChatUtils.debug("dragonOrder was full")
                 if (config.showSingleDragons) sendTitle("§${dragon.colorCode}${dragon.color} is Spawning!")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -125,15 +125,13 @@ class DungeonDragonPriority {
         val z = vec.z.toInt()
         if (y !in 15..22) return
         DragonInfo.entries.forEach {
-            if (!it.hasSpawned && (x in it.xRange && z in it.zRange)) {
-                ChatUtils.debug("try spawning ${it.name}")
-                it.hasSpawned = true
-                assignDragon(it)
-            }
+            if (!it.hasSpawned && (x in it.xRange && z in it.zRange)) assignDragon(it)
         }
     }
 
     private fun assignDragon(dragon: DragonInfo) {
+        ChatUtils.debug("try spawning ${dragon.name}")
+        dragon.hasSpawned = true
         when (DragonInfo.NONE) {
             dragonOrder[0] -> {
                 ChatUtils.debug("${dragon.name} is now dragon0")
@@ -174,6 +172,7 @@ class DungeonDragonPriority {
         split: Int
     ) {
         val purple = DragonInfo.SOUL in dragonOrder
+        ChatUtils.debug("berserkDragon: ${berserkDragon.name} | archerDragon: ${archerDragon.name}")
         if (split == 1 && config.saySplit) {
             ChatUtils.chat("Berserk Team: ${berserkDragon.color} (send in pc)")
             ChatUtils.chat("Archer Team: ${archerDragon.color} (send in pc)")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -143,10 +143,11 @@ class DungeonDragonPriority {
         val y = vec.y.toInt()
         val z = vec.z.toInt()
         if (y !in 15..22) return
+        particleList.add("Position: $vec | Count: ${particle.particleCount} | Speed: ${particle.particleSpeed} | Offset: ${particle.xOffset} ${particle.yOffset} ${particle.zOffset} | LongDistance: ${particle.isLongDistance}")
         DragonInfo.entries.forEach {
-            if (!it.isSpawning) {
-                if (x in it.xRange && z in it.zRange) assignDragon(it)
-                else particleList.add("$vec ${it.name}")
+            if (!it.isSpawning && (x in it.xRange && z in it.zRange)) {
+                particleList.add("matched ${it.name}")
+                assignDragon(it)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -152,23 +152,15 @@ class DungeonDragonPriority {
 
     private fun determinePriority() {
         val power = getPower()
-        var split = 0
         val isEasy: Boolean = dragonOrder[0].isEasy && dragonOrder[1].isEasy
+        val split = if ((!isEasy && power >= config.splitPower) || (isEasy && power >= config.easyPower)) 1 else 0
 
         ChatUtils.debug("isEasy: $isEasy")
-        when {
-            !isEasy && power >= config.splitPower -> split = 1
-            isEasy && power >= config.easyPower -> split = 1
-        }
         ChatUtils.debug("split = $split")
-        val berserkDragon: DragonInfo
-        val archerDragon: DragonInfo
-        if (dragonOrder[0].priority[split] < dragonOrder[1].priority[split]) {
-            berserkDragon = dragonOrder[0]
-            archerDragon = dragonOrder[1]
+        val (berserkDragon, archerDragon) = if (dragonOrder[0].priority[split] < dragonOrder[1].priority[split]) {
+            dragonOrder[0] to dragonOrder[1]
         } else {
-            berserkDragon = dragonOrder[1]
-            archerDragon = dragonOrder[0]
+            dragonOrder[1] to dragonOrder[0]
         }
         displayDragons(berserkDragon, archerDragon, split)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.network.Packet
 import net.minecraft.network.play.server.S2APacketParticles
+import net.minecraft.util.EnumParticleTypes
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -127,14 +128,17 @@ class DungeonDragonPriority {
         if (y !in 15..22) return
         DragonInfo.entries.forEach{
             if (!it.hasSpawned && (x in it.xRange && z in it.zRange)) {
-                particleList.add("${particle.toLorenzVec()}, type: ${particle.particleType}")
-                trySpawnDragon(it)
+                if (particle.particleType == EnumParticleTypes.FLAME) {
+                    particleList.add("${particle.toLorenzVec()}, type: ${particle.particleType}, FOUND ${it.name}")
+                    trySpawnDragon(it)
+                } else {
+                    particleList.add("${particle.toLorenzVec()}, type: ${particle.particleType}")
+                }
             }
         }
     }
 
     private fun trySpawnDragon(dragon: DragonInfo) {
-        if (dragon.hasSpawned) return
         ChatUtils.chat("try spawning ${dragon.name}")
         dragon.hasSpawned = true
         assignDrag(dragon)

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -140,7 +140,6 @@ class DungeonDragonPriority {
             dragonOrder[1] -> {
                 ChatUtils.debug("${dragon.name} is now dragon1")
                 dragonOrder[1] = dragon
-                isSearching = false
                 determinePriority()
             }
             else -> {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -146,7 +146,7 @@ class DungeonDragonPriority {
         DragonInfo.entries.forEach {
             if (!it.isSpawning) {
                 if (x in it.xRange && z in it.zRange) assignDragon(it)
-                else particleList.add(vec.toString())
+                else particleList.add("$vec ${it.name}")
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -143,6 +143,7 @@ class DungeonDragonPriority {
                 determinePriority()
             }
             else -> {
+                ChatUtils.debug("dragonOrder was full")
                 if (config.showSingleDragons) sendTitle("§${dragon.colorCode}${dragon.color} is Spawning!")
                 return
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -73,6 +73,7 @@ class DungeonDragonPriority {
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
+        if (!config.enabled) return
         if (!DungeonAPI.inDungeon()) return
         if (DungeonAPI.dungeonFloor != "M7") return
         if (!startPattern.matches(event.message)) return
@@ -191,6 +192,7 @@ class DungeonDragonPriority {
 
     @SubscribeEvent
     fun onParticle(event: PacketEvent.ReceiveEvent) {
+        if (!config.enabled) return
         if (!DungeonAPI.inDungeon()) return
         if (DungeonAPI.dungeonFloor != "M7") return
         if (!isSearching) return
@@ -201,6 +203,7 @@ class DungeonDragonPriority {
 
     @SubscribeEvent
     fun onDungeonEnd(event: DungeonCompleteEvent) {
+        if (!config.enabled) return
         if (!isSearching) return
         isSearching = false
     }
@@ -235,6 +238,7 @@ class DungeonDragonPriority {
 
     @SubscribeEvent
     fun onRender(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (!config.enabled) return
         if (!DungeonAPI.inDungeon()) return
         if (DungeonAPI.dungeonFloor != "M7") return
         if (titleString == "") return

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -121,33 +121,27 @@ class DungeonDragonPriority {
         particleList.add("```")
     }
 
-    private fun checkCoordinates(particle: Packet<*>, test: Boolean) {
+    private fun checkCoordinates(particle: Packet<*>) {
         if (particle !is S2APacketParticles) return
         val vec = particle.toLorenzVec()
         val x = vec.x.toInt()
         val y = vec.y.toInt()
         val z = vec.z.toInt()
-        if (y !in 14..19) {
-            particleList.add("vec: $vec, type: ${particle.particleType}")
-            return
-        }
+        if (y !in 14..19) return
         when (x) {
             in 27..32 -> {
                 when (z) {
-                    in 54..64 -> if (!test) trySpawnDragon(DragonInfo.POWER)
-                    in 89..99 -> if (!test) trySpawnDragon(DragonInfo.APEX)
-                    else -> particleList.add("vec: $vec, type: ${particle.particleType}")
+                    in 54..64 -> trySpawnDragon(DragonInfo.POWER)
+                    in 89..99 -> trySpawnDragon(DragonInfo.APEX)
                 }
             }
             in 79..85 -> {
                 when (z) {
-                    in 54..64 -> if (!test) trySpawnDragon(DragonInfo.FLAME)
-                    in 89..99 -> if (!test) trySpawnDragon(DragonInfo.ICE)
-                    else -> particleList.add("vec: $vec, type: ${particle.particleType}")
+                    in 54..64 -> trySpawnDragon(DragonInfo.FLAME)
+                    in 89..99 -> trySpawnDragon(DragonInfo.ICE)
                 }
             }
-            in 51..61 -> if (!test) trySpawnDragon(DragonInfo.SOUL)
-            else -> particleList.add("vec: $vec, type: ${particle.particleType}")
+            in 51..61 -> trySpawnDragon(DragonInfo.SOUL)
         }
     }
 
@@ -246,9 +240,9 @@ class DungeonDragonPriority {
         if (!isSearching) return
         if (!DungeonAPI.inDungeon()) return
         if (DungeonAPI.dungeonFloor != "M7") return
-        var test = false
-        if (event.packet.particleType != EnumParticleTypes.ENCHANTMENT_TABLE) test = true
-        checkCoordinates(event.packet, test)
+        if (event.packet.particleType != EnumParticleTypes.ENCHANTMENT_TABLE) return
+        particleList.add("${event.packet.toLorenzVec()}, type: ${event.packet.particleType}")
+        checkCoordinates(event.packet)
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDragonPriority.kt
@@ -189,7 +189,7 @@ class DungeonDragonPriority {
         ChatUtils.debug("isEasy: $isEasy")
         ChatUtils.debug("trySplit = $trySplit")
         ChatUtils.debug("shouldSplit = $shouldSplit")
-        val split = if (!shouldSplit) trySplit else 0
+        val split = if (shouldSplit) trySplit else 0
         val (berserkDragon, archerDragon) = if (dragonOrder[0].priority[split] < dragonOrder[1].priority[split]) {
             dragonOrder[0] to dragonOrder[1]
         } else {


### PR DESCRIPTION
## Dependencies
[Add blessings to DungeonAPI - #1326](https://github.com/hannibal002/SkyHanni/pull/1326)

## What
Adds dragon priority for use in M7's last phase. This is meant for better team coordination, telling you and your teammates which dragon to target first, depending on which class you are, your blessings, and which dragons are spawning.

i can't really do m7 yet so i'm relying on other people to make sure this works
https://canary.discord.com/channels/997079228510117908/1217567283656921210

**for now this doesn't send messages to the server yet, trying to make sure it's logic is the same as the ct module beforehand**

## Changelog New Features
+ Adds Dragon Priority for use in M7. - martimavocado


