### PR TITLE
Improvement: Open rng inv via the Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
@@ -55,7 +55,7 @@ class SlayerRngMeterDisplay {
         "§aYou set your §r.* RNG Meter §r§ato drop §r.*§a!"
     )
 
-    private var display: Renderable = Renderable.placeholder(0, 0)
+    private var display = emptyList<Renderable>()
     private var lastItemDroppedTime = 0L
 
     var rngScore = mapOf<String, Map<NEUInternalName, Long>>()
@@ -188,7 +188,7 @@ class SlayerRngMeterDisplay {
     }
 
     private fun update() {
-        display = makeLink(drawDisplay())
+        display = listOf(makeLink(drawDisplay()))
     }
 
     private fun makeLink(text: String) =
@@ -233,7 +233,7 @@ class SlayerRngMeterDisplay {
         if (!SlayerAPI.isInCorrectArea) return
         if (!SlayerAPI.hasActiveSlayerQuest()) return
 
-        config.pos.renderRenderables(listOf(display), posLabel = "RNG Meter Display")
+        config.pos.renderRenderables(display, posLabel = "RNG Meter Display")
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.events.SlayerChangeEvent
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
@@ -21,11 +22,12 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
-import at.hannibal2.skyhanni.utils.RenderUtils.renderString
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeWordsAtEnd
+import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.math.ceil
@@ -53,7 +55,7 @@ class SlayerRngMeterDisplay {
         "§aYou set your §r.* RNG Meter §r§ato drop §r.*§a!"
     )
 
-    private var display = ""
+    private var display: Renderable = Renderable.placeholder(0, 0)
     private var lastItemDroppedTime = 0L
 
     var rngScore = mapOf<String, Map<NEUInternalName, Long>>()
@@ -186,10 +188,15 @@ class SlayerRngMeterDisplay {
     }
 
     private fun update() {
-        display = drawDisplay()
+        display = makeLink(drawDisplay())
     }
 
-    private fun drawDisplay(): String {
+    private fun makeLink(text: String) =
+        Renderable.clickAndHover(text, listOf("§eClick to open RNG Meter Inventory."), onClick = {
+            HypixelCommands.showRng("slayer", SlayerAPI.getActiveSlayer()?.rngName)
+        })
+
+    fun drawDisplay(): String {
         val storage = getStorage() ?: return ""
 
         if (SlayerAPI.latestSlayerCategory.let {
@@ -221,12 +228,12 @@ class SlayerRngMeterDisplay {
     }
 
     @SubscribeEvent
-    fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    fun onRenderOverlay(event: GuiRenderEvent) {
         if (!isEnabled()) return
         if (!SlayerAPI.isInCorrectArea) return
         if (!SlayerAPI.hasActiveSlayerQuest()) return
 
-        config.pos.renderString(display, posLabel = "RNG Meter Display")
+        config.pos.renderRenderables(listOf(display), posLabel = "RNG Meter Display")
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerType.kt
@@ -6,12 +6,12 @@ import net.minecraft.entity.monster.EntitySpider
 import net.minecraft.entity.monster.EntityZombie
 import net.minecraft.entity.passive.EntityWolf
 
-enum class SlayerType(val displayName: String, val clazz: Class<*>) {
-    REVENANT("Revenant Horror", EntityZombie::class.java),
-    TARANTULA("Tarantula Broodfather", EntitySpider::class.java),
-    SVEN("Sven Packmaster", EntityWolf::class.java),
-    VOID("Voidgloom Seraph", EntityEnderman::class.java),
-    INFERNO("Inferno Demonlord", EntityBlaze::class.java),
-    VAMPIRE("Riftstalker Bloodfiend", EntityZombie::class.java)
+enum class SlayerType(val displayName: String, val rngName: String, val clazz: Class<*>) {
+    REVENANT("Revenant Horror", "revenant", EntityZombie::class.java),
+    TARANTULA("Tarantula Broodfather", "tarantula", EntitySpider::class.java),
+    SVEN("Sven Packmaster", "sven", EntityWolf::class.java),
+    VOID("Voidgloom Seraph", "voidgloom", EntityEnderman::class.java),
+    INFERNO("Inferno Demonlord", "inferno", EntityBlaze::class.java),
+    VAMPIRE("Riftstalker Bloodfiend", "vampire", EntityZombie::class.java)
     ;
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -62,6 +62,11 @@ object HypixelCommands {
         send("ac $message")
     }
 
+    fun showRng(major: String? = null, minor: String? = null) = when {
+        major == null || minor == null -> send("rng")
+        else -> send("rng $major $minor")
+    }
+
     private fun send(command: String) {
         @Suppress("DEPRECATION")
         // TODO rename function


### PR DESCRIPTION
## What
Open the correct rng meter inventory by pressing the slayer rng meter display.
Uses the new /rng command.

## Changelog Improvements
+ Clicking the slayer RNG meter now opens the selection inventory. - Thunderblade73