### PR TITLE
Fix: Duplicate Custom Keybinds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -3,14 +3,18 @@ package at.hannibal2.skyhanni.features.garden.farming
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.mixins.transformers.AccessorKeyBinding
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiEditSign
 import net.minecraft.client.settings.KeyBinding
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import org.lwjgl.input.Keyboard
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 import java.util.IdentityHashMap
+import kotlin.time.Duration.Companion.seconds
 
 object GardenCustomKeybinds {
 
@@ -19,6 +23,7 @@ object GardenCustomKeybinds {
 
     private val map: MutableMap<KeyBinding, () -> Int> = IdentityHashMap()
     private var lastWindowOpenTime = 0L
+    private var lastDuplicateKeybindsWarnTime = SimpleTimeMark.farPast()
 
     init {
         map[mcSettings.keyBindAttack] = { config.attack }
@@ -46,6 +51,18 @@ object GardenCustomKeybinds {
 
         // TODO remove workaround
         if (System.currentTimeMillis() < lastWindowOpenTime + 300) return false
+
+        val areDuplicates = map.values
+            .map { it() }
+            .filter { it != Keyboard.KEY_NONE }
+            .let { values -> values.size != values.toSet().size }
+        if (areDuplicates) {
+            if (lastDuplicateKeybindsWarnTime.passedSince() > 30.seconds) {
+                ChatUtils.clickableUserError("Duplicate Custom Keybinds aren't allowed!", "sh custom keybinds")
+                lastDuplicateKeybindsWarnTime = SimpleTimeMark.now()
+            }
+            return false
+        }
 
         return true
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -53,6 +53,19 @@ object ChatUtils {
     }
 
     /**
+     * Sends a message to the user that they did something incorrectly.
+     * Runs a command when clicked to fix the issue.
+     *
+     * @param message The message to be sent
+     * @param command The command to be executed when the message is clicked
+     *
+     * @see USER_ERROR_PREFIX
+     */
+    fun clickableUserError(message: String, command: String) {
+        internalChat(createClickableChat(USER_ERROR_PREFIX + message, command))
+    }
+
+    /**
      * Sends a message to the user that an error occurred caused by something in the code.
      * This should be used for errors that are not caused by the user.
      *


### PR DESCRIPTION
## What
Fixes being able to use garden custom keybinds to set the same keybind to do multiple actions at once, like moving forwards and breaking blocks, which would be against the Hypixel rules. Also adds a clickableUserError.

## Changelog Fixes
+ Fixed being able to have duplicate custom key binds. - Empa

## Changelog Technical Details
+ Added clickableUserError. - Empa