### PR TITLE
Fix: typo in shclearkismet command

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -387,7 +387,7 @@ object Commands {
             "Shows the status of all the mods constants"
         ) { SkyHanniMod.repo.displayRepoStatus(false) }
         registerCommand(
-            "shclearksimet",
+            "shclearkismet",
             "Cleares the saved values of the applied kismet feathers in Croesus"
         ) { CroesusChestTracker.resetChest() }
         registerCommand(


### PR DESCRIPTION
Changed "shclearksimet" to "shclearkismet", since it's a typo.

## Changelog Fixes
+ Fixed typo in /shclearkismet command. - L3Cache