### PR TITLE
Fix: Buying items may incorrectly trigger compact hoppity messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -87,8 +87,10 @@ object HoppityEggsCompactChat {
         }
 
         HoppityEggsManager.eggBoughtPattern.matchMatcher(event.message) {
-            rabbitBought = true
-            compactChat(event)
+            if (group("rabbitname").equals(lastName)) {
+                rabbitBought = true
+                compactChat(event)
+            }
         }
 
         HoppityEggsManager.rabbitFoundPattern.matchMatcher(event.message) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -49,7 +49,7 @@ object HoppityEggsManager {
      */
     val eggBoughtPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "egg.bought",
-        "§aYou bought §r§.(?<rabbitname>.*?) §r§afor §r§6((\\d|,)*) Coins§r§a!",
+        "§aYou bought §r(?<rabbitname>.*?) §r§afor §r§6((\\d|,)*) Coins§r§a!",
     )
 
     /**


### PR DESCRIPTION
## What
This fixes an issue where sometimes the compact hoppity messages trigger when buying non-rabbits items. However, this does not yet resolve compacting the chat for milestone rabbits (both chocolate shop and all-time chocolate) and golden rabbit side dish egg.

Related forum posts: [Builder buy messages being detected as "COMPACT_HOPPITY" thus being blocked](https://discord.com/channels/997079228510117908/1254691705530224691a), [Rabbit Milestone Message merged with NPC Shop Message](https://discord.com/channels/997079228510117908/1253176196980539422)

## Changelog Fixes
+ Fixed buying items sometimes triggering compact Hoppity messages. - sayomaki
