### PR TITLE
Improvement: import egg locations from NEU PV

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -152,6 +152,7 @@ import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocator
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggsManager
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggsShared
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityNpc
+import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocations
 import at.hannibal2.skyhanni.features.event.jerry.HighlightJerries
 import at.hannibal2.skyhanni.features.event.jerry.frozentreasure.FrozenTreasureTracker
 import at.hannibal2.skyhanni.features.event.lobby.waypoints.christmas.PresentWaypoints
@@ -689,6 +690,7 @@ class SkyHanniMod {
         loadModule(ChocolateFactoryCustomReminder)
         loadModule(HoppityNpc)
         loadModule(HoppityEggsManager)
+        loadModule(HoppityEggLocations)
         loadModule(HoppityEggLocator)
         loadModule(HoppityEggsShared)
         loadModule(HoppityEggDisplayManager)

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -151,7 +151,6 @@ import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocator
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggsManager
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggsShared
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityNpc
-import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocations
 import at.hannibal2.skyhanni.features.event.jerry.HighlightJerries
 import at.hannibal2.skyhanni.features.event.jerry.frozentreasure.FrozenTreasureTracker
 import at.hannibal2.skyhanni.features.event.lobby.waypoints.christmas.PresentWaypoints
@@ -693,7 +692,6 @@ class SkyHanniMod {
         loadModule(ChocolateFactoryCustomReminder)
         loadModule(HoppityNpc)
         loadModule(HoppityEggsManager)
-        loadModule(HoppityEggLocations)
         loadModule(HoppityEggLocator)
         loadModule(HoppityEggsShared)
         loadModule(HoppityEggDisplayManager)

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.features.event.diana.GriffinBurrowHelper
 import at.hannibal2.skyhanni.features.event.diana.InquisitorWaypointShare
 import at.hannibal2.skyhanni.features.event.diana.MythologicalCreatureTracker
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityCollectionStats
+import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocations
 import at.hannibal2.skyhanni.features.event.jerry.frozentreasure.FrozenTreasureTracker
 import at.hannibal2.skyhanni.features.fishing.tracker.FishingProfitTracker
 import at.hannibal2.skyhanni.features.fishing.tracker.SeaCreatureTracker
@@ -537,6 +538,10 @@ object Commands {
             "shaddfoundburrowlocationsfromclipboard",
             "Add all ever found burrow locations from clipboard"
         ) { AllBurrowsList.addFromClipboard() }
+        registerCommand(
+            "shtoggleegglocationdebug",
+            "Shows Hoppity egg locations with their internal API names and status."
+        ) { HoppityEggLocations.toggleDebug() }
     }
 
     private fun internalCommands() {

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -51,6 +51,12 @@ public class HoppityEggsConfig {
     public boolean showNearbyDuplicateEggLocations = false;
 
     @Expose
+    @ConfigOption(name = "Load from NEU PV", desc = "Load Hoppity Egg Location data from API when opening the NEU Profile Viewer.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean loadFromNeuPv = true;
+
+    @Expose
     @ConfigOption(name = "Show Unclaimed Eggs", desc = "Displays which eggs haven't been found in the last SkyBlock day.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/HypixelPlayerApiJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/HypixelPlayerApiJson.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.data.jsonobjects.other
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import javax.annotation.Nullable
 
 data class HypixelPlayerApiJson(
     @Expose val profiles: List<HypixelApiProfile>
@@ -13,7 +14,21 @@ data class HypixelApiProfile(
 )
 
 data class HypixelApiPlayer(
-    @Expose @SerializedName("trophy_fish") val trophyFish: HypixelApiTrophyFish
+    @Expose @SerializedName("trophy_fish") val trophyFish: HypixelApiTrophyFish,
+    @Expose val events: HypixelApiEvents
+)
+
+data class HypixelApiEvents(
+    @Expose val easter: HypixelApiEasterEvent
+)
+
+data class HypixelApiEasterEvent(
+    @Expose val rabbits: HypixelApiRabbits
+)
+
+data class HypixelApiRabbits(
+    @Expose @SerializedName("collected_locations")
+    val collectedLocations: Map<String, List<String>>
 )
 
 data class HypixelApiTrophyFish(

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/HoppityEggLocationsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/HoppityEggLocationsJson.kt
@@ -21,4 +21,5 @@ data class HoppityEggLocationsJson(
     @Expose val coachRabbitIndex: Int,
     @Expose val maxRabbits: Int,
     @Expose val maxPrestige: Int,
+    @Expose val apiEggLocations: Map<String, LorenzVec>,
 )

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/HoppityEggLocationsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/HoppityEggLocationsJson.kt
@@ -21,5 +21,5 @@ data class HoppityEggLocationsJson(
     @Expose val coachRabbitIndex: Int,
     @Expose val maxRabbits: Int,
     @Expose val maxPrestige: Int,
-    @Expose val apiEggLocations: Map<String, LorenzVec>,
+    @Expose val apiEggLocations: Map<IslandType, Map<String, LorenzVec>>,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
-object HoppityUniqueEggLocations {
+object HoppityEggLocations {
 
     var apiEggLocations: Map<IslandType, Map<String, LorenzVec>> = mapOf()
 
@@ -43,6 +43,8 @@ object HoppityUniqueEggLocations {
 
     @SubscribeEvent
     fun onNeuProfileDataLoaded(event: NeuProfileDataLoadedEvent) {
+        ChatUtils.chat("Loading profile data for Hoppity egg locations.")
+
         // optional chaining to hopefully catch any API responses missing data
         val rawLocations = event.getCurrentPlayerData()?.events?.easter?.rabbits?.collectedLocations
 
@@ -52,6 +54,8 @@ object HoppityUniqueEggLocations {
         }
 
         val collectedLocations = rawLocations.values.flatten()
+        ChatUtils.chat("Found ${collectedLocations.size} collected locations.")
+
         val result = mutableMapOf<IslandType, MutableSet<LorenzVec>>()
 
         for ((island, locationNameToCoords) in apiEggLocations) {
@@ -60,6 +64,8 @@ object HoppityUniqueEggLocations {
         }
 
         collectedEggLocations = result
+        ChatUtils.chat("Saved all egg locations.")
+
     }
 
     fun collectedEggsThisIsland() = getCurrentIslandCollectedEggs()?.size ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -81,6 +81,7 @@ object HoppityEggLocations {
 
         // optional chaining to hopefully catch any API responses missing data
         val rawLocations = event.getCurrentPlayerData()?.events?.easter?.rabbits?.collectedLocations ?: return
+        loadedNeuThisProfile = true
 
         val apiCollectedLocations = rawLocations.values.flatten()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -67,7 +67,6 @@ object HoppityEggLocations {
         locations += location
     }
 
-    /* NEU PV loading logic */
     private var loadedNeuThisProfile = false
 
     @SubscribeEvent
@@ -79,13 +78,11 @@ object HoppityEggLocations {
     fun onNeuProfileDataLoaded(event: NeuProfileDataLoadedEvent) {
         if (loadedNeuThisProfile || !HoppityEggsManager.config.loadFromNeuPv) return
 
-        // optional chaining to hopefully catch any API responses missing data
         val rawLocations = event.getCurrentPlayerData()?.events?.easter?.rabbits?.collectedLocations ?: return
         loadedNeuThisProfile = true
 
         val apiCollectedLocations = rawLocations.values.flatten()
 
-        // transform API data into the same format as collectedEggStorage
         val collectedEggsApiData = mutableMapOf<IslandType, MutableSet<LorenzVec>>()
 
         for ((island, locationNameToCoords) in apiEggLocations) {
@@ -94,10 +91,7 @@ object HoppityEggLocations {
         }
 
         val storedEggLocationCount = collectedEggStorage.values.sumOf { it.size }
-
         val diff = apiCollectedLocations.size - storedEggLocationCount
-
-        // don't load if the API is unchanged or behind
         if (diff <= 0) return
 
         val locationStr = StringUtils.pluralize(diff, "location", "locations")
@@ -141,12 +135,12 @@ object HoppityEggLocations {
             val isCollected = collectedLocations.contains(location)
             val color = if (isCollected) LorenzColor.GREEN else LorenzColor.RED
             val nameColorCode = (if (name != null) LorenzColor.GREEN else LorenzColor.RED).getChatColor()
+
             event.drawColor(location, color, false, 0.5f)
             event.drawDynamicText(location.add(y = 0.5), "$nameColorCode$name", 1.2)
             if (location.distanceSqToPlayer() < 100) {
                 event.drawDynamicText(location.add(y = 0.5), location.toCleanString(), 1.0, yOff = 12f)
             }
-
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.NeuProfileDataLoadedEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LocationUtils
@@ -18,6 +19,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
+@SkyHanniModule
 object HoppityEggLocations {
 
     private var collectedEggStorage: MutableMap<IslandType, MutableSet<LorenzVec>>

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -113,7 +113,7 @@ object HoppityEggLocator {
         }
     }
 
-    private fun LorenzRenderWorldEvent.drawDuplicateEggs(islandEggsLocations: List<LorenzVec>, ) {
+    private fun LorenzRenderWorldEvent.drawDuplicateEggs(islandEggsLocations: Set<LorenzVec>, ) {
         if (!config.highlightDuplicateEggLocations || !config.showNearbyDuplicateEggLocations) return
         for (eggLocation in islandEggsLocations) {
             val dist = eggLocation.distanceToPlayer()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -120,7 +120,7 @@ object HoppityEggLocator {
         if (!config.highlightDuplicateEggLocations || !config.showNearbyDuplicateEggLocations) return
         for (eggLocation in islandEggsLocations) {
             val dist = eggLocation.distanceToPlayer()
-            if (dist < 10 && HoppityUniqueEggLocations.hasCollectedEgg(eggLocation)) {
+            if (dist < 10 && HoppityEggLocations.hasCollectedEgg(eggLocation)) {
                 val alpha = ((10 - dist) / 10).coerceAtMost(0.5).toFloat()
                 drawColor(eggLocation, LorenzColor.RED, false, alpha)
                 drawDynamicText(eggLocation.add(y = 1), "§cDuplicate Location!", 1.5)
@@ -153,7 +153,7 @@ object HoppityEggLocator {
 
     private fun LorenzRenderWorldEvent.drawEggWaypoint(location: LorenzVec, label: String) {
         val shouldMarkDuplicate = config.highlightDuplicateEggLocations
-            && HoppityUniqueEggLocations.hasCollectedEgg(location)
+            && HoppityEggLocations.hasCollectedEgg(location)
         val possibleDuplicateLabel = if (shouldMarkDuplicate) "$label §c(Duplicate Location)" else label
         if (!shouldMarkDuplicate) {
             drawWaypointFilled(location, LorenzColor.GREEN.toColor(), seeThroughBlocks = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -91,7 +91,7 @@ object HoppityEggLocator {
             }
         }
 
-        val islandEggsLocations = HoppityEggLocations.currentIslandLocations ?: return
+        val islandEggsLocations = HoppityEggLocations.islandLocations ?: return
 
         if (shouldShowAllEggs()) {
             for (eggLocation in islandEggsLocations) {
@@ -216,7 +216,7 @@ object HoppityEggLocator {
         lastGuessMade = SimpleTimeMark.now()
         possibleEggLocations = emptyList()
 
-        val islandEggsLocations = HoppityEggLocations.currentIslandLocations ?: return
+        val islandEggsLocations = HoppityEggLocations.islandLocations ?: return
         val listSize = validParticleLocations.size
 
         if (listSize < 5) return
@@ -262,7 +262,7 @@ object HoppityEggLocator {
     }
 
     fun isValidEggLocation(location: LorenzVec): Boolean =
-        HoppityEggLocations.currentIslandLocations?.any { it.distance(location) < 5.0 } ?: false
+        HoppityEggLocations.islandLocations?.any { it.distance(location) < 5.0 } ?: false
 
     private fun ReceiveParticleEvent.isVillagerParticle() =
         type == EnumParticleTypes.VILLAGER_HAPPY && speed == 0.0f && count == 1

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.event.hoppity
 
 import at.hannibal2.skyhanni.data.ClickType
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
@@ -56,8 +55,6 @@ object HoppityEggLocator {
     var currentEggType: HoppityEggType? = null
     var currentEggNote: String? = null
 
-    var eggLocations: Map<IslandType, List<LorenzVec>> = mapOf()
-
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         resetData()
@@ -94,7 +91,7 @@ object HoppityEggLocator {
             }
         }
 
-        val islandEggsLocations = getCurrentIslandEggLocations() ?: return
+        val islandEggsLocations = HoppityEggLocations.currentIslandLocations ?: return
 
         if (shouldShowAllEggs()) {
             for (eggLocation in islandEggsLocations) {
@@ -219,7 +216,7 @@ object HoppityEggLocator {
         lastGuessMade = SimpleTimeMark.now()
         possibleEggLocations = emptyList()
 
-        val islandEggsLocations = getCurrentIslandEggLocations() ?: return
+        val islandEggsLocations = HoppityEggLocations.currentIslandLocations ?: return
         val listSize = validParticleLocations.size
 
         if (listSize < 5) return
@@ -264,11 +261,8 @@ object HoppityEggLocator {
         drawLocations = true
     }
 
-    fun getCurrentIslandEggLocations(): List<LorenzVec>? =
-        eggLocations[LorenzUtils.skyBlockIsland]
-
     fun isValidEggLocation(location: LorenzVec): Boolean =
-        getCurrentIslandEggLocations()?.any { it.distance(location) < 5.0 } ?: false
+        HoppityEggLocations.currentIslandLocations?.any { it.distance(location) < 5.0 } ?: false
 
     private fun ReceiveParticleEvent.isVillagerParticle() =
         type == EnumParticleTypes.VILLAGER_HAPPY && speed == 0.0f && count == 1
@@ -281,7 +275,7 @@ object HoppityEggLocator {
 
     private val ItemStack.isLocatorItem get() = getInternalName() == locatorItem
 
-    fun hasLocatorInHotbar() = RecalculatingValue(1.seconds) {
+    private fun hasLocatorInHotbar() = RecalculatingValue(1.seconds) {
         LorenzUtils.inSkyBlock && InventoryUtils.getItemsInHotbar().any { it.isLocatorItem }
     }.getValue()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -110,7 +110,7 @@ object HoppityEggsManager {
         HoppityEggsCompactChat.handleChat(event)
 
         eggFoundPattern.matchMatcher(event.message) {
-            HoppityUniqueEggLocations.saveNearestEgg()
+            HoppityEggLocations.saveNearestEgg()
             HoppityEggLocator.eggFound()
             val meal = getEggType(event)
             val note = group("note").removeColor()
@@ -195,7 +195,7 @@ object HoppityEggsManager {
         if (config.showCollectedLocationCount && LorenzUtils.inSkyBlock) {
             val totalEggs = HoppityEggLocator.getCurrentIslandEggLocations()?.size
             if (totalEggs != null) {
-                val collectedEggs = HoppityUniqueEggLocations.collectedEggsThisIsland()
+                val collectedEggs = HoppityEggLocations.collectedEggsThisIsland()
                 val collectedFormat = formatEggsCollected(collectedEggs)
                 displayList.add("§7Locations: $collectedFormat$collectedEggs§7/§a$totalEggs")
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -2,7 +2,10 @@ package at.hannibal2.skyhanni.features.event.hoppity
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.*
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.test.command.ErrorManager

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -193,7 +193,7 @@ object HoppityEggsManager {
         displayList.add(0, "§bUnclaimed Eggs:")
 
         if (config.showCollectedLocationCount && LorenzUtils.inSkyBlock) {
-            val totalEggs = HoppityEggLocator.getCurrentIslandEggLocations()?.size
+            val totalEggs = HoppityEggLocations.currentIslandLocations?.size
             if (totalEggs != null) {
                 val collectedEggs = HoppityEggLocations.collectedEggsThisIsland()
                 val collectedFormat = formatEggsCollected(collectedEggs)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -2,10 +2,7 @@ package at.hannibal2.skyhanni.features.event.hoppity
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.LorenzChatEvent
-import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.*
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -193,9 +190,9 @@ object HoppityEggsManager {
         displayList.add(0, "§bUnclaimed Eggs:")
 
         if (config.showCollectedLocationCount && LorenzUtils.inSkyBlock) {
-            val totalEggs = HoppityEggLocations.currentIslandLocations?.size
-            if (totalEggs != null) {
-                val collectedEggs = HoppityEggLocations.collectedEggsThisIsland()
+            val totalEggs = HoppityEggLocations.islandLocations.size
+            if (totalEggs > 0) {
+                val collectedEggs = HoppityEggLocations.islandCollectedLocations.size
                 val collectedFormat = formatEggsCollected(collectedEggs)
                 displayList.add("§7Locations: $collectedFormat$collectedEggs§7/§a$totalEggs")
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsShared.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsShared.kt
@@ -47,7 +47,7 @@ object HoppityEggsShared {
 
     fun shareNearbyEggLocation(playerLocation: LorenzVec, meal: HoppityEggType, note: String) {
         if (!isEnabled()) return
-        val islandEggsLocations = HoppityEggLocator.getCurrentIslandEggLocations() ?: return
+        val islandEggsLocations = HoppityEggLocations.currentIslandLocations ?: return
         val closestEgg = islandEggsLocations.minByOrNull { it.distance(playerLocation) } ?: return
 
         val x = closestEgg.x.toInt()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsShared.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsShared.kt
@@ -47,7 +47,7 @@ object HoppityEggsShared {
 
     fun shareNearbyEggLocation(playerLocation: LorenzVec, meal: HoppityEggType, note: String) {
         if (!isEnabled()) return
-        val islandEggsLocations = HoppityEggLocations.currentIslandLocations ?: return
+        val islandEggsLocations = HoppityEggLocations.islandLocations ?: return
         val closestEgg = islandEggsLocations.minByOrNull { it.distance(playerLocation) } ?: return
 
         val x = closestEgg.x.toInt()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityUniqueEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityUniqueEggLocations.kt
@@ -1,14 +1,19 @@
 package at.hannibal2.skyhanni.features.event.hoppity
 
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.NeuProfileDataLoadedEvent
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 object HoppityUniqueEggLocations {
+
+    var apiEggLocations: Map<String, LorenzVec> = mapOf()
 
     private val collectedEggLocations: MutableMap<IslandType, MutableSet<LorenzVec>>?
         get() = ChocolateFactoryAPI.profileStorage?.collectedEggLocations
@@ -30,6 +35,21 @@ object HoppityUniqueEggLocations {
         }
 
         getCurrentIslandCollectedEggs()?.add(location)
+    }
+
+    @SubscribeEvent
+    fun onNeuProfileDataLoaded(event: NeuProfileDataLoadedEvent) {
+        // optional chaining to catch any potential API responses missing some data, hopefully
+        val rawLocations = event.getCurrentPlayerData()?.events?.easter?.rabbits?.collectedLocations
+
+        if (rawLocations == null) {
+            ChatUtils.chat("No collected egg locations found in API, aborting.")
+            return
+        }
+
+        val collected = rawLocations.values.flatten().mapNotNull { apiEggLocations[it] }
+
+        
     }
 
     fun collectedEggsThisIsland() = getCurrentIslandCollectedEggs()?.size ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -9,8 +9,6 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.HoppityEggLocationsJson
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityCollectionStats
-import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocator
-import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocations
 import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityCollectionStats
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocator
+import at.hannibal2.skyhanni.features.event.hoppity.HoppityUniqueEggLocations
 import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -94,6 +95,7 @@ object ChocolateFactoryAPI {
         val data = event.getConstant<HoppityEggLocationsJson>("HoppityEggLocations")
 
         HoppityEggLocator.eggLocations = data.eggLocations
+        HoppityUniqueEggLocations.apiEggLocations = data.apiEggLocations
 
         rabbitSlots = data.rabbitSlots
         otherUpgradeSlots = data.otherUpgradeSlots

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -94,9 +94,6 @@ object ChocolateFactoryAPI {
     fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<HoppityEggLocationsJson>("HoppityEggLocations")
 
-        HoppityEggLocator.eggLocations = data.eggLocations
-        HoppityEggLocations.apiEggLocations = data.apiEggLocations
-
         rabbitSlots = data.rabbitSlots
         otherUpgradeSlots = data.otherUpgradeSlots
         noPickblockSlots = data.noPickblockSlots

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityCollectionStats
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocator
-import at.hannibal2.skyhanni.features.event.hoppity.HoppityUniqueEggLocations
+import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocations
 import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -95,7 +95,7 @@ object ChocolateFactoryAPI {
         val data = event.getConstant<HoppityEggLocationsJson>("HoppityEggLocations")
 
         HoppityEggLocator.eggLocations = data.eggLocations
-        HoppityUniqueEggLocations.apiEggLocations = data.apiEggLocations
+        HoppityEggLocations.apiEggLocations = data.apiEggLocations
 
         rabbitSlots = data.rabbitSlots
         otherUpgradeSlots = data.otherUpgradeSlots


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/207

## What
Allows players to import their collected egg locations from the API using the NEU Profile Viewer, analogous to the existing trophy fishing import feature.

Also adds an egg location viewer for development, toggled with `/shtoggleegglocationdebug`, which shows the internal names and coordinates for each waypoint (see screenshot).

Currently a draft because some API names need to be confirmed; see dependent PR for details.

<details>
<summary>Images</summary>
API import clickable chat:
<img width="500" alt="Screenshot 2024-05-31 at 9 17 38 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/460bd3bf-bdea-4337-8818-7c162c0962dd">

Development viewer:
<img width="500" alt="Screenshot 2024-05-31 at 9 12 48 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/3acc4788-f8dc-4c4f-9f15-42b132b3e333">


</details>

## Changelog Improvements
+ Added collected egg location API import. - appable
    * Open your NEU profile viewer and click the chat message to load data.
