### PR TITLE
Fix: Movable hotbar messing with some other mods

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/MovableHotBar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/MovableHotBar.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.transform
 import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraftforge.client.event.RenderGameOverlayEvent
+import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class MovableHotBar {
@@ -15,7 +16,7 @@ class MovableHotBar {
 
     private var post = false
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     fun onRenderHotbar(event: RenderGameOverlayEvent.Pre) {
         if (event.type != RenderGameOverlayEvent.ElementType.HOTBAR || !isEnabled()) return
         post = true
@@ -28,7 +29,7 @@ class MovableHotBar {
         GuiEditManager.add(config.hotbar, "Hotbar", 182 - 1, 22 - 1) // -1 since the editor for some reason add +1
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
     fun onRenderHotbar(event: RenderGameOverlayEvent.Post) {
         if (event.type != RenderGameOverlayEvent.ElementType.HOTBAR || !post) return
         GlStateManager.popMatrix()


### PR DESCRIPTION
## What
Fixed movable hotbar messing with some other mods that render stuff during RenderGameOverlayEvent.Pre (hobar) as we do OpenGL calls that also would affect them.
An example of an affected mod is https://github.com/TartaricAcid/ExtraPlayerRenderer


## Changelog Fixes
+ Fixed movable hotbar conflicts with some mods. - CalMWolfs

