### PR TITLE
Feature: Moveable and Scaleable Hotbar

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -249,6 +249,7 @@ import at.hannibal2.skyhanni.features.garden.visitor.NPCVisitorFix
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorAPI
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorListener
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorRewardWarning
+import at.hannibal2.skyhanni.features.gui.MovableHotBar
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
 import at.hannibal2.skyhanni.features.gui.quiver.QuiverDisplay
@@ -528,6 +529,7 @@ class SkyHanniMod {
         loadModule(RenderData())
         loadModule(GardenCropMilestones)
         loadModule(GardenCropMilestonesCommunityFix)
+        loadModule(MovableHotBar())
         loadModule(GardenCropUpgrades)
         loadModule(VisitorListener())
         loadModule(VisitorRewardWarning())

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/GUIConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/GUIConfig.java
@@ -62,6 +62,11 @@ public class GUIConfig {
     public DiscordRPCConfig discordRPC = new DiscordRPCConfig();
 
     @Expose
+    @ConfigOption(name = "Hotbar", desc = "Settings for adjusting the hotbar")
+    @Accordion
+    public HotbarConfig hotbar = new HotbarConfig();
+
+    @Expose
     @ConfigOption(name = "Marked Players", desc = "Players that got marked with §e/shmarkplayer§7.")
     @Accordion
     public MarkedPlayerConfig markedPlayers = new MarkedPlayerConfig();

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/HotbarConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/HotbarConfig.java
@@ -25,7 +25,7 @@ public class HotbarConfig {
     public Position hotbar = new Position(20, 20);
 
     @Expose
-    @ConfigOption(name = "Show Outside Skyblock", desc = "Enables the hotbar to be edited even outside of skyblock.")
+    @ConfigOption(name = "Show Outside Skyblock", desc = "Enables the hotbar to be edited even outside of SkyBlock.")
     @ConfigEditorBoolean
     public boolean showOutsideSkyblock = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/HotbarConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/HotbarConfig.java
@@ -1,0 +1,31 @@
+package at.hannibal2.skyhanni.config.features.gui;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import at.hannibal2.skyhanni.config.core.config.Position;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+public class HotbarConfig {
+
+    @Expose
+    @ConfigOption(name = "Editable", desc = "Adds the hotbar to the gui editor. Allows for moving and scaling of the hotbar.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean editable = false;
+
+    @ConfigOption(name = "§cNotice", desc = "This option will be §c§lincompatible §r§7with mods that change the hotbar. Eg: §eApec§7.")
+    @ConfigEditorInfoText
+    public String notice = "";
+
+    @Expose
+    @ConfigLink(owner = HotbarConfig.class, field = "editable")
+    public Position hotbar = new Position(20, 20);
+
+    @Expose
+    @ConfigOption(name = "Show Outside Skyblock", desc = "Enables the hotbar to be edited even outside of skyblock.")
+    @ConfigEditorBoolean
+    public boolean showOutsideSkyblock = false;
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/MovableHotBar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/MovableHotBar.kt
@@ -1,0 +1,38 @@
+package at.hannibal2.skyhanni.features.gui
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.GuiEditManager
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.RenderUtils.transform
+import net.minecraft.client.renderer.GlStateManager
+import net.minecraftforge.client.event.RenderGameOverlayEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class MovableHotBar {
+
+    private val config get() = SkyHanniMod.feature.gui.hotbar
+
+    private var post = false
+
+    fun isEnabled(): Boolean = config.editable && (config.showOutsideSkyblock || LorenzUtils.inSkyBlock)
+
+    @SubscribeEvent
+    fun onRenderHotbar(event: RenderGameOverlayEvent.Pre) {
+        if (event.type != RenderGameOverlayEvent.ElementType.HOTBAR || !isEnabled()) return
+        post = true
+        GlStateManager.pushMatrix()
+        val scaled = event.resolution
+        val x = scaled.scaledWidth / 2 - 91
+        val y = scaled.scaledHeight - 22
+        config.hotbar.transform()
+        GlStateManager.translate(-x.toFloat(), -y.toFloat(), 0f) // Must be after transform to work with scaling
+        GuiEditManager.add(config.hotbar, "Hotbar", 182 - 1, 22 - 1) // -1 since the editor for some reason add +1
+    }
+
+    @SubscribeEvent
+    fun onRenderHotbar(event: RenderGameOverlayEvent.Post) {
+        if (event.type != RenderGameOverlayEvent.ElementType.HOTBAR || !post) return
+        GlStateManager.popMatrix()
+        post = false
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/MovableHotBar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/MovableHotBar.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.GuiEditManager
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.transform
+import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraftforge.client.event.RenderGameOverlayEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -13,8 +14,6 @@ class MovableHotBar {
     private val config get() = SkyHanniMod.feature.gui.hotbar
 
     private var post = false
-
-    fun isEnabled(): Boolean = config.editable && (config.showOutsideSkyblock || LorenzUtils.inSkyBlock)
 
     @SubscribeEvent
     fun onRenderHotbar(event: RenderGameOverlayEvent.Pre) {
@@ -35,4 +34,8 @@ class MovableHotBar {
         GlStateManager.popMatrix()
         post = false
     }
+
+    fun isEnabled(): Boolean =
+        (LorenzUtils.inSkyBlock || (Minecraft.getMinecraft().thePlayer != null && config.showOutsideSkyblock))
+            && config.editable
 }


### PR DESCRIPTION
## What
Adds the hotbar to the gui editor. Will conflict with mods like Apec.
Has no fancy alignment, it is handle like every other gui element. I wouldn't rather add that option to all gui elements then specifically to that feature

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/85900443/16c17421-69c5-44f1-9edc-57be18f5bb9d)
![image](https://github.com/hannibal002/SkyHanni/assets/85900443/0dd62354-978e-4410-b333-95b4d37dfb93)
![image](https://github.com/hannibal002/SkyHanni/assets/85900443/de77b8bd-caab-48b8-9dbf-b5f6b4faa7ab)

</details>

## Changelog New Features
+ Added Editable Hotbar. - Thunderblade73
    * Allows for moving and scaling in the SkyHanni GUI editor.
