### PR TITLE
Improvement: Add Dragon's Nest as a valid Enderman Slayer location

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerAPI.kt
@@ -158,6 +158,7 @@ object SlayerAPI {
         -> SlayerType.SVEN
 
         "The End",
+        "Dragon's Nest",
         "Void Sepulture",
         "Zealot Bruiser Hideout",
         -> SlayerType.VOID


### PR DESCRIPTION
## What
Added Dragon's Nest as a valid Enderman Slayer location.

## Changelog Improvements
+ Added Dragon's Nest as a valid Enderman Slayer location. - Alexia Luna