### PR TITLE
Fix: Farming tool detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -48,6 +48,7 @@ import net.minecraft.item.ItemStack
 import net.minecraft.network.play.client.C09PacketHeldItemChange
 import net.minecraft.util.AxisAlignedBB
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 object GardenAPI {
@@ -96,6 +97,11 @@ object GardenAPI {
     fun onInventoryClose(event: InventoryCloseEvent) {
         if (!inGarden()) return
         checkItemInHand()
+        DelayedRun.runDelayed(500.milliseconds) {
+            if (inGarden()) {
+                checkItemInHand()
+            }
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
fix farming tool detection after inventory close
Reported: https://discord.com/channels/997079228510117908/1235225367191752775

## Changelog Fixes
+ Fixed farming tool detection sometimes not working after closing an inventory. - hannibal2