### PR TITLE
Fix: Max Player Size in Mineshaft

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -182,11 +182,12 @@ class HypixelData {
             ScoreboardData.sidebarLinesFormatted.matchFirst(scoreboardVisitingAmoutPattern) {
                 return group("maxamount").toInt()
             }
-            val islandSpecific = mapOf(
-                IslandType.MINESHAFT to 4,
-                IslandType.CRYSTAL_HOLLOWS to 24
-            )
-            return islandSpecific[skyBlockIsland] ?: if (serverId?.startsWith("mega") == true) 80 else 26
+
+            return when (skyBlockIsland) {
+                IslandType.MINESHAFT -> 4
+                IslandType.CRYSTAL_HOLLOWS -> 24
+                else -> if (serverId?.startsWith("mega") == true) 80 else 26
+            }
         }
 
         // This code is modified from NEU, and depends on NEU (or another mod) sending /locraw.

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.matchFirst
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
@@ -183,8 +182,11 @@ class HypixelData {
             ScoreboardData.sidebarLinesFormatted.matchFirst(scoreboardVisitingAmoutPattern) {
                 return group("maxamount").toInt()
             }
-            if (IslandType.CRYSTAL_HOLLOWS.isInIsland()) return 24
-            return if (serverId?.startsWith("mega") == true) 80 else 26
+            val islandSpecific = mapOf(
+                IslandType.MINESHAFT to 4,
+                IslandType.CRYSTAL_HOLLOWS to 24
+            )
+            return islandSpecific[skyBlockIsland] ?: if (serverId?.startsWith("mega") == true) 80 else 26
         }
 
         // This code is modified from NEU, and depends on NEU (or another mod) sending /locraw.


### PR DESCRIPTION
## What
Max Player Count is 4 in there.

## Changelog Fixes
+ Fixed wrong max lobby size in Custom Scoreboard size while in Mineshaft. - j10a1n15
