### PR TITLE
Backend: Fix self reference occurring when performing an internalizing config move

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.events.LorenzEvent
 import at.hannibal2.skyhanni.features.misc.limbo.LimboTimeTracker
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils.asIntOrNull
+import at.hannibal2.skyhanni.utils.shDeepCopy
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
@@ -11,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 37
+    const val CONFIG_VERSION = 38
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null
@@ -83,7 +84,7 @@ object ConfigUpdaterMigrator {
             }
             movesPerformed++
             if (np == listOf("#player", "personalBest")) LimboTimeTracker.workaroundMigration(oldElem.asInt)
-            newParentElement.add(np.last(), transform(oldElem))
+            newParentElement.add(np.last(), transform(oldElem.shDeepCopy()))
             logger.log("Moved element from $oldPath to $newPath")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningConfig.java
@@ -36,7 +36,7 @@ public class MiningConfig {
     // TODO rename to fossilExcavator
     @Expose
     @Category(name = "Fossil Excavator", desc = "Settings for the Fossil Excavator Features")
-    public FossilExcavatorConfig fossilExcavator2 = new FossilExcavatorConfig();
+    public FossilExcavatorConfig fossilExcavator = new FossilExcavatorConfig();
 
     @Expose
     @ConfigOption(name = "Notifications", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -26,7 +26,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class ExcavatorProfitTracker {
 
-    private val config get() = SkyHanniMod.feature.mining.fossilExcavator2.profitTracker
+    private val config get() = SkyHanniMod.feature.mining.fossilExcavator.profitTracker
 
     private val tracker = SkyHanniItemTracker(
         "Fossil Excavation Profit Tracker",

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/solver/FossilSolverDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/solver/FossilSolverDisplay.kt
@@ -27,7 +27,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 object FossilSolverDisplay {
 
-    private val config get() = SkyHanniMod.feature.mining.fossilExcavator2.solver
+    private val config get() = SkyHanniMod.feature.mining.fossilExcavator.solver
 
     private val patternGroup = RepoPattern.group("mining.fossilexcavator")
     private val chargesRemainingPattern by patternGroup.pattern(
@@ -211,6 +211,7 @@ object FossilSolverDisplay {
     @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(36, "mining.fossilExcavator", "mining.fossilExcavator2.solver")
+        event.move(37, "mining.fossilExcavator2", "mining.fossilExcavator")
     }
 
     fun nextData(slotToClick: FossilTile, correctPercentage: Double, fossilsRemaining: Int) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/JsonUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/JsonUtils.kt
@@ -1,7 +1,9 @@
 package at.hannibal2.skyhanni.utils
 
 import com.google.gson.Gson
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
+import com.google.gson.JsonObject
 import java.io.Reader
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.typeOf
@@ -12,3 +14,24 @@ inline fun <reified T : Any> Gson.fromJson(jsonElement: JsonElement): T =
     this.fromJson(jsonElement, typeOf<T>().javaType)
 
 inline fun <reified T : Any> Gson.fromJson(reader: Reader): T = this.fromJson(reader, typeOf<T>().javaType)
+
+/**
+ * Straight forward deep copy. This is included in gson as well, but different versions have it exposed privately instead of publicly,
+ * so this reimplementation is here as an always public alternative.
+ */
+fun JsonElement.shDeepCopy(): JsonElement {
+    return when (this) {
+        is JsonObject -> JsonObject().also {
+            for (entry in this.entrySet())
+                it.add(entry.key, entry.value.shDeepCopy())
+        }
+
+        is JsonArray -> JsonArray().also {
+            for (entry in this) {
+                it.add(entry.shDeepCopy())
+            }
+        }
+
+        else -> this
+    }
+}


### PR DESCRIPTION
## What

This PR should fix config moves in the style of

```kt
config.move(37, "a.b", "a.b.c")
```

<!-- remove all unused parts -->



<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Technical Details
+ Fixed internalizing config moves introducing a self reference inside the JSON tree. - !nea

