### PR TITLE
Fix: Issues with /gfs on some items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -50,7 +50,20 @@ object HypixelCommands {
     }
 
     fun getFromSacks(itemName: String, amount: Int) {
-        send("gfs $itemName $amount")
+        val realItemName = when (itemName) {
+            // These two are a workaround for a bug with NEU's item lookup.
+            // (The incorrect items cannot go in sacks anyway.)
+            "BUILDER_BROWN_MUSHROOM" -> "BROWN_MUSHROOM"
+            "HAY_BALE" -> "HAY_BLOCK"
+
+            // This one is a workaround for Hypixel's /gfs behavior of taking
+            // both item names and internal IDs causing a collision.
+            // (Actual sulphur will get mapped to SULPHUR_ORE.)
+            "SULPHUR" -> "GUNPOWDER"
+
+            else -> itemName
+        }
+        send("gfs $realItemName $amount")
     }
 
     fun widget() {


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

## What
Fixed `/gfs` using the wrong item ID for Brown Mushroom and Hay Bale, as well as giving Sulphur instead of Gunpowder.

## Changelog Fixes
+ Fixed `/gfs` failing on Brown Mushroom and Hay Bale. - Luna
+ Fixed `/gfs` giving Sulphur instead of Gunpowder. - Luna