### PR TITLE
Feature: Trades menu sell middle click

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -257,6 +257,7 @@ import at.hannibal2.skyhanni.features.inventory.HighlightBonzoMasks
 import at.hannibal2.skyhanni.features.inventory.ItemDisplayOverlayFeatures
 import at.hannibal2.skyhanni.features.inventory.ItemStars
 import at.hannibal2.skyhanni.features.inventory.MaxPurseItems
+import at.hannibal2.skyhanni.features.inventory.MiddleClickInTrade
 import at.hannibal2.skyhanni.features.inventory.PowerStoneGuideFeatures
 import at.hannibal2.skyhanni.features.inventory.QuickCraftFeatures
 import at.hannibal2.skyhanni.features.inventory.RngMeterInventory
@@ -663,6 +664,7 @@ class SkyHanniMod {
         loadModule(HoppityCollectionStats)
         loadModule(SpawnTimers())
         loadModule(MarkedPlayerManager())
+        loadModule(MiddleClickInTrade())
         loadModule(SlayerMiniBossFeatures())
         loadModule(PlayerDeathMessages())
         loadModule(HighlightDungeonDeathmite())

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -228,4 +228,10 @@ public class InventoryConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean shiftClickBrewing = false;
+
+    @Expose
+    @ConfigOption(name = "Middle Click in Trade", desc = "Makes normal clicks to middle clicks in your inventory whilst in trade menu to sell stuff quickly. (Useful in dungeons)")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean middleClickInTrade = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/MiddleClickInTrade.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/MiddleClickInTrade.kt
@@ -14,7 +14,10 @@ class MiddleClickInTrade {
 
     @SubscribeEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!config) return
+        if (!config || !inTradeMenu) return
+        if(event.slot == null) return
+        // only allow clicks in inventory and rebuy slots
+        if(event.slotId < 49) return
         event.makePickblock()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/MiddleClickInTrade.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/MiddleClickInTrade.kt
@@ -1,0 +1,40 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class MiddleClickInTrade {
+    private val config get() = SkyHanniMod.feature.inventory.middleClickInTrade
+
+    private var inTradeMenu = false
+
+    @SubscribeEvent
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!config) return
+        event.makePickblock()
+    }
+
+    @SubscribeEvent
+    fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+        if (!config || event.inventoryName != "Trades") return
+        inTradeMenu = true
+    }
+
+    @SubscribeEvent
+    fun onWorldChange(event: LorenzWorldChangeEvent) {
+        clearData()
+    }
+
+    @SubscribeEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        clearData()
+    }
+
+    private fun clearData() {
+        inTradeMenu = false
+    }
+}


### PR DESCRIPTION
<!-- remove all unused parts -->


## What
When the config it toggled on (InventoryConfig/Middle Click in Trade), it changes the normal clicks into middle clicks for less cooldown and effectively higher selling speed


</details>

## Changelog New Features
+ Middle click in Trades. - Rebix
