### PR TITLE
Fix: Compact Pattern Matching on Legendary+ Rabbits

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -60,7 +60,7 @@ object HoppityEggsManager {
      */
     val newRabbitFound by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.found.new",
-        "§d§lNEW RABBIT! §6\\+(?<chocolate>.*) Chocolate §7and §6\\+(?<perSecond>.*)x Chocolate §7per second!"
+        "§d§lNEW RABBIT! (§6\\+(?<chocolate>.*) Chocolate §7and )?§6\\+(?<perSecond>.*)x Chocolate §7per second!"
     )
     private val noEggsLeftPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "egg.noneleft",


### PR DESCRIPTION
## Dependencies
See #1923 for original context, or the reported issue here: https://discord.com/channels/997079228510117908/1245403391639949464

## What
Fix the pattern matching to correctly identify Legendary rabbits while compacting.

<details>
<summary>Images</summary>

Old expression against legendary test-case.
![image](https://github.com/hannibal002/SkyHanni/assets/40234707/dcd8bbb7-7570-4770-83a4-739315c7acd1)

New expression against legendary test-case.
![image](https://github.com/hannibal002/SkyHanni/assets/40234707/53ccec40-4e85-4113-9e9d-c58714b1f6b4)

New expression against non-legendary test-case.
![image](https://github.com/hannibal002/SkyHanni/assets/40234707/1803a50c-5d5b-404e-b4f2-9e452a8cf44f)

</details>

## Changelog Fixes
+ Fixed compact chat sometimes breaking when obtaining legendary or higher tier rabbits. - Daveed
