### PR TITLE
Fix: hotkey name crash in vistior

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.features.garden.visitor.VisitorAPI.REFUSE_SLOT
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorAPI.VisitorBlockReason
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorAPI.lastClickedNpc
 import at.hannibal2.skyhanni.utils.ItemUtils.name
+import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NumberUtil
@@ -17,8 +18,6 @@ import net.minecraft.item.ItemStack
 import net.minecraftforge.event.entity.player.ItemTooltipEvent
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import org.lwjgl.input.Keyboard
-
 
 class VisitorRewardWarning {
     private val config get() = VisitorAPI.config.rewardWarning
@@ -106,7 +105,7 @@ class VisitorRewardWarning {
                 if (blockReason == VisitorBlockReason.CHEAP_COPPER || blockReason == VisitorBlockReason.EXPENSIVE_COPPER)
                     "${blockReason.description} §7(§6$pricePerCopper §7per)" else blockReason.description
             )
-            blockedToolTip.add("  §7(Bypass by holding ${Keyboard.getKeyName(config.bypassKey)})")
+            blockedToolTip.add("  §7(Bypass by holding ${KeyboardManager.getKeyName(config.bypassKey)})")
 
             visitor.blockedLore = blockedToolTip
         }


### PR DESCRIPTION
## What
Fixing a crash because `-97` is no valid key ID
```
java.lang.ArrayIndexOutOfBoundsException: -97
	at org.lwjgl.input.Keyboard.getKeyName(Keyboard.java:429)
	at at.hannibal2.skyhanni.features.garden.visitor.VisitorRewardWarning.onTooltip(VisitorRewardWarning.kt:109)
```
first reported on https://discord.com/channels/997079228510117908/1228781556085162044

## Changelog Fixes
+ Fixed crash with garden visitor hotkey names. - hannibal2