### PR TITLE
Improvement: Show during contest

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -29,6 +29,12 @@ public class HoppityEggsConfig {
     public boolean showClaimedEggs = false;
 
     @Expose
+    @ConfigOption(name = "Show during Contest", desc = "Show during a farming contest.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean showDuringContest = false;
+
+    @Expose
     @ConfigOption(name = "Shared Hoppity Waypoints", desc = "Enable being able to share and receive egg waypoints in your lobby.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -132,7 +132,7 @@ object HoppityEggsManager {
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.showClaimedEggs) return
-        if (ReminderUtils.isBusy()) return
+        if (ReminderUtils.isBusy(config.showDuringContest)) return
         if (!ChocolateFactoryAPI.isHoppityEvent()) return
 
         val displayList = HoppityEggType.entries

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/ReminderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/ReminderUtils.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 object ReminderUtils {
 
     // TODO: add arachne fight, add slayer boss spawned, add dragon fight
-    fun isBusy(): Boolean =
-        DungeonAPI.inDungeon() || LorenzUtils.inKuudraFight || FarmingContestAPI.inContest ||
+    fun isBusy(ignoreFarmingContest: Boolean = false): Boolean =
+        DungeonAPI.inDungeon() || LorenzUtils.inKuudraFight || (FarmingContestAPI.inContest && !ignoreFarmingContest) ||
             RiftAPI.inRift() || IslandType.DARK_AUCTION.isInIsland()
 }


### PR DESCRIPTION
## What
Added option to show the Hoppity Uncliamed Eggs display during a farming contest.
Suggestion: https://discord.com/channels/997079228510117908/1236009720536367246

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/00a648ff-9883-425b-bbde-5e0244f76298)

</details>

## Changelog Improvements
+ Added option to show the Hoppity Unclaimed Eggs display during a farming contest. - hannibal2