### PR TITLE
Improvement: Use EnumMap and fields for config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-.idea/*
+# Use **/*.* since if a directory is ignored, children of that directory *cannot* be unignored using ! again.
+.idea/**/*.*
 !.idea/icon.svg
 !.idea/dictionaries/default_user.xml
+!.idea/scopes/Mixins.xml
 .vscode/
 run/
 build/

--- a/.idea/scopes/Mixins.xml
+++ b/.idea/scopes/Mixins.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="Mixins" pattern="src:at.hannibal2.skyhanni.mixins.transformers..*" />
+</component>

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -145,13 +145,13 @@ class SkyHanniMod {
         val version: String
             get() = Loader.instance().indexedModList[MODID]!!.version
 
-        @JvmStatic
-        val feature: Features get() = configManager.features
-        val sackData: SackData get() = configManager.sackData
-        val friendsData: FriendsJson get() = configManager.friendsData
-        val knownFeaturesData: KnownFeaturesJson get() = configManager.knownFeaturesData
-        val jacobContestsData: JacobContestsJson get() = configManager.jacobContestData
-        val visualWordsData: VisualWordsJson get() = configManager.visualWordsData
+        @JvmField
+        var feature: Features = Features()
+        lateinit var sackData: SackData
+        lateinit var friendsData: FriendsJson
+        lateinit var knownFeaturesData: KnownFeaturesJson
+        lateinit var jacobContestsData: JacobContestsJson
+        lateinit var visualWordsData: VisualWordsJson
 
         lateinit var repo: RepoManager
         lateinit var configManager: ConfigManager

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -35,7 +35,10 @@ import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.util.EnumMap
 import kotlin.concurrent.fixedRateTimer
+import kotlin.reflect.KMutableProperty0
+import kotlin.reflect.KMutableProperty1
 
 private fun GsonBuilder.registerIfBeta(create: TypeAdapterFactory): GsonBuilder {
     return if (LorenzUtils.isBetaVersion()) {
@@ -53,19 +56,19 @@ class ConfigManager {
         var configDirectory = File("config/skyhanni")
     }
 
-    val features get() = jsonHolder[ConfigFileType.FEATURES] as Features
-    val sackData get() = jsonHolder[ConfigFileType.SACKS] as SackData
-    val friendsData get() = jsonHolder[ConfigFileType.FRIENDS] as FriendsJson
-    val knownFeaturesData get() = jsonHolder[ConfigFileType.KNOWN_FEATURES] as KnownFeaturesJson
-    val jacobContestData get() = jsonHolder[ConfigFileType.JACOB_CONTESTS] as JacobContestsJson
-    val visualWordsData get() = jsonHolder[ConfigFileType.VISUAL_WORDS] as VisualWordsJson
-
     private val logger = LorenzLogger("config_manager")
 
-    private val jsonHolder = mutableMapOf<ConfigFileType, Any>()
+    private val jsonHolder: Map<ConfigFileType, Any> = EnumMap(ConfigFileType::class.java)
 
     lateinit var processor: MoulConfigProcessor<Features>
     private var disableSaving = false
+
+    private fun setConfigHolder(type: ConfigFileType, value: Any) {
+        require(value.javaClass == type.clazz)
+        @Suppress("UNCHECKED_CAST")
+        (type.property as KMutableProperty0<Any>).set(value)
+        (jsonHolder as MutableMap<ConfigFileType, Any>)[type] = value
+    }
 
     fun firstLoad() {
         if (jsonHolder.isNotEmpty()) {
@@ -75,7 +78,7 @@ class ConfigManager {
 
 
         for (fileType in ConfigFileType.entries) {
-            jsonHolder[fileType] = firstLoadFile(fileType.file, fileType, fileType.clazz.newInstance())
+            setConfigHolder(fileType, firstLoadFile(fileType.file, fileType, fileType.clazz.newInstance()))
         }
 
         // TODO use SecondPassedEvent
@@ -260,13 +263,13 @@ class ConfigManager {
     }
 }
 
-enum class ConfigFileType(val fileName: String, val clazz: Class<*>) {
-    FEATURES("config", Features::class.java),
-    SACKS("sacks", SackData::class.java),
-    FRIENDS("friends", FriendsJson::class.java),
-    KNOWN_FEATURES("known_features", KnownFeaturesJson::class.java),
-    JACOB_CONTESTS("jacob_contests", JacobContestsJson::class.java),
-    VISUAL_WORDS("visual_words", VisualWordsJson::class.java),
+enum class ConfigFileType(val fileName: String, val clazz: Class<*>, val property: KMutableProperty0<*>) {
+    FEATURES("config", Features::class.java, SkyHanniMod::feature),
+    SACKS("sacks", SackData::class.java, SkyHanniMod::sackData),
+    FRIENDS("friends", FriendsJson::class.java, SkyHanniMod::friendsData),
+    KNOWN_FEATURES("known_features", KnownFeaturesJson::class.java, SkyHanniMod::knownFeaturesData),
+    JACOB_CONTESTS("jacob_contests", JacobContestsJson::class.java, SkyHanniMod::jacobContestsData),
+    VISUAL_WORDS("visual_words", VisualWordsJson::class.java, SkyHanniMod::visualWordsData),
     ;
 
     val file by lazy { File(ConfigManager.configDirectory, "$fileName.json") }

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/Position.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/Position.java
@@ -91,7 +91,7 @@ public class Position {
     }
 
     public float getEffectiveScale() {
-        return Math.max(Math.min(getScale() * SkyHanniMod.getFeature().gui.globalScale, 10F), 0.1F);
+        return Math.max(Math.min(getScale() * SkyHanniMod.feature.gui.globalScale, 10F), 0.1F);
     }
 
     public float getScale() {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinBlockFire.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinBlockFire.java
@@ -13,7 +13,7 @@ public class MixinBlockFire {
 
     @Redirect(method = "randomDisplayTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnParticle(Lnet/minecraft/util/EnumParticleTypes;DDDDDD[I)V"))
     private void onLivingUpdate(World world, EnumParticleTypes particleType, double x, double y, double z, double xOffset, double yOffset, double zOffset, int[] parameters) {
-        if (!SkyHanniMod.getFeature().misc.particleHiders.hideFireBlockParticles) {
+        if (!SkyHanniMod.feature.misc.particleHiders.hideFireBlockParticles) {
             world.spawnParticle(particleType, x, y, z, xOffset, yOffset, zOffset, parameters);
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityBlaze.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityBlaze.java
@@ -13,7 +13,7 @@ public class MixinEntityBlaze {
 
     @Redirect(method = "onLivingUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnParticle(Lnet/minecraft/util/EnumParticleTypes;DDDDDD[I)V"))
     private void onLivingUpdate(World world, EnumParticleTypes particleType, double x, double y, double z, double xOffset, double yOffset, double zOffset, int[] parameters) {
-        if (!SkyHanniMod.getFeature().misc.particleHiders.hideBlazeParticles) {
+        if (!SkyHanniMod.feature.misc.particleHiders.hideBlazeParticles) {
             world.spawnParticle(particleType, x, y, z, xOffset, yOffset, zOffset, parameters);
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityEnderman.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityEnderman.java
@@ -13,7 +13,7 @@ public class MixinEntityEnderman {
 
     @Redirect(method = "onLivingUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnParticle(Lnet/minecraft/util/EnumParticleTypes;DDDDDD[I)V"))
     private void onLivingUpdate(World world, EnumParticleTypes particleType, double x, double y, double z, double xOffset, double yOffset, double zOffset, int[] parameters) {
-        if (!SkyHanniMod.getFeature().misc.particleHiders.hideEndermanParticles) {
+        if (!SkyHanniMod.feature.misc.particleHiders.hideEndermanParticles) {
             world.spawnParticle(particleType, x, y, z, xOffset, yOffset, zOffset, parameters);
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityFireball.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityFireball.java
@@ -13,7 +13,7 @@ public class MixinEntityFireball {
 
     @Redirect(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnParticle(Lnet/minecraft/util/EnumParticleTypes;DDDDDD[I)V"))
     private void onLivingUpdate(World world, EnumParticleTypes particleType, double x, double y, double z, double xOffset, double yOffset, double zOffset, int[] parameters) {
-        if (!SkyHanniMod.getFeature().misc.particleHiders.hideFireballParticles) {
+        if (!SkyHanniMod.feature.misc.particleHiders.hideFireballParticles) {
             world.spawnParticle(particleType, x, y, z, xOffset, yOffset, zOffset, parameters);
         }
     }


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

## What
The config is accessed quite often and using a hash map for each one of these accesses adds up over time. This isn't suuper bad, but it is bad enough to the point where it does show up in profiles occasionally and the fix is quite easy. Using an `EnumMap` instead of a regular map is already a bit of a performance boost, but since `SkyhanniMod.feature` is used very often, I also added a bit of kotlin reflection to automatically set a field whenever it is loaded. Thanks to kotlins property reflection syntax this is fairly easy to use and extend, as well as type checked during compilation.

### Going further

Almost every feature right now accesses the config multiple times per tick, sometimes per frame. While those accesses are just a few chained `GETFIELD`s, this could probably be improved. Config changes are rare and config changes within the same tick are something that we should simply not consider. The infrastructure for this does not exist right now, but one could imagine a future where moulconfigs properties are used extensively to reduce each config access down to at most two `GETFIELD`s each method call. Is this our future or one of our many divergent timelines? Is this future desirable? Is it worth the effort? I don't have the answer. I just know that performance can be found even in the most unlikely of places if you just open your eyes.

## Changelog Improvements
+ Improved overall performance slightly by about ~1%. - nea

## Changelog Technical Details
+ Added mixin search scope. - nea
+ Changed `.gitignore` so that subdirectories of the `.idea` folder can be manually unignored. - nea


