### PR TITLE
Improvement: Command to clear kismet

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.features.combat.endernodetracker.EnderNodeTracker
 import at.hannibal2.skyhanni.features.combat.ghostcounter.GhostUtil
 import at.hannibal2.skyhanni.features.commands.PartyCommands
 import at.hannibal2.skyhanni.features.commands.WikiManager
+import at.hannibal2.skyhanni.features.dungeon.CroesusChestTracker
 import at.hannibal2.skyhanni.features.event.diana.AllBurrowsList
 import at.hannibal2.skyhanni.features.event.diana.BurrowWarpHelper
 import at.hannibal2.skyhanni.features.event.diana.DianaProfitTracker
@@ -358,6 +359,10 @@ object Commands {
             "shrepostatus",
             "Shows the status of all the mods constants"
         ) { SkyHanniMod.repo.displayRepoStatus(false) }
+        registerCommand(
+            "shclearksimet",
+            "Cleares the saved values of the applied kismet feathers in Croesus"
+        ) { CroesusChestTracker.resetChest() }
         registerCommand(
             "shkingfix",
             "Reseting the local King Talisman Helper offset."

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -40,8 +40,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ProfileSpecificStorage {
 
@@ -434,10 +432,7 @@ public class ProfileSpecificStorage {
         public Map<DungeonFloor, Integer> bosses = new HashMap<>();
 
         @Expose
-        public List<DungeonStorage.DungeonRunInfo> runs = Stream.generate(DungeonStorage.DungeonRunInfo::new)
-            .limit(CroesusChestTracker.Companion.getMaxChests())
-            .collect(Collectors.toCollection(ArrayList::new));
-
+        public List<DungeonStorage.DungeonRunInfo> runs = CroesusChestTracker.Companion.generateMaxChestAsArrayList();
 
         public static class DungeonRunInfo {
 

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -432,7 +432,7 @@ public class ProfileSpecificStorage {
         public Map<DungeonFloor, Integer> bosses = new HashMap<>();
 
         @Expose
-        public List<DungeonStorage.DungeonRunInfo> runs = CroesusChestTracker.Companion.generateMaxChestAsArrayList();
+        public List<DungeonStorage.DungeonRunInfo> runs = CroesusChestTracker.Companion.generateMaxChestAsList();
 
         public static class DungeonRunInfo {
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -261,6 +261,14 @@ class CroesusChestTracker {
 
         private val croesusChests get() = ProfileStorageData.profileSpecific?.dungeons?.runs
 
+        fun resetChest() = croesusChests?.let {
+            it.clear()
+            it.addAll(generateMaxChest())
+        }
+
+        fun generateMaxChest() = generateSequence { DungeonRunInfo() }.take(maxChests)
+        fun generateMaxChestAsArrayList() = generateMaxChest().toCollection(ArrayList())
+
         fun getLastActiveChest(includeDungeonKey: Boolean = false) =
             (croesusChests?.indexOfLast {
                 it.floor != null &&

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI.DungeonChest
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getAmountInInventory
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -264,10 +265,11 @@ class CroesusChestTracker {
         fun resetChest() = croesusChests?.let {
             it.clear()
             it.addAll(generateMaxChest())
+            ChatUtils.chat("Kismet State was cleared!")
         }
 
         fun generateMaxChest() = generateSequence { DungeonRunInfo() }.take(maxChests)
-        fun generateMaxChestAsArrayList() = generateMaxChest().toCollection(ArrayList())
+        fun generateMaxChestAsList() = generateMaxChest().toList()
 
         fun getLastActiveChest(includeDungeonKey: Boolean = false) =
             (croesusChests?.indexOfLast {


### PR DESCRIPTION
## What
A fix to clear the kismet data. Since currently there is one way to bug out the state (finish without milestone).

See: https://discord.com/channels/997079228510117908/1232355086424997910 (does not fix the issue here, but users can get back to a usable state)

## Changelog Improvements
+ Added a command to clear the kismet state in Croesus. - Thunderblade73

