### PR TITLE
Fix: Dont reset item after RNG meter drop

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
@@ -97,7 +97,7 @@ class SlayerRngMeterDisplay {
             if (diff > 0) {
                 storage.gainPerBoss = diff
             } else {
-                storage.itemGoal = ""
+                storage.currentMeter = 0
                 blockChat = false
                 val from = old.addSeparators()
                 val to = storage.goalNeeded.addSeparators()


### PR DESCRIPTION
## What
Hypixel has updated the RNG meter mechanic:
earlier, the user had to re select the RNG meter item after a drop,
now, the last dropped item gets auto-selected.

## Changelog Fixes
+ Fixed resetting the RNG item after dropping it for slayer. - hannibal2