### PR TITLE
Fix: wrong api name conversion for Fish the Rabbit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionData.kt
@@ -31,8 +31,10 @@ object HoppityCollectionData {
             ?: ChocolateBonuses(0, 0.0)
     }
 
-    private fun String.toApiName(): String =
-        lowercase().replace("[- ]".toRegex(), "_")
+    private fun String.toApiName(): String = when (this) {
+        "Fish the Rabbit" -> "fish"
+        else -> lowercase().replace("[- ]".toRegex(), "_")
+    }
 
     @SubscribeEvent
     fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {


### PR DESCRIPTION
<!-- remove all unused parts -->

## Dependencies
- https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/pull/1225

## What
Fixes api name conversion for Fish the Rabbit, which has the irregular API name `fish` instead of `fish_the_rabbit`. Works in mod currently because the NEU Repo name is also incorrect, but will break if the above PR is merged.

## Changelog Fixes
+ Fixed incorrect API name conversion for Fish the Rabbit. - appable