### PR TITLE
Fix: Don't check for thunder sparks when not needed

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.fishing
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
@@ -12,6 +13,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RenderUtils.drawString
 import at.hannibal2.skyhanni.utils.SpecialColour
 import at.hannibal2.skyhanni.utils.getLorenzVec
@@ -30,7 +32,6 @@ class ThunderSparksHighlight {
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
-
 
         EntityUtils.getEntities<EntityArmorStand>().filter {
             it !in sparks && it.hasSkullTexture(texture)
@@ -65,9 +66,8 @@ class ThunderSparksHighlight {
         sparks.clear()
     }
 
-    private fun isEnabled(): Boolean {
-        return LorenzUtils.inSkyBlock && config.highlight
-    }
+    private fun isEnabled() =
+        (IslandType.CRIMSON_ISLE.isInIsland() || LorenzUtils.isStrandedProfile) && config.highlight
 
     @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {


### PR DESCRIPTION
## What
Describe what this pull request does, including technical details, screenshots, links to discord, etc.

Crazy .2% performance boost here (based on some random spark log I found)

## Changelog Fixes
+ Fixed not checking if in an area that thunder can spawn before checking for thunder sparks. - CalMWolfs
