### PR TITLE
Fix: Rift Hay Eaten Scoreboard Line

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -503,6 +503,7 @@ private fun getRiftLines() = getSbLines().filter { line ->
         || SbPattern.timeLeftPattern.matches(line)
         || SbPattern.riftHotdogEatenPattern.matches(line)
         || SbPattern.riftAveikxPattern.matches(line)
+        || SbPattern.riftHayEatenPattern.matches(line)
 }
 
 private fun getEssenceLines(): List<String> = listOf(getSbLines().first { SbPattern.essencePattern.matches(it) })

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -417,7 +417,7 @@ object ScoreboardPattern {
     )
     val riftHayEatenPattern by riftSb.pattern(
         "hayeaten",
-        "^Hay Eaten: §.\\d+/\\d+$"
+        "^Hay Eaten: §.[\\d,.]*/[\\d,.]*\$"
     )
 
     // Stats from the tablist

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -415,6 +415,10 @@ object ScoreboardPattern {
         "aveikx",
         "Time spent sitting|with Ävaeìkx: .*"
     )
+    val riftHayEatenPattern by riftSb.pattern(
+        "hayeaten",
+        "^Hay Eaten: §.\\d+/\\d+$"
+    )
 
     // Stats from the tablist
     private val tablistGroup = group.group("tablist")

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -417,7 +417,7 @@ object ScoreboardPattern {
     )
     val riftHayEatenPattern by riftSb.pattern(
         "hayeaten",
-        "^Hay Eaten: §.[\\d,.]*/[\\d,.]*\$"
+        "^Hay Eaten: §.[\\d,.]+/[\\d,.]+\$"
     )
 
     // Stats from the tablist

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -118,6 +118,7 @@ object UnknownLinesHandler {
             SbPattern.queuePositionPattern,
             SbPattern.fortunateFreezingBonusPattern,
             SbPattern.riftAveikxPattern,
+            SbPattern.riftHayEatenPattern,
             SbPattern.fossilDustPattern,
         )
 


### PR DESCRIPTION
## What
Adds the Hay Eaten scoreboard line in custom scoreboard from the rift.

## Changelog Fixes
+ Fixed missing Hay Eaten line in Custom Scoreboard in Rift. - Empa