### PR TITLE
Improvement: Use SkyblockArea.skyblockAreaWithSymbol for Custom Scoreboard Area

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
@@ -102,6 +103,7 @@ class HypixelData {
         var joinedWorld = SimpleTimeMark.farPast()
 
         var skyBlockArea = "?"
+        var skyBlockAreaWithSymbol = "?"
 
         // Data from locraw
         var locrawData: JsonObject? = null
@@ -158,7 +160,7 @@ class HypixelData {
                 playerAmountGuestingPattern
             )
 
-            out@for (pattern in playerPatternList) {
+            out@ for (pattern in playerPatternList) {
                 for (line in TabListData.getTabList()) {
                     pattern.matchMatcher(line) {
                         amount += group("amount").toInt()
@@ -291,9 +293,10 @@ class HypixelData {
         if (LorenzUtils.inSkyBlock) {
             val originalLocation = ScoreboardData.sidebarLinesFormatted
                 .firstOrNull { it.startsWith(" §7⏣ ") || it.startsWith(" §5ф ") }
-                ?.substring(5)?.removeColor()
+                ?.substring(5)
                 ?: "?"
-            skyBlockArea = LocationFixData.fixLocation(skyBlockIsland) ?: originalLocation
+            skyBlockArea = LocationFixData.fixLocation(skyBlockIsland) ?: originalLocation.removeColor()
+            skyBlockAreaWithSymbol = "§${if (IslandType.THE_RIFT.isInIsland()) "5ф" else "7⏣"} $originalLocation"
 
             checkProfileName()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -482,13 +482,8 @@ private fun getEmptyLineDisplayPair() = listOf("<empty>" to HorizontalAlignment.
 private fun getIslandDisplayPair() =
     listOf("§7㋖ §a" + HypixelData.skyBlockIsland.displayName to HorizontalAlignment.LEFT)
 
-// TODO merge with LorenzUtils.skyBlockArea
 private fun getLocationDisplayPair() = buildList {
-    val location =
-        getGroupFromPattern(ScoreboardData.sidebarLinesFormatted, ScoreboardPattern.locationPattern, "location").trim()
-    if (location == "0") return@buildList
-
-    add(location to HorizontalAlignment.LEFT)
+    add(HypixelData.skyBlockAreaWithSymbol to HorizontalAlignment.LEFT)
 
     ScoreboardData.sidebarLinesFormatted.firstOrNull { ScoreboardPattern.plotPattern.matches(it) }
         ?.let { add(it to HorizontalAlignment.LEFT) }

--- a/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPattern.kt
@@ -63,7 +63,7 @@ interface RepoPattern : ReadOnlyProperty<Any?, Pattern> {
     val defaultPattern: String
 
     /**
-     * Key for this pattern. Used as an identifier when loading from the repo. Should be consistent accross versions.
+     * Key for this pattern. Used as an identifier when loading from the repo. Should be consistent across versions.
      */
     val key: String
 


### PR DESCRIPTION
## What
This Pull Request improves the SkyBlock Area in Custom Scoreboard, so it uses the HypixelData Area instead.


## Changelog Improvements
+ Improved SkyBlock Area in Custom Scoreboard. - j10a1n15

## Changelog Technical Details
+ Added HypixelData.skyblockAreaWithSymbol which includes the symbol and color of the SkyBlock area. - j10a1n15
