### PR TITLE
Fix: Mining Event Error Spam

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -58,7 +58,9 @@ object ErrorManager {
 
     fun skyHanniError(message: String, vararg extraData: Pair<String, Any?>): Nothing {
         val exception = IllegalStateException(message)
-        logErrorWithData(exception, message, extraData = extraData)
+        println("silent SkyHanni error:")
+        println("message: '$message'")
+        println("extraData: \n${buildExtraDataString(extraData)}")
         throw exception
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/APIUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/APIUtil.kt
@@ -65,6 +65,8 @@ object APIUtil {
                     try {
                         return parser.parse(retSrc)
                     } catch (e: JsonSyntaxException) {
+                        val name = e.javaClass.name
+                        val message = "$name: ${e.message}"
                         if (e.message?.contains("Use JsonReader.setLenient(true)") == true) {
                             println("MalformedJsonException: Use JsonReader.setLenient(true)")
                             println(" - getJSONResponse: '$urlString'")
@@ -78,15 +80,17 @@ object APIUtil {
                                     }
                                 )
                             }
-                            ErrorManager.logErrorWithData(
-                                e, "502 Bad Gateway",
+                            ErrorManager.skyHanniError(
+                                "SkyHanni Connection Error",
+                                "error message" to "$message(502 Bad Gateway)",
                                 "apiName" to apiName,
                                 "urlString" to urlString,
                                 "returnedData" to retSrc
                             )
                         } else {
-                            ErrorManager.logErrorWithData(
-                                e, "$apiName error",
+                            ErrorManager.skyHanniError(
+                                "SkyHanni Connection Error",
+                                "error message" to message,
                                 "apiName" to apiName,
                                 "urlString" to urlString,
                                 "returnedData" to retSrc
@@ -95,16 +99,17 @@ object APIUtil {
                     }
                 }
             }
-        } catch (throwable: Throwable) {
+        } catch (e: Throwable) {
             if (silentError) {
-                throw throwable
-            } else {
-                ErrorManager.logErrorWithData(
-                    throwable, "$apiName error for url: '$urlString'",
-                    "apiName" to apiName,
-                    "urlString" to urlString,
-                )
+                throw e
             }
+            val name = e.javaClass.name
+            val message = "$name: ${e.message}"
+            ErrorManager.skyHanniError(
+                "SkyHanni Connection Error",
+                "error message" to message,
+                "urlString" to urlString,
+            )
         } finally {
             client.close()
         }


### PR DESCRIPTION
## What
no longer spam mining event errors in chat, rather count errors in the GUI element

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/2a7e52e8-7b34-4817-9906-2d72891fd5c6)

</details>

## Changelog Fixes
+ Fixed Mining event error spam in chat when the API got connection problems. - hannibal2