### PR TITLE
Improvement: Crash in dev env for @ConfigLink

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -202,12 +202,27 @@ class ConfigManager {
         }
     }
 
+    // Some position elements dont need config links as they dont have a config option.
+    private val ignoredMissingConfigLinks = listOf(
+        // commands
+        "features.garden.GardenConfig.cropSpeedMeterPos",
+        "features.misc.MiscConfig.collectionCounterPos",
+        "features.misc.MiscConfig.lockedMouseDisplay",
+
+        // debug features
+        "features.dev.DebugConfig.trackSoundPosition",
+        "features.dev.DevConfig.debugPos",
+        "features.dev.DevConfig.debugLocationPos",
+        "features.dev.DevConfig.debugItemPos",
+    )
+
     private fun findPositionLinks(obj: Any?, slog: MutableSet<IdentityCharacteristics<Any>>) {
         if (obj == null) return
         if (!obj.javaClass.name.startsWith("at.hannibal2.skyhanni.")) return
         val ic = IdentityCharacteristics(obj)
         if (ic in slog) return
         slog.add(ic)
+        var missingConfigLink = false
         for (field in obj.javaClass.fields) {
             field.isAccessible = true
             if (field.type != Position::class.java) {
@@ -219,12 +234,26 @@ class ConfigManager {
                 if (LorenzUtils.isInDevEnvironment()) {
                     var name = "${field.declaringClass.name}.${field.name}"
                     name = name.replace("at.hannibal2.skyhanni.config.", "")
-                    println("WEE WOO WEE WOO HIER FEHLT EIN @CONFIGLINK: $name")
+                    if (name !in ignoredMissingConfigLinks) {
+                        println("WEE WOO WEE WOO HIER FEHLT EIN @CONFIGLINK: $name")
+                        missingConfigLink = true
+                    }
                 }
                 continue
             }
             val position = field.get(obj) as Position
             position.setLink(configLink)
+        }
+        if (missingConfigLink) {
+            println("")
+            println("This crash is here to remind you to fix the missing @ConfigLink annotation over your new config position config element.")
+            println("")
+            println("Steps to fix:")
+            println("1. Search for `WEE WOO WEE WOO` in the console output.")
+            println("2. Either add the Config Link.")
+            println("3. Or add the name to ignoredMissingConfigLinks.")
+            println("")
+            LorenzUtils.shutdownMinecraft("Missing Config Link")
         }
     }
 


### PR DESCRIPTION
## What
Every new config position element should have a `@ConfigLink` annotation on top, so we can right-click in the GUI editor to instantly open the corresponding config.
This pull request will crash the game while in dev environment to tell the developer to add this config link element.
Also comes with an ignored list for commands only and dev features.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/92cdba9d-cf86-4329-8448-2e7d1f8005af)

</details>

## Changelog Improvements
+ Added support to right-click in GUI editor to open config for all remaining GUI elements. - hannibal2

## Changelog Technical Details
+ Crash in dev env with missing @ConfigLink. - hannibal2