### PR TITLE
Fix: Typo in barn warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryBarnManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryBarnManager.kt
@@ -69,21 +69,13 @@ object ChocolateFactoryBarnManager {
             return
         }
 
-        if (profileStorage.currentRabbits == profileStorage.maxRabbits) {
-            ChatUtils.clickableChat(
-                "§cYour barn is full! §7(${barnStatus()}). §cUpgrade it so they don't get crushed",
-                onClick = {
-                    HypixelCommands.chocolateFactory()
-                }
-            )
-        } else {
-            ChatUtils.clickableChat(
-                "§cYour barn is almost full! §7(${barnStatus()}). §cUpgrade it so they don't get crushed",
-                onClick = {
-                    HypixelCommands.chocolateFactory()
-                }
-            )
-        }
+        ChatUtils.clickableChat(
+            message = if (profileStorage.currentRabbits == profileStorage.maxRabbits) { "§cYour barn is full! §7(${barnStatus()}). §cUpgrade it so they don't get crushed" }
+            else { "§cYour barn is almost full! §7(${barnStatus()}). §cUpgrade it so they don't get crushed"},
+            onClick = {
+                HypixelCommands.chocolateFactory()
+            }
+        )
         SoundUtils.playBeepSound()
         lastBarnFullWarning = SimpleTimeMark.now()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryBarnManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryBarnManager.kt
@@ -69,12 +69,21 @@ object ChocolateFactoryBarnManager {
             return
         }
 
-        ChatUtils.clickableChat(
-            "§cYour barn is almost full! §7(${barnStatus()}). §cUpgrade it so they don't get crushed",
-            onClick = {
-                HypixelCommands.chocolateFactory()
-            }
-        )
+        if (profileStorage.currentRabbits == profileStorage.maxRabbits) {
+            ChatUtils.clickableChat(
+                "§cYour barn is full! §7(${barnStatus()}). §cUpgrade it so they don't get crushed",
+                onClick = {
+                    HypixelCommands.chocolateFactory()
+                }
+            )
+        } else {
+            ChatUtils.clickableChat(
+                "§cYour barn is almost full! §7(${barnStatus()}). §cUpgrade it so they don't get crushed",
+                onClick = {
+                    HypixelCommands.chocolateFactory()
+                }
+            )
+        }
         SoundUtils.playBeepSound()
         lastBarnFullWarning = SimpleTimeMark.now()
     }


### PR DESCRIPTION
## What
this bug wiped my account where do i refund

## Changelog Fixes
+ Fixed a typo in the Barn Warning message. - martimavocado

