### PR TITLE
Improvement: Better Hoppity Egg Warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.core.config.Position;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 
@@ -48,6 +49,16 @@ public class HoppityEggsConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean warnUnclaimedEggs = false;
+
+    @Expose
+    @ConfigOption(name = "Click to Warp", desc = "Makes the eggs ready chat message clickable to warp you to an island.")
+    @ConfigEditorBoolean
+    public boolean warpUnclaimedEggs = false;
+
+    @Expose
+    @ConfigOption(name = "Warp Destination", desc = "A custom island to warp to in the above option.")
+    @ConfigEditorText
+    public String warpDestination = "nucleus";
 
     @Expose
     @ConfigOption(name = "Show during Contest", desc = "Show during a farming contest.")

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactor
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
@@ -189,7 +190,14 @@ object HoppityEggsManager {
 
         lastWarnTime = now()
         val amount = HoppityEggType.entries.size
-        ChatUtils.chat("All $amount Hoppity Eggs are ready to be found.!")
+        val message = "All $amount Hoppity Eggs are ready to be found!"
+        if (config.warpUnclaimedEggs) {
+            ChatUtils.clickableChat(
+                message,
+                onClick = { HypixelCommands.warp(config.warpDestination) },
+                "§eClick to /warp ${config.warpDestination}!"
+            )
+        } else ChatUtils.chat(message)
         LorenzUtils.sendTitle("§e$amount Hoppity Eggs!", 5.seconds)
         SoundUtils.repeatSound(100, 10, SoundUtils.plingSound)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -126,6 +126,7 @@ object ChatUtils {
      * Sends a message to the user that they can click and run an action
      * @param message The message to be sent
      * @param onClick The runnable to be executed when the message is clicked
+     * @param hover The string to be shown when the message is hovered
      * @param expireAt When the click action should expire, default never
      * @param prefix Whether to prefix the message with the chat prefix, default true
      * @param prefixColor Color that the prefix should be, default yellow (§e)
@@ -135,6 +136,7 @@ object ChatUtils {
     fun clickableChat(
         message: String,
         onClick: () -> Any,
+        hover: String = "§eClick here!",
         expireAt: SimpleTimeMark = SimpleTimeMark.farFuture(),
         prefix: Boolean = true,
         prefixColor: String = "§e",
@@ -143,7 +145,7 @@ object ChatUtils {
         val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
         chat(Text.text(msgPrefix + message) {
             this.onClick(expireAt, oneTimeClick, onClick)
-            this.hover = "§eClick here!".asComponent()
+            this.hover = hover.asComponent()
         })
     }
 


### PR DESCRIPTION
## What
Improves the hoppity egg warning by fixing a typo and adding an option to make it clickable to warp to an island.
Also adds an optional custom hover variable to ChatUtils.clickableChat
Resolves [Warp command in hoppity egg reminder](https://discord.com/channels/997079228510117908/1240091008478478377) and [hoppity egg warning has . and !](https://discord.com/channels/997079228510117908/1240085132409438240)


## Changelog Improvements
+ Improved Hoppity Egg warning. - Obsidian
    * Added option to warp to an island on click.
    * Fixed a typo.

## Changelog Technical Details
+ Added an optional custom hover to clickableChat. - Obsidian

