### PR TITLE
Backend: RegexUtils deprecation and new functions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -564,7 +564,7 @@ enum class HotmData(
             }
             entry.enabled = lore.any { enabledPattern.matches(it) }
 
-            if (entry == SKY_MALL) handelSkyMall(lore)
+            if (entry == SKY_MALL) handleSkyMall(lore)
         }
 
         private fun Slot.handlePowder(): Boolean {
@@ -617,10 +617,10 @@ enum class HotmData(
             "§aYour Current Effect",
         )
 
-        private fun handelSkyMall(lore: List<String>) {
+        private fun handleSkyMall(lore: List<String>) {
             if (!SKY_MALL.enabled || !SKY_MALL.isUnlocked) HotmAPI.skymall = null
             else {
-                val index = lore.indexOfFirstMatch(skyMallCurrentEffect) ?: run {
+                val index = skyMallCurrentEffect.indexOfFirstMatch(lore) ?: run {
                     ErrorManager.logErrorStateWithData(
                         "Could not read the skymall effect from the hotm tree",
                         "skyMallCurrentEffect didn't match",

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -50,6 +50,7 @@ object RegexUtils {
 
     fun List<Pattern>.allMatches(list: List<String>): List<String> = list.filter { line -> any { it.matches(line) } }
     fun List<Pattern>.anyMatches(list: List<String>?): Boolean = list?.any { line -> any { it.matches(line) } } ?: false
+    fun List<Pattern>.anyMatches(string: String): Boolean = any { it.matches(string) }
 
     fun Pattern.matches(string: String?): Boolean = string?.let { matcher(it).matches() } ?: false
     fun Pattern.find(string: String?) = string?.let { matcher(it).find() } ?: false

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -10,19 +10,31 @@ object RegexUtils {
     inline fun <T> Pattern.findMatcher(text: String, consumer: Matcher.() -> T) =
         matcher(text).let { if (it.find()) consumer(it) else null }
 
+    @Deprecated("", ReplaceWith("pattern.firstMatcher(this) { consumer() }"))
     inline fun <T> Sequence<String>.matchFirst(pattern: Pattern, consumer: Matcher.() -> T): T? =
-        toList().matchFirst(pattern, consumer)
+        pattern.firstMatcher(this, consumer)
 
-    inline fun <T> List<String>.matchFirst(pattern: Pattern, consumer: Matcher.() -> T): T? {
-        for (line in this) {
-            pattern.matcher(line).let { if (it.matches()) return consumer(it) }
+    inline fun <T> Pattern.firstMatcher(sequence: Sequence<String>, consumer: Matcher.() -> T): T? =
+        firstMatcher(sequence.toList(), consumer)
+
+    @Deprecated("", ReplaceWith("pattern.firstMatcher(this) { consumer() }"))
+    inline fun <T> List<String>.matchFirst(pattern: Pattern, consumer: Matcher.() -> T): T? =
+        pattern.firstMatcher(this, consumer)
+
+    inline fun <T> Pattern.firstMatcher(list: List<String>, consumer: Matcher.() -> T): T? {
+        for (line in list) {
+            matcher(line).let { if (it.matches()) return consumer(it) }
         }
         return null
     }
 
-    inline fun <T> List<String>.matchAll(pattern: Pattern, consumer: Matcher.() -> T): T? {
-        for (line in this) {
-            pattern.matcher(line).let { if (it.find()) consumer(it) }
+    @Deprecated("", ReplaceWith("pattern.matchAll(this) { consumer() }"))
+    inline fun <T> List<String>.matchAll(pattern: Pattern, consumer: Matcher.() -> T): T? =
+        pattern.matchAll(this, consumer)
+
+    inline fun <T> Pattern.matchAll(list: List<String>, consumer: Matcher.() -> T): T? {
+        for (line in list) {
+            matcher(line).let { if (it.find()) consumer(it) }
         }
         return null
     }
@@ -36,23 +48,34 @@ object RegexUtils {
         return null
     }
 
+    fun List<Pattern>.allMatches(list: List<String>): List<String> = list.filter { line -> any { it.matches(line) } }
+    fun List<Pattern>.anyMatches(list: List<String>?): Boolean = list?.any { line -> any { it.matches(line) } } ?: false
+
     fun Pattern.matches(string: String?): Boolean = string?.let { matcher(it).matches() } ?: false
     fun Pattern.find(string: String?) = string?.let { matcher(it).find() } ?: false
 
-    fun Pattern.anyMatches(list: List<String>?): Boolean = list?.any { this.matches(it) } ?: false
+    fun Pattern.anyMatches(list: List<String>?): Boolean = list?.any { matches(it) } ?: false
     fun Pattern.anyMatches(list: Sequence<String>?): Boolean = anyMatches(list?.toList())
+
+    fun Pattern.matchGroup(text: String, groupName: String): String? = matchMatcher(text) { groupOrNull(groupName) }
+
+    fun Pattern.matchGroups(text: String, vararg groups: String): List<String?>? =
+        matchMatcher(text) { groups.toList().map { groupOrNull(it) } }
+
+    fun Pattern.firstMatches(list: List<String>): String? = list.firstOrNull { matches(it) }
+    fun Pattern.allMatches(list: List<String>): List<String> = list.filter { matches(it) }
 
     /**
      * Get the group, otherwise, return null
      * @param groupName The group name in the pattern
      */
-    fun Matcher.groupOrNull(groupName: String): String? = runCatching { this.group(groupName) }.getOrNull()
+    fun Matcher.groupOrNull(groupName: String): String? = runCatching { group(groupName) }.getOrNull()
 
     fun Matcher.hasGroup(groupName: String): Boolean = groupOrNull(groupName) != null
 
-    fun List<String>.indexOfFirstMatch(pattern: Pattern): Int? {
-        for ((index, line) in this.withIndex()) {
-            pattern.matcher(line).let { if (it.matches()) return index }
+    fun Pattern.indexOfFirstMatch(list: List<String>): Int? {
+        for ((index, line) in list.withIndex()) {
+            matcher(line).let { if (it.matches()) return index }
         }
         return null
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -22,15 +22,12 @@ object RegexUtils {
     }
 
     @Deprecated("", ReplaceWith("pattern.firstMatcher(this) { consumer() }"))
-    inline fun <T> List<String>.matchFirst(pattern: Pattern, consumer: Matcher.() -> T): T? =
-        pattern.firstMatcher(this, consumer)
+    inline fun <T> List<String>.matchFirst(pattern: Pattern, consumer: Matcher.() -> T): T? = pattern.firstMatcher(this, consumer)
 
-    inline fun <T> Pattern.firstMatcher(list: List<String>, consumer: Matcher.() -> T): T? =
-        firstMatcher(list.asSequence(), consumer)
+    inline fun <T> Pattern.firstMatcher(list: List<String>, consumer: Matcher.() -> T): T? = firstMatcher(list.asSequence(), consumer)
 
     @Deprecated("", ReplaceWith("pattern.matchAll(this) { consumer() }"))
-    inline fun <T> List<String>.matchAll(pattern: Pattern, consumer: Matcher.() -> T): T? =
-        pattern.matchAll(this, consumer)
+    inline fun <T> List<String>.matchAll(pattern: Pattern, consumer: Matcher.() -> T): T? = pattern.matchAll(this, consumer)
 
     inline fun <T> Pattern.matchAll(list: List<String>, consumer: Matcher.() -> T): T? {
         for (line in list) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -14,19 +14,19 @@ object RegexUtils {
     inline fun <T> Sequence<String>.matchFirst(pattern: Pattern, consumer: Matcher.() -> T): T? =
         pattern.firstMatcher(this, consumer)
 
-    inline fun <T> Pattern.firstMatcher(sequence: Sequence<String>, consumer: Matcher.() -> T): T? =
-        firstMatcher(sequence.toList(), consumer)
+    inline fun <T> Pattern.firstMatcher(sequence: Sequence<String>, consumer: Matcher.() -> T): T? {
+        for (line in sequence) {
+            matcher(line).let { if (it.matches()) return consumer(it) }
+        }
+        return null
+    }
 
     @Deprecated("", ReplaceWith("pattern.firstMatcher(this) { consumer() }"))
     inline fun <T> List<String>.matchFirst(pattern: Pattern, consumer: Matcher.() -> T): T? =
         pattern.firstMatcher(this, consumer)
 
-    inline fun <T> Pattern.firstMatcher(list: List<String>, consumer: Matcher.() -> T): T? {
-        for (line in list) {
-            matcher(line).let { if (it.matches()) return consumer(it) }
-        }
-        return null
-    }
+    inline fun <T> Pattern.firstMatcher(list: List<String>, consumer: Matcher.() -> T): T? =
+        firstMatcher(list.asSequence(), consumer)
 
     @Deprecated("", ReplaceWith("pattern.matchAll(this) { consumer() }"))
     inline fun <T> List<String>.matchAll(pattern: Pattern, consumer: Matcher.() -> T): T? =


### PR DESCRIPTION
## What
Deprecates some regexutils methods so that the reciever parameter is always either a pattern or a list of patterns, so its more consistent. Also adds a bunch of methods that will be used in an upcoming pr.

## Changelog Technical Details
+ Deprecated some methods in RegexUtils, and added some others. - Empa