### PR TITLE
Fix: Stackoverflow for getPrice

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -423,15 +423,9 @@ object ItemUtils {
         return neededItems
     }
 
-    fun getRecipePrice(recipe: NeuRecipe): Double =
+    fun getRecipePrice(recipe: NeuRecipe, pastRecipes: List<NeuRecipe> = emptyList()): Double =
         neededItems(recipe).map {
-            // prevents stack overflow errors with ENDERMAN_MONSTER
-            if (it.key.endsWith("_MONSTER")) {
-                0.0
-            } else {
-                it.key.getPrice() * it.value
-            }
+            it.key.getPrice(pastRecipes = pastRecipes) * it.value
         }.sum()
-
 
 }


### PR DESCRIPTION
## What
Fixes infite recursion for looping recipes. Eg: A is made out of B and B is made out of C and C can be made with A. Makeing a closed loop where it never finishes.

It is fixed in that it keeps track if the recipe was already called in the stack. Meaning it will skip it (since it will lead to no end).

## Changelog Fixes
+ Fix random Stack Overflow Errors. - Thunderblade73
