### PR TITLE
Fix: Visitor timer flickering while farming

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorArrivalEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
+import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
@@ -154,8 +155,8 @@ class GardenVisitorTimer {
             else -> "e"
         }
 
-        val extraSpeed = if (diff in 2.seconds..10.seconds) {
-            val duration = millis / 3
+        val extraSpeed = if (GardenAPI.isCurrentlyFarming()) {
+            val duration = (millis / 3) * (GardenCropSpeed.averageBlocksPerSecond / 20)
             "§7/§$formatColor" + duration.format()
         } else ""
         if (config.newVisitorPing && millis < 10.seconds) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -156,7 +156,7 @@ class GardenVisitorTimer {
         }
 
         val extraSpeed = if (GardenAPI.isCurrentlyFarming()) {
-            val duration = (millis / 3) * (GardenCropSpeed.averageBlocksPerSecond / 20)
+            val duration = (millis / 3) * (GardenCropSpeed.getRecentBPS() / 20)
             "§7/§$formatColor" + duration.format()
         } else ""
         if (config.newVisitorPing && millis < 10.seconds) {


### PR DESCRIPTION
## What
Fixed the secondary visitor timer that appears while you're farming constantly disappearing due to Hypixel changes to the tab list, by using a less hacky method.

## Changelog Improvements
+ Improved Farming Timer. - Luna
    * The secondary visitor timer now accurately checks your BPS (Blocks Per Second) instead of assuming a value of 20.

## Changelog Fixes
+ Fixed the secondary visitor timer constantly disappearing while farming. - Luna