### PR TITLE
Fix: Consider Y=64 part of Magma Fields

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
@@ -33,7 +33,8 @@ object CrystalHollowsWalls {
 
     private const val EXPAND_TIMES = 20
 
-    private const val HEAT_HEIGHT = 64.0
+    // Heat is active at Y=64.0 and below, we draw it one above to show that you're inside
+    private const val HEAT_HEIGHT = 65.0
     private const val MAX_HEIGHT = 190.0
 
     private const val MIN_X = 0.0
@@ -70,7 +71,7 @@ object CrystalHollowsWalls {
     fun onRender(event: LorenzRenderWorldEvent) {
         if (!isEnabled()) return
         val position = RenderUtils.getViewerPos(event.partialTicks)
-        if (position.y <= HEAT_HEIGHT + yViewOffset) {
+        if (position.y < HEAT_HEIGHT + yViewOffset) {
             drawHeat(event)
         } else if (nucleusBBOffsetY.isVecInside(position.toVec3())) {
             if (!config.nucleus) return

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
@@ -70,7 +70,7 @@ object CrystalHollowsWalls {
     fun onRender(event: LorenzRenderWorldEvent) {
         if (!isEnabled()) return
         val position = RenderUtils.getViewerPos(event.partialTicks)
-        if (position.y < HEAT_HEIGHT + yViewOffset) {
+        if (position.y <= HEAT_HEIGHT + yViewOffset) {
             drawHeat(event)
         } else if (nucleusBBOffsetY.isVecInside(position.toVec3())) {
             if (!config.nucleus) return

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
@@ -33,7 +33,8 @@ object CrystalHollowsWalls {
 
     private const val EXPAND_TIMES = 20
 
-    // Heat is active at Y=64.0 and below, we draw it one above to show that you're inside
+    // Heat is active at Y=64.0 and below as of SkyBlock 0.20.1. We draw the line
+    // one above to accurately show whether the player is inside the Magma Fields.
     private const val HEAT_HEIGHT = 65.0
     private const val MAX_HEIGHT = 190.0
 


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

## What
Made Y=64 be considered part of Magma Fields. Hypixel quietly changed this in or around SkyBlock 0.20.1.

## Changelog Fixes
+ Consider Y=64 part of Magma Fields. - Luna
    * Hypixel quietly changed this in or around SkyBlock 0.20.1.