### PR TITLE
Fix: launchers reading mod as libninepatch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -196,7 +196,7 @@ loom {
 // Tasks:
 tasks.processResources {
     inputs.property("version", version)
-    filesMatching("mcmod.info") {
+    filesMatching(listOf("mcmod.info", "fabric.mod.json")) {
         expand("version" to version)
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,0 +1,12 @@
+{
+    "schemaVersion": 1,
+    "version": "${version}",
+    "id": "skyhanni",
+    "name": "SkyHanni",
+    "description": "SkyHanni is a Minecraft Mod for Hypixel SkyBlock.",
+    "icon": "assets/skyhanni/logo.png",
+    "authors": [],
+    "depends": {
+        "minecraft": "1.8.9"
+    }
+}


### PR DESCRIPTION
## What
This fixes launchers like Modrinth detecting the mod as LibNinePatch because it contains a shadowed fabric.mod.json file from MoulConfig which uses LibNinePatch

## Changelog Fixes
+ Fix launchers showing SkyHanni as LibNinePatch. - ThatGravyBoat
