### PR TITLE
Backend: Add automated style checking

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,18 +16,39 @@ ij_any_block_comment_add_space = true
 ij_any_line_comment_add_space = true
 
 # Max line length
-max_line_length = 120
+max_line_length = 140
 
 # Java Files
 [*.java]
 # Java files should not use wildcard imports
-ij_java_names_count_to_use_import_on_demand = 999
-ij_java_class_count_to_use_import_on_demand = 999
-ij_java_packages_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 2147483647
+ij_java_class_count_to_use_import_on_demand = 2147483647
+ij_java_packages_to_use_import_on_demand = 2147483647
 
 [*.kt]
+ktlint_code_style=intellij_idea
+
 # Kotlin files should not use wildcard imports
-ij_kotlin_name_count_to_use_star_import = 999
-ij_kotlin_name_count_to_use_star_import_for_members = 999
-ij_kotlin_packages_to_use_import_on_demand = 999
+ij_kotlin_name_count_to_use_star_import = 2147483647
+ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
 ij_kotlin_enum_constants_wrap = split_into_lines
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_allow_trailing_comma = true
+
+ktlint_standard_no-empty-first-line-in-class-body = disabled
+ktlint_standard_no-single-line-block-comment = disabled
+ktlint_standard_no-blank-line-before-rbrace = disabled
+ktlint_standard_no-consecutive-blank-lines = disabled
+ktlint_standard_no-empty-first-line-in-method-block = disabled
+ktlint_standard_comment-spacing = disabled
+ktlint_standard_string-template = disabled
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_trailing-comma-on-declaration-site = disabled
+ktlint_standard_context-receiver-wrapping = disabled
+ktlint_standard_multiline-expression-wrapping = disabled
+ktlint_standard_string-template-indent = disabled
+ktlint_standard_no-trailing-spaces = disabled
+
+ktlint_standard_no-line-break-before-assignment = true
+ktlint_standard_no-wildcard-imports = enabled
+ktlint_standard_function-expression-body = enabled

--- a/.github/workflows/check-style.yaml
+++ b/.github/workflows/check-style.yaml
@@ -1,0 +1,16 @@
+name: check-style
+on:
+    - pull_request
+jobs:
+    ktlint:
+        name: Check Style
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+              name: Checkout code
+            - name: ktlint
+              uses: ScaCap/action-ktlint@master
+              with:
+                  github_token: ${{ secrets.github_token }}
+                  reporter: github-pr-check


### PR DESCRIPTION
## What
This adds a workflow that will automatically make sure the style of the code is consistent, this will only work for new PRs but overtime it should eventually get to all files, from a quick check there are about 300 existing files that dont make the style config.

This updates the editor config to configure the project style and also increases the line length to 140 which is standard in most projects.

exclude_from_changelog
