### PR TITLE
Backend: Mobdetection First Seen Event

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobData.kt
@@ -19,7 +19,6 @@ object MobData {
         val entityList get() = this.flatMap { listOf(it.baseEntity) + (it.extraEntities) }
     }
 
-
     val players = MobSet()
     val displayNPCs = MobSet()
     val skyblockMobs = MobSet()
@@ -28,6 +27,8 @@ object MobData {
     val currentMobs = MobSet()
 
     val entityToMob = mutableMapOf<EntityLivingBase, Mob>()
+
+    internal val notSeenMobs = MobSet()
 
     internal val currentEntityLiving = mutableSetOf<EntityLivingBase>()
     internal val previousEntityLiving = mutableSetOf<EntityLivingBase>()
@@ -92,12 +93,19 @@ object MobData {
     fun onMobEventSpawn(event: MobEvent.Spawn) {
         entityToMob.putAll(event.mob.makeEntityToMobAssociation())
         currentMobs.add(event.mob)
+        notSeenMobs.add(event.mob)
     }
 
     @SubscribeEvent
     fun onMobEventDeSpawn(event: MobEvent.DeSpawn) {
         event.mob.fullEntityList().forEach { entityToMob.remove(it) }
         currentMobs.remove(event.mob)
+        notSeenMobs.remove(event.mob)
+    }
+
+    @SubscribeEvent
+    fun onMobFirstSeen(event: MobEvent.FirstSeen) {
+        notSeenMobs.remove(event.mob)
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -88,7 +88,6 @@ object MobDetection {
             shouldClear.set(false)
         }
         if (!LorenzUtils.inSkyBlock) return
-        if (event.isMod(2)) return
 
         makeEntityReferenceUpdate()
 

--- a/src/main/java/at/hannibal2/skyhanni/events/MobEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/MobEvent.kt
@@ -20,4 +20,13 @@ open class MobEvent(val mob: Mob) : LorenzEvent() {
         class Special(mob: Mob) : DeSpawn(mob)
         class Projectile(mob: Mob) : DeSpawn(mob)
     }
+
+    open class FirstSeen(mob: Mob) : MobEvent(mob) {
+        class SkyblockMob(mob: Mob) : FirstSeen(mob)
+        class Summon(mob: Mob) : FirstSeen(mob)
+        class Player(mob: Mob) : FirstSeen(mob)
+        class DisplayNPC(mob: Mob) : FirstSeen(mob)
+        class Special(mob: Mob) : FirstSeen(mob)
+        class Projectile(mob: Mob) : FirstSeen(mob)
+    }
 }


### PR DESCRIPTION
## What
Adds an event for when the mob can first be seen. Does not account for the frustum since the canBeSeen check needs to do it (and has a todo for that).
Also increased the rate of the mob detection back to run once per tick. Since the lorenzTick change reduced it to only run every 2 ticks.

## Changelog Technical Details
+ Add Mob Detection First Seen Event. - Thunderblade73
+ Mob Detection now runs every tick instead of every other tick. - Thunderblade73

