### PR TITLE
Backend: Change editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -53,6 +53,7 @@ ktlint_standard_string-template-indent = disabled
 ktlint_standard_no-trailing-spaces = disabled
 ktlint_standard_function-signature = disabled
 ktlint_standard_wrapping = enabled
+ktlint_standard_argument-list-wrapping = disabled
 
 ktlint_standard_no-wildcard-imports = enabled
 ktlint_standard_function-expression-body = disabled

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ ij_any_block_comment_add_space = true
 ij_any_line_comment_add_space = true
 
 # Max line length
-max_line_length = 120
+max_line_length = 140
 
 # Java Files
 [*.java]
@@ -52,7 +52,7 @@ ktlint_standard_multiline-expression-wrapping = false
 ktlint_standard_string-template-indent = disabled
 ktlint_standard_no-trailing-spaces = disabled
 ktlint_standard_function-signature = disabled
-ktlint_standard_wrapping = enabled
+ktlint_standard_wrapping = disabled
 ktlint_standard_argument-list-wrapping = disabled
 
 ktlint_standard_no-wildcard-imports = enabled


### PR DESCRIPTION
Makes max line length be 140 again, and sets ktlint_standard_wrapping and ktlint_standard_argument-list-wrapping to disabled

exclude_from_changelog