### PR TITLE
Improvement: More Harp FPS

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityRenderer.java
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.data.GuiEditManager;
+import at.hannibal2.skyhanni.features.inventory.HarpFeatures;
 import net.minecraft.client.renderer.EntityRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,5 +14,10 @@ public class MixinEntityRenderer {
     @Inject(method = "updateCameraAndRender", at = @At("TAIL"))
     private void onLastRender(float partialTicks, long nanoTime, CallbackInfo ci) {
         GuiEditManager.renderLast();
+    }
+
+    @Inject(method = "renderWorld", at = @At("HEAD"), cancellable = true)
+    private void renderWorld(float partialTicks, long finishTimeNano, CallbackInfo ci) {
+        HarpFeatures.tryBlockRender(ci);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderItem.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderItem.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
+import at.hannibal2.skyhanni.features.inventory.HarpFeatures;
 import at.hannibal2.skyhanni.mixins.hooks.RenderItemHookKt;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.entity.RenderItem;
@@ -20,5 +21,10 @@ public abstract class MixinRenderItem {
     @Inject(method = "renderItemIntoGUI", at = @At("RETURN"))
     public void renderItemReturn(ItemStack stack, int x, int y, CallbackInfo ci) {
         RenderItemHookKt.renderItemReturn(stack, x, y);
+    }
+
+    @Inject(method = "renderItemIntoGUI", at = @At("HEAD"), cancellable = true)
+    private void renderItemOverlayHead(ItemStack stack, int x, int y, CallbackInfo ci) {
+        HarpFeatures.tryBlockItemRender(stack, ci);
     }
 }


### PR DESCRIPTION
## What
Increase the fps of the game while being inside the harp inventory (in the park or on private island) by ignoring those nasty blocks or items in the lower inventory from rendering.
This still doesn't look perfect, as the item numbers are still showing up.
Also, this does not yet have a toggle in the config.

## Changelog Improvements
+ More FPS while playing the Harp. - hannibal2
    * By hiding stuff that is not necessary.