### PR TITLE
Improvement: Enchanted Book Bundle Name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -383,6 +383,9 @@ object ItemUtils {
         if (name.endsWith("Enchanted Book")) {
             return itemStack.getLore()[0]
         }
+        if (name.endsWith("Enchanted Book Bundle")) {
+            return name.replace("Enchanted Book", itemStack.getLore()[0].removeColor())
+        }
 
         // hide pet level
         PetAPI.getCleanName(name)?.let {


### PR DESCRIPTION
## What
Makes it so that enchanted book bundles names show what book they contain, instead of `Enchanted Book Bundle` it would say `Quantum III Bundle`. 

[Discord suggestion](https://ptb.discord.com/channels/997079228510117908/1226218319955234956)

## Changelog Improvements
+ Show enchantment in book bundle name in profit tracker. - Empa