### PR TITLE
Fix: Bazaar buy order error when nothing to cancel

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -53,6 +53,12 @@ class BazaarCancelledBuyOrderClipboard {
             latestAmount = group("amount").formatInt()
             return
         }
+
+        // nothing to cancel
+        if (lore.firstOrNull() == "§7Cannot cancel order while there are") {
+            return
+        }
+
         ErrorManager.logErrorStateWithData(
             "BazaarCancelledBuyOrderClipboard error",
             "lastAmountPattern can not find latestAmount",


### PR DESCRIPTION
## What
Fixed bazaar buy order error when nothing to cancel
Report: https://discord.com/channels/997079228510117908/1234931405167919146

## Changelog Fixes
+ Fixed Bazaar buy order error when nothing to cancel. - hannibal2