### PR TITLE
Fix: renderStringsAndItems y issue

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -20,6 +20,7 @@ import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils.getCorners
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderXAligned
+import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderYAligned
 import at.hannibal2.skyhanni.utils.shader.ShaderManager
 import io.github.moulberry.notenoughupdates.util.Utils
 import io.github.notenoughupdates.moulconfig.internal.TextRenderUtils
@@ -642,11 +643,43 @@ object RenderUtils {
         if (addToGuiManager) GuiEditManager.add(this, posLabel, renderable.width, 0)
     }
 
+    /** This function is discouraged to be used. Please use renderRenderables with List<Renderable> instead with horizontal container.*/
+    fun Position.renderRenderablesDouble(
+        renderables: List<List<Renderable>>,
+        extraSpace: Int = 0,
+        posLabel: String,
+        addToGuiManager: Boolean = true,
+    ) {
+        if (renderables.isEmpty()) return
+        var longestY = 0
+        var longestX = 0
+        GlStateManager.pushMatrix()
+        val (x, y) = transform()
+        Renderable.withMousePosition(x, y) {
+            for (line in renderables) {
+                GlStateManager.pushMatrix()
+                GlStateManager.translate(0f, longestY.toFloat(), 0F)
+                val lineY = line.maxOf { it.height }
+                var lineX = 0
+                for (element in line) {
+                    element.renderYAligned(lineX, longestY, lineY)
+                    GlStateManager.translate(element.width.toFloat(), 0f, 0f)
+                    lineX += element.width
+                }
+                longestY += lineY + extraSpace + 2
+                longestX = max(longestX, lineX)
+                GlStateManager.popMatrix()
+            }
+        }
+        GlStateManager.popMatrix()
+        if (addToGuiManager) GuiEditManager.add(this, posLabel, longestX, longestY)
+    }
+
     /**
      * Accepts a list of lines to print.
      * Each line is a list of things to print. Can print String or ItemStack objects.
      */
-    @Deprecated("use List<Renderable>", ReplaceWith(""))
+    @Deprecated("use List<List<Renderable>>", ReplaceWith("this.renderRenderablesDouble(list,extraSpace,posLabel)"))
     fun Position.renderStringsAndItems(
         list: List<List<Any?>>,
         extraSpace: Int = 0,
@@ -655,24 +688,10 @@ object RenderUtils {
     ) {
         if (list.isEmpty()) return
 
-        var offsetY = 0
-        var longestX = 0
-        try {
-            for (line in list) {
-                val x = renderLine(line, offsetY, itemScale)
-                if (x > longestX) {
-                    longestX = x
-                }
-                offsetY += 10 + extraSpace + 2
-            }
-        } catch (e: NullPointerException) {
-            ErrorManager.logErrorWithData(
-                e,
-                "Failed to render an element",
-                "list" to list,
-            )
-        }
-        GuiEditManager.add(this, posLabel, longestX, offsetY)
+        val render =
+            list.map { it.map { Renderable.fromAny(it, itemScale = itemScale) ?: throw RuntimeException("Unknown render object: $it") } }
+
+        this.renderRenderablesDouble(render, extraSpace, posLabel, true)
     }
 
     /**
@@ -685,11 +704,9 @@ object RenderUtils {
         posLabel: String,
     ) {
         if (list.isEmpty()) return
-        renderRenderables(
-            listOf(
-                Renderable.horizontalContainer(
-                    list.mapNotNull { Renderable.fromAny(it) },
-                ),
+        renderRenderable(
+            Renderable.horizontalContainer(
+                list.mapNotNull { Renderable.fromAny(it) },
             ),
             posLabel = posLabel,
         )


### PR DESCRIPTION
## What
Fixed the issue with elements that don't have a height of 10.
Added a full replacement of renderStringsAndItems, renderRenderablesDouble. (I don't really know what it should be called) 

<details>
<summary>Images</summary>

Does fix the bug that #2248 tried to fix.
![image](https://github.com/user-attachments/assets/46f3827b-4b1b-420a-9832-ded1db2b5ec2)

</details>

## Changelog Fixes
+ Fixed some incorrect boxes in the GUI editor. - Thunderblade73

## Changelog Technical Details
+ Added renderRenderableDouble. - Thunderblade73
    * A direct replacement for renderStringsAndItems.