### PR TITLE
Fix: Supercrafted Items in Profit Trackers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -924,7 +924,7 @@ class SkyHanniMod {
         loadModule(GardenInventoryTooltipOverflow())
         loadModule(SkillTooltip())
         loadModule(MaxPurseItems())
-        loadModule(SuperCraftFeatures)
+        loadModule(SuperCraftFeatures())
         loadModule(InfernoMinionFeatures())
         loadModule(LimboPlaytime())
         loadModule(RareDropMessages())

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -924,7 +924,7 @@ class SkyHanniMod {
         loadModule(GardenInventoryTooltipOverflow())
         loadModule(SkillTooltip())
         loadModule(MaxPurseItems())
-        loadModule(SuperCraftFeatures())
+        loadModule(SuperCraftFeatures)
         loadModule(InfernoMinionFeatures())
         loadModule(LimboPlaytime())
         loadModule(RareDropMessages())

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemAddManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemAddManager.kt
@@ -6,14 +6,11 @@ import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.SackChangeEvent
 import at.hannibal2.skyhanni.events.entity.ItemAddInInventoryEvent
-import at.hannibal2.skyhanni.features.inventory.SuperCraftFeatures.craftedPattern
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
-import at.hannibal2.skyhanni.utils.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.milliseconds
@@ -60,12 +57,11 @@ class ItemAddManager {
 
         for (sackChange in event.sackChanges) {
             val change = sackChange.delta
-            val internalName = sackChange.internalName
-            if (change > 0 && internalName !in superCraftedItems) {
+            if (change > 0) {
+                val internalName = sackChange.internalName
                 Source.SACKS.addItem(internalName, change)
             }
         }
-        superCraftedItems.clear()
     }
 
     @SubscribeEvent
@@ -87,17 +83,11 @@ class ItemAddManager {
     }
 
     private var lastDiceRoll = SimpleTimeMark.farPast()
-    private var superCraftedItems = TimeLimitedSet<NEUInternalName>(30.seconds)
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
         if (diceRollChatPattern.matches(event.message)) {
             lastDiceRoll = SimpleTimeMark.now()
-        }
-        craftedPattern.matchMatcher(event.message) {
-            val internalName = NEUInternalName.fromItemName(group("item"))
-            if (!SackAPI.sackListInternalNames.contains(internalName.asString())) return@matchMatcher
-            superCraftedItems.add(internalName)
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
@@ -12,8 +12,8 @@ import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-class SuperCraftFeatures {
-    private val craftedPattern by RepoPattern.pattern(
+object SuperCraftFeatures {
+    val craftedPattern by RepoPattern.pattern(
         "inventory.supercrafting.craft.new",
         "§eYou Supercrafted §r§r§r§.(?<item>[^§]+)(?:§r§8x(?<amount>[\\d,]+))?§r§e!"
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftFeatures.kt
@@ -12,8 +12,8 @@ import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-object SuperCraftFeatures {
-    val craftedPattern by RepoPattern.pattern(
+class SuperCraftFeatures {
+    private val craftedPattern by RepoPattern.pattern(
         "inventory.supercrafting.craft.new",
         "§eYou Supercrafted §r§r§r§.(?<item>[^§]+)(?:§r§8x(?<amount>[\\d,]+))?§r§e!"
     )


### PR DESCRIPTION
## What
Fixes items that went into sacks after being supercrafted being added to profit trackers.

## Changelog Fixes
+ Fixed supercrafted items being incorrectly added to profit trackers. - Empa