### PR TITLE
Fix: Fixed MayorAPI using the old Mayor after Election Switch

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.data.Mayor.Companion.setAssumeMayorJson
 import at.hannibal2.skyhanni.data.jsonobjects.local.MayorJson
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.utils.APIUtil
 import at.hannibal2.skyhanni.utils.CollectionUtils.put
@@ -14,6 +15,7 @@ import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.asTimeMark
+import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import io.github.moulberry.notenoughupdates.util.SkyBlockTime
 import kotlinx.coroutines.Dispatchers
@@ -25,10 +27,17 @@ import kotlin.time.Duration.Companion.minutes
 
 object MayorAPI {
 
-    val foxyExtraEventPattern by RepoPattern.pattern(
-        "mayorapi.foxy.extraevent",
+    val group = RepoPattern.group("mayorapi")
+    val foxyExtraEventPattern by group.pattern(
+        "foxy.extraevent",
         "Schedules an extra §.(?<event>.*) §.event during the year\\."
     )
+    val electionOver by group.pattern(
+        "election.over",
+        "§eThe election room is now closed\\. Clerk Seraphine is doing a final count of the votes\\.\\.\\."
+    )
+
+    private var lastMayor: Mayor? = null
 
     var lastUpdate = SimpleTimeMark.farPast()
     private var dispatcher = Dispatchers.IO
@@ -41,7 +50,7 @@ object MayorAPI {
     var timeTillNextMayor = Duration.ZERO
         private set
 
-    private const val ELECTION_END_MONTH = 3 //Late Spring
+    private const val ELECTION_END_MONTH = 3 // Late Spring
     private const val ELECTION_END_DAY = 27
 
     /**
@@ -66,10 +75,20 @@ object MayorAPI {
         }
     }
 
+    @SubscribeEvent
+    fun onChat(event: LorenzChatEvent) {
+        if (!LorenzUtils.onHypixel) return
+
+        if (electionOver.matches(event.message)) {
+            lastMayor = currentMayor
+            currentMayor = Mayor.UNKNOWN
+        }
+    }
+
     private fun calculateNextMayorTime(): SimpleTimeMark {
         var mayorYear = SkyBlockTime.now().year
 
-        // Check if either the month is already over or the day is after 27th in the third month
+        // Check if either the month is already over or the day after 27th in the third month
         if (SkyBlockTime.now().month > ELECTION_END_MONTH || (SkyBlockTime.now().day >= ELECTION_END_DAY && SkyBlockTime.now().month == ELECTION_END_MONTH)) {
             // If so, the next mayor will be in the next year
             mayorYear++
@@ -88,13 +107,15 @@ object MayorAPI {
 
         // Check if it is still the mayor from the old SkyBlock year
         currentMayor = candidates[nextMayorTime.toSkyBlockTime().year - 1]?.let {
+            if (it.name == lastMayor?.name) return
+
             // TODO: Once Jerry is active, add the sub mayor perks in here
             setAssumeMayorJson(it.name, it.perks)
         }
     }
 
     private fun checkHypixelAPI() {
-        if (lastUpdate.passedSince() < 20.minutes) return
+        if (lastUpdate.passedSince() < 20.minutes || (currentMayor == Mayor.UNKNOWN && lastUpdate.passedSince() < 1.minutes)) return
         lastUpdate = SimpleTimeMark.now()
 
         SkyHanniMod.coroutineScope.launch {

--- a/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
@@ -31,6 +31,7 @@ enum class Mayor(
     JERRY("Jerry", "§d", Perk.PERKPOCALYPSE, Perk.STATSPOCALYPSE, Perk.JERRYPOCALYPSE),
     DERPY("Derpy", "§d", Perk.TURBO_MINIONS, Perk.AH_CLOSED, Perk.DOUBLE_MOBS_HP, Perk.MOAR_SKILLZ),
 
+    UNKNOWN("Unknown", "§c"),
     DISABLED("§cDisabled", "§7"),
     ;
 


### PR DESCRIPTION
## What
Before anything, this is **NOT** tested.


## Changelog Fixes
+ Fixed Custom Scoreboard occasionally displaying an outdated mayor after an election switch. - j10a1n15

