### PR TITLE
Fix: isKeyHeld crash

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -88,7 +88,7 @@ object KeyboardManager {
             lastClickedMouseButton = -1
         }
 
-        // I don't know when this is needed
+        // This is needed because of other keyboards that don't have a key code for the key, but is read as a character
         if (Keyboard.getEventKey() == 0) {
             LorenzKeyPressEvent(Keyboard.getEventCharacter().code + 256).postAndCatch()
         }
@@ -112,8 +112,11 @@ object KeyboardManager {
         if (this == 0) return false
         return if (this < 0) {
             Mouse.isButtonDown(this + 100)
+        } else if (this >= Keyboard.KEYBOARD_SIZE) {
+            val pressedKey = if (Keyboard.getEventKey() == 0) Keyboard.getEventCharacter().code + 256 else Keyboard.getEventKey()
+            Keyboard.getEventKeyState() && this == pressedKey
         } else {
-            KeybindHelper.isKeyDown(this)
+            Keyboard.isKeyDown(this)
         }
     }
 


### PR DESCRIPTION
## What
Currently `KeyboardManager.isKeyHeld` calls `KeybindHelper.isKeyDown` which calls `Keyboard.isKeyDown` which can only handles the standard 256 keys, some keyboards in other languages have keys which are not apart of these 256 keys and get sent as a NONE key with extra info for the character but mojang store this as the char code + 256 so it crashes when it encounters one of these values.

See: https://discord.com/channels/997079228510117908/1000669238035497022/1250451219902632039

## Changelog Fixes
+ Fixed crash if a key code is set to a non-standard key. - ThatGravyBoat