### PR TITLE
Fix: NPE in visitor reward warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
@@ -47,13 +47,13 @@ class VisitorRewardWarning {
     @SubscribeEvent(priority = EventPriority.HIGH)
     fun onStackClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!VisitorAPI.inInventory) return
-        val slot = event.slot ?: return
+        val stack = event.slot?.stack ?: return
 
         val visitor = VisitorAPI.getVisitor(lastClickedNpc) ?: return
         val blockReason = visitor.blockReason
 
-        val isRefuseSlot = slot.stack.name == "§cRefuse Offer"
-        val isAcceptSlot = slot.stack.name == "§aAccept Offer"
+        val isRefuseSlot = stack.name == "§cRefuse Offer"
+        val isAcceptSlot = stack.name == "§aAccept Offer"
 
         if (blockReason != null && !config.bypassKey.isKeyHeld() &&
             ((blockReason.blockRefusing && isRefuseSlot) || !blockReason.blockRefusing && isAcceptSlot)) {
@@ -66,7 +66,7 @@ class VisitorRewardWarning {
             return
         }
         if (isAcceptSlot) {
-            if (slot.stack?.name != "§eClick to give!") return
+            if (stack.name != "§eClick to give!") return
             VisitorAPI.changeStatus(visitor, VisitorAPI.VisitorStatus.ACCEPTED, "accepted")
             return
         }


### PR DESCRIPTION
## What
I don't know how, but jani succeeded in getting an item stack to be null in SlotClickEvent. He literally clicked on a null item.

SkyHanni 0.25.Beta.8: Caught an NullPointerException in VisitorRewardWarning at SlotClickEvent: getStack(...) must not be null
 
```
Caused by java.lang.NullPointerException: getStack(...) must not be null
    at SH.features.garden.visitor.VisitorRewardWarning.onStackClick(VisitorRewardWarning.kt:56)
    at SH.mixins.hooks.GuiContainerHook.onMouseClick(GuiContainerHook.kt:44)
    at MC.client.gui.inventory.GuiContainer.handler$zmb000$onMouseClick(GuiContainer.java:6895)
    at MC.client.gui.inventory.GuiContainer.func_146984_a(GuiContainer.java:629)
    at MC.client.gui.inventory.GuiChest.func_146984_a(SourceFile)
    at MC.client.gui.inventory.GuiContainer.func_146286_b(GuiContainer.java:504)
    at MC.client.gui.inventory.GuiChest.func_146286_b(SourceFile)
    at MC.client.gui.GuiScreen.func_146274_d(GuiScreen.java:133)
    at MC.client.gui.GuiScreen.func_146269_k(GuiScreen.java:524)
    at MC.client.Minecraft.func_71407_l(Minecraft.java:1674)
    at MC.client.Minecraft.func_71411_J(Minecraft.java:1024)
    at MC.client.Minecraft.handler$zml000$run(Minecraft.java:9227)
    at MC.client.Minecraft.func_99999_d(Minecraft.java)
    at MC.client.main.Main.main(SourceFile:124)
```

## Changelog Fixes
+ Fixed rare error with visitor reward warning. - hannibal2