### PR TITLE
Fix: Memory leak

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.java
@@ -5,13 +5,14 @@ import io.github.notenoughupdates.moulconfig.annotations.Accordion;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import io.github.notenoughupdates.moulconfig.observer.Property;
 
 public class DebugMobConfig {
 
     @Expose
     @ConfigOption(name = "Mob Detection Enable", desc = "Turn off and on again to reset all Mobs.")
     @ConfigEditorBoolean
-    public boolean enable = true;
+    public Property<Boolean> enabled = Property.of(true);
 
     @Expose
     @ConfigOption(name = "Mob Detection", desc = "Debug feature to check the Mob Detection.")

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -327,19 +327,13 @@ class MobDetection {
             event.addData("Mob Detection is manually disabled!")
         } else {
             event.addIrrelevant {
-                add("normal enabled")
-                add("Active Players: ${MobData.players.size}")
-                add("Active players: ${MobData.players.map { "${it.name} - ${System.identityHashCode(it)}" }}")
-                add("Active Mobs: ${MobData.players.size + MobData.displayNPCs.size + MobData.summoningMobs.size + MobData.skyblockMobs.size + MobData.special.size}")
-                add("Active Mobs: ${MobData.currentMobs.map { "${it.name} - ${System.identityHashCode(it)}" }}")
-                val inDistanceMobs = MobData.retries.count { it.value.outsideRange() }
-                add("Searching for Mobs: ${MobData.retries.size - inDistanceMobs}")
-                add("Mobs over Max Search Count: ${MobData.retries.count { it.value.times > MAX_RETRIES }}")
-                add("Mobs outside of Range: $inDistanceMobs")
-                add("")
-                MobData.players.forEach {
-                    add("a")
-                    add("Player: ${it.name} - ${System.identityHashCode(it)}")
+                event.addIrrelevant {
+                    add("normal enabled")
+                    add("Active Mobs: ${MobData.currentMobs.size}")
+                    val inDistanceMobs = MobData.retries.count { it.value.outsideRange() }
+                    add("Searching for Mobs: ${MobData.retries.size - inDistanceMobs}")
+                    add("Mobs over Max Search Count: ${MobData.retries.count { it.value.times > MAX_RETRIES }}")
+                    add("Mobs outside of Range: $inDistanceMobs")
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -327,14 +327,12 @@ class MobDetection {
             event.addData("Mob Detection is manually disabled!")
         } else {
             event.addIrrelevant {
-                event.addIrrelevant {
-                    add("normal enabled")
-                    add("Active Mobs: ${MobData.currentMobs.size}")
-                    val inDistanceMobs = MobData.retries.count { it.value.outsideRange() }
-                    add("Searching for Mobs: ${MobData.retries.size - inDistanceMobs}")
-                    add("Mobs over Max Search Count: ${MobData.retries.count { it.value.times > MAX_RETRIES }}")
-                    add("Mobs outside of Range: $inDistanceMobs")
-                }
+                add("normal enabled")
+                add("Active Mobs: ${MobData.currentMobs.size}")
+                val inDistanceMobs = MobData.retries.count { it.value.outsideRange() }
+                add("Searching for Mobs: ${MobData.retries.size - inDistanceMobs}")
+                add("Mobs over Max Search Count: ${MobData.retries.count { it.value.times > MAX_RETRIES }}")
+                add("Mobs outside of Range: $inDistanceMobs")
             }
         }
     }


### PR DESCRIPTION
## What

WIP: Thunderblade says stuff needs to change a bit

Fix memory leaks caused by some entities not being removed properly.
There may still be other negative performance impacts due to mob detection but this fixes the memory leak of the player not being removed from MobData.players leading to the whole previous world still being stored.

## Changelog Fixes
+ Fixed memory leak. - CalMWolfs

## Changelog Technical Details
+ Clear mob detection data more often. - CalMWolfs
    * Clear on config value update and world switch.

