### PR TITLE
Hotfix: Red Sand Oreblock

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -262,7 +262,7 @@ private fun isHardstoneGlacite(state: IBlockState): Boolean =
         (state.block == Blocks.wool && state.getValue(BlockColored.COLOR) == EnumDyeColor.GRAY)
 
 private fun isRedSand(state: IBlockState): Boolean =
-    (state.block == Blocks.stone && state.getValue(BlockSand.VARIANT) == BlockSand.EnumType.RED_SAND)
+    (state.block == Blocks.sand && state.getValue(BlockSand.VARIANT) == BlockSand.EnumType.RED_SAND)
 
 private fun isLowTierUmber(state: IBlockState): Boolean = state.block == Blocks.hardened_clay ||
     (state.block == Blocks.stained_hardened_clay && state.getValue(BlockColored.COLOR) == EnumDyeColor.BROWN)


### PR DESCRIPTION
fixed miningapi because im stupid and its checking if a stone block is red sand

exclude_from_changelog