### PR TITLE
Fix: Fragged Daedalus Axe not getting detected as farming tool

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -81,6 +81,7 @@ object GardenAPI {
     // TODO USE SH-REPO
     private val otherToolsList = listOf(
         "DAEDALUS_AXE",
+        "STARRED_DAEDALUS_AXE",
         "BASIC_GARDENING_HOE",
         "ADVANCED_GARDENING_AXE",
         "BASIC_GARDENING_AXE",


### PR DESCRIPTION
## What
Fixed fragged Daedalus Axe not being detected as a farming tool.

## Changelog Fixes
+ Fixed a bug where the fragged Daedalus Axe was not being detected as a farming tool. - Luna