### PR TITLE
Feature: Wand of Strength cooldown tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
@@ -48,6 +48,7 @@ enum class ItemAbility(
     FIRE_FURY_STAFF(20),
     SHADOW_FURY(15, "STARRED_SHADOW_FURY"),
     ROYAL_PIGEON(5),
+    WAND_OF_STRENGTH(10),
 
     // doesn't have a sound
     ENDER_BOW("Ender Warp", 5, "Ender Bow"),

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -173,6 +173,10 @@ class ItemAbilityCooldown {
             event.soundName == "mob.bat.idle" && event.pitch == 0.4920635f && event.volume == 1.0f -> {
                 ItemAbility.ROYAL_PIGEON.sound()
             }
+
+            event.soundName == "random.eat" && event.pitch == 0.4920635f && event.volume == 1.0f -> {
+                ItemAbility.WAND_OF_STRENGTH.sound()
+            }
         }
     }
 


### PR DESCRIPTION
## What
Shows the Wand of Strength cooldown using the Item Ability Tracker that is used for other items (like the Wither Cloak). The cooldown displayed is from the buff applied (10 seconds), not the item usage (1 second).

<details>
<summary>Images</summary>

<!-- drop images here -->
![unknown_2024 05 30-18 54-ezgif com-crop](https://github.com/hannibal002/SkyHanni/assets/45262877/58b7bf81-2bed-45ba-815a-fc5b8a92e13d)

</details>

## Changelog New Features
+ Wand of Strength cooldown is now displayed. - saga
    * The cooldown displayed is for the buff, not the item usage.