### PR TITLE
Improvement: Dungeon End Reminder

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
@@ -46,6 +46,7 @@ object DungeonAPI {
 
     var dungeonFloor: String? = null
     var started = false
+    var completed = false
     var inBossRoom = false
     var playerClass: DungeonClass? = null
     var playerClassLevel = -1
@@ -206,6 +207,7 @@ object DungeonAPI {
         isUniqueClass = false
         playerClass = null
         playerClassLevel = -1
+        completed = false
         DungeonBlessings.reset()
     }
 
@@ -230,6 +232,7 @@ object DungeonAPI {
             return
         }
         dungeonComplete.matchMatcher(event.message) {
+            completed = true
             DungeonCompleteEvent(floor).postAndCatch()
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/ReminderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/ReminderUtils.kt
@@ -11,7 +11,7 @@ object ReminderUtils {
 
     // TODO: add arachne fight, add slayer boss spawned, add dragon fight
     fun isBusy(ignoreFarmingContest: Boolean = false): Boolean =
-        DungeonAPI.inDungeon() || LorenzUtils.inKuudraFight || (FarmingContestAPI.inContest && !ignoreFarmingContest) ||
+        (DungeonAPI.inDungeon() && !DungeonAPI.completed) || LorenzUtils.inKuudraFight || (FarmingContestAPI.inContest && !ignoreFarmingContest) ||
             RiftAPI.inRift() || IslandType.DARK_AUCTION.isInIsland() || IslandType.MINESHAFT.isInIsland() ||
             IslandType.NONE.isInIsland() || IslandType.UNKNOWN.isInIsland()
 }


### PR DESCRIPTION
## What
Changed reminders to show on dungeon end.

## Changelog Improvements
+ Changed reminders to show at the end of a dungeon run. - hannibal2
    * E.g. Composter empty, Hoppity Eggs ready, New Year Cake, etc.