### PR TITLE
Fix: Visitor Drop Statistics new data

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
@@ -103,7 +103,7 @@ object GardenVisitorDropStatistics {
     fun onChat(event: LorenzChatEvent) {
         if (!GardenAPI.onBarnPlot) return
         if (!ProfileStorageData.loaded) return
-        if (lastAccept.passedSince() > 1.seconds || lastAccept.isInPast()) return
+        if (lastAccept.passedSince() > 1.seconds) return
 
         val message = event.message.removeColor().trim()
         val storage = GardenAPI.storage?.visitorDrops ?: return


### PR DESCRIPTION
## What
Fixed garden visitor drop statistics not tracking new stuff.

## Changelog Fixes
+ Fixed Garden Visitor Drop Statistics not tracking new data. - hannibal2
    * This may also fix the display not showing up.