### PR TITLE
Improvement: Custom Wardrobe Tooltip Keybind

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customwardrobe/CustomWardrobeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customwardrobe/CustomWardrobeConfig.java
@@ -4,7 +4,9 @@ import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.Accordion;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import org.lwjgl.input.Keyboard;
 
 public class CustomWardrobeConfig {
 
@@ -41,6 +43,16 @@ public class CustomWardrobeConfig {
     @ConfigOption(name = "Loading text", desc = "Shows a \"§cLoading...\" §7text when the wardrobe page hasn't fully loaded in yet.")
     @ConfigEditorBoolean
     public boolean loadingText = true;
+
+    @Expose
+    @ConfigOption(name = "Armor Tooltip Keybind", desc = "Only show the lore of the item hovered when holding a keybind.")
+    @ConfigEditorBoolean
+    public boolean showTooltipOnlyKeybind = false;
+
+    @Expose
+    @ConfigOption(name = "Tooltip Keybind", desc = "Press this key to show the item tooltip.")
+    @ConfigEditorKeybind(defaultKey = Keyboard.KEY_LSHIFT)
+    public int tooltipKeybind = Keyboard.KEY_LSHIFT;
 
     @Expose
     @ConfigOption(name = "Colors", desc = "Change the color settings.")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -25,6 +25,7 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils.getFakePlayer
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.removeEnchants
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
@@ -206,7 +207,13 @@ object CustomWardrobe {
             if (stack != null) {
                 val toolTip = getToolTip(stack, slot, armorIndex)
                 if (toolTip != null) {
-                    renderable = Renderable.hoverTips(renderable, tips = toolTip)
+                    renderable = Renderable.hoverTips(
+                        renderable,
+                        tips = toolTip,
+                        condition = {
+                            !config.showTooltipOnlyKeybind || config.tooltipKeybind.isKeyHeld()
+                        },
+                    )
                 }
             }
             loreList.add(renderable)


### PR DESCRIPTION
## What
Adds an option to only show the item tooltip in wardrobe when holding a keybind.

## Changelog Improvements
+ Added an option to show item tooltips in the Custom Wardrobe only when holding a keybind. - Empa