### PR TITLE
Fix: HotM Blue Cheese Goblin Omelette

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -382,8 +382,14 @@ enum class HotmData(
                 group("level").toInt().transformIf({ group("color") == "b" }, { this.minus(1) })
             } ?: entry.maxLevel
 
-            if (entry.activeLevel > entry.maxLevel) {
-                throw IllegalStateException("Hotm Perk '${entry.name}' over max level")
+            // max level + 1 because Blue Cheese Goblin Omelette adds +1 to each level
+            if (entry.activeLevel > entry.maxLevel + 1) {
+                ErrorManager.skyHanniError(
+                    "Hotm Perk '${entry.name}' over max level",
+                    "name" to entry.name,
+                    "activeLevel" to entry.activeLevel,
+                    "maxLevel" to entry.maxLevel,
+                )
             }
 
             if (entry == PEAK_OF_THE_MOUNTAIN) {


### PR DESCRIPTION
## What
Fixed HotM error with Blue Cheese Goblin Omelette.
Reported at https://discord.com/channels/997079228510117908/1245889057515372554
Also improved the error message handling.

## Changelog Fixes
+ Fixed HotM error with Blue Cheese Goblin Omelette. - hannibal2