### PR TITLE
Improvement: disable mark low levels

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -243,7 +243,9 @@ class DungeonFinderFeatures {
                     group("className")
                 }
             }
-            if (memberLevels.any { (it ?: Integer.MAX_VALUE) <= config.markBelowClassLevel }) {
+            if ((memberLevels.any {
+                    (it ?: Integer.MAX_VALUE) <= config.markBelowClassLevel
+                }) && config.markBelowClassLevel != 0) {
                 map[slot] = LorenzColor.YELLOW
                 continue
             }


### PR DESCRIPTION
## What
if mark low levels is  set to 0 the feature is disabled

## Changelog Improvements
+ Added a way to disable marking low-level parties in dungeon finder by setting it to 0. - seraid
