### PR TITLE
Fix: VisitorRewardWarning only blocking normal clicks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -56,12 +56,13 @@ abstract class GuiContainerEvent(open val gui: GuiContainer, open val container:
         val slot: Slot?,
         val slotId: Int,
         val clickedButton: Int,
+        @Deprecated("old", ReplaceWith("clickTypeEnum"))
         val clickType: Int,
         val clickTypeEnum: ClickType? = ClickType.getTypeById(clickType),
     ) : GuiContainerEvent(gui, container) {
 
         fun makePickblock() {
-            if (this.clickedButton == 2 && this.clickType == 3) return
+            if (this.clickedButton == 2 && this.clickTypeEnum == ClickType.HOTBAR) return
             slot?.slotNumber?.let { slotNumber ->
                 Minecraft.getMinecraft().playerController.windowClick(
                     container.windowId, slotNumber, 2, 3, Minecraft.getMinecraft().thePlayer

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -57,6 +57,8 @@ abstract class GuiContainerEvent(open val gui: GuiContainer, open val container:
         val slotId: Int,
         val clickedButton: Int,
         val clickType: Int,
+        // 0: normal, 1: shift, 2: hotbar, 3: middle, 4: drop
+        // TODO Change clickType to enum
     ) : GuiContainerEvent(gui, container) {
 
         fun makePickblock() {

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -57,8 +57,7 @@ abstract class GuiContainerEvent(open val gui: GuiContainer, open val container:
         val slotId: Int,
         val clickedButton: Int,
         val clickType: Int,
-        // 0: normal, 1: shift, 2: hotbar, 3: middle, 4: drop
-        // TODO Change clickType to enum
+        val clickTypeEnum: ClickType? = ClickType.getTypeById(clickType),
     ) : GuiContainerEvent(gui, container) {
 
         fun makePickblock() {
@@ -69,6 +68,19 @@ abstract class GuiContainerEvent(open val gui: GuiContainer, open val container:
                 )
                 isCanceled = true
             }
+        }
+    }
+
+    enum class ClickType(val id: Int) {
+        NORMAL(1),
+        SHIFT(2),
+        HOTBAR(3),
+        MIDDLE(4),
+        DROP(5),
+        ;
+
+        companion object {
+            fun getTypeById(id: Int) = entries.firstOrNull { it.id == id }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
@@ -52,7 +52,6 @@ class VisitorRewardWarning {
     fun onStackClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!VisitorAPI.inInventory) return
         val stack = event.slot?.stack ?: return
-        println("Clicktype: ${event.clickType} button: ${event.clickedButton}")
 
         val visitor = VisitorAPI.getVisitor(lastClickedNpc) ?: return
         val blockReason = visitor.blockReason
@@ -67,7 +66,7 @@ class VisitorRewardWarning {
         }
 
         // clicktypes 0, 2, 3, and 4 work for interacting with visitor, but not 1
-        if (event.clickType == 1) return
+        if (event.clickTypeEnum == GuiContainerEvent.ClickType.NORMAL) return
         if (isRefuseSlot) {
             VisitorAPI.changeStatus(visitor, VisitorAPI.VisitorStatus.REFUSED, "refused")
             return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
@@ -52,7 +52,7 @@ class VisitorRewardWarning {
     fun onStackClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!VisitorAPI.inInventory) return
         val stack = event.slot?.stack ?: return
-        if (event.clickType != 0) return
+        println("Clicktype: ${event.clickType} button: ${event.clickedButton}")
 
         val visitor = VisitorAPI.getVisitor(lastClickedNpc) ?: return
         val blockReason = visitor.blockReason
@@ -66,6 +66,8 @@ class VisitorRewardWarning {
             return
         }
 
+        // clicktypes 0, 2, 3, and 4 work for interacting with visitor, but not 1
+        if (event.clickType == 1) return
         if (isRefuseSlot) {
             VisitorAPI.changeStatus(visitor, VisitorAPI.VisitorStatus.REFUSED, "refused")
             return


### PR DESCRIPTION
## What
Fixes being able to bypass the reward warning with middle click (or drop or hotbar hotkeys) https://discord.com/channels/997079228510117908/1233943553529610320

## Changelog Fixes
+ Fixed visitor reward warning only blocking normal clicks. - Obsidian