### PR TITLE
Fix: highlights in inventory staying when exiting via NEU recipes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -48,6 +48,7 @@ import at.hannibal2.skyhanni.data.QuiverAPI
 import at.hannibal2.skyhanni.data.RenderData
 import at.hannibal2.skyhanni.data.SackAPI
 import at.hannibal2.skyhanni.data.ScoreboardData
+import at.hannibal2.skyhanni.data.ScreenData
 import at.hannibal2.skyhanni.data.SkillExperience
 import at.hannibal2.skyhanni.data.SlayerAPI
 import at.hannibal2.skyhanni.data.TitleData
@@ -553,6 +554,7 @@ class SkyHanniMod {
         loadModule(ContributorManager)
         loadModule(TabComplete)
         loadModule(HypixelBazaarFetcher)
+        loadModule(ScreenData)
 
         // APIs
         loadModule(BazaarApi())

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -519,6 +519,7 @@ class SkyHanniMod {
         loadModule(VisitorListener())
         loadModule(VisitorRewardWarning())
         loadModule(OwnInventoryData())
+        loadModule(ScreenData)
         loadModule(HighlightVisitorsOutsideOfGarden())
         loadModule(GuiEditManager())
         loadModule(GetFromSackAPI)
@@ -554,7 +555,6 @@ class SkyHanniMod {
         loadModule(ContributorManager)
         loadModule(TabComplete)
         loadModule(HypixelBazaarFetcher)
-        loadModule(ScreenData)
 
         // APIs
         loadModule(BazaarApi())

--- a/src/main/java/at/hannibal2/skyhanni/data/ScreenData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScreenData.kt
@@ -1,0 +1,21 @@
+package at.hannibal2.skyhanni.data
+
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.LorenzTickEvent
+import net.minecraft.client.Minecraft
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+
+object ScreenData {
+    private var isScreenOpen = false
+
+    @SubscribeEvent
+    fun onTick(event: LorenzTickEvent) {
+        if (!isScreenOpen && Minecraft.getMinecraft().currentScreen != null) {
+            isScreenOpen = true
+        } else if (isScreenOpen && Minecraft.getMinecraft().currentScreen == null) {
+            isScreenOpen = false
+            InventoryCloseEvent(false).postAndCatch()
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/ScreenData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScreenData.kt
@@ -5,16 +5,15 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-
 object ScreenData {
-    private var isScreenOpen = false
+    private var wasOpen = false
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
-        if (!isScreenOpen && Minecraft.getMinecraft().currentScreen != null) {
-            isScreenOpen = true
-        } else if (isScreenOpen && Minecraft.getMinecraft().currentScreen == null) {
-            isScreenOpen = false
+        val isOpen = Minecraft.getMinecraft().currentScreen != null
+        if (wasOpen == isOpen) return
+        wasOpen = isOpen
+        if (!wasOpen) {
             InventoryCloseEvent(false).postAndCatch()
         }
     }


### PR DESCRIPTION
## What
Fixes an issue where inventory highlights stay when opening and closing a NEU recipe via the item browser due to it not been detected when closed

## Changelog Fixes
+ Fixed inventory highlights sometimes remaining after exiting. - Mikecraft1224