### PR TITLE
Fix: Visitor's Logbook stats display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.inventory
 
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -7,6 +8,7 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorAPI
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
@@ -40,6 +42,7 @@ class LogBookStats {
 
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+        if (IslandType.GARDEN_GUEST.isInIsland()) return
         val inventoryName = event.inventoryName
         if (inventoryName != "Visitor's Logbook") return
 
@@ -76,6 +79,7 @@ class LogBookStats {
 
     @SubscribeEvent
     fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+        if (IslandType.GARDEN_GUEST.isInIsland()) return
         if (inInventory && config.showLogBookStats) {
             config.logBookStatsPos.renderRenderables(
                 display,


### PR DESCRIPTION
## What
Make the Visitor's logbook stats display do not show while guesting.

## Changelog Fixes
+ Fixed Visitor's logbook stats display showing while guesting. - HiZe

