### PR TITLE
Fix: Diana chat errors without option turned on

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaFixChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaFixChat.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.event.diana
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.events.BurrowGuessEvent
 import at.hannibal2.skyhanni.events.ItemClickEvent
@@ -14,6 +15,8 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class DianaFixChat {
+
+    private val config get() = SkyHanniMod.feature.event.diana
 
     private var hasSetParticleQuality = false
     private var hasSetToggleMusic = false
@@ -117,5 +120,5 @@ class DianaFixChat {
         errorCounter = 0
     }
 
-    private fun isEnabled() = DianaAPI.isDoingDiana()
+    private fun isEnabled() = DianaAPI.isDoingDiana() && config.burrowsSoopyGuess
 }


### PR DESCRIPTION
## What
Fixes showing errors about burrows when the feature isnt turned on.

## Changelog Fixes
+ Fixed Diana errors being shown when the feature is not enabled. - Empa