### PR TITLE
Backend: Keep visual formatting appearance with CharSequence.removeColor(keepFormatting=true)

### DIFF
--- a/src/test/java/at/hannibal2/skyhanni/test/RemoveColorTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/RemoveColorTest.kt
@@ -21,7 +21,16 @@ class RemoveColorTest {
 
     @Test
     fun testKeepNonColor() {
-        Assertions.assertEquals("§k§l§m§n§o§r", "§k§l§m§f§n§o§r".removeColor(true))
+        Assertions.assertEquals("§k§l§m", "§f§k§l§m".removeColor(true))
+    }
+
+    @Test
+    fun testColorToResetIfFormatted() {
+        // Replace color code with §r if a formatting style is being applied
+        Assertions.assertEquals("§k§l§m§r§o", "§k§l§m§f§o".removeColor(true))
+
+        // Remove the color code otherwise
+        Assertions.assertEquals("§m§r§l", "§m§r§f§l".removeColor(true))
     }
 
     @Test
@@ -40,6 +49,13 @@ class RemoveColorTest {
             "Ancient Necron's Chestplate ✪✪✪✪",
             "§dAncient Necron's Chestplate §6✪§6✪§6✪§6✪".removeColor()
         )
+        Assertions.assertEquals(
+            "PROMOTE ➜ [158] Manager",
+            "§5§o§a§lPROMOTE §8➜ §7[158§7] §5Manager".removeColor()
+        )
+        Assertions.assertEquals(
+            "§o§r§lPROMOTE §r➜ [158] Manager",
+            "§5§o§a§lPROMOTE §8➜ §7[158§7] §5Manager".removeColor(true)
+        )
     }
-
 }


### PR DESCRIPTION
## What
Change to `CharSequence#removeColor(keepFormatting=true)` so that the formatting is reset when there are color codes that reset the applied formatting styles. Added additional test cases to cover these situations. Does not change behavior with `keepFormatting=false`.

### Previous behavior
Removed all color codes and kept all non-color formatting codes in the message. 

`Original: §5§o§a§lPROMOTE §8➜ §7[158§7] §5Manager`
`Modified: §o§lPROMOTE ➜ [158] Manager`

<img width="282" alt="Screenshot 2024-05-17 at 12 22 25 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/3b1bc8fb-23ff-4b45-91cc-e1b9fb4d7518">

### New behavior
Keeps all non-color formatting codes. If a non-color formatting code is encountered, replaces the next occurrence of a color code (if one exists) with §r to reset the active formatting. Otherwise, removes all color codes.

`Original: §5§o§a§lPROMOTE §8➜ §7[158§7] §5Manager`
`Modified: §o§r§lPROMOTE §r➜ [158] Manager`

<img width="271" alt="Screenshot 2024-05-17 at 12 24 30 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/30ce34b0-e2d2-4658-b24e-618f59a908c4">


## Changelog Technical Details
+ Modified removeColor for visual formatting consistency. - appable
    * Keeps formatting consistency in the presence of color codes acting as implicit reset codes.
