### PR TITLE
Fix: Item Render in Next Contest Overlay

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -158,7 +158,7 @@ object GardenAPI {
     fun readCounter(itemStack: ItemStack): Long = itemStack.getHoeCounter() ?: itemStack.getCultivatingCounter() ?: -1L
 
     fun MutableList<Any>.addCropIcon(crop: CropType, highlight: Boolean = false) =
-        addItemIcon(crop.icon.copy(), highlight)
+        addItemIcon(crop.icon.copy(), highlight, 1.0)
 
     fun hideExtraGuis() = ComposterOverlay.inInventory || AnitaMedalProfit.inInventory ||
         SkyMartCopperPrice.inInventory || FarmingContestAPI.inInventory || VisitorAPI.inInventory || FFGuideGUI.isInGui()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -390,7 +390,6 @@ object GardenNextJacobContest {
             duration -= contestDuration
         }
         for (crop in nextContest.crops) {
-            list.add(" ")
             list.addCropIcon(crop, highlight = (crop == boostedCrop))
             nextContestCrops.add(crop)
         }
@@ -494,7 +493,7 @@ object GardenNextJacobContest {
         if (display.isEmpty()) {
             config.pos.renderStrings(simpleDisplay, posLabel = "Next Jacob Contest")
         } else {
-            config.pos.renderSingleLineWithItems(display, 1.0, posLabel = "Next Jacob Contest")
+            config.pos.renderSingleLineWithItems(display, posLabel = "Next Jacob Contest")
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -238,7 +238,6 @@ object GardenVisitorFeatures {
                         list.add(" §7(§c?§7)")
                         continue
                     }
-                    list.add(" ")
                     if (items.isEmpty()) {
                         list.add("§7(§fAny§7)")
                     } else {

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -12,8 +12,8 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderXAligned
 import at.hannibal2.skyhanni.utils.shader.ShaderManager
-import io.github.notenoughupdates.moulconfig.internal.TextRenderUtils
 import io.github.moulberry.notenoughupdates.util.Utils
+import io.github.notenoughupdates.moulconfig.internal.TextRenderUtils
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.FontRenderer
 import net.minecraft.client.gui.Gui
@@ -558,12 +558,15 @@ object RenderUtils {
      */
     fun Position.renderSingleLineWithItems(
         list: List<Any?>,
-        itemScale: Double = NEUItems.itemFontSize,
         posLabel: String
     ) {
         if (list.isEmpty()) return
-        val longestX = renderLine(list, 0, itemScale)
-        GuiEditManager.add(this, posLabel, longestX, 10)
+        renderRenderables(
+            listOf(
+                Renderable.horizontalContainer(
+                    list.mapNotNull { Renderable.fromAny(it) }
+                )), posLabel = posLabel)
+        // TODO Future write that better
     }
 
     private fun Position.renderLine(line: List<Any?>, offsetY: Int, itemScale: Double = NEUItems.itemFontSize): Int {
@@ -584,13 +587,17 @@ object RenderUtils {
         return offsetX
     }
 
-    fun MutableList<Any>.addItemIcon(item: ItemStack, highlight: Boolean = false) {
+    fun MutableList<Any>.addItemIcon(
+        item: ItemStack,
+        highlight: Boolean = false,
+        scale: Double = NEUItems.itemFontSize
+    ) {
         try {
             if (highlight) {
                 // Hack to add enchant glint, like Hypixel does it
                 item.addEnchantment(Enchantment.protection, 0)
             }
-            add(item)
+            add(Renderable.itemStack(item, scale))
         } catch (e: NullPointerException) {
             ErrorManager.logErrorWithData(
                 e, "Add item icon to renderable list",


### PR DESCRIPTION
## What
Fixed the next contest overlay render weird because of #1390. Also removed unnecessary space in the next visitor overlay.

<details>
<summary>Images</summary>

Before #1390
![image](https://github.com/hannibal002/SkyHanni/assets/85900443/7703778b-a4c9-4ea0-85b8-9a319f97144f)
Before Fix
![2024-04-08_15](https://github.com/hannibal002/SkyHanni/assets/85900443/41938bc4-d314-4506-907f-6600319b90ec)
After Fix
![image](https://github.com/hannibal002/SkyHanni/assets/85900443/68ea1a64-21c6-475c-8b19-b5b2d2a08c6c)

</details>

## Changelog Fixes
+ Next contest overlay now looks like before. - Thunderblade73


