### PR TITLE
Fix: Pluralize negative changes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolatePositionChange.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolatePositionChange.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 
 object ChocolatePositionChange {
@@ -23,7 +24,7 @@ object ChocolatePositionChange {
             var message = "§b$lastLb §c-> §b$leaderboard"
             val change = lastPosition - position
             val color = if (change > 0) "§a+" else "§c"
-            message += "\n §7Changed by $color${change.addSeparators()} spots"
+            message += "\n §7Changed by $color${change.addSeparators()} ${StringUtils.pluralize(change, "spot")}"
 
             lastTime?.let {
                 message += " §7in §b${it.passedSince().format(maxUnits = 2)}"

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.mixins.transformers.AccessorChatComponentText
 import at.hannibal2.skyhanni.utils.GuiRenderUtils.darkenColor
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
-import at.hannibal2.skyhanni.utils.StringUtils.width
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiUtilRenderComponents
 import net.minecraft.util.ChatComponentText
@@ -209,7 +208,7 @@ object StringUtils {
 
     fun pluralize(number: Int, singular: String, plural: String? = null, withNumber: Boolean = false): String {
         val pluralForm = plural ?: "${singular}s"
-        var str = if (number == 1) singular else pluralForm
+        var str = if (number == 1 || number == -1) singular else pluralForm
         if (withNumber) str = "${number.addSeparators()} $str"
         return str
     }


### PR DESCRIPTION
correctly pluralises the change in positions and also makes -1 count as singular

exclude_from_changelog