### PR TITLE
Improvement + Fix: A few chocolate factory issues

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateAmount.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateAmount.kt
@@ -63,18 +63,18 @@ enum class ChocolateAmount(val chocolate: () -> Long) {
         fun averageChocPerSecond(
             baseMultiplierIncrease: Double = 0.0,
             rawPerSecondIncrease: Int = 0,
-            timeTowerLevelIncrease: Int = 0,
+            includeTower: Boolean = false,
         ): Double {
             val profileStorage = profileStorage ?: return 0.0
 
             val baseMultiplier = profileStorage.rawChocolateMultiplier + baseMultiplierIncrease
             val rawPerSecond = profileStorage.rawChocPerSecond + rawPerSecondIncrease
-            val timeTowerLevel = profileStorage.timeTowerLevel + timeTowerLevelIncrease
 
             val timeTowerCooldown = profileStorage.timeTowerCooldown
 
             val basePerSecond = rawPerSecond * baseMultiplier
-            val towerCalc = (rawPerSecond * timeTowerLevel * .1) / timeTowerCooldown
+            if (!includeTower) return basePerSecond
+            val towerCalc = (rawPerSecond * .1) / timeTowerCooldown
 
             return basePerSecond + towerCalc
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -119,6 +119,8 @@ object ChocolateFactoryDataLoader {
     fun updateInventoryItems(inventory: Map<Int, ItemStack>) {
         val profileStorage = profileStorage ?: return
 
+        ChocolateFactoryAPI.factoryUpgrades.clear()
+
         val chocolateItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.infoIndex) ?: return
         val prestigeItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.prestigeIndex) ?: return
         val productionInfoItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.productionInfoIndex) ?: return
@@ -133,7 +135,6 @@ object ChocolateFactoryDataLoader {
         processBarnItem(barnItem)
         processTimeTowerItem(timeTowerItem)
 
-        ChocolateFactoryAPI.factoryUpgrades.clear()
 
         profileStorage.rawChocPerSecond =
             (ChocolateFactoryAPI.chocolatePerSecond / profileStorage.chocolateMultiplier).toInt()
@@ -266,6 +267,7 @@ object ChocolateFactoryDataLoader {
     }
 
     private fun processItem(item: ItemStack, slotIndex: Int) {
+        if (slotIndex == ChocolateFactoryAPI.prestigeIndex) return
         if (config.rabbitWarning && clickMeRabbitPattern.matches(item.name)) {
             SoundUtils.playBeepSound()
             ChocolateFactoryAPI.clickRabbitSlot = slotIndex

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -90,7 +90,6 @@ object ChocolateFactoryDataLoader {
         "rabbit.unemployed",
         "Rabbit \\w+ - Unemployed"
     )
-
     // todo get coach jackrabbit when prestige 4
     private val otherUpgradePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "other.upgrade",

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -90,6 +90,7 @@ object ChocolateFactoryDataLoader {
         "rabbit.unemployed",
         "Rabbit \\w+ - Unemployed"
     )
+
     // todo get coach jackrabbit when prestige 4
     private val otherUpgradePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "other.upgrade",
@@ -317,9 +318,7 @@ object ChocolateFactoryDataLoader {
                 level = upgradeTierPattern.matchMatcher(itemName) {
                     group("tier").romanToDecimal()
                 } ?: run {
-                    otherUpgradePattern.matchMatcher(itemName) {
-                        0
-                    }
+                    if (otherUpgradePattern.matches(itemName)) 0 else null
                 } ?: return
 
                 if (slotIndex == ChocolateFactoryAPI.timeTowerIndex) this.profileStorage?.timeTowerLevel = level
@@ -361,8 +360,8 @@ object ChocolateFactoryDataLoader {
         val profileStorage = profileStorage ?: return
 
         // removing time tower here as people like to determine when to buy it themselves
-        val notMaxed =
-            ChocolateFactoryAPI.factoryUpgrades.filter { !it.isMaxed && it.slotIndex != ChocolateFactoryAPI.timeTowerIndex }
+        val notMaxed = ChocolateFactoryAPI.factoryUpgrades
+            .filter { !it.isMaxed && it.slotIndex != ChocolateFactoryAPI.timeTowerIndex }
 
         val bestUpgrade = notMaxed.minByOrNull { it.effectiveCost ?: Double.MAX_VALUE }
         profileStorage.bestUpgradeAvailableAt = bestUpgrade?.canAffordAt?.toMillis() ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -350,7 +350,9 @@ object ChocolateFactoryDataLoader {
     private fun findBestUpgrades() {
         val profileStorage = profileStorage ?: return
 
-        val notMaxed = ChocolateFactoryAPI.factoryUpgrades.filter { !it.isMaxed }
+        // also remove time tower here
+        val notMaxed =
+            ChocolateFactoryAPI.factoryUpgrades.filter { !it.isMaxed && it.slotIndex != ChocolateFactoryAPI.timeTowerIndex }
 
         val bestUpgrade = notMaxed.minByOrNull { it.effectiveCost ?: Double.MAX_VALUE }
         profileStorage.bestUpgradeAvailableAt = bestUpgrade?.canAffordAt?.toMillis() ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -91,6 +91,12 @@ object ChocolateFactoryDataLoader {
         "Rabbit \\w+ - Unemployed"
     )
 
+    // todo get coach jackrabbit when prestige 4
+    private val otherUpgradePattern by ChocolateFactoryAPI.patternGroup.pattern(
+        "other.upgrade",
+        "Rabbit Shrine"
+    )
+
     @SubscribeEvent
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!ChocolateFactoryAPI.inChocolateFactory) return
@@ -311,6 +317,10 @@ object ChocolateFactoryDataLoader {
             in ChocolateFactoryAPI.otherUpgradeSlots -> {
                 level = upgradeTierPattern.matchMatcher(itemName) {
                     group("tier").romanToDecimal()
+                } ?: run {
+                    otherUpgradePattern.matchMatcher(itemName) {
+                        0
+                    }
                 } ?: return
 
                 if (slotIndex == ChocolateFactoryAPI.timeTowerIndex) this.profileStorage?.timeTowerLevel = level

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -322,7 +322,7 @@ object ChocolateFactoryDataLoader {
 
                 newAverageChocolate = when (slotIndex) {
                     ChocolateFactoryAPI.timeTowerIndex -> ChocolateAmount.averageChocPerSecond(
-                        timeTowerLevelIncrease = 1
+                        includeTower = true
                     )
 
                     ChocolateFactoryAPI.coachRabbitIndex -> ChocolateAmount.averageChocPerSecond(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -119,8 +119,6 @@ object ChocolateFactoryDataLoader {
     fun updateInventoryItems(inventory: Map<Int, ItemStack>) {
         val profileStorage = profileStorage ?: return
 
-        ChocolateFactoryAPI.factoryUpgrades.clear()
-
         val chocolateItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.infoIndex) ?: return
         val prestigeItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.prestigeIndex) ?: return
         val productionInfoItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.productionInfoIndex) ?: return
@@ -128,13 +126,14 @@ object ChocolateFactoryDataLoader {
         val barnItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.barnIndex) ?: return
         val timeTowerItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.timeTowerIndex) ?: return
 
+        ChocolateFactoryAPI.factoryUpgrades.clear()
+
         processChocolateItem(chocolateItem)
         processPrestigeItem(prestigeItem)
         processProductionItem(productionInfoItem)
         processLeaderboardItem(leaderboardItem)
         processBarnItem(barnItem)
         processTimeTowerItem(timeTowerItem)
-
 
         profileStorage.rawChocPerSecond =
             (ChocolateFactoryAPI.chocolatePerSecond / profileStorage.chocolateMultiplier).toInt()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -245,6 +245,8 @@ object ChocolateFactoryDataLoader {
                     val activeDuration = TimeUtils.getDuration(formattedGroup)
                     val activeUntil = SimpleTimeMark.now() + activeDuration
                     profileStorage.currentTimeTowerEnds = activeUntil.toMillis()
+                } else {
+                    profileStorage.currentTimeTowerEnds = 0
                 }
             }
             timeTowerRechargePattern.matchMatcher(line) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -298,9 +298,7 @@ object ChocolateFactoryDataLoader {
                 level = rabbitAmountPattern.matchMatcher(itemName) {
                     group("amount").formatInt()
                 } ?: run {
-                    unemployedRabbitPattern.matchMatcher(itemName) {
-                        0
-                    }
+                    if (unemployedRabbitPattern.matches(itemName)) 0 else null
                 } ?: return
                 isRabbit = true
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -351,7 +351,7 @@ object ChocolateFactoryDataLoader {
     private fun findBestUpgrades() {
         val profileStorage = profileStorage ?: return
 
-        // also remove time tower here
+        // removing time tower here as people like to determine when to buy it themselves
         val notMaxed =
             ChocolateFactoryAPI.factoryUpgrades.filter { !it.isMaxed && it.slotIndex != ChocolateFactoryAPI.timeTowerIndex }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
@@ -44,7 +44,8 @@ object ChocolateFactoryInventory {
             if (slot.stack == null) continue
             val slotIndex = slot.slotNumber
 
-            ChocolateFactoryAPI.factoryUpgrades.find { it.slotIndex == slotIndex }?.let { upgrade ->
+            val currentUpdates = ChocolateFactoryAPI.factoryUpgrades
+            currentUpdates.find { it.slotIndex == slotIndex }?.let { upgrade ->
                 if (upgrade.canAfford()) {
                     slot highlight LorenzColor.GREEN.addOpacity(75)
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltip.kt
@@ -21,10 +21,6 @@ object ChocolateFactoryTooltip {
 
         val upgradeInfo = ChocolateFactoryAPI.factoryUpgrades.find { it.slotIndex == slotIndex } ?: return
 
-        if (slotIndex == ChocolateFactoryAPI.prestigeIndex) {
-            println(upgradeInfo)
-        }
-
         if (slotIndex == ChocolateFactoryAPI.timeTowerIndex && upgradeInfo.isMaxed) {
             event.toolTip.add("§8§m-----------------")
             event.toolTip.add("§7One charge will give: §6${chocPerTimeTower().addSeparators()}")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltip.kt
@@ -21,6 +21,10 @@ object ChocolateFactoryTooltip {
 
         val upgradeInfo = ChocolateFactoryAPI.factoryUpgrades.find { it.slotIndex == slotIndex } ?: return
 
+        if (slotIndex == ChocolateFactoryAPI.prestigeIndex) {
+            println(upgradeInfo)
+        }
+
         if (slotIndex == ChocolateFactoryAPI.timeTowerIndex && upgradeInfo.isMaxed) {
             event.toolTip.add("§8§m-----------------")
             event.toolTip.add("§7One charge will give: §6${chocPerTimeTower().addSeparators()}")
@@ -34,7 +38,7 @@ object ChocolateFactoryTooltip {
         if (upgradeInfo.effectiveCost == null) return
 
         event.toolTip.add("§7Extra: §6${upgradeInfo.extraPerSecond?.round(2) ?: "N/A"} §7choc/s")
-        event.toolTip.add("§7Effective Cost: §6${upgradeInfo.effectiveCost?.addSeparators() ?: "N/A"}")
+        event.toolTip.add("§7Effective Cost: §6${upgradeInfo.effectiveCost.addSeparators() ?: "N/A"}")
 
         if (slotIndex == ChocolateFactoryAPI.timeTowerIndex) {
             event.toolTip.add("§7One charge will give: §6${chocPerTimeTower().addSeparators()}")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgrade.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgrade.kt
@@ -12,7 +12,7 @@ data class ChocolateFactoryUpgrade(
     val isPrestige: Boolean = false,
 ) {
     private var chocolateAmountType = ChocolateAmount.CURRENT
-    var isMaxed = price == null
+    val isMaxed = price == null
     var canAffordAt: SimpleTimeMark? = null
 
     init {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
@@ -57,7 +57,7 @@ object ChocolateFactoryUpgradeWarning {
 
     fun checkUpgradeChange(slot: Int, level: Int) {
         if (slot != lastUpgradeSlot || level != lastUpgradeLevel) {
-            lastUpgradeWarning = SimpleTimeMark.farPast()
+            lastUpgradeWarning = SimpleTimeMark.now()
             lastUpgradeSlot = slot
             lastUpgradeLevel = level
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
@@ -37,17 +37,16 @@ object ChocolateFactoryUpgradeWarning {
         if (ReminderUtils.isBusy()) return
         if (lastUpgradeWarning.passedSince() < config.timeBetweenWarnings.minutes) return
         lastUpgradeWarning = SimpleTimeMark.now()
-
+        if (config.upgradeWarningSound) {
+            SoundUtils.playBeepSound()
+        }
+        if (ChocolateFactoryAPI.inChocolateFactory) return
         ChatUtils.clickableChat(
             "You have a Chocolate factory upgrade available to purchase!",
             onClick = {
                 HypixelCommands.chocolateFactory()
             }
         )
-        if (config.upgradeWarningSound) {
-            SoundUtils.playBeepSound()
-        }
-
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Fixed checkmark showing on prestige item when it shouldn't.
Fixed recommending time tower as it can cause confusion.
No longer include time tower in effective cost calculation unless its for tower.
Fixed time tower saying it is active if you prestige while it is active.

## Changelog Improvements
+ Improved upgrade recommendations in the Chocolate Factory. - CalMWolfs
    * No longer recommends the time tower upgrade, as it can lead to inefficiencies.

## Changelog Fixes
+ Fixed checkmark incorrectly showing on prestige item. - CalMWolfs
