### PR TITLE
Improvement: Rabbit crush warning only during Hoppity

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -83,6 +83,14 @@ public class ChocolateFactoryConfig {
     public int barnCapacityThreshold = 6;
 
     @Expose
+    @ConfigOption(
+        name = "Rabbit Crush During Hoppity",
+        desc = "Only warn about rabbit crush when the Hoppity event is active."
+    )
+    @ConfigEditorBoolean
+    public boolean rabbitCrushOnlyDuringHoppity = false;
+
+    @Expose
     @ConfigOption(name = "Extra Tooltip Stats", desc = "Shows extra information about upgrades in the tooltip.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
@@ -93,6 +93,8 @@ object ChocolateFactoryBarnManager {
             return
         }
 
+        if (config.rabbitCrushOnlyDuringHoppity && !ChocolateFactoryAPI.isHoppityEvent()) return
+
         ChatUtils.clickableChat(
             message = if (profileStorage.currentRabbits == profileStorage.maxRabbits) {
                 "§cYour barn is full! §7(${barnStatus()}). §cUpgrade it so they don't get crushed"


### PR DESCRIPTION
## What
Adds an option to only notify about rabbit crushes if the hoppity event is active.

[Discord Suggestion](https://ptb.discord.com/channels/997079228510117908/1238882416328839258)

## Changelog Improvements
+ Added an option to only receive Rabbit Crush warnings during the Hoppity event. - Empa