### PR TITLE
Improvement: choc factory stats show prestige level

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.utils.ClipboardUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.toRoman
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -71,7 +72,7 @@ object ChocolateFactoryStats {
         val upgradeAvailableAt = ChocolateAmount.CURRENT.formattedTimeUntilGoal(profileStorage.bestUpgradeCost)
 
         val map = buildMap {
-            put(ChocolateFactoryStat.HEADER, "§6§lChocolate Factory Stats")
+            put(ChocolateFactoryStat.HEADER, "§6§lChocolate Factory ${ChocolateFactoryAPI.currentPrestige.toRoman()}")
 
             put(ChocolateFactoryStat.CURRENT, "§eCurrent Chocolate: §6${ChocolateAmount.CURRENT.formatted}")
             put(ChocolateFactoryStat.THIS_PRESTIGE, "§eThis Prestige: §6${ChocolateAmount.PRESTIGE.formatted}")
@@ -116,12 +117,8 @@ object ChocolateFactoryStats {
             tips = listOf("§bCopy to Clipboard!"),
             onClick = {
                 val list = text.toMutableList()
-                val titleHeader = list.indexOf("§6§lChocolate Factory Stats")
-                if (titleHeader != -1) {
-                    list[titleHeader] = "${LorenzUtils.getPlayerName()}'s Chocolate Factory Stats"
-                } else {
-                    list.add(0, "${LorenzUtils.getPlayerName()}'s Chocolate Factory Stats")
-                }
+                list.add(0, "${LorenzUtils.getPlayerName()}'s Chocolate Factory Stats")
+
                 ClipboardUtils.copyToClipboard(list.joinToString("\n") { it.removeColor() })
             }
         ))


### PR DESCRIPTION
## What
change "Chocolate Factory Stats" to show the prestige level, e.g. "Chocolate Factory IV"

<details>
<summary>Image</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/77941535/84155942-1b75-48a3-917c-184df1e58dc6)

</details>


## Changelog Improvements
+ Added display of prestige level in chocolate factory statistics. - seraid

