### PR TITLE
Fix: Viewrecipe lowercase triggering itself

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
@@ -17,7 +17,7 @@ object ViewRecipeCommand {
         if (!message.startsWith("/viewrecipe ", ignoreCase = true)) return
 
         if (message == message.uppercase()) return
-        val item = message.uppercase().substringAfter("viewrecipe").trim()
+        val item = message.uppercase().substringAfter("VIEWRECIPE").trim()
         if (item.isEmpty()) return
         event.isCanceled = true
         HypixelCommands.viewRecipe(item)

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
@@ -18,7 +18,7 @@ object ViewRecipeCommand {
 
         if (message == message.uppercase()) return
         val item = message.uppercase().substringAfter("VIEWRECIPE").trim()
-        if (item.isEmpty()) return
+        if (item.uppercase() == item) return
         event.isCanceled = true
         HypixelCommands.viewRecipe(item)
     }


### PR DESCRIPTION
## What
Fix viewrecipe lowercase from triggering itself and never working.

<details>
<summary>Images</summary>

Fixes this:
![image](https://github.com/hannibal002/SkyHanni/assets/108832807/0ba62041-6137-4df4-b8d4-f0d53af160af)


</details>

## Changelog Fixes
+ Fixed viewrecipe lowercase not working. - Obsidian