### PR TITLE
Fix: Upgrade warning showing when no upgrade possible

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateAmount.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateAmount.kt
@@ -64,12 +64,13 @@ enum class ChocolateAmount(val chocolate: () -> Long) {
                 it.currentChocolate += amount
                 it.chocolateThisPrestige += amount
                 it.chocolateAllTime += amount
-                updateBestUpgrade(amount)
+                updateBestUpgrade()
             }
         }
 
-        private fun updateBestUpgrade(price: Long) {
+        private fun updateBestUpgrade() {
             profileStorage?.let {
+                if (it.bestUpgradeAvailableAt == 0L || it.bestUpgradeCost == 0L) return
                 val canAffordAt = SimpleTimeMark.now() + CURRENT.timeUntilGoal(it.bestUpgradeCost)
                 it.bestUpgradeAvailableAt = canAffordAt.toMillis()
             }


### PR DESCRIPTION
## What
Fix upgrade warning showing when no upgrade possible

## Changelog Fixes
+ Fixed the Chocolate Factory upgrade warning incorrectly displaying when no upgrade was possible. - CalMWolfs

