### PR TITLE
Fix: Pet Rarity Message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -35,7 +35,7 @@ class RareDropMessages {
      */
     private val petClaimedPattern by chatGroup.pattern(
         "pet.petclaimedmessage",
-        "(?<start>(?:§.)*You claimed a )(?:§.)*§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end>.*)"
+        "(?<start>(?:§.)*You claimed a )(?:§.)*§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end>.*You can manage your Pets.*)"
     )
 
     /**


### PR DESCRIPTION
## What
Fixes other messages being detected as pet drops messages.

## Changelog Fixes
+ Fixed pet rarity drop messages modifying unrelated messages. - Empa