### PR TITLE
Fix: Fish The Rabbit Production Time in Lore

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -20,7 +20,7 @@ object ChocolateFactoryTooltipStray {
      */
     private val chocolateGainedPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.stray",
-        "(?:§.)?+(?:Rabbit§7, so )?(?:[Yy]ou )?(?:gained |received )?§6\\+?(?<amount>[\\d,]+)(?:\$| Chocolate§7!)"
+        "(?:§.)?+(?:Rabbit§7, so )?(?:[Yy]ou )?(?:gained |received )?§6\\+?(?<amount>[\\d,]+)(?:$| Chocolate§7!)"
     )
 
     @SubscribeEvent(priority = EventPriority.HIGH)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -19,7 +19,7 @@ object ChocolateFactoryTooltipStray {
      */
     private val chocolateGainedPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.stray",
-        "(?:§.)+(?:You )?(?:gained )?§6\\+(?<amount>[\\d,]+) Chocolate§7!"
+        "(?:§.)?+(?:Rabbit§7, so )?(?:[Yy]ou )?(?:gained |received )?§6\\+?(?<amount>[\\d,]+) (?:§6)?Chocolate§7!"
     )
 
     @SubscribeEvent(priority = EventPriority.HIGH)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -16,6 +16,7 @@ object ChocolateFactoryTooltipStray {
      * REGEX-TEST: §7You gained §6+2,465,018 Chocolate§7!
      * REGEX-TEST: §7gained §6+30,292 Chocolate§7!
      * REGEX-TEST: §7§6+36,330 Chocolate§7!
+     * REGEX-TEST: §9Rabbit§7, so you received §655,935,257
      */
     private val chocolateGainedPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.stray",

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -20,7 +20,7 @@ object ChocolateFactoryTooltipStray {
      */
     private val chocolateGainedPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.stray",
-        "(?:§.)?+(?:Rabbit§7, so )?(?:[Yy]ou )?(?:gained |received )?§6\\+?(?<amount>[\\d,]+) (?:§6)?Chocolate§7!"
+        "(?:§.)?+(?:Rabbit§7, so )?(?:[Yy]ou )?(?:gained |received )?§6\\+?(?<amount>[\\d,]+)(?:\$| Chocolate§7!)"
     )
 
     @SubscribeEvent(priority = EventPriority.HIGH)


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1262570859470651412
Fix Fish the Rabbit not having production time added to lore, due to having different formatting.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/b143eb6a-1033-4667-b65c-711347dbc1e9)

</details>

## Changelog Fixes
+ Fixed the detection of production time from Fish the Rabbit. - Daveed
