### PR TITLE
Backend: Display in-world the locations of sounds for TrackSoundsCommand

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/command/TrackSoundsCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/TrackSoundsCommand.kt
@@ -2,14 +2,18 @@ package at.hannibal2.skyhanni.test.command
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.OSUtils
+import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.renderables.Renderable
+import com.mojang.realmsclient.gui.ChatFormatting
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.concurrent.ConcurrentLinkedDeque
 import kotlin.time.Duration
@@ -27,6 +31,7 @@ object TrackSoundsCommand {
     private val position get() = SkyHanniMod.feature.dev.debug.trackSoundPosition
 
     private var display: List<Renderable> = emptyList()
+    private var worldSounds: Map<LorenzVec, List<PlaySoundEvent>> = emptyMap()
 
     fun command(args: Array<String>) {
         if (args.firstOrNull() == "end") {
@@ -60,10 +65,13 @@ object TrackSoundsCommand {
     fun onTick(event: LorenzTickEvent) {
         if (!isRecording) return
 
-        display = sounds.takeWhile { startTime.passedSince() - it.first < 3.0.seconds }
+        val soundsToDisplay = sounds.takeWhile { startTime.passedSince() - it.first < 3.0.seconds }
+
+        display = soundsToDisplay
             .take(10).reversed().map {
                 Renderable.string("§3" + it.second.soundName + " §8p:" + it.second.pitch + " §7v:" + it.second.volume)
             }
+        worldSounds = soundsToDisplay.map { it.second }.groupBy { it.location }
 
         // The function must run after cutOfTime has passed to ensure thread safety
         if (cutOfTime.passedSince() <= 0.1.seconds) return
@@ -88,5 +96,31 @@ object TrackSoundsCommand {
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (cutOfTime.isInPast()) return
         position.renderRenderables(display, posLabel = "Track sound log")
+    }
+
+    @SubscribeEvent
+    fun onWorldRender(event: LorenzRenderWorldEvent) {
+        if (cutOfTime.isInPast()) return
+        worldSounds.forEach { (key, value) ->
+            if (value.size != 1) {
+                event.drawDynamicText(key, "§e${value.size} sounds", 0.8)
+
+                var offset = -0.2
+                value.groupBy { it.soundName }.forEach { (soundName, sounds) ->
+                    event.drawDynamicText(key.up(offset), "§7§l$soundName §7(§e${sounds.size}§7)", 0.8)
+                    offset -= 0.2
+                }
+            } else {
+                val sound = value.first()
+                val volumeColor = when(sound.volume) {
+                    in 0.0..0.25 -> ChatFormatting.RED.toString()
+                    in 0.25..0.5 -> ChatFormatting.GOLD.toString()
+                    else -> ChatFormatting.GREEN.toString()
+                }
+
+                event.drawDynamicText(key, "§7§l${sound.soundName}", 0.8)
+                event.drawDynamicText(key.up(-0.2), "§7P: §e%.2f §7V: $volumeColor%.2f".format(sound.pitch, sound.volume), 0.8)
+            }
+        }
     }
 }


### PR DESCRIPTION
## What
This PR adds text displays in-world at the location of a sound packet when `shtracksounds` is recording.
This is useful when Hypixel sends sounds at specific locations which then can then be used to track/triangulate certain actions/points which then requires knowing those exact locations for debugging, for example the egglocator for hoppity hunt when spawning particles also plays a sounds at that specific point.

When only 1 sound is at a specific location it will show as the sound then the pitch and volume but if multiple are at the same exact location then it will display the total sounds followed by a list of each sound name and their amounts.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/26934102/83736ab6-eca0-47fb-b787-89fd2b4d8cd2)

</details>

## Changelog Technical Details
+ Show sound locations in-world for `/shtracksounds`. - ThatGravyBoat
