### PR TITLE
Fix: Removed excess space in chat formatting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -96,7 +96,7 @@ class PlayerChatManager {
      */
     private val privateIslandRankPattern by patternGroup.pattern(
         "privateislandrank",
-        "(?<prefix>.*?)(?<privateIslandRank>§.\\[(?!MVP(§.\\++)?§.]|VIP\\+*|YOU§.TUBE|ADMIN|MOD|GM)[^]]+\\])(?<suffix>.*)"
+        "(?<prefix>.*?)(?<privateIslandRank>§.\\[(?!MVP(§.\\++)?§.]|VIP\\+*|YOU§.TUBE|ADMIN|MOD|GM)[^]]+\\]) (?<suffix>.*)"
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
@@ -167,7 +167,7 @@ class PlayerNameFormatter {
             cleanAuthor = groupOrThrow("author").stripHypixelMessage()
         }
 
-        val name = formatAuthor(cleanAuthor.getText().trim(), levelColor).applyFormattingFrom(cleanAuthor)
+        val name = formatAuthor(cleanAuthor.getText(), levelColor).applyFormattingFrom(cleanAuthor)
         val levelFormat = formatLevel(levelColor, level)
         val guildRankFormat = guildRank?.intoComponent()
         val privateIslandRankFormat = privateIslandRank?.intoComponent()

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
@@ -167,7 +167,7 @@ class PlayerNameFormatter {
             cleanAuthor = groupOrThrow("author").stripHypixelMessage()
         }
 
-        val name = formatAuthor(cleanAuthor.getText(), levelColor).applyFormattingFrom(cleanAuthor)
+        val name = formatAuthor(cleanAuthor.getText().trim(), levelColor).applyFormattingFrom(cleanAuthor)
         val levelFormat = formatLevel(levelColor, level)
         val guildRankFormat = guildRank?.intoComponent()
         val privateIslandRankFormat = privateIslandRank?.intoComponent()


### PR DESCRIPTION
## What
Fix double/unnecessary space before name in chat formatting

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/77755681/916b66d2-a625-4631-9d06-d70ab3be625a)

</details>

## Changelog Fixes
+ Fixed extra space in chat formatting. - Jordyrat