### PR TITLE
Improvement + Fix: Item tooltips disappearing / changing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -166,6 +166,7 @@ object EnchantParser {
                 if (chatComponent != null) editChatComponent(chatComponent, loreList)
                 return
             }
+            loreCache.updateAfter(loreList)
             return
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -37,6 +37,8 @@ object EnchantParser {
         "grayenchants", "^(Respiration|Aqua Affinity|Depth Strider|Efficiency).*"
     )
 
+    private var currentItem: ItemStack? = null
+
     private var indexOfLastGrayEnchant = -1
     private var startEnchant = -1
     private var endEnchant = -1
@@ -84,6 +86,8 @@ object EnchantParser {
         // If enchants doesn't have any enchant data then we have no data to parse enchants correctly
         if (!isEnabled() || !this.enchants.hasEnchantData()) return
 
+        currentItem = event.itemStack
+
         // The enchants we expect to find in the lore, found from the items NBT data
         val enchants = event.itemStack.getEnchantments() ?: return
 
@@ -116,7 +120,11 @@ object EnchantParser {
         // Check if the lore is already cached so continuous hover isn't 1 fps
         if (loreCache.isCached(loreList)) {
             loreList.clear()
-            loreList.addAll(loreCache.cachedLoreAfter)
+            if (loreCache.cachedLoreAfter.isNotEmpty()) {
+                loreList.addAll(loreCache.cachedLoreAfter)
+            } else {
+                loreList.addAll(loreCache.cachedLoreBefore)
+            }
             // Need to still set replacement component even if its cached
             if (chatComponent != null) editChatComponent(chatComponent, loreList)
             return
@@ -147,6 +155,10 @@ object EnchantParser {
         // If we have color parsing off and hide enchant descriptions on, remove them and return from method
         if (!config.colorParsing.get()) {
             if (config.hideEnchantDescriptions.get()) {
+                if (itemIsBook()) {
+                    loreCache.updateAfter(loreList)
+                    return
+                }
                 loreList.removeAll(loreLines)
                 loreCache.updateAfter(loreList)
                 if (chatComponent != null) editChatComponent(chatComponent, loreList)
@@ -261,7 +273,7 @@ object EnchantParser {
                 insertEnchants.add(builder.toString())
 
                 // This will only add enchant descriptions if there were any to begin with
-                if (!config.hideEnchantDescriptions.get()) insertEnchants.addAll(orderedEnchant.getLore())
+                if (!config.hideEnchantDescriptions.get() || itemIsBook()) insertEnchants.addAll(orderedEnchant.getLore())
 
                 builder = StringBuilder()
             }
@@ -290,7 +302,7 @@ object EnchantParser {
     }
 
     private fun stackedFormatting(insertEnchants: MutableList<String>) {
-        if (!config.hideEnchantDescriptions.get()) {
+        if (!config.hideEnchantDescriptions.get() || itemIsBook()) {
             for (enchant: FormattedEnchant in orderedEnchants) {
                 insertEnchants.add(enchant.getFormattedString())
                 insertEnchants.addAll(enchant.getLore())
@@ -342,6 +354,11 @@ object EnchantParser {
         }
 
         return if (removeGrayEnchants) -1 else lastGrayEnchant
+    }
+
+    // Surely Hypixel won't change Enchanted Book display names right... right?
+    private fun itemIsBook() : Boolean {
+        return currentItem?.displayName?.contains("Enchanted Book") ?: false
     }
 
     // We don't check if the main toggle here since we still need to go into

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -9,6 +9,8 @@ import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook
 import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.ItemCategory
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.isEnchanted
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
@@ -356,9 +358,8 @@ object EnchantParser {
         return if (removeGrayEnchants) -1 else lastGrayEnchant
     }
 
-    // Surely Hypixel won't change Enchanted Book display names right... right?
     private fun itemIsBook() : Boolean {
-        return currentItem?.displayName?.contains("Enchanted Book") ?: false
+        return currentItem?.getItemCategoryOrNull() == ItemCategory.ENCHANTED_BOOK
     }
 
     // We don't check if the main toggle here since we still need to go into


### PR DESCRIPTION
## What
Fixes item tooltips disappearing / changin when having the coloring toggle off, causing the code to end up in a situation where `cachedLoreAfter` was never set, but the lore was still considered cached and tried to read an empty `cachedLoreAfter`, also made sure to set the `cachedLoreAfter` in a specific situation where it would cause irrelevant/incorrect tooltips to be shown for other items.

Also makes it so enchant books always show their enchant descriptions.

## Changelog Improvements
+ Enchant books always show descriptions regardless of if 'Hide enchant description' is enabled. - Vixid

## Changelog Fixes
+ Fixed tooltips disappearing with the Enchant Parsing feature. - Vixid
