### PR TITLE
Backend: Unprivate toCleanString() in LorenzVec

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
@@ -82,7 +82,7 @@ data class LorenzVec(
         }
     }
 
-    private fun toCleanString(): String {
+    fun toCleanString(): String {
         return "$x $y $z"
     }
 


### PR DESCRIPTION
## What
Unprivate LorenzVec.toCleanString()
For some reason this was privated, looks unintended.

## Changelog Technical Details
+ Unprivate LorenzVec.toCleanString. - martimavocado
