### PR TITLE
Fix: Max Island Size with Crimson + Catacombs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -185,7 +185,9 @@ class HypixelData {
 
             return when (skyBlockIsland) {
                 IslandType.MINESHAFT -> 4
+                IslandType.CATACOMBS -> 5
                 IslandType.CRYSTAL_HOLLOWS -> 24
+                IslandType.CRIMSON_ISLE -> 24
                 else -> if (serverId?.startsWith("mega") == true) 80 else 26
             }
         }


### PR DESCRIPTION
## Changelog Fixes
+ Fixed max island size display in Crimson Isle and Catacombs in Custom Scoreboard. - j10a1n15
