### PR TITLE
Fix: Event start time being null in custom scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvents.kt
@@ -419,7 +419,7 @@ private fun getActiveEventShowWhen(): Boolean =
 
 private fun getSoonEventLine(): List<String> {
     val soonActiveEvent = getTablistEvent() ?: return emptyList()
-    val soonActiveEventTime = TabListData.getTabList().firstOrNull { SbPattern.eventTimeEndsPattern.matches(it) }
+    val soonActiveEventTime = TabListData.getTabList().firstOrNull { SbPattern.eventTimeStartsPattern.matches(it) }
         ?.let {
             SbPattern.eventTimeStartsPattern.matchMatcher(it) {
                 group("time")


### PR DESCRIPTION
## What
Fixed event start time being null in custom scoreboard.

#2014 may take a while, so making this a separate PR.

## Changelog Fixes
+ Fixed broken event start time for upcoming events in the Custom Scoreboard. - Luna