### PR TITLE
Fix: Golden Strays Causing New Rabbits to Detect as Dupes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -46,14 +46,18 @@ object HoppityEggsCompactChat {
         if (hoppityEggChat.isNotEmpty()) {
             ChatUtils.hoverableChat(createCompactMessage(), hover = hoppityEggChat, prefix = false)
         }
+        resetCompactVars()
+    }
 
+    private fun resetCompactVars(){
+        this.hoppityEggChat = mutableListOf()
         this.duplicate = false
         this.newRabbit = false
-        lastRarity = ""
-        lastName = ""
-        lastProfit = ""
-        lastChatMeal = null
-        lastDuplicateAmount = null
+        this.lastRarity = ""
+        this.lastName = ""
+        this.lastProfit = ""
+        this.lastChatMeal = null
+        this.lastDuplicateAmount = null
     }
 
     private fun createCompactMessage(): String {
@@ -74,7 +78,7 @@ object HoppityEggsCompactChat {
 
     fun handleChat(event: LorenzChatEvent) {
         HoppityEggsManager.eggFoundPattern.matchMatcher(event.message) {
-            hoppityEggChat = mutableListOf()
+            resetCompactVars()
             lastChatMeal = getEggType(event)
             compactChat(event)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -46,10 +46,10 @@ object HoppityEggsCompactChat {
         if (hoppityEggChat.isNotEmpty()) {
             ChatUtils.hoverableChat(createCompactMessage(), hover = hoppityEggChat, prefix = false)
         }
-        resetCompactVars()
+        resetCompactData()
     }
 
-    private fun resetCompactVars() {
+    private fun resetCompactData() {
         this.hoppityEggChat = mutableListOf()
         this.duplicate = false
         this.newRabbit = false
@@ -78,7 +78,7 @@ object HoppityEggsCompactChat {
 
     fun handleChat(event: LorenzChatEvent) {
         HoppityEggsManager.eggFoundPattern.matchMatcher(event.message) {
-            resetCompactVars()
+            resetCompactData()
             lastChatMeal = getEggType(event)
             compactChat(event)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -49,7 +49,7 @@ object HoppityEggsCompactChat {
         resetCompactVars()
     }
 
-    private fun resetCompactVars(){
+    private fun resetCompactVars() {
         this.hoppityEggChat = mutableListOf()
         this.duplicate = false
         this.newRabbit = false

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
@@ -26,7 +26,6 @@ object ChocolateFactoryBarnManager {
     private val newRabbitPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.new",
         "§d§lNEW RABBIT! §6\\+\\d+ Chocolate §7and §6\\+0.\\d+x Chocolate §7per second!"
-        //§d§lNEW RABBIT! §6+4 Chocolate §7and §6+0.004x Chocolate §7per second!
     )
     private val rabbitDuplicatePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.duplicate",

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
@@ -26,6 +26,7 @@ object ChocolateFactoryBarnManager {
     private val newRabbitPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.new",
         "§d§lNEW RABBIT! §6\\+\\d+ Chocolate §7and §6\\+0.\\d+x Chocolate §7per second!"
+        //§d§lNEW RABBIT! §6+4 Chocolate §7and §6+0.004x Chocolate §7per second!
     )
     private val rabbitDuplicatePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.duplicate",


### PR DESCRIPTION
## What
Fix an issue where Golden Strays could cause Hoppity Compact to always flag New Rabbits as dupes.
See this thread for context, and images surrounding the issue itself: https://discord.com/channels/997079228510117908/1251015915739414559

I believe what happened in my case, is that a Golden Stray opened a Dinner egg for me before this compact happened, which did not trigger the compact to fully run, but did pre-populate the variable objects with some dummy data, that was stored and used the next time compacting ran.

The fix for this was doing a full-reset of all variables when `eggFoundPattern` matches. This was moved to a private function so the same set of clearing could be applied to post-send.

## Changelog Fixes
+ Fixed a rare case where golden strays caused incorrect duplicate detection during Compact Chat for Hoppity's. - Daveed

