### PR TITLE
Fix: Slayer warning rift

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
@@ -146,7 +146,7 @@ class SlayerQuestWarning {
 
     @SubscribeEvent
     fun onEntityHealthUpdate(event: EntityHealthUpdateEvent) {
-        if (!(LorenzUtils.inSkyBlock)) return
+        if (!LorenzUtils.inSkyBlock) return
 
         val entity = event.entity
         if (entity.getLorenzVec().distanceToPlayer() < 6 && isSlayerMob(entity)) {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerType.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.features.slayer
 
-import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.entity.monster.EntityBlaze
 import net.minecraft.entity.monster.EntityEnderman
 import net.minecraft.entity.monster.EntitySpider
@@ -13,6 +12,6 @@ enum class SlayerType(val displayName: String, val clazz: Class<*>) {
     SVEN("Sven Packmaster", EntityWolf::class.java),
     VOID("Voidgloom Seraph", EntityEnderman::class.java),
     INFERNO("Inferno Demonlord", EntityBlaze::class.java),
-    VAMPIRE("Riftstalker Bloodfiend", EntityOtherPlayerMP::class.java)
+    VAMPIRE("Riftstalker Bloodfiend", EntityZombie::class.java)
     ;
 }


### PR DESCRIPTION
## What
Fixed slayer failed warnings not showing up in rift.
Report: https://discord.com/channels/997079228510117908/1233385527928033331

## Changelog Fixes
+ Fixed Slayer failed warnings not showing up in Rift. - hannibal2