### PR TITLE
Fix: sendcoords too long description

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherSendCoordinates.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherSendCoordinates.kt
@@ -47,7 +47,7 @@ class PatcherSendCoordinates {
             val end = group("z")
             val z = if (end.contains(" ")) {
                 val split = end.split(" ")
-                val extra = split.drop(1).joinToString(" ")
+                val extra = split.drop(1).joinToString(" ").take(50)
                 description += " $extra"
 
                 split.first().toFloat()


### PR DESCRIPTION
## What
Cut the patcher sendcoords description length to not be too long

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/3efecf77-5cd7-407f-969f-4f65f3082ff8)

</details>

## Changelog Fixes
+ Fixed overly long description for Patcher send coordinates waypoints. - hannibal2