### PR TITLE
Fix: Dungeon Rank Tablist Color

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
@@ -27,20 +27,19 @@ class DungeonRankTabListColor {
     fun onTabListText(event: TabListLineRenderEvent) {
         if (!isEnabled()) return
 
-        val (sbLevel, rank, playerName, className, classLevel) = pattern.matchMatcher(event.text.stripHypixelMessage()) {
-            listOf(
-                group("sbLevel"),
-                groupOrNull("rank") ?: "",
-                group("playerName"),
-                group("className"),
-                group("classLevel"),
-            )
-        } ?: return
+        pattern.matchMatcher(event.text.stripHypixelMessage()) {
+            val sbLevel = group("sbLevel")
+            val rank = groupOrNull("rank") ?: ""
+            val playerName = group("playerName")
+            //val symbols = group("symbols")
+            val className = group("className")
+            val classLevel = group("classLevel")
 
-        val cleanName = playerName.cleanPlayerName(true)
-        val color = DungeonAPI.getColor(classLevel.romanToDecimalIfNecessary())
+            val cleanName = playerName.cleanPlayerName(true)
+            val color = DungeonAPI.getColor(classLevel.romanToDecimalIfNecessary())
 
-        event.text = "§8$sbLevel $rank$cleanName §f(§d$className $color$classLevel§f)"
+            event.text = "§8$sbLevel $rank$cleanName §f(§d$className $color$classLevel§f)"
+        }
     }
 
     fun isEnabled() = DungeonAPI.inDungeon() && config.coloredClassLevel

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
@@ -2,32 +2,46 @@ package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.TabListLineRenderEvent
-import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
+import at.hannibal2.skyhanni.utils.LorenzUtils.groupOrNull
+import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
 import at.hannibal2.skyhanni.utils.StringUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class DungeonRankTabListColor {
 
     private val config get() = SkyHanniMod.feature.dungeon.tabList
-    private val pattern = "§r(?<playerName>.*) §r§f\\(§r§d(?<className>.*) (?<classLevel>.*)§r§f\\)§r".toPattern()
+    private val patternGroup = RepoPattern.group("dungeon.tablist")
+
+    /**
+     * Note:
+     * REGEX-TEST: §8[§r§9319§r§8] §r§bEmpa_ §r§7α §r§f(§r§dMage XXXIV§r§f)
+     */
+    private val pattern by patternGroup.pattern(
+        "rank",
+        "^(?:§.)*(?<sbLevel>\\[(?:§.)*\\d+(?:§.)*]) (?<rank>(?:§.)*\\[(?:§.)*[^]]+(?:§.)*])? ?(?<playerName>\\S+) (?<symbols>[^(]*)\\((?:§.)*(?<className>\\S+) (?<classLevel>[CLXVI]+)(?:§.)*\\)(?:§.)*$"
+    )
 
     @SubscribeEvent
     fun onTabListText(event: TabListLineRenderEvent) {
         if (!isEnabled()) return
 
-        pattern.matchMatcher(event.text) {
-            val playerName = group("playerName")
-            val split = playerName.split(" ")
-            val sbLevel = split[0]
-            val cleanName = split[1].cleanPlayerName(displayName = true)
+        val (sbLevel, rank, playerName, className, classLevel) = pattern.matchMatcher(event.text.stripHypixelMessage()) {
+            listOf(
+                group("sbLevel"),
+                groupOrNull("rank") ?: "",
+                group("playerName"),
+                group("className"),
+                group("classLevel"),
+            )
+        } ?: return
 
-            val className = group("className")
-            val level = group("classLevel").romanToDecimal()
-            val color = DungeonAPI.getColor(level)
+        val cleanName = playerName.cleanPlayerName(true)
+        val color = DungeonAPI.getColor(classLevel.romanToDecimalIfNecessary())
 
-            event.text = "$sbLevel $cleanName §7(§e$className $color$level§7)"
-        }
+        event.text = "§8$sbLevel $rank$cleanName §f(§d$className $color$classLevel§f)"
     }
 
     fun isEnabled() = DungeonAPI.inDungeon() && config.coloredClassLevel

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
@@ -16,7 +16,6 @@ class DungeonRankTabListColor {
     private val patternGroup = RepoPattern.group("dungeon.tablist")
 
     /**
-     * Note:
      * REGEX-TEST: §8[§r§9319§r§8] §r§bEmpa_ §r§7α §r§f(§r§dMage XXXIV§r§f)
      */
     private val pattern by patternGroup.pattern(


### PR DESCRIPTION
## What
Fixes Dungeon Rank Tablist Color not showing the name of players with YouTube/Admin rank. Also made the pattern a repopattern

## Changelog Fixes
+ Fixed Dungeon Rank Tab list color not showing the names of players with YouTube/Admin rank. - Empa