### PR TITLE
Fix: Duration below 1s

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -16,7 +16,7 @@ object TimeUtils {
 
     fun Duration.format(
         biggestUnit: TimeUnit = TimeUnit.YEAR,
-        showMilliSeconds: Boolean = false,
+        showMilliSeconds: Boolean = this in -1.seconds..1.seconds,
         longName: Boolean = false,
         maxUnits: Int = -1,
     ): String {


### PR DESCRIPTION
## What
Fixed Duration.format() function returning an empty for durations below 1 second.
Now we show millis for < 1 second durations, even if showMillis is not set, as it was before.

## Changelog Fixes
+ Fixed multiple features not showing a duration when it was less than one second. - hannibal2