### PR TITLE
Fix: Don't tell player to enter boss room in Entrance

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
@@ -75,7 +75,11 @@ class DungeonCopilot {
         if (message == "§c[BOSS] The Watcher§r§f: That will be enough for now.") changeNextStep("Clear Blood Room")
 
         if (message == "§c[BOSS] The Watcher§r§f: You have proven yourself. You may pass.") {
-            changeNextStep("Enter Boss Room")
+            if (DungeonAPI.dungeonFloor == "E") {
+                changeNextStep("")
+            } else {
+                changeNextStep("Enter Boss Room")
+            }
             return "dungeon_copilot"
         }
         return null


### PR DESCRIPTION
## What
Fixed Dungeon Copilot to not tell the player to enter the boss room in Entrance. There is no such thing there. Clearing the Blood Room is the end of the run.

## Changelog Fixes
+ Dungeon Copilot no longer tells you to enter the nonexistent boss room in The Catacombs - Entrance. - Alexia Luna