### PR TITLE
Backend: Add unimined build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ gradle.properties
 
 .devauth/*
 !.devauth/config.toml
+
+.env

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,13 @@
-import org.apache.commons.lang3.SystemUtils
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import xyz.wagyourtail.unimined.api.minecraft.MinecraftConfig
+import xyz.wagyourtail.unimined.api.minecraft.task.RemapJarTask
+import xyz.wagyourtail.unimined.api.runs.RunConfig
 import java.io.ByteArrayOutputStream
 
 plugins {
     idea
     java
-    id("gg.essential.loom") version "0.10.0.+"
-    id("dev.architectury.architectury-pack200") version "0.1.3"
+    id("xyz.wagyourtail.unimined") version "1.2.0-SNAPSHOT"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     kotlin("jvm") version "1.9.0"
     id("com.bnorm.power.kotlin-power-assert") version "0.13.0"
@@ -38,6 +39,10 @@ sourceSets.main {
     kotlin.destinationDirectory.set(java.destinationDirectory)
 }
 
+val patternSourceSet = sourceSets.create("pattern") {
+    this.runtimeClasspath += sourceSets.main.get().runtimeClasspath
+}
+
 repositories {
     mavenCentral()
     mavenLocal()
@@ -51,15 +56,19 @@ repositories {
     maven("https://repo.nea.moe/releases")
     maven("https://maven.notenoughupdates.org/releases")
     maven("https://repo.hypixel.net/repository/Hypixel/")
+    ivy("https://repo1.maven.org/maven2/org/apache/logging/log4j") {
+        this.content {
+            this.includeGroup("log4jhack")
+        }
+        this.patternLayout {
+            this.artifact("log4j-[artifact]/[revision]/log4j-[artifact]-[revision].[ext]")
+        }
+        this.metadataSources {
+            this.artifact()
+        }
+    }
 }
 
-val shadowImpl: Configuration by configurations.creating {
-    configurations.implementation.get().extendsFrom(this)
-}
-
-val shadowModImpl: Configuration by configurations.creating {
-    configurations.modImplementation.get().extendsFrom(this)
-}
 
 val devenvMod: Configuration by configurations.creating {
     isTransitive = false
@@ -73,10 +82,116 @@ val headlessLwjgl by configurations.creating {
 
 val shot = shots.shot("minecraft", project.file("shots.txt"))
 
+val modRuntimeOnly by configurations.creating {
+    configurations.runtimeOnly.get().extendsFrom(this)
+}
+val modCompileOnly by configurations.creating {
+    configurations.compileOnly.get().extendsFrom(this)
+}
+
+fun RunConfig.setBaseConfig() {
+    val runDir = file("run").absoluteFile
+    this.javaVersion = JavaVersion.VERSION_1_8
+    this.args.addAll(
+        listOf(
+            "--tweakClass",
+            "org.spongepowered.asm.launch.MixinTweaker",
+            "--tweakClass",
+            "io.github.notenoughupdates.moulconfig.tweaker.DevelopmentResourceTweaker",
+            "--mods",
+            devenvMod.resolve().joinToString(",") { it.relativeTo(runDir).path }
+        )
+    )
+    this.args.set(
+        this.args.indexOf("--gameDir") + 1,
+        runDir.absolutePath
+    )
+    this.jvmArgs.removeIf { it.startsWith("-Xmx") }
+    this.jvmArgs.addAll(
+        listOf(
+            "-Xmx4G",
+            "-Dmixin.debug=true",
+            "-Dlog4j.configurationFile=${project.file("log4j2.xml").absolutePath}"
+        )
+    )
+    this.workingDir = runDir
+    if (System.getenv("repo_action") != "true") {
+        this.jvmArgs.add("-Ddevauth.configdir=${rootProject.file(".devauth").absolutePath}")
+    }
+    this.env.putAll(parseEnvFile(file(".env")))
+}
+
+fun MinecraftConfig.defaultMinecraft() {
+    this.version("1.8.9")
+    this.mappings {
+        this.searge()
+        this.mcp("stable", "22-1.8.9")
+    }
+    this.minecraftForge {
+        this.loader("11.15.1.2318-1.8.9")
+        this.mixinConfig("mixins.skyhanni.json")
+    }
+}
+
+unimined.minecraft {
+    this.defaultMinecraft()
+    this.runs {
+        this.config("client") {
+            this.setBaseConfig()
+        }
+    }
+    this.mods {
+        this.remap(modRuntimeOnly)
+        this.remap(devenvMod)
+        this.remap(modCompileOnly)
+    }
+}
+
+unimined.minecraft(patternSourceSet) {
+    this.defaultMinecraft()
+    this.runs {
+        this.config("client") {
+            this.setBaseConfig()
+            this.jvmArgs.addAll(
+                listOf(
+                    "-Dorg.lwjgl.opengl.Display.allowSoftwareOpenGL=true",
+                    "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006",
+                    "-javaagent:${headlessLwjgl.singleFile.absolutePath}"
+                )
+            )
+            val outputFile = project.file("build/regexes/constants.json")
+            this.env.put("SKYHANNI_DUMP_REGEXES", "${gitHash}:${outputFile.absolutePath}")
+            this.env.put("SKYHANNI_DUMP_REGEXES_EXIT", "true")
+        }
+    }
+}
+unimined.minecraft(sourceSets.test.get()) {
+    this.defaultMinecraft()
+}
+val modImplementation by configurations
+val testModImplementation by configurations
+val patternModImplementation by configurations
+
+testModImplementation.extendsFrom(modImplementation)
+patternModImplementation.extendsFrom(testModImplementation)
+
+val shadowImpl: Configuration by configurations.creating {
+    configurations.implementation.get().extendsFrom(this)
+}
+
+val shadowModImpl: Configuration by configurations.creating {
+    modImplementation.extendsFrom(this)
+
+}
+
+configurations.named("minecraftLibraries") {
+    this.resolutionStrategy {
+        this.force("org.apache.logging.log4j:log4j-core:2.8.1")
+        this.force("org.apache.logging.log4j:log4j-api:2.8.1")
+    }
+}
+
 dependencies {
-    minecraft("com.mojang:minecraft:1.8.9")
-    mappings("de.oceanlabs.mcp:mcp_stable:22-1.8.9")
-    forge("net.minecraftforge:forge:1.8.9-11.15.1.2318-1.8.9")
 
     // Discord RPC client
     shadowImpl("com.github.NetheriteMiner:DiscordIPC:3106be5") {
@@ -92,7 +207,6 @@ dependencies {
     shadowImpl("org.spongepowered:mixin:0.7.11-SNAPSHOT") {
         isTransitive = false
     }
-    annotationProcessor("org.spongepowered:mixin:0.8.4-SNAPSHOT")
 
     implementation(kotlin("stdlib-jdk8"))
     shadowImpl("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3") {
@@ -124,9 +238,11 @@ dependencies {
     testImplementation("io.mockk:mockk:1.12.5")
 
     implementation("net.hypixel:mod-api:0.3.1")
-}
-configurations.getByName("minecraftNamed").dependencies.forEach {
-    shot.applyTo(it as HasConfigurableAttributes<*>)
+
+    runtimeOnly(libs.terminalConsoleAppender)
+    // Manually load 2.0-beta.9 on the class path *after* loading 2.8.X, since forge uses some of the helper classes only available in this version.
+    runtimeOnly("log4jhack:api:2.0-beta9")
+    runtimeOnly("log4jhack:core:2.0-beta9")
 }
 
 tasks.withType(Test::class) {
@@ -145,64 +261,19 @@ kotlin {
     }
 }
 
-// Minecraft configuration:
-loom {
-    launchConfigs {
-        "client" {
-            property("mixin.debug", "true")
-            if (System.getenv("repo_action") != "true") {
-                property("devauth.configDir", rootProject.file(".devauth").absolutePath)
-            }
-            arg("--tweakClass", "org.spongepowered.asm.launch.MixinTweaker")
-            arg("--tweakClass", "io.github.notenoughupdates.moulconfig.tweaker.DevelopmentResourceTweaker")
-            arg("--mods", devenvMod.resolve().joinToString(",") { it.relativeTo(file("run")).path })
-        }
-    }
-    forge {
-        pack200Provider.set(dev.architectury.pack200.java.Pack200Adapter())
-        mixinConfig("mixins.skyhanni.json")
-    }
-    @Suppress("UnstableApiUsage")
-    mixin {
-        defaultRefmapName.set("mixins.skyhanni.refmap.json")
-    }
-    runConfigs {
-        "client" {
-            if (SystemUtils.IS_OS_MAC_OSX) {
-                vmArgs.remove("-XstartOnFirstThread")
-            }
-            vmArgs.add("-Xmx4G")
-        }
-        "server" {
-            isIdeConfigGenerated = false
-        }
-    }
-}
-
 // Tasks:
 tasks.processResources {
     inputs.property("version", version)
     filesMatching("mcmod.info") {
         expand("version" to version)
     }
+    this.filesMatching("mixins.skyhanni.json") {
+        this.autoDiscoverMixins(sourceSets.main.get())
+    }
 }
 
-val generateRepoPatterns by tasks.creating(JavaExec::class) {
-    javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
-    mainClass.set("net.fabricmc.devlaunchinjector.Main")
-    workingDir(project.file("run"))
-    classpath(sourceSets.main.map { it.runtimeClasspath }, sourceSets.main.map { it.output })
-    jvmArgs(
-        "-Dfabric.dli.config=${project.file(".gradle/loom-cache/launch.cfg").absolutePath}",
-        "-Dfabric.dli.env=client",
-        "-Dfabric.dli.main=net.minecraft.launchwrapper.Launch",
-        "-Dorg.lwjgl.opengl.Display.allowSoftwareOpenGL=true",
-        "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006",
-        "-javaagent:${headlessLwjgl.singleFile.absolutePath}"
-    )
-    val outputFile = project.file("build/regexes/constants.json")
-    environment("SKYHANNI_DUMP_REGEXES", "${gitHash}:${outputFile.absolutePath}")
-    environment("SKYHANNI_DUMP_REGEXES_EXIT", "true")
+val generateRepoPatterns by tasks.creating() {
+    afterEvaluate { dependsOn(tasks["patternRunClient"]) }
 }
 
 tasks.compileJava {
@@ -215,6 +286,9 @@ tasks.withType(JavaCompile::class) {
 
 tasks.withType(Jar::class) {
     archiveBaseName.set("SkyHanni")
+    if (this.name != "remapJar") {
+        this.destinationDirectory.set(layout.buildDirectory.dir("badjars"))
+    }
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     manifest.attributes.run {
         this["FMLCorePluginContainsFMLMod"] = "true"
@@ -227,21 +301,14 @@ tasks.withType(Jar::class) {
 }
 
 
-val remapJar by tasks.named<net.fabricmc.loom.task.RemapJarTask>("remapJar") {
+val remapJar by tasks.named<RemapJarTask>("remapJar") {
     archiveClassifier.set("")
-    from(tasks.shadowJar)
-    input.set(tasks.shadowJar.get().archiveFile)
+    inputFile.set(tasks.shadowJar.flatMap { it.archiveFile })
 }
 
 tasks.shadowJar {
-    destinationDirectory.set(layout.buildDirectory.dir("badjars"))
     archiveClassifier.set("all-dev")
     configurations = listOf(shadowImpl, shadowModImpl)
-    doLast {
-        configurations.forEach {
-            println("Config: ${it.files}")
-        }
-    }
     exclude("META-INF/versions/**")
     mergeServiceFiles()
     relocate("io.github.notenoughupdates.moulconfig", "at.hannibal2.skyhanni.deps.moulconfig")
@@ -249,9 +316,8 @@ tasks.shadowJar {
 }
 tasks.jar {
     archiveClassifier.set("nodeps")
-    destinationDirectory.set(layout.buildDirectory.dir("badjars"))
 }
-tasks.assemble.get().dependsOn(tasks.remapJar)
+tasks.assemble.get().dependsOn(remapJar)
 
 val compileKotlin: KotlinCompile by tasks
 compileKotlin.kotlinOptions {
@@ -262,14 +328,13 @@ compileTestKotlin.kotlinOptions {
     jvmTarget = "1.8"
 }
 val sourcesJar by tasks.creating(Jar::class) {
-    destinationDirectory.set(layout.buildDirectory.dir("badjars"))
     archiveClassifier.set("src")
     from(sourceSets.main.get().allSource)
 }
 
 publishing.publications {
     create<MavenPublication>("maven") {
-        artifact(tasks.remapJar)
+        artifact(remapJar)
         artifact(sourcesJar) { classifier = "sources" }
         pom {
             name.set("SkyHanni")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,7 @@ fun RunConfig.setBaseConfig() {
         this.args.indexOf("--gameDir") + 1,
         runDir.absolutePath
     )
-    this.jvmArgs.removeIf { it.startsWith("-Xmx") }
+    this.jvmArgs.removeIf { it.startsWith("-Xmx") || it.startsWith("-XX:") }
     this.jvmArgs.addAll(
         listOf(
             "-Xmx4G",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,6 +139,9 @@ unimined.minecraft {
         this.config("client") {
             this.setBaseConfig()
         }
+        this.config("server") {
+            this.disabled = true
+        }
     }
     this.mods {
         this.remap(modRuntimeOnly)
@@ -163,10 +166,16 @@ unimined.minecraft(patternSourceSet) {
             this.env.put("SKYHANNI_DUMP_REGEXES", "${gitHash}:${outputFile.absolutePath}")
             this.env.put("SKYHANNI_DUMP_REGEXES_EXIT", "true")
         }
+        this.config("server") {
+            this.disabled = true
+        }
     }
 }
 unimined.minecraft(sourceSets.test.get()) {
     this.defaultMinecraft()
+    this.runs {
+        this.off = true
+    }
 }
 val modImplementation by configurations
 val testModImplementation by configurations

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,7 +116,7 @@ fun RunConfig.setBaseConfig() {
     )
     this.workingDir = runDir
     if (System.getenv("repo_action") != "true") {
-        this.jvmArgs.add("-Ddevauth.configdir=${rootProject.file(".devauth").absolutePath}")
+        this.jvmArgs.add("-Ddevauth.configDir=${rootProject.file(".devauth").absolutePath}")
     }
     this.env.putAll(parseEnvFile(file(".env")))
 }
@@ -213,7 +213,7 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin")
     }
 
-    modRuntimeOnly("me.djtheredstoner:DevAuth-forge-legacy:1.1.0")
+    modRuntimeOnly("me.djtheredstoner:DevAuth-forge-legacy:1.2.0")
 
     modCompileOnly("com.github.hannibal002:notenoughupdates:4957f0b:all") {
         exclude(module = "unspecified")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,18 @@
+
+plugins {
+    `kotlin-dsl`
+    kotlin("jvm")version "1.8.10"
+}
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.google.code.gson:gson:2.10.1")
+}
+
+sourceSets.main {
+    kotlin {
+        srcDir(file("src"))
+    }
+}

--- a/buildSrc/src/AutoMixinDiscovery.kt
+++ b/buildSrc/src/AutoMixinDiscovery.kt
@@ -1,0 +1,50 @@
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import org.apache.tools.ant.filters.BaseParamFilterReader
+import org.gradle.api.file.FileCopyDetails
+import org.gradle.api.tasks.SourceSet
+import java.io.File
+import java.io.Reader
+import java.io.StringReader
+
+class MixinFilterReader(reader: Reader) : BaseParamFilterReader() {
+    lateinit var sourceRoots: Collection<File>
+    val gson = GsonBuilder().setPrettyPrinting().create()
+    val betterReader: StringReader by lazy {
+        StringReader(run {
+            val json = gson.fromJson(reader.readText(), JsonObject::class.java)
+            val mixinPackage = (json["package"] as JsonPrimitive).asString
+            val allMixins = (json["mixins"] as JsonArray?)?.map { it.asString }?.toMutableSet() ?: mutableSetOf()
+            sourceRoots
+                .forEach { base ->
+                    base.walk()
+                        .filter { it.isFile }
+                        .forEach {
+                            val relativeString = it.toRelativeString(base).replace("\\", "/")
+                            if (relativeString.startsWith(mixinPackage.replace(".", "/") + "/")
+                                && relativeString.endsWith(".java")
+                                && it.readText().contains("@Mixin")
+                            )
+                                allMixins.add(
+                                    relativeString.replace("/", ".").dropLast(5).drop(mixinPackage.length + 1)
+                                )
+                        }
+                }
+            json.add("mixins", JsonArray().also { jsonAllMixins ->
+                allMixins.forEach { jsonAllMixins.add(it) }
+            })
+            gson.toJson(json)
+        })
+
+    }
+
+    override fun read(): Int {
+        return betterReader.read()
+    }
+}
+
+fun FileCopyDetails.autoDiscoverMixins(sourceSet: SourceSet) {
+    filter(mapOf("sourceRoots" to sourceSet.allSource.srcDirs), MixinFilterReader::class.java)
+}

--- a/buildSrc/src/EnvFile.kt
+++ b/buildSrc/src/EnvFile.kt
@@ -1,0 +1,12 @@
+import java.io.File
+
+fun parseEnvFile(file: File): Map<String, String> {
+    if (!file.exists()) return mapOf()
+    val map = mutableMapOf<String, String>()
+    for (line in file.readText().lines()) {
+        if (line.isEmpty() || line.startsWith("#")) continue
+        val parts = line.split("=", limit = 2)
+        map[parts[0]] = parts.getOrNull(1) ?: ""
+    }
+    return map
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-loom.platform=forge
 org.gradle.jvmargs=-Xmx2g

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,3 +10,4 @@ libautoupdate = { module = "moe.nea:libautoupdate", version.ref = "libautoupdate
 headlessLwjgl = { module = "com.github.3arthqu4ke.HeadlessMc:headlessmc-lwjgl", version.ref = "headlessLwjgl" }
 jbAnnotations = { module = "org.jetbrains:annotations", version.ref = "jbAnnotations" }
 hotswapagentforge = { module = "moe.nea:hotswapagent-forge", version = "1.0.1" }
+terminalConsoleAppender = { module = "net.minecrell:terminalconsoleappender", version = "1.3.0" }

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" packages="com.mojang.util,net.minecrell.terminalconsole.util">
+	<Appenders>
+
+		<!--	System out	-->
+		<Console name="SysOut" target="SYSTEM_OUT">
+			<PatternLayout>
+				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="false">
+					<!-- Dont show the logger name for minecraft classes-->
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(Minecraft)}{cyan} %highlight{%msg{nolookups}%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
+				</LoggerNamePatternSelector>
+			</PatternLayout>
+		</Console>
+
+		<!--	latest.log same as vanilla	-->
+		<RollingRandomAccessFile name="LatestFile" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
+			<PatternLayout>
+				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level] (%logger{1}) %msg{nolookups}%n">
+					<!-- Dont show the logger name for minecraft classes-->
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss}] [%t/%level] (Minecraft) %msg{nolookups}%n"/>
+				</LoggerNamePatternSelector>
+			</PatternLayout>
+			<Policies>
+				<TimeBasedTriggeringPolicy />
+				<OnStartupTriggeringPolicy />
+			</Policies>
+		</RollingRandomAccessFile>
+
+		<!--	Debug log file	-->
+		<RollingRandomAccessFile name="DebugFile" fileName="logs/debug.log" filePattern="logs/debug-%i.log.gz">
+			<PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] (%logger) %msg{nolookups}%n" />
+
+			<!--	Keep 5 files max	-->
+			<DefaultRolloverStrategy max="5" fileIndex="min"/>
+
+			<Policies>
+				<SizeBasedTriggeringPolicy size="200MB"/>
+				<OnStartupTriggeringPolicy />
+			</Policies>
+
+		</RollingRandomAccessFile>
+	</Appenders>
+	<Loggers>
+		<Logger level="${sys:fabric.log.level:-info}" name="net.minecraft"/>
+		<Logger level="warn" name="cpw.mods.modlauncher.ClassTransformer"/>
+		<Root level="all">
+			<AppenderRef ref="DebugFile" level="${sys:fabric.log.debug.level:-debug}"/>
+			<AppenderRef ref="SysOut" level="${sys:fabric.log.level:-info}"/>
+			<AppenderRef ref="LatestFile" level="${sys:fabric.log.level:-info}"/>
+			<AppenderRef ref="ServerGuiConsole" level="${sys:fabric.log.level:-info}"/>
+		</Root>
+	</Loggers>
+</Configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,13 +9,8 @@ pluginManagement {
         maven("https://repo.spongepowered.org/maven/")
         maven("https://repo.nea.moe/releases")
         maven("https://repo.sk1er.club/repository/maven-releases/")
-    }
-    resolutionStrategy {
-        eachPlugin {
-            when (requested.id.id) {
-                "gg.essential.loom" -> useModule("gg.essential:architectury-loom:${requested.version}")
-            }
-        }
+        maven("https://maven.wagyourtail.xyz/releases")
+        maven("https://maven.wagyourtail.xyz/snapshots")
     }
 }
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
@@ -4,24 +4,13 @@ import org.spongepowered.asm.lib.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 public class SkyhanniMixinPlugin implements IMixinConfigPlugin {
     @Override
     public void onLoad(String mixinPackage) {
-
     }
 
     @Override
@@ -31,7 +20,7 @@ public class SkyhanniMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        return false;
+        return true;
     }
 
     @Override
@@ -39,85 +28,9 @@ public class SkyhanniMixinPlugin implements IMixinConfigPlugin {
 
     }
 
-    public URL baseUrl(URL classUrl) {
-        String string = classUrl.toString();
-        if (classUrl.getProtocol().equals("jar")) {
-            try {
-                return new URL(string.substring(4).split("!")[0]);
-            } catch (MalformedURLException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        if (string.endsWith(".class")) {
-            try {
-                return new URL(string.replace("\\", "/")
-                    .replace(getClass().getCanonicalName().replace(".", "/") + ".class", ""));
-            } catch (MalformedURLException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return classUrl;
-    }
-
-    String mixinBasePackage = "at.hannibal2.skyhanni.mixins.transformers.";
-    String mixinBaseDir = mixinBasePackage.replace(".", "/");
-
-    List<String> mixins = null;
-
-    public void tryAddMixinClass(String className) {
-        String norm = (className.endsWith(".class") ? className.substring(0, className.length() - ".class".length()) : className)
-            .replace("\\", "/")
-            .replace("/", ".");
-        if (norm.startsWith(mixinBasePackage) && !norm.endsWith(".")) {
-            mixins.add(norm.substring(mixinBasePackage.length()));
-        }
-    }
-
-    public void walkDir(Path file) {
-        System.out.println("Trying to find mixins from directory");
-        try (Stream<Path> classes = Files.walk(file.resolve(mixinBaseDir))) {
-            classes.map(it -> file.relativize(it).toString())
-                .forEach(this::tryAddMixinClass);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Override
     public List<String> getMixins() {
-        if (mixins != null) return mixins;
-        System.out.println("Trying to discover mixins");
-        mixins = new ArrayList<>();
-        URL classUrl = getClass().getProtectionDomain().getCodeSource().getLocation();
-        System.out.println("Found classes at " + classUrl);
-        Path file;
-        try {
-            file = Paths.get(baseUrl(classUrl).toURI());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-        System.out.println("Base directory found at " + file);
-        if (Files.isDirectory(file)) {
-            walkDir(file);
-        } else {
-            walkJar(file);
-        }
-        System.out.println("Found mixins: " + mixins);
-
-        return mixins;
-    }
-
-    private void walkJar(Path file) {
-        System.out.println("Trying to find mixins from jar file");
-        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(file))) {
-            ZipEntry next;
-            while ((next = zis.getNextEntry()) != null) {
-                tryAddMixinClass(next.getName());
-                zis.closeEntry();
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
@@ -11,9 +11,10 @@ import org.apache.logging.log4j.core.Filter
 import org.apache.logging.log4j.core.LogEvent
 import org.apache.logging.log4j.core.Logger
 import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.filter.AbstractFilter
 import org.apache.logging.log4j.message.Message
 
-class MinecraftConsoleFilter(private val loggerConfigName: String) : Filter {
+class MinecraftConsoleFilter(private val loggerConfigName: String) : AbstractFilter(Filter.Result.ACCEPT, Filter.Result.DENY) {
 
     private val config get() = SkyHanniMod.feature.dev.minecraftConsoles
     private val filterConfig get() = config.consoleFilter
@@ -35,8 +36,6 @@ class MinecraftConsoleFilter(private val loggerConfigName: String) : Filter {
         }
     }
 
-    // prevents error sending on every shutdown
-    fun stop() {}
 
     override fun filter(event: LogEvent?): Filter.Result {
         if (event == null) return Filter.Result.ACCEPT
@@ -203,14 +202,6 @@ class MinecraftConsoleFilter(private val loggerConfigName: String) : Filter {
         if (config.printFilteredReason) {
             LorenzUtils.consoleLog("filtered console: $message")
         }
-    }
-
-    override fun getOnMismatch(): Filter.Result {
-        return Filter.Result.DENY
-    }
-
-    override fun getOnMatch(): Filter.Result {
-        return Filter.Result.ACCEPT
     }
 
     override fun filter(


### PR DESCRIPTION
## What
This changes the build system from architectury loom to unimined.

This has some advantages and disadvantages.

### For Loom

- Dependency configurations and tasks get generated during plugin initialization
	- This means you can directly refer to configurations and (most) tasks using type safe accessors
- Logging is set up automatically (including minecrell)
- A decent amount of launching is handled after handing off to the runtime. The build system writes all the config to a shared config file, meaning new run configurations are created quite easily.

### For Unimined

- Non-main source sets can receive minecraft dependencies.
	- This means that configurations for that (and the main source set) are not available as type safe accessors
	- You can create new segregated source sets to limit which parts of the code can access certain dependencies
- Remapping in theory is faster for mixins, but not really. Benchmarks roughly the same. 
- We have more control over logging.
- You can create new run configs only via custom source sets. This does mean that it is slightly more effort to do this, but you also have more capabilities to configure those runs.

### Migration

In theory the only migration that is needed is to delete the `Minecraft Client` run configuration. It will then regenerate as needed by unimined. It will also allow you to directly use the `runClient` gradle task.

### Motive

The main motive behind this is the individual source set support. This allows us to easier export a public (stable) API to allow other mods to interact with us. Another thing is to limit NEU to only a certain subset of the code. Yet another thing would be to potentially allow breaking out parts of the code into another source set for a sort of "libskyhanni" library that other mods can shade and relocate to jumpstart their mod with rich libraries.

## Changelog Technical Details
+ Switched build system to unimined. - !nea
+ Changed auto mixins to be gathered at compile time, rather than runtime. - !nea

exclude_from_changelog
since this pr gets reverted with https://github.com/hannibal002/SkyHanni/commit/e76b3561bf60f62afcf4a4d667492beb85f35f85
