### PR TITLE
Fix: Fine Flour in Sprayonator

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -21,7 +21,6 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.locked
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.name
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.pests
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.uncleared
-import at.hannibal2.skyhanni.features.garden.pests.PestAPI.getPests
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.locked
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.name
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.pests
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.uncleared
+import at.hannibal2.skyhanni.features.garden.pests.PestAPI.getPests
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayFeatures.kt
@@ -28,17 +28,17 @@ object SprayFeatures {
 
     private val changeMaterialPattern by RepoPattern.pattern(
         "garden.spray.material",
-        "§a§lSPRAYONATOR! §r§7Your selected material is now §r§a(?<spray>.*)§r§7!"
+        "§a§lSPRAYONATOR! §r§7Your selected material is now §r§a(?<spray>.*)§r§7!",
     )
 
-    private fun SprayType?.getSprayEffect(): String {
-        return this?.getPests()?.takeIf { it.isNotEmpty() }?.let { pests ->
+    private fun SprayType?.getSprayEffect(): String =
+        this?.getPests()?.takeIf { it.isNotEmpty() }?.let { pests ->
             pests.joinToString("§7, §6") { it.displayName }
         } ?: when (this) {
             SprayType.FINE_FLOUR -> "§6+20☘ Farming Fortune"
             else -> "§cUnknown Effect"
         }
-    }
+
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayFeatures.kt
@@ -32,6 +32,15 @@ object SprayFeatures {
         "§a§lSPRAYONATOR! §r§7Your selected material is now §r§a(?<spray>.*)§r§7!"
     )
 
+    private fun SprayType.getSprayEffect(): String {
+        return this.getPests().takeIf { it.isNotEmpty() }?.let { pests ->
+            pests.joinToString("§7, §6") { it.displayName }
+        } ?: when (this) {
+            SprayType.FINE_FLOUR -> "§a+§620☘ Farming Fortune"
+            else -> "§cUnknown Effect"
+        }
+    }
+
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
         if (!isEnabled()) return
@@ -48,8 +57,8 @@ object SprayFeatures {
             }
         } ?: return
 
-        val pests = type.getPests().joinToString("§7, §6") { it.displayName }
-        display = "§a${type.displayName} §7(§6$pests§7)"
+        val sprayEffect = type.getSprayEffect()
+        display = "§a${type.displayName} §7(§6$sprayEffect§7)"
 
         lastChangeTime = SimpleTimeMark.now()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayFeatures.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotAPI
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.renderPlot
 import at.hannibal2.skyhanni.features.garden.pests.PestAPI.getPests
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -32,11 +31,11 @@ object SprayFeatures {
         "§a§lSPRAYONATOR! §r§7Your selected material is now §r§a(?<spray>.*)§r§7!"
     )
 
-    private fun SprayType.getSprayEffect(): String {
-        return this.getPests().takeIf { it.isNotEmpty() }?.let { pests ->
+    private fun SprayType?.getSprayEffect(): String {
+        return this?.getPests()?.takeIf { it.isNotEmpty() }?.let { pests ->
             pests.joinToString("§7, §6") { it.displayName }
         } ?: when (this) {
-            SprayType.FINE_FLOUR -> "§a+§620☘ Farming Fortune"
+            SprayType.FINE_FLOUR -> "§6+20☘ Farming Fortune"
             else -> "§cUnknown Effect"
         }
     }
@@ -45,20 +44,12 @@ object SprayFeatures {
     fun onChat(event: LorenzChatEvent) {
         if (!isEnabled()) return
 
-        val type = changeMaterialPattern.matchMatcher(event.message) {
+        display = changeMaterialPattern.matchMatcher(event.message) {
             val sprayName = group("spray")
-            SprayType.getByName(sprayName) ?: run {
-                ErrorManager.logErrorStateWithData(
-                    "Error reading spray material", "SprayType is null",
-                    "sprayName" to sprayName,
-                    "event.message" to event.message,
-                )
-                return
-            }
+            val type = SprayType.getByName(sprayName)
+            val sprayEffect = type.getSprayEffect()
+            "§a${type?.displayName ?: sprayName} §7(§6$sprayEffect§7)"
         } ?: return
-
-        val sprayEffect = type.getSprayEffect()
-        display = "§a${type.displayName} §7(§6$sprayEffect§7)"
 
         lastChangeTime = SimpleTimeMark.now()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayType.kt
@@ -6,6 +6,7 @@ enum class SprayType(val displayName: String) {
     DUNG("Dung"),
     HONEY_JAR("Honey Jar"),
     TASTY_CHEESE("Tasty Cheese"),
+    FINE_FLOUR("Fine Flour"),
     ;
 
     companion object {


### PR DESCRIPTION
## What
Add generic effect string getter in SprayFeatures to replace static "get pests", as Fine Flour broke the standard.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/8a5e6d3e-006b-4dd8-9dcf-3fde3208e53b)

</details>

## Changelog Fixes
+ Fixed errors when selecting Fine Flour with the Sprayonator. - Daveed

