### PR TITLE
Feature: Update command

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.SkillAPI
 import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.ConfigGuiManager
+import at.hannibal2.skyhanni.config.features.About.UpdateStream
 import at.hannibal2.skyhanni.data.ChatClickActionManager
 import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.data.GardenCropMilestonesCommunityFix
@@ -53,6 +54,7 @@ import at.hannibal2.skyhanni.features.misc.MiscFeatures
 import at.hannibal2.skyhanni.features.misc.discordrpc.DiscordRPCManager
 import at.hannibal2.skyhanni.features.misc.limbo.LimboTimeTracker
 import at.hannibal2.skyhanni.features.misc.massconfiguration.DefaultConfigFeatures
+import at.hannibal2.skyhanni.features.misc.update.UpdateManager
 import at.hannibal2.skyhanni.features.misc.visualwords.VisualWordGui
 import at.hannibal2.skyhanni.features.rift.area.westvillage.VerminTracker
 import at.hannibal2.skyhanni.features.slayer.SlayerProfitTracker
@@ -362,6 +364,10 @@ object Commands {
             "shkingfix",
             "Reseting the local King Talisman Helper offset."
         ) { KingTalismanHelper.kingFix() }
+        registerCommand(
+            "shupdate",
+            "Updates the mod to the specified update stream."
+        ) { forceUpdate(it) }
     }
 
     private fun developersDebugFeatures() {
@@ -563,6 +569,27 @@ object Commands {
         ChatUtils.chat("clearing farming items")
         storage.farmingItems.clear()
         storage.outdatedItems.clear()
+    }
+
+    private fun forceUpdate(args: Array<String>) {
+        val currentStream = SkyHanniMod.feature.about.updateStream.get()
+        val arg = args.firstOrNull() ?: "current"
+        val updateStream = when {
+            arg.equals("(?i)(?:full|release)s?".toRegex()) -> UpdateStream.RELEASES
+            arg.equals("(?i)(?:beta|latest)s?".toRegex()) -> UpdateStream.BETA
+            else -> currentStream
+        }
+
+        if (updateStream == UpdateStream.BETA && (currentStream != UpdateStream.BETA || UpdateManager.isCurrentlyBeta())) {
+            ChatUtils.clickableChat(
+                "Are you sure you want to switch to beta? These versions may be less stable.",
+                onClick = {
+                    UpdateManager.checkUpdate(true, updateStream)
+                }
+            )
+        } else {
+            UpdateManager.checkUpdate(true, updateStream)
+        }
     }
 
     private fun registerCommand(name: String, description: String, function: (Array<String>) -> Unit) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.features.misc.update
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.config.features.About
+import at.hannibal2.skyhanni.config.features.About.UpdateStream
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.utils.LorenzLogger
 import com.google.gson.JsonElement
 import io.github.moulberry.notenoughupdates.util.ApiUtil
 import io.github.moulberry.notenoughupdates.util.MinecraftExecutor
+import io.github.notenoughupdates.moulconfig.observer.Property
 import io.github.notenoughupdates.moulconfig.processor.MoulConfigProcessor
 import moe.nea.libautoupdate.CurrentVersion
 import moe.nea.libautoupdate.PotentialUpdate
@@ -75,15 +76,15 @@ object UpdateManager {
         logger.log("Reset update state")
     }
 
-    fun checkUpdate() {
+    fun checkUpdate(forceDownload: Boolean = false, updateStream: UpdateStream = config.updateStream.get()) {
         if (updateState != UpdateState.NONE) {
             logger.log("Trying to perform update check while another update is already in progress")
             return
         }
         logger.log("Starting update check")
-        var updateStream = config.updateStream.get()
-        if (updateStream == About.UpdateStream.RELEASES && isCurrentlyBeta()) {
-            updateStream = About.UpdateStream.BETA
+        val currentStream = SkyHanniMod.feature.about.updateStream.get()
+        if (currentStream != UpdateStream.BETA && (updateStream == UpdateStream.BETA || isCurrentlyBeta())) {
+            config.updateStream = Property.of(UpdateStream.BETA)
         }
         activePromise = context.checkUpdate(updateStream.stream)
             .thenAcceptAsync({
@@ -95,8 +96,8 @@ object UpdateManager {
                 potentialUpdate = it
                 if (it.isUpdateAvailable) {
                     updateState = UpdateState.AVAILABLE
-                    if (config.fullAutoUpdates) {
-                        ChatUtils.chat("§aSkyHanni found a new update: ${it.update.versionName}, starting to download now. ")
+                    if (config.fullAutoUpdates || forceDownload) {
+                        ChatUtils.chat("§aSkyHanni found a new update: ${it.update.versionName}, starting to download now.")
                         queueUpdate()
                     } else if (config.autoUpdates) {
                         ChatUtils.chatAndOpenConfig(
@@ -105,6 +106,8 @@ object UpdateManager {
                             SkyHanniMod.feature.about::autoUpdates
                         )
                     }
+                } else if (forceDownload) {
+                    ChatUtils.chat("§aSkyHanni didn't find a new update.")
                 }
             }, MinecraftExecutor.OnThread)
     }


### PR DESCRIPTION
## What
Adds a `/shupdate` command, that can be used to directly start downloading an update. By default it will use the current update stream, but that can be changed by using `/shupdate <beta/release>`.

## Changelog New Features
+ Added `/shupdate` command. - Empa
    * Can be used like `/shupdate <beta/full>` to download updates from a specific update stream.