### PR TITLE
Fix: tooltip event

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
@@ -11,6 +11,8 @@ import net.minecraft.item.ItemStack
 
 // Please use LorenzToolTipEvent over ItemTooltipEvent if no special EventPriority is necessary
 object ToolTipData {
+
+    @JvmStatic
     fun getTooltip(stack: ItemStack, toolTip: MutableList<String>): List<String> {
         onHover(stack, toolTip)
         return onTooltip(toolTip)

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
@@ -1,17 +1,10 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
-import at.hannibal2.skyhanni.data.ToolTipData;
 import at.hannibal2.skyhanni.mixins.hooks.ItemStackCachedData;
 import at.hannibal2.skyhanni.utils.CachedItemData;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.List;
 
 @Mixin(ItemStack.class)
 public class MixinItemStack implements ItemStackCachedData {
@@ -21,11 +14,5 @@ public class MixinItemStack implements ItemStackCachedData {
 
     public CachedItemData getSkyhanni_cachedData() {
         return skyhanni_cachedData;
-    }
-
-    @Inject(method = "getTooltip", at = @At("RETURN"))
-    public void getTooltip(EntityPlayer playerIn, boolean advanced, CallbackInfoReturnable<List<String>> ci) {
-        ItemStack stack = (ItemStack) (Object) this;
-        ToolTipData.INSTANCE.getTooltip(stack, ci.getReturnValue());
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiScreen.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiScreen.java
@@ -20,8 +20,11 @@ public class MixinGuiScreen {
         GuiScreenHookKt.renderToolTip(stack);
     }
 
-    @Inject(method = "renderToolTip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getRarity()Lnet/minecraft/item/EnumRarity;", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "renderToolTip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getRarity()Lnet/minecraft/item/EnumRarity;", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
     public void getTooltip(ItemStack stack, int x, int y, CallbackInfo ci, List<String> list, int i) {
         ToolTipData.getTooltip(stack, list);
+        if (list.isEmpty()) {
+            ci.cancel();
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiScreen.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiScreen.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers.gui;
 
+import at.hannibal2.skyhanni.data.ToolTipData;
 import at.hannibal2.skyhanni.mixins.hooks.GuiScreenHookKt;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.ItemStack;
@@ -7,6 +8,9 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.List;
 
 @Mixin(GuiScreen.class)
 public class MixinGuiScreen {
@@ -14,5 +18,10 @@ public class MixinGuiScreen {
     @Inject(method = "renderToolTip", at = @At("TAIL"))
     public void renderToolTip(ItemStack stack, int x, int y, CallbackInfo ci) {
         GuiScreenHookKt.renderToolTip(stack);
+    }
+
+    @Inject(method = "renderToolTip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getRarity()Lnet/minecraft/item/EnumRarity;", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void getTooltip(ItemStack stack, int x, int y, CallbackInfo ci, List<String> list, int i) {
+        ToolTipData.getTooltip(stack, list);
     }
 }


### PR DESCRIPTION

## What
We were previously mixing into ItemStack.getTooltip, which other mods (neu) use to get the lore of items. This caused some issues especially in places like the auction house, where neu looks at what sort mode you have using getTooltip, making the LorenzToolTipEvent trigger there causing issues in some prs such as #1916. Now we mixin to when the tooltip is actually rendered, hopefully fixing this issue

## Changelog Fixes
+ Fixed LorenzToolTipEvent triggering when not actually hovering over an item. - CalMWolfs

