### PR TITLE
Backend: Remove redundant property from HotmAPI.Powder

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/HotmAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotmAPI.kt
@@ -37,15 +37,13 @@ object HotmAPI {
 
         ;
 
-        val lowName = name.lowercase().firstLetterUppercase()
-
         val heartPattern by RepoPattern.pattern(
             "inventory.${name.lowercase()}.heart",
-            "§7$lowName Powder: §a§.(?<powder>[\\d,]+)"
+            "§7$displayName Powder: §a§.(?<powder>[\\d,]+)"
         )
         val resetPattern by RepoPattern.pattern(
             "inventory.${name.lowercase()}.reset",
-            "\\s+§8- §.(?<powder>[\\d,]+) $lowName Powder"
+            "\\s+§8- §.(?<powder>[\\d,]+) $displayName Powder"
         )
 
         fun pattern(isHeart: Boolean) = if (isHeart) heartPattern else resetPattern

--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -648,13 +648,13 @@ enum class HotmData(
             if (!LorenzUtils.inSkyBlock) return
 
             event.scoreboard.matchFirst(ScoreboardPattern.powderPattern) {
-                val type = HotmAPI.Powder.entries.firstOrNull { it.lowName == group("type") } ?: return
+                val type = HotmAPI.Powder.entries.firstOrNull { it.displayName == group("type") } ?: return
                 val amount = group("amount").formatLong()
                 val difference = amount - type.getCurrent()
 
                 if (difference > 0) {
                     type.gain(difference)
-                    ChatUtils.debug("Gained §a${difference.addSeparators()} §e${type.lowName} Powder")
+                    ChatUtils.debug("Gained §a${difference.addSeparators()} §e${type.displayName} Powder")
                 }
             }
         }
@@ -742,7 +742,7 @@ enum class HotmData(
             event.addIrrelevant {
                 add("Tokens : $availableTokens/$tokens")
                 HotmAPI.Powder.entries.forEach {
-                    add("${it.lowName} Powder: ${it.getCurrent()}/${it.getTotal()}")
+                    add("${it.displayName} Powder: ${it.getCurrent()}/${it.getTotal()}")
                 }
                 add("Ability: ${HotmAPI.activeMiningAbility?.printName}")
                 add("Blue Egg: ${HotmAPI.isBlueEggActive}")


### PR DESCRIPTION
## What
Removed redundant `lowName` property from HotmAPI.Powder. It's the exact same as `displayName`.

## Changelog Technical Details
+ Removed redundant `lowName` property from HotmAPI.Powder. - Luna

