### PR TITLE
Fix: getByNameOrNull using simpleName of Crop

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
@@ -69,7 +69,7 @@ enum class CropType(
         fun getByNameOrNull(itemName: String): CropType? {
             if (itemName == "Red Mushroom" || itemName == "Brown Mushroom") return MUSHROOM
             if (itemName == "Seeds") return WHEAT
-            return entries.firstOrNull { it.cropName.equals(itemName, ignoreCase = true) }
+            return entries.firstOrNull { it.cropName.equals(itemName, ignoreCase = true) || it.simpleName.equals(itemName, ignoreCase = true) }
         }
 
         fun getByName(name: String) = getByNameOrNull(name) ?: error("No valid crop type '$name'")


### PR DESCRIPTION
## What
Change: getByNameOrNull now allows a Crop's simpleName as input to get correct CropType

Fixes: shcropgoal now works with double name crops (Nether Wart, Cocoa Beans, Sugar Cane) by using their simpleNames

## Changelog Fixes
+ Fixed /shcropgoal not working with double-name crops (wart, cocoa, cane). - L3Cache

I'm open to any suggestions for a better way to fix this issue. Still new to programming, especially Kotlin.