### PR TITLE
Fix: Item Scale in Skill Progress Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -418,7 +418,7 @@ object SkillProgress {
             add(Renderable.string("§9[§d$level§9] "))
 
         if (config.useIcon.get()) {
-            add(Renderable.itemStack(activeSkill.item, 1.2))
+            add(Renderable.itemStack(activeSkill.item, 1.0))
         }
 
         add(Renderable.string(buildString {


### PR DESCRIPTION
## What
Fixes the item scale in the skill progress display.

## Changelog Fixes
+ Fixed skill progress item scale being bigger than intended. - martimavocado