### PR TITLE
Feature: party chat commands

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -92,6 +92,7 @@ import at.hannibal2.skyhanni.features.combat.mobs.AreaMiniBossFeatures
 import at.hannibal2.skyhanni.features.combat.mobs.AshfangMinisNametagHider
 import at.hannibal2.skyhanni.features.combat.mobs.MobHighlight
 import at.hannibal2.skyhanni.features.combat.mobs.SpawnTimers
+import at.hannibal2.skyhanni.features.commands.PartyChatCommands
 import at.hannibal2.skyhanni.features.commands.PartyCommands
 import at.hannibal2.skyhanni.features.commands.SendCoordinatedCommand
 import at.hannibal2.skyhanni.features.commands.ViewRecipeCommand
@@ -586,6 +587,7 @@ class SkyHanniMod {
         loadModule(WarpIsCommand())
         loadModule(ViewRecipeCommand)
         loadModule(PartyCommands)
+        loadModule(PartyChatCommands)
         loadModule(SummoningMobManager())
         loadModule(SkyblockXPInChat())
         loadModule(AreaMiniBossFeatures())

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -29,6 +29,10 @@ public class MiscConfig {
     public CommandsConfig commands = new CommandsConfig();
 
     @Expose
+    @Category(name = "Party Commands", desc = "Enable or disable party commands.")
+    public PartyCommandsConfig partyCommands = new PartyCommandsConfig();
+
+    @Expose
     @Category(name = "Minions", desc = "The minions on your private island.")
     public MinionsConfig minions = new MinionsConfig();
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/PartyCommandsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/PartyCommandsConfig.java
@@ -1,0 +1,44 @@
+package at.hannibal2.skyhanni.config.features.misc;
+
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import org.jetbrains.annotations.NotNull;
+
+public class PartyCommandsConfig {
+
+    @Expose
+    @ConfigEditorDropdown
+    @ConfigOption(name = "Party Command Trust Level", desc = "Choose who can run party chat commands.")
+    public @NotNull TrustedUser defaultRequiredTrustLevel = TrustedUser.FRIENDS;
+
+    @Expose
+    @ConfigEditorBoolean
+    @ConfigOption(name = "Party Transfer", desc = "Automatically transfer the party to people who type §b!ptme")
+    public boolean transferCommand = false;
+
+    @Expose
+    @ConfigEditorBoolean
+    @ConfigOption(name = "Party Warp", desc = "Automatically warp the party if someone types §b!warp")
+    public boolean warpCommand = false;
+
+    public enum TrustedUser {
+        BEST_FRIENDS("Best Friends"),
+        FRIENDS("Friends"),
+        ANYONE("Everyone"),
+        NO_ONE("No One"),
+        ;
+        final String label;
+
+        TrustedUser(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/events/PartyChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/PartyChatEvent.kt
@@ -1,0 +1,7 @@
+package at.hannibal2.skyhanni.events
+
+data class PartyChatEvent(
+    val author: String,
+    val text: String,
+    val trigger: LorenzChatEvent,
+) : LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
@@ -1,0 +1,81 @@
+package at.hannibal2.skyhanni.features.commands
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.features.misc.PartyCommandsConfig
+import at.hannibal2.skyhanni.data.FriendAPI
+import at.hannibal2.skyhanni.data.PartyAPI
+import at.hannibal2.skyhanni.events.PartyChatEvent
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+object PartyChatCommands {
+
+    data class PartyChatCommand(
+        val names: List<String>,
+        val isEnabled: () -> Boolean,
+        val requiresPartyLead: Boolean,
+        val executable: (PartyChatEvent) -> Unit,
+    )
+
+    private fun useConfig() = SkyHanniMod.feature.misc.partyCommands
+    val allPartyCommands = listOf(
+        PartyChatCommand(
+            listOf("pt", "ptme", "transfer"),
+            { useConfig().transferCommand },
+            requiresPartyLead = true,
+            executable = {
+                ChatUtils.sendCommandToServer("party transfer ${it.author}")
+            }
+        ),
+        PartyChatCommand(
+            listOf("pw", "warp", "warpus"),
+            { useConfig().warpCommand },
+            requiresPartyLead = true,
+            executable = {
+                ChatUtils.sendCommandToServer("party warp")
+            }
+        ),
+    )
+
+    val indexedPartyChatCommands = buildMap {
+        for (command in allPartyCommands) {
+            for (name in command.names) {
+                put(name.lowercase(), command)
+            }
+        }
+    }
+
+
+    fun isTrustedUser(name: String): Boolean {
+        val friend = FriendAPI.getAllFriends().find { it.name == name }
+        return when (useConfig().defaultRequiredTrustLevel) {
+            PartyCommandsConfig.TrustedUser.FRIENDS -> friend != null
+            PartyCommandsConfig.TrustedUser.BEST_FRIENDS -> friend?.bestFriend == true
+            PartyCommandsConfig.TrustedUser.ANYONE -> true
+            PartyCommandsConfig.TrustedUser.NO_ONE -> false
+        }
+    }
+
+    private val commandBeginChars = ".!?".toSet()
+
+    @SubscribeEvent
+    fun onPartyCommand(event: PartyChatEvent) {
+        if (event.text.firstOrNull() !in commandBeginChars)
+            return
+        val commandLabel = event.text.substring(1).substringBefore(' ')
+        val command = indexedPartyChatCommands[commandLabel.lowercase()] ?: return
+        if (event.author == LorenzUtils.getPlayerName()) {
+            return
+        }
+        if (!command.isEnabled()) return
+        if (command.requiresPartyLead && PartyAPI.partyLeader != LorenzUtils.getPlayerName()) {
+            return
+        }
+        if (!isTrustedUser(event.author)) {
+            ChatUtils.chat("§cIgnoring chat command from ${event.author}. Change your party chat command settings or /friend (best) them.")
+            return
+        }
+        command.executable(event)
+    }
+}


### PR DESCRIPTION
## What
Party chat commands are commands issued by people in your party chat.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/20768569/e66deebc-44a9-4b7d-8b6d-a924f8a703dc)
![image](https://github.com/hannibal002/SkyHanni/assets/20768569/1840ad39-e0dd-4d26-9815-8df1b5bacfe4)
![image](https://github.com/hannibal002/SkyHanni/assets/20768569/12f7e494-a5b0-4f84-9e1a-7fd5ba34362d)


</details>

## Changelog New Features
+ Added party chat commands. - !nea
    * Added `!pt` (and aliases) as a command that allows others to transfer the party to themselves.
    * Added `!pw` (and aliases) as a command that allows others to request a warp.

## Changelog Technical Details
+ Added party leader to `PartyAPI`. - !nea
+ Added party chat event. - !nea
