### PR TITLE
Fix: Some stuff in garden tooltips not showing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/item/ItemHoverEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ItemHoverEvent.kt
@@ -3,4 +3,11 @@ package at.hannibal2.skyhanni.events.item
 import at.hannibal2.skyhanni.events.LorenzEvent
 import net.minecraft.item.ItemStack
 
-class ItemHoverEvent(val itemStack: ItemStack, val toolTip: List<String>) : LorenzEvent()
+class ItemHoverEvent(val itemStack: ItemStack, private val toolTip0: MutableList<String>) : LorenzEvent() {
+    var toolTip
+        set(value) {
+            toolTip0.clear()
+            toolTip0.addAll(value)
+        }
+        get() = toolTip0
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
@@ -6,12 +6,12 @@ import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
-import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.events.PacketEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorOpenEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorRenderEvent
+import at.hannibal2.skyhanni.events.item.ItemHoverEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorAPI.ACCEPT_SLOT
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorAPI.INFO_SLOT
@@ -33,7 +33,6 @@ import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.network.play.client.C02PacketUseEntity
-import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.seconds
 
@@ -133,8 +132,8 @@ object VisitorListener {
         inventory.handleMouseClick_skyhanni(slot, slot.slotIndex, 0, 0)
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGH)
-    fun onTooltip(event: LorenzToolTipEvent) {
+    @SubscribeEvent
+    fun onTooltip(event: ItemHoverEvent) {
         if (!GardenAPI.onBarnPlot) return
         if (!VisitorAPI.inInventory) return
         val visitor = VisitorAPI.getVisitor(lastClickedNpc) ?: return

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.List;
 
@@ -23,9 +24,9 @@ public class MixinItemStack implements ItemStackCachedData {
         return skyhanni_cachedData;
     }
 
-    @Inject(method = "getTooltip", at = @At("RETURN"))
-    public void getTooltip(EntityPlayer playerIn, boolean advanced, CallbackInfoReturnable<List<String>> ci) {
+    @Inject(method = "getTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/event/ForgeEventFactory;onItemTooltip(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/player/EntityPlayer;Ljava/util/List;Z)Lnet/minecraftforge/event/entity/player/ItemTooltipEvent;", shift = At.Shift.BEFORE), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void getTooltip(EntityPlayer playerIn, boolean advanced, CallbackInfoReturnable<List<String>> cir, List<String> list) {
         ItemStack stack = (ItemStack) (Object) this;
-        ToolTipData.onHover(stack, ci.getReturnValue());
+        ToolTipData.onHover(stack, list);
     }
 }


### PR DESCRIPTION
event priority removed because only 2 skyhanni things actually use this function

## Changelog Fixes
+ Fixed stats in visitor inventory not showing under certain circumstances. - CalMWolfs

## Changelog Technical Details
+ Made ItemHoverEvent be called earlier. - Vixid
