### PR TITLE
Fix: Powder Tracker NPE on older versions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestReward.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestReward.kt
@@ -208,7 +208,7 @@ enum class PowderChestReward(val displayName: String, pattern: String) {
     ;
 
     val chatPattern by RepoPattern.pattern(
-        "mining.powder.tracker.reward." + this.patternName(),
+        "mining.powder.tracker.reward.${this.patternName()}.new",
         pattern,
     )
 


### PR DESCRIPTION
## What
Fixed powder tracker NullPointerException on older versions due to the change in #2207.

(Excluding from changelog because this is essentially a repo change, and it is not relevant to people who update to the next beta.)

exclude_from_changelog
