### PR TITLE
Fix: some REFINED_BOTTLE_OF_JYRRE errors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
@@ -33,6 +33,7 @@ class JyrreTimer {
     }
 
     private fun resetDisplay() {
+        if (display.isEmpty()) return
         display = if (config.showInactive) drawDisplay() else emptyList()
         duration = 0.seconds
     }


### PR DESCRIPTION
The reason this specific item had so many errors is because for most it is the first item that was fetched when joining hypixel due to the resetDisplay function being called on profile join

exclude_from_changelog