### PR TITLE
Fix: Crystall Hollows Area Walls wrong offset

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
@@ -200,7 +200,7 @@ class CrystalHollowsWalls {
         val x = if (isMinXEsleMaxX) minX else maxX
 
         val nucleusZ = if (isMinZElseMaxZ) nucleusBBExpand.minZ else nucleusBBExpand.maxZ
-        val middleZ = if (isMinZElseMaxZ) middleX.shiftNZ() else middleX.shiftPZ()
+        val middleZ = if (isMinZElseMaxZ) middleZ.shiftNZ() else middleZ.shiftPZ()
         val z = if (isMinZElseMaxZ) minZ else maxZ
 
         val heatHeight = heatHeight.shiftPY()


### PR DESCRIPTION
## What
Fixes the x axis wall being on the wrong z values.

## Changelog Fixes
+ Fixed some area walls overlapping with blocks. - Thunderblade73

