### PR TITLE
Improvement: Pest line middle of plot

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleLine.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleLine.kt
@@ -6,8 +6,11 @@ import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
+import at.hannibal2.skyhanni.features.garden.GardenPlotAPI
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.LocationUtils
+import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils.isAnyOf
 import at.hannibal2.skyhanni.utils.LorenzVec
@@ -85,6 +88,17 @@ class PestParticleLine {
         for (list in locations) {
             draw(event, list)
         }
+        showMiddle(event)
+    }
+
+    private fun showMiddle(event: LorenzRenderWorldEvent) {
+        if (locations.size <= 0) return
+        val plot = GardenPlotAPI.getCurrentPlot() ?: return
+        val middle = plot.middle.copy(y = LocationUtils.playerLocation().y)
+        if (middle.distanceToPlayer() > 15) return
+
+        event.drawWaypointFilled(middle, LorenzColor.GRAY.toColor())
+        event.drawDynamicText(middle, "Middle", 1.0)
     }
 
     private fun draw(event: LorenzRenderWorldEvent, list: List<ParticleLocation>) {


### PR DESCRIPTION
## What
Show middle of plot while pest line is showing

## Changelog Improvements
+ Displays the middle of the plot while the pest line is showing. - hannibal2
    * This makes it clearer when the guess points to the middle of the plot rather than to a pest.