### PR TITLE
Fix: IndexOutOfBounds Error in Enchant Parser

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -346,6 +346,7 @@ object EnchantParser {
 
         var i = 1
         for (total in 0 until (1 + item.enchantmentTagList.tagCount())) {
+            if (i + 1 == loreList.size) break
             val line = loreList[i]
             if (grayEnchantPattern.matcher(line).matches()) {
                 lastGrayEnchant = i


### PR DESCRIPTION
## What
Fixes an IndexOutOfBounds error when accounting for gray enchants in tooltips by including a bounds check that was there in SBA but I forgot to port over since kotlin for loops don't have conditionals so I forgot to add it originally. (Still have no idea what items trigger it, since the item needs to have enchants in the enchantmentTagList and have a small enough tooltip that an IndexOutOfBounds is triggered).

## Changelog Fixes
+ Fixed tooltip on certain items when using Enchant Parsing. - Vixid

