### PR TITLE
Fix: remove bugged minions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -199,7 +199,7 @@ class MinionFeatures {
     }
 
     private fun removeBuggedMinions() {
-        if (IslandType.HUB.isInIsland()) return
+        if (!IslandType.PRIVATE_ISLAND.isInIsland()) return
         val minions = minions ?: return
 
         val removedEntities = mutableListOf<LorenzVec>()

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -199,10 +199,12 @@ class MinionFeatures {
     }
 
     private fun removeBuggedMinions() {
+        if (IslandType.HUB.isInIsland()) return
         val minions = minions ?: return
 
         val removedEntities = mutableListOf<LorenzVec>()
         for (location in minions.keys) {
+            if (location.distanceToPlayer() > 30) continue
             val entitiesNearby = EntityUtils.getEntities<EntityArmorStand>().map { it.distanceTo(location) }
             if (!entitiesNearby.any { it == 0.0 }) {
                 removedEntities.add(location)


### PR DESCRIPTION
## What
Fixed remove bugged minions

<details>
<summary>Images</summary>

## Changelog Fixes
+ Fixed removal of incorrect minion name tags. - hannibal2
    * No longer resets all minion nametags when clicking the wheat minion in the Hub.
    * No longer resets minion nametags that are far away from the clicked minion.