### PR TITLE
Fix: Deep Sea Protectors being misdetected as Automatons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -40,7 +40,9 @@ object HighlightMiningCommissionMobs {
         TREASURE_HOARDER("Treasure Hoarder Puncher", { it.name == "Treasuer Hunter" }), // typo is intentional
 
         // Crystal Hollows
-        AUTOMATON("Automaton Slayer", { it is EntityIronGolem }),
+        AUTOMATON("Automaton Slayer", {
+            it is EntityIronGolem && (it.hasMaxHealth(15_000) || it.hasMaxHealth(20_000))
+        }),
         TEAM_TREASURITE_MEMBER("Team Treasurite Member Slayer", { it.name == "Team Treasurite" }),
         YOG("Yog Slayer", { it is EntityMagmaCube && it.hasMaxHealth(35_000) }),
         THYST("Thyst Slayer", { it is EntityEndermite && it.hasMaxHealth(5_000) }),


### PR DESCRIPTION
## What
Fixed commission mob highlighter incorrectly highlighting Deep Sea Protectors as Automatons.

## Changelog Fixes
+ Fixed Commission Mob Highlighter incorrectly highlighting Deep Sea Protectors as Automatons. - Luna
