### PR TITLE
Fix: Dungeon Copilot in Entrance floor

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
@@ -86,7 +86,7 @@ class DungeonCopilot {
         if (message == "§c[BOSS] The Watcher§r§f: That will be enough for now.") changeNextStep("Clear Blood Room")
 
         if (message == "§c[BOSS] The Watcher§r§f: You have proven yourself. You may pass.") {
-            if (DungeonAPI.getCurrentBoss() == DungeonFloor.ENTRANCE) {
+            if (DungeonAPI.getCurrentBoss() == DungeonFloor.E) {
                 changeNextStep("")
             } else {
                 changeNextStep("Enter Boss Room")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFloor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFloor.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.features.dungeon
 
 enum class DungeonFloor(private val bossName: String) {
-    ENTRANCE("The Watcher"),
+    E("The Watcher"),
     F1("Bonzo"),
     F2("Scarf"),
     F3("The Professor"),


### PR DESCRIPTION
## What
Fixes IllegalArgumentException when trying to run `getCurrentBoss()` in the entrance floor

## Changelog Fixes
+ Fixed Dungeon Copilot not working on the Entrance Floor. - martimavocado
