### PR TITLE
Backend: Change editor config a bit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ ij_any_block_comment_add_space = true
 ij_any_line_comment_add_space = true
 
 # Max line length
-max_line_length = 140
+max_line_length = 120
 
 # Java Files
 [*.java]

--- a/.editorconfig
+++ b/.editorconfig
@@ -49,6 +49,7 @@ ktlint_standard_context-receiver-wrapping = disabled
 ktlint_standard_multiline-expression-wrapping = disabled
 ktlint_standard_string-template-indent = disabled
 ktlint_standard_no-trailing-spaces = disabled
+ktlint_standard_function-signature = disabled
 
 ktlint_standard_no-line-break-before-assignment = true
 ktlint_standard_no-wildcard-imports = enabled

--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,7 @@ ij_java_class_count_to_use_import_on_demand = 2147483647
 ij_java_packages_to_use_import_on_demand = 2147483647
 
 [*.kt]
-ktlint_code_style=intellij_idea
+ktlint_code_style = intellij_idea
 
 # Kotlin files should not use wildcard imports
 ij_kotlin_name_count_to_use_star_import = 2147483647

--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,7 @@ ij_kotlin_enum_constants_wrap = split_into_lines
 ij_kotlin_allow_trailing_comma_on_call_site = true
 ij_kotlin_allow_trailing_comma = true
 
+ktlint_standard_multiline-if-else = disabled
 ktlint_standard_no-empty-first-line-in-class-body = disabled
 ktlint_standard_no-single-line-block-comment = disabled
 ktlint_standard_no-blank-line-before-rbrace = disabled

--- a/.editorconfig
+++ b/.editorconfig
@@ -50,6 +50,7 @@ ktlint_standard_multiline-expression-wrapping = disabled
 ktlint_standard_string-template-indent = disabled
 ktlint_standard_no-trailing-spaces = disabled
 ktlint_standard_function-signature = disabled
+ktlint_standard_wrapping = disabled
 
 ktlint_standard_no-line-break-before-assignment = true
 ktlint_standard_no-wildcard-imports = enabled


### PR DESCRIPTION
Made the linter less aggressive, we can re-evaluate some more of these later but for now some more rules will be disabled

Re allow:
```kt
if (conditon) {
	something
} else return
```
some wrapping stuff

make it not try to force functions to have their parameters to be on one line

max line length back to 120 from 140 (hopefully will come back once we work out why Hannibal's intellij doesnt recognise this but the reformatter does or something)

exclude_from_changelog