### PR TITLE
Fix: Chocolate per Time Tower charge ignoring Mu Rabbit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -163,7 +163,7 @@ object ChocolateFactoryAPI {
     fun timeTowerChargeDuration() =
         if (HoppityCollectionStats.hasFoundRabbit("Einstein")) 7.hours else 8.hours
 
-    private fun timeTowerMultiplier(): Double {
+    fun timeTowerMultiplier(): Double {
         var multiplier = (profileStorage?.timeTowerLevel ?: 0) * 0.1
         if (HoppityCollectionStats.hasFoundRabbit("Mu")) multiplier += 0.7
         return multiplier

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltip.kt
@@ -44,8 +44,7 @@ object ChocolateFactoryTooltip {
     }
 
     private fun chocPerTimeTower(): Int {
-        val profileStorage = profileStorage ?: return 0
-        val amountPerSecond = profileStorage.rawChocPerSecond * profileStorage.timeTowerLevel * .1
+        val amountPerSecond = profileStorage.rawChocPerSecond * ChocolateFactoryAPI.timeTowerMultiplier()
         val amountPerHour = amountPerSecond * 60 * 60
         return amountPerHour.toInt()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltip.kt
@@ -44,6 +44,7 @@ object ChocolateFactoryTooltip {
     }
 
     private fun chocPerTimeTower(): Int {
+        val profileStorage = profileStorage ?: return 0
         val amountPerSecond = profileStorage.rawChocPerSecond * ChocolateFactoryAPI.timeTowerMultiplier()
         val amountPerHour = amountPerSecond * 60 * 60
         return amountPerHour.toInt()


### PR DESCRIPTION
## What
Fixed Time Tower "One charge will give" calculation not accounting for the player having the Mu Rabbit in their collection.

## Changelog Fixes
+ Fix Time Tower "One charge will give" calculation not accounting for the player having the Mu Rabbit in their collection. - Luna
