### PR TITLE
Feature: Mining Commissions Blocks Color

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -295,6 +295,7 @@ import at.hannibal2.skyhanni.features.mining.DeepCavernsGuide
 import at.hannibal2.skyhanni.features.mining.GoldenGoblinHighlight
 import at.hannibal2.skyhanni.features.mining.HighlightMiningCommissionMobs
 import at.hannibal2.skyhanni.features.mining.KingTalismanHelper
+import at.hannibal2.skyhanni.features.mining.MiningBlockColors
 import at.hannibal2.skyhanni.features.mining.MiningNotifications
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalHollowsNamesInCore
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalHollowsWalls
@@ -812,6 +813,7 @@ class SkyHanniMod {
         loadModule(ShowItemUuid())
         loadModule(FrozenTreasureTracker)
         loadModule(MiningEventDisplay)
+        loadModule(MiningBlockColors)
         loadModule(SlayerRngMeterDisplay())
         loadModule(GhostCounter)
         loadModule(RiftTimer())

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -295,7 +295,7 @@ import at.hannibal2.skyhanni.features.mining.DeepCavernsGuide
 import at.hannibal2.skyhanni.features.mining.GoldenGoblinHighlight
 import at.hannibal2.skyhanni.features.mining.HighlightMiningCommissionMobs
 import at.hannibal2.skyhanni.features.mining.KingTalismanHelper
-import at.hannibal2.skyhanni.features.mining.MiningBlockColors
+import at.hannibal2.skyhanni.features.mining.MiningCommissionsBlocksColor
 import at.hannibal2.skyhanni.features.mining.MiningNotifications
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalHollowsNamesInCore
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalHollowsWalls
@@ -813,7 +813,7 @@ class SkyHanniMod {
         loadModule(ShowItemUuid())
         loadModule(FrozenTreasureTracker)
         loadModule(MiningEventDisplay)
-        loadModule(MiningBlockColors)
+        loadModule(MiningCommissionsBlocksColor)
         loadModule(SlayerRngMeterDisplay())
         loadModule(GhostCounter)
         loadModule(RiftTimer())

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/CommissionsBlocksColorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/CommissionsBlocksColorConfig.java
@@ -1,0 +1,14 @@
+package at.hannibal2.skyhanni.config.features.mining;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+public class CommissionsBlocksColorConfig {
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Change the color of ores on mining island depending on your active commissions.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean enabled = false;
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/CommissionsBlocksColorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/CommissionsBlocksColorConfig.java
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import io.github.notenoughupdates.moulconfig.observer.Property;
 
 public class CommissionsBlocksColorConfig {
     @Expose
@@ -11,4 +12,9 @@ public class CommissionsBlocksColorConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = false;
+
+    @Expose
+    @ConfigOption(name = "Sneak Toggle", desc = "Quickly disable or enable this feature via sneaking.")
+    @ConfigEditorBoolean
+    public Property<Boolean> sneakQuickToggle = Property.of(false);
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/CommissionsBlocksColorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/CommissionsBlocksColorConfig.java
@@ -1,8 +1,10 @@
 package at.hannibal2.skyhanni.config.features.mining;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
+import at.hannibal2.skyhanni.utils.LorenzColor;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 import io.github.notenoughupdates.moulconfig.observer.Property;
 
@@ -17,4 +19,9 @@ public class CommissionsBlocksColorConfig {
     @ConfigOption(name = "Sneak Toggle", desc = "Quickly disable or enable this feature via sneaking.")
     @ConfigEditorBoolean
     public Property<Boolean> sneakQuickToggle = Property.of(false);
+
+    @Expose
+    @ConfigOption(name = "Color", desc = "Change the highlight color.")
+    @ConfigEditorDropdown
+    public Property<LorenzColor> color = Property.of(LorenzColor.GREEN);
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/CommissionsBlocksColorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/CommissionsBlocksColorConfig.java
@@ -8,7 +8,7 @@ import io.github.notenoughupdates.moulconfig.observer.Property;
 
 public class CommissionsBlocksColorConfig {
     @Expose
-    @ConfigOption(name = "Enabled", desc = "Change the color of ores on mining island depending on your active commissions.")
+    @ConfigOption(name = "Enabled", desc = "Change the color of ores on mining island depending on your active commissions. Gray out irrelevant ores.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = false;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningConfig.java
@@ -48,6 +48,11 @@ public class MiningConfig {
     public MiningNotificationsConfig notifications = new MiningNotificationsConfig();
 
     @Expose
+    @ConfigOption(name = "Commissions Blocks Color", desc = "")
+    @Accordion
+    public CommissionsBlocksColorConfig commissionsBlocksColor = new CommissionsBlocksColorConfig();
+
+    @Expose
     @ConfigOption(name = "Highlight Commission Mobs", desc = "Highlight Mobs that are part of active commissions.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -19,7 +19,7 @@ import kotlin.time.Duration.Companion.seconds
 object MiningAPI {
 
     private val group = RepoPattern.group("data.miningapi")
-    private val glaciteAreaPattern by group.pattern("area.glacite", "Glacite Tunnels")
+    private val glaciteAreaPattern by group.pattern("area.glacite", "Glacite Tunnels|Glacite Lake")
     val coldReset by group.pattern(
         "cold.reset",
         "§6The warmth of the campfire reduced your §r§b❄ Cold §r§6to §r§a0§r§6!|§c ☠ §r§7You froze to death§r§7."

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -67,7 +67,7 @@ object GriffinBurrowParticleFinder {
             if (particleType != null) {
 
                 val location = packet.toLorenzVec().toBlockPos().down().toLorenzVec()
-                if (recentlyDugParticleBurrows.contains(location)) return
+                if (location in recentlyDugParticleBurrows) return
                 val burrow = burrows.getOrPut(location) { Burrow(location) }
 
                 when (particleType) {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -43,6 +43,8 @@ class HighlightMiningCommissionMobs {
             it is EntitySlime && (it.hasMaxHealth(5_000) || it.hasMaxHealth(10_000) || it.hasMaxHealth(25_000))
         }),
         CH_GOBLIN_SLAYER("Goblin Slayer", { it.name == "Weakling " }),
+
+        // new commissions
         ;
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -23,8 +23,10 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 class HighlightMiningCommissionMobs {
 
     private val config get() = SkyHanniMod.feature.mining
+    // TODO Commissin API
     private var active = listOf<MobType>()
 
+    // TODO Commissin API
     enum class MobType(val commissionName: String, val isMob: (EntityLivingBase) -> Boolean) {
 
         // Dwarven Mines
@@ -69,6 +71,7 @@ class HighlightMiningCommissionMobs {
     fun onTabListUpdate(event: TabListUpdateEvent) {
         if (!isEnabled()) return
 
+        // TODO Commissin API
         MobType.entries.filter { type ->
             event.tabList.findLast { line -> line.removeColor().trim().startsWith(type.commissionName) }
                 ?.let { !it.endsWith("§aDONE") }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningBlockColors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningBlockColors.kt
@@ -1,0 +1,174 @@
+package at.hannibal2.skyhanni.features.mining
+
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.events.TabListUpdateEvent
+import at.hannibal2.skyhanni.utils.CollectionUtils.equalsOneOf
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
+import net.minecraft.block.BlockCarpet
+import net.minecraft.block.state.IBlockState
+import net.minecraft.client.Minecraft
+import net.minecraft.init.Blocks
+import net.minecraft.item.EnumDyeColor
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+object MiningBlockColors {
+
+    var enabled = false
+    var active = false
+
+    private fun glass() = { state: IBlockState, result: Boolean ->
+        if (result) {
+            state.withProperty(BlockCarpet.COLOR, EnumDyeColor.PINK)
+//                 state.withProperty(BlockCarpet.COLOR, EnumDyeColor.LIME)
+        } else {
+            state.withProperty(BlockCarpet.COLOR, EnumDyeColor.GRAY)
+//                 state.withProperty(BlockCarpet.COLOR, EnumDyeColor.WHITE)
+//                 if (state == Blocks.stained_glass) {
+//                     Blocks.glass.defaultState
+//                 } else {
+//                     Blocks.glass_pane.defaultState
+//                 }
+        }
+    }
+
+    private fun block() = { _: IBlockState, result: Boolean ->
+        val wool = Blocks.wool.defaultState
+        if (result) {
+            wool.withProperty(BlockCarpet.COLOR, EnumDyeColor.PINK)
+//                 wool.withProperty(BlockCarpet.COLOR, EnumDyeColor.LIME)
+        } else {
+
+            wool.withProperty(BlockCarpet.COLOR, EnumDyeColor.GRAY)
+//                 wool.withProperty(BlockCarpet.COLOR, EnumDyeColor.WHITE)
+//                 Blocks.snow.defaultState
+        }
+    }
+
+    val aquamarine = Blocks.stained_glass
+    val aquamarine_2 = Blocks.stained_glass_pane
+
+    val citrine = Blocks.stained_glass
+    val citrine_2 = Blocks.stained_glass_pane
+
+    val glacite = Blocks.packed_ice
+
+    val onyx = Blocks.stained_glass
+    val onyx_2 = Blocks.stained_glass_pane
+
+    val umber = Blocks.hardened_clay
+    val umber_2 = Blocks.stained_hardened_clay
+    val umber_3 = Blocks.double_stone_slab2 // red sandstone
+
+    val peridot = Blocks.stained_glass
+    val peridot_2 = Blocks.stained_glass_pane
+
+    val tungston = Blocks.cobblestone
+    val tungston_2 = Blocks.stone_stairs
+    val tungston_3 = Blocks.clay
+
+
+    private var oldSneakState = false
+
+    private var dirty = false
+
+    @SubscribeEvent
+    fun onTabListUpdate(event: TabListUpdateEvent) {
+        for (value in GlaciteTunnelBlock.entries) {
+            val newValue = event.tabList.any { it.startsWith(value.tabList) && !it.contains("DONE") }
+            if (value.highlight != newValue) {
+                value.highlight = newValue
+                dirty = true
+            }
+        }
+    }
+
+    @SubscribeEvent
+    fun onTick(event: LorenzTickEvent) {
+        if (LorenzUtils.inSkyBlock) {
+            val sneaking = Minecraft.getMinecraft().thePlayer.isSneaking
+
+            if (sneaking != oldSneakState) {
+                oldSneakState = sneaking
+                if (oldSneakState) {
+                    dirty = true
+                    active = !active
+                }
+            }
+
+            if (dirty) {
+                Minecraft.getMinecraft().renderGlobal.loadRenderers()
+                dirty = false
+            }
+        }
+
+        enabled = IslandType.DWARVEN_MINES.isInIsland() && LorenzUtils.skyBlockArea.equalsOneOf(
+            "Glacite Tunnels",
+            "Glacite Lake"
+        )
+    }
+
+    enum class GlaciteTunnelBlock(
+        val tabList: String,
+        val onCheck: (IBlockState) -> Boolean,
+        val onColor: (IBlockState, Boolean) -> IBlockState,
+        var highlight: Boolean = false,
+    ) {
+        GLACITE(
+            " §r§fGlacite Collector: ",
+            onCheck = { state ->
+                state.block == glacite
+            },
+            onColor = block()
+        ),
+        UMBER(
+            " §r§fUmber Collector:",
+            onCheck = { state ->
+                (state.block == umber || state.block == umber_3) ||
+                    (state.block == umber_2 && state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.BROWN))
+            },
+            onColor = block()
+        ),
+        TUNGSTON(
+            " §r§fTungsten Collector: ",
+            onCheck = { state ->
+                state.block == tungston || state.block == tungston_2 || state.block == tungston_3
+            },
+            onColor = block()
+        ),
+        PERIDOT(
+            " §r§fPeridot Gemstone Collector: ",
+            onCheck = { state ->
+                (state.block == peridot || state.block == peridot_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.GREEN)
+            },
+            onColor = glass()
+        ),
+        AQUAMARINE(
+            " §r§fAquamarine Gemstone Collector:",
+            onCheck = { state ->
+                (state.block == aquamarine || state.block == aquamarine_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.BLUE)
+            },
+            onColor = glass()
+        ),
+        CITRINE(
+            " §r§fCitrine Gemstone Collector: ",
+            onCheck = { state ->
+                (state.block == citrine || state.block == citrine_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.BROWN)
+            },
+            onColor = glass()
+        ),
+        ONYX(
+            " §r§fOnyx Gemstone Collector:",
+            onCheck = { state ->
+                (state.block == onyx || state.block == onyx_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.BLACK)
+            },
+            onColor = glass()
+        ),
+        ;
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningBlockColors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningBlockColors.kt
@@ -108,7 +108,8 @@ object MiningBlockColors {
 
         enabled = (IslandType.DWARVEN_MINES.isInIsland() && LorenzUtils.skyBlockArea.equalsOneOf(
             "Glacite Tunnels",
-            "Glacite Lake"
+            "Glacite Lake",
+            "Glacite Mineshafts",
         )) || (IslandType.CRYSTAL_HOLLOWS.isInIsland())
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningBlockColors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningBlockColors.kt
@@ -75,6 +75,7 @@ object MiningBlockColors {
     private var oldSneakState = false
 
     private var dirty = false
+    private var forceDirty = false
 
     @SubscribeEvent
     fun onTabListUpdate(event: TabListUpdateEvent) {
@@ -89,28 +90,42 @@ object MiningBlockColors {
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
-        if (LorenzUtils.inSkyBlock) {
-            val sneaking = Minecraft.getMinecraft().thePlayer.isSneaking
-
-            if (sneaking != oldSneakState) {
-                oldSneakState = sneaking
-                if (oldSneakState) {
-                    dirty = true
-                    active = !active
-                }
-            }
-
-            if (dirty) {
-                Minecraft.getMinecraft().renderGlobal.loadRenderers()
-                dirty = false
-            }
-        }
-
-        enabled = (IslandType.DWARVEN_MINES.isInIsland() && LorenzUtils.skyBlockArea.equalsOneOf(
+        val newEnabled = (IslandType.DWARVEN_MINES.isInIsland() && LorenzUtils.skyBlockArea.equalsOneOf(
             "Glacite Tunnels",
             "Glacite Lake",
             "Glacite Mineshafts",
         )) || (IslandType.CRYSTAL_HOLLOWS.isInIsland())
+
+        var reload = false
+
+        if (newEnabled != enabled) {
+            enabled = newEnabled
+            reload = true
+            if (enabled) {
+                active = true
+            }
+        }
+
+        if (enabled) {
+            val sneaking = Minecraft.getMinecraft().thePlayer.isSneaking
+            if (sneaking != oldSneakState) {
+                oldSneakState = sneaking
+                if (oldSneakState) {
+                    active = !active
+                    dirty = true
+                }
+            }
+        }
+        if (enabled) {
+            if (dirty) {
+                reload = true
+            }
+        }
+
+        if (reload) {
+            Minecraft.getMinecraft().renderGlobal.loadRenderers()
+            dirty = false
+        }
     }
 
     enum class MiningBlock(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningBlockColors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningBlockColors.kt
@@ -68,6 +68,9 @@ object MiningBlockColors {
     val tungston_2 = Blocks.stone_stairs
     val tungston_3 = Blocks.clay
 
+    val mithril = Blocks.stained_hardened_clay
+    val mithril_2 = Blocks.wool
+    val mithril_3 = Blocks.prismarine
 
     private var oldSneakState = false
 
@@ -75,7 +78,7 @@ object MiningBlockColors {
 
     @SubscribeEvent
     fun onTabListUpdate(event: TabListUpdateEvent) {
-        for (value in GlaciteTunnelBlock.entries) {
+        for (value in MiningBlock.entries) {
             val newValue = event.tabList.any { it.startsWith(value.tabList) && !it.contains("DONE") }
             if (value.highlight != newValue) {
                 value.highlight = newValue
@@ -103,18 +106,88 @@ object MiningBlockColors {
             }
         }
 
-        enabled = IslandType.DWARVEN_MINES.isInIsland() && LorenzUtils.skyBlockArea.equalsOneOf(
+        enabled = (IslandType.DWARVEN_MINES.isInIsland() && LorenzUtils.skyBlockArea.equalsOneOf(
             "Glacite Tunnels",
             "Glacite Lake"
-        )
+        )) || (IslandType.CRYSTAL_HOLLOWS.isInIsland())
     }
 
-    enum class GlaciteTunnelBlock(
+    enum class MiningBlock(
         val tabList: String,
         val onCheck: (IBlockState) -> Boolean,
         val onColor: (IBlockState, Boolean) -> IBlockState,
         var highlight: Boolean = false,
     ) {
+        // Dwarven Mines
+        MITHRIL(
+            " §r§fMithril Everywhere:",
+            onCheck = { state ->
+                (state.block == mithril && state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.CYAN)) ||
+                    (state.block == mithril_2 && (state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.GRAY) ||
+                        state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.LIGHT_BLUE))) ||
+                    state.block == mithril_3
+            },
+            onColor = block()
+        ),
+
+        // Crystal Hollows
+        AMBER(
+            " §r§fAmber Gemstone Collector:",
+            onCheck = { state ->
+                (state.block == aquamarine || state.block == aquamarine_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.ORANGE)
+            },
+            onColor = glass()
+        ),
+        TOPAZ(
+            " §r§fTopaz Gemstone Collector:",
+            onCheck = { state ->
+                (state.block == aquamarine || state.block == aquamarine_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.YELLOW)
+            },
+            onColor = glass()
+        ),
+        AMETHYST(
+            " §r§fAmethyst Gemstone Collector:",
+            onCheck = { state ->
+                (state.block == aquamarine || state.block == aquamarine_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.PURPLE)
+            },
+            onColor = glass()
+        ),
+        RUBY(
+            " §r§fRuby Gemstone Collector:",
+            onCheck = { state ->
+                (state.block == aquamarine || state.block == aquamarine_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.RED)
+            },
+            onColor = glass()
+        ),
+        JADE(
+            " §r§fJade Gemstone Collector:",
+            onCheck = { state ->
+                (state.block == aquamarine || state.block == aquamarine_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.LIME)
+            },
+            onColor = glass()
+        ),
+        SAPPHIRE(
+            " §r§fSapphire Gemstone Collector:",
+            onCheck = { state ->
+                (state.block == aquamarine || state.block == aquamarine_2) &&
+                    state.getValue(BlockCarpet.COLOR).equalsOneOf(EnumDyeColor.LIGHT_BLUE)
+            },
+            onColor = glass()
+        ),
+        HARD_STONE(
+            " §r§fHardstone Miner: ",
+            onCheck = { state ->
+                state.block == glacite
+            },
+            onColor = block()
+        ),
+
+        // Glacite Tunnels
         GLACITE(
             " §r§fGlacite Collector: ",
             onCheck = { state ->

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
@@ -43,31 +43,22 @@ object MiningCommissionsBlocksColor {
         "§a§l(?<name>.*) §r§eCommission Complete! Visit the King §r§eto claim your rewards!"
     )
 
+    var color: EnumDyeColor = EnumDyeColor.RED
+
     private fun glass() = { state: IBlockState, result: Boolean ->
         if (result) {
-            state.withProperty(BlockCarpet.COLOR, EnumDyeColor.PINK)
-//                 state.withProperty(BlockCarpet.COLOR, EnumDyeColor.LIME)
+            state.withProperty(BlockCarpet.COLOR, color)
         } else {
             state.withProperty(BlockCarpet.COLOR, EnumDyeColor.GRAY)
-//                 state.withProperty(BlockCarpet.COLOR, EnumDyeColor.WHITE)
-//                 if (state == Blocks.stained_glass) {
-//                     Blocks.glass.defaultState
-//                 } else {
-//                     Blocks.glass_pane.defaultState
-//                 }
         }
     }
 
     private fun block() = { _: IBlockState, result: Boolean ->
         val wool = Blocks.wool.defaultState
         if (result) {
-            wool.withProperty(BlockCarpet.COLOR, EnumDyeColor.PINK)
-//                 wool.withProperty(BlockCarpet.COLOR, EnumDyeColor.LIME)
+            wool.withProperty(BlockCarpet.COLOR, color)
         } else {
-
             wool.withProperty(BlockCarpet.COLOR, EnumDyeColor.GRAY)
-//                 wool.withProperty(BlockCarpet.COLOR, EnumDyeColor.WHITE)
-//                 Blocks.snow.defaultState
         }
     }
 
@@ -181,12 +172,17 @@ object MiningCommissionsBlocksColor {
 
     @SubscribeEvent
     fun onConfigReload(event: ConfigLoadEvent) {
+        color = config.color.get().toDyeColor()
         config.sneakQuickToggle.onToggle {
             oldSneakState = false
             if (!active) {
                 active = true
                 dirty = true
             }
+        }
+        config.color.onToggle {
+            color = config.color.get().toDyeColor()
+            dirty = true
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
@@ -165,7 +165,7 @@ object MiningCommissionsBlocksColor {
 
     @SubscribeEvent
     fun onDebugDataCollect(event: DebugDataCollectEvent) {
-        event.title("Mining Block Colors")
+        event.title("Mining Commissions Blocks Color")
         if (!enabled) {
             event.addIrrelevant("not enabled")
             return

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
@@ -4,11 +4,13 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.MiningAPI
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.utils.CollectionUtils.equalsOneOf
+import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import net.minecraft.block.BlockCarpet
@@ -121,12 +123,14 @@ object MiningCommissionsBlocksColor {
         }
 
         if (enabled) {
-            val sneaking = Minecraft.getMinecraft().thePlayer.isSneaking
-            if (sneaking != oldSneakState) {
-                oldSneakState = sneaking
-                if (oldSneakState) {
-                    active = !active
-                    dirty = true
+            if (config.sneakQuickToggle.get()) {
+                val sneaking = Minecraft.getMinecraft().thePlayer.isSneaking
+                if (sneaking != oldSneakState) {
+                    oldSneakState = sneaking
+                    if (oldSneakState) {
+                        active = !active
+                        dirty = true
+                    }
                 }
             }
             if (dirty) {
@@ -137,6 +141,17 @@ object MiningCommissionsBlocksColor {
         if (reload) {
             Minecraft.getMinecraft().renderGlobal.loadRenderers()
             dirty = false
+        }
+    }
+
+    @SubscribeEvent
+    fun onConfigReload(event: ConfigLoadEvent) {
+        config.sneakQuickToggle.onToggle {
+            oldSneakState = false
+            if (!active) {
+                active = true
+                dirty = true
+            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
@@ -18,7 +18,7 @@ import net.minecraft.item.EnumDyeColor
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
-object MiningBlockColors {
+object MiningCommissionsBlocksColor {
 
     var enabled = false
     var active = false

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.mining
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.MiningAPI
@@ -19,6 +20,8 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
 object MiningCommissionsBlocksColor {
+
+    private val config get() = SkyHanniMod.feature.mining.commissionsBlocksColor
 
     var enabled = false
     var active = false
@@ -99,7 +102,6 @@ object MiningCommissionsBlocksColor {
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
-
         if (LorenzUtils.lastWorldSwitch.passedSince() > 4.seconds) {
             inGlaciteArea = MiningAPI.inGlaciteArea()
             inDwarvenMines = IslandType.DWARVEN_MINES.isInIsland() && !(inGlaciteArea ||
@@ -107,8 +109,8 @@ object MiningCommissionsBlocksColor {
                 )
             inCrystalHollows = IslandType.CRYSTAL_HOLLOWS.isInIsland() && HypixelData.skyBlockArea != "Crystal Nucleus"
         }
-        val newEnabled = inDwarvenMines || inCrystalHollows || inGlaciteArea
 
+        val newEnabled = (inDwarvenMines || inCrystalHollows || inGlaciteArea) && config.enabled
         var reload = false
         if (newEnabled != enabled) {
             enabled = newEnabled

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
@@ -37,7 +37,7 @@ class VerminHighlighter {
 
         for (entity in EntityUtils.getEntities<EntityLivingBase>()) {
             val id = entity.entityId
-            if (checkedEntites.contains(id)) continue
+            if (id in checkedEntites) continue
             checkedEntites.add(id)
 
             if (!isVermin(entity)) continue

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
@@ -22,9 +22,9 @@ fun modifyGetModelFromBlockState(
     if (!LorenzUtils.inSkyBlock) return
 
     if (MiningBlockColors.enabled && MiningBlockColors.active) {
-        for (value in MiningBlockColors.MiningBlock.entries) {
-            if (value.onCheck(state)) {
-                returnState = value.onColor(state, value.highlight)
+        for (block in MiningBlockColors.MiningBlock.entries) {
+            if (block.checkIsland() && block.onCheck(state)) {
+                returnState = block.onColor(state, block.highlight)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.mixins.hooks
+
+import at.hannibal2.skyhanni.features.mining.MiningBlockColors
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraft.block.state.IBlockState
+import net.minecraft.client.renderer.BlockRendererDispatcher
+import net.minecraft.client.resources.model.IBakedModel
+import net.minecraft.util.BlockPos
+import net.minecraft.world.IBlockAccess
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
+
+fun modifyGetModelFromBlockState(
+    blockRendererDispatcher: BlockRendererDispatcher,
+    state: IBlockState?,
+    worldIn: IBlockAccess,
+    pos: BlockPos?,
+    cir: CallbackInfoReturnable<IBakedModel>,
+) {
+    if (state == null || pos == null) return
+    var returnState: IBlockState = state
+
+    if (!LorenzUtils.inSkyBlock) return
+
+    if (MiningBlockColors.enabled && MiningBlockColors.active) {
+        for (value in MiningBlockColors.GlaciteTunnelBlock.entries) {
+            if (value.onCheck(state)) {
+                returnState = value.onColor(state, value.highlight)
+            }
+        }
+    }
+
+    if (returnState !== state) {
+        cir.returnValue = blockRendererDispatcher.blockModelShapes.getModelForState(returnState)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
@@ -22,7 +22,7 @@ fun modifyGetModelFromBlockState(
     if (!LorenzUtils.inSkyBlock) return
 
     if (MiningBlockColors.enabled && MiningBlockColors.active) {
-        for (value in MiningBlockColors.GlaciteTunnelBlock.entries) {
+        for (value in MiningBlockColors.MiningBlock.entries) {
             if (value.onCheck(state)) {
                 returnState = value.onColor(state, value.highlight)
             }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
-import at.hannibal2.skyhanni.features.mining.MiningBlockColors
+import at.hannibal2.skyhanni.features.mining.MiningCommissionsBlocksColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.block.state.IBlockState
 import net.minecraft.client.renderer.BlockRendererDispatcher
@@ -21,8 +21,8 @@ fun modifyGetModelFromBlockState(
 
     if (!LorenzUtils.inSkyBlock) return
 
-    if (MiningBlockColors.enabled && MiningBlockColors.active) {
-        for (block in MiningBlockColors.MiningBlock.entries) {
+    if (MiningCommissionsBlocksColor.enabled && MiningCommissionsBlocksColor.active) {
+        for (block in MiningCommissionsBlocksColor.MiningBlock.entries) {
             if (block.checkIsland() && block.onCheck(state)) {
                 returnState = block.onColor(state, block.highlight)
             }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinBlockRendererDispatcher.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinBlockRendererDispatcher.java
@@ -1,0 +1,21 @@
+package at.hannibal2.skyhanni.mixins.transformers.renderer;
+
+import at.hannibal2.skyhanni.mixins.hooks.BlockRendererDispatcherHookKt;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.BlockRendererDispatcher;
+import net.minecraft.client.resources.IResourceManagerReloadListener;
+import net.minecraft.client.resources.model.IBakedModel;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockRendererDispatcher.class)
+public abstract class MixinBlockRendererDispatcher implements IResourceManagerReloadListener {
+    @Inject(method = "getModelFromBlockState", at = @At("RETURN"), cancellable = true)
+    private void modifyGetModelFromBlockState(IBlockState state, IBlockAccess worldIn, BlockPos pos, CallbackInfoReturnable<IBakedModel> cir) {
+        BlockRendererDispatcherHookKt.modifyGetModelFromBlockState((BlockRendererDispatcher) (Object) this, state, worldIn, pos, cir);
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -118,7 +118,7 @@ object ErrorManager {
             val pair = if (throwable.stackTrace.isNotEmpty()) {
                 throwable.stackTrace[0].let { (it.fileName ?: "<unknown>") to it.lineNumber }
             } else message to 0
-            if (cache.contains(pair)) return
+            if (pair in cache) return
             cache.add(pair)
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/CollectionUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/CollectionUtils.kt
@@ -49,7 +49,7 @@ object CollectionUtils {
 
     // Taken and modified from Skytils
     @JvmStatic
-    fun <T> T.equalsOneOf(vararg other: T): Boolean {
+    fun <T> T?.equalsOneOf(vararg other: T): Boolean {
         for (obj in other) {
             if (this == obj) return true
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzColor.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.utils
 
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import net.minecraft.item.EnumDyeColor
 import java.awt.Color
 
@@ -40,11 +39,33 @@ enum class LorenzColor(val chatColorCode: Char, private val color: Color, privat
 
     fun toConfigColour(): String = "0:255:${color.red}:${color.green}:${color.blue}"
 
+    fun toDyeColor(): EnumDyeColor = when (this) {
+        WHITE -> EnumDyeColor.WHITE
+        GOLD -> EnumDyeColor.ORANGE
+        AQUA -> EnumDyeColor.MAGENTA
+        BLUE -> EnumDyeColor.LIGHT_BLUE
+        YELLOW -> EnumDyeColor.YELLOW
+        GREEN -> EnumDyeColor.LIME
+        LIGHT_PURPLE -> EnumDyeColor.PINK
+        DARK_GRAY -> EnumDyeColor.GRAY
+        GRAY -> EnumDyeColor.SILVER
+        DARK_AQUA -> EnumDyeColor.CYAN
+        DARK_PURPLE -> EnumDyeColor.PURPLE
+        DARK_BLUE -> EnumDyeColor.BLUE
+//         GOLD -> EnumDyeColor.BROWN
+        DARK_GREEN -> EnumDyeColor.GREEN
+        DARK_RED -> EnumDyeColor.RED
+        BLACK -> EnumDyeColor.BLACK
+        RED -> EnumDyeColor.RED
+
+        CHROMA -> EnumDyeColor.WHITE
+    }
+
     companion object {
 
         fun EnumDyeColor.toLorenzColor() = when (this) {
             EnumDyeColor.WHITE -> WHITE
-            EnumDyeColor.MAGENTA -> LIGHT_PURPLE
+            EnumDyeColor.MAGENTA -> AQUA
             EnumDyeColor.PINK -> LIGHT_PURPLE
             EnumDyeColor.RED -> RED
             EnumDyeColor.SILVER -> GRAY
@@ -54,13 +75,11 @@ enum class LorenzColor(val chatColorCode: Char, private val color: Color, privat
             EnumDyeColor.BLUE -> BLUE
             EnumDyeColor.PURPLE -> DARK_PURPLE
             EnumDyeColor.YELLOW -> YELLOW
-            else -> {
-                ErrorManager.logErrorWithData(
-                    Exception("Unknown dye color: $this"),
-                    "Unknown dye color: $this"
-                )
-                null
-            }
+            EnumDyeColor.ORANGE -> GOLD
+            EnumDyeColor.LIGHT_BLUE -> BLUE
+            EnumDyeColor.CYAN -> DARK_AQUA
+            EnumDyeColor.BROWN -> GOLD
+            EnumDyeColor.BLACK -> BLACK
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedSet.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedSet.kt
@@ -8,7 +8,7 @@ class TimeLimitedSet<T>(expireAfterWrite: Duration) {
 
     fun add(element: T) = cache.put(element, Unit)
 
-    fun contains(element: T): Boolean = cache.containsKey(element)
+    operator fun contains(element: T): Boolean = cache.containsKey(element)
 
     fun clear() = cache.clear()
 


### PR DESCRIPTION
## What
highlight blocks you need to break for a commission. Focused on Glacite tunnels. Other blocks are grayed out.

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog New Features
+ Added Commissions Blocks Color. - hannibal2
    * Highlights blocks required for commissions in a custom color.
    * Greys out other blocks for clarity.
    * Works in the Glacite Tunnels and Crystal Hollows.