### PR TITLE
Fix: Bazaar Cancelled Buy Order

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -22,10 +22,11 @@ class BazaarCancelledBuyOrderClipboard {
 
     /**
      * REGEX-TEST: §6§7from §a50§7x §7missing items.
+     * REGEX-TEST: §7§a22§7x §7missing items.
      */
     private val lastAmountPattern by patternGroup.pattern(
         "lastamount",
-        "§6§7from §a(?<amount>.*)§7x §7missing items\\."
+        "(?:§6§7from |§7)§a(?<amount>.*)§7x §7missing items\\."
     )
     private val cancelledMessagePattern by patternGroup.pattern(
         "cancelledmessage",


### PR DESCRIPTION
## What
Fixed Bazaar Cancelled Buy Order Clipboard one last time.

## Changelog Fixes
+ Fixed Bazaar Cancelled Buy Order Clipboard one last time. - hannibal2