### PR TITLE
Fix: Breakfast and Dinner Egg incorrect colors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
@@ -11,9 +11,9 @@ enum class HoppityEggType(
     var lastResetDay: Int = -1,
     private var claimed: Boolean = false,
 ) {
-    BREAKFAST("Breakfast", 7, "§a"),
+    BREAKFAST("Breakfast", 7, "§6"),
     LUNCH("Lunch", 14, "§9"),
-    DINNER("Dinner", 21, "§6"),
+    DINNER("Dinner", 21, "§a"),
     ;
 
     fun timeUntil(): Duration {


### PR DESCRIPTION
## What
Fix Breakfast and Dinner eggs incorrectly having swapped colors.

## Changelog Fixes
+ Fixed swapped colors for Breakfast and Dinner eggs. - yhtez