### PR TITLE
Fix: Missing Fossil Dust Line in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -488,6 +488,11 @@ private fun getMiningEventsLines() = buildList {
     if (getSbLines().any { SbPattern.fortunateFreezingBonusPattern.matches(it) }) {
         add(getSbLines().first { SbPattern.fortunateFreezingBonusPattern.matches(it) })
     }
+
+    // Fossil Dust
+    if (getSbLines().any { SbPattern.fossilDustPattern.matches(it) }) {
+        add(getSbLines().first { SbPattern.fossilDustPattern.matches(it) })
+    }
 }
 
 private fun getMiningEventsShowWhen(): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -235,6 +235,10 @@ object ScoreboardPattern {
         "fortunatefreezing.bonus",
         "Event Bonus: §6\\+\\d+☘"
     )
+    val fossilDustPattern by miningSb.pattern(
+        "fossildust",
+        "Fossil Dust: §f[\\d.,]+.*"
+    )
 
     // combat
     private val combatSb = scoreboardGroup.group("combat")

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -118,6 +118,7 @@ object UnknownLinesHandler {
             SbPattern.queuePositionPattern,
             SbPattern.fortunateFreezingBonusPattern,
             SbPattern.riftAveikxPattern,
+            SbPattern.fossilDustPattern,
         )
 
         unknownLines = unknownLines.filterNot { line ->


### PR DESCRIPTION
## What
This Pull Request fixes the Custom Scoreboard missing the Fossil Dust Line, which apparently appears when you mine Quartz blocks inside Mineshafts?

## Changelog Fixes
+ Fixed missing Fossil Dust line in Custom Scoreboard. - j10a1n15

