### PR TITLE
Fix: Fixed Totem of Corruption Overlay not getting cleared on disable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/TotemOfCorruptionConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/TotemOfCorruptionConfig.java
@@ -9,6 +9,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import io.github.notenoughupdates.moulconfig.observer.Property;
 
 public class TotemOfCorruptionConfig {
 
@@ -18,7 +19,7 @@ public class TotemOfCorruptionConfig {
         "\n§cThis needs to be enabled for the other options to work.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean showOverlay = true;
+    public Property<Boolean> showOverlay = Property.of(true);
 
     @Expose
     @ConfigOption(name = "Distance Threshold", desc = "The minimum distance to the Totem of Corruption for the overlay." +

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.features.fishing.TotemOfCorruptionConfig.Out
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
+import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
@@ -107,6 +108,12 @@ class TotemOfCorruption {
             display = emptyList()
             totems = emptyList()
         }
+    }
+
+    @SubscribeEvent
+    fun onWorldChange(event: LorenzWorldChangeEvent) {
+        display = emptyList()
+        totems = emptyList()
     }
 
     private fun getTimeRemaining(totem: EntityArmorStand): Duration? =

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -103,7 +103,10 @@ class TotemOfCorruption {
 
     @SubscribeEvent
     fun onConfigLoad(event: ConfigLoadEvent) {
-        config.showOverlay.onToggle { display = emptyList() }
+        config.showOverlay.onToggle {
+            display = emptyList()
+            totems = emptyList()
+        }
     }
 
     private fun getTimeRemaining(totem: EntityArmorStand): Duration? =

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -2,11 +2,13 @@ package at.hannibal2.skyhanni.features.fishing
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.features.fishing.TotemOfCorruptionConfig.OutlineType
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
+import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -99,6 +101,11 @@ class TotemOfCorruption {
         }
     }
 
+    @SubscribeEvent
+    fun onConfigLoad(event: ConfigLoadEvent) {
+        config.showOverlay.onToggle { display = emptyList() }
+    }
+
     private fun getTimeRemaining(totem: EntityArmorStand): Duration? =
         EntityUtils.getEntitiesNearby<EntityArmorStand>(totem.getLorenzVec(), 2.0)
             .firstNotNullOfOrNull { entity ->
@@ -143,7 +150,7 @@ class TotemOfCorruption {
             Totem(totem.getLorenzVec(), timeRemaining, owner)
         }
 
-    private fun isOverlayEnabled() = LorenzUtils.inSkyBlock && config.showOverlay
+    private fun isOverlayEnabled() = LorenzUtils.inSkyBlock && config.showOverlay.get()
     private fun isHideParticlesEnabled() = LorenzUtils.inSkyBlock && config.hideParticles
     private fun isEffectiveAreaEnabled() = LorenzUtils.inSkyBlock && config.outlineType != OutlineType.NONE
 }


### PR DESCRIPTION
## What
This Pull Request fixes the totem list not getting cleared on config disable, making the area highlight continue highlighting it.
I tested and changing the option from a boolean to a property wont reset it.


## Changelog Fixes
+ Fixed Totem of Corruption Overlay not getting cleared on disable. - j10a1n15

