### PR TITLE
Backend: RecalculatingValue as a ReadOnlyProperty

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerAPI.kt
@@ -62,7 +62,7 @@ object SlayerAPI {
         }
 
         event.addData {
-            add("activeSlayer: ${getActiveSlayer()}")
+            add("activeSlayer: $activeSlayer")
             add("isInCorrectArea: $isInCorrectArea")
             add("isInAnyArea: $isInAnyArea")
             add("latestSlayerProgress: $latestSlayerProgress")
@@ -82,9 +82,7 @@ object SlayerAPI {
         }
     }
 
-    fun getActiveSlayer() = activeSlayer.getValue()
-
-    private val activeSlayer = RecalculatingValue(1.seconds) {
+    val activeSlayer by RecalculatingValue(1.seconds) {
         grabActiveSlayer()
     }
 
@@ -125,7 +123,7 @@ object SlayerAPI {
             } else {
                 val slayerTypeForCurrentArea = getSlayerTypeForCurrentArea()
                 isInAnyArea = slayerTypeForCurrentArea != null
-                slayerTypeForCurrentArea == getActiveSlayer() && slayerTypeForCurrentArea != null
+                slayerTypeForCurrentArea == activeSlayer && slayerTypeForCurrentArea != null
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -166,7 +166,7 @@ object HoppityEggLocator {
     }
 
     private fun shouldShowAllEggs() =
-        config.showAllWaypoints && !isLocatorInHotbar && HoppityEggType.eggsRemaining()
+        config.showAllWaypoints && !locatorInHotbar && HoppityEggType.eggsRemaining()
 
     fun eggFound() {
         resetData()
@@ -175,7 +175,7 @@ object HoppityEggLocator {
     @SubscribeEvent
     fun onReceiveParticle(event: ReceiveParticleEvent) {
         if (!isEnabled()) return
-        if (!isLocatorInHotbar) return
+        if (!locatorInHotbar) return
         if (!event.isVillagerParticle() && !event.isEnchantmentParticle()) return
 
         val lastParticlePosition = lastParticlePosition ?: run {
@@ -281,7 +281,7 @@ object HoppityEggLocator {
 
     private val ItemStack.isLocatorItem get() = getInternalName() == locatorItem
 
-    private val isLocatorInHotbar by RecalculatingValue(1.seconds) {
+    private val locatorInHotbar by RecalculatingValue(1.seconds) {
         LorenzUtils.inSkyBlock && InventoryUtils.getItemsInHotbar().any { it.isLocatorItem }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -145,10 +145,8 @@ object HoppityEggLocator {
                         )
                         drawDynamicText(it.add(y = 1), "§aGuess", 1.5)
                     }
-                    if (!drawLocations) {
-                        if (config.showLine) {
-                            draw3DLine(eyeLocation, it.add(0.5, 0.5, 0.5), LorenzColor.GREEN.toColor(), 2, false)
-                        }
+                    if (!drawLocations && config.showLine) {
+                        draw3DLine(eyeLocation, it.add(0.5, 0.5, 0.5), LorenzColor.GREEN.toColor(), 2, false)
                     }
                 }
             }
@@ -168,7 +166,7 @@ object HoppityEggLocator {
     }
 
     private fun shouldShowAllEggs() =
-        config.showAllWaypoints && !hasLocatorInHotbar() && HoppityEggType.eggsRemaining()
+        config.showAllWaypoints && !isLocatorInHotbar && HoppityEggType.eggsRemaining()
 
     fun eggFound() {
         resetData()
@@ -177,7 +175,7 @@ object HoppityEggLocator {
     @SubscribeEvent
     fun onReceiveParticle(event: ReceiveParticleEvent) {
         if (!isEnabled()) return
-        if (!hasLocatorInHotbar()) return
+        if (!isLocatorInHotbar) return
         if (!event.isVillagerParticle() && !event.isEnchantmentParticle()) return
 
         val lastParticlePosition = lastParticlePosition ?: run {
@@ -283,9 +281,9 @@ object HoppityEggLocator {
 
     private val ItemStack.isLocatorItem get() = getInternalName() == locatorItem
 
-    private fun hasLocatorInHotbar() = RecalculatingValue(1.seconds) {
+    private val isLocatorInHotbar by RecalculatingValue(1.seconds) {
         LorenzUtils.inSkyBlock && InventoryUtils.getItemsInHotbar().any { it.isLocatorItem }
-    }.getValue()
+    }
 
     private fun LorenzVec.getEggLocationWeight(firstPoint: LorenzVec, secondPoint: LorenzVec): Double {
         val distToLine = this.distanceToLine(firstPoint, secondPoint)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/AtmosphericFilterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/AtmosphericFilterDisplay.kt
@@ -21,7 +21,7 @@ object AtmosphericFilterDisplay {
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
         if (!GardenAPI.inGarden() && !config.outsideGarden) return
-        display = drawDisplay(SkyblockSeason.getCurrentSeason() ?: return)
+        display = drawDisplay(SkyblockSeason.currentSeason ?: return)
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -49,9 +49,7 @@ object ChestValue {
         if (DungeonAPI.inDungeon() && !config.enableInDungeons) return
         if (InventoryUtils.openInventoryName() == "") return
 
-        if (!config.showDuringEstimatedItemValue) {
-            if (EstimatedItemValue.isCurrentlyShowing()) return
-        }
+        if (!config.showDuringEstimatedItemValue && EstimatedItemValue.isCurrentlyShowing()) return
 
         if (inInventory) {
             config.position.renderStringsAndItems(
@@ -236,7 +234,7 @@ object ChestValue {
 
 
         if ((name.contains("Backpack") && name.contains("Slot #") || name.startsWith("Ender Chest (")) &&
-            !InventoryUtils.isNeuStorageEnabled.getValue()
+            !InventoryUtils.isNeuStorageEnabled
         ) {
             return true
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -156,7 +156,7 @@ object ChocolateFactoryAPI {
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
 
     // TODO add debug toggle
-    fun isHoppityEvent() = SkyblockSeason.getCurrentSeason() == SkyblockSeason.SPRING
+    fun isHoppityEvent() = SkyblockSeason.currentSeason == SkyblockSeason.SPRING
 
     fun isMaxPrestige() = currentPrestige >= maxPrestige
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TimeFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TimeFeatures.kt
@@ -28,7 +28,7 @@ object TimeFeatures {
     private val timeFormat24h = SimpleDateFormat("HH:mm:ss")
     private val timeFormat12h = SimpleDateFormat("hh:mm:ss a")
 
-    private val startOfNextYear = RecalculatingValue(1.seconds) {
+    private val startOfNextYear by RecalculatingValue(1.seconds) {
         SkyBlockTime(year = SkyBlockTime.now().year + 1).asTimeMark()
     }
 
@@ -44,7 +44,7 @@ object TimeFeatures {
 
         if (winterConfig.islandCloseTime && IslandType.WINTER.isInIsland()) {
             if (WinterAPI.isDecember()) return
-            val timeTillNextYear = startOfNextYear.getValue().timeUntil()
+            val timeTillNextYear = startOfNextYear.timeUntil()
             val alreadyInNextYear = timeTillNextYear > 5.days
             val text = if (alreadyInNextYear) {
                 "§fJerry's Workshop §cis closing!"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/GlowingDroppedItems.kt
@@ -66,12 +66,12 @@ object GlowingDroppedItems {
         return rarity?.color?.toColor()?.rgb
     }
 
-    private val isShowcaseArea = RecalculatingValue(1.seconds) {
-        showcaseItemIslands.contains(LorenzUtils.skyBlockIsland) || showcaseItemLocations.contains(LorenzUtils.skyBlockArea)
+    private val isShowcaseArea by RecalculatingValue(1.seconds) {
+        LorenzUtils.skyBlockIsland in showcaseItemIslands || LorenzUtils.skyBlockArea in showcaseItemLocations
     }
 
     private fun shouldHideShowcaseItem(entity: EntityItem): Boolean {
-        if (!isShowcaseArea.getValue() || config.highlightShowcase) return false
+        if (!isShowcaseArea || config.highlightShowcase) return false
 
         for (entityArmorStand in entity.worldObj.getEntitiesWithinAABB(
             EntityArmorStand::class.java,

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
@@ -102,7 +102,7 @@ object SlayerQuestWarning {
         if (DianaAPI.isDoingDiana()) return
         // prevent warnings when mobs are hit by other players
         if (lastWeaponUse.passedSince() > 500.milliseconds) return
-      
+
         lastWarning = SimpleTimeMark.now()
         ChatUtils.chat(chatMessage)
 
@@ -124,7 +124,7 @@ object SlayerQuestWarning {
     private fun isSlayerMob(entity: EntityLivingBase): Boolean {
         val slayerType = SlayerAPI.getSlayerTypeForCurrentArea() ?: return false
 
-        val activeSlayer = SlayerAPI.getActiveSlayer()
+        val activeSlayer = SlayerAPI.activeSlayer
 
         if (activeSlayer != null) {
             if (slayerType != activeSlayer) {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
@@ -205,9 +205,12 @@ object SlayerRngMeterDisplay {
     }
 
     private fun makeLink(text: String) =
-        Renderable.clickAndHover(text, listOf("§eClick to open RNG Meter Inventory."), onClick = {
-            HypixelCommands.showRng("slayer", SlayerAPI.getActiveSlayer()?.rngName)
-        })
+        Renderable.clickAndHover(
+            text, listOf("§eClick to open RNG Meter Inventory."),
+            onClick = {
+                HypixelCommands.showRng("slayer", SlayerAPI.activeSlayer?.rngName)
+            },
+        )
 
     fun drawDisplay(): String {
         val storage = getStorage() ?: return ""

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -66,7 +66,7 @@ object InventoryUtils {
     fun getLeggings(): ItemStack? = getArmor()[1]
     fun getBoots(): ItemStack? = getArmor()[0]
 
-    val isNeuStorageEnabled = RecalculatingValue(10.seconds) {
+    val isNeuStorageEnabled by RecalculatingValue(10.seconds) {
         try {
             val config = NotEnoughUpdates.INSTANCE.config
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -315,13 +315,8 @@ object LorenzUtils {
             this.cancel()
         }
     }
-
     // TODO move into mayor api
-    private val recalculateDerpy =
-        RecalculatingValue(1.seconds) { Perk.DOUBLE_MOBS_HP.isActive }
-
-    // TODO move into mayor api
-    val isDerpy get() = recalculateDerpy.getValue()
+    val isDerpy by RecalculatingValue(1.seconds) { Perk.DOUBLE_MOBS_HP.isActive }
 
     // TODO move into mayor api
     fun Int.derpy() = if (isDerpy) this / 2 else this

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -350,7 +350,7 @@ object NEUItems {
     fun neuHasFocus(): Boolean {
         if (AuctionSearchOverlay.shouldReplace()) return true
         if (BazaarSearchOverlay.shouldReplace()) return true
-        if (InventoryUtils.inStorage() && InventoryUtils.isNeuStorageEnabled.getValue()) return true
+        if (InventoryUtils.inStorage() && InventoryUtils.isNeuStorageEnabled) return true
         if (NEUOverlay.searchBarHasFocus) return true
 
         return false

--- a/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
@@ -1,13 +1,24 @@
 package at.hannibal2.skyhanni.utils
 
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
 import kotlin.time.Duration
 
-class RecalculatingValue<T>(private val expireTime: Duration, val calculation: () -> T) {
+class RecalculatingValue<T>(private val expireTime: Duration, private val calculation: () -> T) : ReadOnlyProperty<Any?, T> {
 
     private var currentValue = calculation()
     private var lastAccessTime = SimpleTimeMark.farPast()
 
+    @Deprecated("use by RecalculatingValue instead")
     fun getValue(): T {
+        if (lastAccessTime.passedSince() > expireTime) {
+            currentValue = calculation()
+            lastAccessTime = SimpleTimeMark.now()
+        }
+        return currentValue
+    }
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
         if (lastAccessTime.passedSince() > expireTime) {
             currentValue = calculation()
             lastAccessTime = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
@@ -6,23 +6,18 @@ import kotlin.time.Duration
 
 class RecalculatingValue<T>(private val expireTime: Duration, private val calculation: () -> T) : ReadOnlyProperty<Any?, T> {
 
-    private var currentValue = calculation()
+    private var currentValue: T? = null
     private var lastAccessTime = SimpleTimeMark.farPast()
 
-    @Deprecated("use by RecalculatingValue instead")
+    @Deprecated("use \"by RecalculatingValue\" instead")
     fun getValue(): T {
         if (lastAccessTime.passedSince() > expireTime) {
             currentValue = calculation()
             lastAccessTime = SimpleTimeMark.now()
         }
-        return currentValue
+        return currentValue!!
     }
 
-    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
-        if (lastAccessTime.passedSince() > expireTime) {
-            currentValue = calculation()
-            lastAccessTime = SimpleTimeMark.now()
-        }
-        return currentValue
-    }
+    @Suppress("DEPRECATION")
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T = getValue()
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
@@ -6,7 +6,7 @@ import kotlin.time.Duration
 
 class RecalculatingValue<T>(private val expireTime: Duration, private val calculation: () -> T) : ReadOnlyProperty<Any?, T> {
 
-    private var currentValue: T? = null
+    private var currentValue: Any? = UNINITIALIZED_VALUE
     private var lastAccessTime = SimpleTimeMark.farPast()
 
     @Deprecated("use \"by RecalculatingValue\" instead")
@@ -15,9 +15,14 @@ class RecalculatingValue<T>(private val expireTime: Duration, private val calcul
             currentValue = calculation()
             lastAccessTime = SimpleTimeMark.now()
         }
-        return currentValue!!
+        @Suppress("UNCHECKED_CAST")
+        return currentValue as T
     }
 
     @Suppress("DEPRECATION")
     override fun getValue(thisRef: Any?, property: KProperty<*>): T = getValue()
+
+    companion object {
+        private val UNINITIALIZED_VALUE = Any()
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockSeason.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockSeason.kt
@@ -21,9 +21,7 @@ enum class SkyblockSeason(
 
     companion object {
 
-        fun getCurrentSeason(): SkyblockSeason? = currentSeason.getValue()
-
-        private val currentSeason = RecalculatingValue(1.seconds) {
+        val currentSeason by RecalculatingValue(1.seconds) {
             getSeasonByName(SkyBlockTime.now().monthName)
         }
 


### PR DESCRIPTION
## What
Makes RecalculatingValue be a ReadOnlyProperty, so that it can be used as a property delegate, so you dont need to call .getValue() to use it. Also makes its usages be done like this.

## Changelog Technical Details
+ Made RecalculatingValue a ReadOnlyProperty. - Empa

