### PR TITLE
Fix: Estimated Item Value not visible in PV

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
@@ -1,14 +1,25 @@
 package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.events.item.ItemHoverEvent
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import net.minecraft.inventory.Slot
+import net.minecraft.item.ItemStack
 
 // Please use LorenzToolTipEvent over ItemTooltipEvent if no special EventPriority is necessary
 object ToolTipData {
+    fun getTooltip(stack: ItemStack, toolTip: MutableList<String>): List<String> {
+        onHover(stack, toolTip)
+        return onTooltip(toolTip)
+    }
+
+    private fun onHover(stack: ItemStack, toolTip: MutableList<String>) {
+        ItemHoverEvent(stack, toolTip).postAndCatch()
+    }
+
     fun onTooltip(toolTip: MutableList<String>): List<String> {
         val slot = lastSlot ?: return toolTip
         val itemStack = slot.stack ?: return toolTip

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ItemHoverEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ItemHoverEvent.kt
@@ -1,0 +1,6 @@
+package at.hannibal2.skyhanni.events.item
+
+import at.hannibal2.skyhanni.events.LorenzEvent
+import net.minecraft.item.ItemStack
+
+class ItemHoverEvent(val itemStack: ItemStack, val toolTip: List<String>) : LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -7,10 +7,10 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuReforgeStoneJson
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
-import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.events.RenderItemTooltipEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.item.ItemHoverEvent
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
@@ -63,7 +63,7 @@ object EstimatedItemValue {
     }
 
     @SubscribeEvent
-    fun onTooltip(event: LorenzToolTipEvent) {
+    fun onTooltip(event: ItemHoverEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.enabled) return
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
@@ -25,6 +25,7 @@ public class MixinItemStack implements ItemStackCachedData {
 
     @Inject(method = "getTooltip", at = @At("RETURN"))
     public void getTooltip(EntityPlayer playerIn, boolean advanced, CallbackInfoReturnable<List<String>> ci) {
-        ToolTipData.INSTANCE.onTooltip(ci.getReturnValue());
+        ItemStack stack = (ItemStack) (Object) this;
+        ToolTipData.INSTANCE.getTooltip(stack, ci.getReturnValue());
     }
 }


### PR DESCRIPTION
## What
Fixed Estimated Item Value not visible in PV
Report: https://discord.com/channels/997079228510117908/1233949552617459832

## Changelog Fixes
+ Fixed Estimated Item Value not visible in PV. - hannibal2

## Changelog Technical Details
+ Created new event ItemHoverEvent. - hannibal2