### PR TITLE
Backend: SimpleTimeMark into CachedItemData 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class MixinItemStack implements ItemStackCachedData {
 
     @Unique
-    public CachedItemData skyhanni_cachedData = new CachedItemData();
+    public CachedItemData skyhanni_cachedData = new CachedItemData((Void) null);
 
     public CachedItemData getSkyhanni_cachedData() {
         return skyhanni_cachedData;

--- a/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
@@ -16,8 +16,7 @@ data class CachedItemData(
     // null = not loaded
     var riftExportable: Boolean? = null,
 
-    // null = not loaded
-    var itemRarityLastCheck: Long = 0L, // Can't use SimpleTimeMark here
+    var itemRarityLastCheck: SimpleTimeMark = SimpleTimeMark.farPast(),
 
     // null = not loaded
     var itemRarity: LorenzRarity? = null,
@@ -26,5 +25,12 @@ data class CachedItemData(
 
     var lastInternalName: NEUInternalName? = null,
 
-    var lastInternalNameFetchTime: Long = 0L, // Still can't use SimpleTimeMark here
-)
+    var lastInternalNameFetchTime: SimpleTimeMark = SimpleTimeMark.farPast(),
+) {
+    /**
+     * Delegate constructor to avoid calling a function with default arguments from java.
+     * We can't call the generated no args constructors (or rather we cannot generate that constructor), because inline
+     * classes are not part of the java-kotlin ABI that is super well supported (especially with default arguments).
+     */
+    constructor(void: Void?) : this()
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -98,12 +98,12 @@ object ItemUtils {
 
     fun ItemStack.getInternalNameOrNull(): NEUInternalName? {
         val data = cachedData
-        if (data.lastInternalNameFetchTime.asTimeMark().passedSince() < 1.seconds) {
+        if (data.lastInternalNameFetchTime.passedSince() < 1.seconds) {
             return data.lastInternalName
         }
         val internalName = grabInternalNameOrNull()
         data.lastInternalName = internalName
-        data.lastInternalNameFetchTime = SimpleTimeMark.now().toMillis()
+        data.lastInternalNameFetchTime = SimpleTimeMark.now()
         return internalName
     }
 
@@ -238,7 +238,7 @@ object ItemUtils {
 
     private fun ItemStack.updateCategoryAndRarity() {
         val data = cachedData
-        data.itemRarityLastCheck = SimpleTimeMark.now().toMillis()
+        data.itemRarityLastCheck = SimpleTimeMark.now()
         val internalName = getInternalName()
         if (internalName == NEUInternalName.NONE) {
             data.itemRarity = null
@@ -267,7 +267,7 @@ object ItemUtils {
     }
 
     private fun itemRarityLastCheck(data: CachedItemData) =
-        data.itemRarityLastCheck.asTimeMark().passedSince() > 10.seconds
+        data.itemRarityLastCheck.passedSince() > 10.seconds
 
     /**
      * Use when comparing the name (e.g. regex), not for showing to the user


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

## Changelog Technical Details
+ Changed CachedItemData to use SimpleTimeMark. - nea
    * This is done via an in-Kotlin delegate constructor, since calling functions with default arguments that have an inline class type from Java is not stable.

