### PR TITLE
Fix: Incorrect crop type for rat.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -83,7 +83,7 @@ enum class PestType(
         SprayType.TASTY_CHEESE,
         VinylType.RODENT_REVOLUTION,
         "PEST_RAT_MONSTER".asInternalName(),
-        CropType.COCOA_BEANS,
+        CropType.PUMPKIN,
     ),
     SLUG(
         "Slug",


### PR DESCRIPTION
## What
wrong crop vinyl icon on rat 

## Changelog Fixes
+ Fixed wrong icon for the rat crop type in Stereo Harmony display. - raven

