### PR TITLE
Fix: Farming lane detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneAPI.kt
@@ -26,7 +26,7 @@ object FarmingLaneAPI {
     @SubscribeEvent
     fun onCropClick(event: CropClickEvent) {
         val crop = event.crop
-        GardenAPI.hasFarmingToolInHand()
+        if (!GardenAPI.hasFarmingToolInHand()) return
 
         val lanes = lanes ?: return
         val lane = lanes[crop]


### PR DESCRIPTION
## What
Fixed farming lane corner activating when clicking on crops with non farming tools

## Changelog Fixes
+ Fixed Farming Lane auto-activation when clicking on crops without farming tool. - hannibal2