### PR TITLE
Backend: Move hoppity rabbit chat patterns to eggs manager

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -72,6 +72,12 @@ object HoppityEggsManager {
         "rabbit.found.new",
         "§d§lNEW RABBIT! (?:((§6\\+(?<chocolate>.*) Chocolate §7and )?§6\\+(?<perSecond>.*)x Chocolate §7per second!)|(?<other>.*))"
     )
+
+    val duplicateRabbitFound by ChocolateFactoryAPI.patternGroup.pattern(
+        "rabbit.duplicate",
+        "§7§lDUPLICATE RABBIT! §6\\+(?<amount>[\\d,]+) Chocolate"
+    )
+
     private val noEggsLeftPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "egg.noneleft",
         "§cThere are no hidden Chocolate Rabbit Eggs nearby! Try again later!"

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
@@ -23,15 +23,6 @@ object ChocolateFactoryBarnManager {
     private val hoppityConfig get() = HoppityEggsManager.config
     private val profileStorage get() = ChocolateFactoryAPI.profileStorage
 
-    private val newRabbitPattern by ChocolateFactoryAPI.patternGroup.pattern(
-        "rabbit.new",
-        "§d§lNEW RABBIT! §6\\+\\d+ Chocolate §7and §6\\+0.\\d+x Chocolate §7per second!"
-    )
-    private val rabbitDuplicatePattern by ChocolateFactoryAPI.patternGroup.pattern(
-        "rabbit.duplicate",
-        "§7§lDUPLICATE RABBIT! §6\\+(?<amount>[\\d,]+) Chocolate"
-    )
-
     /**
      * REGEX-TEST: §c§lBARN FULL! §fOlivette §7got §ccrushed§7! §6+290,241 Chocolate
      */
@@ -47,14 +38,14 @@ object ChocolateFactoryBarnManager {
     fun onChat(event: LorenzChatEvent) {
         if (!LorenzUtils.inSkyBlock) return
 
-        newRabbitPattern.matchMatcher(event.message) {
+        HoppityEggsManager.newRabbitFound.matchMatcher(event.message) {
             val profileStorage = profileStorage ?: return
             profileStorage.currentRabbits += 1
             trySendBarnFullMessage()
             HoppityEggsManager.shareWaypointPrompt()
         }
 
-        rabbitDuplicatePattern.matchMatcher(event.message) {
+        HoppityEggsManager.duplicateRabbitFound.matchMatcher(event.message) {
             HoppityEggsManager.shareWaypointPrompt()
             val amount = group("amount").formatLong()
             if (config.showDuplicateTime && !hoppityConfig.compactChat) {


### PR DESCRIPTION
## What
Hoppity rabbit collection patterns should be all in the eggs manager class, so as to avoid maintaining similar patterns across different classes with the same purpose. (e.g. `newRabbitFound` pattern in eggs manager was updated in #2093, but the change was not added to barn manager)

## Changelog Technical Details
+ Move Hoppity Rabbit chat patterns to the eggs manager. - sayomaki

