### PR TITLE
Improvement: Hoppity Menu Shortcut appearing in islands that it's not supposed to be used in.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -1,9 +1,9 @@
 package at.hannibal2.skyhanni.features.event.chocolatefactory
 
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
-import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
@@ -36,7 +36,7 @@ class ChocolateFactoryShortcut {
 
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
-        if (RiftAPI.inRift()) return
+        if (LorenzUtils.inAnyIsland(IslandType.THE_RIFT, IslandType.KUUDRA_ARENA, IslandType.CATACOMBS, IslandType.MINESHAFT)) return
         if (!LorenzUtils.inSkyBlock) return
         showItem = config.hoppityMenuShortcut && event.inventoryName == "SkyBlock Menu"
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -36,6 +36,7 @@ class ChocolateFactoryShortcut {
 
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+        if (!LorenzUtils.inSkyBlock) return
         if (LorenzUtils.inAnyIsland(IslandType.THE_RIFT, IslandType.KUUDRA_ARENA, IslandType.CATACOMBS, IslandType.MINESHAFT)) return
         showItem = config.hoppityMenuShortcut && event.inventoryName == "SkyBlock Menu"
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -37,7 +37,6 @@ class ChocolateFactoryShortcut {
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (LorenzUtils.inAnyIsland(IslandType.THE_RIFT, IslandType.KUUDRA_ARENA, IslandType.CATACOMBS, IslandType.MINESHAFT)) return
-        if (!LorenzUtils.inSkyBlock) return
         showItem = config.hoppityMenuShortcut && event.inventoryName == "SkyBlock Menu"
     }
 


### PR DESCRIPTION
## What
Removed the Hoppity Menu Shortcut in areas that cannot access the Chocolate Factory.

## Changelog Improvements
+ Removed the Hoppity Menu Shortcut in The Rift, Kuudra, Catacombs and Mineshafts. - raven
    * You cannot use the chocolate factory in these areas, resulting in the button being removed.

