### PR TITLE
Improvement: rename mushroom tier

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/cropmilestones/MushroomPetPerkConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/cropmilestones/MushroomPetPerkConfig.java
@@ -44,7 +44,8 @@ public class MushroomPetPerkConfig {
 
     public enum MushroomTextEntry implements HasLegacyId {
         TITLE("§6Mooshroom Cow Perk", 0),
-        MUSHROOM_TIER("§7Mushroom Tier 8", 1),
+        // TODO change to mushroom milestone
+        MUSHROOM_TIER("§7Mushroom Milestone 8", 1),
         NUMBER_OUT_OF_TOTAL("§e6,700§8/§e15,000", 2),
         TIME("§7In §b12m 34s", 3),
         PERCENTAGE("§7Percentage: §e12.34%", 4),

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -319,7 +319,7 @@ object GardenCropMilestoneDisplay {
         lineMap[MushroomTextEntry.TITLE] = Renderable.string("§6Mooshroom Cow Perk")
         lineMap[MushroomTextEntry.MUSHROOM_TIER] = Renderable.horizontalContainer(buildList {
             addCropIconRenderable(mushroom)
-            addString("§7Mushroom Tier $nextTier")
+            addString("§7Mushroom Milestone $nextTier")
         })
 
         lineMap[MushroomTextEntry.NUMBER_OUT_OF_TOTAL] = Renderable.string("§e$haveFormat§8/§e$needFormat")


### PR DESCRIPTION
## What
Rename Mushroom Tier to Mushroom Milestone in Mooshroom Cow Perk.

## Changelog Improvements
+ Rename Mushroom Tier to Mushroom Milestone in Mooshroom Cow Perk. - hannibal2