### PR TITLE
Feature: Favorite Power Stones

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -213,6 +213,13 @@ public class InventoryConfig {
     public boolean powerStoneGuide = true;
 
     @Expose
+    @ConfigOption(name = "Favorite Power Stone", desc = "Shows your favorite power stones. You can add/remove them by shift clicking a Power Stone,")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean favoritePowerStone = false;
+
+
+    @Expose
     @ConfigOption(name = "Shift Click Equipment", desc = "Makes normal clicks to shift clicks in equipment inventory.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -213,11 +213,10 @@ public class InventoryConfig {
     public boolean powerStoneGuide = true;
 
     @Expose
-    @ConfigOption(name = "Favorite Power Stone", desc = "Shows your favorite power stones. You can add/remove them by shift clicking a Power Stone,")
+    @ConfigOption(name = "Favorite Power Stone", desc = "Shows your favorite power stones. You can add/remove them by shift clicking a Power Stone.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean favoritePowerStone = false;
-
 
     @Expose
     @ConfigOption(name = "Shift Click Equipment", desc = "Makes normal clicks to shift clicks in equipment inventory.")

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -151,6 +151,9 @@ public class ProfileSpecificStorage {
 
         @Expose
         public List<MaxwellAPI.ThaumaturgyPowerTuning> tunings = new ArrayList<>();
+
+        @Expose
+        public List<String> favoritePowers = new ArrayList<>();
     }
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -49,6 +49,12 @@ object MaxwellAPI {
             storage?.maxwell?.tunings = value ?: return
         }
 
+    var favoritePowers: List<String>
+        get() = storage?.maxwell?.favoritePowers ?: listOf()
+        set(value) {
+            storage?.maxwell?.favoritePowers = value
+        }
+
     private var powers = mutableListOf<String>()
 
     private val patternGroup = RepoPattern.group("data.maxwell")
@@ -282,7 +288,7 @@ object MaxwellAPI {
         if (!foundMagicalPower) magicalPower = 0
     }
 
-    private fun getPowerByNameOrNull(name: String) = powers.find { it == name }
+    fun getPowerByNameOrNull(name: String) = powers.find { it == name }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && storage != null
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
@@ -6,8 +6,7 @@ import at.hannibal2.skyhanni.data.MaxwellAPI.favoritePowers
 import at.hannibal2.skyhanni.data.MaxwellAPI.isThaumaturgyInventory
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
-import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.name
@@ -23,6 +22,7 @@ object FavoritePowerStone {
 
     private val config get() = SkyHanniMod.feature.inventory
     private val storage get() = ProfileStorageData.profileSpecific
+
     private var highlightedSlots = mutableSetOf<Int>()
 
     @SubscribeEvent
@@ -53,18 +53,13 @@ object FavoritePowerStone {
     }
 
     @SubscribeEvent
-    fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!isEnabled()) return
         if (!isThaumaturgyInventory(event.inventoryName)) return
 
         event.inventoryItems.forEach { (slot, item) ->
             if (item.displayName in favoritePowers) highlightedSlots += slot
         }
-    }
-
-    @SubscribeEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
-        highlightedSlots = mutableSetOf()
     }
 
     private fun isEnabled() =

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
@@ -60,6 +60,5 @@ object FavoritePowerStone {
         }
     }
 
-    private fun isEnabled() =
-        LorenzUtils.inSkyBlock && storage != null && config.favoritePowerStone
+    private fun isEnabled() = LorenzUtils.inSkyBlock && storage != null && config.favoritePowerStone
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
@@ -4,9 +4,10 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.MaxwellAPI
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -21,20 +22,19 @@ object FavoritePowerStone {
     private val config get() = SkyHanniMod.feature.inventory
     private val storage get() = ProfileStorageData.profileSpecific
 
-    private var highlightedSlots = mutableSetOf<Int>()
+    private var highlightedSlots = setOf<Int>()
+    private var inInventory = false
 
     @SubscribeEvent
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!isEnabled()) return
-        if (!MaxwellAPI.isThaumaturgyInventory(InventoryUtils.openInventoryName())) return
+        if (!isEnabled() || !inInventory) return
 
         highlightedSlots.forEach { event.gui.inventorySlots.inventorySlots[it] highlight LorenzColor.AQUA }
     }
 
     @SubscribeEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!isEnabled() || !KeyboardManager.isShiftKeyDown()) return
-        if (!MaxwellAPI.isThaumaturgyInventory(InventoryUtils.openInventoryName())) return
+        if (!isEnabled() || !KeyboardManager.isShiftKeyDown() || !inInventory) return
 
         val displayName = event.item?.name?.removeColor()?.trim() ?: return
         val power = MaxwellAPI.getPowerByNameOrNull(displayName) ?: return
@@ -51,13 +51,25 @@ object FavoritePowerStone {
     }
 
     @SubscribeEvent
-    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
-        if (!isEnabled()) return
-        if (!MaxwellAPI.isThaumaturgyInventory(event.inventoryName)) return
+    fun onInventoryOpen(event: InventoryOpenEvent) {
+        if (!isEnabled() || !MaxwellAPI.isThaumaturgyInventory(event.inventoryName)) return
 
+        inInventory = true
+    }
+
+    @SubscribeEvent
+    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+        if (!isEnabled() || !inInventory) return
+
+        highlightedSlots = setOf()
         event.inventoryItems.forEach { (slot, item) ->
             if (item.displayName in MaxwellAPI.favoritePowers) highlightedSlots += slot
         }
