### PR TITLE
Improvement: RNG Meter slayer menu reading

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.SlayerChangeEvent
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
@@ -22,6 +23,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeWordsAtEnd
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -37,6 +39,10 @@ class SlayerRngMeterDisplay {
     private val inventoryNamePattern by patternGroup.pattern(
         "inventoryname",
         "(?<name>.*) RNG Meter"
+    )
+    private val slayerInventoryNamePattern by patternGroup.pattern(
+        "inventoryname.slayer",
+        "Slayer"
     )
     private val updatePattern by patternGroup.pattern(
         "update",
@@ -127,26 +133,46 @@ class SlayerRngMeterDisplay {
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
 
+        readRngmeterInventory(event)
+        readSlayerInventory(event)
+    }
+
+    private fun readRngmeterInventory(event: InventoryFullyOpenedEvent) {
         val name = inventoryNamePattern.matchMatcher(event.inventoryName) {
             group("name")
         } ?: return
 
         if (name != getCurrentSlayer()) return
 
-        val storage = getStorage() ?: return
+        val internalName = event.inventoryItems.values
+            .find { item -> item.getLore().any { it.contains("§a§lSELECTED") } }
+        setNewGoal(internalName?.getInternalName())
+    }
 
-        val selectedItem =
-            event.inventoryItems.values.find { item -> item.getLore().any { it.contains("§a§lSELECTED") } }
-        if (selectedItem == null) {
+    private fun readSlayerInventory(event: InventoryFullyOpenedEvent) {
+        if (!slayerInventoryNamePattern.matches(event.inventoryName)) return
+        val item = event.inventoryItems[35] ?: return
+        val lore = item.getLore()
+        val name = lore.firstOrNull()?.removeColor() ?: return
+
+        if (name != getCurrentSlayer()) return
+
+        val selectedItem = lore.nextAfter("§7Selected Drop") ?: return
+        val internalName = NEUInternalName.fromItemName(selectedItem)
+        setNewGoal(internalName)
+    }
+
+    private fun setNewGoal(internalName: NEUInternalName?) {
+        val storage = getStorage() ?: return
+        if (internalName == null) {
             storage.itemGoal = ""
             storage.goalNeeded = -1
         } else {
-            storage.itemGoal = selectedItem.itemName
-            storage.goalNeeded = rngScore[getCurrentSlayer()]?.get(selectedItem.getInternalName())
+            storage.itemGoal = internalName.itemName
+            storage.goalNeeded = rngScore[getCurrentSlayer()]?.get(internalName)
                 ?: ErrorManager.skyHanniError(
                     "RNG Meter goal setting failed",
-                    "selectedItem" to selectedItem,
-                    "selectedItemInternalName" to selectedItem.getInternalName(),
+                    "internalName" to internalName,
                     "currentSlayer" to getCurrentSlayer(),
                     "repo" to rngScore
                 )


### PR DESCRIPTION
## What
Added support for reading RNG meter item from slayer inventory directly.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/8525b3e1-6ffc-43d5-b5c4-3020d43715e0)

</details>

## Changelog Improvements
+ RNG meter item will now be detected when opening slayer menu. - hannibal2