### PR TITLE
Fix: Adjust Hoppity's Hunt not active message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -108,7 +108,7 @@ object HoppityEggsManager {
 
             if (config.timeInChat) {
                 val timeUntil = SkyBlockTime(currentYear + 1).asTimeMark().timeUntil()
-                ChatUtils.chat("§eHoppity's Hunt not active. Next Hoppity's Hunt event in §b${timeUntil.format()}§e.")
+                ChatUtils.chat("§eHoppity's Hunt is not active. The next Hoppity's Hunt is in §b${timeUntil.format()}§e.")
                 event.blockedReason = "hoppity_egg"
             }
             return


### PR DESCRIPTION
## What
Adjust Hoppity's Hunt message to be more grammatically accurate. 

## Changelog Fixes
+ Fixed typo in Hoppity's Hunt "not active" message. - walker