### PR TITLE
Fix: Skill Progress ETA

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -149,7 +149,7 @@ object SkillProgress {
         allDisplay = formatAllDisplay(drawAllDisplay())
         etaDisplay = drawETADisplay()
 
-        if (event.repeatSeconds(2)) {
+        if (event.repeatSeconds(1)) {
             update()
             updateSkillInfo()
         }
@@ -503,8 +503,7 @@ object SkillProgress {
             xpInfo.xpGainQueue.removeLast()
         }
 
-        var totalGain = 0f
-        for (f in xpInfo.xpGainQueue) totalGain += f
+        val totalGain = xpInfo.xpGainQueue.sum()
 
         xpInfo.xpGainHour = totalGain * (60 * 60) / xpInfo.xpGainQueue.size
         xpInfo.isActive = true


### PR DESCRIPTION
## What
Since totalGain * (60 * 60) at line 508 is being called with the queued XP gain from the last two seconds, the XP gain per hour would effectively be doubled.

Since this method is still not agnostic to how many times it gets called per second, I might revisit it at some point to clean it up.

## Changelog Fixes
+ Fix the skill progress ETA XP/hour being doubled. - Evhan_
    