### PR TITLE
Fix: compact chat breaking with legendary rabbit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactor
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.NumberUtil
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -84,10 +85,12 @@ object HoppityEggsCompactChat {
             compactChat(event)
         }
         HoppityEggsManager.newRabbitFound.matchMatcher(event.message) {
-            val chocolate = group("chocolate")
+            val chocolate = groupOrNull("chocolate")
             val perSecond = group("perSecond")
             newRabbit = true
-            lastProfit = "§6+$chocolate §7and §6+${perSecond}x c/s!"
+            lastProfit = chocolate?.let {
+                "§6+$it §7and §6+${perSecond}x c/s!"
+            } ?: "§6+${perSecond}x c/s!"
             compactChat(event)
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -45,6 +45,7 @@ object HoppityEggsManager {
     /**
      * REGEX-TEST: §D§LHOPPITY'S HUNT §7You found §fArnie §7(§F§LCOMMON§7)!
      * REGEX-TEST: §D§LHOPPITY'S HUNT §7You found §aPenelope §7(§A§LUNCOMMON§7)!
+     * REGEX-TEST: §D§LHOPPITY'S HUNT §7You found §6Solomon §7(§6§LLEGENDARY§7)!
      */
     val rabbitFoundPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.found",
@@ -53,6 +54,7 @@ object HoppityEggsManager {
 
     /**
      * REGEX-TEST: §d§lNEW RABBIT! §6+2 Chocolate §7and §6+0.003x Chocolate §7per second!
+     * REGEX-TEST: §d§lNEW RABBIT! §6+0.02x Chocolate §7per second!
      */
     val newRabbitFound by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.found.new",


### PR DESCRIPTION
## What
Fixed compact chat breaking sometimes when obtaining legendary or higher tier rabbits
Reported: https://discord.com/channels/997079228510117908/1245403391639949464

## Changelog Fixes
+ Fixed compact chat sometimes breaking when obtaining legendary or higher tier rabbits. - hannibal2