### PR TITLE
Backend: Tooltip Event without forge

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -49,7 +49,6 @@ import at.hannibal2.skyhanni.data.SkillExperience
 import at.hannibal2.skyhanni.data.SlayerAPI
 import at.hannibal2.skyhanni.data.TitleData
 import at.hannibal2.skyhanni.data.TitleManager
-import at.hannibal2.skyhanni.data.ToolTipData
 import at.hannibal2.skyhanni.data.TrackerManager
 import at.hannibal2.skyhanni.data.jsonobjects.local.FriendsJson
 import at.hannibal2.skyhanni.data.jsonobjects.local.JacobContestsJson
@@ -457,7 +456,6 @@ class SkyHanniMod {
         loadModule(GardenCropUpgrades())
         loadModule(VisitorListener())
         loadModule(OwnInventoryData())
-        loadModule(ToolTipData())
         loadModule(HighlightVisitorsOutsideOfGarden())
         loadModule(GuiEditManager())
         loadModule(GetFromSackAPI)

--- a/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
@@ -6,20 +6,16 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import net.minecraft.inventory.Slot
-import net.minecraftforge.event.entity.player.ItemTooltipEvent
-import net.minecraftforge.fml.common.eventhandler.EventPriority
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 // Please use LorenzToolTipEvent over ItemTooltipEvent if no special EventPriority is necessary
-class ToolTipData {
-
-    @SubscribeEvent(priority = EventPriority.LOWEST)
-    fun onTooltip(event: ItemTooltipEvent) {
-        val toolTip = event.toolTip ?: return
-        val slot = lastSlot ?: return
-        val itemStack = event.itemStack ?: return
+object ToolTipData {
+    fun onTooltip(toolTip: MutableList<String>): List<String> {
+        val slot = lastSlot ?: return toolTip
+        val itemStack = slot.stack ?: return toolTip
         try {
-            LorenzToolTipEvent(slot, itemStack, toolTip).postAndCatch()
+            if (LorenzToolTipEvent(slot, itemStack, toolTip).postAndCatch()) {
+                toolTip.clear()
+            }
         } catch (e: Throwable) {
             ErrorManager.logErrorWithData(
                 e, "Error in item tool tip parsing or rendering detected",
@@ -33,10 +29,9 @@ class ToolTipData {
                 "lore" to itemStack.getLore(),
             )
         }
+        return toolTip
     }
 
-    companion object {
+    var lastSlot: Slot? = null
 
-        var lastSlot: Slot? = null
-    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/LorenzToolTipEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/LorenzToolTipEvent.kt
@@ -2,8 +2,18 @@ package at.hannibal2.skyhanni.events
 
 import net.minecraft.inventory.Slot
 import net.minecraft.item.ItemStack
+import net.minecraftforge.fml.common.eventhandler.Cancelable
 
-class LorenzToolTipEvent(val slot: Slot, val itemStack: ItemStack, var toolTip: MutableList<String>) : LorenzEvent() {
+@Cancelable
+class LorenzToolTipEvent(val slot: Slot, val itemStack: ItemStack, private val toolTip0: MutableList<String>) :
+    LorenzEvent() {
+
+    var toolTip
+        set(value) {
+            toolTip0.clear()
+            toolTip0.addAll(value)
+        }
+        get() = toolTip0
 
     fun toolTipRemovedPrefix() = toolTip.map { it.removePrefix("§5§o") }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
@@ -1,10 +1,17 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
+import at.hannibal2.skyhanni.data.ToolTipData;
 import at.hannibal2.skyhanni.mixins.hooks.ItemStackCachedData;
 import at.hannibal2.skyhanni.utils.CachedItemData;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
 
 @Mixin(ItemStack.class)
 public class MixinItemStack implements ItemStackCachedData {
@@ -14,5 +21,10 @@ public class MixinItemStack implements ItemStackCachedData {
 
     public CachedItemData getSkyhanni_cachedData() {
         return skyhanni_cachedData;
+    }
+
+    @Inject(method = "getTooltip", at = @At("RETURN"))
+    public void getTooltip(EntityPlayer playerIn, boolean advanced, CallbackInfoReturnable<List<String>> ci) {
+        ToolTipData.INSTANCE.onTooltip(ci.getReturnValue());
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
@@ -61,6 +61,6 @@ public abstract class MixinGuiContainer extends GuiScreen {
     )
     public void drawScreen_after(int mouseX, int mouseY, float partialTicks, CallbackInfo ci) {
         skyHanni$hook.onDrawScreenAfter(mouseX, mouseY, ci);
-        ToolTipData.Companion.setLastSlot(theSlot);
+        ToolTipData.INSTANCE.setLastSlot(theSlot);
     }
 }


### PR DESCRIPTION
## What
Replaced the ItemTooltip event with a mixin.

## Changelog Technical Details
+ LorenzTooltipEvent no longer uses forge events. - Thunderblade73
