### PR TITLE
Feature: Different color for Zealots holding Chests

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/MobsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/MobsConfig.java
@@ -31,6 +31,12 @@ public class MobsConfig {
     public boolean zealotBruiserHighlighter = false;
 
     @Expose
+    @ConfigOption(name = "Zealot with Chest", desc = "Highlight Zealots holding a Chest in a different color.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean chestZealotHighlighter = false;
+
+    @Expose
     @ConfigOption(
         name = "Special Zealots",
         desc = "Highlight Special Zealots (the ones that drop Summoning Eyes) in the End."

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -81,7 +81,7 @@ class MobHighlight {
                         entity,
                         LorenzColor.GREEN.toColor().withAlpha(127)
                     )
-                    { config.zealotBruiserHighlighter }
+                    { config.chestZealotHighlighter }
                 }
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.events.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.events.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.EntityUtils.hasNameTagWith
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -15,6 +16,7 @@ import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.monster.EntityCaveSpider
 import net.minecraft.entity.monster.EntityEnderman
 import net.minecraft.entity.monster.EntitySpider
+import net.minecraft.init.Blocks
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class MobHighlight {
@@ -59,13 +61,25 @@ class MobHighlight {
         }
 
         if (entity is EntityEnderman) {
+            val isZealot = maxHealth == 13_000 || maxHealth == 13_000 * 4 // runic
+            val isBruiser = maxHealth == 65_000 || maxHealth == 65_000 * 4 // runic
+
             if (config.zealotBruiserHighlighter) {
-                val isZealot = maxHealth == 13_000 || maxHealth == 13_000 * 4 // runic
-                val isBruiser = maxHealth == 65_000 || maxHealth == 65_000 * 4 // runic
                 if (isZealot || isBruiser) {
                     RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                         entity,
                         LorenzColor.DARK_AQUA.toColor().withAlpha(127)
+                    )
+                    { config.zealotBruiserHighlighter }
+                }
+            }
+
+            if (config.chestZealotHighlighter) {
+                val isHoldingChest = (entity as? EntityEnderman)?.getBlockInHand()?.block == Blocks.ender_chest
+                if ((isZealot || isBruiser) && isHoldingChest) {
+                    RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                        entity,
+                        LorenzColor.GREEN.toColor().withAlpha(127)
                     )
                     { config.zealotBruiserHighlighter }
                 }


### PR DESCRIPTION
## What
Added an option to highlight Zealots holding Chests in a different color.

<details>
<summary>Images</summary>

![Screenshot showing a normal Zealot highlighted in blue, and one holding a Chest in green.](https://github.com/hannibal002/SkyHanni/assets/148620615/e5cc1fd6-36fe-4ec3-8109-87241c9484b0)

</details>

## Changelog New Features
+ Added an option to highlight Zealots holding Chests in a different color. - Luna