### PR TITLE
Add shtestmessage for complex messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -438,6 +438,7 @@ import at.hannibal2.skyhanni.test.TestExportTools
 import at.hannibal2.skyhanni.test.TestShowSlotNumber
 import at.hannibal2.skyhanni.test.WorldEdit
 import at.hannibal2.skyhanni.test.command.CopyNearbyParticlesCommand
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.test.command.TrackSoundsCommand
 import at.hannibal2.skyhanni.test.hotswap.HotswapSupport
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -456,6 +457,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiScreen
 import net.minecraftforge.common.MinecraftForge
@@ -1003,6 +1005,16 @@ class SkyHanniMod {
         private var screenTicks = 0
         fun consoleLog(message: String) {
             logger.log(Level.INFO, message)
+        }
+
+        fun launchCoroutine(function: suspend () -> Unit) {
+            coroutineScope.launch {
+                try {
+                    function()
+                } catch (ex: Exception) {
+                    ErrorManager.logErrorWithData(ex, "Asynchronous exception caught")
+                }
+            }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -10,6 +10,7 @@ import net.minecraft.client.Minecraft
 import net.minecraft.event.ClickEvent
 import net.minecraft.event.HoverEvent
 import net.minecraft.util.ChatComponentText
+import net.minecraft.util.IChatComponent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.LinkedList
 import java.util.Queue
@@ -105,11 +106,15 @@ object ChatUtils {
         }
     }
 
+    fun chatComponent(message: IChatComponent) {
+        internalChat(message)
+    }
+
     private fun internalChat(message: String): Boolean {
         return internalChat(ChatComponentText(message))
     }
 
-    private fun internalChat(message: ChatComponentText): Boolean {
+    private fun internalChat(message: IChatComponent): Boolean {
         val formattedMessage = message.formattedText
         log.log(formattedMessage)
 


### PR DESCRIPTION
<!-- remove all unused parts -->



## What
Allows to use `/shtestmessage -complex` to test components in json format (like the ones you get from shift-clicking `/shchathistory`)

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/20768569/ff029462-6935-40f7-89bb-af8993c5c0db)

</details>

## Changelog Technical Details
+ Allows use of `/shtestmessage -complex` to test components in JSON format. - nea
    * Similar to those obtained from shift-clicking `/shchathistory`.
