### PR TITLE
Fix: Dynamic Text being hidden after 80 blocks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/GraphEditor.kt
@@ -152,6 +152,7 @@ object GraphEditor {
             smallestDistanceVew = 12.0,
             ignoreY = true,
             yOff = -15f,
+            maxDistance = 80,
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -209,7 +209,7 @@ object RenderUtils {
         z: Double,
         rgb: Int,
         alphaMultiplier: Float,
-        partialTicks: Float
+        partialTicks: Float,
     ) {
         val height = 300
         val bottomOffset = 0
@@ -1009,6 +1009,7 @@ object RenderUtils {
         smallestDistanceVew: Double = 5.0,
         ignoreBlocks: Boolean = true,
         ignoreY: Boolean = false,
+        maxDistance: Int? = null,
     ) {
         val thePlayer = Minecraft.getMinecraft().thePlayer
         val x = location.x
@@ -1030,7 +1031,9 @@ object RenderUtils {
         distToPlayer = distToPlayer.coerceAtLeast(smallestDistanceVew)
 
         if (distToPlayer < hideTooCloseAt) return
-        if (ignoreBlocks && distToPlayer > 80) return
+        maxDistance?.let {
+            if (ignoreBlocks && distToPlayer > it) return
+        }
 
         val distRender = distToPlayer.coerceAtMost(50.0)
 


### PR DESCRIPTION
## What
This Pull Request fixes the drawDynamicText() method hiding all texts after 80 blocks, and insteads add a parameter named maxDistance. There is a bug report about this, somewhere, but im not able to find it.
<details>
<summary>Images</summary>

old
![image](https://github.com/hannibal002/SkyHanni/assets/45315647/43e14958-b60d-4690-8196-6987a42a9b38)

fixed
![image](https://github.com/hannibal002/SkyHanni/assets/45315647/890297b2-29c3-43e1-bfa4-1b31ed425d56)

</details>


## Changelog Fixes
+ Fixed waypoint text being hidden when more than 80 blocks away. - j10a1n15
