### PR TITLE
Improvement: Add option to maintain sound levels during SoundUtils usage

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -276,4 +276,9 @@ public class MiscConfig {
     @Accordion
     @Expose
     public HideFarEntitiesConfig hideFarEntities = new HideFarEntitiesConfig();
+
+    @ConfigOption(name = "Maintain Volume During Warnings", desc = "Do not change game volume levels when warning sounds are played.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean maintainGameVolume = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -277,6 +277,7 @@ public class MiscConfig {
     @Expose
     public HideFarEntitiesConfig hideFarEntities = new HideFarEntitiesConfig();
 
+    @Expose
     @ConfigOption(name = "Maintain Volume During Warnings", desc = "Do not change game volume levels when warning sounds are played.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -22,7 +22,9 @@ object SoundUtils {
         Minecraft.getMinecraft().addScheduledTask {
             val gameSettings = Minecraft.getMinecraft().gameSettings
             val oldLevel = gameSettings.getSoundLevel(SoundCategory.PLAYERS)
-            gameSettings.setSoundLevel(SoundCategory.PLAYERS, 1f)
+            if(!SkyHanniMod.feature.misc.maintainGameVolume) {
+                gameSettings.setSoundLevel(SoundCategory.PLAYERS, 1f)
+            }
             try {
                 Minecraft.getMinecraft().soundHandler.playSound(this)
             } catch (e: Exception) {
@@ -39,7 +41,9 @@ object SoundUtils {
                     "soundLocation" to this.soundLocation
                 )
             } finally {
-                gameSettings.setSoundLevel(SoundCategory.PLAYERS, oldLevel)
+                if(!SkyHanniMod.feature.misc.maintainGameVolume){
+                    gameSettings.setSoundLevel(SoundCategory.PLAYERS, oldLevel)
+                }
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -41,7 +41,7 @@ object SoundUtils {
                     "soundLocation" to this.soundLocation
                 )
             } finally {
-                if(!SkyHanniMod.feature.misc.maintainGameVolume){
+                if(!SkyHanniMod.feature.misc.maintainGameVolume) {
                     gameSettings.setSoundLevel(SoundCategory.PLAYERS, oldLevel)
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -22,7 +22,7 @@ object SoundUtils {
         Minecraft.getMinecraft().addScheduledTask {
             val gameSettings = Minecraft.getMinecraft().gameSettings
             val oldLevel = gameSettings.getSoundLevel(SoundCategory.PLAYERS)
-            if(!SkyHanniMod.feature.misc.maintainGameVolume) {
+            if (!SkyHanniMod.feature.misc.maintainGameVolume) {
                 gameSettings.setSoundLevel(SoundCategory.PLAYERS, 1f)
             }
             try {
@@ -41,7 +41,7 @@ object SoundUtils {
                     "soundLocation" to this.soundLocation
                 )
             } finally {
-                if(!SkyHanniMod.feature.misc.maintainGameVolume) {
+                if (!SkyHanniMod.feature.misc.maintainGameVolume) {
                     gameSettings.setSoundLevel(SoundCategory.PLAYERS, oldLevel)
                 }
             }


### PR DESCRIPTION
## What
Context here: https://discord.com/channels/997079228510117908/1000669238035497022/1253381260005478493

This PR adds the option to not change system sound levels when `SoundUtils` is used to play a sound. Due to changing the sound level globally, this can lead to obnoxiously loud, and deafening periods of noise.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/40234707/52e70a0e-85e2-4923-91b6-cd94e45a8a80)

</details>

## Changelog Improvements
+ Add config option to maintain "current" sound settings levels while warning sounds are played. - Daveed

