### PR TITLE
Fix: Typo in mythological creature tracker reset command

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -256,7 +256,7 @@ object Commands {
             "Resets the Pest Profit Tracker"
         ) { PestProfitTracker.resetCommand() }
         registerCommand(
-            "shresetmythologicalcreatureracker",
+            "shresetmythologicalcreaturetracker",
             "Resets the Mythological Creature Tracker"
         ) { MythologicalCreatureTracker.resetCommand() }
         registerCommand(


### PR DESCRIPTION
## What
Fix a typo in mythological creature tracker reset command



## Changelog Fixes
+ Fixed typo in the Mythological Creature Tracker reset command. - Jordyrat