### PR TITLE
Improvement: bazaar re-buy

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.java
@@ -32,7 +32,9 @@ public class BazaarConfig {
     public Position bestSellMethodPos = new Position(394, 142, false, true);
 
     @Expose
-    @ConfigOption(name = "Cancelled Buy Order Clipboard", desc = "Saves missing items from cancelled buy orders to clipboard for faster re-entry.")
+    @ConfigOption(name = "Cancelled Buy Order Clipboard",
+        desc = "Sends missing items from cancelled buy orders in chat. " +
+        "Click on the message to quickly order the same item and amount again.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean cancelledBuyOrderClipboard = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/PowerStoneGuideFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/PowerStoneGuideFeatures.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi
 import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
@@ -60,7 +59,7 @@ class PowerStoneGuideFeatures {
         if (!inInventory) return
         val internalName = missing[event.slotId] ?: return
 
-        BazaarApi.searchForBazaarItem(internalName.itemName, 9)
+        BazaarApi.searchForBazaarItem(internalName, 9)
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils.getAllItems
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
+import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -56,6 +57,9 @@ class BazaarApi {
 
         fun NEUInternalName.isBazaarItem() = getBazaarData() != null
 
+        fun searchForBazaarItem(internalName: NEUInternalName, amount: Int = -1) {
+            searchForBazaarItem(internalName.itemNameWithoutColor, amount)
+        }
         fun searchForBazaarItem(displayName: String, amount: Int = -1) {
             if (!LorenzUtils.inSkyBlock) return
             if (NEUItems.neuHasFocus()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -1,13 +1,17 @@
 package at.hannibal2.skyhanni.features.inventory.bazaar
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.OSUtils
@@ -39,7 +43,16 @@ class BazaarCancelledBuyOrderClipboard {
         "Order options"
     )
 
+    /**
+     * REGEX-TEST: §a§lBUY §5Giant Killer VII
+     */
+    private val lastItemClickedPattern by patternGroup.pattern(
+        "lastitemclicked",
+        "§a§lBUY (?<name>.*)"
+    )
+
     private var latestAmount: Int? = null
+    private var lastClickedItem: NEUInternalName? = null
 
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
@@ -67,6 +80,17 @@ class BazaarCancelledBuyOrderClipboard {
     }
 
     @SubscribeEvent
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!BazaarOrderHelper.isBazaarOrderInventory(InventoryUtils.openInventoryName())) return
+        val item = event.slot?.stack ?: return
+
+        val name = lastItemClickedPattern.matchMatcher(item.name) {
+            group("name")
+        } ?: return
+        lastClickedItem = NEUInternalName.fromItemName(name)
+    }
+
+    @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
         if (!isEnabled()) return
         val coins = cancelledMessagePattern.matchMatcher(event.message) {
@@ -75,7 +99,13 @@ class BazaarCancelledBuyOrderClipboard {
 
         val latestAmount = latestAmount ?: return
         event.blockedReason = "bazaar cancelled buy order clipboard"
-        ChatUtils.chat("Bazaar buy order cancelled. ${latestAmount.addSeparators()} saved to clipboard. ($coins coins)")
+        val lastClicked = lastClickedItem ?: error("last clicked bz item is null")
+
+        val message = "Bazaar buy order cancelled. Click to recreate the buy order. " +
+            "(§8${latestAmount.addSeparators()}x §r${lastClicked.itemName}§e)"
+        ChatUtils.clickableChat(message, onClick = {
+            BazaarApi.searchForBazaarItem(lastClicked, latestAmount)
+        })
         OSUtils.copyToClipboard(latestAmount.toString())
         this.latestAmount = null
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialsFromBazaar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialsFromBazaar.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.Companion.isBaz
 import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.CollectionUtils.addString
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
-import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
@@ -109,7 +108,7 @@ class CraftMaterialsFromBazaar {
                 val text = "§8${priceMultiplier.addSeparators()}x " + material.itemName +
                     " §6${NumberUtil.format(material.getPrice() * priceMultiplier)}"
                 add(Renderable.optionalLink(text, onClick = {
-                    BazaarApi.searchForBazaarItem(material.itemNameWithoutColor, priceMultiplier)
+                    BazaarApi.searchForBazaarItem(material, priceMultiplier)
                 }))
             }
             add(


### PR DESCRIPTION
## What
Improved bazaar re-buy order helper to also search in bazaar on chat message click

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/d9fd1b37-9b55-44eb-b725-0abdae1a8cc7)

</details>

## Changelog Improvements
+ Improved Bazaar re-buy order helper to also search in the Bazaar upon chat message click. - hannibal2