### PR TITLE
Fix: Glacite Walkers not being highlighted during commissions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -30,7 +30,7 @@ class HighlightMiningCommissionMobs {
         // Dwarven Mines
         DWARVEN_GOBLIN_SLAYER("Goblin Slayer", { it.name == "Goblin " }),
         STAR_PUNCHER("Star Sentry Puncher", { it.name == "Crystal Sentry" }),
-        ICE_WALKER("Ice Walker Slayer", { it.name == "Ice Walker" }),
+        ICE_WALKER("Glacite Walker Slayer", { it.name == "Ice Walker" }),
         GOLDEN_GOBLIN("Golden Goblin Slayer", { it.name.contains("Golden Goblin") }),
 
         // Crystal Hollows


### PR DESCRIPTION
## What
Fixed Glacite Walkers not being highlighted during commissions. (The mob got renamed, but the internal name is still Ice Walker.)

## Changelog Fixes
+ Fixed Glacite Walkers not being highlighted during commissions. - Luna

