### PR TITLE
Fix: Chocolate factory upgrade warning breaking

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
@@ -34,7 +34,7 @@ object ChocolateFactoryCustomReminder {
             ChocolateFactoryAPI.profileStorage?.targetName = value
         }
 
-    fun isActive() = targetGoal != null
+    fun isActive() = targetGoal != null && configReminder.enabled
 
     private var display = emptyList<Renderable>()
 


### PR DESCRIPTION
## What
If you set a custom goal then turned off the setting, the regular upgrade warning wouldn't work.

## Changelog Fixes
+ Fixed a case where the chocolate factory upgrade warning did not work. - CalMWolfs

