### PR TITLE
Fix: Profile not loaded correctly

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -283,6 +283,7 @@ class HypixelData {
     }
 
     @SubscribeEvent
+    // TODO rewrite everything in here
     fun onTick(event: LorenzTickEvent) {
         if (!LorenzUtils.inSkyBlock) {
             // Modified from NEU.
@@ -302,17 +303,19 @@ class HypixelData {
             }
         }
 
-        if (LorenzUtils.inSkyBlock) {
-            loop@ for (line in ScoreboardData.sidebarLinesFormatted) {
-                skyblockAreaPattern.matchMatcher(line) {
-                    val originalLocation = group("area")
-                    skyBlockArea = LocationFixData.fixLocation(skyBlockIsland) ?: originalLocation
-                    skyBlockAreaWithSymbol = line.trim()
-                    break@loop
+        if (LorenzUtils.onHypixel) {
+            if (LorenzUtils.inSkyBlock) {
+                loop@ for (line in ScoreboardData.sidebarLinesFormatted) {
+                    skyblockAreaPattern.matchMatcher(line) {
+                        val originalLocation = group("area")
+                        skyBlockArea = LocationFixData.fixLocation(skyBlockIsland) ?: originalLocation
+                        skyBlockAreaWithSymbol = line.trim()
+                        break@loop
+                    }
                 }
-            }
 
-            checkProfileName()
+                checkProfileName()
+            }
         }
 
         if (!event.isMod(5)) return


### PR DESCRIPTION
## What
Every time a user joins SkyBlock without properly loading the lobby scoreboard beforehand, the `ProfileJoinEvent` will get fired before the `checkHypixel` logic gets fired. This causes `playerSpecific` to be null inside the `ProfileJoinEvent`. 
This can sometimes happen when joining the game too quickly, especially during laggy times or when using auto-join features from other mods.

## Changelog Fixes
+ Fixed SkyBlock profile data not getting loaded correctly when joining Hypixel too quickly. - hannibal2