### PR TITLE
Improvement: made it possible to disable rabbit crush warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/ChocolateFactoryConfig.java
@@ -81,7 +81,7 @@ public class ChocolateFactoryConfig {
         name = "Rabbit Crush Threshold",
         desc = "How close should you be to your barn capacity should you be before being warned about needing to upgrade it."
     )
-    @ConfigEditorSlider(minValue = 3, maxValue = 20, minStep = 1)
+    @ConfigEditorSlider(minValue = 0, maxValue = 20, minStep = 1)
     public int barnCapacityThreshold = 6;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryBarnManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryBarnManager.kt
@@ -44,6 +44,11 @@ object ChocolateFactoryBarnManager {
 
     fun trySendBarnFullMessage() {
         if (!ChocolateFactoryAPI.isEnabled()) return
+
+        if (config.barnCapacityThreshold <= 0) {
+            return
+        }
+
         val profileStorage = profileStorage ?: return
 
         val remainingSpace = profileStorage.maxRabbits - profileStorage.currentRabbits


### PR DESCRIPTION
## What
made it so if the slider is set to 0, no rabbit crush warning is sent since someone asked for it

## Changelog Improvements
+ Added a way to disable the rabbit crush warning by setting the threshold to zero. - seraid
