### PR TITLE
Feature: Block opening chocolate factory without Mythic Rabbit equipped

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -146,7 +146,7 @@ public class HoppityEggsConfig {
     @Expose
     @ConfigOption(
         name = "Rabbit Pet Warning",
-        desc = "Warn when using the Egglocator without having a §d§lMythic Rabbit Pet §7selected. " +
+        desc = "Warn when using the Egglocator without a §d§lMythic Rabbit Pet §7equipped. " +
             "§eOnly enable this setting when you own a mythic Rabbit pet."
     )
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -216,4 +216,9 @@ public class ChocolateFactoryConfig {
     @Accordion
     public ChocolateFactoryCustomReminderConfig customReminder = new ChocolateFactoryCustomReminderConfig();
 
+    @Expose
+    @ConfigOption(name = "Mythic Rabbit", desc = "Blocks running /cf without a mythic rabbit pet equipped.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean mythicRabbitRequirement = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -217,7 +217,7 @@ public class ChocolateFactoryConfig {
     public ChocolateFactoryCustomReminderConfig customReminder = new ChocolateFactoryCustomReminderConfig();
 
     @Expose
-    @ConfigOption(name = "Mythic Rabbit", desc = "Blocks running /cf without a mythic rabbit pet equipped.")
+    @ConfigOption(name = "Mythic Rabbit", desc = "Blocks running /cf without a §d§lMythic Rabbit Pet §7equipped.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean mythicRabbitRequirement = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/MythicRabbitPetWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/MythicRabbitPetWarning.kt
@@ -15,14 +15,16 @@ object MythicRabbitPetWarning {
 
         if (lastCheck.passedSince() < 30.seconds) return
 
-        if (!PetAPI.isCurrentPet(mythicRabbit)) {
+        if (!correctPet()) {
             lastCheck = SimpleTimeMark.now()
             warn()
         }
     }
 
+    fun correctPet() = PetAPI.isCurrentPet(mythicRabbit)
+
     private fun warn() {
-        ChatUtils.chat("Use a mythic Rabbit pet for more chocolate!")
+        ChatUtils.chat("Use a §dMythic Rabbit Pet §efor more chocolate!")
         LorenzUtils.sendTitle("§cNo Rabbit Pet!", 3.seconds)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -29,7 +29,7 @@ object ChocolateFactoryBlockOpen {
     fun onCommandSend(event: MessageSendToServerEvent) {
         if (!isEnabled()) return
         if (!commandPattern.matches(event.message)) return
-        if (PetAPI.currentPet == "§dRabbit") return
+        if (PetAPI.currentPet?.startsWith("§dRabbit") == true) return
 
         event.cancel()
         ChatUtils.chat("Blocked opening the Chocolate Factory without a mythic §dRabbit §epet equipped.")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -1,9 +1,8 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.config.ConfigGuiManager
-import at.hannibal2.skyhanni.data.PetAPI
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
+import at.hannibal2.skyhanni.features.event.hoppity.MythicRabbitPetWarning
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -25,7 +24,7 @@ object ChocolateFactoryBlockOpen {
      */
     private val commandPattern by RepoPattern.pattern(
         "inventory.chocolatefactory.opencommand",
-        "/(?:cf|chocolatefactory)(?: .*)?",
+        "\\/(?:cf|chocolatefactory)(?: .*)?",
     )
 
     private var commandSentTimer = SimpleTimeMark.farPast()
@@ -35,13 +34,13 @@ object ChocolateFactoryBlockOpen {
         if (!isEnabled()) return
         if (!commandPattern.matches(event.message)) return
         if (commandSentTimer.passedSince() < 5.seconds) return
-        if (PetAPI.currentPet?.startsWith("§dRabbit") == true) return
+        if (MythicRabbitPetWarning.correctPet()) return
 
         commandSentTimer = SimpleTimeMark.now()
         event.cancel()
-        ChatUtils.clickableChat(
-            "Blocked opening the Chocolate Factory without a mythic §dRabbit §epet equipped. Click here to disable!",
-            { ConfigGuiManager.openConfigGui("mythic rabbit pet equipped") },
+        ChatUtils.chatAndOpenConfig(
+            "Blocked opening the Chocolate Factory without a §dMythic Rabbit Pet §eequipped. Click here to disable!",
+            config::mythicRabbitRequirement,
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -1,0 +1,39 @@
+package at.hannibal2.skyhanni.features.inventory.chocolatefactory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.PetAPI
+import at.hannibal2.skyhanni.events.MessageSendToServerEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object ChocolateFactoryBlockOpen {
+    private val config get() = SkyHanniMod.feature.inventory.chocolateFactory
+
+    /**
+     * REGEX-TEST: /cf
+     * REGEX-TEST: /cf test
+     * REGEX-TEST: /chocolatefactory
+     * REGEX-TEST: /chocolatefactory123456789
+     */
+    private val commandPattern by RepoPattern.pattern(
+        "inventory.chocolatefactory.opencommand",
+        "/(?:cf|chocolatefactory)(?: .*)?",
+    )
+
+    @SubscribeEvent
+    fun onCommandSend(event: MessageSendToServerEvent) {
+        if (!isEnabled()) return
+        if (!commandPattern.matches(event.message)) return
+        if (PetAPI.currentPet == "§dRabbit") return
+
+        event.cancel()
+        ChatUtils.chat("Blocked opening the Chocolate Factory without a mythic §dRabbit §epet equipped.")
+    }
+
+    private fun isEnabled() = LorenzUtils.inSkyBlock && config.mythicRabbitRequirement
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -1,14 +1,17 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.config.ConfigGuiManager
 import at.hannibal2.skyhanni.data.PetAPI
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object ChocolateFactoryBlockOpen {
@@ -25,14 +28,21 @@ object ChocolateFactoryBlockOpen {
         "/(?:cf|chocolatefactory)(?: .*)?",
     )
 
+    private var commandSentTimer = SimpleTimeMark.farPast()
+
     @SubscribeEvent
     fun onCommandSend(event: MessageSendToServerEvent) {
         if (!isEnabled()) return
         if (!commandPattern.matches(event.message)) return
+        if (commandSentTimer.passedSince() < 5.seconds) return
         if (PetAPI.currentPet?.startsWith("§dRabbit") == true) return
 
+        commandSentTimer = SimpleTimeMark.now()
         event.cancel()
-        ChatUtils.chat("Blocked opening the Chocolate Factory without a mythic §dRabbit §epet equipped.")
+        ChatUtils.clickableChat(
+            "Blocked opening the Chocolate Factory without a mythic §dRabbit §epet equipped. Click here to disable!",
+            { ConfigGuiManager.openConfigGui("mythic rabbit pet equipped") },
+        )
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.mythicRabbitRequirement


### PR DESCRIPTION
## What
blocks `/cf` from being sent if the current equipped pet is not a mythic rabbit

## Changelog New Features
+ Added an option to block Chocolate Factory access without a mythic rabbit pet. - martimavocado


