### PR TITLE
Feature: Default amount for /gfs with no args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,15 @@
 run/
 build/
 bin/
+deps/
 
 # gradle
 build
 gradle.properties
 .gradle
+./build.gradle.kts
+
+*_client.launch
 
 # other
 .DS_STORE

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,7 +159,10 @@ loom {
             }
             arg("--tweakClass", "org.spongepowered.asm.launch.MixinTweaker")
             arg("--tweakClass", "io.github.notenoughupdates.moulconfig.tweaker.DevelopmentResourceTweaker")
-            arg("--mods", devenvMod.resolve().joinToString(",") { it.relativeTo(file("run")).path })
+
+            val devenvModAbsolutePaths = devenvMod.map { it.absolutePath }
+
+            arg("--mods", devenvModAbsolutePaths.joinToString(",") { it })
         }
     }
     forge {

--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackAPI.kt
@@ -145,7 +145,7 @@ object GetFromSackAPI {
 
         when (result) {
             CommandResult.VALID -> getFromSack(stack ?: return)
-            CommandResult.WRONG_ARGUMENT -> ChatUtils.userError("Missing arguments! Usage: /getfromsacks <name/id> <amount>")
+            CommandResult.WRONG_ARGUMENT -> ChatUtils.userError("Missing arguments! Usage: /getfromsacks <name/id> [amount]")
             CommandResult.WRONG_IDENTIFIER -> ChatUtils.userError("Couldn't find an item with this name or identifier!")
             CommandResult.WRONG_AMOUNT -> ChatUtils.userError("Invalid amount!")
             CommandResult.INTERNAL_ERROR -> {}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.java
@@ -35,6 +35,4 @@ public class GetFromSackConfig {
     @ConfigOption(name = "GfS Default Amount", desc = "The default amount of items to get when §e/gfs §7is used without amount.")
     @ConfigEditorSlider(minValue = 1f, maxValue = 64f, minStep = 1f)
     public int gfsGetDefaultAmount = 1;
-    // 2240 = 35 stacks.
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.java
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features.inventory;
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 
 public class GetFromSackConfig {
@@ -23,4 +24,17 @@ public class GetFromSackConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean superCraftGFS = true;
+
+    @Expose
+    @ConfigOption(name = "GfS Default", desc = "When enabled, using §e/gfs §7without specifying an amount will give a default amount of the item.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean gfsGetDefault = false;
+
+    @Expose
+    @ConfigOption(name = "GfS Default Amount", desc = "The default amount of items to get when §e/gfs §7is used without amount.")
+    @ConfigEditorSlider(minValue = 1f, maxValue = 64f, minStep = 1f)
+    public int gfsGetDefaultAmount = 1;
+    // 2240 = 35 stacks.
+
 }


### PR DESCRIPTION
Add ability to set default amout for /gfs if no amount argument is provided. Feature is togglable.

Also improving on handling the amount before sending to server. (Amount = 0 or negative, or is not integer)

This could have been splitted into further commits but I was too into this that I forgot to switch branch and committing.