### PR TITLE
Fix: npe in inventory utils

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -79,7 +79,8 @@ object InventoryUtils {
 
     fun isSlotInPlayerInventory(itemStack: ItemStack): Boolean {
         val screen = Minecraft.getMinecraft().currentScreen as? GuiContainer ?: return false
-        return screen.slotUnderMouse.inventory is InventoryPlayer && screen.slotUnderMouse.stack == itemStack
+        val slotUnderMouse = screen.slotUnderMouse ?: return false
+        return slotUnderMouse.inventory is InventoryPlayer && slotUnderMouse.stack == itemStack
     }
 
     fun isItemInInventory(name: NEUInternalName) = name.getAmountInInventory() > 0


### PR DESCRIPTION
## What
Fixed a NPE in inventory utils

```
Caused by java.lang.NullPointerException: null
	at SH.utils.InventoryUtils.isSlotInPlayerInventory(InventoryUtils.kt:82)
	at SH.features.misc.items.EstimatedItemValue.draw(EstimatedItemValue.kt:182)
	at SH.features.misc.items.EstimatedItemValue.updateItem(EstimatedItemValue.kt:155)
	at SH.features.misc.items.EstimatedItemValue.onRenderItemTooltip(EstimatedItemValue.kt:132)
	at SH.mixins.hooks.GuiScreenHookKt.renderToolTip(GuiScreenHook.kt:7)
	at MC.client.gui.GuiScreen.handler$znf001$renderToolTip(GuiScreen.java:11264)
	at MC.client.gui.GuiScreen.func_146285_a(GuiScreen.java:148)
	at MC.client.gui.GuiScreen.renderToolTip(GuiScreen.java)
	at de.torui.coflsky.gui.tfm.ButtonRemapper.renderTooltip(ButtonRemapper.java:134)
	at de.torui.coflsky.gui.tfm.ButtonRemapper.drawBox(ButtonRemapper.java:201)
	at de.torui.coflsky.gui.tfm.ButtonRemapper.drawBuyButton(ButtonRemapper.java:233)
	at de.torui.coflsky.gui.tfm.ButtonRemapper.onPostRenderEvent(ButtonRemapper.java:259)
	at FML.common.eventhandler.EventBus.post(EventBus.java:140)
```

## Changelog Fixes
+ Fixed an error in estimated item value calculation. - hannibal2