### PR TITLE
Feature: Hide Useless Armorstands

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -119,6 +119,12 @@ public class MiscConfig {
     public boolean hideExpBottles = false;
 
     @Expose
+    @ConfigOption(name = "Armorstands", desc = "Hides Armorstands that are sometimes visible for a fraction of a second.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hideTemporaryArmorstands = true;
+
+    @Expose
     public Position collectionCounterPos = new Position(10, 10, false, true);
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
@@ -58,8 +58,9 @@ object FixGhostEntities {
     }
 
     @SubscribeEvent
-    fun onCheckRender(event: CheckRenderEntityEvent<EntityArmorStand>) {
+    fun onCheckRender(event: CheckRenderEntityEvent<*>) {
         if (!LorenzUtils.inSkyBlock || !config.hideTemporaryArmorstands) return
+        if (event.entity !is EntityArmorStand) return
         with(event.entity) {
             if (ticksExisted < 10 && name == "Armor Stand" && inventory.all { it == null }) event.cancel()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.MobUtils.isDefaultValue
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.network.play.server.S0CPacketSpawnPlayer
 import net.minecraft.network.play.server.S0FPacketSpawnMob
@@ -62,7 +63,7 @@ object FixGhostEntities {
         if (!LorenzUtils.inSkyBlock || !config.hideTemporaryArmorstands) return
         if (event.entity !is EntityArmorStand) return
         with(event.entity) {
-            if (ticksExisted < 10 && name == "Armor Stand" && inventory.all { it == null }) event.cancel()
+            if (ticksExisted < 10 && isDefaultValue() && inventory.all { it == null }) event.cancel()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
@@ -1,9 +1,11 @@
 package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.network.play.server.S0CPacketSpawnPlayer
 import net.minecraft.network.play.server.S0FPacketSpawnMob
 import net.minecraft.network.play.server.S13PacketDestroyEntities
@@ -52,6 +54,14 @@ object FixGhostEntities {
                     }
                 }
             }
+        }
+    }
+
+    @SubscribeEvent
+    fun onCheckRender(event: CheckRenderEntityEvent<EntityArmorStand>) {
+        if (!LorenzUtils.inSkyBlock || !config.hideTemporaryArmorstands) return
+        with(event.entity) {
+            if (ticksExisted < 10 && name == "Armor Stand" && inventory.all { it == null }) event.cancel()
         }
     }
 


### PR DESCRIPTION
## What
This fixes an issue where Hypixel sometimes shows an armorstand just called "Armor Stand" for a fraction of a second (very noticeable while fishing).

## Changelog New Features
+ Added Hide Useless Armor Stands. - Empa
    * Hides armor stands that briefly appear on Hypixel.