### PR TITLE
Fix: Active Effects in Compact Tab List always showing 0

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
@@ -34,7 +34,7 @@ object TabListReader {
     )
     private val effectCountPattern by patternGroup.pattern(
         "effects.count",
-        "You have (?<effectCount>[0-9]+) active effect"
+        "You have (?:§.)*(?<effectCount>[0-9]+) (?:§.)*active effect"
     )
     private val cookiePattern by patternGroup.pattern(
         "cookie",


### PR DESCRIPTION
## What
Fixed Active Effects in Compact Tab List always showing 0.

## Changelog Fixes
+ Fixed Active Effects in Compact Tab List always showing 0. - Luna