### PR TITLE
Backend: Simplify code for when you can steak Vampire Slayer boss

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -156,13 +156,7 @@ object VampireSlayerFeatures {
                 }
                 contain
             }
-            val neededHealth = when (baseMaxHealth) {
-                625 -> 125f // t1
-                1100 -> 220f // t2
-                1800 -> 360f // t3
-                2400 -> 480f // t4
-                else -> 600f // t5
-            }
+            val neededHealth = baseMaxHealth * 0.2f
             if (containUser && taggedEntityList.contains(this.entityId)) {
                 taggedEntityList.remove(this.entityId)
             }


### PR DESCRIPTION
## What
Simplified the code checking when you can steak your Vampire Slayer boss, multiplying `baseMaxHealth` by 0.2 instead of hardcoding.

## Changelog Technical Details
+ Simplified the code checking when you can steak your Vampire Slayer boss. - Luna
