### PR TITLE
Backend: Ability to switch repo branch

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
@@ -14,15 +14,9 @@ import org.lwjgl.input.Keyboard;
 public class DevConfig {
 
     @Expose
-    @ConfigOption(name = "Repo Auto Update", desc = "Update the repository on every startup.\n" +
-        "§cOnly disable this if you know what you are doing!")
-    @ConfigEditorBoolean
-    public boolean repoAutoUpdate = true;
-
-    @Expose
-    @ConfigOption(name = "Log Expiry Time", desc = "Deletes your SkyHanni logs after this time period in days.")
-    @ConfigEditorSlider(minValue = 1, maxValue = 30, minStep = 1)
-    public int logExpiryTime = 14;
+    @ConfigOption(name = "Repository", desc = "")
+    @Accordion
+    public RepositoryConfig repo = new RepositoryConfig();
 
     @Expose
     @ConfigOption(name = "Debug", desc = "")
@@ -33,6 +27,11 @@ public class DevConfig {
     @ConfigOption(name = "Repo Pattern", desc = "")
     @Accordion
     public RepoPatternConfig repoPattern = new RepoPatternConfig();
+
+    @Expose
+    @ConfigOption(name = "Log Expiry Time", desc = "Deletes your SkyHanni logs after this time period in days.")
+    @ConfigEditorSlider(minValue = 1, maxValue = 30, minStep = 1)
+    public int logExpiryTime = 14;
 
     @Expose
     @ConfigOption(name = "Slot Number", desc = "Show slot number in inventory while pressing this key.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.java
@@ -1,0 +1,50 @@
+package at.hannibal2.skyhanni.config.features.dev;
+
+import at.hannibal2.skyhanni.data.repo.RepoUtils;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.Accordion;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+public class RepositoryConfig {
+
+    @Expose
+    @ConfigOption(name = "Repo Auto Update", desc = "Update the repository on every startup.\n" +
+        "§cOnly disable this if you know what you are doing!")
+    @ConfigEditorBoolean
+    public boolean repoAutoUpdate = true;
+
+    @ConfigOption(name = "Update Repo Now", desc = "Update your repository to the latest version")
+    @ConfigEditorButton(buttonText = "Update")
+    public Runnable updateRepo = RepoUtils::updateRepo;
+
+    @Expose
+    @ConfigOption(name = "Repository Location", desc = "")
+    @Accordion
+    public RepositoryLocation location = new RepositoryLocation();
+
+    public static class RepositoryLocation {
+
+        @ConfigOption(name = "Reset Repository Location", desc = "Reset your repository location to the default.")
+        @ConfigEditorButton(buttonText = "Reset")
+        public Runnable resetRepoLocation = RepoUtils::resetRepoLocation;
+
+        @Expose
+        @ConfigOption(name = "Repository User", desc = "The Repository Branch, default: hannibal002")
+        @ConfigEditorText
+        public String user = "hannibal002";
+
+        @Expose
+        @ConfigOption(name = "Repository Name", desc = "The Repository Name, default: SkyHanni-Repo")
+        @ConfigEditorText
+        public String name = "SkyHanni-Repo";
+
+        @Expose
+        @ConfigOption(name = "Repository Branch", desc = "The Repository Branch, default: main")
+        @ConfigEditorText
+        public String branch = "main";
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.java
@@ -39,7 +39,7 @@ public class RepositoryConfig {
         @Expose
         @ConfigOption(name = "Repository Name", desc = "The Repository Name, default: SkyHanni-Repo")
         @ConfigEditorText
-        public String name = "SkyHanni-Repo";
+        public String name = "SkyHanni-REPO";
 
         @Expose
         @ConfigOption(name = "Repository Branch", desc = "The Repository Branch, default: main")

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -36,22 +36,28 @@ class RepoManager(private val configLocation: File) {
 
     companion object {
 
+        private val config get() = SkyHanniMod.feature.dev.repo
+
         val successfulConstants = mutableListOf<String>()
         val unsuccessfulConstants = mutableListOf<String>()
 
         private var lastConstant: String? = null
 
-        fun setlastConstant(constant: String) {
+        fun setLastConstant(constant: String) {
             lastConstant?.let {
                 successfulConstants.add(it)
             }
             lastConstant = constant
         }
+
+        fun getRepoLocation(): String {
+            return "${config.location.user}/${config.location.name}/${config.location.branch}"
+        }
     }
 
     fun loadRepoInformation() {
         atomicShouldManuallyReload.set(true)
-        if (SkyHanniMod.feature.dev.repoAutoUpdate) {
+        if (config.repoAutoUpdate) {
             fetchRepository(false).thenRun(this::reloadRepository)
         } else {
             reloadRepository()
@@ -62,6 +68,7 @@ class RepoManager(private val configLocation: File) {
 
     fun updateRepo() {
         atomicShouldManuallyReload.set(true)
+        checkRepoLocation()
         fetchRepository(true).thenRun { this.reloadRepository("Repo updated successfully.") }
     }
 
@@ -219,7 +226,7 @@ class RepoManager(private val configLocation: File) {
             if (unsuccessfulConstants.isNotEmpty()) {
                 ChatUtils.error(
                     "§7Repo Issue! Some features may not work. Please report this error on the Discord!\n"
-                        + "§7Repo Auto Update Value: §c${SkyHanniMod.feature.dev.repoAutoUpdate}\n"
+                        + "§7Repo Auto Update Value: §c${config.repoAutoUpdate}\n"
                         + "§7If you have Repo Auto Update turned off, please try turning that on.\n"
                         + "§cUnsuccessful Constants §7(${unsuccessfulConstants.size}):"
                 )
@@ -266,15 +273,15 @@ class RepoManager(private val configLocation: File) {
     }
 
     private fun getCommitApiUrl(): String {
-        val repoUser = "hannibal002"
-        val repoName = "SkyHanni-REPO"
-        val repoBranch = "main"
+        val repoUser = config.location.user
+        val repoName = config.location.name
+        val repoBranch = config.location.branch
         return String.format("https://api.github.com/repos/%s/%s/commits/%s", repoUser, repoName, repoBranch)
     }
 
     private fun getDownloadUrl(commitId: String?): String {
-        val repoUser = "hannibal002"
-        val repoName = "SkyHanni-REPO"
+        val repoUser = config.location.user
+        val repoName = config.location.name
         return String.format("https://github.com/%s/%s/archive/%s.zip", repoUser, repoName, commitId)
     }
 
@@ -292,5 +299,17 @@ class RepoManager(private val configLocation: File) {
     @SubscribeEvent
     fun onNeuRepoReload(event: io.github.moulberry.notenoughupdates.events.RepositoryReloadEvent) {
         NeuRepositoryReloadEvent().postAndCatch()
+    }
+
+    fun resetRepositoryLocation() {
+        config.location.user = "hannibal002"
+        config.location.name = "SkyHanni-Repo"
+        config.location.branch = "main"
+    }
+
+    private fun checkRepoLocation() {
+        if (config.location.user.isEmpty() || config.location.name.isEmpty() || config.location.branch.isEmpty()) {
+            resetRepositoryLocation()
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -301,14 +301,35 @@ class RepoManager(private val configLocation: File) {
         NeuRepositoryReloadEvent().postAndCatch()
     }
 
-    fun resetRepositoryLocation() {
-        config.location.user = "hannibal002"
-        config.location.name = "SkyHanni-Repo"
-        config.location.branch = "main"
+    fun resetRepositoryLocation(manual: Boolean = false) {
+        val defaultUser = "hannibal002"
+        val defaultName = "SkyHanni-Repo"
+        val defaultBranch = "main"
+
+        with(config.location) {
+            if (user == defaultUser && name == defaultName && branch == defaultBranch) {
+                if (manual) {
+                    ChatUtils.chat("Repo settings are already on default!")
+                }
+                return
+            }
+
+            user = defaultUser
+            name = defaultName
+            branch = defaultBranch
+            if (manual) {
+                ChatUtils.clickableChat("Reset Repo settings to default. " +
+                    "Click §aUpdate Repo Now §ein config or run /shupdaterepo to update!",
+                    onClick = {
+                        updateRepo()
+                    })
+            }
+        }
     }
 
     private fun checkRepoLocation() {
         if (config.location.user.isEmpty() || config.location.name.isEmpty() || config.location.branch.isEmpty()) {
+            ChatUtils.userError("Invalid Repo settings detected, resetting default settings.")
             resetRepositoryLocation()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoUtils.kt
@@ -112,6 +112,6 @@ object RepoUtils {
 
     @JvmStatic
     fun resetRepoLocation() {
-        SkyHanniMod.repo.resetRepositoryLocation()
+        SkyHanniMod.repo.resetRepositoryLocation(manual = true)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoUtils.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.data.repo
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import com.google.gson.Gson
 import java.io.BufferedReader
@@ -102,5 +103,15 @@ object RepoUtils {
                 return gson.fromJson(reader, type)
             }
         }
+    }
+
+    @JvmStatic
+    fun updateRepo() {
+        SkyHanniMod.repo.updateRepo()
+    }
+
+    @JvmStatic
+    fun resetRepoLocation() {
+        SkyHanniMod.repo.resetRepositoryLocation()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/RepositoryReloadEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RepositoryReloadEvent.kt
@@ -10,7 +10,7 @@ import java.lang.reflect.Type
 class RepositoryReloadEvent(val repoLocation: File, val gson: Gson) : LorenzEvent() {
 
     inline fun <reified T : Any> getConstant(constant: String, type: Type? = null, gson: Gson = this.gson): T = try {
-        RepoManager.setlastConstant(constant)
+        RepoManager.setLastConstant(constant)
         if (!repoLocation.exists()) throw RepoError("Repo folder does not exist!")
         RepoUtils.getConstant(repoLocation, constant, gson, T::class.java, type)
     } catch (e: Exception) {

--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.test
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.repo.RepoManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -36,6 +37,7 @@ object DebugCommand {
         // calling default debug stuff
         player(event)
         repoAutoUpdate(event)
+        repoLocation(event)
         globalRender(event)
         skyblockStatus(event)
         profileName(event)
@@ -127,11 +129,16 @@ object DebugCommand {
 
     private fun repoAutoUpdate(event: DebugDataCollectEvent) {
         event.title("Repo Auto Update")
-        if (SkyHanniMod.feature.dev.repoAutoUpdate) {
+        if (SkyHanniMod.feature.dev.repo.repoAutoUpdate) {
             event.addIrrelevant("normal enabled")
         } else {
             event.addData("The repo does not auto update because auto update is disabled!")
         }
+    }
+
+    private fun repoLocation(event: DebugDataCollectEvent) {
+        event.title("Repo Location")
+        event.addIrrelevant("repo location: '${RepoManager.getRepoLocation()}'")
     }
 
     private fun player(event: DebugDataCollectEvent) {


### PR DESCRIPTION
## What
Add the ability to switch repo branch exactly like neu does it.


## Changelog Technical Details
+ Added the ability to switch the repo branch. - CalMWolfs
    * Useful for when testing PRs that need an update/new repo file.

