### PR TITLE
Fix: Double Powder Detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
@@ -105,16 +106,14 @@ object PowderTracker {
         calculateResourceHour(chestInfo)
         calculateResourceHour(hardStoneInfo)
 
-        for ((index, line) in TabWidget.EVENT.lines.withIndex()) {
-            if (line.contains("2x Powder")) {
-                if (eventEnded) return
-                doublePowder = true
-                val durationLine = TabWidget.EVENT.lines.getOrNull(index + 1) ?: return
-                tablistEventDuration.matchMatcher(durationLine) {
-                    val duration = group("duration")
-                    powderTimer = TimeUtils.getDuration(duration)
-                    tracker.update()
-                }
+
+        TabWidget.EVENT.lines.nextAfter({ it.contains("2x Powder") })?.let { durationLine ->
+            if (eventEnded) return
+            doublePowder = true
+            tablistEventDuration.matchMatcher(durationLine) {
+                val duration = group("duration")
+                powderTimer = TimeUtils.getDuration(duration)
+                tracker.update()
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -58,11 +58,10 @@ object PowderTracker {
         "powder.bossbar",
         "§e§lPASSIVE EVENT §b§l2X POWDER §e§lRUNNING FOR §a§l(?<time>.*)§r",
     )
-<<<<<<< HEAD
     private val tablistEventDuration by patternGroup.pattern(
         "powder.duration",
         "Ends in: §r§b(?<duration>.*)",
-=======
+    )
 
     /**
      * REGEX-TEST: §b§lCOMPACT! §r§fYou found an §r§aEnchanted Hard Stone§r§f!
@@ -70,7 +69,6 @@ object PowderTracker {
     private val compactedPattern by patternGroup.pattern(
         "compacted",
         "§b§lCOMPACT! §r§fYou found an §r§aEnchanted Hard Stone§r§f!",
->>>>>>> e88f416c48f9659f89b7047d7629cd9a1d1535bc
     )
 
     private var lastChestPicked = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -339,7 +339,7 @@ object PowderTracker {
     }
 
     private fun MutableList<List<Any>>.addPerHour(
-        map: MutableMap<PowderChestReward, Long>,
+        map: Map<PowderChestReward, Long>,
         reward: PowderChestReward,
         info: ResourceInfo,
     ) {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -124,7 +124,6 @@ object PowderTracker {
                 }
             }
         } else {
-            doublePowder = powderBossBarPattern.matcher(BossbarData.getBossbar()).find()
             powderBossBarPattern.matchMatcher(BossbarData.getBossbar()) {
                 val duration = group("time")
                 powderTimer = TimeUtils.getDuration(duration)


### PR DESCRIPTION
## What
Fix detection of 2x Powder event in Powder Tracker

## Changelog Fixes
+ Fixed detection of 2x Powder Event for Powder Tracker. - HiZe
    * Now uses the Tab Widget.

