### PR TITLE
Fix: Reputation Helper wrong miniboss amount

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -41,6 +41,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.StringUtils.removeWordsAtEnd
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.inventory.ContainerChest
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -53,6 +54,12 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
     private val questLoader = QuestLoader(this)
     val quests = mutableListOf<Quest>()
     var greatSpook = false
+
+
+    val minibossAmountPattern by RepoPattern.pattern(
+        "crimson.reputationhelper.quest.minibossamount",
+        "(§7Kill the §c.+ §7|.*)miniboss §a(?<amount>\\d) §7times?!"
+    )
 
     private val config get() = SkyHanniMod.feature.crimsonIsle.reputationHelper
 

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -55,10 +55,14 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
     val quests = mutableListOf<Quest>()
     var greatSpook = false
 
-
+    /**
+     * REGEX-TEST: §7Kill the §cAshfang §7miniboss §a2 §7times!
+     * REGEX-TEST: §7Kill the §cMage Outlaw §7miniboss §a1 §7time!
+     * REGEX-TEST: §7miniboss §a1 §7time!
+     */
     val minibossAmountPattern by RepoPattern.pattern(
         "crimson.reputationhelper.quest.minibossamount",
-        "(§7Kill the §c.+ §7|.*)miniboss §a(?<amount>\\d) §7times?!"
+        "(?:§7Kill the §c.+ §7|.*)miniboss §a(?<amount>\\d) §7times?!"
     )
 
     private val config get() = SkyHanniMod.feature.crimsonIsle.reputationHelper

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
@@ -15,10 +15,13 @@ import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.quest.T
 import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.quest.UnknownQuest
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.TabListData
+import net.minecraft.item.ItemStack
 
 class QuestLoader(private val dailyQuestHelper: DailyQuestHelper) {
 
@@ -165,6 +168,32 @@ class QuestLoader(private val dailyQuestHelper: DailyQuestHelper) {
             val accepted = !stack.getLore().any { it.contains("Click to start!") }
             if (accepted && quest.state == QuestState.NOT_ACCEPTED) {
                 quest.state = QuestState.ACCEPTED
+                dailyQuestHelper.update()
+            }
+            if (name == "Miniboss") {
+                fixMinibossAmount(quest, stack)
+            }
+        }
+    }
+
+    // TODO remove this workaround once hypixel fixes the bug that amount is not in tab list for minibosses
+    private fun fixMinibossAmount(quest: Quest, stack: ItemStack) {
+        if (quest !is MiniBossQuest) return
+        val storedAmount = quest.needAmount
+        if (storedAmount != 1) return
+        val pattern = "§7Kill the §c.+ §7miniboss §a(?<amount>\\d) §7times?!".toPattern()
+        for (line in stack.getLore()) {
+            val realAmount = pattern.matchMatcher(line) {
+                group("amount").toInt()
+            } ?: continue
+            if (storedAmount == realAmount) continue
+
+            ChatUtils.debug("Wrong amount detected! realAmount: $realAmount, storedAmount: $storedAmount")
+            val newQuest = MiniBossQuest(quest.miniBoss, quest.state, realAmount)
+            DelayedRun.runNextTick {
+                dailyQuestHelper.quests.remove(quest)
+                dailyQuestHelper.quests.add(newQuest)
+                ChatUtils.chat("Fixed wrong miniboss amount from tab list.")
                 dailyQuestHelper.update()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
@@ -181,9 +181,8 @@ class QuestLoader(private val dailyQuestHelper: DailyQuestHelper) {
         if (quest !is MiniBossQuest) return
         val storedAmount = quest.needAmount
         if (storedAmount != 1) return
-        val pattern = "§7Kill the §c.+ §7miniboss §a(?<amount>\\d) §7times?!".toPattern()
         for (line in stack.getLore()) {
-            val realAmount = pattern.matchMatcher(line) {
+            val realAmount = dailyQuestHelper.minibossAmountPattern.matchMatcher(line) {
                 group("amount").toInt()
             } ?: continue
             if (storedAmount == realAmount) continue


### PR DESCRIPTION
## What
Fixed wrong miniboss amount from tab list in Crimson Isle Reputation Helper.
This is a Hypixel bug, we are just doing a workaround.
bug report: https://discord.com/channels/997079228510117908/1014624630541144144/1105970808477720616

## Changelog Fixes
+ Fixed incorrect miniboss amount displayed by Crimson Isle Reputation Helper. - hannibal2