### PR TITLE
Feature: Jyrre Bottle and Cacao Truffle held time in lore

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -257,6 +257,7 @@ import at.hannibal2.skyhanni.features.inventory.AuctionsHighlighter
 import at.hannibal2.skyhanni.features.inventory.ChestValue
 import at.hannibal2.skyhanni.features.inventory.DojoRankDisplay
 import at.hannibal2.skyhanni.features.inventory.HarpFeatures
+import at.hannibal2.skyhanni.features.inventory.HeldTimeInLore
 import at.hannibal2.skyhanni.features.inventory.HideNotClickableItems
 import at.hannibal2.skyhanni.features.inventory.HighlightBonzoMasks
 import at.hannibal2.skyhanni.features.inventory.ItemDisplayOverlayFeatures
@@ -934,6 +935,7 @@ class SkyHanniMod {
         loadModule(SkillTooltip())
         loadModule(MaxPurseItems())
         loadModule(SuperCraftFeatures)
+        loadModule(HeldTimeInLore())
         loadModule(InfernoMinionFeatures())
         loadModule(LimboPlaytime)
         loadModule(CopyPlaytime)

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -935,7 +935,7 @@ class SkyHanniMod {
         loadModule(SkillTooltip())
         loadModule(MaxPurseItems())
         loadModule(SuperCraftFeatures)
-        loadModule(HeldTimeInLore())
+        loadModule(HeldTimeInLore)
         loadModule(InfernoMinionFeatures())
         loadModule(LimboPlaytime)
         loadModule(CopyPlaytime)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -231,8 +231,8 @@ public class InventoryConfig {
     public boolean shiftClickBrewing = false;
 
     @Expose
-    @ConfigOption(name = "Held Time in Lore", desc = "Shows the held time for Bottle of Jyrre and Dark Cacao Truffle in lore.")
+    @ConfigOption(name = "Time Held in Lore", desc = "Shows time held for Bottle of Jyrre and Dark Cacao Truffle in the lore.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean heldTimeInLore = false;
+    public boolean timeHeldInLore = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -127,6 +127,7 @@ public class InventoryConfig {
         DUNGEON_POTION_LEVEL("§bDungeon Potion Level", 13),
         VACUUM_GARDEN("§bVacuum (Garden)", 14),
         BOTTLE_OF_JYRRE("§bBottle Of Jyrre", 15),
+        DARK_CACAO_TRUFFLE("§bDark Cacao Truffle"),
         EDITION_NUMBER("§bEdition Number", 16),
         BINGO_GOAL_RANK("§bBingo Goal Rank"),
         ;
@@ -228,4 +229,10 @@ public class InventoryConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean shiftClickBrewing = false;
+
+    @Expose
+    @ConfigOption(name = "Held Time in Lore", desc = "Shows the held time for Bottle of Jyrre and Dark Cacao Truffle in lore.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean heldTimeInLore = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
@@ -3,13 +3,16 @@ package at.hannibal2.skyhanni.features.inventory
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getBottleOfJyrreSeconds
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getSecondsHeld
-import at.hannibal2.skyhanni.utils.TimeUtils
+import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
-class HeldTimeInLore {
+object HeldTimeInLore {
     private val config get() = SkyHanniMod.feature.inventory
 
     private val jyrreBottle by lazy { "NEW_BOTTLE_OF_JYRRE".asInternalName() }
@@ -17,18 +20,19 @@ class HeldTimeInLore {
 
     @SubscribeEvent
     fun onTooltip(event: LorenzToolTipEvent) {
-        if (!config.heldTimeInLore) return
-        if (event.toolTip.size < 10) return // to fix when tooltip isn't fully loaded
-
+        if (!config.timeHeldInLore) return
+        if (!LorenzUtils.inSkyBlock) return
+        if (event.toolTip.size < 10) return // Fixes conflict with NEU's sort warning
         val stack = event.itemStack
         val internalName = stack.getInternalName()
-        val timeHeld = TimeUtils.formatDuration(
+        val timeHeld = (
             when (internalName) {
                 jyrreBottle -> stack.getBottleOfJyrreSeconds() ?: return
                 cacaoTruffle -> stack.getSecondsHeld() ?: return
                 else -> return
-            }.toLong() * 1000 - 999
-        )
+            }
+            ).toDuration(DurationUnit.SECONDS).format()
+
         event.toolTip.add(10, "§7Time Held: §b$timeHeld")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
@@ -21,13 +21,14 @@ object HeldTimeInLore {
     fun onTooltip(event: LorenzToolTipEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.timeHeldInLore) return
+
         val stack = event.itemStack
-        val internalName = stack.getInternalName()
-        val timeHeld = when (internalName) {
+        val timeHeld = when (stack.getInternalName()) {
             jyrreBottle -> stack.getBottleOfJyrreSeconds()
             cacaoTruffle -> stack.getSecondsHeld()
             else -> return
         } ?: return
+
         val formatted = timeHeld.seconds.format()
         
         event.toolTip.add(10, "§7Time Held: §b$formatted")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
@@ -1,0 +1,34 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getBottleOfJyrreSeconds
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getSecondsHeld
+import at.hannibal2.skyhanni.utils.TimeUtils
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class HeldTimeInLore {
+    private val config get() = SkyHanniMod.feature.inventory
+
+    private val jyrreBottle by lazy { "NEW_BOTTLE_OF_JYRRE".asInternalName() }
+    private val cacaoTruffle by lazy { "DARK_CACAO_TRUFFLE".asInternalName() }
+
+    @SubscribeEvent
+    fun onTooltip(event: LorenzToolTipEvent) {
+        if (!config.heldTimeInLore) return
+        if (event.toolTip.size < 10) return // to fix when tooltip isn't fully loaded
+
+        val stack = event.itemStack
+        val internalName = stack.getInternalName()
+        val timeHeld = TimeUtils.formatDuration(
+            when (internalName) {
+                jyrreBottle -> stack.getBottleOfJyrreSeconds() ?: return
+                cacaoTruffle -> stack.getSecondsHeld() ?: return
+                else -> return
+            }.toLong() * 1000 - 999
+        )
+        event.toolTip.add(10, "§7Time Held: §b$timeHeld")
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
@@ -9,8 +9,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getBottleOfJyrreSec
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getSecondsHeld
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
+import kotlin.time.Duration.Companion.seconds
 
 object HeldTimeInLore {
     private val config get() = SkyHanniMod.feature.inventory

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getBottleOfJyrreSeconds
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getSecondsHeld
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
@@ -22,15 +23,15 @@ object HeldTimeInLore {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.timeHeldInLore) return
 
-        val stack = event.itemStack
-        val timeHeld = when (stack.getInternalName()) {
-            jyrreBottle -> stack.getBottleOfJyrreSeconds()
-            cacaoTruffle -> stack.getSecondsHeld()
-            else -> return
-        } ?: return
+        val seconds = event.itemStack.getSeconds() ?: return
+        val formatted = seconds.seconds.format()
 
-        val formatted = timeHeld.seconds.format()
-        
         event.toolTip.add(10, "§7Time Held: §b$formatted")
+    }
+
+    private fun ItemStack.getSeconds(): Int? = when (getInternalName()) {
+        jyrreBottle -> getBottleOfJyrreSeconds()
+        cacaoTruffle -> getSecondsHeld()
+        else -> null
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
@@ -19,8 +19,8 @@ object HeldTimeInLore {
 
     @SubscribeEvent
     fun onTooltip(event: LorenzToolTipEvent) {
-        if (!config.timeHeldInLore) return
         if (!LorenzUtils.inSkyBlock) return
+        if (!config.timeHeldInLore) return
         val stack = event.itemStack
         val internalName = stack.getInternalName()
         val timeHeld = when (internalName) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
@@ -22,7 +22,6 @@ object HeldTimeInLore {
     fun onTooltip(event: LorenzToolTipEvent) {
         if (!config.timeHeldInLore) return
         if (!LorenzUtils.inSkyBlock) return
-        if (event.toolTip.size < 10) return // Fixes conflict with NEU's sort warning
         val stack = event.itemStack
         val internalName = stack.getInternalName()
         val timeHeld = (

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
@@ -24,14 +24,13 @@ object HeldTimeInLore {
         if (!LorenzUtils.inSkyBlock) return
         val stack = event.itemStack
         val internalName = stack.getInternalName()
-        val timeHeld = (
-            when (internalName) {
-                jyrreBottle -> stack.getBottleOfJyrreSeconds() ?: return
-                cacaoTruffle -> stack.getSecondsHeld() ?: return
-                else -> return
-            }
-            ).toDuration(DurationUnit.SECONDS).format()
-
-        event.toolTip.add(10, "§7Time Held: §b$timeHeld")
+        val timeHeld = when (internalName) {
+            jyrreBottle -> stack.getBottleOfJyrreSeconds()
+            cacaoTruffle -> stack.getSecondsHeld()
+            else -> return
+        } ?: return
+        val formatted = timeHeld.seconds.format()
+        
+        event.toolTip.add(10, "§7Time Held: §b$formatted")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumbe
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.BINGO_GOAL_RANK
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.BOTTLE_OF_JYRRE
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.COLLECTION_LEVEL
+import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.DARK_CACAO_TRUFFLE
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.DUNGEON_HEAD_FLOOR_NUMBER
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.DUNGEON_POTION_LEVEL
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.EDITION_NUMBER
@@ -48,6 +49,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEdition
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getNewYearCake
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetLevel
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getRanchersSpeed
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getSecondsHeld
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonArray
@@ -240,6 +242,11 @@ object ItemDisplayOverlayFeatures {
 
         if (BOTTLE_OF_JYRRE.isSelected() && internalName == "NEW_BOTTLE_OF_JYRRE".asInternalName()) {
             val seconds = item.getBottleOfJyrreSeconds() ?: 0
+            return "§a${(seconds / 3600)}"
+        }
+
+        if (DARK_CACAO_TRUFFLE.isSelected() && internalName == "DARK_CACAO_TRUFFLE".asInternalName()) {
+            val seconds = item.getSecondsHeld() ?: 0
             return "§a${(seconds / 3600)}"
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -179,18 +179,20 @@ object SkyBlockItemModifierUtils {
 
     fun ItemStack.getLivingMetalProgress() = getAttributeInt("lm_evo")
 
-
     fun ItemStack.getSecondsHeld() = getAttributeInt("seconds_held")
+
     fun ItemStack.getBottleOfJyrreSeconds() = getAttributeInt("bottle_of_jyrre_seconds")
 
     fun ItemStack.getEdition() = getAttributeInt("edition")
 
     fun ItemStack.getNewYearCake() = getAttributeInt("new_years_cake")
 
-    fun ItemStack.getEnchantments(): Map<String, Int>? = getExtraAttributes()?.takeIf { it.hasKey("enchantments") }?.run {
-        val enchantments = this.getCompoundTag("enchantments")
-        enchantments.keySet.associateWith { enchantments.getInteger(it) }
-    }
+    fun ItemStack.getEnchantments(): Map<String, Int>? = getExtraAttributes()
+        ?.takeIf { it.hasKey("enchantments") }
+        ?.run {
+            val enchantments = this.getCompoundTag("enchantments")
+            enchantments.keySet.associateWith { enchantments.getInteger(it) }
+        }
 
     fun ItemStack.getAppliedPocketSackInASack(): Int? {
         val data = cachedData

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -179,6 +179,8 @@ object SkyBlockItemModifierUtils {
 
     fun ItemStack.getLivingMetalProgress() = getAttributeInt("lm_evo")
 
+
+    fun ItemStack.getSecondsHeld() = getAttributeInt("seconds_held")
     fun ItemStack.getBottleOfJyrreSeconds() = getAttributeInt("bottle_of_jyrre_seconds")
 
     fun ItemStack.getEdition() = getAttributeInt("edition")


### PR DESCRIPTION
## Dependencies
- #1920 

## What
Shows the held time in lore of Bottles of Jyrre and Dark Cacao Truffles.
Also adds the option to show the dark cacao hours held as a stack size (same as existing bottle of jyrre stack size).

I think the name of the config might need to be changed. I couldn't come up with a good name for it (Currently `Time Held in Lore`).

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/108832807/7e3d89b3-dfa3-4f78-b44e-73427515c838)
![image](https://github.com/hannibal002/SkyHanni/assets/108832807/26a2dda4-9402-4d73-9254-dcb79c0bb0c7)
![image](https://github.com/hannibal002/SkyHanni/assets/108832807/a4cd6f31-920e-4031-a49b-3ba8779d2d75)

</details>

## Changelog New Features
+ Added option to show time held in lore for Jyrre Bottles and Cacao Truffles. - Obsidian
+ Added Dark Cacao Truffle hours held as stack size. - Obsidian