### PR TITLE
Improvement: Add Cold Resistance 4 non god effect

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
@@ -54,9 +54,9 @@ class NonGodPotEffectDisplay {
 
         INVISIBILITY("§8Invisibility I"), // when wearing sorrow armor
 
-        REV("§cZombie Brain Mixin", true, "§cZombie Brain Mixin I"),
-        TARA("§6Spider Egg Mixin", true, "§6Spider Egg Mixin I"),
-        SVEN("§bWolf Fur Mixin", true, "§bWolf Fur Mixin I"),
+        REV("§cZombie Brain Mixin", true),
+        TARA("§6Spider Egg Mixin", true),
+        SVEN("§bWolf Fur Mixin", true),
         VOID("§6Ender Portal Fumes", true),
         BLAZE("§fGabagoey", true),
         GLOWING_MUSH("§2Glowing Mush Mixin", true),
@@ -196,7 +196,7 @@ class NonGodPotEffectDisplay {
         for (stack in event.inventoryItems.values) {
             val name = stack.name
             for (effect in NonGodPotEffect.entries) {
-                if (name != effect.inventoryItemName) continue
+                if (!name.contains(effect.inventoryItemName)) continue
                 for (line in stack.getLore()) {
                     if (line.contains("Remaining") &&
                         line != "§7Time Remaining: §aCompleted!" &&

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
@@ -54,9 +54,9 @@ class NonGodPotEffectDisplay {
 
         INVISIBILITY("§8Invisibility I"), // when wearing sorrow armor
 
-        REV("§cZombie Brain Mixin", true),
-        TARA("§6Spider Egg Mixin", true),
-        SVEN("§bWolf Fur Mixin", true),
+        REV("§cZombie Brain Mixin", true, "§cZombie Brain Mixin I"),
+        TARA("§6Spider Egg Mixin", true, "§6Spider Egg Mixin I"),
+        SVEN("§bWolf Fur Mixin", true, "§bWolf Fur Mixin I"),
         VOID("§6Ender Portal Fumes", true),
         BLAZE("§fGabagoey", true),
         GLOWING_MUSH("§2Glowing Mush Mixin", true),
@@ -71,6 +71,8 @@ class NonGodPotEffectDisplay {
         PEST_REPELLENT_MAX("§6Pest Repellent II"),
 
         CURSE_OF_GREED("§4Curse of Greed I"),
+
+        COLD_RESISTANCE_4("§bCold Resistance IV"),
         ;
     }
 
@@ -194,7 +196,7 @@ class NonGodPotEffectDisplay {
         for (stack in event.inventoryItems.values) {
             val name = stack.name
             for (effect in NonGodPotEffect.entries) {
-                if (!name.contains(effect.inventoryItemName)) continue
+                if (name != effect.inventoryItemName) continue
                 for (line in stack.getLore()) {
                     if (line.contains("Remaining") &&
                         line != "§7Time Remaining: §aCompleted!" &&


### PR DESCRIPTION
## What
Adds the Cold Resistance 4 non god effect, so it gets correctly detected.

I plan to rewrite the logic that reads the effects so this can be moved to repo and use Regex, so this can stop using `.contains`, `.startsWith`, `.split` etc. and make the code more reliable.
Adding the other tiers was causing conflict issues, so I'm only adding this one for now, as it's the most popular tier, and everyone can get a dirty fix while the rewrite isn't completed.

## Changelog Improvements
+ Added Cold Resistance 4 to Non God Pot Effects. - martimavocado

