### PR TITLE
Fix: Stray Rabbit Production Time Tooltip

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -2,8 +2,10 @@ package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -20,7 +22,7 @@ object ChocolateFactoryTooltipStray {
      */
     private val chocolateGainedPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.stray",
-        "(?:§.)?+(?:Rabbit§7, so )?(?:[Yy]ou )?(?:gained |received )?§6\\+?(?<amount>[\\d,]+)(?:$| Chocolate§7!)"
+        "(?:§.)*(?:Rabbit§7, so )?(?:[Yy]ou )?(?:gained |received )?§6\\+?(?<amount>[\\d,]+)(?: Chocolate§7!)?"
     )
 
     @SubscribeEvent(priority = EventPriority.HIGH)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -13,10 +13,10 @@ object ChocolateFactoryTooltipStray {
     private val config get() = ChocolateFactoryAPI.config
 
     /**
-     * REGEX-TEST: §7You gained §6+2,465,018 Chocolate§7!
-     * REGEX-TEST: §7gained §6+30,292 Chocolate§7!
-     * REGEX-TEST: §7§6+36,330 Chocolate§7!
-     * REGEX-TEST: §9Rabbit§7, so you received §655,935,257
+     * REGEX-TEST: §5§o§7You gained §6+2,465,018 Chocolate§7!
+     * REGEX-TEST: §5§o§7gained §6+30,292 Chocolate§7!
+     * REGEX-TEST: §5§o§7§6+36,330 Chocolate§7!
+     * REGEX-TEST: §5§o§9Rabbit§7, so you received §655,935,257
      */
     private val chocolateGainedPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.stray",

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -2,10 +2,8 @@ package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent


### PR DESCRIPTION
## What
Leading formatting of tooltips was causing the pattern to not match.

## Changelog Fixes
+ Fixed stray rabbit production time tooltip display. - Daveed

