### PR TITLE
Fix: Gillsplash in Estimated Item Value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.java
@@ -66,6 +66,11 @@ public class DebugConfig {
     public boolean showNpcPrice = false;
 
     @Expose
+    @ConfigOption(name = "Show Craft Price", desc = "Show craft price in item lore.")
+    @ConfigEditorBoolean
+    public boolean showCraftPrice = false;
+
+    @Expose
     @ConfigOption(name = "Show BZ Price", desc = "Show BZ price in item lore.")
     @ConfigEditorBoolean
     public boolean showBZPrice = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
@@ -10,10 +10,10 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.CollectionUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
-import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NEUItems.getPrice
 import at.hannibal2.skyhanni.utils.NEUItems.isVanillaItem
@@ -26,7 +26,6 @@ import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import io.github.moulberry.notenoughupdates.recipes.CraftingRecipe
-import io.github.moulberry.notenoughupdates.recipes.NeuRecipe
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.math.floor
 
@@ -85,7 +84,7 @@ object CraftableItemList {
         pricePer: MutableMap<NEUInternalName, Double>,
         internalName: NEUInternalName,
     ): Renderable? {
-        val neededItems = neededItems(recipe)
+        val neededItems = ItemUtils.neededItems(recipe)
         // Just a fail save, should not happen normally
         if (neededItems.isEmpty()) return null
 
@@ -140,16 +139,6 @@ object CraftableItemList {
             canCraftTotal.add(canCraft)
         }
         return canCraftTotal.min()
-    }
-
-    private fun neededItems(recipe: NeuRecipe): MutableMap<NEUInternalName, Int> {
-        val neededItems = mutableMapOf<NEUInternalName, Int>()
-        for (ingredient in recipe.ingredients) {
-            val material = ingredient.internalItemId.asInternalName()
-            val amount = ingredient.count.toInt()
-            neededItems.addOrPut(material, amount)
-        }
-        return neededItems
     }
 
     private fun readItems(): Map<NEUInternalName, Long> {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -16,8 +16,10 @@ import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.NEUItems.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.getPrice
 import at.hannibal2.skyhanni.utils.NEUItems.getPriceOrNull
+import at.hannibal2.skyhanni.utils.NEUItems.getRawCraftCostOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAbilityScrolls
@@ -536,6 +538,17 @@ object EstimatedItemValueCalculator {
         var price = internalName.getPrice()
         if (price == -1.0) {
             price = 0.0
+        }
+
+        // If craft cost price is greater than npc price, and there is no ah/bz price, use craft cost instead
+        internalName.getNpcPriceOrNull()?.let { npcPrice ->
+            if (price == npcPrice) {
+                internalName.getRawCraftCostOrNull()?.let { rawCraftPrice ->
+                    if (rawCraftPrice > npcPrice) {
+                        price = rawCraftPrice
+                    }
+                }
+            }
         }
 
         val name = internalName.itemName

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -46,6 +46,7 @@ import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.getPriceOrNull
+import at.hannibal2.skyhanni.utils.NEUItems.getRawCraftCostOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.ReflectionUtils.makeAccessible
@@ -466,6 +467,15 @@ object SkyHanniDebugsAndTests {
 
         val npcPrice = internalName.getNpcPriceOrNull() ?: return
         event.toolTip.add("§7NPC price: ${npcPrice.addSeparators()}")
+    }
+
+    @SubscribeEvent
+    fun onSHowCraftPrice(event: LorenzToolTipEvent) {
+        if (!LorenzUtils.inSkyBlock) return
+        if (!debugConfig.showCraftPrice) return
+        val price = event.itemStack.getInternalNameOrNull()?.getRawCraftCostOrNull() ?: return
+
+        event.toolTip.add("§7Craft price: ${price.addSeparators()}")
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -2,8 +2,10 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.data.PetAPI
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.NEUItems.getPrice
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -14,6 +16,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
+import io.github.moulberry.notenoughupdates.recipes.NeuRecipe
 import net.minecraft.client.Minecraft
 import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
@@ -340,7 +343,7 @@ object ItemUtils {
                 "internal name" to pet.getInternalName(),
                 "item name" to name,
                 "rarity id" to rarityId,
-                "inventory name" to InventoryUtils.openInventoryName()
+                "inventory name" to InventoryUtils.openInventoryName(),
             )
         }
         return rarity
@@ -410,4 +413,20 @@ object ItemUtils {
         }
         return list
     }
+
+    fun neededItems(recipe: NeuRecipe): Map<NEUInternalName, Int> {
+        val neededItems = mutableMapOf<NEUInternalName, Int>()
+        for (ingredient in recipe.ingredients) {
+            val material = ingredient.internalItemId.asInternalName()
+            val amount = ingredient.count.toInt()
+            neededItems.addOrPut(material, amount)
+        }
+        return neededItems
+    }
+
+    fun getRecipePrice(recipe: NeuRecipe): Double =
+        neededItems(recipe).map {
+            it.key.getPrice() * it.value
+        }.sum()
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -197,7 +197,10 @@ object NEUItems {
         return getNpcPriceOrNull() ?: getRawCraftCostOrNull()
     }
 
-    fun NEUInternalName.getRawCraftCostOrNull(): Double? = manager.auctionManager.getCraftCost(asString())?.craftCost
+    // If NEU fails to calculate the craft costs, we calculate it ourself.
+    fun NEUInternalName.getRawCraftCostOrNull(): Double? = manager.auctionManager.getCraftCost(asString())?.craftCost ?: run {
+        getRecipes(this).map { ItemUtils.getRecipePrice(it) }.minOrNull()
+    }
 
     fun NEUInternalName.getItemStackOrNull(): ItemStack? = ItemResolutionQuery(manager)
         .withKnownInternalName(asString())


### PR DESCRIPTION
## What
Fixed wrong item prices in Estimated Item Value when the craft price is higher than NPC price and the item is soulbound.
E.g. for Gillsplash (fishing equipment).
technically we have the following rule now: If craft cost price is greater than NPC price, and there is no ah/bz price, use craft cost instead.

<details>
<summary>Images</summary>

![image](https://github.com/hannibal002/SkyHanni/assets/24389977/450a0c77-a307-4434-83aa-07024836399d)

</details>

## Changelog Fixes
+ Fix wrong item prices in Estimated Item Value when the craft price is higher than the NPC price and the item is soulbound. - hannibal2
    * E.g. for Gillsplash (fishing equipment).