### PR TITLE
Backend: Change colour (UK) to color (US)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ for more information and usages.
 - Do not use `fixedRateTimer` when possible and instead use `SecondPassedEvent` to safely execute the repeating event on
   the main thread.
 - When updating a config option variable, use the `ConfigUpdaterMigrator.ConfigFixEvent` with event.move() when moving a value, and event.transform() when updating a value. [For Example](https://github.com/hannibal002/SkyHanni/blob/e88f416c48f9659f89b7047d7629cd9a1d1535bc/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt#L276).
+- Use American English spelling conventions (e.g., "color" not "colour").
 
 ## Software Used in SkyHanni
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -903,7 +903,7 @@
 + Chocolate Shop now updates chocolate availability every second. -
   hannibal2 (https://github.com/hannibal002/SkyHanni/pull/1652)
 + Chocolate Shop now also shows time until affordable. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/1652)
-+ Changed the colour of time to blue in Chocolate Factory displays. -
++ Changed the color of time to blue in Chocolate Factory displays. -
   hannibal2 (https://github.com/hannibal002/SkyHanni/pull/1652)
 + Star now shows on time tower and coach jackrabbit. - CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/1641)
 + Maxed upgrades in Chocolate Factory now show a checkmark. -
@@ -1300,7 +1300,7 @@
   CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/1758)
 + Fixed Chocolate Factory time remaining calculations while the Time Tower is active. -
   hannibal2 (https://github.com/hannibal002/SkyHanni/pull/1774)
-+ Fixed enchantment colours showing as white when SkyHanni chroma is not enabled. -
++ Fixed enchantment colors showing as white when SkyHanni chroma is not enabled. -
   CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/1798)
 + Fixed Chocolate Factory Shop. - seraid (https://github.com/hannibal002/SkyHanni/pull/1815)
     + Profit calculations now show in sub-menus.
@@ -1667,7 +1667,7 @@
     + Show in a crafting view a shopping list of materials needed when buying from the Bazaar.
 + Added AH Show Price Comparison. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/339)
     + Highlight auctions based on the difference between their estimated value and the value they are listed for.
-    + Options to change the colours
+    + Options to change the colors
 + Added Highlight options in /tab. - Conutik (https://github.com/hannibal002/SkyHanni/pull/1175)
     + Green for enabled
     + Red for disabled
@@ -2635,7 +2635,7 @@
 + Fixed render overlapping problem with chat, SkyHanni GUIs and title. - Thunderblade73
 + Fixed GUI positions moving into the bottom-right corner when leaving the GUI position editor while pressing the mouse
   button on next reopen. - hannibal2
-+ Fixed parts of Compact Tab List being uncoloured. - CalMWolfs
++ Fixed parts of Compact Tab List being uncolored. - CalMWolfs
 + Fixed Compact Tab List' Toggle Tab not working when using Patcher. - hannibal2
 + Fixed Skill progress display size too small when not using the progress bar. - Thunderblade73
 + Fixed the skill progress bar trying to get out of the screen. - HiZe
@@ -3182,7 +3182,7 @@
 
 ### Fixes
 
-+ Fixed the wrong colouring of hidden items in Slayer Profit Tracker. - hannibal2
++ Fixed the wrong coloring of hidden items in Slayer Profit Tracker. - hannibal2
 + Added support for NEU Heavy Pearl TO-DO fix working without nether sacks as well. - hannibal2
 + Fixed Estimated Item Value getting shown in pet rule creation wardrobe slot pick menu. - hannibal2
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -195,7 +195,7 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
     + Blocks picking up the Inferno Minion or replacing the fuel inside when expensive minion fuels are in use.
 + AH Show Price Comparison. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/339)
     + Highlight auctions based on the difference between their estimated value and the value they are listed for.
