### PR TITLE
Improvement: Add Recipe Link to Shopping List Craftable! text

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -80,24 +80,24 @@ object GardenVisitorFeatures {
 
     private val patternGroup = RepoPattern.group("garden.visitor")
     private val visitorArrivePattern by patternGroup.pattern(
-            "visitorarrive",
-            ".* §r§ehas arrived on your §r§bGarden§r§e!",
+        "visitorarrive",
+        ".* §r§ehas arrived on your §r§bGarden§r§e!"
     )
     private val copperPattern by patternGroup.pattern(
-            "copper",
-            " §8\\+§c(?<amount>.*) Copper",
+        "copper",
+        " §8\\+§c(?<amount>.*) Copper"
     )
     private val gardenExperiencePattern by patternGroup.pattern(
-            "gardenexperience",
-            " §8\\+§2(?<amount>.*) §7Garden Experience",
+        "gardenexperience",
+        " §8\\+§2(?<amount>.*) §7Garden Experience"
     )
     private val visitorChatMessagePattern by patternGroup.pattern(
-            "visitorchat",
-            "§e\\[NPC] (?<color>§.)?(?<name>.*)§f: §r.*",
+        "visitorchat",
+        "§e\\[NPC] (?<color>§.)?(?<name>.*)§f: §r.*"
     )
     private val partialAcceptedPattern by patternGroup.pattern(
-            "partialaccepted",
-            "§aYou gave some of the required items!",
+        "partialaccepted",
+        "§aYou gave some of the required items!"
     )
 
     private val logger = LorenzLogger("garden/visitors")
@@ -126,11 +126,11 @@ object GardenVisitorFeatures {
 
             val (itemName, amount) = ItemUtils.readItemAmount(line) ?: run {
                 ErrorManager.logErrorStateWithData(
-                        "Could not read Shopping List in Visitor Inventory", "ItemUtils.readItemAmount returns null",
-                        "line" to line,
-                        "offerItem" to offerItem,
-                        "lore" to lore,
-                        "visitor" to visitor,
+                    "Could not read Shopping List in Visitor Inventory", "ItemUtils.readItemAmount returns null",
+                    "line" to line,
+                    "offerItem" to offerItem,
+                    "lore" to lore,
+                    "visitor" to visitor
                 )
                 continue
             }
@@ -194,18 +194,13 @@ object GardenVisitorFeatures {
             list.add(" §7- ")
             list.add(itemStack)
 
-            list.add(
-                    Renderable.optionalLink(
-                            "$name §ex${amount.addSeparators()}",
-                            {
-                                if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
-                                    LorenzUtils.setTextIntoSign("$amount")
-                                } else {
-                                    BazaarApi.searchForBazaarItem(name, amount)
-                                }
-                            },
-                    ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() },
-            )
+            list.add(Renderable.optionalLink("$name §ex${amount.addSeparators()}", {
+                if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
+                    LorenzUtils.setTextIntoSign("$amount")
+                } else {
+                    BazaarApi.searchForBazaarItem(name, amount)
+                }
+            }) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() })
 
             if (config.shoppingList.showPrice) {
                 val price = internalName.getPrice() * amount
@@ -259,22 +254,19 @@ object GardenVisitorFeatures {
             }
         }
         if (hasIngredients) {
-            val leftToCraft = amount - amountInSacks
+            val leftToCraft = amount - amountInSacks;
             list.add(" §7(")
-            list.add(
-                    Renderable.optionalLink(
-                            "§aCraftable!",
-                            {
-                                if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
-                                    LorenzUtils.setTextIntoSign("$leftToCraft")
-                                } else {
-                                    //  Possibly extract to a RecipeAPI object?
-                                    //  TBD whether internal name or 'display name' as itemName better suited here?
-                                    HypixelCommands.recipe(internalName.itemName)
-                                }
-                            },
-                    ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() },
-            )
+            list.add(Renderable.optionalLink(
+                "§aCraftable!", {
+                    if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
+                        LorenzUtils.setTextIntoSign("$leftToCraft")
+                    } else {
+                        //  Possibly extract to a RecipeAPI object?
+                        //  TBD whether internal name or 'display name' as itemName better suited here?
+                        HypixelCommands.recipe(internalName.itemName)
+                    }
+                }
+            ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() })
             list.add("§7)")
         }
     }
