### PR TITLE
Fix: Some cases where egg locator solver would trigger incorrectly

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
+import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
@@ -116,7 +117,7 @@ object HoppityEggLocator {
         }
 
         if (!config.showAllWaypoints) return
-        if (hasLocatorInInventory()) return
+        if (hasLocatorInHotbar()) return
         if (!HoppityEggType.eggsRemaining()) return
 
         val islandEggsLocations = getCurrentIslandEggLocations() ?: return
@@ -137,8 +138,7 @@ object HoppityEggLocator {
     @SubscribeEvent
     fun onReceiveParticle(event: ReceiveParticleEvent) {
         if (!isEnabled()) return
-        if (!hasLocatorInInventory()) return
-        if (GardenAPI.inGarden()) return
+        if (!hasLocatorInHotbar()) return
         if (!event.isVillagerParticle() && !event.isEnchantmentParticle()) return
 
         val lastParticlePosition = lastParticlePosition ?: run {
@@ -231,13 +231,13 @@ object HoppityEggLocator {
     private fun ReceiveParticleEvent.isEnchantmentParticle() =
         type == EnumParticleTypes.ENCHANTMENT_TABLE && speed == -2.0f && count == 10
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.waypoints
-        && ChocolateFactoryAPI.isHoppityEvent()
+    private fun isEnabled() = LorenzUtils.inSkyBlock && config.waypoints && !GardenAPI.inGarden()
+        && !ReminderUtils.isBusy(true) && ChocolateFactoryAPI.isHoppityEvent()
 
     private val ItemStack.isLocatorItem get() = getInternalName() == locatorItem
 
-    fun hasLocatorInInventory() = RecalculatingValue(1.seconds) {
-        LorenzUtils.inSkyBlock && InventoryUtils.getItemsInOwnInventory().any { it.isLocatorItem }
+    fun hasLocatorInHotbar() = RecalculatingValue(1.seconds) {
+        LorenzUtils.inSkyBlock && InventoryUtils.getItemsInHotbar().any { it.isLocatorItem }
     }.getValue()
 
     private fun LorenzVec.getEggLocationWeight(firstPoint: LorenzVec, secondPoint: LorenzVec): Double {

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -37,9 +37,12 @@ object InventoryUtils {
     fun ContainerChest.getInventoryName() = this.lowerChestInventory.displayName.unformattedText.trim()
 
     fun getItemsInOwnInventory() =
-        Minecraft.getMinecraft().thePlayer?.inventory?.mainInventory?.filterNotNull() ?: emptyList()
+        getItemsInOwnInventoryWithNull()?.filterNotNull() ?: emptyList()
 
-    fun getItemsInOwnInventoryWithNull() = Minecraft.getMinecraft().thePlayer.inventory.mainInventory
+    fun getItemsInOwnInventoryWithNull() = Minecraft.getMinecraft().thePlayer?.inventory?.mainInventory
+
+    fun getItemsInHotbar() =
+        getItemsInOwnInventoryWithNull()?.sliceArray(0..8)?.filterNotNull() ?: emptyList()
 
     fun countItemsInLowerInventory(predicate: (ItemStack) -> Boolean) =
         getItemsInOwnInventory().filter { predicate(it) }.sumOf { it.stackSize }


### PR DESCRIPTION
## What
Fix some cases where egg locator solver would trigger incorrectly.
There are still other cases but this fixes or adds work arounds for it wrongly guessing.

## Changelog Fixes
+ Fixed some cases where egg locator solver would trigger incorrectly. - CalMWolfs

## Changelog Technical Details
+ Added InventoryUtils.getItemsInHotbar() and slightly cleaned up some code in InventoryUtils. - CalMWolfs