### PR TITLE
Fix error where query is not checked for github instead path is

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
+++ b/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
@@ -121,7 +121,7 @@ public class DownloadSourceChecker {
             URI host = getHost(file);
             if (host == null) return null;
 
-            if (host.getHost().equals("objects.githubusercontent.com") && host.getPath().contains(GITHUB_REPO_TEXT)) {
+            if (host.getHost().equals("objects.githubusercontent.com") && host.getQuery().contains(GITHUB_REPO_TEXT)) {
                 return null;
             } else if (host.getHost().equals("cdn.modrinth.com") && host.getPath().startsWith(MODRINTH_URL)) {
                 return null;


### PR DESCRIPTION
## What
Fix error where query is not checked for github instead path is, it was imeplmented when adding suggestions because the type was changed from URL to URI [`9bc3ef7` (#1914)](https://github.com/hannibal002/SkyHanni/pull/1914/commits/9bc3ef785560a61bf8d2345996749ae23c23074f)

## Changelog Fixes
+ Fixed getting security error when downloading from GitHub. - ThatGravyBoat
