### PR TITLE
Fix: HotM total powder being reset

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -673,7 +673,8 @@ enum class HotmData(
         @SubscribeEvent
         fun onInventoryFullyOpen(event: InventoryFullyOpenedEvent) {
             if (!LorenzUtils.inSkyBlock) return
-            if (!inventoryPattern.matches(event.inventoryName)) return
+            inInventory = inventoryPattern.matches(event.inventoryName)
+            if (!inInventory) return
             DelayedRun.runNextTick {
                 InventoryUtils.getItemsInOpenChest().forEach { it.parse() }
                 abilities.filter { it.isUnlocked }.forEach {

--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -673,7 +673,7 @@ enum class HotmData(
         @SubscribeEvent
         fun onInventoryFullyOpen(event: InventoryFullyOpenedEvent) {
             if (!LorenzUtils.inSkyBlock) return
-            inInventory = inventoryPattern.matches(event.inventoryName)
+            if (!inventoryPattern.matches(event.inventoryName)) return
             DelayedRun.runNextTick {
                 InventoryUtils.getItemsInOpenChest().forEach { it.parse() }
                 abilities.filter { it.isUnlocked }.forEach {


### PR DESCRIPTION
## What
Fixed HotmAPI not checking the inventory name causing total powder to reset when opening the SkyBlock Menu on a mining island.

## Changelog Fixes
+ Fixed total powder amounts resetting when opening the SkyBlock Menu on a mining island. - Luna