### PR TITLE
Backend: isKeyClicked

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardDisplay.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
-import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -26,7 +25,6 @@ import net.minecraft.client.gui.GuiChat
 import net.minecraft.client.gui.inventory.GuiInventory
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.milliseconds
 
 class BingoCardDisplay {
 
@@ -102,8 +100,6 @@ class BingoCardDisplay {
         }
         return newList
     }
-
-    private var lastClick = SimpleTimeMark.farPast()
 
     private fun MutableList<Renderable>.addCommunityGoals() {
         add(Renderable.string("§6Community Goals:"))
@@ -199,9 +195,6 @@ class BingoCardDisplay {
                         add("§eClick to $clickName this goal as highlight!")
                     },
                     onClick = {
-                        if (lastClick.passedSince() < 300.milliseconds) return@clickAndHover
-                        lastClick = SimpleTimeMark.now()
-
                         it.highlight = !currentlyHighlighted
                         it.displayName
                         update()

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -28,9 +28,11 @@ object KeyboardManager {
 
     private fun isControlKeyDown() = Keyboard.KEY_LCONTROL.isKeyHeld() || Keyboard.KEY_RCONTROL.isKeyHeld()
 
-    fun isDeleteWordDown() = Keyboard.KEY_BACK.isKeyHeld() && if (SystemUtils.IS_OS_MAC) isMenuKeyDown() else isControlKeyDown()
+    fun isDeleteWordDown() =
+        Keyboard.KEY_BACK.isKeyHeld() && if (SystemUtils.IS_OS_MAC) isMenuKeyDown() else isControlKeyDown()
 
-    fun isDeleteLineDown() = Keyboard.KEY_BACK.isKeyHeld() && if (SystemUtils.IS_OS_MAC) isCommandKeyDown() else isControlKeyDown() && isShiftKeyDown()
+    fun isDeleteLineDown() =
+        Keyboard.KEY_BACK.isKeyHeld() && if (SystemUtils.IS_OS_MAC) isCommandKeyDown() else isControlKeyDown() && isShiftKeyDown()
 
     fun isShiftKeyDown() = Keyboard.KEY_LSHIFT.isKeyHeld() || Keyboard.KEY_RSHIFT.isKeyHeld()
 
@@ -109,6 +111,21 @@ object KeyboardManager {
         } else {
             KeybindHelper.isKeyDown(this)
         }
+    }
+
+    private val pressedKeys = mutableMapOf<Int, Boolean>()
+
+    /** Can only be used once per click. Since the function locks itself until the key is no longer held*/
+    fun Int.isKeyClicked(): Boolean = if (this.isKeyHeld()) {
+        if (pressedKeys[this] != true) {
+            pressedKeys[this] = true
+            true
+        } else {
+            false
+        }
+    } else {
+        pressedKeys[this] = false
+        false
     }
 
     fun getKeyName(keyCode: Int): String = KeybindHelper.getKeyName(keyCode)

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.features.chroma.ChromaShaderManager
 import at.hannibal2.skyhanni.features.chroma.ChromaType
 import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.darker
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.NEUItems
@@ -27,7 +28,6 @@ import net.minecraft.client.gui.inventory.GuiEditSign
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.item.ItemStack
 import net.minecraft.util.ResourceLocation
-import org.lwjgl.input.Mouse
 import java.awt.Color
 import java.util.Collections
 import kotlin.math.max
@@ -124,16 +124,12 @@ interface Renderable {
             override val horizontalAlign = render.horizontalAlign
             override val verticalAlign = render.verticalAlign
 
-            private var wasDown = false
-
             override fun render(posX: Int, posY: Int) {
-                val isDown = Mouse.isButtonDown(button)
-                if (isDown > wasDown && isHovered(posX, posY) && condition() &&
-                    shouldAllowLink(true, bypassChecks)
+                if (isHovered(posX, posY) && condition() &&
+                    shouldAllowLink(true, bypassChecks) && (button - 100).isKeyClicked()
                 ) {
                     onClick()
                 }
-                wasDown = isDown
                 render.render(posX, posY)
             }
         }
@@ -418,7 +414,7 @@ interface Renderable {
                 percent.toInt()
             }
 
-            private var color = if (texture == null) {
+            private val color = if (texture == null) {
                 ColorUtils.blendRGB(startColor, endColor, percent)
             } else {
                 startColor

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
@@ -31,8 +31,6 @@ class SkyHanniItemTracker<Data : ItemTrackerData>(
         val SKYBLOCK_COIN = NEUInternalName.SKYBLOCK_COIN
     }
 
-    private var lastClickDelay = 0L
-
     fun addCoins(coins: Int) {
         addItem(SKYBLOCK_COIN, coins)
     }
@@ -131,19 +129,16 @@ class SkyHanniItemTracker<Data : ItemTrackerData>(
             val lore = buildLore(data, itemProfit, hidden, newDrop, internalName)
             val renderable = if (isInventoryOpen()) Renderable.clickAndHover(displayName, lore,
                 onClick = {
-                    if (System.currentTimeMillis() > lastClickDelay + 150) {
-                        if (KeyboardManager.isModifierKeyDown()) {
-                            data.items.remove(internalName)
-                            ChatUtils.chat("Removed $cleanName §efrom $name.")
-                            lastClickDelay = System.currentTimeMillis() + 500
-                        } else {
-                            modify {
-                                it.items[internalName]?.hidden = !hidden
-                            }
-                            lastClickDelay = System.currentTimeMillis()
+                    if (KeyboardManager.isModifierKeyDown()) {
+                        data.items.remove(internalName)
+                        ChatUtils.chat("Removed $cleanName §efrom $name.")
+                    } else {
+                        modify {
+                            it.items[internalName]?.hidden = !hidden
                         }
-                        update()
                     }
+                    update()
+
                 }
             ) else Renderable.string(displayName)
 


### PR DESCRIPTION
## What
Fixes the need to add an delay to Renderable.clickable to insure that holding won't trigger onClick. The issue was that most of the time the renderable was newly instaniated after an press, therefore not saving the keyWasDown state.

This way the "clicked" state is saved globally and can only trigger one caller for one keyDown.

## Changelog Technical Details
+ Added isKeyClicked. - Thunderblade73
    * This cleans up the Renderable.clickable.
