### PR TITLE
Improvement: Hoppity egg warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -191,7 +191,7 @@ object HoppityEggsManager {
         val amount = HoppityEggType.entries.size
         ChatUtils.chat("All $amount Hoppity Eggs are ready to be found.!")
         LorenzUtils.sendTitle("§e$amount Hoppity Eggs!", 5.seconds)
-        SoundUtils.playPlingSound()
+        SoundUtils.repeatSound(100, 10, SoundUtils.plingSound)
     }
 
     private fun isBuzy() = ReminderUtils.isBusy(config.showDuringContest)


### PR DESCRIPTION
## What
Made the Hoppity three eggs ready to claim warning sound go 5 times instead of just once as people were missing the warning

## Changelog Improvements
+ Extended warning sound duration when all 3 Hoppity Eggs are found. - seraid

