### PR TITLE
Fix: showing time to upgrade when maxed

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -359,7 +359,8 @@ object ChocolateFactoryDataLoader {
         val profileStorage = profileStorage ?: return
 
         // removing time tower here as people like to determine when to buy it themselves
-        val notMaxed = list.filter { !it.isMaxed && it.slotIndex != ChocolateFactoryAPI.timeTowerIndex }
+        val notMaxed =
+            list.filter { !it.isMaxed && it.slotIndex != ChocolateFactoryAPI.timeTowerIndex && it.effectiveCost != null }
 
         val bestUpgrade = notMaxed.minByOrNull { it.effectiveCost ?: Double.MAX_VALUE }
         profileStorage.bestUpgradeAvailableAt = bestUpgrade?.canAffordAt?.toMillis() ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
@@ -155,7 +155,9 @@ object ChocolateFactoryStats {
         TIME_TO_PRESTIGE("§eTime To Prestige: §b1d 13h 59m 4s", { ChocolateFactoryAPI.currentPrestige != 5 }),
         RAW_PER_SECOND("§eRaw Per Second: §62,136"),
         CHOCOLATE_UNTIL_PRESTIGE("§eChocolate To Prestige: §65,851", { ChocolateFactoryAPI.currentPrestige != 5 }),
-        TIME_TO_BEST_UPGRADE("§eBest Upgrade: §b 59m 4s"),
+        TIME_TO_BEST_UPGRADE(
+            "§eBest Upgrade: §b 59m 4s",
+            { ChocolateFactoryAPI.profileStorage?.bestUpgradeCost != 0L }),
         ;
 
         override fun toString(): String {


### PR DESCRIPTION
## What
Fixed showing time to upgrade when maxed.

## Changelog Fixes
+ Fixed upgrade time display when Chocolate Factory Upgrades are maxed. - CalMWolfs

