### PR TITLE
Improvement: Faction Quest Widget is disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/ReputationHelperConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/ReputationHelperConfig.java
@@ -18,7 +18,7 @@ public class ReputationHelperConfig {
     @ConfigOption(name = "Enabled", desc = "Enable features around Reputation features in the Crimson Isle.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean enabled = false;
+    public Property<Boolean> enabled = Property.of(false);
 
     @Expose
     @ConfigOption(name = "Hide Completed", desc = "Hides tasks after they've been completed.")

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -88,7 +88,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
         if (!IslandType.CRIMSON_ISLE.isInIsland()) return
-        if (!config.enabled) return
+        if (!config.enabled.get()) return
         if (!dirty && display.isEmpty()) {
             dirty = true
         }
@@ -141,7 +141,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!config.enabled) return
+        if (!config.enabled.get()) return
         if (!IslandType.CRIMSON_ISLE.isInIsland()) return
 
         if (config.useHotkey && !config.hotkey.isKeyHeld()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -42,6 +42,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
 
     private var display = emptyList<List<Any>>()
     private var dirty = true
+    var tabListQuestsMissing = false
 
     /**
      *  c - Barbarian Not Accepted
@@ -124,10 +125,16 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
         // TODO test
         if (factionType == FactionType.NONE) return
 
-        newList.addAsSingletonList("Reputation Helper:")
-        questHelper.render(newList)
-        miniBossHelper.render(newList)
-        kuudraBossHelper.render(newList)
+        newList.addAsSingletonList("§e§lReputation Helper")
+        if (tabListQuestsMissing) {
+            newList.addAsSingletonList("§cFaction Quests Widget not found!")
+            newList.addAsSingletonList("§7Open §e/tab §7and enable it!")
+        } else {
+            questHelper.render(newList)
+            miniBossHelper.render(newList)
+            kuudraBossHelper.render(newList)
+        }
+
 
         display = newList
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -74,12 +74,31 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
         questLoader.checkInventory(event)
     }
 
+    // TODO use WidgetUpdateEvent once its merged
     @SubscribeEvent
     fun onTabListUpdate(event: TabListUpdateEvent) {
         if (!isEnabled()) return
 
         questLoader.loadFromTabList()
     }
+
+//     @SubscribeEvent
+//     fun onTabListWidgetUpdate(event: WidgetUpdateEvent.NewValues) {
+//         if (!isEnabled()) return
+//         if (event.isWidget(TabWidget.FACTION_QUESTS)) {
+//             println("WidgetUpdateEvent.NewValues")
+//             questLoader.loadFromTabList(event.lines)
+//         }
+//     }
+//
+//     @SubscribeEvent
+//     fun onTabListWidgetUpdate(event: WidgetUpdateEvent.Clear) {
+//         if (!isEnabled()) return
+//         if (event.isWidget(TabWidget.FACTION_QUESTS)) {
+//             println("WidgetUpdateEvent.Clear")
+//             questLoader.loadFromTabList(emptyList())
+//         }
+//     }
 
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.SackAPI.getAmountInSacksOrNull
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
@@ -28,6 +29,7 @@ import at.hannibal2.skyhanni.features.nether.reputationhelper.miniboss.CrimsonMi
 import at.hannibal2.skyhanni.test.GriffinUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getInventoryName
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
@@ -72,6 +74,15 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
         if (!isEnabled()) return
 
         questLoader.checkInventory(event)
+    }
+
+    @SubscribeEvent
+    fun onConfigLoad(event: ConfigLoadEvent) {
+        ConditionalUtils.onToggle(config.enabled) {
+            if (IslandType.CRIMSON_ISLE.isInIsland()) {
+                questLoader.loadFromTabList()
+            }
+        }
     }
 
     // TODO use WidgetUpdateEvent once its merged
@@ -336,5 +347,5 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
         }
     }
 
-    private fun isEnabled() = IslandType.CRIMSON_ISLE.isInIsland() && config.enabled
+    private fun isEnabled() = IslandType.CRIMSON_ISLE.isInIsland() && config.enabled.get()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
@@ -35,11 +35,17 @@ class QuestLoader(private val dailyQuestHelper: DailyQuestHelper) {
         }
     }
 
+    // TODO use WidgetUpdateEvent once its merged
+    //     fun loadFromTabList(lines: List<String>) {
     fun loadFromTabList() {
         var i = -1
         dailyQuestHelper.greatSpook = false
+        var found = 0
+
+
         for (line in TabListData.getTabList()) {
-            if (line.contains("Faction Quests:")) {
+//         for (line in lines) {
+            if (line == "§5§lFaction Quests:") {
                 i = 0
                 continue
             }
@@ -47,11 +53,15 @@ class QuestLoader(private val dailyQuestHelper: DailyQuestHelper) {
 
             i++
             readQuest(line)
+            found++
             if (dailyQuestHelper.greatSpook) return
             if (i == 5) {
                 break
             }
         }
+
+        dailyQuestHelper.reputationHelper.tabListQuestsMissing = found == 0
+        dailyQuestHelper.update()
     }
 
     private fun readQuest(line: String) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/kuudra/DailyKuudraBossHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/kuudra/DailyKuudraBossHelper.kt
@@ -30,7 +30,7 @@ class DailyKuudraBossHelper(private val reputationHelper: CrimsonIsleReputationH
     @SubscribeEvent
     fun onRenderWorld(event: LorenzRenderWorldEvent) {
         if (!IslandType.CRIMSON_ISLE.isInIsland()) return
-        if (!config.enabled) return
+        if (!config.enabled.get()) return
         if (!reputationHelper.showLocations()) return
         if (allKuudraDone) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/miniboss/DailyMiniBossHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/miniboss/DailyMiniBossHelper.kt
@@ -115,5 +115,5 @@ class DailyMiniBossHelper(private val reputationHelper: CrimsonIsleReputationHel
     }
 
     private fun getByDisplayName(name: String) = miniBosses.firstOrNull { it.displayName == name }
-    private fun isEnabled() = IslandType.CRIMSON_ISLE.isInIsland() && config.enabled
+    private fun isEnabled() = IslandType.CRIMSON_ISLE.isInIsland() && config.enabled.get()
 }


### PR DESCRIPTION
## What
Added a warning when the Faction Quest Widget is disabled in the tab list. Needed for Crimson Isle Reputation Helper

## Changelog Improvements
+ Crimson Isle Reputation Helper now warns when the Faction Quest Widget is disabled in the tab list. - hannibal2