### PR TITLE
Feature: Chocolate factory shortcut

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -624,6 +624,7 @@ class SkyHanniMod {
         loadModule(AreaMiniBossFeatures())
         loadModule(MobHighlight())
         loadModule(ChocolateFactoryBarnManager)
+        loadModule(ChocolateFactoryShortcut())
         loadModule(ChocolateFactoryInventory)
         loadModule(ChocolateFactoryStats)
         loadModule(HoppityEggsManager)
@@ -884,7 +885,6 @@ class SkyHanniMod {
         loadModule(ColdOverlay())
         loadModule(QuiverDisplay())
         loadModule(QuiverWarning())
-        loadModule(ChocolateFactoryShortcut())
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -128,6 +128,7 @@ import at.hannibal2.skyhanni.features.event.UniqueGiftingOpportunitiesFeatures
 import at.hannibal2.skyhanni.features.event.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.features.event.chocolatefactory.ChocolateFactoryBarnManager
 import at.hannibal2.skyhanni.features.event.chocolatefactory.ChocolateFactoryInventory
+import at.hannibal2.skyhanni.features.event.chocolatefactory.ChocolateFactoryShortcut
 import at.hannibal2.skyhanni.features.event.chocolatefactory.ChocolateFactoryStats
 import at.hannibal2.skyhanni.features.event.chocolatefactory.HoppityCollectionStats
 import at.hannibal2.skyhanni.features.event.chocolatefactory.HoppityEggLocator
@@ -883,6 +884,7 @@ class SkyHanniMod {
         loadModule(ColdOverlay())
         loadModule(QuiverDisplay())
         loadModule(QuiverWarning())
+        loadModule(ChocolateFactoryShortcut())
 
         init()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/ChocolateFactoryConfig.java
@@ -91,6 +91,12 @@ public class ChocolateFactoryConfig {
     public boolean hoppityCollectionStats = true;
 
     @Expose
+    @ConfigOption(name = "Hoppity Menu Shortcut", desc = "Add a Chocolate Factory button in the SkyBlock Menu that runs /chocolatefactory on click.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hoppityMenuShortcut = true;
+
+    @Expose
     @ConfigLink(owner = ChocolateFactoryConfig.class, field = "statsDisplay")
     public Position position = new Position(183, 160, false, true);
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -53,7 +53,7 @@ class ChocolateFactoryShortcut {
     @SubscribeEvent(priority = EventPriority.HIGH)
     fun onStackClick(event: GuiContainerEvent.SlotClickEvent) {
         if (showItem && event.slotId == 15) {
-            event.isCanceled = true
+            event.cancel()
             HypixelCommands.chocolateFactory()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -1,0 +1,61 @@
+package at.hannibal2.skyhanni.features.event.chocolatefactory
+
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
+import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
+import io.github.moulberry.notenoughupdates.events.ReplaceItemEvent
+import io.github.moulberry.notenoughupdates.util.Utils
+import net.minecraft.client.player.inventory.ContainerLocalMenu
+import net.minecraftforge.fml.common.eventhandler.EventPriority
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class ChocolateFactoryShortcut {
+
+    private val config get() = ChocolateFactoryAPI.config
+    private var showItem = false
+
+    private val item by lazy {
+        val neuItem = "COOKIE".asInternalName().getItemStack()
+        Utils.createItemStack(
+            neuItem.item,
+            "§6Open Chocolate Factory",
+            "§8(From SkyHanni)",
+            "",
+            "§7Click here to",
+            "§7run §e/chocolatefactory"
+
+        )
+
+    }
+
+    @SubscribeEvent
+    fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+        showItem = config.hoppityMenuShortcut && event.inventoryName == "SkyBlock Menu"
+    }
+
+    @SubscribeEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        showItem = false
+    }
+
+    @SubscribeEvent
+    fun replaceItem(event: ReplaceItemEvent) {
+        if (event.inventory is ContainerLocalMenu && showItem && event.slotNumber == 15) {
+            event.replaceWith(item)
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    fun onStackClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (showItem && event.slotId == 15) {
+            event.isCanceled = true
+            HypixelCommands.chocolateFactory()
+        }
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.event.chocolatefactory
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
@@ -32,6 +33,7 @@ class ChocolateFactoryShortcut {
 
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+        if (RiftAPI.inRift()) return
         if (!LorenzUtils.inSkyBlock) return
         showItem = config.hoppityMenuShortcut && event.inventoryName == "SkyBlock Menu"
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -25,8 +25,8 @@ class ChocolateFactoryShortcut {
             "§6Open Chocolate Factory",
             "§8(From SkyHanni)",
             "",
-            "§7Click here to",
-            "§7run §e/chocolatefactory"
+            "§7Click here to run",
+            "§e/chocolatefactory"
 
         )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -8,16 +8,19 @@ import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import io.github.moulberry.notenoughupdates.events.ReplaceItemEvent
 import io.github.moulberry.notenoughupdates.util.Utils
 import net.minecraft.client.player.inventory.ContainerLocalMenu
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.seconds
 
 class ChocolateFactoryShortcut {
 
     private val config get() = ChocolateFactoryAPI.config
     private var showItem = false
+    private var lastClick = SimpleTimeMark.farPast()
 
     private val item by lazy {
         val neuItem = "COOKIE".asInternalName().getItemStack()
@@ -54,7 +57,10 @@ class ChocolateFactoryShortcut {
     fun onStackClick(event: GuiContainerEvent.SlotClickEvent) {
         if (showItem && event.slotId == 15) {
             event.cancel()
-            HypixelCommands.chocolateFactory()
+            if (lastClick.passedSince() > 2.seconds) {
+                HypixelCommands.chocolateFactory()
+                lastClick = SimpleTimeMark.now()
+            }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -27,9 +27,7 @@ class ChocolateFactoryShortcut {
             "",
             "§7Click here to run",
             "§e/chocolatefactory"
-
         )
-
     }
 
     @SubscribeEvent
@@ -57,5 +55,4 @@ class ChocolateFactoryShortcut {
             HypixelCommands.chocolateFactory()
         }
     }
-
 }


### PR DESCRIPTION
## What
Add a Chocolate Factory button in the SkyBlock Menu that runs /chocolatefactory on click.

![image](https://github.com/hannibal002/SkyHanni/assets/168305416/0ccb96e6-78f4-4e3c-b2c1-31c8491704a8)

## Changelog New Features
+ Added Chocolate Factory Menu Shortcut (Hoppity Menu Shortcut). - raven + martimavocado

