### PR TITLE
Fix: Craftable! Text and Internal Names

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
@@ -115,7 +115,7 @@ object CraftableItemList {
             "§8x$amountFormat ${internalName.itemName}",
             tips = tooltip,
             onClick = {
-                HypixelCommands.viewRecipe(internalName.asString())
+                HypixelCommands.viewRecipe(internalName.asString().replace("internalName:", ""))
             },
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
@@ -115,7 +115,7 @@ object CraftableItemList {
             "§8x$amountFormat ${internalName.itemName}",
             tips = tooltip,
             onClick = {
-                HypixelCommands.viewRecipe(internalName.asString().replace("internalName:", ""))
+                HypixelCommands.viewRecipe(internalName.itemName)
             },
         )
     }


### PR DESCRIPTION
## What
Sometime before #2075 was merged, `itemName` was changed to `itemName.toString()`, which left the feature non-functional, trying to run `/viewrecipe` with `internalname:` leading it. This fixes that. There's hesitancy to use `itemName` itself, I would guess based in the fact that some items aren't searchable by display name, but none of those items are requested from visitors in the garden.

<details>
<summary>Images</summary>

Before
![image](https://github.com/hannibal002/SkyHanni/assets/40234707/7c986ece-8dfe-40d7-bbd4-afcc8105b303)

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fix Craftable! text not opening the recipe. - Daveed

