### PR TITLE
Fix: Rift NPC shops not using Motes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -271,7 +271,7 @@ class HideNotClickableItems {
 
     private fun hideRiftMotesGrubber(chestName: String, stack: ItemStack): Boolean {
         if (!RiftAPI.inRift()) return false
-        if (chestName != "Motes Grubber") return false
+        if (chestName != "Motes Grubber" && !ShiftClickNPCSell.inInventory) return false
 
         showGreenLine = true
 
@@ -477,6 +477,7 @@ class HideNotClickableItems {
     }
 
     private fun hideNpcSell(stack: ItemStack): Boolean {
+        if (RiftAPI.inRift()) return false
         if (!ShiftClickNPCSell.inInventory) return false
         if (VisitorAPI.inInventory) return false
         showGreenLine = true


### PR DESCRIPTION
## What
There are some merchants in the Rift you can buy items from where you can also sell your items for Motes, not just at the Motes Grubber. This fixes them being treated as regular overworld NPC shops.

## Changelog Fixes
+ Fixed Rift NPC shops being treated as overworld ones for selling items to them. - Luna
