### PR TITLE
Removed Feature: /sh limbo

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -321,10 +321,6 @@ object Commands {
             "Prints your Limbo Stats.\n §7This includes your Personal Best, Playtime, and §aSkyHanni User Luck§7!",
         ) { LimboTimeTracker.printStats() }
         registerCommand(
-            "shlimbo",
-            "Warps you to Limbo.",
-        ) { MiscFeatures.goToLimbo() }
-        registerCommand(
             "shlanedetection",
             "Detect a farming lane in garden",
         ) { FarmingLaneCreator.commandLaneDetection() }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MiscFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MiscFeatures.kt
@@ -54,8 +54,4 @@ object MiscFeatures {
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "mobs", "combat.mobs")
     }
-
-    fun goToLimbo() {
-        ChatUtils.sendMessageToServer("§")
-    }
 }


### PR DESCRIPTION
## What
Removes the /shlimbo command

![image](https://github.com/user-attachments/assets/3aea7b5e-754e-4060-a378-ef055c0ecc07)


## Changelog Removed Features
+ Removed the /shlimbo command. - nopo
    * Hypixel added /limbo.

