### PR TITLE
Fix: Wardrobe slot color & Event priority

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -584,7 +584,7 @@ object CustomWardrobe {
     private fun WardrobeSlot.getSlotColor(): Color = with(config.color) {
         when {
             isCurrentSlot() -> equippedColor
-            favorite -> favoriteColor
+            favorite && !config.onlyFavorites -> favoriteColor
             else -> null
         }?.toChromaColor()?.transformIf({ !isInCurrentPage() }) { darker() }
             ?: (if (isInCurrentPage()) samePageColor else otherPageColor).toChromaColor()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeAPI.kt
@@ -21,6 +21,7 @@ import net.minecraft.init.Blocks
 import net.minecraft.init.Items
 import net.minecraft.item.EnumDyeColor
 import net.minecraft.item.ItemStack
+import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -109,7 +110,7 @@ object WardrobeAPI {
         }
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGH)
     fun onInventoryUpdate(event: InventoryUpdatedEvent) {
         if (!LorenzUtils.inSkyBlock) return
 


### PR DESCRIPTION
## What
Fixes having to switch wardrobe pages on first load to actually display the correct data, and also showing the favorite background color when only favorites is enabled.

## Changelog Fixes
+ Fixed showing the favorite wardrobe slot background color while in "Only Favorites" mode. - Empa