### PR TITLE
Fix: Item Size in Crop Milestones GUI

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -63,17 +63,17 @@ object GardenCropMilestoneDisplay {
         if (GardenAPI.hideExtraGuis()) return
 
         config.progressDisplayPos.renderStringsAndItems(
-            progressDisplay, posLabel = "Crop Milestone Progress"
+            progressDisplay, posLabel = "Crop Milestone Progress", itemScale = 0.8
         )
 
         if (config.mushroomPetPerk.enabled) {
             config.mushroomPetPerk.pos.renderStringsAndItems(
-                mushroomCowPerkDisplay, posLabel = "Mushroom Cow Perk"
+                mushroomCowPerkDisplay, posLabel = "Mushroom Cow Perk", itemScale = 0.8
             )
         }
 
         if (config.next.bestDisplay) {
-            config.next.displayPos.renderStringsAndItems(bestCropTime.display, posLabel = "Best Crop Time")
+            config.next.displayPos.renderStringsAndItems(bestCropTime.display, posLabel = "Best Crop Time", itemScale = 0.8)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -25,6 +25,7 @@ import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.round
+import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
 import at.hannibal2.skyhanni.utils.SoundUtils
@@ -63,17 +64,17 @@ object GardenCropMilestoneDisplay {
         if (GardenAPI.hideExtraGuis()) return
 
         config.progressDisplayPos.renderStringsAndItems(
-            progressDisplay, posLabel = "Crop Milestone Progress", itemScale = 0.8
+            progressDisplay, posLabel = "Crop Milestone Progress", itemScale = NEUItems.itemFontSize
         )
 
         if (config.mushroomPetPerk.enabled) {
             config.mushroomPetPerk.pos.renderStringsAndItems(
-                mushroomCowPerkDisplay, posLabel = "Mushroom Cow Perk", itemScale = 0.8
+                mushroomCowPerkDisplay, posLabel = "Mushroom Cow Perk", itemScale = NEUItems.itemFontSize
             )
         }
 
         if (config.next.bestDisplay) {
-            config.next.displayPos.renderStringsAndItems(bestCropTime.display, posLabel = "Best Crop Time", itemScale = 0.8)
+            config.next.displayPos.renderStringsAndItems(bestCropTime.display, posLabel = "Best Crop Time", itemScale = NEUItems.itemFontSize)
         }
     }
 


### PR DESCRIPTION
## What
Fixes the item scale in the Crop Milestones, Mooshroom Crop Milestones, and Best Crop GUIs to be closer to how it used to be.
<details>
<summary>Images</summary>

old:
![image](https://github.com/hannibal002/SkyHanni/assets/39881008/fbea4bc8-f774-46ea-95af-7447ceeacbd9)

new: 
![image](https://github.com/hannibal002/SkyHanni/assets/39881008/edc80bb8-8137-47d3-ba7f-ccb66c4d76c6)

</details>

## Changelog Fixes
+ Fixed item sizes in the Crop Milestone display. - martimavocado