### PR TITLE
Improvement: Estimated Item Value support in Custom Wardrobe

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customwardrobe/CustomWardrobeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customwardrobe/CustomWardrobeConfig.java
@@ -4,7 +4,9 @@ import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.Accordion;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import org.lwjgl.input.Keyboard;
 
 public class CustomWardrobeConfig {
 
@@ -41,6 +43,16 @@ public class CustomWardrobeConfig {
     @ConfigOption(name = "Loading text", desc = "Shows a \"§cLoading...\" §7text when the wardrobe page hasn't fully loaded in yet.")
     @ConfigEditorBoolean
     public boolean loadingText = true;
+
+    @Expose
+    @ConfigOption(name = "Armor Tooltip Keybind", desc = "Only show the lore of the item hovered when holding a keybind.")
+    @ConfigEditorBoolean
+    public boolean showTooltipOnlyKeybind = false;
+
+    @Expose
+    @ConfigOption(name = "Tooltip Keybind", desc = "Press this key to show the item tooltip.")
+    @ConfigEditorKeybind(defaultKey = Keyboard.KEY_LSHIFT)
+    public int tooltipKeybind = Keyboard.KEY_LSHIFT;
 
     @Expose
     @ConfigOption(name = "Colors", desc = "Change the color settings.")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeAPI.MAX_PAGES
 import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeAPI.MAX_SLOT_PER_PAGE
+import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.mixins.transformers.gui.AccessorGuiContainer
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -210,8 +211,14 @@ object CustomWardrobe {
                     renderable = Renderable.hoverTips(
                         renderable,
                         tips = toolTip,
+                        stack = stack,
                         condition = {
                             !config.showTooltipOnlyKeybind || config.tooltipKeybind.isKeyHeld()
+                        },
+                        onHover = {
+                            if (EstimatedItemValue.config.enabled) {
+                                EstimatedItemValue.updateItem(stack)
+                            }
                         },
                     )
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -25,6 +25,7 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils.getFakePlayer
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.removeEnchants
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
@@ -206,7 +207,13 @@ object CustomWardrobe {
             if (stack != null) {
                 val toolTip = getToolTip(stack, slot, armorIndex)
                 if (toolTip != null) {
-                    renderable = Renderable.hoverTips(renderable, tips = toolTip)
+                    renderable = Renderable.hoverTips(
+                        renderable,
+                        tips = toolTip,
+                        condition = {
+                            !config.showTooltipOnlyKeybind || config.tooltipKeybind.isKeyHeld()
+                        },
+                    )
                 }
             }
             loreList.add(renderable)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -42,7 +42,6 @@ import java.awt.Color
 import kotlin.math.min
 import kotlin.time.Duration.Companion.milliseconds
 
-// TODO add support for estimated item value
 @SkyHanniModule
 object CustomWardrobe {
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -89,9 +89,16 @@ object CustomWardrobe {
             loadingPos.renderRenderable(loadingRenderable, posLabel = guiName, addToGuiManager = false)
         }
 
+        GlStateManager.pushMatrix()
         GlStateManager.translate(0f, 0f, 100f)
+
         pos.renderRenderable(renderable, posLabel = guiName, addToGuiManager = false)
-        GlStateManager.translate(0f, 0f, -100f)
+
+        if (EstimatedItemValue.config.enabled) {
+            GlStateManager.translate(0f, 0f, 400f)
+            EstimatedItemValue.tryRendering()
+        }
+        GlStateManager.popMatrix()
         event.cancel()
     }
 
@@ -216,9 +223,7 @@ object CustomWardrobe {
                             !config.showTooltipOnlyKeybind || config.tooltipKeybind.isKeyHeld()
                         },
                         onHover = {
-                            if (EstimatedItemValue.config.enabled) {
-                                EstimatedItemValue.updateItem(stack)
-                            }
+                            if (EstimatedItemValue.config.enabled) EstimatedItemValue.updateItem(stack)
                         },
                     )
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -40,7 +40,7 @@ import kotlin.math.roundToLong
 @SkyHanniModule
 object EstimatedItemValue {
 
-    private val config get() = SkyHanniMod.feature.inventory.estimatedItemValues
+    val config get() = SkyHanniMod.feature.inventory.estimatedItemValues
     private var display = emptyList<List<Any>>()
     private val cache = mutableMapOf<ItemStack, List<List<Any>>>()
     private var lastToolTipTime = 0L
@@ -90,7 +90,7 @@ object EstimatedItemValue {
         renderedItems = 0
     }
 
-    private fun tryRendering() {
+    fun tryRendering() {
         currentlyShowing = checkCurrentlyVisible()
         if (!currentlyShowing) return
 
@@ -133,7 +133,7 @@ object EstimatedItemValue {
         updateItem(event.stack)
     }
 
-    private fun updateItem(item: ItemStack) {
+    fun updateItem(item: ItemStack) {
         cache[item]?.let {
             display = it
             lastToolTipTime = System.currentTimeMillis()


### PR DESCRIPTION
## Dependencies
- #2078 

## What
Adds support for showing estimated item value on items inside the custom wardrobe.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/42304516/7382c4d0-38bd-480b-89b1-4e68fa38d217)

</details>

## Changelog Improvements
+ Add support for Estimated Item Value to Custom Wardrobe. - Empa