### PR TITLE
Backend: Disable class-signature

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -54,6 +54,8 @@ ktlint_standard_no-trailing-spaces = disabled
 ktlint_standard_function-signature = disabled
 ktlint_standard_wrapping = disabled
 ktlint_standard_argument-list-wrapping = disabled
+ktlint_standard_class-signature = disabled
+ktlint_standard_final-newline = disabled
 
 ktlint_standard_no-wildcard-imports = enabled
 ktlint_standard_function-expression-body = disabled


### PR DESCRIPTION
## What
Currently Ktlint has a bug with the class signature rule causing it to say that the parentheses are not needed for a constructor when they are, as of right now until https://github.com/pinterest/ktlint/issues/2690 gets closed we will need to disable this rule.

In addition also disabling requiring final newline.

exclude_from_changelog
