### PR TITLE
Improvement: Teleport to Infested plot defaults to Warp Garden

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestFinderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestFinderConfig.java
@@ -87,4 +87,9 @@ public class PestFinderConfig {
     @ConfigOption(name = "Always Teleport", desc = "Allow teleporting with the Teleport Hotkey even when you're already in an infested plot.")
     @ConfigEditorBoolean
     public boolean alwaysTp = false;
+
+    @Expose
+    @ConfigOption(name = "Back to Garden", desc = "Make the Teleport Hotkey warp you to Garden if you don't have any pests.")
+    @ConfigEditorBoolean
+    public boolean backToGarden = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -172,7 +172,10 @@ object PestFinder {
         if (!GardenAPI.inGarden()) {
             ChatUtils.userError("This command only works while on the Garden!")
         }
+
         val plot = PestAPI.getNearestInfestedPlot() ?: run {
+            if (config.backToGarden) return HypixelCommands.warp("garden")
+
             ChatUtils.userError("No infested plots detected to warp to!")
             return
         }


### PR DESCRIPTION
## What
"Teleport to Infested Plot" keybind warps you to garden if you don't have any pests. Tested and working.
## Changelog Improvements
+ Warp to Infested Plot warps to garden home when no pests are found. - saga
    * Affects both hotkey and command.