@@ -576,8 +568,8 @@ object GardenVisitorFeatures {
                 val color = visitor.status.color
                 if (color != -1) {
                     RenderLivingEntityHelper.setEntityColor(
-                            entity,
-                            color,
+                        entity,
+                        color
                     ) { config.highlightStatus == HighlightMode.COLOR || config.highlightStatus == HighlightMode.BOTH }
                 }
                 // Haven't gotten either of the known effected visitors (Vex and Leo) so can't test for sure
@@ -694,9 +686,9 @@ object GardenVisitorFeatures {
         event.move(3, "garden.visitorRewardWarning.notifyInChat", "garden.visitors.rewardWarning.notifyInChat")
         event.move(3, "garden.visitorRewardWarning.showOverName", "garden.visitors.rewardWarning.showOverName")
         event.move(
-                3,
-                "garden.visitorRewardWarning.preventRefusing",
-                "garden.visitors.rewardWarning.preventRefusing",
+            3,
+            "garden.visitorRewardWarning.preventRefusing",
+            "garden.visitors.rewardWarning.preventRefusing"
         )
         event.move(3, "garden.visitorRewardWarning.bypassKey", "garden.visitors.rewardWarning.bypassKey")
         event.move(3, "garden.visitorRewardWarning.drops", "garden.visitors.rewardWarning.drops")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -265,7 +265,7 @@ object GardenVisitorFeatures {
                         } else {
                             //  Possibly extract to a RecipeAPI object?
                             //  TBD whether internal name or 'display name' as itemName better suited here?
-                            HypixelCommands.recipe(internalName.itemName)
+                            HypixelCommands.viewRecipe(internalName.toString())
                         }
                     },
                 ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() },

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -263,8 +263,6 @@ object GardenVisitorFeatures {
                         if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
                             LorenzUtils.setTextIntoSign("$leftToCraft")
                         } else {
-                            //  Possibly extract to a RecipeAPI object?
-                            //  TBD whether internal name or 'display name' as itemName better suited here?
                             HypixelCommands.viewRecipe(internalName.toString())
                         }
                     },

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -254,19 +254,21 @@ object GardenVisitorFeatures {
             }
         }
         if (hasIngredients) {
-            val leftToCraft = amount - amountInSacks;
+            val leftToCraft = amount - amountInSacks
             list.add(" §7(")
-            list.add(Renderable.optionalLink(
+            list.add(
+                Renderable.optionalLink(
                 "§aCraftable!", {
-                    if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
-                        LorenzUtils.setTextIntoSign("$leftToCraft")
-                    } else {
-                        //  Possibly extract to a RecipeAPI object?
-                        //  TBD whether internal name or 'display name' as itemName better suited here?
-                        HypixelCommands.recipe(internalName.itemName)
+                        if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
+                            LorenzUtils.setTextIntoSign("$leftToCraft")
+                        } else {
+                            //  Possibly extract to a RecipeAPI object?
+                            //  TBD whether internal name or 'display name' as itemName better suited here?
+                            HypixelCommands.recipe(internalName.itemName)
+                        }
                     }
-                }
-            ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() })
+                ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() }
+            )
             list.add("§7)")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -80,24 +80,24 @@ object GardenVisitorFeatures {
 
     private val patternGroup = RepoPattern.group("garden.visitor")
     private val visitorArrivePattern by patternGroup.pattern(
-        "visitorarrive",
-        ".* §r§ehas arrived on your §r§bGarden§r§e!"
+            "visitorarrive",
+            ".* §r§ehas arrived on your §r§bGarden§r§e!",
     )
     private val copperPattern by patternGroup.pattern(
-        "copper",
-        " §8\\+§c(?<amount>.*) Copper"
+            "copper",
+            " §8\\+§c(?<amount>.*) Copper",
     )
     private val gardenExperiencePattern by patternGroup.pattern(
-        "gardenexperience",
-        " §8\\+§2(?<amount>.*) §7Garden Experience"
+            "gardenexperience",
+            " §8\\+§2(?<amount>.*) §7Garden Experience",
     )
     private val visitorChatMessagePattern by patternGroup.pattern(
-        "visitorchat",
-        "§e\\[NPC] (?<color>§.)?(?<name>.*)§f: §r.*"
+            "visitorchat",
+            "§e\\[NPC] (?<color>§.)?(?<name>.*)§f: §r.*",
     )
     private val partialAcceptedPattern by patternGroup.pattern(
-        "partialaccepted",
-        "§aYou gave some of the required items!"
+            "partialaccepted",
+            "§aYou gave some of the required items!",
     )
 
     private val logger = LorenzLogger("garden/visitors")
@@ -126,11 +126,11 @@ object GardenVisitorFeatures {
 
             val (itemName, amount) = ItemUtils.readItemAmount(line) ?: run {
                 ErrorManager.logErrorStateWithData(
-                    "Could not read Shopping List in Visitor Inventory", "ItemUtils.readItemAmount returns null",
-                    "line" to line,
-                    "offerItem" to offerItem,
-                    "lore" to lore,
-                    "visitor" to visitor
+                        "Could not read Shopping List in Visitor Inventory", "ItemUtils.readItemAmount returns null",
+                        "line" to line,
+                        "offerItem" to offerItem,
+                        "lore" to lore,
+                        "visitor" to visitor,
                 )
                 continue
             }
@@ -194,13 +194,18 @@ object GardenVisitorFeatures {
             list.add(" §7- ")
             list.add(itemStack)
 
-            list.add(Renderable.optionalLink("$name §ex${amount.addSeparators()}", {
-                if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
-                    LorenzUtils.setTextIntoSign("$amount")
-                } else {
-                    BazaarApi.searchForBazaarItem(name, amount)
-                }
-            }) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() })
+            list.add(
+                    Renderable.optionalLink(
+                            "$name §ex${amount.addSeparators()}",
+                            {
+                                if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
+                                    LorenzUtils.setTextIntoSign("$amount")
+                                } else {
+                                    BazaarApi.searchForBazaarItem(name, amount)
+                                }
+                            },
+                    ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() },
+            )
 
             if (config.shoppingList.showPrice) {
                 val price = internalName.getPrice() * amount
@@ -254,17 +259,22 @@ object GardenVisitorFeatures {
             }
         }
         if (hasIngredients) {
-            val leftToCraft = amount - amountInSacks;
+            val leftToCraft = amount - amountInSacks
             list.add(" §7(")
-            list.add(Renderable.optionalLink("§aCraftable!", {
-                if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
-                    LorenzUtils.setTextIntoSign("$leftToCraft")
-                } else {
-                    //  Possibly extract to a RecipeAPI object?
-                    //  TBD whether internal name or 'display name' as itemName better suited here?
-                    HypixelCommands.recipe(internalName.itemName)
-                }
-            }) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() })
+            list.add(
+                    Renderable.optionalLink(
+                            "§aCraftable!",
+                            {
+                                if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
+                                    LorenzUtils.setTextIntoSign("$leftToCraft")
+                                } else {
+                                    //  Possibly extract to a RecipeAPI object?
+                                    //  TBD whether internal name or 'display name' as itemName better suited here?
+                                    HypixelCommands.recipe(internalName.itemName)
+                                }
+                            },
+                    ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() },
+            )
             list.add("§7)")
         }
     }
