### PR TITLE
Fix: Custom Scoreboard Empty Lines

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -263,7 +263,6 @@ private fun getDungeonsLines() = listOf(
     SbPattern.keysPattern,
     SbPattern.timeElapsedPattern,
     SbPattern.clearedPattern,
-    SbPattern.emptyLinesPattern, // Forcing an empty line
     SbPattern.soloPattern,
     SbPattern.teammatesPattern,
     SbPattern.floor3GuardiansPattern
@@ -521,7 +520,6 @@ private fun getMagmaBossShowWhen(): Boolean = SbPattern.magmaChamberPattern.matc
 private fun getCarnivalLines() = listOf(
     SbPattern.carnivalPattern,
     SbPattern.carnivalTokensPattern,
-    SbPattern.emptyLinesPattern, // Forcing an empty line
     SbPattern.carnivalTasksPattern,
     SbPattern.timeLeftPattern,
     SbPattern.carnivalCatchStreakPattern,


### PR DESCRIPTION
## What
This Pull Request reverts me trying to add empty lines as a seperator while in Catacombs and during a Carnival.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/45315647/b6fbaf9a-ac68-4080-914c-5369ad34dd14)

</details>


## Changelog Fixes
+ Fixed multiple empty lines appearing in Custom Scoreboard while in Dungeons. - j10a1n15

