### PR TITLE
Improvement: Highlight Treasure Hoarders during commission

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -34,6 +34,7 @@ class HighlightMiningCommissionMobs {
         STAR_PUNCHER("Star Sentry Puncher", { it.name == "Crystal Sentry" }),
         ICE_WALKER("Ice Walker Slayer", { it.name == "Ice Walker" }),
         GOLDEN_GOBLIN("Golden Goblin Slayer", { it.name.contains("Golden Goblin") }),
+        TREASURE_HOARDER("Treasure Hoarder Puncher", { it.name == "Treasuer Hunter" }), // typo is intentional
 
         // Crystal Hollows
         AUTOMATON("Automaton Slayer", { it is EntityIronGolem }),


### PR DESCRIPTION
## What
Added detection to highlight Treasure Hoarders during Treasure Hoarder Puncher commissions.

(Not 100% sure on the categorization of this one, feel free to change if desired.)

## Changelog Improvements
+ Highlight Treasure Hoarders during Treasure Hoarder Puncher commissions. - Luna