### PR TITLE
Improvement: Enchant Parsing support for other mods' chat tooltips

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -109,6 +109,9 @@ object EnchantParser {
 
         val lore = event.getHoverEvent().value.formattedText.split("\n").toMutableList()
 
+        // Check for any vanilla gray enchants at the top of the tooltip
+        indexOfLastGrayEnchant = accountForAndRemoveGrayEnchants(lore, null)
+
         // Since we don't get given an item stack from /show, we pass an empty enchants map and
         // use all enchants from the Enchants class instead
         parseEnchants(lore, mapOf(), event.component)
@@ -337,16 +340,24 @@ object EnchantParser {
         GuiChatHook.replaceOnlyHoverEvent(hoverEvent)
     }
 
-    private fun accountForAndRemoveGrayEnchants(loreList: MutableList<String>, item: ItemStack): Int {
-        // If the item has no enchantmentTagList then there will be no gray enchants
-        if (!item.isEnchanted() || item.enchantmentTagList.tagCount() == 0) return -1
+    /**
+     * Finds where the gray enchants (vanilla) end and optionally remove them from the tooltip.
+     *
+     * Allow for a null item stack in odd situations like when other mods add them in chat components, i.e,
+     * Skytils party finder feature showing a players inventory in chat
+     */
+    private fun accountForAndRemoveGrayEnchants(loreList: MutableList<String>, item: ItemStack?): Int {
+        if (item != null) {
+            // If the item has no enchantmentTagList then there will be no gray enchants
+            if (!item.isEnchanted() || item.enchantmentTagList.tagCount() == 0) return -1
+        }
 
         var lastGrayEnchant = -1
         val removeGrayEnchants = config.hideVanillaEnchants.get()
 
         var i = 1
-        for (total in 0 until (1 + item.enchantmentTagList.tagCount())) {
-            if (i + 1 == loreList.size) break
+        for (total in 0 until 2) { // Using the fact that there should be at most 2 vanilla enchants
+            if (i + 1 >= loreList.size) break // In case the tooltip is very short (i.e, hovering over a short chat component)
             val line = loreList[i]
             if (grayEnchantPattern.matcher(line).matches()) {
                 lastGrayEnchant = i


### PR DESCRIPTION
## What
Adds support for enchant parsing on tooltips shown in chat from other mods where they perhaps include the vanilla enchants.

## Changelog Improvements
+ Enchant Parsing support for other mods' chat tooltips. - Vixid

