### PR TITLE
Fix: Bumped Custom Scoreboard Error Time to 2 seconds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -47,7 +47,7 @@ import kotlin.time.Duration.Companion.seconds
 
 internal var confirmedUnknownLines = mutableListOf<String>()
 internal var unconfirmedUnknownLines = listOf<String>()
-internal var unknownLinesSet = TimeLimitedSet<String>(1.seconds) { onRemoval(it) }
+internal var unknownLinesSet = TimeLimitedSet<String>(2.seconds) { onRemoval(it) }
 
 private fun onRemoval(line: String) {
     if (!unconfirmedUnknownLines.contains(line)) return


### PR DESCRIPTION
## What
This Pull Requests bumps the Unknown Lines Warning time from 1s to 2s, hopefully reducing the amount of false positives even more. Part 2.

exclude_from_changelog