### PR TITLE
Improvement: updating scoreboard and tab list less often

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
@@ -1,10 +1,12 @@
 package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.events.ScoreboardChangeEvent
 import at.hannibal2.skyhanni.events.ScoreboardRawChangeEvent
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import net.minecraft.client.Minecraft
+import net.minecraft.network.play.server.S3BPacketScoreboardObjective
 import net.minecraft.scoreboard.Score
 import net.minecraft.scoreboard.ScorePlayerTeam
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -66,8 +68,19 @@ class ScoreboardData {
         var objectiveTitle = ""
     }
 
+    var dirty = false
+
+    @SubscribeEvent(receiveCanceled = true)
+    fun onChatPacket(event: PacketEvent.ReceiveEvent) {
+        if (event.packet is S3BPacketScoreboardObjective) {
+            dirty = true
+        }
+    }
+
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     fun onTick(event: LorenzTickEvent) {
+        if (!dirty) return
+        dirty = false
 
         val list = fetchScoreboardLines().reversed()
         val semiFormatted = list.map { cleanSB(it) }

--- a/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
@@ -71,7 +71,7 @@ class ScoreboardData {
     var dirty = false
 
     @SubscribeEvent(receiveCanceled = true)
-    fun onChatPacket(event: PacketEvent.ReceiveEvent) {
+    fun onPacketReceive(event: PacketEvent.ReceiveEvent) {
         if (event.packet is S3BPacketScoreboardObjective) {
             dirty = true
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
@@ -111,7 +111,7 @@ object TabListData {
     var dirty = false
 
     @SubscribeEvent(receiveCanceled = true)
-    fun onChatPacket(event: PacketEvent.ReceiveEvent) {
+    fun onPacketReceive(event: PacketEvent.ReceiveEvent) {
         if (event.packet is S38PacketPlayerListItem) {
             dirty = true
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.TablistFooterUpdateEvent
 import at.hannibal2.skyhanni.mixins.hooks.tabListGuard
@@ -14,6 +15,7 @@ import com.google.common.collect.Ordering
 import kotlinx.coroutines.launch
 import net.minecraft.client.Minecraft
 import net.minecraft.client.network.NetworkPlayerInfo
+import net.minecraft.network.play.server.S38PacketPlayerListItem
 import net.minecraft.world.WorldSettings
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.relauncher.Side
@@ -106,9 +108,19 @@ object TabListData {
         return result.dropLast(1)
     }
 
+    var dirty = false
+
+    @SubscribeEvent(receiveCanceled = true)
+    fun onChatPacket(event: PacketEvent.ReceiveEvent) {
+        if (event.packet is S38PacketPlayerListItem) {
+            dirty = true
+        }
+    }
+
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
-        if (!event.isMod(2)) return
+        if (!dirty) return
+        dirty = false
 
         val tabList = readTabList() ?: return
         if (tablistCache != tabList) {


### PR DESCRIPTION
## What
Should improve performance
Updating scoreboard and tab list only after receiving the update packet, not all the time.

## Changelog Improvements
+ Improved the performance of scoreboard and tab list reading. - hannibal2