### PR TITLE
Backend: Color Code escape in getGemstones()'s debug messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -222,7 +222,7 @@ object SkyBlockItemModifierUtils {
 
                 val quality = GemstoneQuality.getByName(value)
                 if (quality == null) {
-                    ChatUtils.debug("Gemstone quality is null for item $name: ('$key' = '$value')")
+                    ChatUtils.debug("Gemstone quality is null for item $name§7: ('$key' = '$value')")
                     continue
                 }
                 if (type != null) {
@@ -231,7 +231,7 @@ object SkyBlockItemModifierUtils {
                     val newKey = gemstones.getString(key + "_gem")
                     val newType = GemstoneType.getByName(newKey)
                     if (newType == null) {
-                        ChatUtils.debug("Gemstone type is null for item $name: ('$newKey' with '$key' = '$value')")
+                        ChatUtils.debug("Gemstone type is null for item $name§7: ('$newKey' with '$key' = '$value')")
                         continue
                     }
                     list.add(GemstoneSlot(newType, quality))


### PR DESCRIPTION
## What
Fixes color code not being reset after potential change from item name in debug messages.
i don't really know why i'm fixing this

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/39881008/d78abfdd-be3b-40d0-a657-318caf83a2f8)

</details>

## Changelog Technical Details
+ Fixed colors in debug messages. - martimavocado
