### PR TITLE
Improvement: Made Hoppity Egg Waypoint Color customizable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
@@ -25,6 +26,11 @@ public class HoppityEggsConfig {
     )
     @ConfigEditorBoolean
     public boolean waypointsImmediately = false;
+
+    @Expose
+    @ConfigOption(name = "Color", desc = "Color of the waypoint.")
+    @ConfigEditorColour
+    public String waypointColor = "0:53:46:224:73";
 
     @Expose
     @ConfigOption(name = "Show Line", desc = "Show a line to the waypoint.")

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -140,7 +141,7 @@ object HoppityEggLocator {
                     if (eyeLocation.distance(it) > 2) {
                         drawWaypointFilled(
                             it,
-                            LorenzColor.GREEN.toColor(),
+                            config.waypointColor.toChromaColor(),
                             seeThroughBlocks = true,
                         )
                         drawDynamicText(it.add(y = 1), "§aGuess", 1.5)
@@ -158,7 +159,7 @@ object HoppityEggLocator {
             && HoppityEggLocations.hasCollectedEgg(location)
         val possibleDuplicateLabel = if (shouldMarkDuplicate) "$label §c(Duplicate Location)" else label
         if (!shouldMarkDuplicate) {
-            drawWaypointFilled(location, LorenzColor.GREEN.toColor(), seeThroughBlocks = true)
+            drawWaypointFilled(location, config.waypointColor.toChromaColor(), seeThroughBlocks = true)
         } else {
             drawColor(location, LorenzColor.RED.toColor(), false, 0.5f)
         }


### PR DESCRIPTION
## What
Made it so you can change the color of the hoppity egg waypoints.

<details>
<summary>Images</summary>

![grafik](https://github.com/user-attachments/assets/660c8973-94d2-466b-8e8a-ec85b4d67570)

</details>

## Changelog Improvements
+ Added an option to choose the color of Hoppity Egg Waypoints. - jani

