### PR TITLE
Fix: Typo in shcommands

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
@@ -75,7 +75,7 @@ object HelpCommand {
 
         if (filtered.isEmpty()) {
             text.add(Text.EMPTY)
-            text.add("§cNo reminders found.".asComponent().center())
+            text.add("§cNo commands found.".asComponent().center())
             text.add(Text.EMPTY)
         } else {
             val start = (page - 1) * COMMANDS_PER_PAGE


### PR DESCRIPTION
## What
Fix no results found in shcommands being "No reminders found."

## Changelog Fixes
+ Fixed a typo in /shcommands. - Obsidian