### PR TITLE
Fix: Config reset on unknown enum values

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -111,6 +111,7 @@ object ConfigUpdaterMigrator {
         val lastVersion = (config["lastVersion"] as? JsonPrimitive)?.asIntOrNull ?: -1
         if (lastVersion > CONFIG_VERSION) {
             logger.log("Attempted to downgrade config version")
+            config.add("lastVersion", JsonPrimitive(CONFIG_VERSION))
             return config
         }
         if (lastVersion == CONFIG_VERSION) return config

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/BaseGsonBuilder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/BaseGsonBuilder.kt
@@ -33,5 +33,7 @@ object BaseGsonBuilder {
         .registerTypeAdapter(SimpleTimeMark::class.java, SkyHanniTypeAdapters.TIME_MARK.nullSafe())
         .enableComplexMapKeySerialization()
 
-    fun lenientGson(): GsonBuilder = gson().registerTypeAdapterFactory(SkippingTypeAdapterFactory)
+    fun lenientGson(): GsonBuilder = gson()
+        .registerTypeAdapterFactory(SkippingTypeAdapterFactory)
+        .registerTypeAdapterFactory(ListEnumSkippingTypeAdapterFactory)
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/EnumSkippingTypeAdapter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/EnumSkippingTypeAdapter.kt
@@ -1,0 +1,56 @@
+package at.hannibal2.skyhanni.utils.json
+
+import com.google.gson.Gson
+import com.google.gson.TypeAdapter
+import com.google.gson.TypeAdapterFactory
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken
+import com.google.gson.stream.JsonWriter
+import java.lang.reflect.ParameterizedType
+
+object ListEnumSkippingTypeAdapterFactory : TypeAdapterFactory {
+    override fun <T> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T>? {
+        val rawType = type.rawType
+        if (rawType == List::class.java) {
+            val actualType = (type.type as ParameterizedType).actualTypeArguments[0]
+            if (actualType is Class<*> && actualType.isEnum) {
+                @Suppress("UNCHECKED_CAST")
+                return ListEnumSkippingTypeAdapter(actualType as Class<out Enum<*>>) as TypeAdapter<T>
+            }
+        }
+        return null
+    }
+}
+
+/*
+    Instead of saving null to the config when the enum value is unknown we instead skip the value.
+    We also skip the value if it is null inside a list of enums. This ensures we don't crash later,
+    either in moulconfig or outside of it, as we assume lists of enums don't contain null values.
+ */
+class ListEnumSkippingTypeAdapter<T : Enum<T>>(private val enumClass: Class<T>) : TypeAdapter<List<T>>() {
+    override fun write(out: JsonWriter, value: List<T>?) {
+        if (value == null) {
+            out.nullValue()
+        } else {
+            out.beginArray()
+            value.forEach { out.value(it.name) }
+            out.endArray()
+        }
+    }
+
+    override fun read(reader: JsonReader): List<T> {
+        val list = mutableListOf<T>()
+        reader.beginArray()
+        while (reader.hasNext()) {
+            if (reader.peek() == JsonToken.NULL) {
+                reader.nextNull()
+                continue
+            }
+            val name = reader.nextString()
+            enumClass.enumConstants.firstOrNull { it.name == name }?.let { list.add(it) }
+        }
+        reader.endArray()
+        return list
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/EnumSkippingTypeAdapterFactory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/EnumSkippingTypeAdapterFactory.kt
@@ -30,13 +30,10 @@ object ListEnumSkippingTypeAdapterFactory : TypeAdapterFactory {
  */
 class ListEnumSkippingTypeAdapter<T : Enum<T>>(private val enumClass: Class<T>) : TypeAdapter<List<T>>() {
     override fun write(out: JsonWriter, value: List<T>?) {
-        if (value == null) {
-            out.nullValue()
-        } else {
-            out.beginArray()
-            value.forEach { out.value(it.name) }
-            out.endArray()
-        }
+        value ?: return
+        out.beginArray()
+        value.forEach { out.value(it.name) }
+        out.endArray()
     }
 
     override fun read(reader: JsonReader): List<T> {
@@ -44,7 +41,7 @@ class ListEnumSkippingTypeAdapter<T : Enum<T>>(private val enumClass: Class<T>) 
         reader.beginArray()
         while (reader.hasNext()) {
             if (reader.peek() == JsonToken.NULL) {
-                reader.nextNull()
+                reader.skipValue()
                 continue
             }
             val name = reader.nextString()

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SkippingTypeAdapterFactory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SkippingTypeAdapterFactory.kt
@@ -8,6 +8,11 @@ import com.google.gson.reflect.TypeToken
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 
+/*
+    Instead of crashing on a wrong value in the config we set the value to null and log a warning.
+    This prevents user's config from resetting to default values.
+    Which is especially important for when people downgrade their mod version, either on purpose or by accident.
+ */
 object SkippingTypeAdapterFactory : TypeAdapterFactory {
 
     override fun <T : Any?> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T> {

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SkippingTypeAdapterFactory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SkippingTypeAdapterFactory.kt
@@ -12,6 +12,7 @@ import com.google.gson.stream.JsonWriter
     Instead of crashing on a wrong value in the config we set the value to null and log a warning.
     This prevents user's config from resetting to default values.
     Which is especially important for when people downgrade their mod version, either on purpose or by accident.
+    This does not always work, and can cause a crash later on, but the full config reset is avoided.
  */
 object SkippingTypeAdapterFactory : TypeAdapterFactory {
 


### PR DESCRIPTION
## What
Unknown enum elements in lists will be ignored, this means you dont crash when opening moulconfig to that draggable list. Also would fix crashes in other places where the values of the list are assumed not null. 
Also makes config version go back to current config version when downgrading so you arent stuck on a newer config version.

## Changelog Fixes
+ Fixed config reset on encountering unknown enum values in the config. - CalMWolfs

## Changelog Technical Details
+ Ensured correct config version when downgrading the mod. - CalMWolfs

