### PR TITLE
Fix: Updater wrong version

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -601,7 +601,7 @@ object Commands {
             else -> currentStream
         }
 
-        if (updateStream == UpdateStream.BETA && (currentStream != UpdateStream.BETA || UpdateManager.isCurrentlyBeta())) {
+        if (updateStream == UpdateStream.BETA && (currentStream != UpdateStream.BETA || !UpdateManager.isCurrentlyBeta())) {
             ChatUtils.clickableChat(
                 "Are you sure you want to switch to beta? These versions may be less stable.",
                 onClick = {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -76,7 +76,8 @@ object UpdateManager {
         logger.log("Reset update state")
     }
 
-    fun checkUpdate(forceDownload: Boolean = false, updateStream: UpdateStream = config.updateStream.get()) {
+    fun checkUpdate(forceDownload: Boolean = false, forcedUpdateStream: UpdateStream = config.updateStream.get()) {
+        var updateStream = forcedUpdateStream
         if (updateState != UpdateState.NONE) {
             logger.log("Trying to perform update check while another update is already in progress")
             return
@@ -85,6 +86,7 @@ object UpdateManager {
         val currentStream = config.updateStream.get()
         if (currentStream != UpdateStream.BETA && (updateStream == UpdateStream.BETA || isCurrentlyBeta())) {
             config.updateStream = Property.of(UpdateStream.BETA)
+            updateStream = UpdateStream.BETA
         }
         activePromise = context.checkUpdate(updateStream.stream)
             .thenAcceptAsync({


### PR DESCRIPTION
## What
Fixed the updater downloading latest full release if the update stream is set to full release while on a beta (oops).

## Changelog Fixes
+ Fixed updater downloading the wrong version. - Empa