### PR TITLE
Fix: Pest Profit Tracker Coins

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -133,6 +133,7 @@ object PestProfitTracker {
     fun onPurseChange(event: PurseChangeEvent) {
         if (!isEnabled()) return
         val coins = event.coins
+        if (coins > 1000) return
         if (event.reason == PurseChangeCause.GAIN_MOB_KILL && lastPestKillTime.passedSince() < 2.seconds) {
             tracker.addCoins(coins.toInt())
         }


### PR DESCRIPTION
## What
Fixes coins gotten from other methods (like leveling up farming skill) from being added to the pest profit tracker.

https://ptb.discord.com/channels/997079228510117908/1225487709058105495

## Changelog Fixes
+ Fixed coins from leveling up farming counting to Pest Profit Tracker. - Empa