### PR TITLE
Fix: Excavator Profile Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -58,7 +58,11 @@ class ExcavatorProfitTracker {
 
         @Expose
         var timesExcavated = 0L
+
+        @Expose
         var glacitePowderGained = 0L
+
+        @Expose
         var fossilDustGained = 0L
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorAPI.kt
@@ -112,7 +112,7 @@ object FossilExcavatorAPI {
             ItemUtils.readItemAmount(group("item"))
         } ?: return
         // Workaround: If it is a enchanted book, we assume it is a paleontologist I book
-        if (pair.first.let { it ==  "§fEnchanted" || it == "§fEnchanted Book"}) {
+        if (pair.first.let { it == "§fEnchanted" || it == "§fEnchanted Book" }) {
             pair = "Paleontologist I" to pair.second
         }
         loot.add(pair)

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
@@ -21,10 +21,11 @@ class ProfitPerExcavation {
 
         var totalProfit = 0.0
         val map = mutableMapOf<String, Double>()
-        loot.forEach { (name, amount) ->
+        for ((name, amount) in loot) {
+            if (name == "§bGlacite Powder") continue
             NEUInternalName.fromItemNameOrNull(name)?.let {
                 val pricePer = it.getPrice()
-                if (pricePer == -1.0) return@forEach
+                if (pricePer == -1.0) continue
                 val profit = amount * pricePer
                 val text = "Found $name §8${amount.addSeparators()}x §7(§6${NumberUtil.format(profit)}§7)"
                 map[text] = profit


### PR DESCRIPTION
## What
Fixed two bugs in the bone search mini-game in the Dwarven base camp.

<details>
<summary>Images</summary>
![image](https://github.com/hannibal002/SkyHanni/assets/24389977/edd4627c-98a6-4183-a133-59932cc238b5)

</details>

## Changelog Fixes
+ Fixed Profit per Excavation including Glacite Powder. - hannibal2
+ Fixed Fossil Dust and Glacite Powder saving in Excavation Profit tracker. - hannibal2