### PR TITLE
Fix: Jasper Gemstone Color

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -176,7 +176,7 @@ enum class OreBlock(
         checkArea = { inCrystalHollows || inGlacite },
     ),
     JASPER(
-        checkBlock = { it.isGemstoneWithColor(EnumDyeColor.PINK) },
+        checkBlock = { it.isGemstoneWithColor(EnumDyeColor.MAGENTA) },
         checkArea = { inCrystalHollows || inGlacite },
     ),
     OPAL(


### PR DESCRIPTION
## What
Fixed the check for Jasper gemstones using pink color instead of magenta.

<details>
<summary>Images</summary>

![image](https://i.imgur.com/z2DPGor.png)
</details>

## Changelog Technical Details
+ Fixed wrong color for Jasper gemstone in OreBlock API. - Luna