### PR TITLE
Fix: Fixed "No Power" showing "No" in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -542,11 +542,10 @@ private fun getLobbyDisplayPair(): List<ScoreboardElementType> {
 private fun getPowerDisplayPair() = listOf(
     (MaxwellAPI.currentPower?.let {
         val mp = if (maxwellConfig.showMagicalPower) "§7(§6${MaxwellAPI.magicalPower?.addSeparators()}§7)" else ""
-        val name = it.replace(" Power", "")
         if (displayConfig.displayNumbersFirst) {
-            "§a$name Power $mp"
+            "§a${it.replace(" Power", "")} Power $mp"
         } else {
-            "Power: §a$name $mp"
+            "Power: §a$it $mp"
         }
     }
         ?: "§cOpen \"Your Bags\"!") to HorizontalAlignment.LEFT


### PR DESCRIPTION
## What
Describe what this pull request does, including technical details, screenshots, links to discord, etc.

<details>
<summary>Images</summary>

intended
![image](https://github.com/hannibal002/SkyHanni/assets/45315647/043a09ae-4272-4560-8dbc-177f7ee1e18e)

unintended
![image](https://github.com/hannibal002/SkyHanni/assets/45315647/e25aa906-e0ac-4322-a345-c796dcfc3384)

</details>

## Changelog Fixes
+ Fixed "No Power" being displayed as "No" in Custom Scoreboard. - j10a1n15

