### PR TITLE
Fix: Compact Hoppity Chat for Purchased Rabbits

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -97,7 +97,7 @@ object HoppityEggsCompactChat {
             // in this case, we want to reset variables to a clean state during this capture,
             // as the important capture for the purchased message is the final message in
             // the chain; "You found [rabbit]" -> "Dupe/New Rabbit" -> "You bought [rabbit]"
-            if(hoppityEggChat.isEmpty() || hoppityEggChat.size > 1) {
+            if (hoppityEggChat.isEmpty() || hoppityEggChat.size > 1) {
                 resetCompactData()
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -97,7 +97,7 @@ object HoppityEggsCompactChat {
             // in this case, we want to reset variables to a clean state during this capture,
             // as the important capture for the purchased message is the final message in
             // the chain; "You found [rabbit]" -> "Dupe/New Rabbit" -> "You bought [rabbit]"
-            if(hoppityEggChat.isEmpty() || hoppityEggChat.size > 1){
+            if(hoppityEggChat.isEmpty() || hoppityEggChat.size > 1) {
                 resetCompactData()
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -63,7 +63,8 @@ object HoppityEggsCompactChat {
     }
 
     private fun createCompactMessage(): String {
-        val mealName = lastChatMeal?.coloredName ?: if (rabbitBought) "§aPurchased" else ""
+        val mealName = lastChatMeal?.coloredName ?: ""
+        val mealNameFormatted = if (rabbitBought) "§aBought Rabbit" else "$mealName Egg"
 
         return if (duplicate) {
             val format = lastDuplicateAmount?.shortFormat() ?: "?"
@@ -72,9 +73,9 @@ object HoppityEggsCompactChat {
             } ?: "?"
 
             val timeStr = if (config.showDuplicateTime) ", §a+§b$timeFormatted§7" else ""
-            "$mealName Egg! §7Duplicate $lastName §7(§6+$format Chocolate§7$timeStr)"
+            "$mealNameFormatted! §7Duplicate $lastName §7(§6+$format Chocolate§7$timeStr)"
         } else if (newRabbit) {
-            "$mealName Egg! §d§lNEW $lastName §7(${lastProfit}§7)"
+            "$mealNameFormatted! §d§lNEW $lastName §7(${lastProfit}§7)"
         } else "?"
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -63,10 +63,10 @@ object HoppityEggsCompactChat {
     }
 
     private fun createCompactMessage(): String {
-        val mealName = lastChatMeal?.coloredName ?: if(rabbitBought) "&aPurchased" else ""
+        val mealName = lastChatMeal?.coloredName ?: if(rabbitBought) "§aPurchased" else ""
 
         return if (duplicate) {
-            val format = lastDuplicateAmount?.let { it.shortFormat() } ?: "?"
+            val format = lastDuplicateAmount?.shortFormat() ?: "?"
             val timeFormatted = lastDuplicateAmount?.let {
                 ChocolateFactoryAPI.timeUntilNeed(it).format(maxUnits = 2)
             } ?: "?"

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -63,7 +63,7 @@ object HoppityEggsCompactChat {
     }
 
     private fun createCompactMessage(): String {
-        val mealName = lastChatMeal?.coloredName ?: if(rabbitBought) "§aPurchased" else ""
+        val mealName = lastChatMeal?.coloredName ?: if (rabbitBought) "§aPurchased" else ""
 
         return if (duplicate) {
             val format = lastDuplicateAmount?.shortFormat() ?: "?"
@@ -85,7 +85,7 @@ object HoppityEggsCompactChat {
             compactChat(event)
         }
 
-        HoppityEggsManager.eggBoughtPattern.matchMatcher(event.message){
+        HoppityEggsManager.eggBoughtPattern.matchMatcher(event.message) {
             rabbitBought = true
             compactChat(event)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -50,7 +50,7 @@ object HoppityEggsManager {
      */
     val eggBoughtPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "egg.bought",
-        "§aYou bought §.(?<rabbitname>.*?) §afor §6((\\d|,)*) Coins§a!"
+        "§aYou bought §r§.(?<rabbitname>.*?) §r§afor §r§6((\\d|,)*) Coins§r§a!"
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -45,6 +45,15 @@ object HoppityEggsManager {
     )
 
     /**
+     * REGEX-TEST: §aYou bought §r§9Casanova §r§afor §r§6970,000 Coins§r§a!
+     * REGEX-TEST: §aYou bought §r§fHeidie §r§afor §r§6194,000 Coins§r§a!
+     */
+    val eggBoughtPattern by ChocolateFactoryAPI.patternGroup.pattern(
+        "egg.bought",
+        "§aYou bought §.(?<rabbitname>.*?) §afor §6((\\d|,)*) Coins§a!"
+    )
+
+    /**
      * REGEX-TEST: §D§LHOPPITY'S HUNT §7You found §fArnie §7(§F§LCOMMON§7)!
      * REGEX-TEST: §D§LHOPPITY'S HUNT §7You found §aPenelope §7(§A§LUNCOMMON§7)!
      * REGEX-TEST: §D§LHOPPITY'S HUNT §7You found §6Solomon §7(§6§LLEGENDARY§7)!


### PR DESCRIPTION
## What
Reported by Luna here: https://discord.com/channels/997079228510117908/1251294395140145322

The issue stemmed from having no capturing for the case where a rabbit is purchased from hoppity, so the chats were allowed through. This PR addresses that while leaving all other aspects untouched.

The main issue, and reason for the complexity of the comment in the new `reset` call, is that when finding a meal egg, the "you found [meal egg]" is the first message in the chain, whereas when purchasing, the "you bought [rabbit]" message is the last in the chain, so a new flow had to be designed.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/40234707/e3af267b-e91a-4f78-97dc-6826975a9d70)

</details>

## Changelog Fixes
+ Fixed Compact Hoppity Chat not working with rabbits purchased from the Hoppity NPC. - Daveed

