### PR TITLE
Improvement: Add Incoming Tablist Event to Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -158,12 +158,12 @@ enum class ScoreboardEvents(
     ACTIVE_TABLIST_EVENTS(
         ::getActiveEventLine,
         ::getActiveEventShowWhen,
-        "§dHoppity's Hunt\n §fEnds in: §e26h"
+        "§7(All Active Tablist Events)\n§dHoppity's Hunt\n §fEnds in: §e26h"
     ),
     STARTING_SOON_TABLIST_EVENTS(
         ::getSoonEventLine,
         ::getSoonEventShowWhen,
-        "§6Mining Fiesta\n §fStarts in: §e52min"
+        "§7(All Starting Soon Tablist Events)\n§6Mining Fiesta\n §fStarts in: §e52min"
     ),
     REDSTONE(
         ::getRedstoneLines,

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -158,7 +158,12 @@ enum class ScoreboardEvents(
     ACTIVE_TABLIST_EVENTS(
         ::getActiveEventLine,
         ::getActiveEventShowWhen,
-        "§7(All Active Tablist Events)"
+        "§dHoppity's Hunt\n §fEnds in: §e26h"
+    ),
+    STARTING_SOON_TABLIST_EVENTS(
+        ::getSoonEventLine,
+        ::getSoonEventShowWhen,
+        "§6Mining Fiesta\n §fStarts in: §e52min"
     ),
     REDSTONE(
         ::getRedstoneLines,
@@ -369,26 +374,43 @@ private fun getSpookyLines() = buildList {
 
 private fun getSpookyShowWhen(): Boolean = getSbLines().any { ScoreboardPattern.spookyPattern.matches(it) }
 
-private fun getActiveEventLine(): List<String> {
-    val currentActiveEvent = TabListData.getTabList().firstOrNull { SbPattern.eventNamePattern.matches(it) }
+private fun getTablistEvent(): String? =
+    TabListData.getTabList().firstOrNull { SbPattern.eventNamePattern.matches(it) }
         ?.let {
             SbPattern.eventNamePattern.matchMatcher(it) {
                 group("name")
             }
         }
-    val currentActiveEventEndsIn = TabListData.getTabList().firstOrNull { SbPattern.eventTimeEndsPattern.matches(it) }
+
+private fun getActiveEventLine(): List<String> {
+    val currentActiveEvent = getTablistEvent() ?: return emptyList()
+    val currentActiveEventTime = TabListData.getTabList().firstOrNull { SbPattern.eventTimeEndsPattern.matches(it) }
         ?.let {
             SbPattern.eventTimeEndsPattern.matchMatcher(it) {
                 group("time")
             }
         }
 
-    return listOf("$currentActiveEvent $currentActiveEventEndsIn")
+    return listOf(currentActiveEvent, " Ends in: §e$currentActiveEventTime")
 }
 
 private fun getActiveEventShowWhen(): Boolean =
-    TabListData.getTabList().any { SbPattern.eventNamePattern.matches(it) } &&
-        TabListData.getTabList().any { SbPattern.eventTimeEndsPattern.matches(it) }
+    getTablistEvent() != null && TabListData.getTabList().any { SbPattern.eventTimeEndsPattern.matches(it) }
+
+private fun getSoonEventLine(): List<String> {
+    val soonActiveEvent = getTablistEvent() ?: return emptyList()
+    val soonActiveEventTime = TabListData.getTabList().firstOrNull { SbPattern.eventTimeEndsPattern.matches(it) }
+        ?.let {
+            SbPattern.eventTimeStartsPattern.matchMatcher(it) {
+                group("time")
+            }
+        }
+
+    return listOf(soonActiveEvent, " Starts in: §e$soonActiveEventTime")
+}
+
+private fun getSoonEventShowWhen(): Boolean =
+    getTablistEvent() != null && TabListData.getTabList().any { SbPattern.eventTimeStartsPattern.matches(it) }
 
 private fun getBroodmotherLines(): List<String> =
     listOf(getSbLines().first { SbPattern.broodmotherPattern.matches(it) })

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -446,4 +446,8 @@ object ScoreboardPattern {
         "eventtime",
         "^\\s+Ends In: §r§e(?<time>.*)$"
     )
+    val eventTimeStartsPattern by tablistGroup.pattern(
+        "eventtimestarts",
+        "^\\s+Starts In: §r§e(?<time>.*)$"
+    )
 }


### PR DESCRIPTION
## What
This Pull Request adds the option to also show the incoming tablist event to the Custom Scoreboard. I do not want to auto add this to everyones Events Dropdown.


## Changelog Improvements
+ Added incoming tab list event to Custom Scoreboard. - j10a1n15

