### PR TITLE
Improvement: Don't hide Maeve dialogue

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -570,7 +570,7 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
   is empty when fully filled and show a preview how these stats change when hovering over an upgrade
 + Hide crop money display, crop milestone display and garden visitor list while inside anita show, SkyMart or the
   composter inventory
-+ Hide chat messages from the visitors in the garden. (Except Beth and Spaceman)
++ Hide chat messages from the visitors in the garden. (Except Beth, Maeve and Spaceman)
 + Show the average crop milestone in the crop milestone inventory.
 + **FF for Contest** - Show the minimum needed Farming Fortune for reaching a medal in the Jacob's Farming Contest
   inventory.

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -485,8 +485,7 @@ object GardenVisitorFeatures {
         if (color == null || color == "§e") return false // Non-visitor NPC, probably Jacob
 
         val name = group("name")
-        if (name == "Spaceman") return false
-        if (name == "Beth") return false
+        if (name in setOf("Beth", "Maeve", "Spaceman")) return false
 
         return VisitorAPI.getVisitorsMap().keys.any { it.removeColor() == name }
     } ?: false


### PR DESCRIPTION
## What
Don't hide Maeve's Garden visitor dialogue. This avoids people thinking it's bugged because her GUI takes a while to show up.

## Changelog Improvements
+ Do Not Hide Maeve's Garden Chat Dialogue. - Luna
    * Maeve's Garden visitor dialogue is no longer hidden, preventing confusion about potential bugs.