### PR TITLE
Fix: Visitor Reward Spelling

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/RewardWarningConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/RewardWarningConfig.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class RewardWarningConfig {
 
     @Expose
-    @ConfigOption(name = "Notify in Chat", desc = "Send a chat message once you talk to a visitor with reward.")
+    @ConfigOption(name = "Notify in Chat", desc = "Send a chat message once you talk to a visitor with a reward.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean notifyInChat = true;
@@ -29,7 +29,7 @@ public class RewardWarningConfig {
     public boolean showOverName = true;
 
     @Expose
-    @ConfigOption(name = "Block Refusing Reward", desc = "Prevent the refusal of a visitor with reward.")
+    @ConfigOption(name = "Block Refusing Reward", desc = "Prevent refusing visitors with a reward.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean preventRefusing = true;
@@ -59,26 +59,26 @@ public class RewardWarningConfig {
     @Expose
     @ConfigOption(
         name = "Coins Per Copper",
-        desc = "The price to use for the below options.\n" +
-            "Requires one of the below options to be on."
+        desc = "The price to use for the options below.\n" +
+            "Requires at least one of them to be on."
     )
     @ConfigEditorSlider(minValue = 1, maxValue = 50_000, minStep = 250)
     public int coinsPerCopperPrice = 6_000;
 
     @Expose
-    @ConfigOption(name = "Block Refusing Copper", desc = "Prevent refusing a visitor with a coins per copper lower than the set value.")
+    @ConfigOption(name = "Block Refusing Copper", desc = "Prevent refusing visitors with a coins per copper lower than the set value.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean preventRefusingCopper = false;
 
     @Expose
-    @ConfigOption(name = "Block Accepting Copper", desc = "Prevent accepting a visitor with a coins per copper higher than the set value.")
+    @ConfigOption(name = "Block Accepting Copper", desc = "Prevent accepting visitors with a coins per copper higher than the set value.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean preventAcceptingCopper = false;
 
     @Expose
-    @ConfigOption(name = "Block Refusing New Visitors", desc = "Prevents refusing a visitor you've never completed an offer with.")
+    @ConfigOption(name = "Block Refusing New Visitors", desc = "Prevent refusing visitors you've never completed an offer with.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean preventRefusingNew = true;
@@ -86,7 +86,7 @@ public class RewardWarningConfig {
     @Expose
     @ConfigOption(
         name = "Opacity",
-        desc = "How strong should the offer buttons be grayed out when blocked?"
+        desc = "How strong the offer buttons should be grayed out when blocked."
     )
     @ConfigEditorSlider(
         minValue = 0,
@@ -96,7 +96,7 @@ public class RewardWarningConfig {
     public int opacity = 180;
 
     @Expose
-    @ConfigOption(name = "Outline", desc = "Adds a red/green line around the best offer button.")
+    @ConfigOption(name = "Outline", desc = "Adds a red/green line around the best offer buttons.")
     @ConfigEditorBoolean
     public boolean optionOutline = true;
 }


### PR DESCRIPTION
## What
Fixes some misc spelling inconsistencies in the visitor reward config.

exclude_from_changelog