### PR TITLE
Fix: Rift Blood Effigies not being properly detected

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
@@ -85,7 +85,8 @@ class ScoreboardData {
     }
 
     private fun cleanSB(scoreboard: String): String {
-        return scoreboard.toCharArray().filter { it.code in 21..126 || it.code == 167 }.joinToString(separator = "")
+        // 10735 = Rift Blood Effigies symbol
+        return scoreboard.toCharArray().filter { it.code in 21..126 || it.code == 167 || it.code == 10735 }.joinToString(separator = "")
     }
 
     private fun fetchScoreboardLines(): List<String> {


### PR DESCRIPTION
## What
Fixed Rift Blood Effigies not being detected from the scoreboard because the effigy symbol we're checking for was being stripped away by the scoreboard cleaning code.

## Changelog Fixes
+ Fixed Rift Blood Effigies not being detected from the scoreboard. - Luna
