### PR TITLE
Fix: Bestiary Display when in search results

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
@@ -39,11 +39,19 @@ object BestiaryData {
 
     private val patternGroup = RepoPattern.group("combat.bestiary.data")
 
+    /**
+     * REGEX-TEST: §7Progress to Tier 14: §b26%
+     * REGEX-TEST: §7Progress to Tier XV: §b57.1%
+     */
     private val tierProgressPattern by patternGroup.pattern(
         "tierprogress",
         "§7Progress to Tier [\\dIVXC]+: §b[\\d.]+%"
     )
 
+    /**
+     * REGEX-TEST: §7Overall Progress: §b55.2%
+     * REGEX-TEST: §7Overall Progress: §b100% §7(§c§lMAX!§7)
+     */
     private val overallProgressPattern by patternGroup.pattern(
         "overallprogress",
         "§7Overall Progress: §b[\\d.]+%(?: §7\\(§c§lMAX!§7\\))?"


### PR DESCRIPTION
## What
Allows the bestiary display to display in search mode (`/be [query]`) when Overall Progress is enabled. Previously, it was always disabled and stated that Overall Progress was not enabled whenever in search mode.

Unsolvable issue: when in search mode and the only results are already-maxed bestiaries, it is impossible to determine whether Overall Progress is enabled. It simply assumes that Overall Progress is enabled in this case.

<details>
<summary>Images</summary>
<img width="874" alt="Screenshot 2024-05-17 at 4 15 54 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/a0fb43ff-84a5-4ebb-8ad0-e201472037bc">
</details>

## Changelog Fixes
+ Fixed bestiary display always being disabled in search mode. - appable