### PR TITLE
Fix: Double Spooky Festival Time in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.StringUtils.anyMatches
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
 import at.hannibal2.skyhanni.utils.TabListData
 import java.util.function.Supplier
@@ -113,7 +114,9 @@ enum class ScoreboardEvents(
     SPOOKY(
         ::getSpookyLines,
         ::getSpookyShowWhen,
-        "§7(All Spooky Event Lines)"
+        "§6Spooky Festival§f 50:54\n" +
+            "§7Your Candy:\n" +
+            "§a1 Green§7, §50 Purple §7(§61 §7pts.)"
     ),
     BROODMOTHER(
         ::getBroodmotherLines,
@@ -384,6 +387,12 @@ private fun getTablistEvent(): String? =
 
 private fun getActiveEventLine(): List<String> {
     val currentActiveEvent = getTablistEvent() ?: return emptyList()
+
+    // Some Active Events are better not shown from the tablist,
+    // but from other locations like the scoreboard
+    val blockedEvents = listOf("Spooky Festival")
+    if (blockedEvents.contains(currentActiveEvent.removeColor())) return emptyList()
+
     val currentActiveEventTime = TabListData.getTabList().firstOrNull { SbPattern.eventTimeEndsPattern.matches(it) }
         ?.let {
             SbPattern.eventTimeEndsPattern.matchMatcher(it) {


### PR DESCRIPTION
## What
As specified in the code, some event times should rather be shown from the Scoreboard.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/45315647/6834baa7-1e17-4625-b74c-b8f7d8ee8e70)

</details>


## Changelog Fixes
+ Fixed Custom Scoreboard showing the Spooky Festival Time twice. - j10a1n15

