### PR TITLE
Backend: MobDetection Memory Leak

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -19,6 +19,7 @@ import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.monster.EntityZombie
 import net.minecraft.util.AxisAlignedBB
 import java.awt.Color
+import java.util.UUID
 
 /**
  * Represents a Mob in Hypixel Skyblock.
@@ -56,6 +57,7 @@ import java.awt.Color
  * Gives back the second additional armor stand.
  *
  *   (should be called in the [MobEvent.Spawn] since it is a lazy)
+ * @property id Unique identifier for each Mob instance
  */
 class Mob(
     var baseEntity: EntityLivingBase,
@@ -68,6 +70,8 @@ class Mob(
     val attribute: MobFilter.DungeonAttribute? = null,
     val levelOrTier: Int = -1,
 ) {
+
+    private val id: UUID = UUID.randomUUID()
 
     val owner: MobUtils.OwnerShip?
 
@@ -200,16 +204,14 @@ class Mob(
         }
     }
 
-    override fun hashCode() = baseEntity.hashCode()
+    override fun hashCode() = id.hashCode()
 
     override fun toString(): String = "$name - ${baseEntity.entityId}"
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
+        if (other !is Mob) return false
 
-        other as Mob
-
-        return baseEntity == other.baseEntity
+        return id == other.id
     }
 }


### PR DESCRIPTION
## What
Fixed the hash of mobs to be consitent. Which fixes the issue that HashSets broke do to not being consitent.

## Changelog Technical Details
+ Fixed a small Memory Leak in MobData. - Thunderblade73

