### PR TITLE
Improvement: Auto-detect whether Great Explorer is maxed

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
@@ -46,11 +46,6 @@ public class PowderTrackerConfig {
     public boolean onlyWhenPowderGrinding = false;
 
     @Expose
-    @ConfigOption(name = "Great Explorer", desc = "Enable this if your Great Explorer perk is maxed.")
-    @ConfigEditorBoolean
-    public boolean greatExplorerMaxed = false;
-
-    @Expose
     @ConfigOption(
         name = "Text Format",
         desc = "Drag text to change the appearance of the overlay."

--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -247,6 +247,9 @@ enum class HotmData(
             storage?.perks?.computeIfAbsent(this.name) { HotmTree.HotmPerk() }?.level = value
         }
 
+    val isMaxLevel: Boolean
+        get() = activeLevel >= maxLevel // >= to account for +1 from Blue Cheese
+
     private fun blueEgg() = if (this != PEAK_OF_THE_MOUNTAIN && maxLevel != 1 && HotmAPI.isBlueEggActive) 1 else 0
 
     var enabled: Boolean

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -133,10 +133,7 @@ object PowderTracker {
         if (!isEnabled()) return
         val msg = event.message
 
-        val greatExplorerMaxed = HotmData.GREAT_EXPLORER.let { it.enabled && it.activeLevel == 20 }
-        ChatUtils.debug("Great Explorer maxed: $greatExplorerMaxed")
-
-        if (greatExplorerMaxed) {
+        if (HotmData.GREAT_EXPLORER.let { it.enabled && it.activeLevel == 20 }) {
             uncoveredPattern.matchMatcher(msg) {
                 tracker.modify {
                     it.totalChestPicked += 1

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConfigUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -132,7 +132,7 @@ object PowderTracker {
         if (!isEnabled()) return
         val msg = event.message
 
-        if (HotmData.GREAT_EXPLORER.let { it.enabled && it.activeLevel == 20 }) {
+        if (HotmData.GREAT_EXPLORER.let { it.enabled && it.isMaxLevel }) {
             uncoveredPattern.matchMatcher(msg) {
                 tracker.modify {
                     it.totalChestPicked += 1

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry
 import at.hannibal2.skyhanni.data.BossbarData
+import at.hannibal2.skyhanni.data.HotmData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -12,6 +13,7 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConfigUtils
@@ -131,7 +133,10 @@ object PowderTracker {
         if (!isEnabled()) return
         val msg = event.message
 
-        if (config.greatExplorerMaxed) {
+        val greatExplorerMaxed = HotmData.GREAT_EXPLORER.let { it.enabled && it.activeLevel == 20 }
+        ChatUtils.debug("Great Explorer maxed: $greatExplorerMaxed")
+
+        if (greatExplorerMaxed) {
             uncoveredPattern.matchMatcher(msg) {
                 tracker.modify {
                     it.totalChestPicked += 1


### PR DESCRIPTION
## What
Auto-detect whether Great Explorer is maxed instead of requiring the user to manually specify it.

## Changelog Improvements
+ Powder Tracker: Auto-detect whether Great Explorer is maxed. - Luna
    * The configuration option to manually specify this has been removed.

## Changelog Technical Details
+ Added `HotmData.isMaxLevel`, which also accounts for Blue Cheese. - Luna