### PR TITLE
Fix: Farming Weight Overtake ETA

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -310,7 +310,7 @@ object FarmingWeightDisplay {
 
         val timeFormat = if (weightPerSecond != -1.0) {
             val timeTillOvertake = try {
-                (weightUntilOvertake / weightPerSecond).minutes
+                (weightUntilOvertake / weightPerSecond).seconds
             } catch (e: Exception) {
                 ErrorManager.logErrorWithData(
                     e,


### PR DESCRIPTION
<!-- remove all unused parts -->

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

## What
This is a simple fix to the Farming Weight Overtake ETA.

## Changelog Fixes
+ Fix an issue where the farming overtake ETA was being displayed as 60 times longer than it actually was. - Evhan_