### PR TITLE
Fix: Stop rendering an empty string on every item

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/RenderItemTipEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RenderItemTipEvent.kt
@@ -9,6 +9,7 @@ class RenderItemTipEvent(
 
     var stackTip = ""
         set(value) {
+            if (value.isEmpty()) return
             renderObjects.add(RenderObject(value, 0, 0))
         }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -82,10 +82,10 @@ object ItemDisplayOverlayFeatures {
 
     @SubscribeEvent
     fun onRenderItemTip(event: RenderItemTipEvent) {
-        event.stackTip = getStackTip(event.stack)
+        event.stackTip = getStackTip(event.stack) ?: return
     }
 
-    private fun getStackTip(item: ItemStack): String {
+    private fun getStackTip(item: ItemStack): String? {
         val itemName = item.cleanName()
         val internalName = item.getInternalName()
         val chestName = InventoryUtils.openInventoryName()
@@ -258,7 +258,7 @@ object ItemDisplayOverlayFeatures {
             }
         }
 
-        return ""
+        return null
     }
 
     private fun isOwnVacuum(lore: List<String>) =


### PR DESCRIPTION
## What
Stop rendering an empty string on every item.
Also made ItemDisplayOverlayFeatures.getStackTip return null by default instead of an empty string.

## Changelog Fixes
+ Fixed rendering an empty string on every single item. - CalMWolfs
    * This change improves performance.
