### PR TITLE
Backend: MinecraftConsoleFilter not extending AbstractFilter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
@@ -15,8 +15,8 @@ import org.apache.logging.log4j.core.filter.AbstractFilter
 import org.apache.logging.log4j.message.Message
 
 class MinecraftConsoleFilter(private val loggerConfigName: String) : AbstractFilter(
-    Filter.Result.ACCEPT,
-    Filter.Result.DENY,
+    /* onMatch = */ Filter.Result.ACCEPT,
+    /* onMismatch = */ Filter.Result.DENY,
 ) {
 
     private val config get() = SkyHanniMod.feature.dev.minecraftConsoles

--- a/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MinecraftConsoleFilter.kt
@@ -11,9 +11,13 @@ import org.apache.logging.log4j.core.Filter
 import org.apache.logging.log4j.core.LogEvent
 import org.apache.logging.log4j.core.Logger
 import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.filter.AbstractFilter
 import org.apache.logging.log4j.message.Message
 
-class MinecraftConsoleFilter(private val loggerConfigName: String) : Filter {
+class MinecraftConsoleFilter(private val loggerConfigName: String) : AbstractFilter(
+    Filter.Result.ACCEPT,
+    Filter.Result.DENY,
+) {
 
     private val config get() = SkyHanniMod.feature.dev.minecraftConsoles
     private val filterConfig get() = config.consoleFilter
@@ -34,9 +38,6 @@ class MinecraftConsoleFilter(private val loggerConfigName: String) : Filter {
             }
         }
     }
-
-    // prevents error sending on every shutdown
-    fun stop() {}
 
     override fun filter(event: LogEvent?): Filter.Result {
         if (event == null) return Filter.Result.ACCEPT
@@ -203,14 +204,6 @@ class MinecraftConsoleFilter(private val loggerConfigName: String) : Filter {
         if (config.printFilteredReason) {
             LorenzUtils.consoleLog("filtered console: $message")
         }
-    }
-
-    override fun getOnMismatch(): Filter.Result {
-        return Filter.Result.DENY
-    }
-
-    override fun getOnMatch(): Filter.Result {
-        return Filter.Result.ACCEPT
     }
 
     override fun filter(


### PR DESCRIPTION
<!-- remove all unused parts -->

## What
Make `MinecraftConsoleFilter` extend `AbstractFilter` instead of implementing `onMatch` and `onMismatch` and creating a `stop` method which was to stop the abstract method error because of not extending `AbstractFilter`

exclude_from_changelog