### PR TITLE
Fix: Shift click visitor buttons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
@@ -49,6 +49,7 @@ class VisitorRewardWarning {
     fun onStackClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!VisitorAPI.inInventory) return
         val slot = event.slot ?: return
+        if (event.clickType != 0) return
 
         val visitor = VisitorAPI.getVisitor(lastClickedNpc) ?: return
         val blockReason = visitor.blockReason


### PR DESCRIPTION
## What
Only allow normal click type to change highlight color.

## Changelog Fixes
+ Fixed shift click on accept/refusal no longer changes the visitor highlight. - hannibal2