### PR TITLE
Backend: EditorConfig always wrap enums

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,3 +30,4 @@ ij_java_packages_to_use_import_on_demand =
 ij_kotlin_name_count_to_use_star_import = 999
 ij_kotlin_name_count_to_use_star_import_for_members = 999
 ij_kotlin_packages_to_use_import_on_demand =
+ij_kotlin_enum_constants_wrap = split_into_lines


### PR DESCRIPTION
## What
Since we always do it manual, why not automate it. There are 2-3 enums that are not wrapped but it also does not really hurt there.

## Changelog Technical Details
+ Force wrapping of enums. - Thunderblade73