@@ -566,8 +576,8 @@ object GardenVisitorFeatures {
                 val color = visitor.status.color
                 if (color != -1) {
                     RenderLivingEntityHelper.setEntityColor(
-                        entity,
-                        color
+                            entity,
+                            color,
                     ) { config.highlightStatus == HighlightMode.COLOR || config.highlightStatus == HighlightMode.BOTH }
                 }
                 // Haven't gotten either of the known effected visitors (Vex and Leo) so can't test for sure
@@ -684,9 +694,9 @@ object GardenVisitorFeatures {
         event.move(3, "garden.visitorRewardWarning.notifyInChat", "garden.visitors.rewardWarning.notifyInChat")
         event.move(3, "garden.visitorRewardWarning.showOverName", "garden.visitors.rewardWarning.showOverName")
         event.move(
-            3,
-            "garden.visitorRewardWarning.preventRefusing",
-            "garden.visitors.rewardWarning.preventRefusing"
+                3,
+                "garden.visitorRewardWarning.preventRefusing",
+                "garden.visitors.rewardWarning.preventRefusing",
         )
         event.move(3, "garden.visitorRewardWarning.bypassKey", "garden.visitors.rewardWarning.bypassKey")
         event.move(3, "garden.visitorRewardWarning.drops", "garden.visitors.rewardWarning.drops")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -30,6 +30,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils.getAmountInInventory
 import at.hannibal2.skyhanni.utils.ItemBlink
 import at.hannibal2.skyhanni.utils.ItemUtils
@@ -253,7 +254,18 @@ object GardenVisitorFeatures {
             }
         }
         if (hasIngredients) {
-            list.add(" §7(§aCraftable!§7)")
+            val leftToCraft = amount - amountInSacks;
+            list.add(" §7(")
+            list.add(Renderable.optionalLink("§aCraftable!", {
+                if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
+                    LorenzUtils.setTextIntoSign("$leftToCraft")
+                } else {
+                    //  Possibly extract to a RecipeAPI object?
+                    //  TBD whether internal name or 'display name' as itemName better suited here?
+                    HypixelCommands.recipe(internalName.itemName)
+                }
+            }) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() })
+            list.add("§7)")
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -258,7 +258,8 @@ object GardenVisitorFeatures {
             list.add(" §7(")
             list.add(
                 Renderable.optionalLink(
-                "§aCraftable!", {
+                    "§aCraftable!",
+                    {
                         if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
                             LorenzUtils.setTextIntoSign("$leftToCraft")
                         } else {
@@ -266,8 +267,8 @@ object GardenVisitorFeatures {
                             //  TBD whether internal name or 'display name' as itemName better suited here?
                             HypixelCommands.recipe(internalName.itemName)
                         }
-                    }
-                ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() }
+                    },
+                ) { GardenAPI.inGarden() && !NEUItems.neuHasFocus() },
             )
             list.add("§7)")
         }


### PR DESCRIPTION
## What
(Dupe of #2054 - was merged over and auto-closed by git)
Turn the `Craftable!` text in the visitor shopping list into a link to run `/viewrecipe [item]` to allow for quick super-crafting.

Originally I put this in here: https://discord.com/channels/997079228510117908/1248097757810528329

Would appreciate feedback on the two in-code comments, as to whether or not the current implementation has any problems. Cheers.

<details>
<summary>Images</summary>

Images don't really do this justice. I recorded a ~20 second clip of it working, which you can view here:
https://www.youtube.com/watch?v=eEfXDzq70Cw

Clip shows `/recipe` being used, has since been updated to `/viewrecipe`.

</details>

## Changelog Improvements
+ Allow clicking on the Craftable! text in the shopping list to open the "view recipe" menu. - Daveed
