### PR TITLE
Improvement + Fix: More Hoppity Waypoint options

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -17,6 +17,21 @@ public class HoppityEggsConfig {
     public boolean waypoints = true;
 
     @Expose
+    @ConfigOption(
+        name = "Show Waypoints Immediately",
+        desc = "Show a raw estimate waypoint immedialtey after clicking. " +
+            "§cThis might cause issues with other paricle sources."
+    )
+    @ConfigEditorBoolean
+    public boolean waypointsImmediately = false;
+
+    @Expose
+    @ConfigOption(name = "Show Line", desc = "Show a line to the waypoint.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean showLine = false;
+
+    @Expose
     @ConfigOption(name = "Show All Waypoints", desc = "Show all possible egg waypoints for the current lobby. §e" +
         "Only works when you don't have an Egglocator in your inventory.")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -115,15 +115,12 @@ object HoppityEggLocator {
             return
         }
 
-        val sharedEggLocation = sharedEggLocation
-        if (sharedEggLocation != null && config.sharedWaypoints) {
-            event.drawWaypointFilled(
-                sharedEggLocation,
-                LorenzColor.GREEN.toColor(),
-                seeThroughBlocks = true,
-            )
-            event.drawDynamicText(sharedEggLocation.add(y = 1), "§aShared Egg", 1.5)
-            return
+        sharedEggLocation?.let {
+            if (config.sharedWaypoints) {
+                event.drawWaypointFilled(it, LorenzColor.GREEN.toColor(), seeThroughBlocks = true,)
+                event.drawDynamicText(it.add(y = 1), "§aShared Egg", 1.5)
+                return
+            }
         }
 
         if (!config.showAllWaypoints) return
@@ -182,12 +179,10 @@ object HoppityEggLocator {
     @SubscribeEvent
     fun onItemClick(event: ItemClickEvent) {
         if (!isEnabled()) return
-        if (event.clickType == ClickType.RIGHT_CLICK) {
-            event.itemInHand?.let {
-                if (it.isLocatorItem) {
-                    lastClick = SimpleTimeMark.now()
-                }
-            }
+        val item = event.itemInHand ?: return
+
+        if (event.clickType == ClickType.RIGHT_CLICK && item.isLocatorItem) {
+            lastClick = SimpleTimeMark.now()
         }
     }
 


### PR DESCRIPTION
## What
Added config option to enable the estimated guess via first particle and the line, both default disabled.
Added a "has clicked" check as hotfix to not show on particles from other sources.

## Changelog Improvements
+ Expanded options for Hoppity Waypoint rendering. - hannibal2

## Changelog Fixes
+ Fixed incorrect Hoppity Waypoint rendering. - hannibal2