### PR TITLE
Improvement + Fix: Quiver Warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/QuiverUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/QuiverUpdateEvent.kt
@@ -2,4 +2,4 @@ package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.data.ArrowType
 
-class QuiverUpdateEvent(val currentArrow: ArrowType?, val currentAmount: Int, val hideAmount: Boolean) : LorenzEvent()
+class QuiverUpdateEvent(val currentArrow: ArrowType?, val currentAmount: Int) : LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverDisplay.kt
@@ -64,7 +64,7 @@ class QuiverDisplay {
     fun onQuiverUpdate(event: QuiverUpdateEvent) {
         arrow = event.currentArrow
         amount = event.currentAmount
-        hideAmount = event.hideAmount
+        hideAmount = QuiverAPI.wearingSkeletonMasterChestplate
 
         updateDisplay()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverWarning.kt
@@ -2,15 +2,24 @@ package at.hannibal2.skyhanni.features.gui.quiver
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.ArrowType
+import at.hannibal2.skyhanni.data.QuiverAPI
+import at.hannibal2.skyhanni.data.QuiverAPI.amount
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.DungeonCompleteEvent
 import at.hannibal2.skyhanni.events.KuudraCompleteEvent
+import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.QuiverUpdateEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
+import at.hannibal2.skyhanni.features.nether.kuudra.KuudraAPI
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
+import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
@@ -19,8 +28,7 @@ class QuiverWarning {
     private val config get() = SkyHanniMod.feature.combat.quiverConfig
 
     private var lastLowQuiverReminder = SimpleTimeMark.farPast()
-    private var lowDuringInstance = false
-    private var amount = 0
+    private var arrowsInInstance = mutableSetOf<ArrowType>()
 
     @SubscribeEvent
     fun onDungeonComplete(event: DungeonCompleteEvent) {
@@ -33,15 +41,28 @@ class QuiverWarning {
     }
 
     private fun onInstanceComplete() {
-        if (!lowDuringInstance) return
-        lowDuringInstance = false
+        val arrows = arrowsInInstance
+        arrowsInInstance.clear()
+        arrows.filter { it.amount <= config.lowQuiverAmount }
 
-        if (config.reminderAfterRun) {
-            lowQuiverAlert()
+        if (arrows.isNotEmpty() && config.reminderAfterRun) {
+            DelayedRun.runNextTick {
+                instanceAlert(arrows)
+            }
         }
     }
 
-    private fun lowQuiverAlert() {
+    private fun instanceAlert(arrows: Set<ArrowType>) {
+        val arrowsText = arrows.map { arrowType ->
+            val rarity = arrowType.internalName.getItemStackOrNull()?.getItemRarityOrNull()?.chatColorCode ?: "§f"
+            "$rarity${arrowType.arrow}"
+        }.createCommaSeparatedList()
+        TitleManager.sendTitle("§cLow on arrows!", 5.seconds, 3.6, 7f)
+        ChatUtils.chat("Low on $arrowsText!")
+        SoundUtils.repeatSound(100, 30, SoundUtils.plingSound)
+    }
+
+    private fun lowQuiverAlert(amount: Int) {
         if (lastLowQuiverReminder.passedSince() < 30.seconds) return
         lastLowQuiverReminder = SimpleTimeMark.now()
         TitleManager.sendTitle("§cLow on arrows!", 5.seconds, 3.6, 7f)
@@ -50,16 +71,24 @@ class QuiverWarning {
 
     @SubscribeEvent
     fun onQuiverUpdate(event: QuiverUpdateEvent) {
-        amount = event.currentAmount
+        val amount = event.currentAmount
+        val arrow = event.currentArrow ?: return
+        if (arrow == QuiverAPI.NONE_ARROW_TYPE) return
+
+        if (inInstance()) arrowsInInstance.add(arrow)
 
         if (amount > config.lowQuiverAmount) return
-        if (DungeonAPI.inDungeon() || LorenzUtils.inKuudraFight) {
-            lowDuringInstance = true
-        }
         if (config.lowQuiverNotification) {
-            lowQuiverAlert()
+            lowQuiverAlert(amount)
         }
     }
+
+    @SubscribeEvent
+    fun onWorldSwitch(event: LorenzWorldChangeEvent) {
+        arrowsInInstance.clear()
+    }
+
+    private fun inInstance() = DungeonAPI.inDungeon() || KuudraAPI.inKuudra()
 
     @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {


### PR DESCRIPTION
## What
Fixes low quiver warning
 triggering when switching to no arrow type, and also makes the low arrows after run reminder specify what arrows to use again. also some cleanup and simplification around other quiver related things.


## Changelog Improvements
+ Re-added different arrow types in Quiver Reminder after a run. - Empa

## Changelog Fixes
+ Fixed Low Quiver Warning incorrectly appearing when switching to no arrows. - Empa