### PR TITLE
Feature: Mobs since last Inquisitor 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
@@ -110,7 +110,7 @@ object MythologicalCreatureTracker {
             addAsSingletonList(" §7- §e${amount.addSeparators()} ${creatureType.displayName}$percentageSuffix")
         }
         addAsSingletonList(" §7- §e${total.addSeparators()} §7Total Mythological Creatures")
-        addAsSingletonList("§e${data.mobsSinceLastInquisitor.addSeparators()} §7Since last Minos Inquisitor")
+        addAsSingletonList(" §7- §e${data.mobsSinceLastInquisitor.addSeparators()} §7Mobs since last Minos Inquisitor")
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
@@ -57,7 +57,11 @@ object MythologicalCreatureTracker {
 
         override fun reset() {
             count.clear()
+            mobsSinceLastInquisitor = 0
         }
+
+        @Expose
+        var mobsSinceLastInquisitor: Int = 0
 
         @Expose
         var count: MutableMap<MythologicalCreatureType, Int> = mutableMapOf()
@@ -78,7 +82,14 @@ object MythologicalCreatureTracker {
             if (creatureType.pattern.matches(event.message)) {
                 BurrowAPI.lastBurrowRelatedChatMessage = SimpleTimeMark.now()
                 tracker.modify { it.count.addOrPut(creatureType, 1) }
-
+                when (creatureType) {
+                    MythologicalCreatureType.MINOS_INQUISITOR -> {
+                        tracker.modify { it.mobsSinceLastInquisitor = 0 }
+                    }
+                    else -> {
+                        tracker.modify { it.mobsSinceLastInquisitor += 1 }
+                    }
+                }
                 if (config.hideChat) {
                     event.blockedReason = "mythological_creature_dug"
                 }
@@ -99,6 +110,7 @@ object MythologicalCreatureTracker {
             addAsSingletonList(" §7- §e${amount.addSeparators()} ${creatureType.displayName}$percentageSuffix")
         }
         addAsSingletonList(" §7- §e${total.addSeparators()} §7Total Mythological Creatures")
+        addAsSingletonList("§e${data.mobsSinceLastInquisitor.addSeparators()} §7Since last Minos Inquisitor")
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Adds a line to the Mythological Creature Tracker that tells you how many mobs you spawned since the last Minos Inquisitor.

<details>
<summary>Images</summary>

![2024-04-03_15 23 08](https://github.com/hannibal002/SkyHanni/assets/58398364/fab91638-b415-4159-b4b6-e95dd15c2f4f)

</details>

## Changelog New Features
+ Added mobs since last Inquisitor to Mythological Creature Tracker. - CuzImClicks