### PR TITLE
Improvement: Wardrobe Outline Color

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeAPI.MAX_SLOT_PE
 import at.hannibal2.skyhanni.mixins.transformers.gui.AccessorGuiContainer
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.darker
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
@@ -316,6 +317,7 @@ object CustomWardrobe {
         val rowsRenderables = chunkedList.map { row ->
             val slotsRenderables = row.map { slot ->
                 val armorTooltipRenderable = createArmorTooltipRenderable(slot, containerHeight, containerWidth)
+                val (topOutline, bottomOutline) = slot.getOutlineColor()
 
                 val playerBackground = createHoverableRenderable(
                     armorTooltipRenderable,
@@ -324,6 +326,8 @@ object CustomWardrobe {
                     borderOutlineThickness = config.spacing.outlineThickness.get(),
                     borderOutlineBlur = config.spacing.outlineBlur.get(),
                     onClick = { slot.clickSlot() },
+                    topOutlineColor = topOutline,
+                    bottomOutlineColor = bottomOutline,
                 )
 
                 val playerRenderable = createFakePlayerRenderable(slot, playerWidth, containerHeight, containerWidth)
@@ -560,6 +564,8 @@ object CustomWardrobe {
         borderOutlineBlur: Float = 0.5f,
         onClick: () -> Unit,
         onHover: () -> Unit = {},
+        topOutlineColor: Color,
+        bottomOutlineColor: Color,
     ): Renderable =
         Renderable.hoverable(
             Renderable.drawInsideRoundedRectWithOutline(
@@ -572,8 +578,8 @@ object CustomWardrobe {
                 ),
                 hoveredColor,
                 padding = padding,
-                topOutlineColor = config.color.topBorderColor.toChromaColorInt(),
-                bottomOutlineColor = config.color.bottomBorderColor.toChromaColorInt(),
+                topOutlineColor = topOutlineColor.rgb,
+                bottomOutlineColor = bottomOutlineColor.rgb,
                 borderOutlineThickness = borderOutlineThickness,
                 blur = borderOutlineBlur,
                 horizontalAlign = horizontalAlignment,
@@ -588,6 +594,15 @@ object CustomWardrobe {
             ),
             onHover = { onHover() },
         )
+
+    private fun WardrobeSlot.getOutlineColor(): Pair<Color, Color> {
+        val (top, bottom) = config.color.topBorderColor.toChromaColor() to config.color.bottomBorderColor.toChromaColor()
+        return when {
+            isEmpty() -> ColorUtils.TRANSPARENT_COLOR to ColorUtils.TRANSPARENT_COLOR
+            !isInCurrentPage() -> top.darker(0.5) to bottom.darker(0.5)
+            else -> top to bottom
+        }
+    }
 
     private fun WardrobeSlot.clickSlot() {
         val previousPageSlot = 45

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -598,7 +598,7 @@ object CustomWardrobe {
     private fun WardrobeSlot.getOutlineColor(): Pair<Color, Color> {
         val (top, bottom) = config.color.topBorderColor.toChromaColor() to config.color.bottomBorderColor.toChromaColor()
         return when {
-            isEmpty() -> ColorUtils.TRANSPARENT_COLOR to ColorUtils.TRANSPARENT_COLOR
+            isEmpty() || locked -> ColorUtils.TRANSPARENT_COLOR to ColorUtils.TRANSPARENT_COLOR
             !isInCurrentPage() -> top.darker(0.5) to bottom.darker(0.5)
             else -> top to bottom
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -457,44 +457,45 @@ object CustomWardrobe {
     }
 
     private fun addSlotHoverableButtons(wardrobeSlot: WardrobeSlot): Renderable {
-        val list = mutableListOf<Renderable>()
         val textScale = 1.5 * (activeScale / 100.0)
-        list.add(
-            Renderable.clickable(
-                Renderable.hoverable(
-                    Renderable.string(
-                        (if (wardrobeSlot.favorite) "§c" else "§7") + "❤",
-                        scale = textScale,
-                        horizontalAlign = HorizontalAlignment.CENTER,
-                        verticalAlign = VerticalAlignment.CENTER,
+        val shouldRender = !wardrobeSlot.isEmpty() && !wardrobeSlot.locked
+        if (!shouldRender && !wardrobeSlot.favorite) return Renderable.placeholder(0, 0)
+        val list = buildList {
+            add(
+                Renderable.clickable(
+                    Renderable.hoverable(
+                        Renderable.string(
+                            (if (wardrobeSlot.favorite) "§c" else "§7") + "❤",
+                            scale = textScale,
+                            horizontalAlign = HorizontalAlignment.CENTER,
+                            verticalAlign = VerticalAlignment.CENTER,
+                        ),
+                        Renderable.string(
+                            (if (wardrobeSlot.favorite) "§4" else "§8") + "❤",
+                            scale = textScale,
+                            horizontalAlign = HorizontalAlignment.CENTER,
+                            verticalAlign = VerticalAlignment.CENTER,
+                        ),
                     ),
-                    Renderable.string(
-                        (if (wardrobeSlot.favorite) "§4" else "§8") + "❤",
-                        scale = textScale,
-                        horizontalAlign = HorizontalAlignment.CENTER,
-                        verticalAlign = VerticalAlignment.CENTER,
-                    ),
-                ),
-                onClick = {
-                    wardrobeSlot.favorite = !wardrobeSlot.favorite
-                    update()
-                },
-            ),
-        )
-
-        if (config.estimatedValue && !wardrobeSlot.isEmpty()) {
-            val lore = WardrobeAPI.createPriceLore(wardrobeSlot)
-            list.add(
-                Renderable.hoverTips(
-                    Renderable.string(
-                        "§2$",
-                        scale = textScale,
-                        horizontalAlign = HorizontalAlignment.CENTER,
-                        verticalAlign = VerticalAlignment.CENTER,
-                    ),
-                    lore,
+                    onClick = {
+                        wardrobeSlot.favorite = !wardrobeSlot.favorite
+                        update()
+                    },
                 ),
             )
+            if (config.estimatedValue && shouldRender) {
+                add(
+                    Renderable.hoverTips(
+                        Renderable.string(
+                            "§2$",
+                            scale = textScale,
+                            horizontalAlign = HorizontalAlignment.CENTER,
+                            verticalAlign = VerticalAlignment.CENTER,
+                        ),
+                        WardrobeAPI.createPriceLore(wardrobeSlot),
+                    ),
+                )
+            }
         }
 
         return Renderable.verticalContainer(list, 1, HorizontalAlignment.RIGHT)

--- a/src/main/java/at/hannibal2/skyhanni/utils/ColorUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ColorUtils.kt
@@ -29,8 +29,10 @@ object ColorUtils {
         (red * factor).toInt().coerceIn(0, 255),
         (green * factor).toInt().coerceIn(0, 255),
         (blue * factor).toInt().coerceIn(0, 255),
-        alpha
+        alpha,
     )
+
+    val TRANSPARENT_COLOR = Color(0, 0, 0, 0)
 
     fun Color.withAlpha(alpha: Int): Int = (alpha.coerceIn(0, 255) shl 24) or (this.rgb and 0x00ffffff)
 


### PR DESCRIPTION
## What
Darken the color of the custom wardrobe slot outline color when the slot is in another page, and hide it completely if its an empty or locked slot.
Also makes the favorite button not show in empty/locked slots.

## Changelog Improvements
+ Improved Custom Wardrobe outline color. - Empa