### PR TITLE
Fix: chroma not applying alpha correctly

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chroma/ChromaFontRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chroma/ChromaFontRenderer.kt
@@ -42,12 +42,12 @@ class ChromaFontRenderer(private val baseColor: Int) {
         return this
     }
 
-    fun bindActualColor(): ChromaFontRenderer {
+    fun bindActualColor(alpha: Float): ChromaFontRenderer {
         GlStateManager.color(
             ColorUtils.getRed(baseColor).toFloat() / 255f,
             ColorUtils.getGreen(baseColor).toFloat() / 255f,
             ColorUtils.getBlue(baseColor).toFloat() / 255f,
-            ColorUtils.getAlpha(baseColor).toFloat() / 255f
+            alpha
         )
         return this
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
@@ -2,11 +2,9 @@ package at.hannibal2.skyhanni.mixins.hooks
 
 import at.hannibal2.skyhanni.features.chroma.ChromaFontRenderer
 import at.hannibal2.skyhanni.features.chroma.ChromaManager
-import at.hannibal2.skyhanni.mixins.transformers.AccessorFontRenderer
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import net.minecraft.client.Minecraft
+import at.hannibal2.skyhanni.utils.RenderUtils
 import net.minecraft.client.renderer.GlStateManager
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
 
 /**
  * Object to handle chroma font states from handler methods from MixinFontRenderer
@@ -16,6 +14,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
  * Credit: [FontRendererHook.java](https://github.com/BiscuitDevelopment/SkyblockAddons/blob/main/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/FontRendererHook.java)
  */
 object FontRendererHook {
+
+    private const val CHROMA_FORMAT_INDEX = 22
+    private const val WHITE_FORMAT_INDEX = 15
 
     private var CHROMA_COLOR: Int = -0x1
     private val DRAW_CHROMA = ChromaFontRenderer(CHROMA_COLOR)
@@ -74,22 +75,15 @@ object FontRendererHook {
             setupChromaFont()
         }
 
-        val alpha = (Minecraft.getMinecraft().fontRendererObj as AccessorFontRenderer).alpha
-        if (shadow) {
-            currentDrawState = DRAW_CHROMA_SHADOW
-            CHROMA_COLOR_SHADOW = ((255 * alpha).toInt() shl 24 or 0x555555)
-        } else {
-            currentDrawState = DRAW_CHROMA
-            CHROMA_COLOR = ((255 * alpha).toInt() shl 24 or 0xFFFFFF)
-        }
+        currentDrawState = if (shadow) DRAW_CHROMA_SHADOW else DRAW_CHROMA
 
         // Best feature ngl
         if (ChromaManager.config.allChroma) {
             // Handles setting the base color of text when they don't use color codes i.e. MoulConfig
             if (shadow) {
-                GlStateManager.color(0.33f, 0.33f, 0.33f, 1f)
+                GlStateManager.color(0.33f, 0.33f, 0.33f, RenderUtils.getAlpha())
             } else {
-                GlStateManager.color(1f, 1f, 1f, 1f)
+                GlStateManager.color(1f, 1f, 1f, RenderUtils.getAlpha())
             }
             setupChromaFont()
         }
@@ -101,23 +95,21 @@ object FontRendererHook {
     fun toggleChromaOn() {
         if (!LorenzUtils.inSkyBlock) return
 
-        currentDrawState?.newChromaEnv()?.bindActualColor()
+        currentDrawState?.newChromaEnv()?.bindActualColor(RenderUtils.getAlpha())
     }
 
     @JvmStatic
-    fun forceWhiteColorCode(i1: Int): Int {
-        if (!LorenzUtils.inSkyBlock) return i1
+    fun forceWhiteColorCode(formatIndex: Int): Int {
+        if (!LorenzUtils.inSkyBlock) return formatIndex
 
-        if (!ChromaManager.config.enabled) return i1
+        if (!ChromaManager.config.enabled) return formatIndex
 
-        val drawState = currentDrawState ?: return i1
-        if (drawState.getChromaState()) {
-            if (i1 < 16) {
-                return 15
-            }
+        val drawState = currentDrawState ?: return formatIndex
+        if (drawState.getChromaState() && formatIndex <= WHITE_FORMAT_INDEX) { // If it's a color code
+            return WHITE_FORMAT_INDEX
         }
 
-        return i1
+        return formatIndex
     }
 
     @JvmStatic
@@ -148,19 +140,11 @@ object FontRendererHook {
         return if (LorenzUtils.inSkyBlock && !ChromaManager.config.enabled) constant else "0123456789abcdefklmnorz"
     }
 
-    // TODO add better parameter names
     @JvmStatic
-    fun toggleChromaCondition_shouldResetStyles(
-        text: String,
-        shadow: Boolean,
-        ci: CallbackInfo,
-        i: Int,
-        c0: Char,
-        i1: Int,
-    ): Boolean {
+    fun toggleChromaAndResetStyle(formatIndex: Int): Boolean {
         if (!LorenzUtils.inSkyBlock) return false
         if (!ChromaManager.config.enabled) return false
-        if (i1 == 22) {
+        if (formatIndex == CHROMA_FORMAT_INDEX) {
             toggleChromaOn()
             return true
         }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinFontRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinFontRenderer.java
@@ -52,7 +52,7 @@ public abstract class MixinFontRenderer {
      */
     @Inject(method = "renderStringAtPos", at = @At(value = "INVOKE", target = "Ljava/lang/String;indexOf(I)I", ordinal = 0, shift = At.Shift.BY, by = 2), locals = LocalCapture.CAPTURE_FAILHARD)
     public void toggleChromaCondition(String text, boolean shadow, CallbackInfo ci, int i, char c0, int i1) {
-        if (FontRendererHook.toggleChromaCondition_shouldResetStyles(text, shadow, ci, i, c0, i1)) {
+        if (FontRendererHook.toggleChromaAndResetStyle(i1)) {
             this.resetStyles();
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -66,7 +66,8 @@ object RenderUtils {
 
     private val beaconBeam = ResourceLocation("textures/entity/beacon_beam.png")
 
-    private val matrixBuffer = GLAllocation.createDirectFloatBuffer(16);
+    private val matrixBuffer = GLAllocation.createDirectFloatBuffer(16)
+    private val colourBuffer = GLAllocation.createDirectFloatBuffer(16)
 
     infix fun Slot.highlight(color: LorenzColor) {
         highlight(color.toColor())
@@ -1629,5 +1630,12 @@ object RenderUtils {
         with(ScaledResolution(Minecraft.getMinecraft())) {
             Utils.drawTexturedRect(x, y, scaledWidth.toFloat(), scaledHeight.toFloat(), GL11.GL_NEAREST)
         }
+    }
+
+    fun getAlpha(): Float {
+        colourBuffer.clear()
+        GlStateManager.getFloat(GL11.GL_CURRENT_COLOR, colourBuffer)
+        if (colourBuffer.limit() < 4) return 1f
+        return colourBuffer.get(3)
     }
 }


### PR DESCRIPTION
## What
Fixes the chroma colour not being affected by alpha.
Also cleaned up some chroma code to not numbers and reference a constant.

The easiest way to test is set chroma to all and then setting chat opacity setting to like 50%

## Changelog Fixes
+ Fixed chroma not being affected by alpha. - ThatGravyBoat

