### PR TITLE
Improvement: Farming Fortune Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -218,7 +218,7 @@ object FarmingFortuneDisplay {
             lastUniversalFortuneMissingError = SimpleTimeMark.now()
         }
         if (firstBrokenCropTime.passedSince() > 10.seconds && !foundTabCropFortune && !firstBrokenCropTime.isFarPast()) {
-            if (lastCropFortuneMissingError.passedSince() < 1.minutes) return
+            if (lastCropFortuneMissingError.passedSince() < 1.minutes || !GardenAPI.isCurrentlyFarming()) return
             ChatUtils.clickableChat(
                 "§cCan not read Crop Fortune from tab list! Open /widget and enable the Stats Widget " +
                     "and showing latest Crop Fortune.",


### PR DESCRIPTION
## What
Made crop fortune not found warning only get shown in chat when actively farming.

[Discord Suggestion](https://ptb.discord.com/channels/997079228510117908/1229021376099385344)

## Changelog Improvements
+ Only warn that crop fortune is missing in tab list while actively farming. - Empa