### PR TITLE
Fix: Typo in Tunnels Maps

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -267,7 +267,7 @@ class TunnelsMaps {
     }
 
     private fun generateLocationsDisplay() = buildList {
-        add(Renderable.string("§6Loactions:"))
+        add(Renderable.string("§6Locations:"))
         add(
             Renderable.multiClickAndHover(
                 campfire.name!!, listOf(


### PR DESCRIPTION
## What
Fixed a typo

## Changelog Fixes
+ Fixed a typo in Tunnels Maps. - hannibal2