### PR TITLE
Improvement + Fix: Custom Scoreboard not detection M7 Dragons during Derpy

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
@@ -44,12 +44,6 @@ public class DevConfig {
     @ConfigEditorBoolean
     public boolean worldEdit = false;
 
-    @Expose
-    @ConfigOption(name = "Unknown Lines warning", desc = "Gives a chat warning when unknown lines are found in the scoreboard." +
-        "\nCustom Scoreboard debug option")
-    @ConfigEditorBoolean
-    public boolean unknownLinesWarning = false;
-
     @ConfigOption(name = "Parkour Waypoints", desc = "")
     @Accordion
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/CustomScoreboardConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/CustomScoreboardConfig.java
@@ -47,6 +47,11 @@ public class CustomScoreboardConfig {
     public InformationFilteringConfig informationFiltering = new InformationFilteringConfig();
 
     @Expose
+    @ConfigOption(name = "Unknown Lines warning", desc = "Gives a chat warning when unknown lines are found in the scoreboard.")
+    @ConfigEditorBoolean
+    public boolean unknownLinesWarning = true;
+
+    @Expose
     @ConfigLink(owner = CustomScoreboardConfig.class, field = "enabled")
     public Position position = new Position(10, 80, false, true);
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -103,7 +103,6 @@ class CustomScoreboard {
         internal val maxwellConfig get() = displayConfig.maxwell
         internal val informationFilteringConfig get() = config.informationFiltering
         internal val backgroundConfig get() = config.background
-        internal val devConfig get() = SkyHanniMod.feature.dev
     }
 
     private fun createLines() = buildList<ScoreboardElementType> {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -18,7 +18,7 @@ import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.data.SlayerAPI
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.arrowConfig
-import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.devConfig
+import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.config
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.displayConfig
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.informationFilteringConfig
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.Companion.maxwellConfig
@@ -778,7 +778,7 @@ private fun getExtraDisplayPair(): List<ScoreboardElementType> {
     if (unknownLines.isEmpty()) return listOf("<hidden>" to HorizontalAlignment.LEFT)
 
     val size = unknownLines.size
-    if (amountOfUnknownLines != size && devConfig.unknownLinesWarning) {
+    if (amountOfUnknownLines != size && config.unknownLinesWarning) {
         val message = "CustomScoreboard detected ${pluralize(unknownLines.size, "unknown line", withNumber = true)}"
         ErrorManager.logErrorWithData(
             CustomScoreboardUtils.UndetectedScoreboardLines(message),
@@ -787,6 +787,7 @@ private fun getExtraDisplayPair(): List<ScoreboardElementType> {
             "Island" to HypixelData.skyBlockIsland,
             "Area" to HypixelData.skyBlockArea,
             noStackTrace = true,
+            betaOnly = true,
         )
         amountOfUnknownLines = size
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -94,7 +94,7 @@ object ScoreboardPattern {
     private val dungeonSb = scoreboardGroup.group("dungeon")
     val m7dragonsPattern by dungeonSb.pattern(
         "m7dragons",
-        "^(§cNo Alive Dragons|§8- (§.)+[\\w\\s]+Dragon§a \\w+§.❤)$"
+        "^(§cNo Alive Dragons|§8- (?:§.)+[\\w\\s]+Dragon§a [\\w,.]+§.❤)$"
     )
     val keysPattern by dungeonSb.pattern(
         "keys",


### PR DESCRIPTION
## What
Decided to move the Unknown Lines Warning back into Custom Scoreboard to still get reminded of that, but added the betaOnly check.


## Changelog Improvements
+ Moved Unknown Lines warning option back into Custom Scoreboard Category. - j10a1n15

## Changelog Fixes
+ Fixed Custom Scoreboard not detection M7 dragons during Derpy. - j10a1n15

