### PR TITLE
Fix: Quiver Warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/QuiverAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/QuiverAPI.kt
@@ -224,7 +224,7 @@ object QuiverAPI {
                     if (currentArrowType != currentArrow || amount != currentAmount) {
                         currentArrow = currentArrowType
                         currentAmount = amount
-                        QuiverUpdateEvent(currentArrowType, currentAmount, shouldHideAmount()).postAndCatch()
+                        QuiverUpdateEvent(currentArrowType, amount, shouldHideAmount()).postAndCatch()
                     }
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverWarning.kt
@@ -2,24 +2,15 @@ package at.hannibal2.skyhanni.features.gui.quiver
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.ArrowType
-import at.hannibal2.skyhanni.data.QuiverAPI
-import at.hannibal2.skyhanni.data.QuiverAPI.arrowAmount
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.DungeonCompleteEvent
-import at.hannibal2.skyhanni.events.DungeonEnterEvent
 import at.hannibal2.skyhanni.events.KuudraCompleteEvent
-import at.hannibal2.skyhanni.events.KuudraEnterEvent
-import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.QuiverUpdateEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.DelayedRun
-import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
-import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.SoundUtils
-import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
@@ -27,35 +18,9 @@ class QuiverWarning {
 
     private val config get() = SkyHanniMod.feature.combat.quiverConfig
 
-    private var arrow: ArrowType? = null
-    private var amount = QuiverAPI.currentAmount
     private var lastLowQuiverReminder = SimpleTimeMark.farPast()
-    private var arrowsUsedInRun = mutableListOf<ArrowType>()
-    private var arrowsToAlert = mutableListOf<String>()
-    private var inInstance = false
-
-    @SubscribeEvent
-    fun onWorldChange(event: LorenzWorldChangeEvent) {
-        arrowsUsedInRun = mutableListOf()
-        arrowsToAlert = mutableListOf()
-        inInstance = false
-    }
-
-    @SubscribeEvent
-    fun onDungeonEnter(event: DungeonEnterEvent) {
-        onInstanceEnter()
-    }
-
-    @SubscribeEvent
-    fun onKuudraEnter(event: KuudraEnterEvent) {
-        onInstanceEnter()
-    }
-
-    private fun onInstanceEnter() {
-        arrowsUsedInRun = mutableListOf()
-        arrowsToAlert = mutableListOf()
-        inInstance = true
-    }
+    private var lowDuringInstance = false
+    private var amount = 0
 
     @SubscribeEvent
     fun onDungeonComplete(event: DungeonCompleteEvent) {
@@ -68,46 +33,31 @@ class QuiverWarning {
     }
 
     private fun onInstanceComplete() {
-        if (!config.reminderAfterRun) return
-        if (arrowsUsedInRun.isEmpty()) return
-        for (arrow in arrowsUsedInRun) {
-            val internalName = arrow.internalName
-            val amount = arrowAmount[internalName] ?: continue
-            if (amount > config.lowQuiverAmount) continue
-            val rarity = internalName.getItemStackOrNull()?.getItemRarityOrNull()?.chatColorCode ?: "§f"
-            arrowsToAlert.add(rarity + arrow.arrow)
-        }
-        if (arrowsToAlert.isNotEmpty()) instanceAlert()
-    }
+        if (!lowDuringInstance) return
+        lowDuringInstance = false
 
-    private fun instanceAlert() {
-        DelayedRun.runNextTick {
-            TitleManager.sendTitle("§cLow on arrows!", 5.seconds, 3.6, 7f)
-            ChatUtils.chat("Low on ${arrowsToAlert.createCommaSeparatedList()}!")
-            SoundUtils.repeatSound(100, 30, SoundUtils.plingSound)
+        if (config.reminderAfterRun) {
+            lowQuiverAlert()
         }
     }
 
     private fun lowQuiverAlert() {
         if (lastLowQuiverReminder.passedSince() < 30.seconds) return
         lastLowQuiverReminder = SimpleTimeMark.now()
-        val itemStack = getItemStackOrNull(arrow?.internalName?.asString() ?: return) ?: return
-        val rarity = itemStack.getItemRarityOrNull()?.chatColorCode ?: "§f"
-        TitleManager.sendTitle("§cLow on $rarity${arrow?.arrow}!", 5.seconds, 3.6, 7f)
-        ChatUtils.chat("Low on $rarity${arrow?.arrow} §e(${amount.addSeparators()} left)")
+        TitleManager.sendTitle("§cLow on arrows!", 5.seconds, 3.6, 7f)
+        ChatUtils.chat("Low on arrows §e(${amount.addSeparators()} left)")
     }
 
     @SubscribeEvent
     fun onQuiverUpdate(event: QuiverUpdateEvent) {
-        val lastArrow = arrow
-        val lastAmount = amount
+        amount = event.currentAmount
 
-        if (config.lowQuiverNotification && amount <= config.lowQuiverAmount) {
-            if (arrow != lastArrow || (arrow == lastArrow && amount <= lastAmount)) lowQuiverAlert()
+        if (amount > config.lowQuiverAmount) return
+        if (DungeonAPI.inDungeon() || LorenzUtils.inKuudraFight) {
+            lowDuringInstance = true
         }
-
-        if (inInstance) {
-            if (!arrowsUsedInRun.contains(arrow)) arrowsUsedInRun.add(arrow ?: return)
+        if (config.lowQuiverNotification) {
+            lowQuiverAlert()
         }
     }
 


### PR DESCRIPTION
## What
Rewrote the quiver warning logic almost entirely. Before, it was using arrow type. This was not working fine. Even if the quiver type had worked, the logic was broken.
We can surely add back the arrow type support later on. But first, a quick fix.
Report: https://discord.com/channels/997079228510117908/1234525082630492316

## Changelog Fixes
+ Fixed the low quiver warning. - hannibal2