### PR TITLE
Feature: Add chocolate production time for stray rabbits

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -298,7 +298,6 @@ import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactor
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryTimeTowerManager
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryTooltip
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryTooltipCompact
-import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryTooltipStray
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryUpgradeWarning
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateShopPrice
 import at.hannibal2.skyhanni.features.inventory.tiarelay.TiaRelayHelper
@@ -683,7 +682,6 @@ class SkyHanniMod {
         loadModule(ChocolateFactoryInventory)
         loadModule(ChocolateFactoryStats)
         loadModule(ChocolateFactoryTooltipCompact)
-        loadModule(ChocolateFactoryTooltipStray)
         loadModule(ChocolateFactoryTimeTowerManager)
         loadModule(ChocolateFactoryTooltip)
         loadModule(ChocolateFactoryKeybinds)

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -298,6 +298,7 @@ import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactor
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryTimeTowerManager
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryTooltip
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryTooltipCompact
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryTooltipStray
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryUpgradeWarning
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateShopPrice
 import at.hannibal2.skyhanni.features.inventory.tiarelay.TiaRelayHelper
@@ -682,6 +683,7 @@ class SkyHanniMod {
         loadModule(ChocolateFactoryInventory)
         loadModule(ChocolateFactoryStats)
         loadModule(ChocolateFactoryTooltipCompact)
+        loadModule(ChocolateFactoryTooltipStray)
         loadModule(ChocolateFactoryTimeTowerManager)
         loadModule(ChocolateFactoryTooltip)
         loadModule(ChocolateFactoryKeybinds)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -99,6 +99,12 @@ public class ChocolateFactoryConfig {
     public boolean showDuplicateTime = false;
 
     @Expose
+    @ConfigOption(name = "Stray Rabbit Time", desc = "Show the production time of chocolate gained from stray rabbits.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean showStrayTime = false;
+
+    @Expose
     @ConfigOption(name = "Time Tower Usage Warning", desc = "Notification when you have a new time tower usage available and " +
         "continuously warn when your time tower is full.")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.features.inventory.chocolatefactory
+
+import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
+import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.TimeUtils.format
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+object ChocolateFactoryTooltipStray {
+    private val config get() = ChocolateFactoryAPI.config
+
+    /**
+     * REGEX-TEST: §7You gained §6+2,465,018 Chocolate§7!
+     * REGEX-TEST: §7gained §6+30,292 Chocolate§7!
+     * REGEX-TEST: §7§6+36,330 Chocolate§7!
+     */
+    private val chocolateGainedPattern by ChocolateFactoryAPI.patternGroup.pattern(
+        "rabbit.stray",
+        "(?:§.)+(?:You )?(?:gained )?§6\\+(?<amount>[\\d,]+) Chocolate§7!"
+    )
+
+    @SubscribeEvent
+    fun onTooltip(event: LorenzToolTipEvent) {
+        if (!ChocolateFactoryAPI.inChocolateFactory) return
+        if (!config.showStrayTime) return
+        if (event.slot.slotNumber > 26 || event.slot.slotNumber == ChocolateFactoryAPI.infoIndex) return
+
+        val tooltip = event.toolTip
+        tooltip.matchFirst(chocolateGainedPattern) {
+            val amount = group("amount").formatLong()
+            val format = ChocolateFactoryAPI.timeUntilNeed(amount).format(maxUnits = 2)
+            tooltip[tooltip.lastIndex] += " §7(§a+§b$format §aof production§7)"
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
@@ -21,7 +22,7 @@ object ChocolateFactoryTooltipStray {
         "(?:§.)+(?:You )?(?:gained )?§6\\+(?<amount>[\\d,]+) Chocolate§7!"
     )
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGH)
     fun onTooltip(event: LorenzToolTipEvent) {
         if (!ChocolateFactoryAPI.inChocolateFactory) return
         if (!config.showStrayTime) return
@@ -30,7 +31,7 @@ object ChocolateFactoryTooltipStray {
         val tooltip = event.toolTip
         tooltip.matchFirst(chocolateGainedPattern) {
             val amount = group("amount").formatLong()
-            val format = ChocolateFactoryAPI.timeUntilNeed(amount).format(maxUnits = 2)
+            val format = ChocolateFactoryAPI.timeUntilNeed(amount + 1).format(maxUnits = 2)
             tooltip[tooltip.lastIndex] += " §7(§a+§b$format §aof production§7)"
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -1,11 +1,13 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
+@SkyHanniModule
 object ChocolateFactoryTooltipStray {
     private val config get() = ChocolateFactoryAPI.config
 


### PR DESCRIPTION
## What
Show the chocolate production time for stray/golden rabbits caught in the chocolate factory menu. 

- New config option (added below duplicate rabbit time since they are somewhat related) to toggle this feature on/off
- Added regex tests to find chocolate gained from stray/golden rabbits
- Following format from duplicated rabbits (in chat message) but instead shown as a tooltip beside the stray rabbit caught
- Not adding regex pattern for Fish the Rabbit since it adds a new rabbit instead of giving chocolates (except duplicate, but handled by duplicate rabbit time already)
- I have tested the code and confirmed that it works (except golden rabbits since hobbity hunt event is currently inactive, but the pattern has been added)

Refer to attached images for an example tooltip.

<details>
<summary>Images</summary>

<img width="524" alt="Screenshot" src="https://github.com/hannibal002/SkyHanni/assets/26355099/a46982f7-5597-42ba-979b-f2a3047882f5">

</details>

## Changelog New Features
+ Added stray/golden chocolate rabbit production time. - sayomaki
