### PR TITLE
Fix: White Enchantments

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.java
@@ -10,6 +10,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import io.github.notenoughupdates.moulconfig.observer.Property;
 
 public class ChromaConfig {
 
@@ -22,7 +23,7 @@ public class ChromaConfig {
     @ConfigOption(name = "Enabled", desc = "Toggle for SkyHanni's chroma. (Disables Patcher's Optimized Font Renderer while enabled)")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean enabled = false;
+    public Property<Boolean> enabled = Property.of(false);
 
     @Expose
     @ConfigOption(name = "Chroma Size", desc = "Change the size of each color in the chroma.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.java
@@ -39,8 +39,8 @@ public class EnchantParsingConfig {
     }
 
     @Expose
-    @ConfigOption(name = "Perfect Enchantment Color", desc = "The color an enchantment will be at max level. §eIf SkyHanni chroma " +
-        "is disabled this will default to §6Gold.")
+    @ConfigOption(name = "Perfect Enchantment Color", desc = "The color an enchantment will be at max level. " +
+        "§eIf SkyHanni chroma is disabled this will default to §6Gold.")
     @ConfigEditorDropdown
     public Property<LorenzColor> perfectEnchantColor = Property.of(LorenzColor.CHROMA);
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.java
@@ -39,7 +39,7 @@ public class EnchantParsingConfig {
     }
 
     @Expose
-    @ConfigOption(name = "Perfect Enchantment Color", desc = "The color an enchantment will be at max level. §eIf  SkyHanni chroma " +
+    @ConfigOption(name = "Perfect Enchantment Color", desc = "The color an enchantment will be at max level. §eIf SkyHanni chroma " +
         "is disabled this will default to §6Gold.")
     @ConfigEditorDropdown
     public Property<LorenzColor> perfectEnchantColor = Property.of(LorenzColor.CHROMA);

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.java
@@ -39,7 +39,8 @@ public class EnchantParsingConfig {
     }
 
     @Expose
-    @ConfigOption(name = "Perfect Enchantment Color", desc = "The color an enchantment will be at max level.")
+    @ConfigOption(name = "Perfect Enchantment Color", desc = "The color an enchantment will be at max level. §eIf  SkyHanni chroma " +
+        "is disabled this will default to §6Gold.")
     @ConfigEditorDropdown
     public Property<LorenzColor> perfectEnchantColor = Property.of(LorenzColor.CHROMA);
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
@@ -30,15 +30,15 @@ open class Enchant : Comparable<Enchant> {
 
         // TODO change color to string (support for bold)
         val colour = when {
-            level >= maxLevel -> config.perfectEnchantColor.get()
-            level > goodLevel -> config.greatEnchantColor.get()
-            level == goodLevel -> config.goodEnchantColor.get()
-            else -> config.poorEnchantColor.get()
+            level >= maxLevel -> config.perfectEnchantColor
+            level > goodLevel -> config.greatEnchantColor
+            level == goodLevel -> config.goodEnchantColor
+            else -> config.poorEnchantColor
         }
 
         // TODO when chroma is disabled maybe use the neu chroma style instead of gold
-        if (colour == LorenzColor.CHROMA && !(ChromaManager.config.enabled.get() || EnchantParser.isSbaLoaded)) return "§6§l"
-        return colour.getChatColor()
+        if (colour.get() == LorenzColor.CHROMA && !(ChromaManager.config.enabled.get() || EnchantParser.isSbaLoaded)) return "§6§l"
+        return colour.get().getChatColor()
     }
 
     override fun toString() = "$nbtName $goodLevel $maxLevel\n"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
@@ -37,7 +37,7 @@ open class Enchant : Comparable<Enchant> {
         }
 
         // TODO when chroma is disabled maybe use the neu chroma style instead of gold
-        if (colour == LorenzColor.CHROMA && !ChromaManager.config.enabled.get()) return "§6"
+        if (colour == LorenzColor.CHROMA && !(ChromaManager.config.enabled.get() || EnchantParser.isSbaLoaded)) return "§6"
         return colour.getChatColor()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
@@ -37,7 +37,7 @@ open class Enchant : Comparable<Enchant> {
         }
 
         // TODO when chroma is disabled maybe use the neu chroma style instead of gold
-        if (colour == LorenzColor.CHROMA && !(ChromaManager.config.enabled.get() || EnchantParser.isSbaLoaded)) return "§6"
+        if (colour == LorenzColor.CHROMA && !(ChromaManager.config.enabled.get() || EnchantParser.isSbaLoaded)) return "§6§l"
         return colour.getChatColor()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.features.misc.items.enchants
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.features.chroma.ChromaManager
+import at.hannibal2.skyhanni.utils.LorenzColor
 import com.google.gson.annotations.Expose
 import java.util.TreeSet
 
@@ -25,11 +27,18 @@ open class Enchant : Comparable<Enchant> {
 
     open fun getFormat(level: Int): String {
         val config = SkyHanniMod.feature.inventory.enchantParsing
+
         // TODO change color to string (support for bold)
-        if (level >= maxLevel) return config.perfectEnchantColor.get().getChatColor()
-        if (level > goodLevel) return config.greatEnchantColor.get().getChatColor()
-        if (level == goodLevel) return config.goodEnchantColor.get().getChatColor()
-        return config.poorEnchantColor.get().getChatColor()
+        val colour = when {
+            level >= maxLevel -> config.perfectEnchantColor.get()
+            level > goodLevel -> config.greatEnchantColor.get()
+            level == goodLevel -> config.goodEnchantColor.get()
+            else -> config.poorEnchantColor.get()
+        }
+
+        // TODO when chroma is disabled maybe use the neu chroma style instead of gold
+        if (colour == LorenzColor.CHROMA && !ChromaManager.config.enabled.get()) return "§6"
+        return colour.getChatColor()
     }
 
     override fun toString() = "$nbtName $goodLevel $maxLevel\n"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -23,6 +23,7 @@ import net.minecraft.event.HoverEvent
 import net.minecraft.item.ItemStack
 import net.minecraft.util.ChatComponentText
 import net.minecraft.util.IChatComponent
+import net.minecraftforge.fml.common.Loader
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.TreeSet
 
@@ -58,6 +59,8 @@ object EnchantParser {
     private var orderedEnchants: TreeSet<FormattedEnchant> = TreeSet()
 
     private val loreCache: Cache = Cache()
+
+    val isSbaLoaded by lazy { Loader.isModLoaded("skyblockaddons") }
 
     // Maps for all enchants
     private var enchants: EnchantsJson = EnchantsJson()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.ChatHoverEvent
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.features.chroma.ChromaManager
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ConditionalUtils
@@ -79,6 +80,7 @@ object EnchantParser {
             config.commaFormat,
             config.hideVanillaEnchants,
             config.hideEnchantDescriptions,
+            ChromaManager.config.enabled,
         ) {
             markCacheDirty()
         }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
@@ -15,6 +15,8 @@ import net.minecraft.client.renderer.GlStateManager
  */
 object FontRendererHook {
 
+    private val config get() = ChromaManager.config
+
     private const val CHROMA_FORMAT_INDEX = 22
     private const val WHITE_FORMAT_INDEX = 15
 
@@ -63,9 +65,8 @@ object FontRendererHook {
 
     @JvmStatic
     fun beginChromaRendering(text: String, shadow: Boolean) {
-        if (!LorenzUtils.inSkyBlock) return
-        if (!ChromaManager.config.enabled.get()) return
-        if (ChromaManager.config.allChroma && ChromaManager.config.ignoreChat && cameFromChat) {
+        if (!isEnabled()) return
+        if (config.allChroma && config.ignoreChat && cameFromChat) {
             endChromaFont()
             return
         }
@@ -78,7 +79,7 @@ object FontRendererHook {
         currentDrawState = if (shadow) DRAW_CHROMA_SHADOW else DRAW_CHROMA
 
         // Best feature ngl
-        if (ChromaManager.config.allChroma) {
+        if (config.allChroma) {
             // Handles setting the base color of text when they don't use color codes i.e. MoulConfig
             if (shadow) {
                 GlStateManager.color(0.33f, 0.33f, 0.33f, RenderUtils.getAlpha())
@@ -100,9 +101,7 @@ object FontRendererHook {
 
     @JvmStatic
     fun forceWhiteColorCode(formatIndex: Int): Int {
-        if (!LorenzUtils.inSkyBlock) return formatIndex
-
-        if (!ChromaManager.config.enabled.get()) return formatIndex
+        if (!isEnabled()) return formatIndex
 
         val drawState = currentDrawState ?: return formatIndex
         if (drawState.getChromaState() && formatIndex <= WHITE_FORMAT_INDEX) { // If it's a color code
@@ -114,40 +113,40 @@ object FontRendererHook {
 
     @JvmStatic
     fun restoreChromaState() {
-        if (!LorenzUtils.inSkyBlock) return
-        if (!ChromaManager.config.enabled.get()) return
+        if (!isEnabled()) return
 
         currentDrawState?.restoreChromaEnv()
     }
 
     @JvmStatic
     fun endChromaRendering() {
-        if (!LorenzUtils.inSkyBlock) return
-        if (!ChromaManager.config.enabled.get()) return
+        if (!isEnabled()) return
 
         if (previewChroma) {
             previewChroma = false
             endChromaFont()
         }
 
-        if (ChromaManager.config.allChroma) endChromaFont()
+        if (config.allChroma) endChromaFont()
 
         currentDrawState?.endChromaEnv()
     }
 
     @JvmStatic
     fun insertZColorCode(constant: String): String {
-        return if (LorenzUtils.inSkyBlock && !ChromaManager.config.enabled.get()) constant else "0123456789abcdefklmnorz"
+        return if (LorenzUtils.inSkyBlock && !isChromaEnabled()) constant else "0123456789abcdefklmnorz"
     }
 
     @JvmStatic
     fun toggleChromaAndResetStyle(formatIndex: Int): Boolean {
-        if (!LorenzUtils.inSkyBlock) return false
-        if (!ChromaManager.config.enabled.get()) return false
+        if (!isEnabled()) return false
         if (formatIndex == CHROMA_FORMAT_INDEX) {
             toggleChromaOn()
             return true
         }
         return false
     }
+
+    private fun isChromaEnabled() = config.enabled.get()
+    private fun isEnabled() = LorenzUtils.inSkyBlock && isChromaEnabled()
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
@@ -64,7 +64,7 @@ object FontRendererHook {
     @JvmStatic
     fun beginChromaRendering(text: String, shadow: Boolean) {
         if (!LorenzUtils.inSkyBlock) return
-        if (!ChromaManager.config.enabled) return
+        if (!ChromaManager.config.enabled.get()) return
         if (ChromaManager.config.allChroma && ChromaManager.config.ignoreChat && cameFromChat) {
             endChromaFont()
             return
@@ -102,7 +102,7 @@ object FontRendererHook {
     fun forceWhiteColorCode(formatIndex: Int): Int {
         if (!LorenzUtils.inSkyBlock) return formatIndex
 
-        if (!ChromaManager.config.enabled) return formatIndex
+        if (!ChromaManager.config.enabled.get()) return formatIndex
 
         val drawState = currentDrawState ?: return formatIndex
         if (drawState.getChromaState() && formatIndex <= WHITE_FORMAT_INDEX) { // If it's a color code
@@ -115,7 +115,7 @@ object FontRendererHook {
     @JvmStatic
     fun restoreChromaState() {
         if (!LorenzUtils.inSkyBlock) return
-        if (!ChromaManager.config.enabled) return
+        if (!ChromaManager.config.enabled.get()) return
 
         currentDrawState?.restoreChromaEnv()
     }
@@ -123,7 +123,7 @@ object FontRendererHook {
     @JvmStatic
     fun endChromaRendering() {
         if (!LorenzUtils.inSkyBlock) return
-        if (!ChromaManager.config.enabled) return
+        if (!ChromaManager.config.enabled.get()) return
 
         if (previewChroma) {
             previewChroma = false
@@ -137,13 +137,13 @@ object FontRendererHook {
 
     @JvmStatic
     fun insertZColorCode(constant: String): String {
-        return if (LorenzUtils.inSkyBlock && !ChromaManager.config.enabled) constant else "0123456789abcdefklmnorz"
+        return if (LorenzUtils.inSkyBlock && !ChromaManager.config.enabled.get()) constant else "0123456789abcdefklmnorz"
     }
 
     @JvmStatic
     fun toggleChromaAndResetStyle(formatIndex: Int): Boolean {
         if (!LorenzUtils.inSkyBlock) return false
-        if (!ChromaManager.config.enabled) return false
+        if (!ChromaManager.config.enabled.get()) return false
         if (formatIndex == CHROMA_FORMAT_INDEX) {
             toggleChromaOn()
             return true

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MixinPatcherFontRendererHookHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MixinPatcherFontRendererHookHook.kt
@@ -11,7 +11,7 @@ class MixinPatcherFontRendererHookHook {
         fun overridePatcherFontRenderer(string: String, shadow: Boolean, cir: CallbackInfoReturnable<Boolean>) {
             if (!LorenzUtils.onHypixel) return
 
-            if (ChromaManager.config.enabled) {
+            if (ChromaManager.config.enabled.get()) {
                 cir.cancel()
                 cir.returnValue = false
             }


### PR DESCRIPTION
## What
Fix max enchantments showing as white when the user has sh (and sba) chroma off.

## Changelog Fixes
+ Fixed enchantment colours showing as white when SkyHanni chroma is not enabled. - CalMWolfs
