### PR TITLE
Fix: Skill tab list pattern sometimes not matching

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
@@ -57,11 +57,11 @@ object SkillAPI {
     )
     private val skillTabPattern by patternGroup.pattern(
         "skill.tab",
-        " (?<type>\\w+) (?<level>\\d+): §r§a(?<progress>.+)%$"
+        "(?:§e§lSkills: §r§a)?\\s*(?<type>\\w+) (?<level>\\d+): §r§.(?<progress>.+)%$"
     )
     private val maxSkillTabPattern by patternGroup.pattern(
         "skill.tab.max",
-        "^§e§lSkills: §r§a(?<type>\\w+) (?<level>\\d+): §r§c§lMAX\$"
+        "(?:§e§lSkills: §r§a)?\\s*(?<type>\\w+) (?<level>\\d+): §r§c§lMAX\$"
     )
 
     var skillXPInfoMap = mutableMapOf<SkillType, SkillXPInfo>()


### PR DESCRIPTION
## What
Fixed the skill tab list pattern sometimes not matching.
- Sometimes Hypixel compresses the skill info into the same line as "Skills:". For some reason, previously this was a hardcoded assumption only for maxed skills.
- Sometimes they use a different color code for the percentage.

## Changelog Fixes
+ Fixed the skill tab list pattern sometimes not matching. - Alexia Luna