### PR TITLE
Feature: Hide Players around shared & guessed hoppity eggs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -34,6 +34,12 @@ public class HoppityEggsConfig {
     public boolean sharedWaypoints = true;
 
     @Expose
+    @ConfigOption(name = "Hide Players", desc = "Hide players around shared and guessed egg waypoints.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hidePlayers = true;
+
+    @Expose
     @ConfigLink(owner = HoppityEggsConfig.class, field = "showClaimedEggs")
     public Position position = new Position(33, 72, false, true);
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/HoppityEggLocator.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.event.chocolatefactory
 
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
@@ -9,6 +10,7 @@ import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.round
@@ -18,6 +20,7 @@ import at.hannibal2.skyhanni.utils.RecalculatingValue
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 import net.minecraft.util.EnumParticleTypes
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -104,6 +107,23 @@ object HoppityEggLocator {
                 seeThroughBlocks = true,
             )
             event.drawDynamicText(eggLocation.add(y = 1), "§aEgg", 1.5)
+        }
+    }
+
+    @SubscribeEvent
+    fun onCheckRender(event: CheckRenderEntityEvent<*>) {
+        if (!isEnabled()) return
+        if (!config.hidePlayers) return
+        if (event.entity !is EntityPlayer) return
+
+        if (event.entity.distanceTo(sharedEggLocation ?: return) < 4.0) {
+            event.isCanceled = true
+        }
+
+        possibleEggLocations.forEach {
+            if (event.entity.distanceTo(it) < 4.0) {
+                event.isCanceled = true
+            }
         }
     }
 


### PR DESCRIPTION
## What
Hides players within a proximity of 4 blocks within a shared or guessed egg waypoint

<details>
<summary>Images</summary>

Before
![image](https://github.com/hannibal002/SkyHanni/assets/36107150/dd8e984a-1249-4098-b1fc-8ee32e49dab9)
After
![image](https://github.com/hannibal002/SkyHanni/assets/36107150/dff07968-b84d-4e13-9615-daf3c0c4c012)

</details>

## Changelog New Features
+ Hide Players around shared & guessed hoppity eggs - RobotHanzo