### PR TITLE
Fix: Powder loss on scoreboard not being accounted for

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -652,9 +652,10 @@ enum class HotmData(
                 val amount = group("amount").formatLong()
                 val difference = amount - type.getCurrent()
 
-                if (difference > 0) {
+                if (difference != 0L) {
                     type.gain(difference)
-                    ChatUtils.debug("Gained §a${difference.addSeparators()} §e${type.lowName} Powder")
+                    val what = if (difference > 0) "Gained" else "Lost"
+                    ChatUtils.debug("$what §a${difference.addSeparators()} §e${type.lowName} Powder")
                 }
             }
         }


### PR DESCRIPTION
## What
Fixed powder loss on scoreboard not being accounted for.

## Changelog Fixes
+ Fixed powder loss on scoreboard not being counted. - Luna
    * This could happen if your powder amount changed while SkyHanni wasn't there to see it, or Hypixel sent an incomplete scoreboard line, and would sometimes lead to incorrect powder amounts being displayed until you open `/hotm`.
