### PR TITLE
Backend: gardencropmilestonefix triggering on skills

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropMilestoneFix.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropMilestoneFix.kt
@@ -28,7 +28,7 @@ class GardenCropMilestoneFix {
      */
     private val tabListPattern by patternGroup.pattern(
         "tablist",
-        " (?<crop>.*) (?<tier>\\d+): §r§a(?<percentage>.*)%"
+        " (?<crop>Wheat|Carrot|Potato|Pumpkin|Sugar Cane|Melon|Cactus|Cocoa Beans|Mushroom|Nether Wart) (?<tier>\\d+): §r§a(?<percentage>.*)%"
     )
     private val levelUpPattern by patternGroup.pattern(
         "levelup",


### PR DESCRIPTION
## What
fixes GardenCropMilestoneFix also triggering on skills, which obviously aren't crops
https://discord.com/channels/997079228510117908/1094190239532208228/1236416158253449237

## Changelog Technical Details
+ Fixed the GardenCropMilestoneFix tab pattern to not trigger on skills. - martimavocado

