### PR TITLE
Backend: Cleanup code

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RendererLivingEntityHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RendererLivingEntityHook.kt
@@ -7,8 +7,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.player.EntityPlayer
-import net.minecraft.entity.player.EnumPlayerModelParts
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 
 class RendererLivingEntityHook {
     private val config get() = SkyHanniMod.feature.dev
@@ -26,40 +24,22 @@ class RendererLivingEntityHook {
         }
     }
 
-    fun isWearing(entityPlayer: EntityPlayer, parts: EnumPlayerModelParts?): Boolean {
-        if (!LorenzUtils.inSkyBlock) return entityPlayer.isWearing(parts)
-        return isCoolPerson(entityPlayer.name) || entityPlayer.isWearing(parts)
-    }
-
-    fun <T> rotateCorpse(displayName: String, bat: T): Boolean {
-        if (isCoolPerson(displayName)) {
-            GlStateManager.rotate(getRotation(bat).toFloat(), 0f, 1f, 0f)
-        }
-        return isCoolPerson(displayName)
-    }
-
-    fun onIsWearing(entityPlayer: EntityPlayer, cir: CallbackInfoReturnable<Boolean>) {
-        if (!isCoolPerson(entityPlayer.name)) return
-        GlStateManager.rotate(getRotation(entityPlayer).toFloat(), 0f, 1f, 0f)
-        cir.returnValue = true
-    }
-
-    fun onEquals(displayName: String, cir: CallbackInfoReturnable<Boolean>) {
-        if (isCoolPerson(displayName)) {
-            cir.returnValue = true
-        }
-    }
-
-    private fun isCoolPerson(userName: String?): Boolean {
+    /**
+     * Check if the player is on the cool person list and if they should be flipped.
+     */
+    fun isCoolPerson(userName: String?): Boolean {
         if (!LorenzUtils.inSkyBlock) return false
         if (!config.flipContributors && !LorenzUtils.isAprilFoolsDay) return false
         val name = userName ?: return false
         return ContributorManager.canSpin(name)
     }
 
-    private fun <T> getRotation(entity: T): Int {
-        if (!config.rotateContributors) return 0
-        if (entity !is EntityPlayer) return 0
-        return (entity.ticksExisted % 90) * 4
+    /**
+     * Player is already on the cool person list so rotate them if the option is on.
+     */
+    fun rotatePlayer(player: EntityPlayer) {
+        if (!config.rotateContributors) return
+        val rotation = ((player.ticksExisted % 90) * 4).toFloat()
+        GlStateManager.rotate(rotation, 0f, 1f, 0f)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinContributorRendererEntityLiving.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinContributorRendererEntityLiving.java
@@ -17,12 +17,13 @@ public class MixinContributorRendererEntityLiving<T extends EntityLivingBase> {
     private final RendererLivingEntityHook skyHanni$hook = new RendererLivingEntityHook();
 
     @Redirect(method = "rotateCorpse", at = @At(value = "INVOKE", target = "Ljava/lang/String;equals(Ljava/lang/Object;)Z", ordinal = 0))
-    private boolean rotateCorpse(String displayName, Object v2, T bat, float p_77043_2_, float p_77043_3_, float partialTicks) {
-        return skyHanni$hook.rotateCorpse(displayName, bat);
+    private boolean checkName(String displayName, Object v2, T bat, float p_77043_2_, float p_77043_3_, float partialTicks) {
+        return skyHanni$hook.isCoolPerson(displayName);
     }
 
     @Redirect(method = "rotateCorpse", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isWearing(Lnet/minecraft/entity/player/EnumPlayerModelParts;)Z"))
-    private boolean rotateCorpse(EntityPlayer bat, EnumPlayerModelParts p_175148_1_) {
-        return skyHanni$hook.isWearing(bat, EnumPlayerModelParts.CAPE);
+    private boolean isWearing(EntityPlayer player, EnumPlayerModelParts p_175148_1_) {
+        skyHanni$hook.rotatePlayer(player);
+        return true;
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinRendererLivingEntityHookSBA.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinRendererLivingEntityHookSBA.java
@@ -20,11 +20,14 @@ public class MixinRendererLivingEntityHookSBA<T extends EntityLivingBase> {
 
     @Inject(method = "equals", at = @At("HEAD"), cancellable = true, remap = false)
     private static void onEquals(String displayName, Object otherString, CallbackInfoReturnable<Boolean> cir) {
-        skyHanni$hook.onEquals(displayName, cir);
+        if (skyHanni$hook.isCoolPerson(displayName)) {
+            cir.setReturnValue(true);
+        }
     }
 
     @Inject(method = "isWearing", at = @At("HEAD"), cancellable = true, remap = false)
-    private static void onIsWearing(EntityPlayer entityPlayer, EnumPlayerModelParts p_175148_1_, CallbackInfoReturnable<Boolean> cir) {
-        skyHanni$hook.onIsWearing(entityPlayer, cir);
+    private static void onIsWearing(EntityPlayer player, EnumPlayerModelParts p_175148_1_, CallbackInfoReturnable<Boolean> cir) {
+        skyHanni$hook.rotatePlayer(player);
+        cir.setReturnValue(true);
     }
 }


### PR DESCRIPTION
This simplifies the mixin logic used, now we only check cool person where the original mc code checks for Dinnerbone. As we dont want to use the cape logic from the original code we always return true here. If this check for the cape is occurring they are already on the cool person list (or they are Grum) so we see if the flipping logic needs to be applied then we apply it

exclude_from_changelog
