### PR TITLE
Fix: Incomplete Scoreboard Lines

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -297,10 +297,6 @@ object ScoreboardPattern {
         "essence",
         "^\\s*.*Essence: §.(?<essence>-?\\d+(:?,\\d{3})*(?:\\.\\d+)?)$"
     )
-    val brokenRedstonePattern by miscSb.pattern(
-        "brokenredstone",
-        "\\s*(?:(?:§.)*⚡ (§.)*Redston|e: (?:§.)*\\d+%)\\s*"
-    )
     val redstonePattern by miscSb.pattern(
         "redstone",
         "\\s*(§.)*⚡ §cRedstone: (§.)*\\d{1,3}%$"

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.data.PurseAPI
 import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.features.misc.ServerRestartTitle
 import at.hannibal2.skyhanni.features.rift.area.stillgorechateau.RiftBloodEffigies
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
@@ -14,7 +15,7 @@ object UnknownLinesHandler {
     fun handleUnknownLines() {
         val sidebarLines = ScoreboardData.sidebarLinesFormatted
 
-        unknownLines = sidebarLines
+        unconfirmedUnknownLines = sidebarLines
             .map { it.removeResets() }
             .filter { it.isNotBlank() }
             .filter { it.trim().length > 3 }
@@ -86,7 +87,6 @@ object UnknownLinesHandler {
             SbPattern.bossDamagePattern,
             SbPattern.slayerQuestPattern,
             SbPattern.essencePattern,
-            SbPattern.brokenRedstonePattern,
             SbPattern.redstonePattern,
             SbPattern.visitingPattern,
             SbPattern.flightDurationPattern,
@@ -123,7 +123,7 @@ object UnknownLinesHandler {
             SbPattern.cluesPattern,
         )
 
-        unknownLines = unknownLines.filterNot { line ->
+        unconfirmedUnknownLines = unconfirmedUnknownLines.filterNot { line ->
             patternsToExclude.any { pattern -> pattern.matches(line) }
         }
 
@@ -134,16 +134,16 @@ object UnknownLinesHandler {
         val objectiveLine =
             sidebarLines.firstOrNull { SbPattern.objectivePattern.matches(it) }
                 ?: "Objective"
-        unknownLines = unknownLines.filter { sidebarLines.nextAfter(objectiveLine) != it }
+        unconfirmedUnknownLines = unconfirmedUnknownLines.filter { sidebarLines.nextAfter(objectiveLine) != it }
         // TODO create function
-        unknownLines = unknownLines.filter {
+        unconfirmedUnknownLines = unconfirmedUnknownLines.filter {
             sidebarLines.nextAfter(objectiveLine, 2) != it
                 && !SbPattern.thirdObjectiveLinePattern.matches(it)
         }
 
         // Remove jacobs contest
         for (i in 1..3)
-            unknownLines = unknownLines.filter {
+            unconfirmedUnknownLines = unconfirmedUnknownLines.filter {
                 sidebarLines.nextAfter(sidebarLines.firstOrNull { line ->
                     SbPattern.jacobsContestPattern.matches(line)
                 } ?: "§eJacob's Contest", i) != it
@@ -151,24 +151,43 @@ object UnknownLinesHandler {
 
         // Remove slayer
         for (i in 1..2)
-            unknownLines = unknownLines.filter {
+            unconfirmedUnknownLines = unconfirmedUnknownLines.filter {
                 sidebarLines.nextAfter(sidebarLines.firstOrNull { line ->
                     SbPattern.slayerQuestPattern.matches(line)
                 } ?: "Slayer Quest", i) != it
             }
 
         // remove trapper mob location
-        unknownLines = unknownLines.filter {
+        unconfirmedUnknownLines = unconfirmedUnknownLines.filter {
             sidebarLines.nextAfter(sidebarLines.firstOrNull { line ->
                 SbPattern.mobLocationPattern.matches(line)
             } ?: "Tracker Mob Location:") != it
         }
 
         // da
-        unknownLines = unknownLines.filter {
+        unconfirmedUnknownLines = unconfirmedUnknownLines.filter {
             sidebarLines.nextAfter(sidebarLines.firstOrNull { line ->
                 SbPattern.darkAuctionCurrentItemPattern.matches(line)
             } ?: "Current Item:") != it
+        }
+
+
+        /*
+         * handle broken scoreboard lines
+         */
+        confirmedUnknownLines.forEach { line ->
+            if (!unconfirmedUnknownLines.contains(line)) {
+                confirmedUnknownLines = confirmedUnknownLines.filterNot { it == line }.toMutableList()
+                unconfirmedUnknownLines = unconfirmedUnknownLines.filterNot { it == line }
+            }
+        }
+        unconfirmedUnknownLines.forEach { line ->
+            if (confirmedUnknownLines.contains(line)) {
+                unconfirmedUnknownLines = unconfirmedUnknownLines.filterNot { it == line }
+            } else if (!unknownLinesSet.contains(line)) {
+                ChatUtils.debug("Unknown Scoreboard line: '$line'")
+                unknownLinesSet.add(line)
+            }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedCache.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedCache.kt
@@ -1,18 +1,17 @@
 package at.hannibal2.skyhanni.utils
 
 import com.google.common.cache.CacheBuilder
-import com.google.common.cache.RemovalListener
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 
 class TimeLimitedCache<K, V>(
     expireAfterWrite: Duration,
-    removalListener: RemovalListener<K, V>? = null
+    private val removalListener: (K?, V?) -> Unit = { _, _ -> },
 ) {
 
     private val cache = CacheBuilder.newBuilder()
         .expireAfterWrite(expireAfterWrite.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-        .apply { if (removalListener != null) removalListener(removalListener) }
+        .removalListener { removalListener(it.key, it.value) }
         .build<K, V>()
 
     fun put(key: K, value: V) = cache.put(key, value)

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedCache.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedCache.kt
@@ -1,13 +1,19 @@
 package at.hannibal2.skyhanni.utils
 
 import com.google.common.cache.CacheBuilder
+import com.google.common.cache.RemovalListener
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 
-class TimeLimitedCache<K, V>(expireAfterWrite: Duration) {
+class TimeLimitedCache<K, V>(
+    expireAfterWrite: Duration,
+    removalListener: RemovalListener<K, V>? = null
+) {
 
     private val cache = CacheBuilder.newBuilder()
-        .expireAfterWrite(expireAfterWrite.inWholeMilliseconds, TimeUnit.MILLISECONDS).build<K, V>()
+        .expireAfterWrite(expireAfterWrite.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        .apply { if (removalListener != null) removalListener(removalListener) }
+        .build<K, V>()
 
     fun put(key: K, value: V) = cache.put(key, value)
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedSet.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedSet.kt
@@ -1,10 +1,14 @@
 package at.hannibal2.skyhanni.utils
 
+import com.google.common.cache.RemovalListener
 import kotlin.time.Duration
 
-class TimeLimitedSet<T>(expireAfterWrite: Duration) {
+class TimeLimitedSet<T>(
+    expireAfterWrite: Duration,
+    removalListener: RemovalListener<T, Unit>? = null
+) {
 
-    private val cache = TimeLimitedCache<T, Unit>(expireAfterWrite)
+    private val cache = TimeLimitedCache<T, Unit>(expireAfterWrite, removalListener)
 
     fun add(element: T) = cache.put(element, Unit)
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedSet.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedSet.kt
@@ -1,14 +1,13 @@
 package at.hannibal2.skyhanni.utils
 
-import com.google.common.cache.RemovalListener
 import kotlin.time.Duration
 
 class TimeLimitedSet<T>(
     expireAfterWrite: Duration,
-    removalListener: RemovalListener<T, Unit>? = null
+    private val removalListener: (T) -> Unit = {},
 ) {
 
-    private val cache = TimeLimitedCache<T, Unit>(expireAfterWrite, removalListener)
+    private val cache = TimeLimitedCache<T, Unit>(expireAfterWrite) { key, _ -> key?.let { removalListener(it) } }
 
     fun add(element: T) = cache.put(element, Unit)
 


### PR DESCRIPTION
## What
Fixes detecting unknown scoreboard lines when hypixel briefly sends data of scoreboard when a fraction of the line is missing, by only showing unknown lines if they have been shown in the scoreboard for more than 0.5 seconds. Also adds an optional removal listener in time limited cache/set.

Broken scoreboard lines are still sent in chat as debug messages even if they are shown for less than 0.5 seconds.

## Changelog Fixes
+ Fixed unknown scoreboard lines chat error message when Hypixel sends incomplete line data. - Empa

## Changelog Technical Details
+ Added a RemovalListener to TimeLimitedCache and TimeLimitedSet. - Empa

