### PR TITLE
Fix: Voidgloom Summons pattern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -16,8 +16,8 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.NumberUtil
-import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.entity.EntityLiving
@@ -49,7 +49,12 @@ class SummoningMobManager {
         "health",
         "§a§o(.+)'s (.+)§r §[ae]([\\dkm]+)§c❤"
     )
-    private val seraphRecallPattern by patternGroup.pattern( //§cThe Seraph recalled your 3 summoned allies!
+
+    /**
+     * REGEX-TEST: §cThe Seraph recalled your 3 summoned allies!
+     * REGEX-TEST: §cThe Seraph recalled your 10 summoned allies!
+     */
+    private val seraphRecallPattern by patternGroup.pattern(
         "seraphrecall",
         "§cThe Seraph recalled your (\\d+) summoned allies!"
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -51,7 +51,7 @@ class SummoningMobManager {
     )
     private val seraphRecallPattern by patternGroup.pattern( //§cThe Seraph recalled your 3 summoned allies!
         "seraphrecall",
-        "§cThe Seraph recalled your (\\d) summoned allies!"
+        "§cThe Seraph recalled your (\\d+) summoned allies!"
     )
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Fixes summons not getting properly removed if the number of summons was 10 or higher.

## Changelog Fixes
+ Fixed summons not being removed from Summoning Mob Display. - Empa