### PR TITLE
Backend: better error detection in enchant parser

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
@@ -174,7 +175,18 @@ object EnchantParser {
         }
 
         // Remove enchantment lines so we can insert ours
-        loreList.subList(startEnchant, endEnchant + 1).clear()
+        try {
+            loreList.subList(startEnchant, endEnchant + 1).clear()
+        } catch (e: IndexOutOfBoundsException) {
+            ErrorManager.logErrorWithData(
+                e,
+                "Error parsing enchantment info from item",
+                "loreList" to loreList,
+                "startEnchant" to startEnchant,
+                "endEnchant" to endEnchant,
+            )
+            return
+        }
 
         val insertEnchants: MutableList<String> = mutableListOf()
 
@@ -256,10 +268,10 @@ object EnchantParser {
         // Normal is leaving the formatting as Hypixel provides it
         if (config.format.get() == EnchantParsingConfig.EnchantFormat.NORMAL) {
             normalFormatting(insertEnchants)
-        // Compressed is always forcing 3 enchants per line, except when there is stacking enchant progress visible
+            // Compressed is always forcing 3 enchants per line, except when there is stacking enchant progress visible
         } else if (config.format.get() == EnchantParsingConfig.EnchantFormat.COMPRESSED && !shouldBeSingleColumn) {
             compressedFormatting(insertEnchants)
-        // Stacked is always forcing 1 enchant per line
+            // Stacked is always forcing 1 enchant per line
         } else {
             stackedFormatting(insertEnchants)
         }
@@ -320,7 +332,11 @@ object EnchantParser {
         }
     }
 
-    private fun finishFormatting(insertEnchants: MutableList<String>, builder: StringBuilder, commaFormat: CommaFormat) {
+    private fun finishFormatting(
+        insertEnchants: MutableList<String>,
+        builder: StringBuilder,
+        commaFormat: CommaFormat,
+    ) {
         if (builder.isNotEmpty()) insertEnchants.add(builder.toString())
 
         // Check if there is a trailing space (therefore also a comma) and remove the last 2 chars
@@ -371,7 +387,7 @@ object EnchantParser {
         return if (removeGrayEnchants) -1 else lastGrayEnchant
     }
 
-    private fun itemIsBook() : Boolean {
+    private fun itemIsBook(): Boolean {
         return currentItem?.getItemCategoryOrNull() == ItemCategory.ENCHANTED_BOOK
     }
 


### PR DESCRIPTION
## What
better error detection in the enchant parser
Report: https://discord.com/channels/997079228510117908/1235273260661473441

<details>
<summary>Stack Trace</summary>

```
SkyHanni 0.25.Beta.17: Caught an IndexOutOfBoundsException in EnchantParser at LorenzToolTipEvent: fromIndex = -1
 
Caused by java.lang.IndexOutOfBoundsException: fromIndex = -1
    at java.util.ArrayList.subListRangeCheck(ArrayList.java:1012)
    at java.util.ArrayList.subList(ArrayList.java:1006)
    at SH.features.misc.items.enchants.EnchantParser.parseEnchants(EnchantParser.kt:177)
    at SH.features.misc.items.enchants.EnchantParser.onTooltipEvent(EnchantParser.kt:99)
    at SH.data.ToolTipData.onTooltip(ToolTipData.kt:16)
    at MC.item.ItemStack.handler$zij000$getTooltip(ItemStack.java:3566)
    at MC.item.ItemStack.func_82840_a(ItemStack.java:752)
    at MC.client.gui.GuiScreen.func_146285_a(GuiScreen.java:132)
    at MC.client.gui.inventory.GuiContainer.func_73863_a(GuiContainer.java:165)
    at net.minecraftforge.client.ForgeHooksClient.drawScreen(ForgeHooksClient.java:311)
    at MC.client.renderer.EntityRenderer.func_181560_a(EntityRenderer.java:1436)
    at MC.client.Minecraft.func_71411_J(Minecraft.java:1051)
    at MC.client.Minecraft.handler$bgo000$run(Minecraft.java:3250)
    at MC.client.Minecraft.func_99999_d(Minecraft.java)
    at MC.client.main.Main.main(SourceFile:124)
```

</details>

## Changelog Technical Details
+ Better error detection in the enchant parser. - hannibal2