### PR TITLE
Improvement: Add OneConfig mods to quick mod switcher

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/QuickModMenuSwitch.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/QuickModMenuSwitch.kt
@@ -34,17 +34,10 @@ object QuickModMenuSwitch {
     @SubscribeEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         val modsJar = event.getConstant<ModGuiSwitcherJson>("ModGuiSwitcher")
-        mods = buildList {
-            out@ for ((name, mod) in modsJar.mods) {
-                for (path in mod.guiPath) {
-                    try {
-                        Class.forName(path)
-                        add(Mod(name, mod.description, mod.command, mod.guiPath))
-                        continue@out
-                    } catch (_: Exception) {
-                    }
-                }
-            }
+        mods = modsJar.mods.filter { mod ->
+            mod.value.guiPath.any { runCatching { Class.forName(it) }.isSuccess }
+        }.map { (name, mod) ->
+            Mod(name, mod.description, mod.command, mod.guiPath)
         }
     }
 
@@ -108,11 +101,21 @@ object QuickModMenuSwitch {
             return config.javaClass.name
         }
         if (openGui == "cc.polyfrost.oneconfig.gui.OneConfigGui") {
-            /** TODO support different oneconfig mods:
-             * Partly Sane Skies
-             * Dankers SkyBlock Mod
-             * Dulkir
-             */
+            val actualGui = Minecraft.getMinecraft().currentScreen
+            val currentPage = actualGui.javaClass.getDeclaredField("currentPage")
+                .makeAccessible()
+                .get(actualGui)
+            if (currentPage.javaClass.simpleName == "ModConfigPage") {
+                val optionPage = currentPage.javaClass.getDeclaredField("page")
+                    .makeAccessible()
+                    .get(currentPage)
+                val mod = optionPage.javaClass.getField("mod")
+                    .makeAccessible()
+                    .get(optionPage)
+                val modName = mod.javaClass.getField("name")
+                    .get(mod) as String
+                return "cc.polyfrost.oneconfig.gui.OneConfigGui:$modName"
+            }
         }
 
         return openGui
@@ -132,7 +135,7 @@ object QuickModMenuSwitch {
                 Renderable.string(nameFormat + mod.name),
                 bypassChecks = true,
                 onClick = { open(mod) },
-                condition = { System.currentTimeMillis() > lastGuiOpen + 250 }
+                condition = { System.currentTimeMillis() > lastGuiOpen + 250 },
             )
             add(listOf(renderable, nameSuffix))
         }
@@ -143,44 +146,8 @@ object QuickModMenuSwitch {
         currentlyOpeningMod = mod.name
         update()
         try {
-            when (mod.command) {
-                "patcher" -> {
-                    val patcher = Class.forName("club.sk1er.patcher.Patcher")
-                    val instance = patcher.getDeclaredField("instance").get(null)
-                    val config = instance.javaClass.getDeclaredMethod("getPatcherConfig").invoke(instance)
-                    val gui = Class.forName("gg.essential.vigilance.Vigilant").getDeclaredMethod("gui").invoke(config)
-                    val guiUtils = Class.forName("gg.essential.api.utils.GuiUtil")
-                    for (method in guiUtils.declaredMethods) {
-                        try {
-                            method.invoke(null, gui)
-                            return
-                        } catch (_: Exception) {
-                        }
-                    }
-                    ErrorManager.skyHanniError("Error trying to open the gui for mod " + mod.name + "!")
-                }
-
-                "hytil" -> {
-                    val hytilsReborn = Class.forName("cc.woverflow.hytils.HytilsReborn")
-                    val instance = hytilsReborn.getDeclaredField("INSTANCE").get(null)
-                    val config = instance.javaClass.getDeclaredMethod("getConfig").invoke(instance)
-                    val gui = Class.forName("gg.essential.vigilance.Vigilant").getDeclaredMethod("gui").invoke(config)
-                    val guiUtils = Class.forName("gg.essential.api.utils.GuiUtil")
-                    for (method in guiUtils.declaredMethods) {
-                        try {
-                            method.invoke(null, gui)
-                            return
-                        } catch (_: Exception) {
-                        }
-                    }
-                    ChatUtils.chat("Error trying to open the gui for mod " + mod.name + "!")
-                }
-
-                else -> {
-                    val thePlayer = Minecraft.getMinecraft().thePlayer
-                    ClientCommandHandler.instance.executeCommand(thePlayer, "/${mod.command}")
-                }
-            }
+            val thePlayer = Minecraft.getMinecraft().thePlayer
+            ClientCommandHandler.instance.executeCommand(thePlayer, "/" + mod.command)
         } catch (e: Exception) {
             ErrorManager.logErrorWithData(e, "Error trying to open the gui for mod " + mod.name)
         }


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/219

## What
This PR adds the ability to select oneconfig mods in the mod quick switcher. This is implemented via the display name of the oneconfig mod. Note that detecting a sub mod does not prevent detecting the main oneconfig mod (since this uses startswith). I don't think this is a problem since the you are still inside of oneconfig.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/20768569/2ff7dc91-da41-490e-acc4-8289a316ce80)

</details>

## Changelog Improvements
+ Add some OneConfig mods to the quick mod switcher. - nea
