### PR TITLE
Fix: Magical Power not setting to 0 when the Line doesn't exist

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -277,6 +277,9 @@ object MaxwellAPI {
                 return@matchMatcher
             }
         }
+
+        // If Magical Power isn't in the lore
+        magicalPower = 0
     }
 
     private fun getPowerByNameOrNull(name: String) = powers.find { it == name }


### PR DESCRIPTION
## What
Describe what this pull request does, including technical details, screenshots, links to discord, etc.


## Changelog Fixes
+ Fixed Magical Power not setting to zero when the mod can't find the magical power line. - j10a1n15