### PR TITLE
Fix: sigma bonus ignored in hoppity collection stats

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -63,7 +63,6 @@ object HoppityCollectionStats {
 
         inInventory = true
         display = buildDisplay(event)
-        checkSpecialRabbits()
     }
 
     @SubscribeEvent
@@ -107,7 +106,7 @@ object HoppityCollectionStats {
     }
 
     private fun getRabbitStats(): MutableList<DisplayTableEntry> {
-        var totalAmountFound = 0
+        var totalUniquesFound = 0
         var totalDuplicates = 0
         var totalChocolatePerSecond = 0
         var totalChocolateMultiplier = 0.0
@@ -121,8 +120,8 @@ object HoppityCollectionStats {
             }
 
             val title = "${rarity.displayName} Rabbits"
-            val amountFound = foundOfRarity.size
-            val duplicates = foundOfRarity.values.sum() - amountFound
+            val uniquesFound = foundOfRarity.size
+            val duplicates = foundOfRarity.values.sum() - uniquesFound
 
             val chocolateBonuses = foundOfRarity.keys.map {
                 HoppityCollectionData.getChocolateBonuses(it)
@@ -131,14 +130,18 @@ object HoppityCollectionStats {
             val chocolatePerSecond = chocolateBonuses.sumOf { it.chocolate }
             val chocolateMultiplier = chocolateBonuses.sumOf { it.multiplier }
 
+            if (hasFoundRabbit("Sigma") && rarity == RabbitCollectionRarity.MYTHIC) {
+                totalChocolatePerSecond += uniquesFound * 5
+            }
+
             if (!isTotal) {
-                totalAmountFound += amountFound
+                totalUniquesFound += uniquesFound
                 totalDuplicates += duplicates
                 totalChocolatePerSecond += chocolatePerSecond
                 totalChocolateMultiplier += chocolateMultiplier
             }
 
-            val displayFound = if (isTotal) totalAmountFound else amountFound
+            val displayFound = if (isTotal) totalUniquesFound else uniquesFound
             val displayTotal = if (isTotal) {
                 HoppityCollectionData.knownRabbitCount
             } else {
@@ -175,7 +178,6 @@ object HoppityCollectionStats {
         val rabbit = name.removeColor()
         if (!HoppityCollectionData.isKnownRabbit(rabbit)) return
         loggedRabbits[rabbit] = (loggedRabbits[rabbit] ?: 0) + 1
-        checkSpecialRabbits()
     }
 
     // Gets the found rabbits according to the Hypixel progress bar
@@ -215,20 +217,7 @@ object HoppityCollectionStats {
         ChatUtils.chat("Cleared saved rabbit data.")
     }
 
-
-    // checks special rabbits whenever loggedRabbits is modified to update misc stored values
-    // TODO: make this better than hard-coded checks
-    private fun checkSpecialRabbits() {
-        if (hasFoundRabbit("Einstein")) {
-            ChocolateFactoryAPI.profileStorage?.timeTowerCooldown = 7
-        }
-
-        if (hasFoundRabbit("Mu")) {
-            ChocolateFactoryAPI.profileStorage?.hasMuRabbit = true
-        }
-    }
-
-    private fun hasFoundRabbit(rabbit: String): Boolean = loggedRabbits.containsKey(rabbit)
+    fun hasFoundRabbit(rabbit: String): Boolean = loggedRabbits.containsKey(rabbit)
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.hoppityCollectionStats
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.HoppityEggLocationsJson
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.features.event.hoppity.HoppityCollectionStats
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocator
 import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.DelayedRun
@@ -21,6 +22,7 @@ import at.hannibal2.skyhanni.utils.UtilsPatterns
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 
 object ChocolateFactoryAPI {
@@ -149,20 +151,27 @@ object ChocolateFactoryAPI {
 
     fun isMaxPrestige() = currentPrestige >= maxPrestige
 
+    fun timeTowerChargeDuration() =
+        if (HoppityCollectionStats.hasFoundRabbit("Einstein")) 7.hours else 8.hours
+
+    private fun timeTowerMultiplier(): Double {
+        var multiplier = (profileStorage?.timeTowerLevel ?: 0) * 0.1
+        if (HoppityCollectionStats.hasFoundRabbit("Mu")) multiplier += 0.7
+        return multiplier
+    }
+
     fun timeUntilNeed(goal: Long): Duration {
         var needed = goal
         val profileStorage = profileStorage ?: return Duration.ZERO
 
         val baseMultiplier = profileStorage.rawChocolateMultiplier
         val rawChocolatePerSecond = profileStorage.rawChocPerSecond
-        var timeTowerMultiplier = baseMultiplier + profileStorage.timeTowerLevel * 0.1
-        if (profileStorage.hasMuRabbit) timeTowerMultiplier += 0.7
 
         if (rawChocolatePerSecond == 0) return Duration.INFINITE
 
         val secondsUntilTowerExpires = ChocolateFactoryTimeTowerManager.timeTowerActiveDuration().inWholeSeconds
 
-        val timeTowerChocPerSecond = rawChocolatePerSecond * timeTowerMultiplier
+        val timeTowerChocPerSecond = rawChocolatePerSecond * (baseMultiplier + timeTowerMultiplier())
 
         val secondsAtRate = needed / timeTowerChocPerSecond
         if (secondsAtRate < secondsUntilTowerExpires) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -128,7 +128,7 @@ object ChocolateFactoryTimeTowerManager {
         if (timeTowerFull()) return SimpleTimeMark.farPast()
         val nextChargeDuration = SimpleTimeMark(profileStorage.nextTimeTower)
         val remainingChargesAfter = profileStorage.maxTimeTowerUses - (profileStorage.currentTimeTowerUses + 1)
-        val endTime = nextChargeDuration + (profileStorage.timeTowerCooldown).hours * remainingChargesAfter
+        val endTime = nextChargeDuration + ChocolateFactoryAPI.timeTowerChargeDuration() * remainingChargesAfter
 
         return endTime
     }


### PR DESCRIPTION
## What
Fixes sigma bonus not shown in HoppityCollectionStats display (+5 chocolate per second per mythic rabbit owned).

Also did a minor refactor to replace the one-off rabbit profile storage (`hasMuRabbit` and `timeTowerCooldown`) with `hasFoundRabbit(rabbit)`. Probably all of these could be moved to the repo at some point, but since we have no idea how they'd stack if other rabbits with similar perks were added, that might be premature.

## Changelog Fixes
+ Fixed Sigma Rabbit bonuses not counting in collection stats display. - appable