### PR TITLE
Improvement: Better Hypixel detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -38,6 +38,14 @@ import kotlin.time.Duration.Companion.seconds
 class HypixelData {
 
     private val patternGroup = RepoPattern.group("data.hypixeldata")
+    private val serverNameConnectionPattern by patternGroup.pattern(
+        "servername.connection",
+        "(?<prefix>.+\\.)?hypixel\\.net",
+    )
+    private val serverNameScoreboardPattern by patternGroup.pattern(
+        "servername.scoreboard",
+        "§e(?<prefix>.+\\.)?hypixel\\.net",
+    )
     private val islandNamePattern by patternGroup.pattern(
         "islandname",
         "(?:§.)*(Area|Dungeon): (?:§.)*(?<island>.*)",
@@ -370,12 +378,34 @@ class HypixelData {
     }
 
     private fun checkHypixel() {
-        val list = ScoreboardData.sidebarLinesFormatted
-        if (list.isEmpty()) return
+        val mc = Minecraft.getMinecraft()
+        val player = mc.thePlayer ?: return
 
-        val last = list.last()
-        hypixelLive = last == "§ewww.hypixel.net"
-        hypixelAlpha = last == "§ealpha.hypixel.net"
+        var hypixel = false
+
+        player.clientBrand?.let {
+            if (it.contains("hypixel", ignoreCase = true)) {
+                hypixel = true
+            }
+        }
+
+        serverNameConnectionPattern.matchMatcher(mc.getCurrentServerData().serverIP) {
+            hypixel = true
+            if (group("prefix") == "alpha.") {
+                hypixelAlpha = true
+            }
+        }
+
+        for (line in ScoreboardData.sidebarLinesFormatted) {
+            serverNameScoreboardPattern.matchMatcher(line) {
+                hypixel = true
+                if (group("prefix") == "alpha.") {
+                    hypixelAlpha = true
+                }
+            }
+        }
+
+        hypixelLive = hypixel && !hypixelAlpha
     }
 
     private fun checkSidebar() {


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

## What
Improved Hypixel detection. Now also checks clientBrand and address the player connected to, and works even if the scoreboard line isn't the last (as has been shown to be possible lately).

## Changelog Improvements
+ Improved Hypixel server detection. - Luna