### PR TITLE
Fix: Chocolate factory position not showing when line overflows

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -57,7 +57,7 @@ object ChocolateFactoryDataLoader {
      */
     private val leaderboardPlacePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "leaderboard.place",
-        "(?:§.)+You are §8#§b(?<position>[\\d,]+)(?: §7in all-time Chocolate\\.)?"
+        "(?:§.)+You are §8#§b(?<position>[\\d,]+)(?: §7in all-time)?(?: Chocolate\\.)?"
     )
     private val leaderboardPercentilePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "leaderboard.percentile",

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -54,6 +54,7 @@ object ChocolateFactoryDataLoader {
     /**
      * REGEX-TEST: §7You are §8#§b114
      * REGEX-TEST: §7§7You are §8#§b5,139 §7in all-time Chocolate.
+     * REGEX-TEST: §7§7You are §8#§b5,139 §7in all-time
      */
     private val leaderboardPlacePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "leaderboard.place",


### PR DESCRIPTION
## What
Currently, the chocolate factory statistics do not show leaderboard position (and instead shown as ???) for players with a low position (more than 5 or 6 digits, exact digit count not confirmed) (see attached screenshot for more information)

This is caused by the regex pattern unable to match since the optional group has to either match completely or not match at all (as the line overflows with the "Chocolate" bit ending on the next line).

<details>
<summary>Images</summary>

<img width="407" alt="Screenshot 2024-05-28 at 10 35 44 PM" src="https://github.com/hannibal002/SkyHanni/assets/26355099/9d7baa70-f0aa-42b1-8277-fdd1314d7118">

Text description:
```
§7§7You are §8#§b112,910 §7in all-time
§7Chocolate.
§7§8You are in the top §67.93%§8 of players!
```

</details>

## Changelog Fixes
+ Fixed a bug where the chocolate factory leaderboard position was not showing when the position had many digits. - sayomaki
