### PR TITLE
Fix: inventory hotkeys hotbar item move behaviour

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -152,6 +152,17 @@ object HarpFeatures {
     @SubscribeEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!LorenzUtils.inSkyBlock) return
+
+        if (isHarpGui(InventoryUtils.openInventoryName())) {
+            if (config.keybinds) {
+                // needed to not send duplicate clicks via keybind feature
+                if (event.clickTypeEnum == GuiContainerEvent.ClickType.HOTBAR) {
+                    event.cancel()
+                    return
+                }
+            }
+        }
+
         if (!config.quickRestart) return
         if (!isMenuGui(InventoryUtils.openInventoryName())) return
         if (event.slot?.slotNumber != closeButtonSlot) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
@@ -92,7 +92,11 @@ object ChocolateFactoryInventory {
         val slotNumber = slot.slotNumber
         if (!config.useMiddleClick) return
         if (slotNumber in ChocolateFactoryAPI.noPickblockSlots &&
-            (slotNumber != ChocolateFactoryAPI.timeTowerIndex || event.clickedButton == 1)) return
+            (slotNumber != ChocolateFactoryAPI.timeTowerIndex || event.clickedButton == 1)
+        ) return
+
+        // this would break ChocolateFactoryKeybinds otherwise
+        if (event.clickTypeEnum == GuiContainerEvent.ClickType.HOTBAR) return
 
         event.makePickblock()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryKeybinds.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
+import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -37,6 +38,18 @@ object ChocolateFactoryKeybinds {
                 Minecraft.getMinecraft().thePlayer
             )
             break
+        }
+    }
+
+    @SubscribeEvent
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+        if (!config.enabled) return
+        if (!ChocolateFactoryAPI.inChocolateFactory) return
+
+        // needed to not send duplicate clicks via keybind feature
+        if (event.clickTypeEnum == GuiContainerEvent.ClickType.HOTBAR) {
+            event.cancel()
         }
     }
 


### PR DESCRIPTION
## What
fix inventory hotkeys hotbar item move behaviour

## Changelog Fixes
+ Fixed unintended clicks while using keybind feature in Melody's Harp or Chocolate Factory menu. - hannibal2