### PR TITLE
Backend: Add option to copy raw scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyScoreboardCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyScoreboardCommand.kt
@@ -10,12 +10,14 @@ object CopyScoreboardCommand {
 
     fun command(args: Array<String>) {
         val resultList = mutableListOf<String>()
-        val noColor = args.size == 1 && args[0] == "true"
+        val noColor = args.contains("-nocolor")
+        val raw = args.contains("-raw")
         resultList.add("Title:")
         resultList.add(ScoreboardData.objectiveTitle.transformIf({ noColor }) { removeColor() })
         resultList.add("")
 
-        for (line in ScoreboardData.sidebarLinesFormatted) {
+        val lines = if (raw) ScoreboardData.sidebarLinesRaw else ScoreboardData.sidebarLinesFormatted
+        for (line in lines) {
             val scoreboardLine = line.transformIf({ noColor }) { removeColor() }
             resultList.add("'$scoreboardLine'")
         }


### PR DESCRIPTION
## What
Added an option to copy the raw scoreboard, including all the weird invisible symbols Hypixel adds.

## Changelog Technical Details
+ Added an option to copy the raw scoreboard. - Alexia Luna
    * This is accessed with `/shcopyscoreboard -raw`.
    * `/shcopyscoreboard true` has been changed to `/shcopyscoreboard -nocolor`.
