### PR TITLE
Fix: Worldedit command

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/WorldEdit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/WorldEdit.kt
@@ -125,7 +125,7 @@ object WorldEdit {
             }
 
             "right", "pos2" -> {
-                leftPos = LocationUtils.playerLocation().toBlockPos()
+                rightPos = LocationUtils.playerLocation().toBlockPos()
                 ChatUtils.chat("Set right pos.")
             }
 


### PR DESCRIPTION
## What
Fixed setting left pos instead of right pos with the command.


## Changelog Fixes
+ Fix "/worldedit right" setting the left position. - HiZe


