### PR TITLE
Fix: ChocoFactory Custom Reminder trigger on TimeTower charge use.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -182,6 +182,12 @@ public class ChocolateFactoryConfig {
     public boolean highlightRabbitsWithRequirement = false;
 
     @Expose
+    @ConfigOption(name = "Only Requirement Not Met", desc = "Only highlight the rabbits you don't have the requirement for.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean onlyHighlightRequirementNotMet = true;
+
+    @Expose
     @ConfigOption(
         name = "Show Missing Location Rabbits",
         desc = "Show the locations you have yet to find enough egg locations for in order to unlock the rabbit for that location."
@@ -189,12 +195,6 @@ public class ChocolateFactoryConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean showLocationRequirementsRabbitsInHoppityStats = false;
-
-    @Expose
-    @ConfigOption(name = "Only Requirement Not Met", desc = "Only highlight the rabbits you don't have the requirement for.")
-    @ConfigEditorBoolean
-    @FeatureToggle
-    public boolean onlyHighlightRequirementNotMet = true;
 
     @Expose
     @ConfigOption(name = "Rabbit Warning", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
@@ -63,6 +63,7 @@ object ChocolateFactoryCustomReminder {
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled()) return
         val item = event.item ?: return
+        if (event.clickedButton != 0) return
         // TODO add support for prestige and for Chocolate Milestone
         val cost = ChocolateFactoryAPI.getChocolateBuyCost(item.getLore()) ?: return
         val duration = ChocolateAmount.CURRENT.timeUntilGoal(cost)
@@ -110,9 +111,14 @@ object ChocolateFactoryCustomReminder {
     private fun update() {
         display = mutableListOf<Renderable>().also { list ->
             getTargetDescription()?.let {
-                list.add(Renderable.clickAndHover(it, listOf("§eClick to remove the goal!"), onClick = {
-                    reset()
-                }))
+                list.add(
+                    Renderable.clickAndHover(
+                        it, listOf("§eClick to remove the goal!"),
+                        onClick = {
+                            reset()
+                        },
+                    ),
+                )
             }
         }
     }
@@ -138,10 +144,12 @@ object ChocolateFactoryCustomReminder {
         if (configUpgradeWarnings.upgradeWarningSound) {
             SoundUtils.playBeepSound()
         }
-        ChatUtils.clickableChat("You can now purchase §f$targetName §ein Chocolate factory!",
+        ChatUtils.clickableChat(
+            "You can now purchase §f$targetName §ein Chocolate factory!",
             onClick = {
                 HypixelCommands.chocolateFactory()
-            })
+            },
+        )
     }
 
     private fun reset() {


### PR DESCRIPTION
## What
Only left click for reminders. Since right click triggers the time tower.
Also moved one config element, since 2 config elements got seperated at some point.

## Changelog Fixes
+ Fixed the custom reminder in the Chocolate Factory activating when using the Time Tower charge. - Thunderblade73
