### PR TITLE
Fix: No longer hide boss bars by accident

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraft.entity.boss.EntityWither
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class HideFarEntities {
@@ -30,7 +31,9 @@ class HideFarEntities {
 
     @SubscribeEvent
     fun onCheckRender(event: CheckRenderEntityEvent<*>) {
-        if (isEnabled() && event.entity.entityId in ignored) {
+        val entity = event.entity
+        if (entity is EntityWither && entity.entityId < 0) return
+        if (isEnabled() && entity.entityId in ignored) {
             event.cancel()
         }
     }


### PR DESCRIPTION
## What
No longer hide boss bars by accident.
Entity id of bossbar is always negative

## Changelog Fixes
+ Fixed accidental hiding of boss bars. - CalMWolfs

