### PR TITLE
Fix: Allow middle clicking time tower

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/ChocolateFactoryInventory.kt
@@ -121,8 +121,10 @@ object ChocolateFactoryInventory {
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!ChocolateFactoryAPI.inChocolateFactory) return
         val slot = event.slot ?: return
+        val slotNumber = slot.slotNumber
         if (!config.useMiddleClick) return
-        if (slot.slotNumber in ChocolateFactoryAPI.noPickblockSlots) return
+        if (slotNumber in ChocolateFactoryAPI.noPickblockSlots &&
+            (slotNumber != ChocolateFactoryAPI.timeTowerIndex || event.clickedButton == 1)) return
 
         event.makePickblock()
     }


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1234703158727671960


## Changelog Fixes
+ Fixed middle-clicking not working on time tower. - Obsidian
    * You can still right click to activate it.