### PR TITLE
Fix: Not showing MP when no power

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -100,6 +100,10 @@ object MaxwellAPI {
         "gui.selectedpower",
         "§aPower is selected!"
     )
+    private val noPowerSelectedPattern by group.pattern(
+        "gui.noselectedpower",
+        "(?:§.)*Visit Maxwell in the Hub to learn"
+    )
     private val accessoryBagStack by group.pattern(
         "stack.accessorybag",
         "§.Accessory Bag"
@@ -241,6 +245,8 @@ object MaxwellAPI {
                 magicalPower = 0
                 return
             }
+
+            if (noPowerSelectedPattern.matches(line)) currentPower = getPowerByNameOrNull("No Power")
 
             inventoryMPPattern.matchMatcher(line) {
                 // MagicalPower is boosted in catacombs


### PR DESCRIPTION
## What
Fixes not setting no power active when there's no power active, and therefore not showing MP on new profiles if no power has been selected yet.

[Bug Report](https://ptb.discord.com/channels/997079228510117908/1224335491072135178)

## Changelog Fixes
+ Fixed not setting No Power Active. - Empa