### PR TITLE
Improvement: Add config to hide duplication egg locations

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -51,6 +51,12 @@ public class HoppityEggsConfig {
     public boolean showNearbyDuplicateEggLocations = false;
 
     @Expose
+    @ConfigOption(name = "Hide Duplicate Locations", desc = "Hides egg location waypoints which you have already found.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hideDuplicateEggLocations = false;
+
+    @Expose
     @ConfigOption(name = "Load from NEU PV", desc = "Load Hoppity Egg Location data from API when opening the NEU Profile Viewer.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -39,6 +39,13 @@ public class HoppityEggsConfig {
     public boolean showAllWaypoints = false;
 
     @Expose
+    @ConfigOption(name = "Hide Duplicate Waypoints", desc = "Hides egg waypoints you have found. §e" +
+        "Only works when you don't have an Egglocator in your inventory.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hideDuplicateWaypoints = false;
+
+    @Expose
     @ConfigOption(name = "Mark Duplicate Locations", desc = "Marks egg location waypoints which you have already found in red.")
     @ConfigEditorBoolean
     @FeatureToggle
@@ -49,12 +56,6 @@ public class HoppityEggsConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean showNearbyDuplicateEggLocations = false;
-
-    @Expose
-    @ConfigOption(name = "Hide Duplicate Locations", desc = "Hides egg location waypoints which you have already found.")
-    @ConfigEditorBoolean
-    @FeatureToggle
-    public boolean hideDuplicateEggLocations = false;
 
     @Expose
     @ConfigOption(name = "Load from NEU PV", desc = "Load Hoppity Egg Location data from API when opening the NEU Profile Viewer.")

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -99,8 +99,9 @@ object HoppityEggLocator {
             }
             return
         }
-
-        event.drawDuplicateEggs(islandEggsLocations)
+        if (!config.hideDuplicateEggLocations) {
+            event.drawDuplicateEggs(islandEggsLocations)
+        }
     }
 
     private fun LorenzRenderWorldEvent.drawGuessLocations() {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -91,17 +91,21 @@ object HoppityEggLocator {
             }
         }
 
-        val islandEggsLocations = HoppityEggLocations.islandLocations ?: return
+        var islandEggsLocations = HoppityEggLocations.islandLocations ?: return
 
         if (shouldShowAllEggs()) {
+            if (config.hideDuplicateWaypoints) {
+                islandEggsLocations = islandEggsLocations.filter {
+                    !HoppityEggLocations.hasCollectedEgg(it)
+                }.toSet()
+            }
             for (eggLocation in islandEggsLocations) {
                 event.drawEggWaypoint(eggLocation, "§aEgg")
             }
             return
         }
-        if (!config.hideDuplicateEggLocations) {
-            event.drawDuplicateEggs(islandEggsLocations)
-        }
+
+        event.drawDuplicateEggs(islandEggsLocations)
     }
 
     private fun LorenzRenderWorldEvent.drawGuessLocations() {
@@ -114,7 +118,7 @@ object HoppityEggLocator {
         }
     }
 
-    private fun LorenzRenderWorldEvent.drawDuplicateEggs(islandEggsLocations: Set<LorenzVec>, ) {
+    private fun LorenzRenderWorldEvent.drawDuplicateEggs(islandEggsLocations: Set<LorenzVec>) {
         if (!config.highlightDuplicateEggLocations || !config.showNearbyDuplicateEggLocations) return
         for (eggLocation in islandEggsLocations) {
             val dist = eggLocation.distanceToPlayer()


### PR DESCRIPTION
## What
Add config to hide duplication egg locations, to check locations that haven't been found yet more easily

<details>
<summary>Images</summary>

![2024-06-04_00 04 33](https://github.com/hannibal002/SkyHanni/assets/88066006/1c9026d1-d71b-4305-ad34-87c9e73c014d)
![2024-06-04_00 04 38](https://github.com/hannibal002/SkyHanni/assets/88066006/a96e8aa6-aede-44c7-9bbc-4c613ea8a121)
</details>

## Changelog Improvements
+ Added option to hide duplicate egg locations. - maxime-bodifee
