### PR TITLE
Fix: Fixed Bits Available being out of sync after Rift

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
@@ -205,6 +205,12 @@ object BitsAPI {
                 if (bitsAvailable != amount) {
                     bitsAvailable = amount
                     sendBitsAvailableGainedEvent()
+
+                    val difference = bits - bitsAvailable
+                    if (difference > 0) {
+                        ChatUtils.debug("You have gained §3${difference} Bits §7according to the menu!")
+                        bits += difference
+                    }
                 }
             }
             lore.matchFirst(cookieDurationPattern) {


### PR DESCRIPTION
## What



## Changelog Fixes
+ Fixed Bits Available being out of sync after leaving the Rift. - j10a1n15
