### PR TITLE
Improvement: Add percent to hoppity display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryAPI.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
+import at.hannibal2.skyhanni.utils.NumberUtil.formatFloat
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
@@ -74,6 +75,10 @@ object ChocolateFactoryAPI {
         "leaderboard.place",
         "§7You are §8#§b(?<position>[\\d,]+)"
     )
+    private val leaderboardPercentilePattern by patternGroup.pattern(
+        "leaderboard.percentile",
+        "§7§8You are in the top §.(?<percent>[\\d.]+)%§8 of players!"
+    )
 
     var rabbitSlots = mapOf<Int, Int>()
     var otherUpgradeSlots = setOf<Int>()
@@ -95,6 +100,7 @@ object ChocolateFactoryAPI {
     var chocolateThisPrestige = 0L
     var chocolateMultiplier = 1.0
     var leaderboardPosition: Int? = null
+    var leaderboardPercentile: Double? = null
 
     val upgradeableSlots: MutableSet<Int> = mutableSetOf()
     var bestUpgrade: Int? = null
@@ -178,6 +184,11 @@ object ChocolateFactoryAPI {
         productionItem: ItemStack,
         leaderboardItem: ItemStack,
     ) {
+        leaderboardPosition = null
+        leaderboardPercentile = null
+
+        chocolateMultiplier = 1.0
+
         chocolateAmountPattern.matchMatcher(chocolateItem.name.removeColor()) {
             chocolateCurrent = group("amount").formatLong()
         }
@@ -198,9 +209,15 @@ object ChocolateFactoryAPI {
         productionItem.getLore().matchFirst(chocolateMultiplierPattern) {
             chocolateMultiplier = group("amount").formatDouble()
         }
-        leaderboardItem.getLore().matchFirst(leaderboardPlacePattern) {
-            leaderboardPosition = group("position").formatInt()
+        for (line in leaderboardItem.getLore()) {
+            leaderboardPlacePattern.matchMatcher(line) {
+                leaderboardPosition = group("position").formatInt()
+            }
+            leaderboardPercentilePattern.matchMatcher(line) {
+                leaderboardPercentile = group("percent").formatDouble()
+            }
         }
+
         if (!config.statsDisplay) return
         ChocolateFactoryStats.updateDisplay()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryAPI.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
-import at.hannibal2.skyhanni.utils.NumberUtil.formatFloat
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryStats.kt
@@ -25,6 +25,7 @@ object ChocolateFactoryStats {
         val perHour = perMinute * 60
         val perDay = perHour * 24
         val position = ChocolateFactoryAPI.leaderboardPosition?.addSeparators() ?: "???"
+        val percentile = ChocolateFactoryAPI.leaderboardPercentile?.let { "§7(§a$it%§7)" } ?: ""
 
         displayList = formatList(buildList {
             add("§6§lChocolate Factory Stats")
@@ -41,7 +42,7 @@ object ChocolateFactoryStats {
             add("§eChocolate Multiplier: §6${ChocolateFactoryAPI.chocolateMultiplier}")
             add("§eBarn: §6${ChocolateFactoryBarnManager.barnStatus()}")
 
-            add("§ePosition: §7#§b$position")
+            add("§ePosition: §7#§b$position $percentile")
 
             add("")
             add("")

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryStats.kt
@@ -25,7 +25,7 @@ object ChocolateFactoryStats {
         val perHour = perMinute * 60
         val perDay = perHour * 24
         val position = ChocolateFactoryAPI.leaderboardPosition?.addSeparators() ?: "???"
-        val percentile = ChocolateFactoryAPI.leaderboardPercentile?.let { "§7(§a$it%§7)" } ?: ""
+        val percentile = ChocolateFactoryAPI.leaderboardPercentile?.let { "§7Top §a$it%" } ?: ""
 
         displayList = formatList(buildList {
             add("§6§lChocolate Factory Stats")
@@ -67,7 +67,7 @@ object ChocolateFactoryStats {
         PER_DAY("§ePer Day: §6326,654,208"),
         MULTIPLIER("§eChocolate Multiplier: §61.77"),
         BARN("§eBarn: §6171/190 Rabbits"),
-        LEADERBOARD_POS("§ePosition: §7#§b103"),
+        LEADERBOARD_POS("§ePosition: §7#§b103 §7Top §a0.87%"),
         EMPTY(""),
         EMPTY_2(""),
         EMPTY_3(""),


### PR DESCRIPTION
## What
adds the players ranking percentage to the hoppity side bar text thingy

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/77941535/e804c502-4a77-4e9f-a7c1-0bb29f62af65)

</details>

## Changelog Improvements
+ Added ranking percentage to Hoppity Display. - seraid
