### PR TITLE
Feature: Custom Scoreboard Outside of SkyBlock

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/enums/OutsideSbFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/enums/OutsideSbFeature.kt
@@ -18,7 +18,9 @@ enum class OutsideSbFeature(private val displayName: String) {
     FOLLOWING_LINE("Following Line"),
     ARROW_TRAIL("Arrow Trail"),
     HIGHLIGHT_PARTY_MEMBERS("Highlight Party Members"),
-    MOVEMENT_SPEED("Movement Speed");
+    MOVEMENT_SPEED("Movement Speed"),
+    CUSTOM_SCOREBOARD("Custom Scoreboard"),
+    ;
 
     override fun toString() = displayName
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -186,7 +186,7 @@ class CustomScoreboard {
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         runDelayed(2.seconds) {
-            if (!LorenzUtils.inSkyBlock && OutsideSbFeature.CUSTOM_SCOREBOARD.isSelected()) dirty = true
+            if (!LorenzUtils.inSkyBlock && !OutsideSbFeature.CUSTOM_SCOREBOARD.isSelected()) dirty = true
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -21,6 +21,8 @@ package at.hannibal2.skyhanni.features.gui.customscoreboard
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.enums.OutsideSbFeature
+import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiPositionMovedEvent
@@ -116,30 +118,36 @@ class CustomScoreboard {
     }
 
     private fun createLines() = buildList<ScoreboardElementType> {
-        for (element in config.scoreboardEntries) {
-            val lines = element.getVisiblePair()
-            if (lines.isEmpty()) continue
+        if (LorenzUtils.inSkyBlock) {
+            for (element in config.scoreboardEntries) {
+                val lines = element.getVisiblePair()
+                if (lines.isEmpty()) continue
 
-            // Hide consecutive empty lines
-            if (
-                informationFilteringConfig.hideConsecutiveEmptyLines &&
-                lines.first().first == "<empty>" && lastOrNull()?.first?.isEmpty() == true
-            ) {
-                continue
+                // Hide consecutive empty lines
+                if (
+                    informationFilteringConfig.hideConsecutiveEmptyLines &&
+                    lines.first().first == "<empty>" && lastOrNull()?.first?.isEmpty() == true
+                ) {
+                    continue
+                }
+
+                // Adds empty lines
+                if (lines.first().first == "<empty>") {
+                    add("" to HorizontalAlignment.LEFT)
+                    continue
+                }
+
+                // Does not display this line
+                if (lines.any { it.first == "<hidden>" }) {
+                    continue
+                }
+
+                addAll(lines)
             }
-
-            // Adds empty lines
-            if (lines.first().first == "<empty>") {
-                add("" to HorizontalAlignment.LEFT)
-                continue
-            }
-
-            // Does not display this line
-            if (lines.any { it.first == "<hidden>" }) {
-                continue
-            }
-
-            addAll(lines)
+        } else {
+            addAll(ScoreboardElement.TITLE.getVisiblePair())
+            addAll(ScoreboardData.sidebarLinesFormatted.dropLast(1).map { it to HorizontalAlignment.LEFT })
+            addAll(ScoreboardElement.FOOTER.getVisiblePair())
         }
     }
 
@@ -178,7 +186,7 @@ class CustomScoreboard {
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         runDelayed(2.seconds) {
-            if (!LorenzUtils.inSkyBlock) dirty = true
+            if (!LorenzUtils.inSkyBlock && OutsideSbFeature.CUSTOM_SCOREBOARD.isSelected()) dirty = true
         }
     }
 
@@ -200,7 +208,9 @@ class CustomScoreboard {
         }
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled.get()
+    private fun isEnabled() =
+        (LorenzUtils.inSkyBlock || OutsideSbFeature.CUSTOM_SCOREBOARD.isSelected()) && config.enabled.get()
+
     private fun isHideVanillaScoreboardEnabled() = isEnabled() && displayConfig.hideVanillaScoreboard.get()
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -28,6 +28,7 @@ import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils.getGroupFromPattern
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.inAdvancedMiningIsland
 import at.hannibal2.skyhanni.utils.LorenzUtils.inAnyIsland
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -50,6 +51,7 @@ internal var unconfirmedUnknownLines = listOf<String>()
 internal var unknownLinesSet = TimeLimitedSet<String>(500.milliseconds) { onRemoval(it) }
 
 private fun onRemoval(line: String) {
+    if (!LorenzUtils.inSkyBlock) return
     if (!unconfirmedUnknownLines.contains(line)) return
     unconfirmedUnknownLines = unconfirmedUnknownLines.filterNot { it == line }
     confirmedUnknownLines.add(line)


### PR DESCRIPTION
## What
This Pull Request adds the functionality to use the Custom Scoreboard outside of Hypixel, if it is added to the Dropdown. But there's a catch: You aren't able to use your own lines, it's just the normal outside lines + custom Title & Footer.
<details>
<summary>Images</summary>

![grafik](https://github.com/hannibal002/SkyHanni/assets/45315647/e3739ffa-611a-458b-be7e-2b92a06fa70d)
![grafik](https://github.com/hannibal002/SkyHanni/assets/45315647/0ac75207-adc8-4a78-b058-b0fec1226d62)


</details>

## Changelog New Features
+ Allow usage of Custom Scoreboard outside of SkyBlock. - j10a1n15
