### PR TITLE
Fix: Fine Flour exportation pattern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CarrolynTable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CarrolynTable.kt
@@ -27,8 +27,8 @@ enum class CarrolynTable(val crop: CropType, val label: String, completeMessage:
     FINE_FLOUR(
         CropType.WHEAT,
         "Fine Flour",
-        "WHEATS EXPORTATION COMPLETE!",
-        "[NPC] Carrolyn: Thank you for the flour.", // TODO confirm this, since this is only a estimate
+        "FINE FLOURS EXPORTATION COMPLETE!",
+        "[NPC] Carrolyn: Thank you for the flour.",
     ),
     ;
 


### PR DESCRIPTION
## What
Fixed Fine Flour exportation pattern. Confirmed by testing in-game.

## Changelog Fixes
+ Fixed Fine Flour exportation not getting detected from chat messages for use in FF Guide. - Luna