### PR TITLE
Improvement: Cleanup /shcommand hover description

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -78,6 +78,7 @@ import at.hannibal2.skyhanni.utils.APIUtil
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.StringUtils.splitLines
 import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPatternGui
 import net.minecraft.command.ICommandSender
@@ -532,11 +533,11 @@ object Commands {
             val hoverText = buildList {
                 add("§e/$name")
                 if (command.description.isNotEmpty()) {
-                    add(" §7${command.description}")
+                    addDescription(command.description)
                 }
                 add("")
                 add("$color${category.categoryName}")
-                add("  §7${category.description}")
+                addDescription(category.description)
             }
 
             val commandInfo = ChatUtils.createHoverableChat("$color/$name", hoverText, "/$name", false)
@@ -546,6 +547,21 @@ object Commands {
         }
         components.add(ChatComponentText("\n "))
         ChatUtils.multiComponentMessage(components)
+    }
+
+    private fun MutableList<String>.addDescription(description: String) {
+        val lines = description.splitLines(200).removeSuffix("§r").replace("§r", "§7").addOptionalDot()
+        for (line in lines.split("\n")) {
+            add("  §7${line}")
+        }
+    }
+
+    private fun String.addOptionalDot(): String {
+        if (endsWith(".")) return this
+        if (endsWith("?")) return this
+        if (endsWith("!")) return this
+
+        return "$this."
     }
 
     @JvmStatic
@@ -592,7 +608,11 @@ object Commands {
             name,
             createCommand(function),
             object : SimpleCommand.TabCompleteRunnable {
-                override fun tabComplete(sender: ICommandSender?, args: Array<String>?, pos: BlockPos?): List<String> {
+                override fun tabComplete(
+                    sender: ICommandSender?,
+                    args: Array<String>?,
+                    pos: BlockPos?,
+                ): List<String> {
                     return autoComplete(args ?: emptyArray())
                 }
             }


### PR DESCRIPTION
## What
We now dynamically cut the description text in /shcommands into multiple lines and fix color weirdness.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/298a8a23-4bcb-414c-8dfb-2822898cd006)

</details>

## Changelog Improvements
+ Cleanup the format for the /shcommand hover description. - hannibal2