### PR TITLE
Fix: Wrong Visitor Time

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -99,6 +99,9 @@ class GardenVisitorTimer {
                 }
                 millis = TimeUtils.getDuration(timeInfo)
             }
+        } ?: run {
+            display = "§cVisitor time info not in tab list"
+            return
         }
 
         if (lastVisitors != -1 && visitorsAmount - lastVisitors == 1) {


### PR DESCRIPTION
## What
Fixed showing wrong visitor time when info not in tab list 

## Changelog Fixes
+ Fixed showing the wrong visitor time when info is not in the tab list. - hannibal2