### PR TITLE
Fix: Double-Bit in Reforge Helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ReforgeAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ReforgeAPI.kt
@@ -68,7 +68,7 @@ object ReforgeAPI {
 
         val rawReforgeStoneName = reforgeStone?.itemNameWithoutColor
 
-        val lowercaseName = name.lowercase()
+        val lowercaseName = name.lowercase().replace('-', '_')
 
         fun isValid(itemStack: ItemStack) = isValid(itemStack.getItemCategoryOrNull(), itemStack.getInternalName())
 


### PR DESCRIPTION
## What
It did not work since the - gets replaced as an _ in the modifer from Hypixel. And we compare with the modifer and lowerCaseName. But lowerCaseName had a - in it instead of an _ .

## Discord
https://discord.com/channels/997079228510117908/1257381966748323961

## Changelog Fixes
+ Double-Bit now works in reforge helper . - Thunderblade73

