### PR TITLE
Improvement: Patcher Coords Color and Duration

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 38
+    const val CONFIG_VERSION = 39
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -103,6 +103,11 @@ public class MiscConfig {
     public NoBitsWarningConfig noBitsWarning = new NoBitsWarningConfig();
 
     @Expose
+    @ConfigOption(name = "Patcher Coords Waypoints", desc = "")
+    @Accordion
+    public PatcherCoordsWaypointConfig patcherCoordsWaypoint = new PatcherCoordsWaypointConfig();
+
+    @Expose
     @ConfigOption(name = "Show Outside SB", desc = "Show these features outside of SkyBlock.")
     @ConfigEditorDraggableList
     public List<OutsideSbFeature> showOutsideSB = new ArrayList<>();
@@ -186,13 +191,6 @@ public class MiscConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean restorePieceOfWizardPortalLore = true;
-
-    @Expose
-    @ConfigOption(name = "Patcher Coords Waypoint", desc = "Highlight the coordinates sent by Patcher.")
-    @ConfigEditorBoolean
-    @FeatureToggle
-    public boolean patcherSendCoordWaypoint = false;
-
 
     @Expose
     @ConfigOption(name = "Account Upgrade Reminder", desc = "Remind you to claim account upgrades when complete.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/PatcherCoordsWaypointConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/PatcherCoordsWaypointConfig.java
@@ -1,0 +1,28 @@
+package at.hannibal2.skyhanni.config.features.misc;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+public class PatcherCoordsWaypointConfig {
+
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Highlight the coordinates sent by Patcher.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean enabled = false;
+
+    @Expose
+    @ConfigOption(name = "Color", desc = "Color of the waypoint.")
+    @ConfigEditorColour
+    public String color = "0:194:75:197:64";
+
+    @Expose
+    @ConfigOption(name = "Duration", desc = "Duration of the waypoint.")
+    @ConfigEditorSlider(minStep = 5, maxValue = 120, minValue = 1)
+    public int duration = 60;
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherSendCoordinates.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherSendCoordinates.kt
@@ -88,6 +88,6 @@ class PatcherSendCoordinates {
 
     @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
-        event.move(39, "misc.patcherSendCoordWaypoint", "misc.patchercoordswaypointconfig.enabled")
+        event.move(39, "misc.patcherSendCoordWaypoint", "misc.patcherCoordsWaypoint.enabled")
     }
 }


### PR DESCRIPTION
<!-- remove all unused parts -->

## What
Added option to choose the duration and the color of patcher send coords

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/69345714/ab41eaae-53b2-406f-bb57-f995d2a21e78)

</details>


## Changelog Improvements
+ Added the option to choose the duration and color of Patcher Coords Waypoints. - jani270