### PR TITLE
Improvement: Armor Drop Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/ArmorDropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/ArmorDropTracker.kt
@@ -94,6 +94,7 @@ object ArmorDropTracker {
         if (!GardenAPI.inGarden()) return
         if (!config.enabled) return
         if (!hasArmor) return
+        if (!GardenAPI.hasFarmingToolInHand()) return
 
         tracker.renderDisplay(config.pos)
     }


### PR DESCRIPTION
## What
Only show armor drop tracker when holding a farming tool.

## Changelog Improvements
+ Armor drop tracker now displays only when holding a farming tool. - hannibal2