### PR TITLE
Fix: Defer renderable tooltips to end of rendering

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -442,6 +442,7 @@ import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NEUVersionCheck.checkIfNeuIsLoaded
 import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.UtilsPatterns
+import at.hannibal2.skyhanni.utils.renderables.RenderableTooltips
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPatternManager
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -572,6 +573,7 @@ class SkyHanniMod {
         loadModule(MiningAPI)
         loadModule(FossilExcavatorAPI)
         loadModule(ChocolateFactoryAPI)
+        loadModule(RenderableTooltips)
 
         // features
         loadModule(BazaarOrderHelper())

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -22,7 +22,6 @@ import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.calculateTableYOf
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderXAligned
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderXYAligned
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderYAligned
-import io.github.moulberry.notenoughupdates.util.Utils
 import io.github.notenoughupdates.moulconfig.gui.GuiScreenElementWrapper
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
@@ -210,15 +209,11 @@ interface Renderable {
                             GlStateManager.pushMatrix()
                             GlStateManager.translate(0F, 0F, 400F)
 
-                            RenderLineTooltips.drawHoveringText(
-                                posX = posX,
-                                posY = posY,
+                            RenderableTooltips.setTooltipForRender(
                                 tips = tipsRender,
                                 stack = stack,
                                 borderColor = color,
                                 snapsToTopIfToLong = snapsToTopIfToLong,
-                                mouseX = currentRenderPassMousePosition?.first ?: Utils.getMouseX(),
-                                mouseY = currentRenderPassMousePosition?.second ?: Utils.getMouseY(),
                             )
                             GlStateManager.popMatrix()
                         }


### PR DESCRIPTION
## What
This PR moves the actual rendering of renderable tooltips to the end of all rendering as to not have issues with overlays in guis rendering over them. i.e. highlights

## Changelog Fixes
+ Fixed slot highlight showing over item tooltip. - ThatGravyBoat

## Changelog Technical Details
+ Renderable tooltips are now deferred in end of RenderTick. - ThatGravyBoat
    * Tooltips should only be set in between RenderTickEvent start and RenderTickEvent end. i.e. screen render events.
