### PR TITLE
Fix: Also block opening Chocolate Factory with /factory

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -21,10 +21,11 @@ object ChocolateFactoryBlockOpen {
      * REGEX-TEST: /cf test
      * REGEX-TEST: /chocolatefactory
      * REGEX-TEST: /chocolatefactory123456789
+     * REGEX-TEST: /factory
      */
     private val commandPattern by RepoPattern.pattern(
         "inventory.chocolatefactory.opencommand",
-        "\\/(?:cf|chocolatefactory)(?: .*)?",
+        "\\/(?:cf|(?:chocolate)?factory)(?: .*)?",
     )
 
     private var commandSentTimer = SimpleTimeMark.farPast()


### PR DESCRIPTION
## What
Fixed opening Chocolate Factory without Mythic Rabbit Pet not being blocked when using the `/factory` command.

## Changelog Fixes
+ Fix opening Chocolate Factory without Mythic Rabbit Pet not being blocked when using the `/factory` command. - Luna