### PR TITLE
Fix: inquisitor pattern includes trailing commas

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -41,7 +41,7 @@ object InquisitorWaypointShare {
      */
     private val partyOnlyCoordsPattern by patternGroup.pattern(
         "party.onlycoords",
-        "(?<party>§9Party §8> )?(?<playerName>.+)§f: §rx: (?<x>[^ ]+),? y: (?<y>[^ ]+),? z: (?<z>[^ ]+)"
+        "(?<party>§9Party §8> )?(?<playerName>.+)§f: §rx: (?<x>[^ ,]+),? y: (?<y>[^ ,]+),? z: (?<z>[^ ,]+)"
     )
 
     //Support for https://www.chattriggers.com/modules/v/inquisitorchecker


### PR DESCRIPTION
## What
Fixes inquisitor regex pattern including trailing commas in coordinate capture groups

## Changelog Fixes
+ Fixed Inquisitor chat sharing sometimes not working. - yhtez