### PR TITLE
Improvement: Add an exclude dungeon toggle to hide far entities

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/HideFarEntitiesConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/HideFarEntitiesConfig.java
@@ -27,4 +27,9 @@ public class HideFarEntitiesConfig {
     @ConfigOption(name = "Exclude Garden", desc = "Disable this feature while in the Garden.")
     @ConfigEditorBoolean
     public boolean excludeGarden = false;
+
+    @Expose
+    @ConfigOption(name = "Exclude Dungeon", desc = "Disable this feature while in Dungeon.")
+    @ConfigEditorBoolean
+    public boolean excludeDungeon = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
@@ -40,5 +41,6 @@ object HideFarEntities {
         }
     }
 
-    fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled && !(GardenAPI.inGarden() && config.excludeGarden)
+    fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled && (!(GardenAPI.inGarden() && config.excludeGarden) && !(DungeonAPI.inDungeon() && config.excludeDungeon))
+
 }


### PR DESCRIPTION
## What
Its a toggle to disable the hide far Entities Feature in Dungeons.

## Changelog Improvements
+ Added an exclude dungeon toggle to hide far entities. - Iceshadow

