### PR TITLE
Fix: Hoppity Abiphone Call Compact

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -122,9 +122,9 @@ object HoppityEggsManager {
             return
         }
 
-        if (!ChocolateFactoryAPI.isHoppityEvent()) return
-
         HoppityEggsCompactChat.handleChat(event)
+
+        if (!ChocolateFactoryAPI.isHoppityEvent()) return
 
         eggFoundPattern.matchMatcher(event.message) {
             HoppityEggLocations.saveNearestEgg()


### PR DESCRIPTION
## What
Update the blocking of hoppity compacting so that it is not dependent on it being a hoppity's event. Since hoppity can call outside of the event, this caused compacting to break for abiphone calls.

Since the UI there is just a re-skinned version of what you get when you buy rabbits from hoppity normally, no other code changes were needed, as the existing `Bought rabbit!` code will detect it (see image).

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/eddc3c3d-9607-4e85-abf0-99aaf68f9a38)

</details>

## Changelog Fixes
+ Fixed Hoppity Chat Compact not working outside of Hoppity's event for Abiphone users who have Hoppity as a contact. - Daveed
