### PR TITLE
Backend: Make build fail on wrong annotation

### DIFF
--- a/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
+++ b/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
@@ -81,7 +81,7 @@ class ModuleProcessor(private val codeGenerator: CodeGenerator, private val logg
 
         if (warnings.isNotEmpty()) {
             warnings.forEach { logger.warn(it) }
-            error("${warnings.size} errors related to event annotations found, please fix them before continuing")
+            error("${warnings.size} errors related to event annotations found, please fix them before continuing. Click on the kspKotlin build log for more information.")
         }
 
         val dependencies = symbols.mapNotNull { it.containingFile }.toTypedArray()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent
@@ -131,7 +130,7 @@ object HarpFeatures {
         unSetGUIScale()
     }
 
-    @HandleEvent
+    @SubscribeEvent
     fun onDisconnect(event: ClientDisconnectEvent) {
         if (!config.guiScale) return
         unSetGUIScale()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -58,7 +58,7 @@ object HarpFeatures {
     private fun isHarpGui(chestName: String) = inventoryTitlePattern.matches(chestName)
     private fun isMenuGui(chestName: String) = menuTitlePattern.matches(chestName)
 
-    @HandleEvent
+    @SubscribeEvent
     fun onGui(event: GuiKeyPressEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.keybinds) return
@@ -98,7 +98,7 @@ object HarpFeatures {
 
     private var openTime: SimpleTimeMark = SimpleTimeMark.farPast()
 
-    @HandleEvent
+    @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (config.quickRestart && isMenuGui(event.inventoryName)) {
@@ -124,14 +124,14 @@ object HarpFeatures {
         minecraft.currentScreen.setWorldAndResolution(minecraft, i, j)
     }
 
-    @HandleEvent
+    @SubscribeEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.guiScale) return
         unSetGUIScale()
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onDisconnect(event: ClientDisconnectEvent) {
         if (!config.guiScale) return
         unSetGUIScale()
@@ -154,7 +154,7 @@ object HarpFeatures {
         isGUIScaled = false
     }
 
-    @HandleEvent
+    @SubscribeEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!LorenzUtils.inSkyBlock) return
 
@@ -186,7 +186,7 @@ object HarpFeatures {
         }
     }
 
-    @HandleEvent
+    @SubscribeEvent
     fun onRenderItemTip(event: RenderItemTipEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.showNumbers) return
@@ -201,13 +201,13 @@ object HarpFeatures {
         event.stackTip = KeyboardManager.getKeyName(keyCode).take(3)
     }
 
-    @HandleEvent
+    @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "misc.harpKeybinds", "inventory.helper.harp.keybinds")
         event.move(2, "misc.harpNumbers", "inventory.helper.harp.showNumbers")
     }
 
-    @HandleEvent
+    @SubscribeEvent
     fun onTooltip(event: LorenzToolTipEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.hideMelodyTooltip) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent
@@ -57,7 +58,7 @@ object HarpFeatures {
     private fun isHarpGui(chestName: String) = inventoryTitlePattern.matches(chestName)
     private fun isMenuGui(chestName: String) = menuTitlePattern.matches(chestName)
 
-    @SubscribeEvent
+    @HandleEvent
     fun onGui(event: GuiKeyPressEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.keybinds) return
@@ -97,7 +98,7 @@ object HarpFeatures {
 
     private var openTime: SimpleTimeMark = SimpleTimeMark.farPast()
 
-    @SubscribeEvent
+    @HandleEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (config.quickRestart && isMenuGui(event.inventoryName)) {
@@ -123,7 +124,7 @@ object HarpFeatures {
         minecraft.currentScreen.setWorldAndResolution(minecraft, i, j)
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.guiScale) return
@@ -153,7 +154,7 @@ object HarpFeatures {
         isGUIScaled = false
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!LorenzUtils.inSkyBlock) return
 
@@ -185,7 +186,7 @@ object HarpFeatures {
         }
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onRenderItemTip(event: RenderItemTipEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.showNumbers) return
@@ -200,13 +201,13 @@ object HarpFeatures {
         event.stackTip = KeyboardManager.getKeyName(keyCode).take(3)
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "misc.harpKeybinds", "inventory.helper.harp.keybinds")
         event.move(2, "misc.harpNumbers", "inventory.helper.harp.showNumbers")
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onTooltip(event: LorenzToolTipEvent) {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.hideMelodyTooltip) return


### PR DESCRIPTION
## What
Make build fail when event functions have wrong annotation. This is because while both our own live plugin and the minecraft development plugin give warnings when you have the wrong annotation, neither of them will actually stop the build from finishing, and the build task that is run on prs does not get far enough into launching that it will crash. This means if a branch is updated and the person doesnt launch it, they will not know that it breaks. As we switch over events to the new system this makes it so that if I or another contributor updates a pr we can tell immediately that it does not build and needs attention making it so that we can identify prs that need fixing quicker.


Example error message:
```
w: [ksp] Function in at.hannibal2.skyhanni.features.inventory.HarpFeatures must have an event assignable from SkyHanniEvent because it is annotated with @HandleEvent
w: [ksp] Function in at.hannibal2.skyhanni.features.inventory.HarpFeatures must have an event assignable from SkyHanniEvent because it is annotated with @HandleEvent
w: [ksp] Function in at.hannibal2.skyhanni.features.inventory.HarpFeatures must have an event assignable from SkyHanniEvent because it is annotated with @HandleEvent
w: [ksp] Function in at.hannibal2.skyhanni.features.inventory.HarpFeatures must have an event assignable from Event because it is annotated with @SubscribeEvent
w: [ksp] Function in at.hannibal2.skyhanni.features.inventory.HarpFeatures must have an event assignable from SkyHanniEvent because it is annotated with @HandleEvent
w: [ksp] Function in at.hannibal2.skyhanni.features.inventory.HarpFeatures must have an event assignable from SkyHanniEvent because it is annotated with @HandleEvent
w: [ksp] Function in at.hannibal2.skyhanni.features.inventory.HarpFeatures must have an event assignable from SkyHanniEvent because it is annotated with @HandleEvent
w: [ksp] Function in at.hannibal2.skyhanni.features.inventory.HarpFeatures must have an event assignable from SkyHanniEvent because it is annotated with @HandleEvent
```

## Changelog Technical Details
+ Make build fail when event functions have wrong annotation. - CalMWolfs

