### PR TITLE
Fix: Farming ETA Duration "NaN"

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -372,6 +372,9 @@ object FarmingWeightDisplay {
     private fun isEtaEnabled() = config.overtakeETA
 
     fun addCrop(crop: CropType, addedCounter: Int) {
+        //Prevent div-by-0 errors
+        if(addedCounter == 0) return;
+
         val before = getExactWeight()
         localCounter[crop] = crop.getLocalCounter() + addedCounter
         val after = getExactWeight()
@@ -384,7 +387,7 @@ object FarmingWeightDisplay {
     private fun updateWeightPerSecond(crop: CropType, before: Double, after: Double, diff: Int) {
         val speed = crop.getSpeed() ?: return
         val weightDiff = (after - before) * 1000
-        weightPerSecond = if (diff == 0) -1.0 else ((weightDiff / diff) * (speed / 1000))
+        weightPerSecond = ((weightDiff / diff) * (speed / 1000))
     }
 
     private fun getExactWeight(): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -384,7 +384,7 @@ object FarmingWeightDisplay {
     private fun updateWeightPerSecond(crop: CropType, before: Double, after: Double, diff: Int) {
         val speed = crop.getSpeed() ?: return
         val weightDiff = (after - before) * 1000
-        weightPerSecond = if(diff == 0 || weightDiff == 0.0) -1.0 else ((weightDiff / diff) * (speed / 1000))
+        weightPerSecond = if(diff == 0) -1.0 else ((weightDiff / diff) * (speed / 1000))
     }
 
     private fun getExactWeight(): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -384,7 +384,7 @@ object FarmingWeightDisplay {
     private fun updateWeightPerSecond(crop: CropType, before: Double, after: Double, diff: Int) {
         val speed = crop.getSpeed() ?: return
         val weightDiff = (after - before) * 1000
-        weightPerSecond = weightDiff / diff * speed / 1000
+        weightPerSecond = if(diff == 0 || weightDiff == 0.0) -1.0 else ((weightDiff / diff) * (speed / 1000))
     }
 
     private fun getExactWeight(): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -384,7 +384,7 @@ object FarmingWeightDisplay {
     private fun updateWeightPerSecond(crop: CropType, before: Double, after: Double, diff: Int) {
         val speed = crop.getSpeed() ?: return
         val weightDiff = (after - before) * 1000
-        weightPerSecond = if(diff == 0) -1.0 else ((weightDiff / diff) * (speed / 1000))
+        weightPerSecond = if (diff == 0) -1.0 else ((weightDiff / diff) * (speed / 1000))
     }
 
     private fun getExactWeight(): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -373,7 +373,7 @@ object FarmingWeightDisplay {
 
     fun addCrop(crop: CropType, addedCounter: Int) {
         //Prevent div-by-0 errors
-        if(addedCounter == 0) return;
+        if (addedCounter == 0) return;
 
         val before = getExactWeight()
         localCounter[crop] = crop.getLocalCounter() + addedCounter


### PR DESCRIPTION
## What
Re: #2158, which had a suggested but not-implemented fix for this issue, fix the `NaN` issue that occasionally appears when starting/stopping farming or killing pests. This was due to `diff` being 0, causing a div-by-0 error.

## Changelog Fixes
+ Fixed an error in the Farming ETA Duration calculation. - Daveed
