### PR TITLE
Fix: Double Hook not detected with thunder bottle filled message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -7,6 +7,8 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.SeaCreatureFishEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
@@ -18,20 +20,26 @@ object SeaCreatureManager {
     var allFishingMobs = mapOf<String, SeaCreature>()
     var allVariants = mapOf<String, List<String>>()
 
-    private val doubleHookMessages = setOf(
-        "§eIt's a §r§aDouble Hook§r§e! Woot woot!",
-        "§eIt's a §r§aDouble Hook§r§e!"
+    private val patternGroup = RepoPattern.group("fishing.seacreature")
+
+    private val doubleHookPattern by patternGroup.pattern(
+        "doublehook",
+        "§eIt's a §r§aDouble Hook§r§e!(?: Woot woot!)?"
+    )
+    private val thunderBottleChargedPattern by patternGroup.pattern(
+        "thundercharged",
+        "§e> Your bottle of thunder has fully charged!"
     )
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
         if (!LorenzUtils.inSkyBlock) return
-        if (doubleHookMessages.contains(event.message)) {
+        if (doubleHookPattern.matches(event.message)) {
             if (SkyHanniMod.feature.fishing.compactDoubleHook) {
                 event.blockedReason = "double_hook"
             }
             doubleHook = true
-        } else {
+        } else if (!doubleHook || !thunderBottleChargedPattern.matches(event.message)) {
             val seaCreature = getSeaCreatureFromMessage(event.message)
             if (seaCreature != null) {
                 SeaCreatureFishEvent(seaCreature, event, doubleHook).postAndCatch()


### PR DESCRIPTION
## What
Fixes double hook sea creatures not being properly detected when a thunder bottle is filled simultaneously. Resolves [this Discord bug report](https://discord.com/channels/997079228510117908/1252318543714717766).

**Note**: I bypassed the thunder bottle filled message instead of ignoring the first non-sea-creature message after a double hook. This is to avoid double hook being assigned to the wrong sea creature if the first sea creature isn't detected (e.g. if Hypixel adds new sea creatures).

## Changelog Fixes
+ Fixed a rare double hook detection issue. - appable