### PR TITLE
Fix: Rift Slayer Oubliette Guard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
@@ -135,7 +135,9 @@ class SlayerQuestWarning {
                 )
             }
         }
-        return (getSlayerData().lastSlayerType == slayerType) && slayerType.clazz.isInstance(entity)
+        // workaround for rift mob that is unrelated to slayer
+        val isSlayer = slayerType.clazz.isInstance(entity) && entity.name != "Oubliette Guard"
+        return (getSlayerData().lastSlayerType == slayerType) && isSlayer
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Fixed rift slayer warning showing while hitting Oubliette Guard
reported at https://discord.com/channels/997079228510117908/1245823436341907578

## Changelog Fixes
+ Fixed rift slayer warning showing while hitting Oubliette Guard. - hannibal2