### PR TITLE
Fix: Pest Tp Delay

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
-import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
+import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
@@ -198,7 +198,7 @@ object PestAPI {
         for (line in event.newList) {
             // gets the total amount of pests in the garden
             pestsInScoreboardPattern.matchMatcher(line) {
-                val newPests = group("pests").formatLong().toInt()
+                val newPests = group("pests").formatInt()
                 if (newPests != scoreboardPests) {
                     scoreboardPests = newPests
                     updatePests()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
-import at.hannibal2.skyhanni.utils.NumberUtil.formatNumber
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
@@ -53,6 +53,7 @@ object PestAPI {
         "scoreboard.pests",
         " §7⏣ §[ac]The Garden §4§lൠ§7 x(?<pests>.*)"
     )
+
     /**
      * REGEX-TEST:  §7⏣ §aPlot §7- §b22a
      * REGEX-TEST:  §7⏣ §aThe Garden
@@ -61,6 +62,7 @@ object PestAPI {
         "scoreboard.nopests",
         " §7⏣ §a(?:The Garden|Plot §7- §b.+)$"
     )
+
     /**
      * REGEX-TEST:    §aPlot §7- §b4 §4§lൠ§7 x1
      */
@@ -68,6 +70,7 @@ object PestAPI {
         "scoreboard.plot.pests",
         "\\s*(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.+) (?:§.)*ൠ(?:§.)* x(?<pests>\\d+)"
     )
+
     /**
      * REGEX-TEST:  §aPlot §7- §b3
      */
@@ -79,6 +82,7 @@ object PestAPI {
         "inventory",
         "§4§lൠ §cThis plot has §6(?<amount>\\d) Pests?§c!"
     )
+
     /**
      * REGEX-TEST:  Plots: §r§b4§r§f, §r§b12§r§f, §r§b13§r§f, §r§b18§r§f, §r§b20
      */
@@ -195,7 +199,7 @@ object PestAPI {
         for (line in event.newList) {
             // gets the total amount of pests in the garden
             pestsInScoreboardPattern.matchMatcher(line) {
-                val newPests = group("pests").formatNumber().toInt()
+                val newPests = group("pests").formatLong().toInt()
                 if (newPests != scoreboardPests) {
                     removePests(scoreboardPests - newPests)
                     scoreboardPests = newPests

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.isBarn
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.isPestCountInaccurate
-import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.isPlayerInside
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.locked
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.pests
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.uncleared
@@ -201,7 +200,6 @@ object PestAPI {
             pestsInScoreboardPattern.matchMatcher(line) {
                 val newPests = group("pests").formatLong().toInt()
                 if (newPests != scoreboardPests) {
-                    removePests(scoreboardPests - newPests)
                     scoreboardPests = newPests
                     updatePests()
                 }
@@ -244,6 +242,7 @@ object PestAPI {
         if (!GardenAPI.inGarden()) return
         if (pestDeathChatPattern.matches(event.message)) {
             lastPestKillTime = SimpleTimeMark.now()
+            removeNearestPest()
         }
         if (noPestsChatPattern.matches(event.message)) {
             resetAllPests()
@@ -263,10 +262,7 @@ object PestAPI {
 
     fun getPlotsWithoutPests() = GardenPlotAPI.plots.filter { it.pests == 0 || !it.isPestCountInaccurate }
 
-    fun getNearestInfestedPlot(ignoreCurrent: Boolean = false): GardenPlotAPI.Plot? {
-        return getInfestedPlots().filterNot { ignoreCurrent && it.isPlayerInside() }
-            .minByOrNull { it.middle.distanceSqToPlayer() }
-    }
+    fun getNearestInfestedPlot() = getInfestedPlots().minByOrNull { it.middle.distanceSqToPlayer() }
 
     private fun removePests(removedPests: Int) {
         if (removedPests < 1) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -137,9 +137,8 @@ class PestFinder {
         if (event.keyCode != config.teleportHotkey) return
         if (lastKeyPress.passedSince() < 2.seconds) return
         lastKeyPress = SimpleTimeMark.now()
-        val shouldTeleportToCurrentPlot = PestAPI.lastPestKillTime.passedSince() > 3.seconds
 
-        val plot = PestAPI.getNearestInfestedPlot(shouldTeleportToCurrentPlot) ?: run {
+        val plot = PestAPI.getNearestInfestedPlot() ?: run {
             ChatUtils.userError("No infested plots detected to warp to!")
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -137,8 +137,9 @@ class PestFinder {
         if (event.keyCode != config.teleportHotkey) return
         if (lastKeyPress.passedSince() < 2.seconds) return
         lastKeyPress = SimpleTimeMark.now()
+        val shouldTeleportToCurrentPlot = PestAPI.lastPestKillTime.passedSince() > 3.seconds
 
-        val plot = PestAPI.getNearestInfestedPlot() ?: run {
+        val plot = PestAPI.getNearestInfestedPlot(shouldTeleportToCurrentPlot) ?: run {
             ChatUtils.userError("No infested plots detected to warp to!")
             return
         }


### PR DESCRIPTION
## What
Fixed not being able to teleport to other infested plots immediately after killing a pest.

## Changelog Fixes
+ Fixed not being able to teleport to other infested plots immediately after killing a pest. - Empa