### PR TITLE
Improvement: Time until Full Tower Charges

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -50,6 +50,7 @@ public class ChocolateFactoryConfig {
         ChocolateFactoryStat.MULTIPLIER,
         ChocolateFactoryStat.BARN,
         ChocolateFactoryStat.TIME_TOWER,
+        ChocolateFactoryStat.TIME_TOWER_FULL,
         ChocolateFactoryStat.LEADERBOARD_POS,
         ChocolateFactoryStat.TIME_TO_BEST_UPGRADE
     ));

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
@@ -55,6 +56,8 @@ object ChocolateFactoryStats {
             "§6${ChocolateFactoryTimeTowerManager.timeTowerCharges()}"
         }
 
+        val timeTowerFull = ChocolateFactoryTimeTowerManager.timeTowerFullTimemark()
+
         val prestigeEstimate = ChocolateAmount.PRESTIGE.formattedTimeUntilGoal(ChocolateFactoryAPI.chocolateForPrestige)
         val chocolateUntilPrestigeCalculation =
             ChocolateFactoryAPI.chocolateForPrestige - ChocolateAmount.PRESTIGE.chocolate()
@@ -90,6 +93,11 @@ object ChocolateFactoryStats {
             put(ChocolateFactoryStat.EMPTY_4, "")
 
             put(ChocolateFactoryStat.TIME_TOWER, "§eTime Tower: §6$timeTowerInfo")
+            put(
+                ChocolateFactoryStat.TIME_TOWER_FULL,
+                "§eFull Tower Charges: §b${timeTowerFull.timeUntil().format()}\n" +
+                    "§bHappens at: ${timeTowerFull.formattedDate("EEEE, MMM d h:mm a")}"
+            )
             put(ChocolateFactoryStat.TIME_TO_PRESTIGE, "§eTime To Prestige: $prestigeEstimate")
             put(
                 ChocolateFactoryStat.RAW_PER_SECOND,
@@ -101,7 +109,7 @@ object ChocolateFactoryStats {
             )
             put(ChocolateFactoryStat.TIME_TO_BEST_UPGRADE, "§eBest Upgrade: $upgradeAvailableAt")
         }
-        val text = config.statsDisplayList.filter { it.shouldDisplay() }.mapNotNull { map[it] }
+        val text = config.statsDisplayList.filter { it.shouldDisplay() }.flatMap { map[it]?.split("\n") ?: listOf() }
 
         display = listOf(Renderable.clickAndHover(
             Renderable.verticalContainer(text.map(Renderable::string)),
@@ -152,6 +160,9 @@ object ChocolateFactoryStats {
         EMPTY_3(""),
         EMPTY_4(""),
         TIME_TOWER("§eTime Tower: §62/3 Charges", { ChocolateFactoryTimeTowerManager.currentCharges() != -1 }),
+        TIME_TOWER_FULL(
+            "§eTime Tower Full Charges: §b5h 13m 59s\n§bHappens at: Monday, May 13 5:32 AM",
+            { ChocolateFactoryTimeTowerManager.currentCharges() != -1 || ChocolateFactoryTimeTowerManager.timeTowerFull() }),
         TIME_TO_PRESTIGE("§eTime To Prestige: §b1d 13h 59m 4s", { ChocolateFactoryAPI.currentPrestige != 5 }),
         RAW_PER_SECOND("§eRaw Per Second: §62,136"),
         CHOCOLATE_UNTIL_PRESTIGE("§eChocolate To Prestige: §65,851", { ChocolateFactoryAPI.currentPrestige != 5 }),

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -97,6 +97,16 @@ object ChocolateFactoryTimeTowerManager {
         return endTime > currentTime
     }
 
+    fun timeTowerFullTimemark(): SimpleTimeMark {
+        val profileStorage = profileStorage ?: return SimpleTimeMark.farPast()
+        if (timeTowerFull()) return SimpleTimeMark.farPast()
+        val nextChargeDuration = SimpleTimeMark(profileStorage.nextTimeTower)
+        val remainingChargesAfter = profileStorage.maxTimeTowerUses - (profileStorage.currentTimeTowerUses + 1)
+        val endTime = nextChargeDuration + (profileStorage.timeTowerCooldown).hours * remainingChargesAfter
+
+        return endTime
+    }
+
     fun timeTowerActiveDuration(): Duration {
         if (!timeTowerActive()) return Duration.ZERO
         val currentTime = profileStorage?.lastDataSave ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
@@ -1,6 +1,9 @@
 package at.hannibal2.skyhanni.utils
 
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -30,6 +33,13 @@ value class SimpleTimeMark(private val millis: Long) : Comparable<SimpleTimeMark
     override fun toString(): String {
         if (millis == 0L) return "The Far Past"
         return Instant.ofEpochMilli(millis).toString()
+    }
+
+    fun formattedDate(pattern: String): String {
+        val instant = Instant.ofEpochMilli(millis)
+        val localDateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
+        val formatter = DateTimeFormatter.ofPattern(pattern)
+        return localDateTime.format(formatter)
     }
 
     fun toMillis() = millis


### PR DESCRIPTION
## What
Adds a line for showing how long until your tower charges are fully filled, and the RL time for that (using local timezone)

<details>
<summary>Images</summary>

![image](https://i.imgur.com/QoVqw7P.png)

</details>

## Changelog Improvements
+ Added a display for the time remaining until Tower Charges are full. - Empa