### PR TITLE
Feature & Fix: Powder Tracker Hard Stone & Goblin Eggs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
@@ -22,6 +22,7 @@ import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.P
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.FTX;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.GEMSTONE_POWDER;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.GOLD_ESSENCE;
+import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.HARD_STONE;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.JADE;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.MITHRIL_POWDER;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.ROBOTRON;
@@ -32,7 +33,6 @@ import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.P
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.SPACER_3;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.TOPAZ;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.TOTAL_CHESTS;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.HARD_STONE;
 
 public class PowderTrackerConfig {
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
@@ -99,7 +99,7 @@ public class PowderTrackerConfig {
         CONTROL_SWITCH("§b14 §9Control Switch", 20),
         SYNTHETIC_HEART("§b14 §9Synthetic Heart", 21),
         TOTAL_ROBOT_PARTS("§b14 §9Total Robot Parts", 22),
-        GOBLIN_EGGS("§30-§c0-§e0-§a0-§90 §fGoblin Egg", 23),
+        GOBLIN_EGGS("§30§7-§c0§7-§e0§7-§a0§f-§90 §fGoblin Egg", 23),
         WISHING_COMPASS("§b12 §aWishing Compass", 24),
         SLUDGE_JUICE("§b320 §aSludge Juice", 25),
         ASCENSION_ROPE("§b2 §9Ascension Rope", 26),

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
@@ -29,8 +29,10 @@ import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.P
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.SAPPHIRE;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.SPACER_1;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.SPACER_2;
+import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.SPACER_3;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.TOPAZ;
 import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.TOTAL_CHESTS;
+import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.HARD_STONE;
 
 public class PowderTrackerConfig {
 
@@ -60,6 +62,8 @@ public class PowderTrackerConfig {
         DIAMOND_ESSENCE,
         GOLD_ESSENCE,
         SPACER_2,
+        HARD_STONE,
+        SPACER_3,
         RUBY,
         SAPPHIRE,
         AMBER,
@@ -80,6 +84,8 @@ public class PowderTrackerConfig {
         DIAMOND_ESSENCE("§b129 §bDiamond Essence §7(600/h)", 7),
         GOLD_ESSENCE("§b234 §6Gold Essence §7(700/h)", 8),
         SPACER_2("", 9),
+        HARD_STONE("§b1000 §fHard Stone §bCompacted §7(500/h)"),
+        SPACER_3(""),
         RUBY("§50§7-§90§7-§a0§f-0 §cRuby Gemstone", 10),
         SAPPHIRE("§50§7-§90§7-§a0§f-0 §bSapphire Gemstone", 11),
         AMBER("§50§7-§90§7-§a0§f-0 §6Amber Gemstone", 12),
@@ -93,7 +99,7 @@ public class PowderTrackerConfig {
         CONTROL_SWITCH("§b14 §9Control Switch", 20),
         SYNTHETIC_HEART("§b14 §9Synthetic Heart", 21),
         TOTAL_ROBOT_PARTS("§b14 §9Total Robot Parts", 22),
-        GOBLIN_EGGS("§90§7-§a0§7-§c0§f-§e0§f-§30 §fGoblin Egg", 23),
+        GOBLIN_EGGS("§30-§c0-§e0-§a0-§90 §fGoblin Egg", 23),
         WISHING_COMPASS("§b12 §aWishing Compass", 24),
         SLUDGE_JUICE("§b320 §aSludge Juice", 25),
         ASCENSION_ROPE("§b2 §9Ascension Rope", 26),

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/PowderTrackerConfig.java
@@ -99,7 +99,7 @@ public class PowderTrackerConfig {
         CONTROL_SWITCH("§b14 §9Control Switch", 20),
         SYNTHETIC_HEART("§b14 §9Synthetic Heart", 21),
         TOTAL_ROBOT_PARTS("§b14 §9Total Robot Parts", 22),
-        GOBLIN_EGGS("§30§7-§c0§7-§e0§7-§a0§f-§90 §fGoblin Egg", 23),
+        GOBLIN_EGGS("§30§7-§c0§7-§e0§f-§a0§f-§90 §fGoblin Egg", 23),
         WISHING_COMPASS("§b12 §aWishing Compass", 24),
         SLUDGE_JUICE("§b320 §aSludge Juice", 25),
         ASCENSION_ROPE("§b2 §9Ascension Rope", 26),

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -56,9 +56,13 @@ object PowderTracker {
         "powder.bossbar",
         "§e§lPASSIVE EVENT §b§l2X POWDER §e§lRUNNING FOR §a§l(?<time>.*)§r"
     )
+
+    /**
+     * REGEX-TEST: §b§lCOMPACT! §r§fYou found an §r§aEnchanted Hard Stone§r§f!
+     */
     private val compactedPattern by patternGroup.pattern(
         "compacted",
-        "§b§lCOMPACT! §r§fYou found an §r§aEnchanted Hard Stone§r§f!"
+        "§b§lCOMPACT! §r§fYou found an §r§aEnchanted Hard Stone§r§f!",
     )
 
     private var lastChestPicked = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -56,6 +56,10 @@ object PowderTracker {
         "powder.bossbar",
         "§e§lPASSIVE EVENT §b§l2X POWDER §e§lRUNNING FOR §a§l(?<time>.*)§r"
     )
+    private val compactedPattern by patternGroup.pattern(
+        "compacted",
+        "§b§lCOMPACT! §r§fYou found an §r§aEnchanted Hard Stone§r§f!"
+    )
 
     private var lastChestPicked = SimpleTimeMark.farPast()
     private var isGrinding = false
@@ -64,6 +68,7 @@ object PowderTracker {
     private val diamondEssenceInfo = ResourceInfo(0L, 0L, 0, 0.0, mutableListOf())
     private val goldEssenceInfo = ResourceInfo(0L, 0L, 0, 0.0, mutableListOf())
     private val chestInfo = ResourceInfo(0L, 0L, 0, 0.0, mutableListOf())
+    private val hardStoneInfo = ResourceInfo(0L, 0L, 0, 0.0, mutableListOf())
     private var doublePowder = false
     private var powderTimer = ""
     private val gemstones = listOf(
@@ -109,10 +114,14 @@ object PowderTracker {
         override fun reset() {
             rewards.clear()
             totalChestPicked = 0
+            totalHardStoneCompacted = 0
         }
 
         @Expose
         var totalChestPicked = 0
+
+        @Expose
+        var totalHardStoneCompacted = 0
 
         @Expose
         var rewards: MutableMap<PowderChestReward, Long> = mutableMapOf()
@@ -153,6 +162,12 @@ object PowderTracker {
         powderStartedPattern.matchMatcher(msg) { doublePowder = true }
         powderEndedPattern.matchMatcher(msg) { doublePowder = false }
 
+        compactedPattern.matchMatcher(msg) {
+            tracker.modify {
+                it.totalHardStoneCompacted += 1
+            }
+        }
+
         for (reward in PowderChestReward.entries) {
             reward.chatPattern.matchMatcher(msg) {
                 tracker.modify {
@@ -192,6 +207,9 @@ object PowderTracker {
         chestInfo.perHour = 0.0
         chestInfo.stoppedChecks = 0
         chestInfo.perMin.clear()
+        hardStoneInfo.perHour = 0.0
+        hardStoneInfo.stoppedChecks = 0
+        hardStoneInfo.perMin.clear()
         doublePowder = false
         tracker.update()
     }
@@ -240,6 +258,7 @@ object PowderTracker {
         calculate(data, diamondEssenceInfo, PowderChestReward.DIAMOND_ESSENCE)
         calculate(data, goldEssenceInfo, PowderChestReward.GOLD_ESSENCE)
         calculateChest(data)
+        calculateHardStone(data)
 
         val chestPerHour = format(chestInfo.perHour)
         addAsSingletonList("§d${data.totalChestPicked.addSeparators()} Total Chests Picked §7($chestPerHour/h)")
@@ -252,11 +271,10 @@ object PowderTracker {
         addAsSingletonList("")
         addPerHour(rewards, entries[46], diamondEssenceInfo)
         addPerHour(rewards, entries[47], goldEssenceInfo)
-
-
         addAsSingletonList("")
-
-
+        val hardStonePerHour = format(hardStoneInfo.perHour)
+        addAsSingletonList("§f${data.totalHardStoneCompacted.addSeparators()} Hard Stone Compacted §7($hardStonePerHour/h)")
+        addAsSingletonList("")
         for ((gem, color) in gemstones) {
             var totalGemstone = 0L
 
@@ -289,7 +307,7 @@ object PowderTracker {
         val redEgg = rewards.getOrDefault(PowderChestReward.RED_GOBLIN_EGG, 0)
         val yellowEgg = rewards.getOrDefault(PowderChestReward.YELLOW_GOBLIN_EGG, 0)
         val blueEgg = rewards.getOrDefault(PowderChestReward.BLUE_GOBLIN_EGG, 0)
-        addAsSingletonList("§9$goblinEgg§7-§a$greenEgg§7-§c$redEgg§f-§e$yellowEgg§f-§3$blueEgg §fGoblin Egg")
+        addAsSingletonList("§3$blueEgg-§c$redEgg-§e$yellowEgg-§a$greenEgg-§9$goblinEgg §fGoblin Egg")
 
         for (reward in entries.subList(37, 46)) {
             val count = rewards.getOrDefault(reward, 0).addSeparators()
@@ -339,6 +357,10 @@ object PowderTracker {
 
     private fun calculateChest(data: Data) {
         chestInfo.estimated = data.totalChestPicked.toLong()
+    }
+
+    private fun calculateHardStone(data: Data) {
+        hardStoneInfo.estimated = data.totalHardStoneCompacted.toLong()
     }
 
     private fun convert(roughCount: Long): Gem {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -92,6 +92,7 @@ object PowderTracker {
         calculateResourceHour(diamondEssenceInfo)
         calculateResourceHour(goldEssenceInfo)
         calculateResourceHour(chestInfo)
+        calculateResourceHour(hardStoneInfo)
 
         doublePowder = powderBossBarPattern.matcher(BossbarData.getBossbar()).find()
         powderBossBarPattern.matchMatcher(BossbarData.getBossbar()) {
@@ -273,7 +274,7 @@ object PowderTracker {
         addPerHour(rewards, entries[47], goldEssenceInfo)
         addAsSingletonList("")
         val hardStonePerHour = format(hardStoneInfo.perHour)
-        addAsSingletonList("§f${data.totalHardStoneCompacted.addSeparators()} Hard Stone Compacted §7($hardStonePerHour/h)")
+        addAsSingletonList("§b${data.totalHardStoneCompacted.addSeparators()} §fHard Stone §bCompacted §7($hardStonePerHour/h)")
         addAsSingletonList("")
         for ((gem, color) in gemstones) {
             var totalGemstone = 0L
@@ -307,7 +308,7 @@ object PowderTracker {
         val redEgg = rewards.getOrDefault(PowderChestReward.RED_GOBLIN_EGG, 0)
         val yellowEgg = rewards.getOrDefault(PowderChestReward.YELLOW_GOBLIN_EGG, 0)
         val blueEgg = rewards.getOrDefault(PowderChestReward.BLUE_GOBLIN_EGG, 0)
-        addAsSingletonList("§3$blueEgg-§c$redEgg-§e$yellowEgg-§a$greenEgg-§9$goblinEgg §fGoblin Egg")
+        addAsSingletonList("§3$blueEgg§f-§c$redEgg§f-§e$yellowEgg§f-§a$greenEgg§f-§9$goblinEgg §fGoblin Egg")
 
         for (reward in entries.subList(37, 46)) {
             val count = rewards.getOrDefault(reward, 0).addSeparators()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -308,7 +308,7 @@ object PowderTracker {
         val redEgg = rewards.getOrDefault(PowderChestReward.RED_GOBLIN_EGG, 0)
         val yellowEgg = rewards.getOrDefault(PowderChestReward.YELLOW_GOBLIN_EGG, 0)
         val blueEgg = rewards.getOrDefault(PowderChestReward.BLUE_GOBLIN_EGG, 0)
-        addAsSingletonList("§3$blueEgg§7-§c$redEgg§7-§e$yellowEgg§7-§a$greenEgg§f-§9$goblinEgg §fGoblin Egg")
+        addAsSingletonList("§3$blueEgg§7-§c$redEgg§7-§e$yellowEgg§f-§a$greenEgg§f-§9$goblinEgg §fGoblin Egg")
 
         for (reward in entries.subList(37, 46)) {
             val count = rewards.getOrDefault(reward, 0).addSeparators()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -308,7 +308,7 @@ object PowderTracker {
         val redEgg = rewards.getOrDefault(PowderChestReward.RED_GOBLIN_EGG, 0)
         val yellowEgg = rewards.getOrDefault(PowderChestReward.YELLOW_GOBLIN_EGG, 0)
         val blueEgg = rewards.getOrDefault(PowderChestReward.BLUE_GOBLIN_EGG, 0)
-        addAsSingletonList("§3$blueEgg§f-§c$redEgg§f-§e$yellowEgg§f-§a$greenEgg§f-§9$goblinEgg §fGoblin Egg")
+        addAsSingletonList("§3$blueEgg§7-§c$redEgg§7-§e$yellowEgg§7-§a$greenEgg§f-§9$goblinEgg §fGoblin Egg")
 
         for (reward in entries.subList(37, 46)) {
             val count = rewards.getOrDefault(reward, 0).addSeparators()


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1254291997460664331
Fixed the order of goblin eggs within the powder tracker to adhere to R2L Rarity increasing order.
Added config option for tracking Compacted Hard Stone in powder tracker (with #/hr calculation).

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/40234707/e86e9315-a9e4-4d80-b572-8817242d976a)

</details>

## Changelog New Features
+ Added Compacted Hard Stone to Powder Tracker. - Daveed

## Changelog Fixes
+ Fixed the order of Goblin Eggs in the Powder Tracker. - Daveed

