### PR TITLE
Feature: Replace Roman Numerals with Arabic Numerals

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -342,6 +342,7 @@ import at.hannibal2.skyhanni.features.misc.PetItemDisplay
 import at.hannibal2.skyhanni.features.misc.PocketSackInASackDisplay
 import at.hannibal2.skyhanni.features.misc.PrivateIslandNoPickaxeAbility
 import at.hannibal2.skyhanni.features.misc.QuickModMenuSwitch
+import at.hannibal2.skyhanni.features.misc.ReplaceRomanNumerals
 import at.hannibal2.skyhanni.features.misc.RestorePieceOfWizardPortalLore
 import at.hannibal2.skyhanni.features.misc.ServerRestartTitle
 import at.hannibal2.skyhanni.features.misc.SkyBlockKickDuration
@@ -721,6 +722,7 @@ class SkyHanniMod {
         loadModule(TpsCounter())
         loadModule(ParticleHider())
         loadModule(MiscFeatures())
+        loadModule(ReplaceRomanNumerals())
         loadModule(GardenPlotMenuHighlighting())
         loadModule(SkyMartCopperPrice())
         loadModule(GardenVisitorFeatures)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -256,7 +256,7 @@ public class MiscConfig {
     @ConfigOption(name = "Replace Roman Numerals", desc = "Replaces Roman Numerals with Arabic Numerals on any item.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean replaceRomanNumerals = true;
+    public boolean replaceRomanNumerals = false;
 
     @ConfigOption(name = "Hide Far Entities", desc = "")
     @Accordion

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -252,6 +252,12 @@ public class MiscConfig {
     @FeatureToggle
     public boolean fixGhostEntities = true;
 
+    @Expose
+    @ConfigOption(name = "Replace Roman Numerals", desc = "Replaces Roman Numerals with Arabic Numerals on any item.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean replaceRomanNumerals = true;
+
     @ConfigOption(name = "Hide Far Entities", desc = "")
     @Accordion
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatModifier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatModifier.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.features.misc.MarkedPlayerManager
+import at.hannibal2.skyhanni.utils.StringUtils.applyIfPossible
 import net.minecraft.event.ClickEvent
 import net.minecraft.event.HoverEvent
 import net.minecraft.util.ChatComponentText
@@ -22,28 +23,7 @@ class PlayerChatModifier {
 
     @SubscribeEvent
     fun onChat(event: SystemMessageEvent) {
-        val original = event.chatComponent.formattedText
-        val new = cutMessage(original)
-        if (new == original) return
-
-        val clickEvents = mutableListOf<ClickEvent>()
-        val hoverEvents = mutableListOf<HoverEvent>()
-        findClickableTexts(event.chatComponent, clickEvents)
-        findHoverTexts(event.chatComponent, hoverEvents)
-        val clickSize = clickEvents.size
-        val hoverSize = hoverEvents.size
-
-        // do not change the message if more than one hover or click is found
-        if (clickSize > 1 || hoverSize > 1) return
-
-        val text = ChatComponentText(new)
-        if (clickSize == 1) {
-            text.chatStyle.chatClickEvent = clickEvents.first()
-        }
-        if (hoverSize == 1) {
-            text.chatStyle.chatHoverEvent = hoverEvents.first()
-        }
-        event.chatComponent = text
+        event.applyIfPossible { cutMessage(it) }
     }
 
     private fun findClickableTexts(chatComponent: IChatComponent, clickEvents: MutableList<ClickEvent>) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.events.ChatHoverEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook
@@ -8,12 +9,17 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.StringUtils.isRoman
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import net.minecraft.event.ClickEvent
 import net.minecraft.event.HoverEvent
 import net.minecraft.util.ChatComponentText
+import net.minecraft.util.IChatComponent
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class ReplaceRomanNumerals {
+    // Using toRegex here since toPattern doesn't seem to provide the necessary functionality
+    private val splitRegex = "((§\\w)|(\\s+)|(\\W))+|(\\w*)".toRegex()
+
     @SubscribeEvent(priority = EventPriority.LOWEST)
     fun onTooltip(event: LorenzToolTipEvent) {
         if (!isEnabled()) return
@@ -35,7 +41,46 @@ class ReplaceRomanNumerals {
         GuiChatHook.replaceOnlyHoverEvent(hoverEvent)
     }
 
-    private fun String.transformLine() = split(" ").joinToString(" ") {
+    @SubscribeEvent
+    fun onSystemMessage(event: SystemMessageEvent) {
+        if (!isEnabled()) return
+        event.applyIfPossible { it.transformLine() }
+    }
+
+    private fun SystemMessageEvent.applyIfPossible(transform: (String) -> String) {
+        val original = chatComponent.formattedText
+        val new = transform(original)
+        if (new == original) return
+
+        val clickEvents = mutableListOf<ClickEvent>()
+        val hoverEvents = mutableListOf<HoverEvent>()
+        chatComponent.findAllEvents(clickEvents, hoverEvents)
+
+        if (clickEvents.size > 1 || hoverEvents.size > 1) return
+
+        chatComponent = ChatComponentText(new)
+        if (clickEvents.size == 1) chatComponent.chatStyle.chatClickEvent = clickEvents.first()
+        if (hoverEvents.size == 1) chatComponent.chatStyle.chatHoverEvent = hoverEvents.first()
+    }
+
+    private fun IChatComponent.findAllEvents(
+        clickEvents: MutableList<ClickEvent>,
+        hoverEvents: MutableList<HoverEvent>
+    ) {
+        siblings.forEach { it.findAllEvents(clickEvents, hoverEvents) }
+
+        val clickEvent = chatStyle.chatClickEvent
+        val hoverEvent = chatStyle.chatHoverEvent
+
+        if (clickEvent?.action != null && clickEvents.none { it.value == clickEvent.value }) {
+            clickEvents.add(clickEvent)
+        }
+        if (hoverEvent?.action != null && hoverEvents.none { it.value == hoverEvent.value }) {
+            hoverEvents.add(hoverEvent)
+        }
+    }
+
+    private fun String.transformLine() = splitRegex.findAll(this).map { it.value }.joinToString("") {
         it.takeIf { it.isValidRomanNumeral() }?.coloredRomanToDecimal() ?: it
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
@@ -1,0 +1,51 @@
+package at.hannibal2.skyhanni.features.misc
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.ChatHoverEvent
+import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
+import at.hannibal2.skyhanni.utils.StringUtils.isRoman
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import net.minecraft.event.HoverEvent
+import net.minecraft.util.ChatComponentText
+import net.minecraftforge.fml.common.eventhandler.EventPriority
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class ReplaceRomanNumerals {
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    fun onTooltip(event: LorenzToolTipEvent) {
+        if (!isEnabled()) return
+
+        event.toolTip.replaceAll { it.transformLine() }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    fun onChatHover(event: ChatHoverEvent) {
+        if (event.getHoverEvent().action != HoverEvent.Action.SHOW_TEXT) return
+        if (!isEnabled()) return
+
+        val lore = event.getHoverEvent().value.formattedText.split("\n").toMutableList()
+        lore.replaceAll { it.transformLine() }
+
+        val chatComponentText = ChatComponentText(lore.joinToString("\n"))
+        val hoverEvent = HoverEvent(event.component.chatStyle.chatHoverEvent.action, chatComponentText)
+
+        GuiChatHook.replaceOnlyHoverEvent(hoverEvent)
+    }
+
+    private fun String.transformLine() = split(" ").joinToString(" ") {
+        it.takeIf { it.isValidRomanNumeral() }?.coloredRomanToDecimal() ?: it
+    }
+
+    private fun String.removeFormatting() = removeColor().replace(",", "")
+
+    private fun String.isValidRomanNumeral() = removeFormatting()
+        .let { it.isRoman() && it.isNotEmpty() }
+
+    private fun String.coloredRomanToDecimal() = removeFormatting()
+        .let { replace(it, it.romanToDecimal().toString()) }
+
+    private fun isEnabled() = LorenzUtils.inSkyBlock && SkyHanniMod.feature.misc.replaceRomanNumerals
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
+import at.hannibal2.skyhanni.utils.StringUtils.applyIfPossible
 import at.hannibal2.skyhanni.utils.StringUtils.isRoman
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraft.event.ClickEvent
@@ -45,39 +46,6 @@ class ReplaceRomanNumerals {
     fun onSystemMessage(event: SystemMessageEvent) {
         if (!isEnabled()) return
         event.applyIfPossible { it.transformLine() }
-    }
-
-    private fun SystemMessageEvent.applyIfPossible(transform: (String) -> String) {
-        val original = chatComponent.formattedText
-        val new = transform(original)
-        if (new == original) return
-
-        val clickEvents = mutableListOf<ClickEvent>()
-        val hoverEvents = mutableListOf<HoverEvent>()
-        chatComponent.findAllEvents(clickEvents, hoverEvents)
-
-        if (clickEvents.size > 1 || hoverEvents.size > 1) return
-
-        chatComponent = ChatComponentText(new)
-        if (clickEvents.size == 1) chatComponent.chatStyle.chatClickEvent = clickEvents.first()
-        if (hoverEvents.size == 1) chatComponent.chatStyle.chatHoverEvent = hoverEvents.first()
-    }
-
-    private fun IChatComponent.findAllEvents(
-        clickEvents: MutableList<ClickEvent>,
-        hoverEvents: MutableList<HoverEvent>
-    ) {
-        siblings.forEach { it.findAllEvents(clickEvents, hoverEvents) }
-
-        val clickEvent = chatStyle.chatClickEvent
-        val hoverEvent = chatStyle.chatHoverEvent
-
-        if (clickEvent?.action != null && clickEvents.none { it.value == clickEvent.value }) {
-            clickEvents.add(clickEvent)
-        }
-        if (hoverEvent?.action != null && hoverEvents.none { it.value == hoverEvent.value }) {
-            hoverEvents.add(hoverEvent)
-        }
     }
 
     private fun String.transformLine() = splitRegex.findAll(this).map { it.value }.joinToString("") {


### PR DESCRIPTION
## What
Replaces Roman Numerals in almost all cases
- Tooltips on item (enchants etc.)
- Bestiary and Collections Milestones
- Skills and Collections in chat

~~This might conflict with https://github.com/hannibal002/SkyHanni/pull/1717 and will be tested.~~
This was tested, though there were issues found, they were not related with this feature.


## Changelog New Features
+ Option to Replace Roman Numerals. - Mikecraft1224