### PR TITLE
Improvement: Use raw craft cost

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -150,7 +150,6 @@ object NEUItems {
     fun getInternalNameOrNull(nbt: NBTTagCompound): NEUInternalName? =
         ItemResolutionQuery(manager).withItemNBT(nbt).resolveInternalName()?.asInternalName()
 
-
     fun NEUInternalName.getPrice(useSellingPrice: Boolean = false) = getPriceOrNull(useSellingPrice) ?: -1.0
 
     fun NEUInternalName.getNpcPrice() = getNpcPriceOrNull() ?: -1.0
@@ -184,8 +183,11 @@ object NEUItems {
             // 6.8 for some players
             return 7.0 // NPC price
         }
-        return getNpcPriceOrNull()
+
+        return getNpcPriceOrNull() ?: getRawCraftCostOrNull()
     }
+
+    fun NEUInternalName.getRawCraftCostOrNull(): Double? = manager.auctionManager.getCraftCost(asString())?.craftCost
 
     fun NEUInternalName.getItemStackOrNull(): ItemStack? = ItemResolutionQuery(manager)
         .withKnownInternalName(asString())


### PR DESCRIPTION
## What
We now use raw craft cost if an item price is not in ah, Bazaar or NPC price.
To reproduce:
`/pv utopla` - see pendant of divan in equipment slot.
Without this pr, the base item price is 0.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/59fd8e3b-ab2e-4ce9-9f6a-30ee477ed3dc)

</details>

## Changelog Improvements
+ Use raw craft cost of an item if no Auction House price is available. - hannibal2