### PR TITLE
Fix: Supercraft /gfs not working for 1,000+ items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.GetFromSackAPI
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.NEUInternalName
+import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
@@ -13,7 +13,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class SuperCraftFeatures {
     private val craftedPattern by RepoPattern.pattern(
-        "inventory.supercrafting.craft",
+        "inventory.supercrafting.craft.new",
         "§eYou Supercrafted §r§r§r§.(?<item>[^§]+)(?:§r§8x(?<amount>[\\d,]+))?§r§e!"
     )
     private val config get() = SkyHanniMod.feature.inventory.gfs

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
@@ -13,7 +13,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 class SuperCraftFeatures {
     private val craftedPattern by RepoPattern.pattern(
         "inventory.supercrafting.craft",
-        "§eYou Supercrafted §r§r§r§.(?<item>[^§]+)(?:§r§8x(?<amount>\\d+))?§r§e!"
+        "§eYou Supercrafted §r§r§r§.(?<item>[^§]+)(?:§r§8x(?<amount>[\\d,]+))?§r§e!"
     )
     private val config get() = SkyHanniMod.feature.inventory.gfs
 
@@ -21,7 +21,7 @@ class SuperCraftFeatures {
     fun onChat(event: LorenzChatEvent) {
         if (!config.superCraftGFS) return
         val (internalName, amount) = craftedPattern.matchMatcher(event.message) {
-            NEUInternalName.fromItemName(this.group("item")) to (this.group("amount")?.toInt() ?: 1)
+            NEUInternalName.fromItemName(this.group("item")) to (this.group("amount")?.formatInt() ?: 1)
         } ?: return
         if (!GetFromSackAPI.sackListInternalNames.contains(internalName.asString())) return
         DelayedRun.runNextTick {


### PR DESCRIPTION
## What
Fixed the Supercraft /gfs prompt not showing when you crafted 1,000 or more items.

## Changelog Fixes
+ Fixed the Supercraft /gfs prompt not showing when you crafted 1,000 or more items. - Alexia Luna