+    }
+
+    @SubscribeEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        inInventory = false
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && storage != null && config.favoritePowerStone

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
@@ -2,8 +2,6 @@ package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.MaxwellAPI
-import at.hannibal2.skyhanni.data.MaxwellAPI.favoritePowers
-import at.hannibal2.skyhanni.data.MaxwellAPI.isThaumaturgyInventory
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
@@ -28,7 +26,7 @@ object FavoritePowerStone {
     @SubscribeEvent
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!isEnabled()) return
-        if (!isThaumaturgyInventory(InventoryUtils.openInventoryName())) return
+        if (!MaxwellAPI.isThaumaturgyInventory(InventoryUtils.openInventoryName())) return
 
         highlightedSlots.forEach { event.gui.inventorySlots.inventorySlots[it] highlight LorenzColor.AQUA }
     }
@@ -36,16 +34,16 @@ object FavoritePowerStone {
     @SubscribeEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled() || !KeyboardManager.isShiftKeyDown()) return
-        if (!isThaumaturgyInventory(InventoryUtils.openInventoryName())) return
+        if (!MaxwellAPI.isThaumaturgyInventory(InventoryUtils.openInventoryName())) return
 
         val displayName = event.item?.name?.removeColor()?.trim() ?: return
         val power = MaxwellAPI.getPowerByNameOrNull(displayName) ?: return
 
         if (power in favoritePowers) {
-            favoritePowers -= power
+            MaxwellAPI.favoritePowers -= power
             highlightedSlots -= event.slotId
         } else {
-            favoritePowers += power
+            MaxwellAPI.favoritePowers += power
             highlightedSlots += event.slotId
         }
 
@@ -55,10 +53,10 @@ object FavoritePowerStone {
     @SubscribeEvent
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!isEnabled()) return
-        if (!isThaumaturgyInventory(event.inventoryName)) return
+        if (!MaxwellAPI.isThaumaturgyInventory(event.inventoryName)) return
 
         event.inventoryItems.forEach { (slot, item) ->
-            if (item.displayName in favoritePowers) highlightedSlots += slot
+            if (item.displayName in MaxwellAPI.favoritePowers) highlightedSlots += slot
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
@@ -39,7 +39,7 @@ object FavoritePowerStone {
         val displayName = event.item?.name?.removeColor()?.trim() ?: return
         val power = MaxwellAPI.getPowerByNameOrNull(displayName) ?: return
 
-        if (power in favoritePowers) {
+        if (power in MaxwellAPI.favoritePowers) {
             MaxwellAPI.favoritePowers -= power
             highlightedSlots -= event.slotId
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
@@ -1,0 +1,72 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.MaxwellAPI
+import at.hannibal2.skyhanni.data.MaxwellAPI.favoritePowers
+import at.hannibal2.skyhanni.data.MaxwellAPI.isThaumaturgyInventory
+import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.name
+import at.hannibal2.skyhanni.utils.KeyboardManager
+import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.RenderUtils.highlight
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object FavoritePowerStone {
+
+    private val config get() = SkyHanniMod.feature.inventory
+    private val storage get() = ProfileStorageData.profileSpecific
+    private var highlightedSlots = mutableSetOf<Int>()
+
+    @SubscribeEvent
+    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+        if (!isEnabled()) return
+        if (!isThaumaturgyInventory(InventoryUtils.openInventoryName())) return
+
+        highlightedSlots.forEach { event.gui.inventorySlots.inventorySlots[it] highlight LorenzColor.AQUA }
+    }
+
+    @SubscribeEvent
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!isEnabled() || !KeyboardManager.isShiftKeyDown()) return
+        if (!isThaumaturgyInventory(InventoryUtils.openInventoryName())) return
+
+        val displayName = event.item?.name?.removeColor()?.trim() ?: return
+        val power = MaxwellAPI.getPowerByNameOrNull(displayName) ?: return
+
+        if (power in favoritePowers) {
+            favoritePowers -= power
+            highlightedSlots -= event.slotId
+        } else {
+            favoritePowers += power
+            highlightedSlots += event.slotId
+        }
+
+        event.cancel()
+    }
+
+    @SubscribeEvent
+    fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+        if (!isEnabled()) return
+        if (!isThaumaturgyInventory(event.inventoryName)) return
+
+        event.inventoryItems.forEach { (slot, item) ->
+            if (item.displayName in favoritePowers) highlightedSlots += slot
+        }
+    }
+
+    @SubscribeEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        highlightedSlots = mutableSetOf()
+    }
+
+    private fun isEnabled() =
+        LorenzUtils.inSkyBlock && storage != null && config.favoritePowerStone
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
@@ -61,10 +61,9 @@ object FavoritePowerStone {
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!isEnabled() || !inInventory) return
 
-        highlightedSlots = setOf()
-        event.inventoryItems.forEach { (slot, item) ->
-            if (item.displayName in MaxwellAPI.favoritePowers) highlightedSlots += slot
-        }
+        highlightedSlots = event.inventoryItems
+            .filter { (_, item) -> item.displayName.removeColor() in MaxwellAPI.favoritePowers }
+            .keys
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Highlights your favorite power stones. You can add/remove them with Shift Click.

<details>
<summary>Images</summary>

<!-- drop images here -->
![image](https://github.com/hannibal002/SkyHanni/assets/45262877/3fb4f25b-e0fb-47d7-b33b-def7a214be12)

</details>

## Changelog New Features
+ Added Favorite Power Stones. - saga
    * Highlighted in the Thaumaturgy inventory.
    * Shift-click to add/remove them.