### PR TITLE
Improvement: Change Unfound Eggs to Unclaimed Eggs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -183,7 +183,7 @@ object HoppityEggsManager {
         val displayList = HoppityEggType.entries
             .map { "§7 - ${it.formattedName} ${it.timeUntil().format()}" }
             .toMutableList()
-        displayList.add(0, "§bUnfound Eggs:")
+        displayList.add(0, "§bUnclaimed Eggs:")
         if (displayList.size == 1) return
 
         config.position.renderStrings(displayList, posLabel = "Hoppity Eggs")


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

## What
Changed "Unfound Eggs" to "Unclaimed Eggs" for the Hoppity event.

"Unfound" is a pretty uncommon spelling, and the Egglocator uses "unclaimed", so I think it's better to just use that.

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Improvements
+ Renamed "Unfound Eggs" to "Unclaimed Eggs" for the Hoppity event. - Luna