-    + Options to change the colours
+    + Options to change the colors
 + Highlight options in /tab. - Conutik (https://github.com/hannibal002/SkyHanni/pull/1175)
     + Green for enabled
     + Red for disabled

--- a/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/MatriarchHelperConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/MatriarchHelperConfig.java
@@ -20,7 +20,7 @@ public class MatriarchHelperConfig {
     public boolean highlight = true;
 
     @Expose
-    @ConfigOption(name = "Highlight Color", desc = "Colour the pearls are highlighted in.")
+    @ConfigOption(name = "Highlight Color", desc = "Color the pearls are highlighted in.")
     @ConfigEditorColour
     public String highlightColor = "0:114:126:255:41";
 
@@ -30,7 +30,7 @@ public class MatriarchHelperConfig {
     public boolean line = true;
 
     @Expose
-    @ConfigOption(name = "Line Color", desc = "Colour of the line.")
+    @ConfigOption(name = "Line Color", desc = "Color of the line.")
     @ConfigEditorColour
     public String lineColor = "0:230:163:38:255";
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/TextBoxConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/TextBoxConfig.java
@@ -22,7 +22,7 @@ public class TextBoxConfig {
 
     @Expose
     @ConfigOption(name = "Text", desc = "Enter text you want to display here.\n" +
-        "§eUse '&' as the colour code character.\n" +
+        "§eUse '&' as the color code character.\n" +
         "§eUse '\\n' as the line break character.")
     @ConfigEditorText
     public Property<String> text = Property.of("&aYour Text Here\\n&bYour new line here");

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/AuctionHousePriceComparisonConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/AuctionHousePriceComparisonConfig.java
@@ -20,22 +20,22 @@ public class AuctionHousePriceComparisonConfig {
     public boolean enabled = false;
 
     @Expose
-    @ConfigOption(name = "Good Colour", desc = "What colour to highlight good value items with.")
+    @ConfigOption(name = "Good Color", desc = "What color to highlight good value items with.")
     @ConfigEditorColour
-    public String good = LorenzColor.GREEN.toConfigColour();
+    public String good = LorenzColor.GREEN.toConfigColor();
 
     @Expose
-    @ConfigOption(name = "Very Good Colour", desc = "What colour to highlight very good value items with.")
+    @ConfigOption(name = "Very Good Color", desc = "What color to highlight very good value items with.")
     @ConfigEditorColour
     public String veryGood = "0:255:0:139:0";
 
     @Expose
-    @ConfigOption(name = "Bad Colour", desc = "What colour to highlight bad items with.")
+    @ConfigOption(name = "Bad Color", desc = "What color to highlight bad items with.")
     @ConfigEditorColour
-    public String bad = LorenzColor.YELLOW.toConfigColour();
+    public String bad = LorenzColor.YELLOW.toConfigColor();
 
     @Expose
-    @ConfigOption(name = "Very Bad Colour", desc = "What colour to highlight very bad items with.")
+    @ConfigOption(name = "Very Bad Color", desc = "What color to highlight very bad items with.")
     @ConfigEditorColour
     public String veryBad = "0:255:225:43:30";
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -62,7 +62,7 @@ public class ChocolateFactoryConfig {
 
     @Expose
     @ConfigOption(name = "Highlight Upgrades", desc = "Highlight any upgrades that you can afford.\n" +
-        "The upgrade with a star is the most optimal and the lightest colour of green is the most optimal you can afford.")
+        "The upgrade with a star is the most optimal and the lightest color of green is the most optimal you can afford.")
     @ConfigEditorBoolean
     public boolean highlightUpgrades = true;
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/TunnelMapsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/TunnelMapsConfig.java
@@ -50,13 +50,15 @@ public class TunnelMapsConfig {
     public boolean leftClickPigeon = true;
 
     @Expose
-    @ConfigOption(name = "Dynamic Path Colour", desc = "Instead of the selected color use the color of the target as line colour.")
+    @ConfigOption(name = "Dynamic Path Color", desc = "Instead of the selected color use the color of the target as line color.")
     @ConfigEditorBoolean
+    // TODO rename to dynamicPathColor
     public boolean dynamicPathColour = true;
 
     @Expose
-    @ConfigOption(name = "Path Colour", desc = "The colour for the paths, if the dynamic colour option is turned off.")
+    @ConfigOption(name = "Path Color", desc = "The color for the paths, if the dynamic color option is turned off.")
     @ConfigEditorColour
+    // TODO rename to pathColor
     public String pathColour = "0:255:0:255:0";
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/dreadfarm/VoltCruxConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/dreadfarm/VoltCruxConfig.java
@@ -23,6 +23,7 @@ public class VoltCruxConfig {
     @Expose
     @ConfigOption(name = "Volt Range Highlighter Color", desc = "In which color should the Volt range be highlighted?")
     @ConfigEditorColour
+    // TODO rename to voltColor
     public String voltColour = "0:60:0:0:255";
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/westvillage/KloonHackingConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/westvillage/KloonHackingConfig.java
@@ -17,6 +17,7 @@ public class KloonHackingConfig {
     @ConfigOption(name = "Color Guide", desc = "Show which color to pick.")
     @ConfigEditorBoolean
     @FeatureToggle
+    // TODO rename to color
     public boolean colour = true;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDeathCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDeathCounter.kt
@@ -94,7 +94,7 @@ object DungeonDeathCounter {
         if (!isEnabled()) return
 
         config.deathCounterPos.renderString(
-            DungeonMilestonesDisplay.colour + display,
+            DungeonMilestonesDisplay.color + display,
             posLabel = "Dungeon Death Counter"
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMilestonesDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMilestonesDisplay.kt
@@ -27,7 +27,7 @@ object DungeonMilestonesDisplay {
     private var display = ""
     private var currentMilestone = 0
     private var timeReached = SimpleTimeMark.farPast()
-    var colour = ""
+    var color = ""
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
@@ -54,7 +54,7 @@ object DungeonMilestonesDisplay {
             timeReached = SimpleTimeMark.now()
         }
 
-        colour = when (currentMilestone) {
+        color = when (currentMilestone) {
             0, 1 -> "§c"
             2 -> "§e"
             else -> "§a"
@@ -79,7 +79,7 @@ object DungeonMilestonesDisplay {
         if (!isEnabled()) return
 
         config.showMileStonesDisplayPos.renderString(
-            colour + display,
+            color + display,
             posLabel = "Dungeon Milestone"
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
@@ -6,7 +6,7 @@ import kotlin.time.Duration
 
 enum class HoppityEggType(
     val mealName: String,
-    private val mealColour: String,
+    private val mealColor: String,
     val resetsAt: Int,
     var lastResetDay: Int = -1,
     private var claimed: Boolean = false,
@@ -34,8 +34,8 @@ enum class HoppityEggType(
     }
 
     fun isClaimed() = claimed
-    val formattedName get() = "${if (isClaimed()) "§7§m" else mealColour}$mealName:$mealColour"
-    val coloredName get() = "$mealColour$mealName"
+    val formattedName get() = "${if (isClaimed()) "§7§m" else mealColor}$mealName:$mealColor"
+    val coloredName get() = "$mealColor$mealName"
 
     companion object {
         fun allFound() = entries.forEach { it.markClaimed() }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RenderUtils.drawString
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
-import at.hannibal2.skyhanni.utils.SpecialColour
+import at.hannibal2.skyhanni.utils.SpecialColor
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.init.Blocks
@@ -45,7 +45,7 @@ object ThunderSparksHighlight {
         if (!isEnabled()) return
 
         val special = config.color
-        val color = Color(SpecialColour.specialToChromaRGB(special), true)
+        val color = Color(SpecialColor.specialToChromaRGB(special), true)
 
         val playerLocation = LocationUtils.playerLocation()
         for (spark in sparks) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GeyserFishing.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GeyserFishing.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.drawFilledBoundingBox_nea
-import at.hannibal2.skyhanni.utils.SpecialColour
+import at.hannibal2.skyhanni.utils.SpecialColor
 import net.minecraft.util.AxisAlignedBB
 import net.minecraft.util.EnumParticleTypes
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -63,7 +63,7 @@ object GeyserFishing {
         if (!IslandType.CRIMSON_ISLE.isInIsland()) return
         if (config.onlyWithRod && !FishingAPI.holdingLavaRod) return
 
-        val color = Color(SpecialColour.specialToChromaRGB(config.boxColor), true)
+        val color = Color(SpecialColor.specialToChromaRGB(config.boxColor), true)
         event.drawFilledBoundingBox_nea(geyserBox, color)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CarrolynTable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CarrolynTable.kt
@@ -32,12 +32,12 @@ enum class CarrolynTable(val crop: CropType, val label: String, completeMessage:
     ),
     ;
 
-    /** Pattern without colour codes */
+    /** Pattern without color codes */
     val completeMessagePattern by RepoPattern.pattern(
         "garden.ff.carrolyn.complete.${crop.patternKeyName}", completeMessage,
     )
 
-    /** Pattern without colour codes */
+    /** Pattern without color codes */
     val thxMessagePattern by RepoPattern.pattern(
         "garden.ff.carrolyn.thx.${crop.patternKeyName}", thxMessage,
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorColorNames.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorColorNames.kt
@@ -9,23 +9,23 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 @SkyHanniModule
 object GardenVisitorColorNames {
 
-    private var visitorColours = mutableMapOf<String, String>() // name -> color code
+    private var visitorColors = mutableMapOf<String, String>() // name -> color code
     var visitorItems = mutableMapOf<String, List<String>>()
 
     @SubscribeEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<GardenJson>("Garden")
-        visitorColours.clear()
+        visitorColors.clear()
         visitorItems.clear()
         for ((visitor, visitorData) in data.visitors) {
-            visitorColours[visitor] = visitorData.rarity.color.getChatColor()
+            visitorColors[visitor] = visitorData.rarity.color.getChatColor()
             visitorItems[visitor] = visitorData.needItems
         }
     }
 
     fun getColoredName(name: String): String {
         val cleanName = name.removeColor()
-        val color = visitorColours[cleanName] ?: return name
+        val color = visitorColors[cleanName] ?: return name
         return color + cleanName
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -234,8 +234,8 @@ object GardenVisitorFeatures {
         var amountInSacks = 0
         internalName.getAmountInSacksOrNull()?.let {
             amountInSacks = it
-            val textColour = if (it >= amount) "a" else "e"
-            list.add(" §7(§${textColour}x${it.addSeparators()} §7in sacks)")
+            val textColor = if (it >= amount) "a" else "e"
+            list.add(" §7(§${textColor}x${it.addSeparators()} §7in sacks)")
         }
 
         val ingredients = NEUItems.getRecipes(internalName)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
@@ -236,7 +236,7 @@ object ReforgeHelper {
         this.addAll(list)
     }
 
-    private fun getReforgeColour(reforge: ReforgeAPI.Reforge) = when {
+    private fun getReforgeColor(reforge: ReforgeAPI.Reforge) = when {
         currentReforge == reforge -> "§6"
         reforgeToSearch == reforge -> "§3"
         reforge.isReforgeStone -> "§9"
@@ -244,7 +244,7 @@ object ReforgeHelper {
     }
 
     private fun getReforgeView(itemRarity: LorenzRarity): (ReforgeAPI.Reforge) -> Renderable = { reforge ->
-        val text = getReforgeColour(reforge) + reforge.name
+        val text = getReforgeColor(reforge) + reforge.name
         val tips = getReforgeTips(reforge, itemRarity)
         val onHover = if (!isInHexReforgeMenu) {
             {}

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventType.kt
@@ -21,7 +21,7 @@ enum class MiningEventType(
     val eventName: String,
     private val shortName: String,
     val defaultLength: Duration,
-    private val colourCode: Char,
+    private val colorCode: Char,
     val dwarvenSpecific: Boolean,
     iconInput: Renderable,
 ) {
@@ -101,18 +101,18 @@ enum class MiningEventType(
         eventName: String,
         shortName: String,
         defaultLength: Duration,
-        colourCode: Char,
+        colorCode: Char,
         dwarvenSpecific: Boolean,
         iconInput: ItemStack,
     ) : this(
-        eventName, shortName, defaultLength, colourCode, dwarvenSpecific, Renderable.itemStack(
+        eventName, shortName, defaultLength, colorCode, dwarvenSpecific, Renderable.itemStack(
             iconInput, xSpacing = 0
         )
     )
 
     val icon = Renderable.hoverTips(iconInput, listOf(eventName))
-    val compactText = Renderable.string("§$colourCode$shortName")
-    val normalText = Renderable.string("§$colourCode$eventName")
+    val compactText = Renderable.string("§$colorCode$shortName")
+    val normalText = Renderable.string("§$colorCode$eventName")
 
     val compactTextWithIcon = Renderable.horizontalContainer(listOf(icon, compactText), 0)
     val normalTextWithIcon = Renderable.horizontalContainer(listOf(icon, normalText), 0)

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -46,7 +46,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawString
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.SpecialColour
+import at.hannibal2.skyhanni.utils.SpecialColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -143,7 +143,7 @@ object MinionFeatures {
         if (!config.lastClickedMinion.display) return
 
         val special = config.lastClickedMinion.color
-        val color = Color(SpecialColour.specialToChromaRGB(special), true)
+        val color = Color(SpecialColor.specialToChromaRGB(special), true)
 
         val loc = lastMinion
         if (loc != null) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -63,7 +63,7 @@ object MarkedPlayerManager {
         }
     }
 
-    private fun refreshColours() =
+    private fun refreshColors() =
         markedPlayers.forEach {
             it.value.setColor()
         }
@@ -104,7 +104,7 @@ object MarkedPlayerManager {
                 playerNamesToMark.remove(name)
             }
         }
-        config.entityColor.onToggle(::refreshColours)
+        config.entityColor.onToggle(::refreshColors)
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PartyMemberOutlines.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PartyMemberOutlines.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.SpecialColour
+import at.hannibal2.skyhanni.utils.SpecialColor
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.entity.Entity
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -30,6 +30,6 @@ object PartyMemberOutlines {
     private fun getEntityOutlineColor(entity: Entity): Int? {
         if (entity !is EntityOtherPlayerMP || !PartyAPI.partyMembers.contains(entity.name)) return null
 
-        return SpecialColour.specialToChromaRGB(config.outlineColor)
+        return SpecialColor.specialToChromaRGB(config.outlineColor)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
@@ -29,7 +29,7 @@ open class Enchant : Comparable<Enchant> {
         val config = SkyHanniMod.feature.inventory.enchantParsing
 
         // TODO change color to string (support for bold)
-        val colour = when {
+        val color = when {
             level >= maxLevel -> config.perfectEnchantColor
             level > goodLevel -> config.greatEnchantColor
             level == goodLevel -> config.goodEnchantColor
@@ -37,8 +37,8 @@ open class Enchant : Comparable<Enchant> {
         }
 
         // TODO when chroma is disabled maybe use the neu chroma style instead of gold
-        if (colour.get() == LorenzColor.CHROMA && !(ChromaManager.config.enabled.get() || EnchantParser.isSbaLoaded)) return "§6§l"
-        return colour.get().getChatColor()
+        if (color.get() == LorenzColor.CHROMA && !(ChromaManager.config.enabled.get() || EnchantParser.isSbaLoaded)) return "§6§l"
+        return color.get().getChatColor()
     }
 
     override fun toString() = "$nbtName $goodLevel $maxLevel\n"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
@@ -112,8 +112,8 @@ open class VisualWordGui : GuiScreen() {
             val y = guiTop + 170
 
             drawUnmodifiedStringCentered("§aAdd New", x, y)
-            val colour = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
-            drawRect(x - 30, y - 10, x + 30, y + 10, colour)
+            val color = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
+            drawRect(x - 30, y - 10, x + 30, y + 10, color)
 
             if (shouldDrawImport) {
                 val importX = guiLeft + sizeX - 45
@@ -250,12 +250,12 @@ open class VisualWordGui : GuiScreen() {
             var x = guiLeft + 180
             var y = guiTop + 140
             drawUnmodifiedStringCentered("§cDelete", x, y)
-            var colour = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
-            drawRect(x - 30, y - 10, x + 30, y + 10, colour)
+            var color = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
+            drawRect(x - 30, y - 10, x + 30, y + 10, color)
             y += 30
             drawUnmodifiedStringCentered("§eBack", x, y)
-            colour = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
-            drawRect(x - 30, y - 10, x + 30, y + 10, colour)
+            color = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
+            drawRect(x - 30, y - 10, x + 30, y + 10, color)
 
             if (currentIndex < modifiedWords.size && currentIndex != -1) {
                 val currentPhrase = modifiedWords[currentIndex]
@@ -264,15 +264,15 @@ open class VisualWordGui : GuiScreen() {
                 drawUnmodifiedStringCentered("§bReplacement Enabled", x, y - 20)
                 var status = if (currentPhrase.enabled) "§2Enabled" else "§4Disabled"
                 drawUnmodifiedStringCentered(status, x, y)
-                colour = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
-                drawRect(x - 30, y - 10, x + 30, y + 10, colour)
+                color = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
+                drawRect(x - 30, y - 10, x + 30, y + 10, color)
 
                 x += 200
                 drawUnmodifiedStringCentered("§bCase Sensitive", x, y - 20)
                 status = if (!currentPhrase.isCaseSensitive()) "§2True" else "§4False"
                 drawUnmodifiedStringCentered(status, x, y)
-                colour = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
-                drawRect(x - 30, y - 10, x + 30, y + 10, colour)
+                color = if (isPointInMousePos(x - 30, y - 10, 60, 20)) colorA else colorB
+                drawRect(x - 30, y - 10, x + 30, y + 10, color)
 
                 drawUnmodifiedString("§bIs replaced by:", guiLeft + 30, guiTop + 75)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/SulphurSkitterBox.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/SulphurSkitterBox.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.expandBlock
-import at.hannibal2.skyhanni.utils.SpecialColour
+import at.hannibal2.skyhanni.utils.SpecialColor
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.init.Blocks
 import net.minecraft.util.AxisAlignedBB
@@ -78,7 +78,7 @@ object SulphurSkitterBox {
     }
 
     private fun drawBox(axis: AxisAlignedBB, partialTicks: Float) {
-        val color = Color(SpecialColour.specialToChromaRGB(config.boxColor), true)
+        val color = Color(SpecialColor.specialToChromaRGB(config.boxColor), true)
         when (config.boxType) {
             SulphurSkitterBoxConfig.BoxType.FULL -> {
                 RenderUtils.drawFilledBoundingBox_nea(

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangGravityOrbs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangGravityOrbs.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawString
-import at.hannibal2.skyhanni.utils.SpecialColour
+import at.hannibal2.skyhanni.utils.SpecialColor
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -42,7 +42,7 @@ object AshfangGravityOrbs {
     fun onRenderWorld(event: LorenzRenderWorldEvent) {
         if (!isEnabled()) return
 
-        val color = Color(SpecialColour.specialToChromaRGB(config.color), true)
+        val color = Color(SpecialColor.specialToChromaRGB(config.color), true)
         val playerLocation = LocationUtils.playerLocation()
         for (orb in orbs) {
             if (orb.isDead) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.exactLocation
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.SpecialColour
+import at.hannibal2.skyhanni.utils.SpecialColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraft.client.Minecraft
 import net.minecraft.entity.Entity
@@ -65,7 +65,7 @@ object VoltHighlighter {
                 ) { config.voltMoodMeter }
             if (state == VoltState.DOING_LIGHTNING && config.voltRange) {
                 RenderUtils.drawCylinderInWorld(
-                    Color(SpecialColour.specialToChromaRGB(config.voltColour), true),
+                    Color(SpecialColor.specialToChromaRGB(config.voltColour), true),
                     entity.posX,
                     entity.posY - 4f,
                     entity.posZ,

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/kloon/KloonHacking.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/kloon/KloonHacking.kt
@@ -29,14 +29,14 @@ object KloonHacking {
 
     private val config get() = RiftAPI.config.area.westVillage.hacking
 
-    private val colourPattern by RepoPattern.pattern(
-        "rift.area.westvillage.kloon.colour",
-        "You've set the color of this terminal to (?<colour>.*)!"
+    private val colorPattern by RepoPattern.pattern(
+        "rift.area.westvillage.kloon.color",
+        "You've set the color of this terminal to (?<color>.*)!"
     )
 
     private var wearingHelmet = false
     private var inTerminalInventory = false
-    private var inColourInventory = false
+    private var inColorInventory = false
     private val correctButtons = mutableListOf<String>()
     private var nearestTerminal: KloonTerminal? = null
 
@@ -53,7 +53,7 @@ object KloonHacking {
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         inTerminalInventory = false
-        inColourInventory = false
+        inColorInventory = false
         nearestTerminal = null
         if (!RiftAPI.inRift()) return
         if (!config.solver) return
@@ -67,14 +67,14 @@ object KloonHacking {
             }
         }
         if (event.inventoryName == "Hacked Terminal Color Picker") {
-            inColourInventory = true
+            inColorInventory = true
         }
     }
 
     @SubscribeEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
         inTerminalInventory = false
-        inColourInventory = false
+        inColorInventory = false
     }
 
     @SubscribeEvent
@@ -97,11 +97,11 @@ object KloonHacking {
                 }
             }
         }
-        if (inColourInventory) {
+        if (inColorInventory) {
             if (!config.colour) return
-            val targetColour = nearestTerminal ?: getNearestTerminal()
+            val targetColor = nearestTerminal ?: getNearestTerminal()
             for (slot in InventoryUtils.getItemsInOpenChest()) {
-                if (slot.stack.getLore().any { it.contains(targetColour?.name ?: "") }) {
+                if (slot.stack.getLore().any { it.contains(targetColor?.name ?: "") }) {
                     slot highlight LorenzColor.GREEN
                 }
             }
@@ -131,10 +131,10 @@ object KloonHacking {
     fun onChat(event: LorenzChatEvent) {
         if (!RiftAPI.inRift()) return
         if (!wearingHelmet) return
-        colourPattern.matchMatcher(event.message.removeColor()) {
+        colorPattern.matchMatcher(event.message.removeColor()) {
             val storage = ProfileStorageData.profileSpecific?.rift ?: return
-            val colour = group("colour")
-            val completedTerminal = KloonTerminal.entries.firstOrNull { it.name == colour } ?: return
+            val color = group("color")
+            val completedTerminal = KloonTerminal.entries.firstOrNull { it.name == color } ?: return
             if (completedTerminal != nearestTerminal) return
             storage.completedKloonTerminals.add(completedTerminal)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -30,7 +30,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
-import at.hannibal2.skyhanni.utils.SpecialColour
+import at.hannibal2.skyhanni.utils.SpecialColor
 import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -112,7 +112,7 @@ object SkillProgress {
             maxWidth = 182
             Renderable.progressBar(
                 percent = factor.toDouble(),
-                startColor = Color(SpecialColour.specialToChromaRGB(barConfig.barStartColor)),
+                startColor = Color(SpecialColor.specialToChromaRGB(barConfig.barStartColor)),
                 texture = barConfig.texturedBar.usedTexture.get(),
                 useChroma = barConfig.useChroma.get()
             )
@@ -122,8 +122,8 @@ object SkillProgress {
             val factor = skillExpPercentage.coerceAtMost(1.0)
             Renderable.progressBar(
                 percent = factor,
-                startColor = Color(SpecialColour.specialToChromaRGB(barConfig.barStartColor)),
-                endColor = Color(SpecialColour.specialToChromaRGB(barConfig.barStartColor)),
+                startColor = Color(SpecialColor.specialToChromaRGB(barConfig.barStartColor)),
+                endColor = Color(SpecialColor.specialToChromaRGB(barConfig.barStartColor)),
                 width = maxWidth,
                 height = barConfig.regularBar.height,
                 useChroma = barConfig.useChroma.get()

--- a/src/main/java/at/hannibal2/skyhanni/utils/ColorUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ColorUtils.kt
@@ -6,17 +6,17 @@ object ColorUtils {
 
     /** Transfer string colors from the config to [Color] */
     fun String.toChromaColor() = Color(toChromaColorInt(), true)
-    fun String.toChromaColorInt() = SpecialColour.specialToChromaRGB(this)
+    fun String.toChromaColorInt() = SpecialColor.specialToChromaRGB(this)
 
     fun String.getFirstColorCode() = this.takeIf { it.firstOrNull() == '§' }?.getOrNull(1)
 
-    fun getRed(colour: Int) = colour shr 16 and 0xFF
+    fun getRed(color: Int) = color shr 16 and 0xFF
 
-    fun getGreen(colour: Int) = colour shr 8 and 0xFF
+    fun getGreen(color: Int) = color shr 8 and 0xFF
 
-    fun getBlue(colour: Int) = colour and 0xFF
+    fun getBlue(color: Int) = color and 0xFF
 
-    fun getAlpha(colour: Int) = colour shr 24 and 0xFF
+    fun getAlpha(color: Int) = color shr 24 and 0xFF
 
     fun blendRGB(start: Color, end: Color, percent: Double) = Color(
         (start.red * (1 - percent) + end.red * percent).toInt(),

--- a/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
@@ -28,12 +28,12 @@ import kotlin.math.min
 // TODO cleanup of redundant functions
 object GuiRenderUtils {
 
-    fun drawStringCentered(str: String?, fr: FontRenderer, x: Float, y: Float, shadow: Boolean, colour: Int) {
+    fun drawStringCentered(str: String?, fr: FontRenderer, x: Float, y: Float, shadow: Boolean, color: Int) {
         val strLen = fr.getStringWidth(str)
         val x2 = x - strLen / 2f
         val y2 = y - fr.FONT_HEIGHT / 2f
         GL11.glTranslatef(x2, y2, 0f)
-        fr.drawString(str, 0f, 0f, colour, shadow)
+        fr.drawString(str, 0f, 0f, color, shadow)
         GL11.glTranslatef(-x2, -y2, 0f)
     }
 
@@ -222,19 +222,19 @@ object GuiRenderUtils {
         return Color(color.red / 5, color.green / 5, color.blue / 5).rgb
     }
 
-    fun drawScaledRec(left: Int, top: Int, right: Int, bottom: Int, colour: Int, inverseScale: Float) {
+    fun drawScaledRec(left: Int, top: Int, right: Int, bottom: Int, color: Int, inverseScale: Float) {
         GuiScreen.drawRect(
             (left * inverseScale).toInt(),
             (top * inverseScale).toInt(),
             (right * inverseScale).toInt(),
             (bottom * inverseScale).toInt(),
-            colour
+            color,
         )
     }
 
-    fun renderItemAndBackground(item: ItemStack, x: Int, y: Int, colour: Int) {
+    fun renderItemAndBackground(item: ItemStack, x: Int, y: Int, color: Int) {
         renderItemStack(item, x, y)
-        GuiScreen.drawRect(x, y, x + 16, y + 16, colour)
+        GuiScreen.drawRect(x, y, x + 16, y + 16, color)
     }
 
     // Taken and edited from NEU <- it's broken

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzColor.kt
@@ -50,7 +50,7 @@ enum class LorenzColor(val chatColorCode: Char, private val color: Color, privat
 
     override fun toString(): String = coloredLabel
 
-    fun toConfigColour(): String = "0:255:${color.red}:${color.green}:${color.blue}"
+    fun toConfigColor(): String = "0:255:${color.red}:${color.green}:${color.blue}"
 
     fun toDyeColor(): EnumDyeColor = when (this) {
         WHITE -> EnumDyeColor.WHITE

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -74,7 +74,7 @@ object RenderUtils {
     private val beaconBeam = ResourceLocation("textures/entity/beacon_beam.png")
 
     private val matrixBuffer: FloatBuffer = GLAllocation.createDirectFloatBuffer(16)
-    private val colourBuffer: FloatBuffer = GLAllocation.createDirectFloatBuffer(16)
+    private val colorBuffer: FloatBuffer = GLAllocation.createDirectFloatBuffer(16)
     private val bezier2Buffer: FloatBuffer = GLAllocation.createDirectFloatBuffer(9)
 
     infix fun Slot.highlight(color: LorenzColor) {
@@ -992,12 +992,12 @@ object RenderUtils {
         y: Float,
         shadow: Boolean,
         len: Int,
-        colour: Int,
+        color: Int,
     ) {
         val strLen = fr.getStringWidth(str)
         var factor = len / strLen.toFloat()
         factor = 1f.coerceAtMost(factor)
-        TextRenderUtils.drawStringScaled(str, fr, x, y, shadow, colour, factor)
+        TextRenderUtils.drawStringScaled(str, fr, x, y, shadow, color, factor)
     }
 
     fun LorenzRenderWorldEvent.drawDynamicText(
@@ -1591,14 +1591,14 @@ object RenderUtils {
     fun LorenzRenderWorldEvent.outlineTopFace(
         boundingBox: AxisAlignedBB,
         lineWidth: Int,
-        colour: Color,
+        color: Color,
         depth: Boolean,
     ) {
         val (cornerOne, cornerTwo, cornerThree, cornerFour) = boundingBox.getCorners(boundingBox.maxY)
-        this.draw3DLine(cornerOne, cornerTwo, colour, lineWidth, depth)
-        this.draw3DLine(cornerTwo, cornerThree, colour, lineWidth, depth)
-        this.draw3DLine(cornerThree, cornerFour, colour, lineWidth, depth)
-        this.draw3DLine(cornerFour, cornerOne, colour, lineWidth, depth)
+        this.draw3DLine(cornerOne, cornerTwo, color, lineWidth, depth)
+        this.draw3DLine(cornerTwo, cornerThree, color, lineWidth, depth)
+        this.draw3DLine(cornerThree, cornerFour, color, lineWidth, depth)
+        this.draw3DLine(cornerFour, cornerOne, color, lineWidth, depth)
     }
 
     // TODO nea please merge with 'draw3DLine'
@@ -1844,9 +1844,9 @@ object RenderUtils {
     }
 
     fun getAlpha(): Float {
-        colourBuffer.clear()
-        GlStateManager.getFloat(GL11.GL_CURRENT_COLOR, colourBuffer)
-        if (colourBuffer.limit() < 4) return 1f
-        return colourBuffer.get(3)
+        colorBuffer.clear()
+        GlStateManager.getFloat(GL11.GL_CURRENT_COLOR, colorBuffer)
+        if (colorBuffer.limit() < 4) return 1f
+        return colorBuffer.get(3)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SpecialColor.java
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SpecialColor.java
@@ -5,7 +5,7 @@ import java.awt.Color;
 /**
  * Taken from NotEnoughUpdates
  */
-public class SpecialColour {
+public class SpecialColor {
 
     private static final int RADIX = 10;
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -25,7 +25,7 @@ object StringUtils {
     private val whiteSpacePattern = "^\\s*|\\s*$".toPattern()
     private val resetPattern = "(?i)§R".toPattern()
     private val sFormattingPattern = "(?i)§S".toPattern()
-    private val stringColourPattern = "§[0123456789abcdef].*".toPattern()
+    private val stringColorPattern = "§[0123456789abcdef].*".toPattern()
     private val asciiPattern = "[^\\x00-\\x7F]".toPattern()
 
     fun String.trimWhiteSpaceAndResets(): String = whiteSpaceResetPattern.matcher(this).replaceAll("")
@@ -194,7 +194,7 @@ object StringUtils {
     }
 
     fun getColor(string: String, default: Int, darker: Boolean = true): Int {
-        val matcher = stringColourPattern.matcher(string)
+        val matcher = stringColorPattern.matcher(string)
         if (matcher.matches()) {
             val colorInt = Minecraft.getMinecraft().fontRendererObj.getColorCode(string[1])
             return if (darker) {


### PR DESCRIPTION
## What
For consistency, we change all usages of `colour` to `color`.

Only exceptions in this PR:
- `@ConfigEditorColour` (From MoulConfig)
- `Utils.chromaStringByColourCode()` (From NotEnoughUpdates)
- Config names (Added To-dos to all of them, might change a ton/all config rename To-dos in a later pr at once)

<details>
<summary>Without this PR</summary>

![image](https://github.com/user-attachments/assets/02fe7245-4c0c-47a4-9d62-de45ac42fa58)
![image](https://github.com/user-attachments/assets/9a8798a8-3afd-46b6-8a3f-d88c00a3273a)

</details>

<details>
<summary>With this PR</summary>

![image](https://github.com/user-attachments/assets/4c59a78f-dba4-4aab-9194-bc509dcc08bf)
![image](https://github.com/user-attachments/assets/34cf1d8e-3f0f-49a6-97d9-5eb776aa9838)

</details>

## Changelog Technical Details
+ Changed "colour" to "color" internally, everywhere. - hannibal2