### PR TITLE
Fix: Summons messages not being blocked

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -89,6 +89,8 @@ object SummoningMobManager {
 
     @SubscribeEvent
     fun onMobDeSpawn(event: MobEvent.DeSpawn.Summon) {
+        if (!config.summonMessages) return;
+
         val mob = event.mob
         if (mob !in mobs) return
         mobs -= mob

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -89,15 +89,13 @@ object SummoningMobManager {
 
     @SubscribeEvent
     fun onMobDeSpawn(event: MobEvent.DeSpawn.Summon) {
-        if (!config.summonMessages) return
-
         val mob = event.mob
         if (mob !in mobs) return
         mobs -= mob
 
         if (!mob.isInRender()) return
         DelayedRun.runNextTick {
-            if (lastChatTime.passedSince() > timeOut) {
+            if (lastChatTime.passedSince() > timeOut && config.summonMessages) {
                 ChatUtils.chat("Your Summoning Mob just §cdied!")
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -89,7 +89,7 @@ object SummoningMobManager {
 
     @SubscribeEvent
     fun onMobDeSpawn(event: MobEvent.DeSpawn.Summon) {
-        if (!config.summonMessages) return;
+        if (!config.summonMessages) return
 
         val mob = event.mob
         if (mob !in mobs) return


### PR DESCRIPTION
## What
Fix `Your summoning mob just died` messages not being blocked when the config is set to false.
https://discord.com/channels/997079228510117908/1000669238035497022/1253417396040105984

## Changelog Fixes
+ Fixed summons death messages getting blocked even when the feature is disabled. - Daveed