### PR TITLE
Fix: Bump ipc version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
     forge("net.minecraftforge:forge:1.8.9-11.15.1.2318-1.8.9")
 
     // Discord RPC client
-    shadowImpl("com.jagrosh:DiscordIPC:0.5.2") {
+    shadowImpl("com.jagrosh:DiscordIPC:0.5.3") {
         exclude(module = "log4j")
         because("Different version conflicts with Minecraft's Log4J")
         exclude(module = "gson")


### PR DESCRIPTION
## What
Fixes issue where unix socket was missing method, even though it was just marked as deprecated.
See: https://github.com/ThatGravyBoat/DiscordIPC/commit/b0a41062b539af771004f8b526d34050806a16bc

## Changelog Fixes
+ Fixed crash on Unix with Discord Rich Presence. - ThatGravyBoat
