### PR TITLE
Improvement + Fix: Barn full message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
@@ -101,9 +101,9 @@ object ChocolateFactoryBarnManager {
 
         if (config.rabbitCrushOnlyDuringHoppity && !ChocolateFactoryAPI.isHoppityEvent()) return
 
-        val fullLevel = if (profileStorage.currentRabbits == profileStorage.maxRabbits) "almost full" else "full"
+        val fullLevel = if (profileStorage.currentRabbits == profileStorage.maxRabbits) "full" else "almost full"
         ChatUtils.clickableChat(
-            "§cYour barn is $fullLevel! §7(${barnStatus()}). §cUpgrade it so they don't get crushed",
+            "§cYour barn is $fullLevel §7(${barnStatus()}). §cUpgrade it so they don't get crushed!",
             onClick = { HypixelCommands.chocolateFactory() },
             "§eClick to run /cf!",
         )


### PR DESCRIPTION
## What
Fixed the Hoppity barn full/almost full message having the condition inverted, as well as some punctuation improvements.

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fix the warning messages for the rabbit barn being full/almost full being reversed. - Luna

## Changelog Improvements
+ Improve punctuation in the rabbit barn full/almost full messages. - Luna
