### PR TITLE
Improvement: Reword maximum clicks message for experiments

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperpairsClicksAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperpairsClicksAlert.kt
@@ -56,7 +56,7 @@ class SuperpairsClicksAlert {
                 .any { it.value.stackSize > roundsNeeded })
         ) {
             SoundUtils.playBeepSound()
-            ChatUtils.chat("You have reached the maximum extra Superpairs clicks!")
+            ChatUtils.chat("You have reached the maximum extra Superpairs clicks from this add-on!")
             roundsNeeded = -1
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperpairsClicksAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperpairsClicksAlert.kt
@@ -56,7 +56,7 @@ class SuperpairsClicksAlert {
                 .any { it.value.stackSize > roundsNeeded })
         ) {
             SoundUtils.playBeepSound()
-            ChatUtils.chat("You have reached the maximum possible clicks!")
+            ChatUtils.chat("You have reached the maximum extra Superpairs clicks!")
             roundsNeeded = -1
         }
     }


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

## What
Reworded the maximum clicks message for experiments to clarify what it actually is instead of implying that you can't click any more in the current experiment if you really want to for some reason.

## Changelog Improvements
+ Clarified the maximum clicks message for experiments. - Luna