### PR TITLE
Backend: Storage SimpleTimeMark

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/storage/PlayerSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/PlayerSpecificStorage.java
@@ -2,7 +2,9 @@ package at.hannibal2.skyhanni.config.storage;
 
 import at.hannibal2.skyhanni.features.bingo.card.goals.BingoGoal;
 import at.hannibal2.skyhanni.features.fame.UpgradeReminder;
+import at.hannibal2.skyhanni.utils.GenericWrapper;
 import at.hannibal2.skyhanni.utils.NEUInternalName;
+import at.hannibal2.skyhanni.utils.SimpleTimeMark;
 import com.google.gson.annotations.Expose;
 
 import java.util.ArrayList;
@@ -24,7 +26,7 @@ public class PlayerSpecificStorage {
     public Integer gardenCommunityUpgrade = -1;
 
     @Expose
-    public long nextCityProjectParticipationTime = 0L;
+    public SimpleTimeMark nextCityProjectParticipationTime = GenericWrapper.getSimpleTimeMark(SimpleTimeMark.farPast()).getIt();
 
     @Expose
     public UpgradeReminder.CommunityShopUpgrade communityShopAccountUpgrade = null;

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -35,6 +35,7 @@ import at.hannibal2.skyhanni.features.rift.area.westvillage.VerminTracker;
 import at.hannibal2.skyhanni.features.rift.area.westvillage.kloon.KloonTerminal;
 import at.hannibal2.skyhanni.features.skillprogress.SkillType;
 import at.hannibal2.skyhanni.features.slayer.SlayerProfitTracker;
+import at.hannibal2.skyhanni.utils.GenericWrapper;
 import at.hannibal2.skyhanni.utils.LorenzVec;
 import at.hannibal2.skyhanni.utils.NEUInternalName;
 import at.hannibal2.skyhanni.utils.SimpleTimeMark;
@@ -49,6 +50,10 @@ import java.util.Map;
 import java.util.Set;
 
 public class ProfileSpecificStorage {
+
+    private static SimpleTimeMark SimpleTimeMarkFarPast() {
+        return GenericWrapper.getSimpleTimeMark(SimpleTimeMark.farPast()).getIt();
+    }
 
     @Expose
     public String currentPet = "";
@@ -85,10 +90,10 @@ public class ProfileSpecificStorage {
         public int timeTowerLevel = 0;
 
         @Expose
-        public long currentTimeTowerEnds = 0;
+        public SimpleTimeMark currentTimeTowerEnds = SimpleTimeMarkFarPast();
 
         @Expose
-        public long nextTimeTower = 0;
+        public SimpleTimeMark nextTimeTower = SimpleTimeMarkFarPast();
 
         @Expose
         public int currentTimeTowerUses = -1;
@@ -103,20 +108,21 @@ public class ProfileSpecificStorage {
         public boolean hasMuRabbit = false;
 
         @Expose
-        public long bestUpgradeAvailableAt = 0;
+        public SimpleTimeMark bestUpgradeAvailableAt = SimpleTimeMarkFarPast();
 
         @Expose
         public long bestUpgradeCost = 0;
 
         @Expose
-        public long lastDataSave = 0;
+        public SimpleTimeMark lastDataSave = SimpleTimeMarkFarPast();
 
         @Expose
         public PositionChange positionChange = new PositionChange();
 
         public static class PositionChange {
             @Expose
-            public Long lastTime = null;
+            @Nullable
+            public SimpleTimeMark lastTime = null;
 
             @Expose
             public int lastPosition = -1;
@@ -183,7 +189,8 @@ public class ProfileSpecificStorage {
         public int bitsAvailable = -1;
 
         @Expose
-        public Long boosterCookieExpiryTime = null;
+        @Nullable
+        public SimpleTimeMark boosterCookieExpiryTime = null;
     }
 
     @Expose
@@ -194,6 +201,7 @@ public class ProfileSpecificStorage {
         @Expose
         public String displayName = "";
 
+        // TODO use SimpleTimeMark
         @Expose
         public long lastClicked = -1;
 
@@ -212,7 +220,8 @@ public class ProfileSpecificStorage {
     public static class BeaconPowerStorage {
 
         @Expose
-        public Long beaconPowerExpiryTime = null;
+        @Nullable
+        public SimpleTimeMark beaconPowerExpiryTime = null;
 
         @Expose
         public String boostedStat = null;
@@ -267,16 +276,16 @@ public class ProfileSpecificStorage {
         public DicerRngDropTracker.Data dicerDropTracker = new DicerRngDropTracker.Data();
 
         @Expose
-        public long informedAboutLowMatter = 0;
+        public SimpleTimeMark informedAboutLowMatter = SimpleTimeMarkFarPast();
 
         @Expose
-        public long informedAboutLowFuel = 0;
+        public SimpleTimeMark informedAboutLowFuel = SimpleTimeMarkFarPast();
 
         @Expose
         public long visitorInterval = 15 * 60_000L;
 
         @Expose
-        public long nextSixthVisitorArrival = 0;
+        public SimpleTimeMark nextSixthVisitorArrival = SimpleTimeMarkFarPast();
 
         @Expose
         public ArmorDropTracker.Data armorDropTracker = new ArmorDropTracker.Data();
@@ -388,10 +397,10 @@ public class ProfileSpecificStorage {
         }
 
         @Expose
-        public long composterEmptyTime = 0;
+        public SimpleTimeMark composterEmptyTime = SimpleTimeMarkFarPast();
 
         @Expose
-        public long lastComposterEmptyWarningTime = 0;
+        public SimpleTimeMark lastComposterEmptyWarningTime = SimpleTimeMarkFarPast();
 
         @Expose
         public GardenStorage.FarmingWeightConfig farmingWeight = new GardenStorage.FarmingWeightConfig();

--- a/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.asTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
 import at.hannibal2.skyhanni.utils.StringUtils.trimWhiteSpace
 import at.hannibal2.skyhanni.utils.TimeUtils
@@ -49,9 +48,9 @@ object BitsAPI {
         }
 
     var cookieBuffTime: SimpleTimeMark?
-        get() = profileStorage?.boosterCookieExpiryTime?.asTimeMark()
+        get() = profileStorage?.boosterCookieExpiryTime
         private set(value) {
-            profileStorage?.boosterCookieExpiryTime = value?.toMillis()
+            profileStorage?.boosterCookieExpiryTime = value
         }
 
     private const val defaultcookiebits = 4800
@@ -308,7 +307,9 @@ object BitsAPI {
 
     fun hasCookieBuff() = cookieBuffTime?.isInFuture() ?: false
 
-    private fun sendBitsGainEvent(difference: Int) = BitsUpdateEvent.BitsGain(bits, bitsAvailable, difference).postAndCatch()
+    private fun sendBitsGainEvent(difference: Int) =
+        BitsUpdateEvent.BitsGain(bits, bitsAvailable, difference).postAndCatch()
+
     private fun sendBitsSpentEvent() = BitsUpdateEvent.BitsSpent(bits, bitsAvailable).postAndCatch()
     private fun sendBitsAvailableGainedEvent() = BitsUpdateEvent.BitsAvailableGained(bits, bitsAvailable).postAndCatch()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -73,8 +73,8 @@ object CityProjectFeatures {
 
         if (LorenzUtils.skyBlockArea == "Community Center") return
 
-        if (playerSpecific.nextCityProjectParticipationTime == 0L) return
-        if (System.currentTimeMillis() <= playerSpecific.nextCityProjectParticipationTime) return
+        if (playerSpecific.nextCityProjectParticipationTime.isFarPast()) return
+        if (playerSpecific.nextCityProjectParticipationTime.isInFuture()) return
         if (lastReminderSend.passedSince() < 30.seconds) return
         lastReminderSend = SimpleTimeMark.now()
 
@@ -131,7 +131,7 @@ object CityProjectFeatures {
                 if (item.name != "§eContribute this component!") continue
                 nextTime = now
             }
-            ProfileStorageData.playerSpecific?.nextCityProjectParticipationTime = nextTime.toMillis()
+            ProfileStorageData.playerSpecific?.nextCityProjectParticipationTime = nextTime
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -17,11 +17,13 @@ import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
-import at.hannibal2.skyhanni.utils.TimeUtils
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.Collections
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -84,7 +86,7 @@ object ComposterDisplay {
 
     private fun addComposterEmptyTime(emptyTime: Duration?): List<Any> {
         return if (emptyTime != null) {
-            GardenAPI.storage?.composterEmptyTime = System.currentTimeMillis() + emptyTime.inWholeMilliseconds
+            GardenAPI.storage?.composterEmptyTime = emptyTime.fromNow()
             val format = emptyTime.format()
             listOf(bucket, "§b$format")
         } else {
@@ -127,22 +129,21 @@ object ComposterDisplay {
 
         val storage = storage ?: return
 
-        if (ComposterAPI.getOrganicMatter() <= config.notifyLow.organicMatter && System.currentTimeMillis() >= storage.informedAboutLowMatter) {
+        if (ComposterAPI.getOrganicMatter() <= config.notifyLow.organicMatter && storage.informedAboutLowMatter.isInPast()) {
             if (config.notifyLow.title) {
                 LorenzUtils.sendTitle("§cYour Organic Matter is low", 4.seconds)
             }
             ChatUtils.chat("§cYour Organic Matter is low!")
-            storage.informedAboutLowMatter = System.currentTimeMillis() + 60_000 * 5
+            storage.informedAboutLowMatter = 5.0.minutes.fromNow()
         }
 
-        if (ComposterAPI.getFuel() <= config.notifyLow.fuel &&
-            System.currentTimeMillis() >= storage.informedAboutLowFuel
+        if (ComposterAPI.getFuel() <= config.notifyLow.fuel && storage.informedAboutLowFuel.isInPast()
         ) {
             if (config.notifyLow.title) {
                 LorenzUtils.sendTitle("§cYour Fuel is low", 4.seconds)
             }
             ChatUtils.chat("§cYour Fuel is low!")
-            storage.informedAboutLowFuel = System.currentTimeMillis() + 60_000 * 5
+            storage.informedAboutLowFuel = 5.0.minutes.fromNow()
         }
     }
 
@@ -159,13 +160,13 @@ object ComposterDisplay {
 
     private fun checkWarningsAndOutsideGarden() {
         val format = GardenAPI.storage?.let {
-            if (it.composterEmptyTime != 0L) {
-                val duration = it.composterEmptyTime - System.currentTimeMillis()
-                if (duration > 0) {
-                    if (duration < 1000 * 60 * 20) {
+            if (!it.composterEmptyTime.isFarPast()) {
+                val duration = it.composterEmptyTime.timeUntil()
+                if (duration > 0.0.seconds) {
+                    if (duration < 20.0.minutes) {
                         warn("Your composter in the garden is almost empty!")
                     }
-                    TimeUtils.formatDuration(duration, maxUnits = 3)
+                    duration.format(maxUnits = 3)
                 } else {
                     warn("Your composter is empty!")
                     "§cComposter is empty!"
@@ -187,8 +188,8 @@ object ComposterDisplay {
 
         if (ReminderUtils.isBusy()) return
 
-        if (System.currentTimeMillis() < storage.lastComposterEmptyWarningTime + 1000 * 60 * 2) return
-        storage.lastComposterEmptyWarningTime = System.currentTimeMillis()
+        if (storage.lastComposterEmptyWarningTime.passedSince() >= 2.0.minutes) return
+        storage.lastComposterEmptyWarningTime = SimpleTimeMark.now()
         if (IslandType.GARDEN.isInIsland()) {
             ChatUtils.chat(warningMessage)
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.asTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TabListData
@@ -120,7 +119,7 @@ object GardenVisitorTimer {
             millis = sixthVisitorArrivalTime.timeUntil()
 
             val nextSixthVisitorArrival = SimpleTimeMark.now() + millis + (visitorInterval * (5 - visitorsAmount))
-            GardenAPI.storage?.nextSixthVisitorArrival = nextSixthVisitorArrival.toMillis()
+            GardenAPI.storage?.nextSixthVisitorArrival = nextSixthVisitorArrival
             if (isSixthVisitorEnabled() && millis.isNegative()) {
                 visitorsAmount++
                 if (!sixthVisitorReady) {
@@ -183,9 +182,8 @@ object GardenVisitorTimer {
     fun onWorldChange(event: LorenzWorldChangeEvent) {
         lastVisitors = -1
         GardenAPI.storage?.nextSixthVisitorArrival?.let {
-            val badTime = Duration.INFINITE.inWholeMilliseconds
-            if (it != badTime && it != -9223370336633802065) {
-                sixthVisitorArrivalTime = it.asTimeMark()
+            if (it.isFarFuture() && it.toMillis() != -9223370336633802065) {
+                sixthVisitorArrivalTime = it
             }
         }
         sixthVisitorReady = false

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.asTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -45,9 +44,9 @@ object BeaconPower {
     )
 
     private var expiryTime: SimpleTimeMark
-        get() = storage?.beaconPowerExpiryTime?.asTimeMark() ?: SimpleTimeMark.farPast()
+        get() = storage?.beaconPowerExpiryTime ?: SimpleTimeMark.farPast()
         set(value) {
-            storage?.beaconPowerExpiryTime = value.toMillis()
+            storage?.beaconPowerExpiryTime = value
         }
 
     private var stat: String?
@@ -117,7 +116,6 @@ object BeaconPower {
             if (config.beaconPowerStat) append(" §7(${stat ?: "§cNo stat"}§7)")
         }
     }
-
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.beaconPower
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateAmount.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateAmount.kt
@@ -26,13 +26,13 @@ enum class ChocolateAmount(val chocolate: () -> Long) {
 
     fun timeUntilGoal(goal: Long): Duration {
         val profileStorage = profileStorage ?: return Duration.ZERO
-        val updatedAgo = SimpleTimeMark(profileStorage.lastDataSave).passedSince().inWholeSeconds
+        val updatedAgo = profileStorage.lastDataSave.passedSince().inWholeSeconds
         return ChocolateFactoryAPI.timeUntilNeed(goal - chocolate()) - updatedAgo.seconds
     }
 
     companion object {
         fun chocolateSinceUpdate(): Long {
-            val lastUpdate = SimpleTimeMark(profileStorage?.lastDataSave ?: return 0)
+            val lastUpdate = profileStorage?.lastDataSave ?: return 0
             val currentTime = SimpleTimeMark.now()
             val secondsSinceUpdate = (currentTime - lastUpdate).inWholeSeconds
 
@@ -77,9 +77,9 @@ enum class ChocolateAmount(val chocolate: () -> Long) {
 
         private fun updateBestUpgrade() {
             profileStorage?.let {
-                if (it.bestUpgradeAvailableAt == 0L || it.bestUpgradeCost == 0L) return
+                if (it.bestUpgradeAvailableAt.isFarPast() || it.bestUpgradeCost == 0L) return
                 val canAffordAt = SimpleTimeMark.now() + CURRENT.timeUntilGoal(it.bestUpgradeCost)
-                it.bestUpgradeAvailableAt = canAffordAt.toMillis()
+                it.bestUpgradeAvailableAt = canAffordAt
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -180,7 +180,7 @@ object ChocolateFactoryDataLoader {
 
         profileStorage.rawChocPerSecond =
             (ChocolateFactoryAPI.chocolatePerSecond / profileStorage.chocolateMultiplier + .01).toInt()
-        profileStorage.lastDataSave = SimpleTimeMark.now().toMillis()
+        profileStorage.lastDataSave = SimpleTimeMark.now()
 
         ChocolateFactoryStats.updateDisplay()
 
@@ -287,9 +287,9 @@ object ChocolateFactoryDataLoader {
 
                     val activeDuration = TimeUtils.getDuration(formattedGroup)
                     val activeUntil = SimpleTimeMark.now() + activeDuration
-                    profileStorage.currentTimeTowerEnds = activeUntil.toMillis()
+                    profileStorage.currentTimeTowerEnds = activeUntil
                 } else {
-                    profileStorage.currentTimeTowerEnds = 0
+                    profileStorage.currentTimeTowerEnds = SimpleTimeMark.farPast()
                 }
             }
             timeTowerRechargePattern.matchMatcher(line) {
@@ -298,7 +298,7 @@ object ChocolateFactoryDataLoader {
 
                 val timeUntilTower = TimeUtils.getDuration(formattedGroup)
                 val nextTimeTower = SimpleTimeMark.now() + timeUntilTower
-                profileStorage.nextTimeTower = nextTimeTower.toMillis()
+                profileStorage.nextTimeTower = nextTimeTower
             }
         }
     }
@@ -435,7 +435,7 @@ object ChocolateFactoryDataLoader {
             list.filter { !it.isMaxed && it.slotIndex != ChocolateFactoryAPI.timeTowerIndex && it.effectiveCost != null }
 
         val bestUpgrade = notMaxed.minByOrNull { it.effectiveCost ?: Double.MAX_VALUE }
-        profileStorage.bestUpgradeAvailableAt = bestUpgrade?.canAffordAt?.toMillis() ?: 0
+        profileStorage.bestUpgradeAvailableAt = bestUpgrade?.canAffordAt ?: SimpleTimeMark.farPast()
         profileStorage.bestUpgradeCost = bestUpgrade?.price ?: 0
         ChocolateFactoryAPI.bestPossibleSlot = bestUpgrade?.getValidUpgradeIndex() ?: -1
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.utils.SoundUtils
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -30,8 +29,8 @@ object ChocolateFactoryTimeTowerManager {
         if (!LorenzUtils.inSkyBlock) return
         val profileStorage = profileStorage ?: return
 
-        if (SimpleTimeMark(profileStorage.currentTimeTowerEnds).isInPast()) {
-            profileStorage.currentTimeTowerEnds = SimpleTimeMark.farPast().toMillis()
+        if (profileStorage.currentTimeTowerEnds.isInPast()) {
+            profileStorage.currentTimeTowerEnds = SimpleTimeMark.farPast()
         }
 
         if (ChocolateFactoryAPI.inChocolateFactory) return
@@ -40,13 +39,13 @@ object ChocolateFactoryTimeTowerManager {
             timeTowerReminder()
         }
 
-        val nextCharge = SimpleTimeMark(profileStorage.nextTimeTower)
+        val nextCharge = profileStorage.nextTimeTower
 
         if (nextCharge.isInPast() && !nextCharge.isFarPast() && currentCharges() < maxCharges()) {
             profileStorage.currentTimeTowerUses++
 
-            val nextTimeTower = SimpleTimeMark(profileStorage.nextTimeTower) + (profileStorage.timeTowerCooldown).hours
-            profileStorage.nextTimeTower = nextTimeTower.toMillis()
+            val nextTimeTower = profileStorage.nextTimeTower + (profileStorage.timeTowerCooldown).hours
+            profileStorage.nextTimeTower = nextTimeTower
 
             if (!config.timeTowerWarning) return
             ChatUtils.clickableChat(
@@ -98,20 +97,20 @@ object ChocolateFactoryTimeTowerManager {
     fun timeTowerFull() = currentCharges() >= maxCharges()
 
     fun timeTowerActive(): Boolean {
-        val currentTime = profileStorage?.lastDataSave ?: 0
+        val currentTime = profileStorage?.lastDataSave ?: SimpleTimeMark.farPast()
         val endTime = timeTowerEnds()
 
         return endTime > currentTime
     }
 
-    private fun timeTowerEnds(): Long {
-        return profileStorage?.currentTimeTowerEnds ?: 0
+    private fun timeTowerEnds(): SimpleTimeMark {
+        return profileStorage?.currentTimeTowerEnds ?: SimpleTimeMark.farPast()
     }
 
     private fun timeTowerReminder() {
         if (lastTimeTowerReminder.passedSince() < 20.seconds) return
 
-        val timeUntil = SimpleTimeMark(timeTowerEnds()).timeUntil()
+        val timeUntil = timeTowerEnds().timeUntil()
         if (timeUntil < 1.minutes && timeUntil.isPositive()) {
             ChatUtils.clickableChat(
                 "§cYour Time Tower is about to end! " +
@@ -128,7 +127,7 @@ object ChocolateFactoryTimeTowerManager {
     fun timeTowerFullTimeMark(): SimpleTimeMark {
         val profileStorage = profileStorage ?: return SimpleTimeMark.farPast()
         if (timeTowerFull()) return SimpleTimeMark.farPast()
-        val nextChargeDuration = SimpleTimeMark(profileStorage.nextTimeTower)
+        val nextChargeDuration = profileStorage.nextTimeTower
         val remainingChargesAfter = profileStorage.maxTimeTowerUses - (profileStorage.currentTimeTowerUses + 1)
         val endTime = nextChargeDuration + ChocolateFactoryAPI.timeTowerChargeDuration() * remainingChargesAfter
 
@@ -137,11 +136,11 @@ object ChocolateFactoryTimeTowerManager {
 
     fun timeTowerActiveDuration(): Duration {
         if (!timeTowerActive()) return Duration.ZERO
-        val currentTime = profileStorage?.lastDataSave ?: 0
-        val endTime = profileStorage?.currentTimeTowerEnds ?: 0
+        val currentTime = profileStorage?.lastDataSave ?: SimpleTimeMark.farPast()
+        val endTime = profileStorage?.currentTimeTowerEnds ?: SimpleTimeMark.farPast()
 
         val duration = endTime - currentTime
-        return duration.milliseconds
+        return duration
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
@@ -27,7 +27,7 @@ object ChocolateFactoryUpgradeWarning {
         if (!LorenzUtils.inSkyBlock) return
         val profileStorage = profileStorage ?: return
 
-        val upgradeAvailableAt = SimpleTimeMark(profileStorage.bestUpgradeAvailableAt)
+        val upgradeAvailableAt = profileStorage.bestUpgradeAvailableAt
         if (upgradeAvailableAt.isInPast() && !upgradeAvailableAt.isFarPast()) {
             checkUpgradeWarning()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolatePositionChange.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolatePositionChange.kt
@@ -14,7 +14,7 @@ object ChocolatePositionChange {
     fun update(position: Int?, leaderboard: String) {
         position ?: return
         val storage = storage ?: return
-        val lastTime = storage.lastTime?.let { SimpleTimeMark(it) }
+        val lastTime = storage.lastTime
         val lastPosition = storage.lastPosition
         val lastLeaderboard = storage.lastLeaderboard
 
@@ -34,7 +34,7 @@ object ChocolatePositionChange {
             }
         }
 
-        storage.lastTime = SimpleTimeMark.now().toMillis()
+        storage.lastTime = SimpleTimeMark.now()
         storage.lastLeaderboard = leaderboard
         storage.lastPosition = position
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/GenericWrapper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GenericWrapper.kt
@@ -1,0 +1,9 @@
+package at.hannibal2.skyhanni.utils
+
+class GenericWrapper<T>(val it: T) {
+    companion object {
+        @JvmStatic
+        @JvmName("getSimpleTimeMark")
+        fun getSimpleTimeMark(it: SimpleTimeMark) = GenericWrapper(it)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
@@ -33,9 +33,10 @@ value class SimpleTimeMark(private val millis: Long) : Comparable<SimpleTimeMark
 
     override fun compareTo(other: SimpleTimeMark): Int = millis.compareTo(other.millis)
 
-    override fun toString(): String {
-        if (millis == 0L) return "The Far Past"
-        return Instant.ofEpochMilli(millis).toString()
+    override fun toString(): String = when (this) {
+        farPast() -> "The Far Past"
+        farFuture() -> "The Far Future"
+        else -> Instant.ofEpochMilli(millis).toString()
     }
 
     fun formattedDate(pattern: String): String {
@@ -60,6 +61,9 @@ value class SimpleTimeMark(private val millis: Long) : Comparable<SimpleTimeMark
     companion object {
 
         fun now() = SimpleTimeMark(System.currentTimeMillis())
+
+        @JvmStatic
+        @JvmName("farPast")
         fun farPast() = SimpleTimeMark(0)
         fun farFuture() = SimpleTimeMark(Long.MAX_VALUE)
 


### PR DESCRIPTION
## What
Changes the long value that are time marks to use the SimpleTimeMark.

The GenericWrapper is added to construct a SimpleTimeMark in Java since it can't be directly since the compiler unboxes the class.

## Changelog Technical Details
+ Migrated long to SimpleTimeMark in Storage if they are time marks. - Thunderblade73

