### PR TITLE
Fix: Kill Combo Chat Filter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -89,9 +89,13 @@ object ChatFilter {
     )
 
     // Kill Combo
+    // To note: there is an intentional space left after the "50" kill combo test case,
+    // as said space is evidently present for 50, but no further values in the chain.
     private val killComboPatterns = listOf(
         //§a§l+5 Kill Combo §r§8+§r§b3% §r§b? Magic Find
-        "§.§l\\+(.*) Kill Combo (.*)".toPattern(),
+        //"§6§l+50 Kill Combo "
+        //§6§l+75 Kill Combo
+        "§.§l\\+(.*) Kill Combo(.*)".toPattern(),
         "§cYour Kill Combo has expired! You reached a (.*) Kill Combo!".toPattern()
     )
     private val killComboMessages = listOf(

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -95,7 +95,8 @@ object ChatFilter {
         //§a§l+5 Kill Combo §r§8+§r§b3% §r§b? Magic Find
         //"§6§l+50 Kill Combo "
         //§6§l+75 Kill Combo
-        "§.§l\\+(.*) Kill Combo(.*)".toPattern(),
+        "§.§l\\+(.*) Kill Combo (.*)".toPattern(),
+        "§.§l\\+(.*) Kill Combo$".toPattern(),
         "§cYour Kill Combo has expired! You reached a (.*) Kill Combo!".toPattern()
     )
     private val killComboMessages = listOf(


### PR DESCRIPTION
## What
Reported here: https://discord.com/channels/997079228510117908/1252469848991072307
Kill combo chat filter stops working at kill combos 75 and above, due to malformed pattern.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/40234707/4f7bc17b-7ce7-485d-8200-3cd807855653)

</details>

## Changelog Fixes
+ Fixed kill combo chat filter not working at high combo counts. - Daveed