### PR TITLE
Improvement: Estimated Item Value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/EstimatedItemValueConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/EstimatedItemValueConfig.java
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
@@ -62,6 +63,36 @@ public class EstimatedItemValueConfig {
     @ConfigOption(name = "Ignore Runes", desc = "Ignore Runes from the total value.")
     @ConfigEditorBoolean
     public boolean ignoreRunes = false;
+
+    @Expose
+    @ConfigOption(name = "Bazaar Price Source", desc = "Use Instant Buy or Buy Order.")
+    @ConfigEditorDropdown
+    public BazaarPriceSource bazaarPriceSource = BazaarPriceSource.BUY_ORDER;
+
+    public enum BazaarPriceSource {
+        INSTANT_BUY("Instant Buy"),
+        BUY_ORDER("Buy Order"),
+        ;
+        private final String str;
+
+        BazaarPriceSource(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public String toString() {
+            return str;
+        }
+    }
+
+    @Expose
+    @ConfigOption(
+        name = "Use Attribute Price",
+        desc = "Show composite price for attributes instead of lowest bin. " +
+            "This will drastically decrease the estimated value but might be correct when buying multiple low tier items and combining them."
+    )
+    @ConfigEditorBoolean
+    public boolean useAttributeComposite = false;
 
     @Expose
     @ConfigLink(owner = EstimatedItemValueConfig.class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.getNpcPriceOrNull
-import at.hannibal2.skyhanni.utils.NEUItems.getPrice
 import at.hannibal2.skyhanni.utils.NEUItems.getPriceOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.getRawCraftCostOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat


### PR DESCRIPTION
## Changelog Improvements
+ Update Estimated Item Value calculation. - hannibal2
    * Change attribute prices from composited to the lowest bin, and added an option to use composited prices again.
    * Add Toxophilite.
    * Add option to choose whether to use Bazaar buy order or instant buy prices.
    * Calculating with tier 5 prices for Ferocious Mana, Hardened Mana, Mana Vampire and Strong Mana.