### PR TITLE
Feature: Add SkyCrypt button to RPC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,10 +148,7 @@ folder for how to properly do this. You also may have to disable repo auto updat
 ### Discord IPC
 
 DiscordIPC is a service that SkyHanni uses to send information from SkyBlock to Discord in Rich Presence. <br>
-Specifically, we use [NetheriteMiner's Fork](https://github.com/NetheriteMiner/DiscordIPC) of a fork of a fork of a fork of
-the [original](https://github.com/jagrosh/DiscordIPC).
-For info on usage, look
-at [DiscordRPCManager.kt](https://github.com/hannibal002/SkyHanni/blob/beta/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt)
+For info on usage, look at [DiscordRPCManager.kt](https://github.com/hannibal002/SkyHanni/blob/beta/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt)
 
 ### Auto Updater
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ repositories {
     maven("https://repo.nea.moe/releases")
     maven("https://maven.notenoughupdates.org/releases")
     maven("https://repo.hypixel.net/repository/Hypixel/")
+    maven("https://maven.teamresourceful.com/repository/thatgravyboat/")
 }
 
 val shadowImpl: Configuration by configurations.creating {
@@ -79,7 +80,7 @@ dependencies {
     forge("net.minecraftforge:forge:1.8.9-11.15.1.2318-1.8.9")
 
     // Discord RPC client
-    shadowImpl("com.github.NetheriteMiner:DiscordIPC:3106be5") {
+    shadowImpl("com.jagrosh:DiscordIPC:0.5") {
         exclude(module = "log4j")
         because("Different version conflicts with Minecraft's Log4J")
         exclude(module = "gson")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/DiscordRPCConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/DiscordRPCConfig.java
@@ -92,6 +92,11 @@ public class DiscordRPCConfig {
     @ConfigEditorDropdown
     public Property<LineEntry> auto = Property.of(NOTHING);
 
+    @Expose
+    @ConfigOption(name = "Show Button for SkyCrypt", desc = "Adds a button to the RPC that opens your SkyCrypt profile.")
+    @ConfigEditorBoolean
+    public Property<Boolean> showSkyCryptButton = Property.of(true);
+
     public enum LineEntry implements HasLegacyId {
         NOTHING("Nothing", 0),
         LOCATION("Location", 1),

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.SkyHanniMod.Companion.feature
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.misc.DiscordRPCConfig.LineEntry
 import at.hannibal2.skyhanni.config.features.misc.DiscordRPCConfig.PriorityEntry
+import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.StackingEnchantData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.StackingEnchantsJson
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
@@ -26,6 +27,7 @@ import com.google.gson.JsonObject
 import com.jagrosh.discordipc.IPCClient
 import com.jagrosh.discordipc.IPCListener
 import com.jagrosh.discordipc.entities.RichPresence
+import com.jagrosh.discordipc.entities.RichPresenceButton
 import kotlinx.coroutines.launch
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.network.FMLNetworkEvent
@@ -131,13 +133,20 @@ object DiscordRPCManager : IPCListener {
         // TODO, change functionality to use enum rather than ordinals
         secondLine = getStatusByConfigId(config.secondLine.get().ordinal)
         firstLine = getStatusByConfigId(config.firstLine.get().ordinal)
-        val presence: RichPresence = RichPresence.Builder()
+
+        var presence = RichPresence.Builder()
             .setDetails(firstLine.getDisplayString())
             .setState(secondLine.getDisplayString())
             .setStartTimestamp(startTimestamp!!)
             .setLargeImage(discordIconKey, location)
-            .build()
-        client?.sendRichPresence(presence)
+        if (config.showSkyCryptButton.get()) {
+            val skyCryptUrl = "https://sky.shiiyu.moe/stats/${LorenzUtils.getPlayerName()}/${HypixelData.profileName}"
+            presence = presence.setButtons(arrayOf(
+                RichPresenceButton(skyCryptUrl, "Open SkyCrypt Profile")
+            ))
+        }
+
+        client?.sendRichPresence(presence.build())
     }
 
     override fun onReady(client: IPCClient) {


### PR DESCRIPTION
## What
Adds SkyCrypt button to the Discord RPC

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/26934102/cc2f6879-099d-41aa-8f93-4d7e2c7d6888)

</details>

## Changelog New Features
+ Added SkyCrypt button to Discord RPC. - ThatGravyBoat

## Changelog Technical Details
+ Moved Discord RPC to ThatGravyBoat version on TeamResourceful maven. - ThatGravyBoat

