### PR TITLE
Fix: Hypixel detection via Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -409,7 +409,6 @@ object HypixelData {
 
         for (line in ScoreboardData.sidebarLinesFormatted) {
             serverNameScoreboardPattern.matchMatcher(line) {
-                println("line: $line")
                 hypixel = true
                 if (group("prefix") == "alpha.") {
                     hypixelAlpha = true

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
+import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
@@ -272,6 +273,15 @@ object HypixelData {
         locrawData = null
         skyBlockArea = null
         skyBlockAreaWithSymbol = null
+        hasScoreboardUpdated = false
+    }
+
+    private var hasScoreboardUpdated = false
+
+    @SubscribeEvent
+    fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
+        if (hasScoreboardUpdated) return
+        hasScoreboardUpdated = true
     }
 
     @SubscribeEvent
@@ -378,6 +388,7 @@ object HypixelData {
     }
 
     private fun checkHypixel() {
+        if (!hasScoreboardUpdated) return
         val mc = Minecraft.getMinecraft()
         val player = mc.thePlayer ?: return
 
@@ -398,6 +409,7 @@ object HypixelData {
 
         for (line in ScoreboardData.sidebarLinesFormatted) {
             serverNameScoreboardPattern.matchMatcher(line) {
+                println("line: $line")
                 hypixel = true
                 if (group("prefix") == "alpha.") {
                     hypixelAlpha = true

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -114,6 +114,7 @@ object HypixelData {
     )
 
     private var lastLocRaw = SimpleTimeMark.farPast()
+    private var hasScoreboardUpdated = false
 
     var hypixelLive = false
     var hypixelAlpha = false
@@ -275,8 +276,6 @@ object HypixelData {
         skyBlockAreaWithSymbol = null
         hasScoreboardUpdated = false
     }
-
-    private var hasScoreboardUpdated = false
 
     @SubscribeEvent
     fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -279,7 +279,6 @@ object HypixelData {
 
     @SubscribeEvent
     fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
-        if (hasScoreboardUpdated) return
         hasScoreboardUpdated = true
     }
 


### PR DESCRIPTION
## What
fixes scoreboard wrongly detecting inHypixel from cached data 
https://discord.com/channels/997079228510117908/1253372705760088064

## Changelog Fixes
+ Fixed Hypixel detection on non-Hypixel servers. - martimavocado
