### PR TITLE
Fix: Guild Rank Chat Formatting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -62,7 +62,7 @@ object PlayerChatManager {
      */
     private val guildPattern by patternGroup.pattern(
         "guild",
-        "§2Guild > (?<author>.+?)(?<guildRank> §e\\[\\w*])?§f: (?<message>.*)"
+        "§2Guild > (?<author>.+?) ?(?<guildRank>§e\\[\\w*])?§f: (?<message>.*)",
     )
 
     /**


### PR DESCRIPTION
## What
Fixes guild rank having an extra space before in chat formatting.

[Report](https://discord.com/channels/997079228510117908/1000669238035497022/1258095233984630875)

## Changelog Fixes
+ Fix Guild Rank formatting having an extra space. - Empa