### PR TITLE
Fix: Chat formatting categorising stash pickup messages as private chat

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -68,14 +68,15 @@ object PlayerChatManager {
     /**
      * REGEX-TEST: To nea89o: lol
      * REGEX-TEST: From nea89o: hiii
-     * REGEX-TEST: §eFrom stash: §r§fPufferfish
+     * REGEX-TEST: From stash: Pufferfish
+     * REGEX-TEST: From stash: Wheat
      * REGEX-TEST: To [MVP+] Eisengolem: Boop!
      * REGEX-TEST: From [MVP+] Eisengolem: Boop!
      * REGEX-TEST: To [MVP+] Eisengolem: danke
      */
     private val privateMessagePattern by patternGroup.pattern(
         "privatemessage",
-        "^(?!§eFrom stash: §r)(?<direction>From|To) (?<author>[^:]*): (?<message>.*)"
+        "^(?!From stash: )(?<direction>From|To) (?<author>[^:]*): (?<message>.*)"
     )
 
     /**


### PR DESCRIPTION
## What
Chat formatting erroneously detects stash pickup messages as private messages, and the issue appears yet to be resolved from #1716. The problem was that the chat messages captured (into `chatComponent`) has already been removed of formatting (unformatted text, refer to the `intoSpan()` function), and thus the regex does not work correctly to not capture the stash pickup messages.

I have updated the regex accordingly without the formatting codes, and these changes have been tested and confirmed working (see attached images, expected behaviour screenshots are generated after applying the fix)

<details>
<summary>Images</summary>

### Expected Behaviour (when picking up stash):

<img width="737" alt="Screenshot 2024-06-12 at 4 39 44 PM" src="https://github.com/hannibal002/SkyHanni/assets/26355099/3e1e1de2-80f3-475b-9d2b-8a802a5fd6dc">
<img width="498" alt="Screenshot 2024-06-12 at 4 39 32 PM" src="https://github.com/hannibal002/SkyHanni/assets/26355099/8c4932e5-d845-4359-a0f3-d5404b3a4429">
  
### Actual (unintended) Behaviour:

<img width="492" alt="Screenshot 2024-06-12 at 4 06 14 PM" src="https://github.com/hannibal002/SkyHanni/assets/26355099/6125e5d8-5078-4b42-ac08-3ada74b4120e">

</details>

## Changelog Fixes
+ Fixed stash getting detected as a private message. - sayomaki
