### PR TITLE
Improvement: Clarify prompt to load trophy fishing data from NEU PV

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishManager.kt
@@ -55,7 +55,7 @@ object TrophyFishManager {
         }
         if (changed) {
             ChatUtils.clickableChat(
-                "Click here to load data from NEU PV!", onClick = {
+                "Click here to load Trophy Fishing data from NEU PV!", onClick = {
                     updateFromNeuPv(savedFishes, neuData)
                 },
                 "§eClick to load!",


### PR DESCRIPTION
## What
Clarified prompt to load trophy fishing data from NEU PV, since there is now another thing (found egg locations) being loaded from NEU PV which is not updated by this.

## Changelog Improvements
+ Clarified chat prompt to load trophy fishing data from NEU PV. - Luna