### PR TITLE
Improvement: Chocolate Factory

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -60,9 +60,21 @@ public class ChocolateFactoryConfig {
     public boolean showStackSizes = true;
 
     @Expose
-    @ConfigOption(name = "Highlight Upgrades", desc = "Highlight any upgrades that you can afford. The upgrade with a star is the most optimal and the lightest colour of green is the most optimal you can afford.")
+    @ConfigOption(
+        name = "Highlight Best Upgrade",
+        desc = "Highlight the most optimal you can afford."
+    )
     @ConfigEditorBoolean
-    public boolean highlightUpgrades = true;
+    public boolean highlightBestUpgrade = true;
+
+    @Expose
+    @ConfigOption(
+        name = "Highlight Affordable Upgrades",
+        desc = "Highlight any upgrades that you can afford. " +
+            "The lightest colour of green is the most optimal you can afford."
+    )
+    @ConfigEditorBoolean
+    public boolean highlightAffordableUpgrades = true;
 
     @Expose
     @ConfigOption(name = "Use Middle Click", desc = "Click on slots with middle click to speed up interactions.")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
@@ -22,7 +22,7 @@ object ChocolateFactoryInventory {
     @SubscribeEvent
     fun onForegroundDrawn(event: GuiContainerEvent.ForegroundDrawnEvent) {
         if (!ChocolateFactoryAPI.inChocolateFactory) return
-        if (!config.highlightBestUpgrade) return
+        if (!config.highlightBestUpgrade || !config.highlightAffordableUpgrades) return
 
         for (slot in InventoryUtils.getItemsInOpenChest()) {
             if (slot.stack == null) continue
@@ -54,9 +54,11 @@ object ChocolateFactoryInventory {
             val currentUpdates = ChocolateFactoryAPI.factoryUpgrades
             currentUpdates.find { it.slotIndex == slotIndex }?.let { upgrade ->
                 if (upgrade.canAfford()) {
-                    slot highlight LorenzColor.GREEN.addOpacity(75)
+                    slot highlight LorenzColor.GREEN.addOpacity(200)
+                    return
                 }
             }
+            slot highlight LorenzColor.GOLD.addOpacity(200)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
@@ -22,8 +22,7 @@ object ChocolateFactoryInventory {
     @SubscribeEvent
     fun onForegroundDrawn(event: GuiContainerEvent.ForegroundDrawnEvent) {
         if (!ChocolateFactoryAPI.inChocolateFactory) return
-        if (!config.highlightUpgrades) return
-
+        if (!config.highlightBestUpgrade) return
 
         for (slot in InventoryUtils.getItemsInOpenChest()) {
             if (slot.stack == null) continue
@@ -38,7 +37,7 @@ object ChocolateFactoryInventory {
     @SubscribeEvent
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!ChocolateFactoryAPI.inChocolateFactory) return
-        if (!config.highlightUpgrades) return
+        if (!config.highlightAffordableUpgrades) return
 
         for (slot in InventoryUtils.getItemsInOpenChest()) {
             if (slot.stack == null) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
@@ -37,8 +37,30 @@ object ChocolateFactoryInventory {
     @SubscribeEvent
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!ChocolateFactoryAPI.inChocolateFactory) return
-        if (!config.highlightAffordableUpgrades) return
+        if (config.highlightAffordableUpgrades) {
+            highlightAffordableUpgrades()
+        } else {
+            highlightBestUpgrades()
+        }
+    }
 
+    private fun highlightBestUpgrades() {
+        if (!config.highlightBestUpgrade) return
+        for (slot in InventoryUtils.getItemsInOpenChest()) {
+            if (slot.stack == null) continue
+            val slotIndex = slot.slotNumber
+
+            if (slotIndex != ChocolateFactoryAPI.bestPossibleSlot) continue
+            val currentUpdates = ChocolateFactoryAPI.factoryUpgrades
+            currentUpdates.find { it.slotIndex == slotIndex }?.let { upgrade ->
+                if (upgrade.canAfford()) {
+                    slot highlight LorenzColor.GREEN.addOpacity(75)
+                }
+            }
+        }
+    }
+
+    private fun highlightAffordableUpgrades() {
         for (slot in InventoryUtils.getItemsInOpenChest()) {
             if (slot.stack == null) continue
             val slotIndex = slot.slotNumber


### PR DESCRIPTION
## What
split upgrades into highlight best upgrade and highlight affordable upgrades

## Changelog Improvements
+ Chocolate Factory changes. - hannibal2
    * Split upgrades into highlight best upgrade and highlight affordable upgrades.
    * Highlight best upgrade when affordable.
    * Highlight best slot green when affordable, even when "highlight affordable upgrades" is disabled.
