### PR TITLE
Fix: flicker in tooltip move

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/menu/ChocolateFactoryTooltipCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/chocolatefactory/menu/ChocolateFactoryTooltipCompact.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 object ChocolateFactoryTooltipCompact {
@@ -43,7 +42,7 @@ object ChocolateFactoryTooltipCompact {
     fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!ChocolateFactoryAPI.inChocolateFactory) return
         if (config.tooltipMove) {
-            if (lastHover.passedSince() < 300.milliseconds) {
+            if (lastHover.passedSince() < 1.seconds) {
                 config.tooltipMovePosition.renderStrings(tooltipToHover, posLabel = "Tooltip Move")
             }
         }


### PR DESCRIPTION
## What
Fix flicker in tooltip move.
Report: https://discord.com/channels/997079228510117908/1234485432859889665

## Changelog Fixes
+ Fixed Chocolate Factory Move Tooltip flickering when clicking quickly. - hannibal2