### PR TITLE
Fix: Unknown Lines not appearing instantly

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -815,15 +815,15 @@ private fun getFooterDisplayPair(): List<ScoreboardElementType> =
     ).flatten()
 
 private fun getExtraDisplayPair(): List<ScoreboardElementType> {
-    if (confirmedUnknownLines.isEmpty()) return listOf("<hidden>" to HorizontalAlignment.LEFT)
-    amountOfUnknownLines = confirmedUnknownLines.size
+    if (unconfirmedUnknownLines.isEmpty()) return listOf("<hidden>" to HorizontalAlignment.LEFT)
+    amountOfUnknownLines = unconfirmedUnknownLines.size
 
-    return listOf("§cUndetected Lines:" to HorizontalAlignment.LEFT) + confirmedUnknownLines.map { it to HorizontalAlignment.LEFT }
+    return listOf("§cUndetected Lines:" to HorizontalAlignment.LEFT) + unconfirmedUnknownLines.map { it to HorizontalAlignment.LEFT }
 }
 
 private fun getExtraShowWhen(): Boolean {
-    if (confirmedUnknownLines.isEmpty()) {
+    if (unconfirmedUnknownLines.isEmpty()) {
         amountOfUnknownLines = 0
     }
-    return confirmedUnknownLines.isNotEmpty()
+    return unconfirmedUnknownLines.isNotEmpty()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -173,7 +173,7 @@ object UnknownLinesHandler {
 
 
         /*
-         * handle broken scoreboard lines
+         * Handle broken scoreboard lines
          */
         confirmedUnknownLines.forEach { line ->
             if (!unconfirmedUnknownLines.contains(line)) {


### PR DESCRIPTION
## Changelog Fixes
+ Fixed unknown lines not appearing instantly in the Custom Scoreboard. - j10a1n15
