### PR TITLE
Backend: Add PR review policy

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -8,7 +8,10 @@ Make sure to only mark your PR as "Ready to review" when it is. If you still wan
 
 ## Dependencies
 
+<!--
 - pr_number_or_link_here
+-->
+
 
 ## What
 Describe what this pull request does, including technical details, screenshots, links to discord, etc.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ## PR Reviews
 
-When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us now (preferably with a code comment).
+When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).
 
 Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,7 +4,7 @@
 
 When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us now (preferably with a code comment).
 
-Make sure to only mark your PR as "Ready to review" when it is. You can keep a draft PR open until then.
+Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.
 
 ## Dependencies
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,13 @@
 <!-- remove all unused parts -->
 
+## PR Reviews
+
+When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us now (preferably with a code comment).
+
+Make sure to only mark your PR as "Ready to review" when it is. You can keep a draft PR open until then.
+
 ## Dependencies
+
 - pr_number_or_link_here
 
 ## What

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -8,10 +8,7 @@ Make sure to only mark your PR as "Ready to review" when it is. If you still wan
 
 ## Dependencies
 
-<!--
 - pr_number_or_link_here
--->
-
 
 ## What
 Describe what this pull request does, including technical details, screenshots, links to discord, etc.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,7 +7,6 @@ When your PR is marked as ready for review, some of our maintainers will look th
 Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.
 
 ## Dependencies
-
 - pr_number_or_link_here
 
 ## What


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us now (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. You can keep a draft PR open until then.


## Dependencies

## What
Describe what this pull request does, including technical details, screenshots, links to discord, etc.

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Technical Details
+ Added PR review policy. - nea
    * This should help us speed up the PR review process.


