### PR TITLE
Improvement: Class Highlight in Party Finder

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/PartyFinderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/PartyFinderConfig.java
@@ -1,8 +1,10 @@
 package at.hannibal2.skyhanni.config.features.dungeon;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
+import at.hannibal2.skyhanni.config.HasLegacyId;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 
@@ -12,6 +14,42 @@ public class PartyFinderConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean coloredClassLevel = true;
+
+    @Expose
+    @ConfigOption(name = "Colored Class", desc = "Color selected class in Party Finder.")
+    @ConfigEditorDropdown
+    public ClassEntry markClass = ClassEntry.TANK;
+
+    public enum ClassEntry implements HasLegacyId {
+        TANK("Tank", 0),
+        HEALER("Healer", 1),
+        MAGE("Mage", 2),
+        ARCHER("Archer", 3),
+        BERSERK("Berserk", 4),
+        ;
+        private final String str;
+        private final int legacyId;
+
+        ClassEntry(String str, int legacyId) {
+            this.str = str;
+            this.legacyId = legacyId;
+        }
+
+        // Constructor if new enum elements are added post-migration
+        ClassEntry(String str) {
+            this(str, -1);
+        }
+
+        @Override
+        public int getLegacyId() {
+            return legacyId;
+        }
+
+        @Override
+        public String toString() {
+            return str;
+        }
+    }
 
     @Expose
     @ConfigOption(name = "Floor Stack Size", desc = "Display the party finder floor as the item stack size.")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -253,6 +253,13 @@ object DungeonFinderFeatures {
                 }
             }
 
+            val markedClass = memberClasses.any { it == config.markClass.toString() }
+            if (markedClass) {
+                map[slot] = LorenzColor.WHITE
+                continue
+            }
+
+
             if (config.markMissingClass && memberClasses.none { it == selectedClass }) {
                 map[slot] = LorenzColor.GREEN
             }


### PR DESCRIPTION
## What
Highlight selected class in Party Finder

<details>
<summary>Images</summary>

<!-- drop images here -->
![image](https://github.com/user-attachments/assets/615c02a9-75cb-4462-b8ca-51ef7e0929da)
![image](https://github.com/user-attachments/assets/faef5119-b7d7-4866-85cf-6338ac5bff28)

</details>

## Changelog Improvements
+ Added Class Highlight. - Trîggered
