### PR TITLE
Fix: bazaar empty data

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/bazaar/HypixelBazaarFetcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/bazaar/HypixelBazaarFetcher.kt
@@ -62,6 +62,11 @@ object HypixelBazaarFetcher {
         val internalName = NEUItems.transHypixelNameToInternalName(key)
         val sellOfferPrice = product.buySummary.minOfOrNull { it.pricePerUnit } ?: 0.0
         val insantBuyPrice = product.sellSummary.maxOfOrNull { it.pricePerUnit } ?: 0.0
+
+        if (product.quickStatus.isEmpty()) {
+            return@mapNotNull null
+        }
+
         if (internalName.getItemStackOrNull() == null) {
             // Items that exist in Hypixel's Bazaar API, but not in NEU repo (not visible in in the ingame bazaar).
             // Should only include Enchants
@@ -71,6 +76,17 @@ object HypixelBazaarFetcher {
         }
         internalName to BazaarData(internalName.itemName, sellOfferPrice, insantBuyPrice, product)
     }.toMap()
+
+    private fun BazaarQuickStatus.isEmpty(): Boolean = with(this) {
+        sellPrice == 0.0 &&
+            sellVolume == 0L &&
+            sellMovingWeek == 0L &&
+            sellOrders == 0L &&
+            buyPrice == 0.0 &&
+            buyVolume == 0L &&
+            buyMovingWeek == 0L &&
+            buyOrders == 0L
+    }
 
     private fun onError(fetchType: String, e: Exception, rawResponse: String? = null) {
         val userMessage = "Failed fetching bazaar price data from hypixel"


### PR DESCRIPTION
## What
Fixed invalid bazaar items being highlighted in the clickable items feature.
Invlaid = in hypixel api, but not really part of the bz in game

## Changelog Fixes
+ Fixed invalid bazaar items being highlighted in the clickable items feature. - hannibal2