### PR TITLE
Fix: HypixelData Npe

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -394,7 +394,7 @@ object HypixelData {
             }
         }
 
-        serverNameConnectionPattern.matchMatcher(mc.getCurrentServerData().serverIP) {
+        serverNameConnectionPattern.matchMatcher(mc.currentServerData?.serverIP ?: "") {
             hypixel = true
             if (group("prefix") == "alpha.") {
                 hypixelAlpha = true


### PR DESCRIPTION
## What
mc.currentServerData can be null. This way it won't throw a npe, so that the other detections ways still could work.

## Changelog Fixes
+ Fix a bug in the Hypixel detection. - Thunderblade73
