### PR TITLE
Fix: Hot Potato Book in Community Project

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -294,11 +294,11 @@ object ItemUtils {
 
     private val itemAmountCache = mutableMapOf<String, Pair<String, Int>>()
 
+    private val bookPattern = "(?<name>.* [IVX]+) Book".toPattern()
+
     fun readItemAmount(originalInput: String): Pair<String, Int>? {
         // This workaround fixes 'Turbo Cacti I Book'
-        val input = (if (originalInput.endsWith(" Book")) {
-            originalInput.replace(" Book", "")
-        } else originalInput).removeResets()
+        val input = (bookPattern.matchMatcher(originalInput) { group("name") } ?: originalInput).removeResets()
 
         if (itemAmountCache.containsKey(input)) {
             return itemAmountCache[input]!!


### PR DESCRIPTION
## What
Fixes hot potato book being recognized as a potato in the community center

[Bug Report](https://discord.com/channels/997079228510117908/1260378195887263855/1260378195887263855)

## Changelog Fixes
+ Fixed detecting Hot Potato Books inside the Community Project as potatoes. - Empa