### PR TITLE
Improvement: Custom Reminder

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -276,6 +276,7 @@ import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarOrderHelper
 import at.hannibal2.skyhanni.features.inventory.bazaar.CraftMaterialsFromBazaar
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryBarnManager
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryCustomReminder
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryDataLoader
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryInventory
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryKeybinds
@@ -660,6 +661,7 @@ class SkyHanniMod {
         loadModule(ChocolateFactoryKeybinds)
         loadModule(ChocolateShopPrice)
         loadModule(ChocolateFactoryUpgradeWarning)
+        loadModule(ChocolateFactoryCustomReminder)
         loadModule(HoppityNpc)
         loadModule(HoppityEggsManager)
         loadModule(HoppityEggLocator)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -166,4 +166,9 @@ public class ChocolateFactoryConfig {
     @Accordion
     public ChocolateFactoryKeybindsConfig keybinds = new ChocolateFactoryKeybindsConfig();
 
+    @Expose
+    @ConfigOption(name = "Chocolate Factory Custom Reminder", desc = "")
+    @Accordion
+    public ChocolateFactoryCustomReminderConfig customReminder = new ChocolateFactoryCustomReminderConfig();
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryCustomReminderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryCustomReminderConfig.java
@@ -1,0 +1,37 @@
+package at.hannibal2.skyhanni.config.features.inventory.chocolatefactory;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import at.hannibal2.skyhanni.config.core.config.Position;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+public class ChocolateFactoryCustomReminderConfig {
+
+    @Expose
+    @ConfigOption(
+        name = "Enabled",
+        desc = "Show a custom reminder until you can purchase the next upgrade. " +
+            "Click on one item you cant buy to select/deselect it."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean enabled = false;
+
+    @Expose
+    @ConfigOption(name = "Always Custom Reminder", desc = "Always show the display always, even outside the chocolate factory.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean always = false;
+
+    @Expose
+    @ConfigOption(name = "Hide No Chocolate Message", desc = "Hide the chat message telling you you dont have enough chocolate to buy/purchase something.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hideChat = true;
+
+    @Expose
+    @ConfigLink(owner = ChocolateFactoryConfig.class, field = "customReminder")
+    public Position position = new Position(390, 90, 1f, true);
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -114,6 +114,12 @@ public class ProfileSpecificStorage {
             @Expose
             public String lastLeaderboard = null;
         }
+
+        @Expose
+        public Long targetGoal = null;
+
+        @Expose
+        public String targetName = null;
     }
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/ReminderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/ReminderUtils.kt
@@ -12,5 +12,6 @@ object ReminderUtils {
     // TODO: add arachne fight, add slayer boss spawned, add dragon fight
     fun isBusy(ignoreFarmingContest: Boolean = false): Boolean =
         DungeonAPI.inDungeon() || LorenzUtils.inKuudraFight || (FarmingContestAPI.inContest && !ignoreFarmingContest) ||
-            RiftAPI.inRift() || IslandType.DARK_AUCTION.isInIsland()|| IslandType.MINESHAFT.isInIsland()
+            RiftAPI.inRift() || IslandType.DARK_AUCTION.isInIsland() || IslandType.MINESHAFT.isInIsland() ||
+            IslandType.NONE.isInIsland() || IslandType.UNKNOWN.isInIsland()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
@@ -21,8 +21,8 @@ import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 object ChocolateFactoryCustomReminder {
-    private val configReminder get() = SkyHanniMod.feature.inventory.chocolateFactory.customReminder
-    private val configUpgradeWarnings get() = SkyHanniMod.feature.inventory.chocolateFactory.chocolateUpgradeWarnings
+    private val configReminder get() = ChocolateFactoryAPI.config.customReminder
+    private val configUpgradeWarnings get() = ChocolateFactoryAPI.config.chocolateUpgradeWarnings
 
     private var targetGoal: Long?
         get() = ChocolateFactoryAPI.profileStorage?.targetGoal

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
-import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
@@ -1,0 +1,148 @@
+package at.hannibal2.skyhanni.features.inventory.chocolatefactory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.features.fame.ReminderUtils
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.name
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.TimeUtils.minutes
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.inventory.GuiChest
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+object ChocolateFactoryCustomReminder {
+    private val configReminder get() = SkyHanniMod.feature.inventory.chocolateFactory.customReminder
+    private val configUpgradeWarnings get() = SkyHanniMod.feature.inventory.chocolateFactory.chocolateUpgradeWarnings
+
+    private var targetGoal: Long?
+        get() = ChocolateFactoryAPI.profileStorage?.targetGoal
+        set(value) {
+            ChocolateFactoryAPI.profileStorage?.targetGoal = value
+        }
+    private var targetName: String?
+        get() = ChocolateFactoryAPI.profileStorage?.targetName
+        set(value) {
+            ChocolateFactoryAPI.profileStorage?.targetName = value
+        }
+
+    fun isActive() = targetGoal != null
+
+    private var display = emptyList<Renderable>()
+
+    private var lastUpgradeWarning = SimpleTimeMark.farPast()
+
+    @SubscribeEvent
+    fun onChat(event: SystemMessageEvent) {
+        if (!isEnabled()) return
+        if (configReminder.hideChat) {
+            if (event.message == "§cYou don't have enough Chocolate!") {
+                event.blockedReason = "custom_reminder"
+            }
+        }
+    }
+
+    @SubscribeEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
+        if (!isEnabled()) return
+        update()
+    }
+
+    @SubscribeEvent(receiveCanceled = true)
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!isEnabled()) return
+        val item = event.item ?: return
+        // TODO add support for prestige and for Chocolate Milestone
+        val cost = ChocolateFactoryAPI.getChocolateBuyCost(item.getLore()) ?: return
+        val duration = ChocolateAmount.CURRENT.timeUntilGoal(cost)
+
+        // the user has enough chocolate, and just bought something
+        if (duration.isNegative()) {
+            reset()
+            return
+        }
+        setReminder(cost, item.name)
+    }
+
+    @SubscribeEvent
+    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+        if (!isEnabled()) return
+        if (!inChocolateMenu()) return
+
+        configReminder.position.renderRenderables(display, posLabel = "Chocolate Factory Custom Reminder")
+    }
+
+    @SubscribeEvent
+    fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (!isEnabled()) return
+        if (!configReminder.always) return
+        if (Minecraft.getMinecraft().currentScreen is GuiChest) return
+
+        configReminder.position.renderRenderables(display, posLabel = "Chocolate Factory Custom Reminder")
+    }
+
+    private fun inChocolateMenu() = ChocolateShopPrice.inInventory || ChocolateFactoryAPI.inChocolateFactory ||
+        ChocolateFactoryAPI.chocolateFactoryPaused
+
+    private fun setReminder(target: Long, name: String) {
+        if (targetName == name) {
+            reset()
+            return
+        }
+        targetGoal = target
+        targetName = name
+        update()
+    }
+
+    private fun update() {
+        display = mutableListOf<Renderable>().also { list ->
+            getTargetDescription()?.let {
+                list.add(Renderable.clickAndHover(it, listOf("§eClick to remove the goal!"), onClick = {
+                    reset()
+                }))
+            }
+        }
+    }
+
+    private fun getTargetDescription(): String? {
+        val goal = targetGoal ?: return null
+        val duration = ChocolateAmount.CURRENT.timeUntilGoal(goal)
+        if (duration.isNegative()) {
+            warn()
+            return "§aGoal Reached! §eBuy §f$targetName"
+        }
+        val format = duration.format(maxUnits = 2)
+        return "§f$targetName §ein §b$format"
+    }
+
+    private fun warn() {
+        if (ReminderUtils.isBusy()) return
+        if (inChocolateMenu()) return
+
+        if (lastUpgradeWarning.passedSince() < configUpgradeWarnings.timeBetweenWarnings.minutes) return
+        lastUpgradeWarning = SimpleTimeMark.now()
+
+        if (configUpgradeWarnings.upgradeWarningSound) {
+            SoundUtils.playBeepSound()
+        }
+        ChatUtils.chat("You can now purchase §f$targetName §ein Chocolate factory!")
+    }
+
+    private fun reset() {
+        targetGoal = null
+        targetName = ""
+
+        display = emptyList()
+    }
+
+    fun isEnabled() = LorenzUtils.inSkyBlock && configReminder.enabled
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
@@ -35,6 +35,7 @@ object ChocolateFactoryUpgradeWarning {
         if (!ChocolateFactoryAPI.isEnabled()) return
         if (!config.upgradeWarning) return
         if (ReminderUtils.isBusy()) return
+        if (ChocolateFactoryCustomReminder.isActive()) return
         if (lastUpgradeWarning.passedSince() < config.timeBetweenWarnings.minutes) return
         lastUpgradeWarning = SimpleTimeMark.now()
         if (config.upgradeWarningSound) {


### PR DESCRIPTION
## What
Added custom reminder to chocolate factory

## Changelog Improvements
+ Added Custom Chocolate Factory Reminder. - hannibal2
    * Click an item that can be upgraded/purchased with chocolate to set it as a reminder goal.
    * Works with Rabbits, Barn, Time Tower, etc.
    * Option to display this timer universally, even outside the inventory.