### PR TITLE
Improvement: Better Farming Fortune error message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -230,7 +230,7 @@ object FarmingFortuneDisplay {
             if (lastCropFortuneMissingError.passedSince() < 1.minutes || !GardenAPI.isCurrentlyFarming()) return
             ChatUtils.clickableChat(
                 "§cCan not read Crop Fortune from tab list! Open /widget, enable the Stats Widget and " +
-                    "showing latest Crop Fortune, and give the widget enough priority.",
+                    "show latest Crop Fortune, also give the widget enough priority.",
                 onClick = {
                     HypixelCommands.widget()
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -219,7 +219,7 @@ object FarmingFortuneDisplay {
             if (lastUniversalFortuneMissingError.passedSince() < 1.minutes) return
             ChatUtils.clickableChat(
                 "§cCan not read Farming Fortune from tab list! Open /widget, enable the Stats Widget and " +
-                    "showing the Farming Fortune stat, and give the widget enough priority.",
+                    "show the Farming Fortune stat, also give the widget enough priority.",
                 onClick = {
                     HypixelCommands.widget()
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -218,8 +218,8 @@ object FarmingFortuneDisplay {
         if (gardenJoinTime.passedSince() > 5.seconds && !foundTabUniversalFortune && !gardenJoinTime.isFarPast()) {
             if (lastUniversalFortuneMissingError.passedSince() < 1.minutes) return
             ChatUtils.clickableChat(
-                "§cCan not read Farming Fortune from tab list! Open /widget and enable the Stats Widget " +
-                    "and showing the Farming Fortune stat.",
+                "§cCan not read Farming Fortune from tab list! Open /widget, enable the Stats Widget and " +
+                    "showing the Farming Fortune stat, and give the widget enough priority.",
                 onClick = {
                     HypixelCommands.widget()
                 }
@@ -229,8 +229,8 @@ object FarmingFortuneDisplay {
         if (firstBrokenCropTime.passedSince() > 10.seconds && !foundTabCropFortune && !firstBrokenCropTime.isFarPast()) {
             if (lastCropFortuneMissingError.passedSince() < 1.minutes || !GardenAPI.isCurrentlyFarming()) return
             ChatUtils.clickableChat(
-                "§cCan not read Crop Fortune from tab list! Open /widget and enable the Stats Widget " +
-                    "and showing latest Crop Fortune.",
+                "§cCan not read Crop Fortune from tab list! Open /widget, enable the Stats Widget and " +
+                    "showing latest Crop Fortune, and give the widget enough priority.",
                 onClick = {
                     HypixelCommands.widget()
                 }


### PR DESCRIPTION
## What
Makes the error you get from missing farming fortune stats in tablist also mention setting the widget to a higher priority

exclude_from_changelog