### PR TITLE
Fix upside down mixin and split up spinny from upside down

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ContributorsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ContributorsJson.kt
@@ -10,5 +10,6 @@ data class ContributorsJson(
 data class ContributorJsonEntry(
     @Expose val suffix: String = "§c:O",
     @Expose val spinny: Boolean = false,
+    @Expose val upsideDown: Boolean = false,
     @Expose @SerializedName("external_mod") val externalMod: String? = null,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -18,7 +18,8 @@ object ContributorManager {
 
     fun getTabListSuffix(username: String): String? = getContributor(username)?.suffix
 
-    fun canSpin(username: String): Boolean = getContributor(username)?.spinny ?: false
+    fun shouldSpin(username: String): Boolean = getContributor(username)?.spinny ?: false
+    fun shouldBeUpsideDown(username: String): Boolean = getContributor(username)?.upsideDown ?: false
 
     private fun getContributor(username: String) =
         contributors[username.lowercase()]?.let { it.takeIf { it.isAllowed() } }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RendererLivingEntityHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RendererLivingEntityHook.kt
@@ -41,7 +41,6 @@ object RendererLivingEntityHook {
      */
     @JvmStatic
     fun rotatePlayer(player: EntityPlayer) {
-        if (!config.rotateContributors) return
         if (!LorenzUtils.inSkyBlock) return
         if (!config.rotateContributors && !LorenzUtils.isAprilFoolsDay) return
         val name = player.name ?: return

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RendererLivingEntityHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RendererLivingEntityHook.kt
@@ -8,9 +8,10 @@ import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.player.EntityPlayer
 
-class RendererLivingEntityHook {
+object RendererLivingEntityHook {
     private val config get() = SkyHanniMod.feature.dev
 
+    @JvmStatic
     fun setOutlineColor(red: Float, green: Float, blue: Float, alpha: Float, entity: EntityLivingBase) {
         val color = EntityOutlineRenderer.getCustomOutlineColor(entity)
 
@@ -27,18 +28,24 @@ class RendererLivingEntityHook {
     /**
      * Check if the player is on the cool person list and if they should be flipped.
      */
-    fun isCoolPerson(userName: String?): Boolean {
+    @JvmStatic
+    fun shouldBeUpsideDown(userName: String?): Boolean {
         if (!LorenzUtils.inSkyBlock) return false
         if (!config.flipContributors && !LorenzUtils.isAprilFoolsDay) return false
         val name = userName ?: return false
-        return ContributorManager.canSpin(name)
+        return ContributorManager.shouldBeUpsideDown(name)
     }
 
     /**
-     * Player is already on the cool person list so rotate them if the option is on.
+     * Check if the player should spin and rotate them if the option is on.
      */
+    @JvmStatic
     fun rotatePlayer(player: EntityPlayer) {
         if (!config.rotateContributors) return
+        if (!LorenzUtils.inSkyBlock) return
+        if (!config.rotateContributors && !LorenzUtils.isAprilFoolsDay) return
+        val name = player.name ?: return
+        if (!ContributorManager.shouldSpin(name)) return
         val rotation = ((player.ticksExisted % 90) * 4).toFloat()
         GlStateManager.rotate(rotation, 0f, 1f, 0f)
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRendererLivingEntity.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRendererLivingEntity.java
@@ -4,18 +4,14 @@ import at.hannibal2.skyhanni.mixins.hooks.RendererLivingEntityHook;
 import net.minecraft.client.renderer.entity.RendererLivingEntity;
 import net.minecraft.entity.EntityLivingBase;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(RendererLivingEntity.class)
 public class MixinRendererLivingEntity {
 
-    @Unique
-    private final RendererLivingEntityHook skyHanni$hook = new RendererLivingEntityHook();
-
     @Redirect(method = "setScoreTeamColor", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GlStateManager;color(FFFF)V"))
     public void setOutlineColor(float colorRed, float colorGreen, float colorBlue, float colorAlpha, EntityLivingBase entity) {
-        skyHanni$hook.setOutlineColor(colorRed, colorGreen, colorBlue, colorAlpha, entity);
+        RendererLivingEntityHook.setOutlineColor(colorRed, colorGreen, colorBlue, colorAlpha, entity);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinContributorRendererEntityLiving.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinContributorRendererEntityLiving.java
@@ -6,24 +6,37 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EnumPlayerModelParts;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = RendererLivingEntity.class, priority = 500)
 public class MixinContributorRendererEntityLiving<T extends EntityLivingBase> {
 
-    @Unique
-    private final RendererLivingEntityHook skyHanni$hook = new RendererLivingEntityHook();
-
-    @Redirect(method = "rotateCorpse", at = @At(value = "INVOKE", target = "Ljava/lang/String;equals(Ljava/lang/Object;)Z", ordinal = 0))
-    private boolean checkName(String displayName, Object v2, T bat, float p_77043_2_, float p_77043_3_, float partialTicks) {
-        return skyHanni$hook.isCoolPerson(displayName);
+    @ModifyVariable(
+        method = "rotateCorpse",
+        at = @At(value = "INVOKE", target = "Ljava/lang/String;equals(Ljava/lang/Object;)Z", ordinal = 0, shift = At.Shift.BEFORE)
+    )
+    private String checkNameForUpsideDown(String displayName) {
+        if (RendererLivingEntityHook.shouldBeUpsideDown(displayName))
+            return "Grumm";
+        return displayName;
     }
 
-    @Redirect(method = "rotateCorpse", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isWearing(Lnet/minecraft/entity/player/EnumPlayerModelParts;)Z"))
-    private boolean isWearing(EntityPlayer player, EnumPlayerModelParts p_175148_1_) {
-        skyHanni$hook.rotatePlayer(player);
+    @Redirect(
+        method = "rotateCorpse",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isWearing(Lnet/minecraft/entity/player/EnumPlayerModelParts;)Z"))
+    private boolean alwaysMarkAsHavingCape(EntityPlayer instance, EnumPlayerModelParts p_175148_1_) {
+        // Always returning true here ensures maximal compatibility with other mods. This will no longer block other mods from implementing this same mixin.
         return true;
+    }
+
+    @Inject(method = "rotateCorpse", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/EnumChatFormatting;getTextWithoutFormattingCodes(Ljava/lang/String;)Ljava/lang/String;", shift = At.Shift.AFTER))
+    private void rotateThePlayer(T bat, float p_77043_2_, float p_77043_3_, float partialTicks, CallbackInfo ci) {
+        if (bat instanceof EntityPlayer) {
+            RendererLivingEntityHook.rotatePlayer((EntityPlayer) bat);
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinRendererLivingEntityHookSBA.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinRendererLivingEntityHookSBA.java
@@ -6,7 +6,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EnumPlayerModelParts;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -15,19 +14,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(targets = "codes/biscuit/skyblockaddons/asm/hooks/RendererLivingEntityHook")
 public class MixinRendererLivingEntityHookSBA<T extends EntityLivingBase> {
 
-    @Unique
-    private static final RendererLivingEntityHook skyHanni$hook = new RendererLivingEntityHook();
-
     @Inject(method = "equals", at = @At("HEAD"), cancellable = true, remap = false)
     private static void onEquals(String displayName, Object otherString, CallbackInfoReturnable<Boolean> cir) {
-        if (skyHanni$hook.isCoolPerson(displayName)) {
+        if (RendererLivingEntityHook.shouldBeUpsideDown(displayName)) {
             cir.setReturnValue(true);
         }
     }
 
     @Inject(method = "isWearing", at = @At("HEAD"), cancellable = true, remap = false)
     private static void onIsWearing(EntityPlayer player, EnumPlayerModelParts p_175148_1_, CallbackInfoReturnable<Boolean> cir) {
-        skyHanni$hook.rotatePlayer(player);
         cir.setReturnValue(true);
     }
+
 }


### PR DESCRIPTION
## Pseudo Dependency
Works entirely without https://github.com/hannibal002/SkyHanni-REPO/pull/182, but that PR would be useful.

## What
Fixes the upside down mixin being incompatible with other mods and also splits upside down and spinny into two options in the contributors.json

exclude_from_changelog
