### PR TITLE
Improvement: Added SkyBlock Level to Item Number

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -137,6 +137,7 @@ public class InventoryConfig {
         DARK_CACAO_TRUFFLE("§bDark Cacao Truffle"),
         EDITION_NUMBER("§bEdition Number", 16),
         BINGO_GOAL_RANK("§bBingo Goal Rank"),
+        SKYBLOCK_LEVEL("§bSkyblock Level")
         ;
 
         private final String str;

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -84,9 +84,14 @@ object ItemDisplayOverlayFeatures {
         "bingogoalrank",
         "(§.)*You were the (§.)*(?<rank>[\\w]+)(?<ordinal>(st|nd|rd|th)) (§.)*to"
     )
+
+    /**
+     * REGEX-TEST: §7Your SkyBlock Level: §8[§a156§8]
+     * REGEX-TEST: §7Your SkyBlock Level: §8[§5399§8]
+     */
     private val skyblockLevelPattern by patternGroup.pattern(
         "skyblocklevel",
-        "§7Your SkyBlock Level: §8\\[(?<level>§\\S\\d+)§8]"
+        "§7Your SkyBlock Level: §8\\[(?<level>§.\\d+)§8]"
     )
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -86,7 +86,7 @@ object ItemDisplayOverlayFeatures {
     )
     private val skyblockLevelPattern by patternGroup.pattern(
         "skyblocklevel",
-        "§7Your SkyBlock Level: §\\S\\[(?<level>§\\S\\d+)§\\S]"
+        "§7Your SkyBlock Level: §8\\[(?<level>§\\S\\d+)§8]"
     )
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumbe
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.PET_LEVEL
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.RANCHERS_BOOTS_SPEED
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.SKILL_LEVEL
+import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.SKYBLOCK_LEVEL
 import at.hannibal2.skyhanni.config.features.inventory.InventoryConfig.ItemNumberEntry.VACUUM_GARDEN
 import at.hannibal2.skyhanni.data.PetAPI
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
@@ -82,6 +83,10 @@ object ItemDisplayOverlayFeatures {
     private val bingoGoalRankPattern by patternGroup.pattern(
         "bingogoalrank",
         "(§.)*You were the (§.)*(?<rank>[\\w]+)(?<ordinal>(st|nd|rd|th)) (§.)*to"
+    )
+    private val skyblockLevelPattern by patternGroup.pattern(
+        "skyblocklevel",
+        "§7Your SkyBlock Level: §\\S\\[(?<level>§\\S\\d+)§\\S]"
     )
 
     @SubscribeEvent
@@ -264,6 +269,12 @@ object ItemDisplayOverlayFeatures {
             lore.matchFirst(bingoGoalRankPattern) {
                 val rank = group("rank").formatLong()
                 if (rank < 10000) return "§6${rank.shortFormat()}"
+            }
+        }
+
+        if (SKYBLOCK_LEVEL.isSelected() && chestName == "SkyBlock Menu" && itemName == "SkyBlock Leveling") {
+            lore.matchFirst(skyblockLevelPattern) {
+                return group("level")
             }
         }
 


### PR DESCRIPTION
## What
Added the option to display your SkyBlock Level in the SkyBlock Menu as an item number.

## Changelog Improvements
+ Added SkyBlock Level number in SB Menu to Item Number config. - ILike2WatchMemes