### PR TITLE
Fix: Time to prestige being wrong the second after using time tower

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -127,20 +127,20 @@ object ChocolateFactoryDataLoader {
 
         val chocolateItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.infoIndex) ?: return
         val prestigeItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.prestigeIndex) ?: return
+        val timeTowerItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.timeTowerIndex) ?: return
         val productionInfoItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.productionInfoIndex) ?: return
         val leaderboardItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.leaderboardIndex) ?: return
         val barnItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.barnIndex) ?: return
-        val timeTowerItem = InventoryUtils.getItemAtSlotIndex(ChocolateFactoryAPI.timeTowerIndex) ?: return
 
         ChocolateFactoryAPI.factoryUpgrades = emptyList()
 
         processChocolateItem(chocolateItem)
         val list = mutableListOf<ChocolateFactoryUpgrade>()
         processPrestigeItem(list, prestigeItem)
+        processTimeTowerItem(timeTowerItem)
         processProductionItem(productionInfoItem)
         processLeaderboardItem(leaderboardItem)
         processBarnItem(barnItem)
-        processTimeTowerItem(timeTowerItem)
 
         profileStorage.rawChocPerSecond =
             (ChocolateFactoryAPI.chocolatePerSecond / profileStorage.chocolateMultiplier + .01).toInt()


### PR DESCRIPTION
## What
 Fixed time to prestige being wrong the second after using time tower.

## Changelog Fixes
+ Fixed incorrect time to prestige after using the Time Tower. - CalMWolfs
