### PR TITLE
Feature: Time Tower Reminder feature

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -113,6 +113,12 @@ public class ChocolateFactoryConfig {
     public boolean timeTowerWarning = false;
 
     @Expose
+    @ConfigOption(name = "Time Tower Expiry Reminder", desc = "Notify when the time tower ends and you have one or more remaining charges.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean timeTowerReminder = true;
+
+    @Expose
     @ConfigOption(name = "Upgrade Warnings", desc = "")
     @Accordion
     public ChocolateUpgradeWarningsConfig chocolateUpgradeWarnings = new ChocolateUpgradeWarningsConfig();

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -113,12 +113,6 @@ public class ChocolateFactoryConfig {
     public boolean timeTowerWarning = false;
 
     @Expose
-    @ConfigOption(name = "Time Tower Reminder", desc = "Notify a minute before the time tower ends.")
-    @ConfigEditorBoolean
-    @FeatureToggle
-    public boolean timeTowerReminder = true;
-
-    @Expose
     @ConfigOption(name = "Upgrade Warnings", desc = "")
     @Accordion
     public ChocolateUpgradeWarningsConfig chocolateUpgradeWarnings = new ChocolateUpgradeWarningsConfig();

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -68,10 +68,10 @@ object ChocolateFactoryTimeTowerManager {
 
     private fun checkTimeTowerExpired() {
         val isTimeTowerActive = timeTowerActive()
-        if (!isTimeTowerActive && wasTimeTowerRecentlyActive && config.timeTowerWarning && currentCharges() > 0) {
+        if (!isTimeTowerActive && wasTimeTowerRecentlyActive && config.timeTowerReminder && currentCharges() > 0) {
             val charges = StringUtils.pluralize(currentCharges(), "charge", "charges", true)
             ChatUtils.clickableChat(
-                "§cYour Time Tower expired and has $charges remaining. Click here to use one.",
+                "§cYour Time Tower just expired and has $charges remaining. Click here to use one.",
                 onClick = {
                     HypixelCommands.chocolateFactory()
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -70,12 +70,13 @@ object ChocolateFactoryTimeTowerManager {
     private fun checkTimeTowerExpired() {
         val isTimeTowerActive = timeTowerActive()
         if (!isTimeTowerActive && wasTimeTowerRecentlyActive && config.timeTowerReminder && currentCharges() > 0) {
-            val charges = StringUtils.pluralize(currentCharges(), "charge", "charges", true)
+            val charges = StringUtils.pluralize(currentCharges(), "charge", "charges", withNumber = true)
             ChatUtils.clickableChat(
                 "§cYour Time Tower just expired and has $charges remaining. Click here to use one.",
                 onClick = {
                     HypixelCommands.chocolateFactory()
                 },
+                hover = "§eClick to run /cf!",
             )
             SoundUtils.playBeepSound()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -22,7 +22,6 @@ object ChocolateFactoryTimeTowerManager {
     private val profileStorage get() = ChocolateFactoryAPI.profileStorage
 
     private var lastTimeTowerWarning = SimpleTimeMark.farPast()
-    private var lastTimeTowerReminder = SimpleTimeMark.farPast()
 
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {
@@ -34,10 +33,6 @@ object ChocolateFactoryTimeTowerManager {
         }
 
         if (ChocolateFactoryAPI.inChocolateFactory) return
-
-        if (config.timeTowerReminder) {
-            timeTowerReminder()
-        }
 
         val nextCharge = profileStorage.nextTimeTower
 
@@ -104,23 +99,6 @@ object ChocolateFactoryTimeTowerManager {
     }
 
     private fun timeTowerEnds(): SimpleTimeMark = profileStorage?.currentTimeTowerEnds ?: SimpleTimeMark.farPast()
-
-    private fun timeTowerReminder() {
-        if (lastTimeTowerReminder.passedSince() < 20.seconds) return
-
-        val timeUntil = timeTowerEnds().timeUntil()
-        if (timeUntil < 1.minutes && timeUntil.isPositive()) {
-            ChatUtils.clickableChat(
-                "§cYour Time Tower is about to end! " +
-                    "Open the Chocolate Factory to avoid wasting the multiplier!",
-                onClick = {
-                    HypixelCommands.chocolateFactory()
-                }
-            )
-            SoundUtils.playBeepSound()
-            lastTimeTowerReminder = SimpleTimeMark.now()
-        }
-    }
 
     fun timeTowerFullTimeMark(): SimpleTimeMark {
         val profileStorage = profileStorage ?: return SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -22,6 +22,12 @@ object ChocolateFactoryTimeTowerManager {
     private val profileStorage get() = ChocolateFactoryAPI.profileStorage
 
     private var lastTimeTowerWarning = SimpleTimeMark.farPast()
+    private var justJoinedProfile = true
+
+    @SubscribeEvent
+    fun onProfileJoin(event: ProfileJoinEvent) {
+        justJoinedProfile = true
+    }
 
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {
@@ -29,6 +35,7 @@ object ChocolateFactoryTimeTowerManager {
         val profileStorage = profileStorage ?: return
 
         if (profileStorage.currentTimeTowerEnds.isInPast()) {
+            if (!justJoinedProfile) onTimeTowerJustExpired()
             profileStorage.currentTimeTowerEnds = SimpleTimeMark.farPast()
         }
 
@@ -55,6 +62,19 @@ object ChocolateFactoryTimeTowerManager {
             return
         }
         checkTimeTowerWarning(false)
+    }
+
+    private fun onTimeTowerJustExpired() {
+        if (config.timeTowerWarning && currentCharges() > 0) {
+            ChatUtils.clickableChat(
+                "§cYour Time Tower just expired and has §7(${timeTowerCharges()} remaining)§c," +
+                    "Click here to use one",
+                onClick = {
+                    HypixelCommands.chocolateFactory()
+                }
+            )
+            SoundUtils.playBeepSound()
+        }
     }
 
     fun checkTimeTowerWarning(inInventory: Boolean) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.StringUtils
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -39,7 +40,7 @@ object ChocolateFactoryTimeTowerManager {
         }
 
         checkTimeTowerExpired()
-        
+
         if (ChocolateFactoryAPI.inChocolateFactory) return
 
         val nextCharge = profileStorage.nextTimeTower
@@ -53,7 +54,7 @@ object ChocolateFactoryTimeTowerManager {
             if (!config.timeTowerWarning || timeTowerActive()) return
             ChatUtils.clickableChat(
                 "Your Time Tower has another charge available §7(${timeTowerCharges()})§e, " +
-                    "Click here to use one",
+                    "Click here to use one.",
                 onClick = {
                     HypixelCommands.chocolateFactory()
                 }
@@ -68,9 +69,9 @@ object ChocolateFactoryTimeTowerManager {
     private fun checkTimeTowerExpired() {
         val isTimeTowerActive = timeTowerActive()
         if (!isTimeTowerActive && wasTimeTowerRecentlyActive && config.timeTowerWarning && currentCharges() > 0) {
+            val charges = StringUtils.pluralize(currentCharges(), "charge", "charges", true)
             ChatUtils.clickableChat(
-                "§cYour Time Tower expired and has §7(${timeTowerCharges()} remaining)§c," +
-                    "Click here to use one",
+                "§cYour Time Tower expired and has $charges remaining. Click here to use one.",
                 onClick = {
                     HypixelCommands.chocolateFactory()
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -27,7 +27,7 @@ object ChocolateFactoryTimeTowerManager {
 
     @SubscribeEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
-        wasTimeTowerRecentlyActive = true
+        wasTimeTowerRecentlyActive = false
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -75,7 +75,7 @@ object ChocolateFactoryTimeTowerManager {
                 "§cYour Time Tower just expired and has $charges remaining. Click here to use one.",
                 onClick = {
                     HypixelCommands.chocolateFactory()
-                }
+                },
             )
             SoundUtils.playBeepSound()
         }
@@ -95,7 +95,7 @@ object ChocolateFactoryTimeTowerManager {
             "§cYour Time Tower is full §7(${timeTowerCharges()})§c, " +
                 "Use one to avoid wasting time tower usages!",
             onClick = { HypixelCommands.chocolateFactory() },
-            HOVER_TEXT
+            HOVER_TEXT,
         )
         SoundUtils.playBeepSound()
         lastTimeTowerWarning = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -42,7 +42,7 @@ object ChocolateFactoryTimeTowerManager {
             val nextTimeTower = profileStorage.nextTimeTower + profileStorage.timeTowerCooldown.hours
             profileStorage.nextTimeTower = nextTimeTower
 
-            if (!config.timeTowerWarning) return
+            if (!config.timeTowerWarning || timeTowerActive()) return
             ChatUtils.clickableChat(
                 "Your Time Tower has another charge available §7(${timeTowerCharges()})§e, " +
                     "Click here to use one",


### PR DESCRIPTION
## What
Removes and replaces "Time Tower Reminder" feature. The original intent of the feature is not longer needed based on my testing:
```
Test duration: 4500 seconds

Theoretical chocolate gained if TT:
- doesn't work offline: 112,572,000
- works offline: 144,432,000

Experimental:
Starting chocolate: 284,023,769
Ending chocolate: 428,688,227
Chocolate gained: 144,664,458
```
This feature now sends a single notification when the time tower expires and there are remaining charges. 
<details>
<summary>Image</summary>
<img width="596" alt="Screenshot 2024-06-20 at 11 04 54 PM" src="https://github.com/hannibal002/SkyHanni/assets/16139460/8e04229e-7806-4839-a0e4-ca094a0c680a">

</details>

## Changelog New Features
+ Add reminder that the Time Tower is expired and has extra charges available. - appable
    * Replaces the previous Time Tower Reminder feature.

## Changelog Removed Features
+ Remove the original Time Tower Reminder feature. - appable
    * Hypixel now correctly calculates Time Tower offline.

