### PR TITLE
Improvement: shresettracker command

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -84,8 +84,10 @@ import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.chat.ChatClickActionManager
 import at.hannibal2.skyhanni.utils.chat.Text
 import at.hannibal2.skyhanni.utils.chat.Text.hover
+import at.hannibal2.skyhanni.utils.chat.Text.onClick
 import at.hannibal2.skyhanni.utils.chat.Text.suggest
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPatternGui
+import at.hannibal2.skyhanni.utils.tracker.Resettable
 import net.minecraft.command.ICommandSender
 import net.minecraft.util.BlockPos
 import net.minecraft.util.ChatComponentText
@@ -165,6 +167,7 @@ object Commands {
     }
 
     private fun usersNormal() {
+        registerCommand("shresettracker", "Reset SkyHanni trackers") { commandTracker(it) }
         registerCommand(
             "shmarkplayer",
             "Add a highlight effect to a player for better visibility"
@@ -187,10 +190,6 @@ object Commands {
             "Manually sets the crop start location"
         ) { GardenStartLocation.setLocationCommand() }
         registerCommand(
-            "shclearslayerprofits",
-            "Clearing the total slayer profit for the current slayer type"
-        ) { SlayerProfitTracker.clearProfitCommand(it) }
-        registerCommand(
             "shimportghostcounterdata",
             "Manually importing the ghost counter data from GhostCounterV3"
         ) { GhostUtil.importCTGhostCounterData() }
@@ -198,29 +197,6 @@ object Commands {
             "shclearfarmingitems",
             "Clear farming items saved for the Farming Fortune Guide"
         ) { clearFarmingItems() }
-        registerCommand("shresetghostcounter", "Resets the ghost counter") { GhostUtil.reset() }
-        registerCommand("shresetpowdertracker", "Resets the Powder Tracker") { PowderTracker.resetCommand() }
-        registerCommand("shresetdicertracker", "Resets the Dicer Drop Tracker") { DicerRngDropTracker.resetCommand() }
-        registerCommand(
-            "shresetendernodetracker",
-            "Resets the Ender Node Tracker"
-        ) { EnderNodeTracker.resetCommand() }
-        registerCommand(
-            "shresetarmordroptracker",
-            "Resets the Armor Drop Tracker"
-        ) { ArmorDropTracker.resetCommand() }
-        registerCommand(
-            "shresetfrozentreasuretracker",
-            "Resets the Frozen Treasure Tracker"
-        ) { FrozenTreasureTracker.resetCommand() }
-        registerCommand(
-            "shresetfishingtracker",
-            "Resets the Fishing Profit Tracker"
-        ) { FishingProfitTracker.resetCommand() }
-        registerCommand(
-            "shresetvisitordrops",
-            "Reset the Visitors Drop Statistics"
-        ) { GardenVisitorDropStatistics.resetCommand() }
         registerCommand("shbingotoggle", "Toggle the bingo card display mode") { BingoCardDisplay.toggleCommand() }
         registerCommand(
             "shfarmingprofile",
@@ -243,26 +219,6 @@ object Commands {
             "shsensreduce",
             "Lowers the mouse sensitivity for easier small adjustments (for farming)"
         ) { SensitivityReducer.manualToggle() }
-        registerCommand(
-            "shresetvermintracker",
-            "Resets the Vermin Tracker"
-        ) { VerminTracker.resetCommand() }
-        registerCommand(
-            "shresetdianaprofittracker",
-            "Resets the Diana Profit Tracker"
-        ) { DianaProfitTracker.resetCommand() }
-        registerCommand(
-            "shresetpestprofittracker",
-            "Resets the Pest Profit Tracker"
-        ) { PestProfitTracker.resetCommand() }
-        registerCommand(
-            "shresetmythologicalcreaturetracker",
-            "Resets the Mythological Creature Tracker"
-        ) { MythologicalCreatureTracker.resetCommand() }
-        registerCommand(
-            "shresetseacreaturetracker",
-            "Resets the Sea Creature Tracker"
-        ) { SeaCreatureTracker.resetCommand() }
         registerCommand(
             "shfandomwiki",
             "Searches the fandom wiki with SkyHanni's own method."
@@ -544,6 +500,26 @@ object Commands {
         registerCommand("pt", "Transfer the party to another party member") { PartyCommands.transfer(it) }
         registerCommand("pp", "Promote a specific party member") { PartyCommands.promote(it) }
         registerCommand("pd", "Disbands the party") { PartyCommands.disband() }
+    }
+
+    private fun commandTracker(args: Array<String>) {
+        val trackers: List<Resettable> = listOf(
+            SlayerProfitTracker, VerminTracker, PowderTracker, GardenVisitorDropStatistics, PestProfitTracker,
+            DicerRngDropTracker, ArmorDropTracker, SeaCreatureTracker, FishingProfitTracker, FrozenTreasureTracker,
+            MythologicalCreatureTracker, DianaProfitTracker, GhostUtil, EnderNodeTracker
+        )
+
+        val components = mutableListOf<ChatComponentText>()
+        components.add(ChatComponentText("§7Click to reset a SkyHanni tracker:"))
+        for (tracker in trackers) {
+            components.add(ChatComponentText(("\n")))
+            val trackerComponent = Text.text(" §7§l- §b${tracker.name}") {
+                onClick { tracker.resetCommand() }
+                hover = ChatComponentText("§eClick to reset §b${tracker.name}")
+            }
+            components.add(trackerComponent)
+        }
+        ChatUtils.multiComponentMessage(components)
     }
 
     private fun commandHelp(args: Array<String>) {

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/ghostcounter/GhostCounterConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/ghostcounter/GhostCounterConfig.java
@@ -133,10 +133,6 @@ public class GhostCounterConfig {
     @ConfigEditorBoolean
     public boolean showMax = false;
 
-    @ConfigOption(name = "Reset", desc = "Reset the counter.")
-    @ConfigEditorButton(buttonText = "Reset")
-    public Runnable resetCounter = GhostUtil.INSTANCE::reset;
-
     @Expose
     @ConfigLink(owner = GhostCounterConfig.class, field = "enabled")
     public Position position = new Position(50, 50, false, true);

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/endernodetracker/EnderNodeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/endernodetracker/EnderNodeTracker.kt
@@ -25,13 +25,15 @@ import at.hannibal2.skyhanni.utils.NEUItems.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.getPriceOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.format
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.annotations.Expose
 import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-object EnderNodeTracker {
+object EnderNodeTracker: SimpleTracker() {
+    override val name = "Ender Node Tracker"
 
     private val config get() = SkyHanniMod.feature.combat.enderNodeTracker
 
@@ -40,7 +42,7 @@ object EnderNodeTracker {
     private val enderNodeRegex = Regex("""ENDER NODE!.+You found (\d+x )?§r(.+)§r§f!""")
     private val endermanRegex = Regex("""(RARE|PET) DROP! §r(.+) §r§b\(""")
 
-    private val tracker = SkyHanniTracker("Ender Node Tracker", { Data() }, { it.enderNodeTracker }) {
+    override val tracker = SkyHanniTracker("Ender Node Tracker", { Data() }, { it.enderNodeTracker }) {
         formatDisplay(
             drawDisplay(it)
         )
@@ -255,9 +257,5 @@ object EnderNodeTracker {
             newList.add(map[index.ordinal])
         }
         return newList
-    }
-
-    fun resetCommand() {
-        tracker.resetCommand()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghostcounter/GhostUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghostcounter/GhostUtil.kt
@@ -7,18 +7,31 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.NumberUtil
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundToPrecision
+import at.hannibal2.skyhanni.utils.tracker.Resettable
 import io.github.moulberry.notenoughupdates.util.Utils
 import java.io.FileReader
 
-object GhostUtil {
+object GhostUtil: Resettable {
+    override val name = "Ghost Counter"
 
-    fun reset() {
-        for (opt in GhostData.Option.entries) {
-            opt.set(0.0)
-            opt.set(0.0, true)
-        }
-        GhostCounter.storage?.totalMF = 0.0
-        GhostCounter.update()
+    override fun resetCommand() {
+        ChatUtils.clickableChat(
+            "Are you sure you want to reset your Ghost Counter? Click here to confirm.",
+            onClick = {
+                for (opt in GhostData.Option.entries) {
+                    opt.set(0.0)
+                    opt.set(0.0, true)
+                }
+                GhostCounter.storage?.totalMF = 0.0
+                GhostCounter.update()
+                ChatUtils.chat("Ghost Counter reset!")
+            },
+            oneTimeClick = true
+        )
+    }
+
+    private fun reset() {
+
     }
 
     fun isUsingCTGhostCounter(): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
@@ -19,11 +19,13 @@ import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
+import at.hannibal2.skyhanni.utils.tracker.Resettable
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-object DianaProfitTracker {
+object DianaProfitTracker: SimpleTracker() {
 
     private val config get() = SkyHanniMod.feature.event.diana.dianaProfitTracker
     private var allowedDrops = listOf<NEUInternalName>()
@@ -38,7 +40,7 @@ object DianaProfitTracker {
         "§6§lWow! §r§eYou dug out §r§6(?<coins>.*) coins§r§e!"
     )
 
-    private val tracker = SkyHanniItemTracker(
+    override val tracker = SkyHanniItemTracker(
         "Diana Profit Tracker",
         { Data() },
         { it.diana.dianaProfitTracker }) { drawDisplay(it) }
@@ -147,10 +149,6 @@ object DianaProfitTracker {
     @SubscribeEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         allowedDrops = event.getConstant<DianaDrops>("DianaDrops").diana_drops
-    }
-
-    fun resetCommand() {
-        tracker.resetCommand()
     }
 
     private fun isEnabled() = DianaAPI.isDoingDiana() && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.annotations.Expose
@@ -20,7 +21,7 @@ import net.minecraft.util.ChatComponentText
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.regex.Pattern
 
-object MythologicalCreatureTracker {
+object MythologicalCreatureTracker: SimpleTracker() {
 
     private val config get() = SkyHanniMod.feature.event.diana.mythologicalMobtracker
 
@@ -50,7 +51,7 @@ object MythologicalCreatureTracker {
         ".* §r§eYou dug out a §r§2Minos Inquisitor§r§e!"
     )
 
-    private val tracker =
+    override val tracker =
         SkyHanniTracker("Mythological Creature Tracker", { Data() }, { it.diana.mythologicalMobTracker })
         { drawDisplay(it) }
 
@@ -125,10 +126,6 @@ object MythologicalCreatureTracker {
         if (!isEnabled()) return
 
         tracker.renderDisplay(config.position)
-    }
-
-    fun resetCommand() {
-        tracker.resetCommand()
     }
 
     private fun isEnabled() = DianaAPI.isDoingDiana() && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/event/jerry/frozentreasure/FrozenTreasureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/jerry/frozentreasure/FrozenTreasureTracker.kt
@@ -20,12 +20,13 @@ import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-object FrozenTreasureTracker {
+object FrozenTreasureTracker: SimpleTracker() {
 
     private val config get() = SkyHanniMod.feature.event.winter.frozenTreasureTracker
 
@@ -39,7 +40,7 @@ object FrozenTreasureTracker {
     private var icePerSecond = mutableListOf<Long>()
     private var icePerHour = 0
     private var stoppedChecks = 0
-    private val tracker = SkyHanniTracker("Frozen Treasure Tracker", { Data() }, { it.frozenTreasureTracker })
+    override val tracker = SkyHanniTracker("Frozen Treasure Tracker", { Data() }, { it.frozenTreasureTracker })
     { formatDisplay(drawDisplay(it)) }
 
     init {
@@ -189,8 +190,4 @@ object FrozenTreasureTracker {
 
     private fun inGlacialCave() =
         onJerryWorkshop() && ScoreboardData.sidebarLinesFormatted.contains(" §7⏣ §3Glacial Cave")
-
-    fun resetCommand() {
-        tracker.resetCommand()
-    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
@@ -26,6 +26,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import com.google.gson.annotations.Expose
@@ -35,7 +36,7 @@ import kotlin.time.Duration.Companion.seconds
 
 typealias CategoryName = String
 
-object FishingProfitTracker {
+object FishingProfitTracker: SimpleTracker() {
 
     val config get() = SkyHanniMod.feature.fishing.fishingProfitTracker
 
@@ -45,7 +46,7 @@ object FishingProfitTracker {
     )
 
     private var lastCatchTime = SimpleTimeMark.farPast()
-    private val tracker = SkyHanniItemTracker(
+    override val tracker = SkyHanniItemTracker(
         "Fishing Profit Tracker",
         { Data() },
         { it.fishing.fishingProfitTracker }) { drawDisplay(it) }
@@ -235,10 +236,6 @@ object FishingProfitTracker {
     @SubscribeEvent
     fun onBobberThrow(event: FishingBobberCastEvent) {
         tracker.firstUpdate()
-    }
-
-    fun resetCommand() {
-        tracker.resetCommand()
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled && !LorenzUtils.inKuudraFight

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/SeaCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/SeaCreatureTracker.kt
@@ -22,13 +22,14 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.allLettersFirstUppercase
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
-object SeaCreatureTracker {
+object SeaCreatureTracker: SimpleTracker() {
 
     private val config get() = SkyHanniMod.feature.fishing.seaCreatureTracker
 
@@ -37,7 +38,7 @@ object SeaCreatureTracker {
         "(BRONZE|SILVER|GOLD|DIAMOND)_HUNTER_(HELMET|CHESTPLATE|LEGGINGS|BOOTS)"
     )
 
-    private val tracker = SkyHanniTracker("Sea Creature Tracker", { Data() }, { it.fishing.seaCreatureTracker })
+    override val tracker = SkyHanniTracker("Sea Creature Tracker", { Data() }, { it.fishing.seaCreatureTracker })
     { drawDisplay(it) }
     private var lastArmorCheck = SimpleTimeMark.farPast()
     private var isTrophyFishing = false
@@ -165,10 +166,6 @@ object SeaCreatureTracker {
         if (!FishingAPI.isFishing(checkRodInHand = false)) return
 
         tracker.renderDisplay(config.position)
-    }
-
-    fun resetCommand() {
-        tracker.resetCommand()
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled && !isTrophyFishing && !LorenzUtils.inKuudraFight

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/ArmorDropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/ArmorDropTracker.kt
@@ -20,6 +20,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.JsonObject
@@ -27,7 +28,7 @@ import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
-object ArmorDropTracker {
+object ArmorDropTracker: SimpleTracker() {
 
     private val config get() = GardenAPI.config.farmingArmorDrop
 
@@ -38,7 +39,7 @@ object ArmorDropTracker {
 
     private var hasArmor = false
 
-    private val tracker = SkyHanniTracker("Armor Drop Tracker", { Data() }, { it.garden.armorDropTracker })
+    override val tracker = SkyHanniTracker("Armor Drop Tracker", { Data() }, { it.garden.armorDropTracker })
     { drawDisplay(it) }
 
     class Data : TrackerData() {
@@ -164,9 +165,5 @@ object ArmorDropTracker {
             new.add("drops", old)
             new
         }
-    }
-
-    fun resetCommand() {
-        tracker.resetCommand()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/DicerRngDropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/DicerRngDropTracker.kt
@@ -14,18 +14,21 @@ import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.Resettable
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.regex.Pattern
 
-object DicerRngDropTracker {
-
+object DicerRngDropTracker: SimpleTracker() {
     private val itemDrops = mutableListOf<ItemDrop>()
     private val config get() = GardenAPI.config.dicerCounters
-    private val tracker = SkyHanniTracker("Dicer RNG Drop Tracker", { Data() }, { it.garden.dicerDropTracker })
+    override val tracker = SkyHanniTracker("Dicer RNG Drop Tracker", { Data() }, { it.garden.dicerDropTracker })
     { drawDisplay(it) }
+
+    override val name = tracker.name
 
     class Data : TrackerData() {
 
@@ -170,9 +173,5 @@ object DicerRngDropTracker {
 
             ConfigManager.gson.toJsonTree(items)
         }
-    }
-
-    fun resetCommand() {
-        tracker.resetCommand()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -18,12 +18,13 @@ import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
-object PestProfitTracker {
+object PestProfitTracker: SimpleTracker() {
     val config get() = SkyHanniMod.feature.garden.pests.pestProfitTacker
 
     private val patternGroup = RepoPattern.group("garden.pests.tracker")
@@ -39,7 +40,7 @@ object PestProfitTracker {
     )
 
     private var lastPestKillTime = SimpleTimeMark.farPast()
-    private val tracker = SkyHanniItemTracker(
+    override val tracker = SkyHanniItemTracker(
         "Pest Profit Tracker",
         { Data() },
         { it.garden.pestProfitTracker }) { drawDisplay(it) }
@@ -138,10 +139,6 @@ object PestProfitTracker {
         if (event.newIsland == IslandType.GARDEN) {
             tracker.firstUpdate()
         }
-    }
-
-    fun resetCommand() {
-        tracker.resetCommand()
     }
 
     fun isEnabled() = GardenAPI.inGarden() && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
@@ -25,9 +25,11 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.Resettable
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-object GardenVisitorDropStatistics {
+object GardenVisitorDropStatistics: Resettable {
+    override val name = "Garden Visitor Drop Statistics"
 
     private val config get() = GardenAPI.config.visitors.dropsStatistics
     private var display = emptyList<List<Any>>()
@@ -241,7 +243,7 @@ object GardenVisitorDropStatistics {
         display = formatDisplay(drawDisplay(storage))
     }
 
-    fun resetCommand() {
+    override fun resetCommand() {
         val storage = GardenAPI.storage?.visitorDrops ?: return
         ChatUtils.clickableChat("Click here to reset Visitor Drops Statistics.", onClick = {
             acceptedVisitors = 0

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -20,6 +20,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.JsonArray
@@ -27,8 +28,7 @@ import com.google.gson.JsonNull
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-object PowderTracker {
-
+object PowderTracker: SimpleTracker() {
     private val config get() = SkyHanniMod.feature.mining.powderTracker
 
     private val patternGroup = RepoPattern.group("mining.powder.tracker")
@@ -85,7 +85,7 @@ object PowderTracker {
         calculateResourceHour(chestInfo)
     }
 
-    private val tracker = SkyHanniTracker("Powder Tracker", { Data() }, { it.powderTracker })
+    override val tracker = SkyHanniTracker("Powder Tracker", { Data() }, { it.powderTracker })
     { formatDisplay(drawDisplay(it)) }
 
     class Data : TrackerData() {
@@ -370,8 +370,4 @@ object PowderTracker {
     )
 
     private fun isEnabled() = IslandType.CRYSTAL_HOLLOWS.isInIsland() && config.enabled
-
-    fun resetCommand() {
-        tracker.resetCommand()
-    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminTracker.kt
@@ -18,13 +18,15 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.Resettable
+import at.hannibal2.skyhanni.utils.tracker.SimpleTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.regex.Pattern
 
-object VerminTracker {
+object VerminTracker: SimpleTracker() {
 
     private val patternGroup = RepoPattern.group("rift.area.westvillage.vermintracker")
     private val silverfishPattern by patternGroup.pattern(
@@ -53,7 +55,7 @@ object VerminTracker {
 
     private val config get() = RiftAPI.config.area.westVillage.verminTracker
 
-    private val tracker = SkyHanniTracker("Vermin Tracker", { Data() }, { it.rift.verminTracker })
+    override val tracker = SkyHanniTracker("Vermin Tracker", { Data() }, { it.rift.verminTracker })
     { drawDisplay(it) }
 
     class Data : TrackerData() {
@@ -174,10 +176,6 @@ object VerminTracker {
         if (event.newIsland == IslandType.THE_RIFT) {
             tracker.firstUpdate()
         }
-    }
-
-    fun resetCommand() {
-        tracker.resetCommand()
     }
 
     private fun isEnabled() = RiftAPI.inRift() && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -25,13 +25,15 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
+import at.hannibal2.skyhanni.utils.tracker.Resettable
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-object SlayerProfitTracker {
+object SlayerProfitTracker: Resettable {
+    override val name = "Slayer Profit Tracker"
 
     private val config get() = SkyHanniMod.feature.slayer.itemProfitTracker
 
@@ -240,7 +242,7 @@ object SlayerProfitTracker {
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
 
-    fun clearProfitCommand(args: Array<String>) {
+    override fun resetCommand() {
         if (itemLogCategory == "") {
             ChatUtils.userError(
                 "No current slayer data found! " +
@@ -249,6 +251,12 @@ object SlayerProfitTracker {
             return
         }
 
-        getTracker()?.resetCommand()
+        val tracker = getTracker() ?: return
+
+        ChatUtils.clickableChat(
+            "Are you sure you want to reset your total ${tracker.name}? Click here to confirm.",
+            onClick = { tracker.resetCommand() },
+            oneTimeClick = true
+        )
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/Resettable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/Resettable.kt
@@ -1,0 +1,9 @@
+package at.hannibal2.skyhanni.utils.tracker
+
+/**
+ * Interface for objects which are resettable using the /shreset command.
+ */
+interface Resettable {
+    val name: String
+    fun resetCommand(): Unit
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SimpleTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SimpleTracker.kt
@@ -1,0 +1,14 @@
+package at.hannibal2.skyhanni.utils.tracker
+
+import at.hannibal2.skyhanni.utils.ChatUtils
+
+/**
+ * Implementation of `Resettable` for all objects with an underlying SkyHanniTracker.
+ */
+abstract class SimpleTracker: Resettable {
+    abstract val tracker: SkyHanniTracker<*>
+    override val name
+        get() = tracker.name
+
+    override fun resetCommand() = tracker.resetCommand()
+}


### PR DESCRIPTION
## What
Replaces all tracker reset commands (/shresetdianaprofittracker, /shclearslayerprofits, etc) with /shresettracker. This command provides an index of all trackers (see images), which can be clicked to reset (with a confirmation).

Definitely a first working draft, not convinced this is the best way to do it. Putting a reset button inside the tracker itself, with some sort of additional confirmation, might be better.

<details>
<summary>
Command appearance
</summary>
<img width="446" alt="Screenshot 2024-05-20 at 4 44 21 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/8223102e-3af3-426d-b4f1-e7fe45518d69">
</details>

## Changelog Improvements
+ Merged tracker reset commands into /shresettracker - appable
    * This removes all old commands associated with resetting trackers.