### PR TITLE
Fix: Profit Trackers int limit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
@@ -178,7 +178,7 @@ class SkyHanniItemTracker<Data : ItemTrackerData>(
     }
 
     fun addTotalProfit(profit: Double, totalAmount: Long, action: String): Renderable {
-        val profitFormat = profit.toInt().addSeparators()
+        val profitFormat = profit.toLong().addSeparators()
         val profitPrefix = if (profit < 0) "§c" else "§6"
 
         val tips = if (totalAmount > 0) {


### PR DESCRIPTION
## What
Fixed Profit Trackers showing no more than 2.1b coins.
Reported: https://discord.com/channels/997079228510117908/1232549164441931886

## Changelog Fixes
+ Fixed Profit Trackers showing no more than 2.1b coins. - hannibal2