### PR TITLE
Fix: Ignore Jasper/Ruby Crystal price

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
@@ -11,8 +11,10 @@ class NEUInternalName private constructor(private val internalName: String) {
         val NONE = "NONE".asInternalName()
         val MISSING_ITEM = "MISSING_ITEM".asInternalName()
 
-        val WISP_POTION = "WISP_POTION".asInternalName()
+        val JASPER_CRYSTAL = "JASPER_CRYSTAL".asInternalName()
+        val RUBY_CRYSTAL = "RUBY_CRYSTAL".asInternalName()
         val SKYBLOCK_COIN = "SKYBLOCK_COIN".asInternalName()
+        val WISP_POTION = "WISP_POTION".asInternalName()
 
         fun String.asInternalName(): NEUInternalName {
             val internalName = uppercase().replace(" ", "_")

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -182,8 +182,10 @@ object NEUItems {
         pastRecipes: List<NeuRecipe> = emptyList(),
     ): Double? {
         when (this) {
-            NEUInternalName.WISP_POTION -> return 20_000.0
+            NEUInternalName.JASPER_CRYSTAL -> return 0.0
+            NEUInternalName.RUBY_CRYSTAL -> return 0.0
             NEUInternalName.SKYBLOCK_COIN -> return 1.0
+            NEUInternalName.WISP_POTION -> return 20_000.0
         }
 
         if (priceSource != ItemPriceSource.NPC_SELL) {


### PR DESCRIPTION
## What
Ignore Jasper/Ruby Crystal price. These crystals used to have an item form, and may be sold on the Auction House for overinflated prices (e.g. over 900M for a Jasper Crystal), which inflates corpse profit numbers for example.

![image](https://github.com/user-attachments/assets/ba43c98e-b746-4f77-add1-3bb1c53f52be)
![image](https://github.com/user-attachments/assets/8f777205-a811-4dca-a205-6a6a758b09fe)

## Changelog Fixes
+ Ignore Jasper/Ruby Crystal price. - Luna
    * These crystals used to have an item form and may be sold on the Auction House for overinflated prices (e.g., over 900M for a Jasper Crystal), which can inflate values like Corpse Profit.