### PR TITLE
Fix: Farming ETA Approaches 0

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -387,7 +387,7 @@ object FarmingWeightDisplay {
     private fun updateWeightPerSecond(crop: CropType, before: Double, after: Double, diff: Int) {
         val speed = crop.getSpeed() ?: return
         val weightDiff = (after - before) * 1000
-        weightPerSecond = ((weightDiff / diff) * (speed / 1000))
+        weightPerSecond = (((weightDiff / diff) * speed) / 1000)
     }
 
     private fun getExactWeight(): Double {


### PR DESCRIPTION
## What
Fix skill issue with PEMDAS causing incorrect farming weight overtake numbers.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/560f87f5-b5dd-4675-bbd3-1ea628e22136)

</details>

## Changelog Fixes
+ Fixed farming weight estimate being much too large. - DavidArthurCole

