### PR TITLE
Fix: Estimated item value not working in pv

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
@@ -13,12 +13,12 @@ import net.minecraft.item.ItemStack
 object ToolTipData {
 
     @JvmStatic
-    fun getTooltip(stack: ItemStack, toolTip: MutableList<String>): List<String> {
-        onHover(stack, toolTip)
-        return onTooltip(toolTip)
+    fun getTooltip(stack: ItemStack, toolTip: MutableList<String>) {
+        onTooltip(toolTip)
     }
 
-    private fun onHover(stack: ItemStack, toolTip: MutableList<String>) {
+    @JvmStatic
+    fun onHover(stack: ItemStack, toolTip: MutableList<String>) {
         ItemHoverEvent(stack, toolTip).postAndCatch()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.name
 import net.minecraft.inventory.Slot
 import net.minecraft.item.ItemStack
 
-// Please use LorenzToolTipEvent over ItemTooltipEvent if no special EventPriority is necessary
+// Please use LorenzToolTipEvent over ItemHoverEvent, ItemHoverEvent is only used for special use cases (e.g. neu pv)
 object ToolTipData {
 
     @JvmStatic

--- a/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
@@ -14,17 +14,8 @@ object ToolTipData {
 
     @JvmStatic
     fun getTooltip(stack: ItemStack, toolTip: MutableList<String>) {
-        onTooltip(toolTip)
-    }
-
-    @JvmStatic
-    fun onHover(stack: ItemStack, toolTip: MutableList<String>) {
-        ItemHoverEvent(stack, toolTip).postAndCatch()
-    }
-
-    fun onTooltip(toolTip: MutableList<String>): List<String> {
-        val slot = lastSlot ?: return toolTip
-        val itemStack = slot.stack ?: return toolTip
+        val slot = lastSlot ?: return
+        val itemStack = slot.stack ?: return
         try {
             if (LorenzToolTipEvent(slot, itemStack, toolTip).postAndCatch()) {
                 toolTip.clear()
@@ -42,7 +33,11 @@ object ToolTipData {
                 "lore" to itemStack.getLore(),
             )
         }
-        return toolTip
+    }
+
+    @JvmStatic
+    fun onHover(stack: ItemStack, toolTip: MutableList<String>) {
+        ItemHoverEvent(stack, toolTip).postAndCatch()
     }
 
     var lastSlot: Slot? = null

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -66,14 +66,13 @@ object EstimatedItemValue {
     fun onTooltip(event: ItemHoverEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.enabled) return
+        if (Minecraft.getMinecraft().currentScreen !is GuiProfileViewer) return
 
-        if (Minecraft.getMinecraft().currentScreen is GuiProfileViewer) {
-            if (renderedItems == 0) {
-                updateItem(event.itemStack)
-            }
-            tryRendering()
-            renderedItems++
+        if (renderedItems == 0) {
+            updateItem(event.itemStack)
         }
+        tryRendering()
+        renderedItems++
     }
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
@@ -1,10 +1,17 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
+import at.hannibal2.skyhanni.data.ToolTipData;
 import at.hannibal2.skyhanni.mixins.hooks.ItemStackCachedData;
 import at.hannibal2.skyhanni.utils.CachedItemData;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
 
 @Mixin(ItemStack.class)
 public class MixinItemStack implements ItemStackCachedData {
@@ -14,5 +21,11 @@ public class MixinItemStack implements ItemStackCachedData {
 
     public CachedItemData getSkyhanni_cachedData() {
         return skyhanni_cachedData;
+    }
+
+    @Inject(method = "getTooltip", at = @At("RETURN"))
+    public void getTooltip(EntityPlayer playerIn, boolean advanced, CallbackInfoReturnable<List<String>> ci) {
+        ItemStack stack = (ItemStack) (Object) this;
+        ToolTipData.onHover(stack, ci.getReturnValue());
     }
 }


### PR DESCRIPTION
## What
Fixed estimated item value not showing in neu pv.

LorenzToolTipEvent should be used for proper tooltips, ItemHoverEvent should be used when we need to directly mixin to Minecraft's getTooltip function (for things like neu pv)

In future the names of these events needs to be re-looked at as right now they are not clear

## Changelog Fixes
+ Fixed estimated item value not showing in NEU PV. - CalMWolfs

