### PR TITLE
Fix: mining islands slayer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -38,6 +38,7 @@ class MiningEventTracker {
         "bossbar.active",
         "§e§lEVENT (?<event>.+) §e§lACTIVE IN (?<area>.+) §e§lfor §a§l(?<time>\\S+)§r"
     )
+    // TODO add test messages
     private val eventStartedPattern by patternGroup.pattern(
         "started",
         "(?:§.)*\\s+(?:§.)+§l(?<event>.+) STARTED!"
@@ -98,6 +99,9 @@ class MiningEventTracker {
     }
 
     private fun sendData(eventName: String, time: String?) {
+        // TODO fix this via regex
+        if (eventName == "SLAYER QUEST") return
+
         val eventType = MiningEventType.fromEventName(eventName) ?: run {
             if (!config.enabled) return
             ErrorManager.logErrorWithData(


### PR DESCRIPTION
## What
Fixed error message when starting slayer quest in mining islands.
Report: https://discord.com/channels/997079228510117908/1234068934576312390

## Changelog Fixes
+ Fixed error message when starting slayer quest in mining islands. - hannibal2