### PR TITLE
Fix: Co-op capitalization in PlayerNameFormatter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
@@ -85,7 +85,7 @@ class PlayerNameFormatter {
         if (!isEnabled()) return
         event.chatComponent = StringUtils.replaceIfNeeded(
             event.chatComponent,
-            Text.text("§bCo-Op > ") {
+            Text.text("§bCo-op > ") {
                 appendSibling(nameFormat(event.authorComponent))
                 appendText("§f: ")
                 appendSibling(event.messageComponent.intoComponent())


### PR DESCRIPTION
## What
Fixes "Co-Op" -> "Co-op" for consistency with the default Hypixel chat formatting.
<img width="296" alt="Screenshot 2024-05-17 at 12 48 11 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/f0599353-74b3-4771-af8b-dab3420e4dde">


## Changelog Fixes
+ Minor co-op chat capitalization fix. - appable
