### PR TITLE
Improvement: Add Config option for Time Tower in "Best Upgrade" 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateUpgradeWarningsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateUpgradeWarningsConfig.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import io.github.notenoughupdates.moulconfig.observer.Property;
 
 public class ChocolateUpgradeWarningsConfig {
     @Expose
@@ -30,6 +31,5 @@ public class ChocolateUpgradeWarningsConfig {
     @Expose
     @ConfigOption(name = "Include Time Tower", desc = "Include Time Tower in the list of upgrades to be considered 'next best'.")
     @ConfigEditorBoolean
-    @FeatureToggle
-    public boolean upgradeWarningTimeTower = false;
+    public Property<Boolean> upgradeWarningTimeTower = Property.of(false);
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateUpgradeWarningsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateUpgradeWarningsConfig.java
@@ -26,4 +26,10 @@ public class ChocolateUpgradeWarningsConfig {
     )
     @ConfigEditorSlider(minValue = 0, maxValue = 10, minStep = 0.25f)
     public float timeBetweenWarnings = 1;
+
+    @Expose
+    @ConfigOption(name = "Include Time Tower", desc = "Include Time Tower in the list of upgrades to be considered 'next best'.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean upgradeWarningTimeTower = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -28,6 +28,7 @@ import at.hannibal2.skyhanni.features.garden.fortuneguide.FarmingItems;
 import at.hannibal2.skyhanni.features.garden.pests.PestProfitTracker;
 import at.hannibal2.skyhanni.features.garden.pests.VinylType;
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorReward;
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryUpgrade;
 import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeAPI;
 import at.hannibal2.skyhanni.features.mining.MineshaftPityDisplay;
 import at.hannibal2.skyhanni.features.mining.fossilexcavator.ExcavatorProfitTracker;
@@ -150,6 +151,9 @@ public class ProfileSpecificStorage {
 
         @Expose
         public Integer hoppityShopYearOpened = null;
+
+        @Expose
+        public List<ChocolateFactoryUpgrade> upgradeList = new ArrayList<>();
     }
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -151,9 +151,6 @@ public class ProfileSpecificStorage {
 
         @Expose
         public Integer hoppityShopYearOpened = null;
-
-        @Expose
-        public List<ChocolateFactoryUpgrade> upgradeList = new ArrayList<>();
     }
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage.ChocolateFactoryStorage
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -430,7 +430,9 @@ object ChocolateFactoryDataLoader {
         // removing time tower here as people like to determine when to buy it themselves
         // - Updated to be configurable with a config option instead of removing it statically
         val notMaxed = list.filter {
-            !it.isMaxed && (config.chocolateUpgradeWarnings.upgradeWarningTimeTower || it.slotIndex != ChocolateFactoryAPI.timeTowerIndex) && it.effectiveCost != null
+            !it.isMaxed &&
+                (config.chocolateUpgradeWarnings.upgradeWarningTimeTower || it.slotIndex != ChocolateFactoryAPI.timeTowerIndex) &&
+                it.effectiveCost != null
         }
 
         val bestUpgrade = notMaxed.minByOrNull { it.effectiveCost ?: Double.MAX_VALUE }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -83,7 +83,7 @@ object ChocolateFactoryDataLoader {
     )
     private val timeTowerStatusPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "timetower.status",
-        "§7Status: §.§l(?<status>INACTIVE|ACTIVE)(?: §f)?(?<activeTime>\\w*)",
+        "§7Status: §.§l(?<status>INACTIVE|ACTIVE)(?: §f)?(?<acitveTime>\\w*)",
     )
     private val timeTowerRechargePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "timetower.recharge",
@@ -298,7 +298,7 @@ object ChocolateFactoryDataLoader {
                 ChocolateFactoryTimeTowerManager.checkTimeTowerWarning(true)
             }
             timeTowerStatusPattern.matchMatcher(line) {
-                val activeTime = group("activeTime")
+                val activeTime = group("acitveTime")
                 if (activeTime.isNotEmpty()) {
                     // todo in future fix this issue with TimeUtils.getDuration
                     val formattedGroup = activeTime.replace("h", "h ").replace("m", "m ")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -1,13 +1,16 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage.ChocolateFactoryStorage
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI.specialRabbitTextures
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
@@ -81,7 +84,7 @@ object ChocolateFactoryDataLoader {
     )
     private val timeTowerStatusPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "timetower.status",
-        "§7Status: §.§l(?<status>INACTIVE|ACTIVE)(?: §f)?(?<acitveTime>\\w*)",
+        "§7Status: §.§l(?<status>INACTIVE|ACTIVE)(?: §f)?(?<activeTime>\\w*)",
     )
     private val timeTowerRechargePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "timetower.recharge",
@@ -148,6 +151,20 @@ object ChocolateFactoryDataLoader {
         ConditionalUtils.onToggle(soundProperty) {
             ChocolateFactoryAPI.warningSound = SoundUtils.createSound(soundProperty.get(), 1f)
         }
+
+        config.chocolateUpgradeWarnings.upgradeWarningTimeTower.whenChanged { _, _ ->
+            ChocolateFactoryAPI.factoryUpgrades.takeIf { it.isNotEmpty() }?.let {
+                findBestUpgrades(it)
+            } ?: profileStorage?.let {
+                findBestUpgrades(it.upgradeList)
+            } ?: run {
+                ChatUtils.clickableChat(
+                    "Could not determine your current statistics to get next upgrade. Open CF to fix this!",
+                    onClick = { HypixelCommands.chocolateFactory() },
+                    "§eClick to run /cf!"
+                )
+            }
+        }
     }
 
     private fun clearData() {
@@ -184,6 +201,9 @@ object ChocolateFactoryDataLoader {
         ChocolateFactoryStats.updateDisplay()
 
         processInventory(list, inventory)
+
+        //Store list for use in async changes to config
+        profileStorage.upgradeList = list;
 
         findBestUpgrades(list)
         ChocolateFactoryAPI.factoryUpgrades = list
@@ -279,7 +299,7 @@ object ChocolateFactoryDataLoader {
                 ChocolateFactoryTimeTowerManager.checkTimeTowerWarning(true)
             }
             timeTowerStatusPattern.matchMatcher(line) {
-                val activeTime = group("acitveTime")
+                val activeTime = group("activeTime")
                 if (activeTime.isNotEmpty()) {
                     // todo in future fix this issue with TimeUtils.getDuration
                     val formattedGroup = activeTime.replace("h", "h ").replace("m", "m ")
@@ -429,10 +449,12 @@ object ChocolateFactoryDataLoader {
 
         // removing time tower here as people like to determine when to buy it themselves
         // - Updated to be configurable with a config option instead of removing it statically
-        val notMaxed = list.filter {
-            !it.isMaxed &&
-                (config.chocolateUpgradeWarnings.upgradeWarningTimeTower || it.slotIndex != ChocolateFactoryAPI.timeTowerIndex) &&
-                it.effectiveCost != null
+        val ttFiltered = list.filter {
+            config.chocolateUpgradeWarnings.upgradeWarningTimeTower.get() || it.slotIndex != ChocolateFactoryAPI.timeTowerIndex
+        }
+
+        val notMaxed = ttFiltered.filter {
+            !it.isMaxed && it.effectiveCost != null
         }
 
         val bestUpgrade = notMaxed.minByOrNull { it.effectiveCost ?: Double.MAX_VALUE }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -428,8 +428,9 @@ object ChocolateFactoryDataLoader {
         val profileStorage = profileStorage ?: return
 
         // removing time tower here as people like to determine when to buy it themselves
+        // - Updated to be configurable with a config option instead of removing it statically
         val notMaxed = list.filter {
-            !it.isMaxed && it.slotIndex != ChocolateFactoryAPI.timeTowerIndex && it.effectiveCost != null
+            !it.isMaxed && (config.chocolateUpgradeWarnings.upgradeWarningTimeTower || it.slotIndex != ChocolateFactoryAPI.timeTowerIndex) && it.effectiveCost != null
         }
 
         val bestUpgrade = notMaxed.minByOrNull { it.effectiveCost ?: Double.MAX_VALUE }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -203,7 +203,7 @@ object ChocolateFactoryDataLoader {
         processInventory(list, inventory)
 
         //Store list for use in async changes to config
-        profileStorage.upgradeList = list;
+        profileStorage.upgradeList = list
 
         findBestUpgrades(list)
         ChocolateFactoryAPI.factoryUpgrades = list

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -154,8 +154,6 @@ object ChocolateFactoryDataLoader {
         config.chocolateUpgradeWarnings.upgradeWarningTimeTower.whenChanged { _, _ ->
             ChocolateFactoryAPI.factoryUpgrades.takeIf { it.isNotEmpty() }?.let {
                 findBestUpgrades(it)
-            } ?: profileStorage?.let {
-                findBestUpgrades(it.upgradeList)
             } ?: run {
                 ChatUtils.clickableChat(
                     "Could not determine your current statistics to get next upgrade. Open CF to fix this!",
@@ -200,9 +198,6 @@ object ChocolateFactoryDataLoader {
         ChocolateFactoryStats.updateDisplay()
 
         processInventory(list, inventory)
-
-        //Store list for use in async changes to config
-        profileStorage.upgradeList = list
 
         findBestUpgrades(list)
         ChocolateFactoryAPI.factoryUpgrades = list

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -441,8 +441,6 @@ object ChocolateFactoryDataLoader {
     private fun findBestUpgrades(list: List<ChocolateFactoryUpgrade>) {
         val profileStorage = profileStorage ?: return
 
-        // removing time tower here as people like to determine when to buy it themselves
-        // - Updated to be configurable with a config option instead of removing it statically
         val ttFiltered = list.filter {
             config.chocolateUpgradeWarnings.upgradeWarningTimeTower.get() || it.slotIndex != ChocolateFactoryAPI.timeTowerIndex
         }


### PR DESCRIPTION
## What
Add a config option that can be switched on to allow for adding Time Tower to the list of upgrades to be marked as "next best".

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/40234707/a27d1230-8431-4f6b-81a9-2e1746180aae)

![image](https://github.com/hannibal002/SkyHanni/assets/40234707/32e9ee09-6835-4a3c-b144-980510fb0f7f)

</details>

## Changelog Improvements
+ Add a configuration option to allow Time Tower to appear in the Chocolate Factory next upgrade list. - Daveed

