### PR TITLE
Fix: Removed the Player

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.java
@@ -44,7 +44,7 @@ public class DebugMobConfig {
         public boolean logEvents = false;
 
         @Expose
-        @ConfigOption(name = "Show RayHit", desc = "Highlights the mob that is currently in front of your view (only SkyblockMob).")
+        @ConfigOption(name = "Show RayHit", desc = "Highlights the mob that is currently in front of your view.")
         @ConfigEditorBoolean
         public boolean showRayHit = false;
 

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
@@ -46,7 +46,7 @@ class MobDebug {
     fun onWorldRenderDebug(event: LorenzRenderWorldEvent) {
         if (config.showRayHit || config.showInvisible) {
             lastRayHit = MobUtils.rayTraceForMobs(Minecraft.getMinecraft().thePlayer, event.partialTicks)
-                ?.firstOrNull { it.canBeSeen() && (config.showInvisible || it.isInvisible()) }
+                ?.firstOrNull { it.canBeSeen() && (!config.showInvisible || !it.isInvisible()) }
         }
 
         if (config.skyblockMob.isHighlight()) {

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.data.mob.MobFilter.isRealPlayer
 import at.hannibal2.skyhanni.data.mob.MobFilter.isSkyBlockMob
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.EntityHealthUpdateEvent
-import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.PacketEvent
@@ -20,7 +19,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.getLorenzVec
-import net.minecraft.client.Minecraft
+import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.monster.EntityCreeper
@@ -96,7 +95,7 @@ class MobDetection {
         MobData.previousEntityLiving.addAll(MobData.currentEntityLiving)
         MobData.currentEntityLiving.clear()
         MobData.currentEntityLiving.addAll(EntityUtils.getEntities<EntityLivingBase>()
-            .filter { it !is EntityArmorStand })
+            .filter { it !is EntityArmorStand && it !is EntityPlayerSP })
 
         if (forceReset) {
             MobData.currentEntityLiving.clear() // Naturally removing the mobs using the despawn
@@ -317,11 +316,6 @@ class MobDetection {
                 allEntitiesViaPacketId.clear()
             }
         }
-    }
-
-    @SubscribeEvent
-    fun onIslandChange(event: IslandChangeEvent) {
-        MobData.currentEntityLiving.remove(Minecraft.getMinecraft().thePlayer) // Fix for the Player
     }
 
     private val allEntitiesViaPacketId = mutableSetOf<Int>()

--- a/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
@@ -72,7 +72,7 @@ object MobUtils {
             )
         }.values
         if (possibleEntities.isEmpty()) return null
-        return possibleEntities.distinct().sortedBy { it.baseEntity.distanceTo(pos) }.drop(1) // drop to remove player
+        return possibleEntities.distinct().sortedBy { it.baseEntity.distanceTo(pos) }
     }
 
     val EntityLivingBase.mob get() = MobData.entityToMob[this]


### PR DESCRIPTION
## What
Yourself will never enter the mob detection. Solving part of the "memory leak".
The "memory leak" was that the player was not properly disspawned at world switch which saved the whole old wolrd. And this could be done over and over without limit.

Also fixes an issue with the mob debug show rayhit not working (wrong boolean logic 😅)

## Changelog Fixes
+ Removed weird edge case which increased memory use. - Thunderblade73
