### PR TITLE
Backend: Double Color in ScoreboardData

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -83,4 +83,16 @@ object RegexUtils {
         return this.any { it.matches(string) }
     }
 
+    /**
+     * Returns a sequence of all occurrences of a regular expression within the [input] string.
+     */
+    fun Pattern.findAll(input: String): List<String> {
+        val matcher = this.matcher(input)
+
+        return buildList {
+            while (matcher.find()) {
+                add(matcher.group())
+            }
+        }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -87,7 +87,7 @@ object RegexUtils {
      * Returns a list of all occurrences of a pattern within the [input] string.
      */
     fun Pattern.findAll(input: String): List<String> {
-        val matcher = this.matcher(input)
+        val matcher = matcher(input)
 
         return buildList {
             while (matcher.find()) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -84,7 +84,7 @@ object RegexUtils {
     }
 
     /**
-     * Returns a sequence of all occurrences of a regular expression within the [input] string.
+     * Returns a list of all occurrences of a pattern within the [input] string.
      */
     fun Pattern.findAll(input: String): List<String> {
         val matcher = this.matcher(input)

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.mixins.transformers.AccessorChatComponentText
 import at.hannibal2.skyhanni.utils.GuiRenderUtils.darkenColor
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RegexUtils.findAll
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiUtilRenderComponents
 import net.minecraft.event.ClickEvent
@@ -27,6 +28,7 @@ object StringUtils {
     private val sFormattingPattern = "(?i)§S".toPattern()
     private val stringColourPattern = "§[0123456789abcdef].*".toPattern()
     private val asciiPattern = "[^\\x00-\\x7F]".toPattern()
+    private val minecraftColorCodesPattern = "(?i)(§[0-9a-fklmnor])+".toPattern()
 
     fun String.trimWhiteSpaceAndResets(): String = whiteSpaceResetPattern.matcher(this).replaceAll("")
     fun String.trimWhiteSpace(): String = whiteSpacePattern.matcher(this).replaceAll("")
@@ -556,7 +558,7 @@ object StringUtils {
 
     fun IChatComponent.contains(string: String): Boolean = formattedText.contains(string)
 
-    fun String.width(): Int {
-        return Minecraft.getMinecraft().fontRendererObj.getStringWidth(this)
-    }
+    fun String.width(): Int = Minecraft.getMinecraft().fontRendererObj.getStringWidth(this)
+
+    fun String.lastColorCode(): String? = minecraftColorCodesPattern.findAll(this).lastOrNull()
 }


### PR DESCRIPTION
## What
This Pull Request fixes the formatLines() in ScoreboardData to also work on doubled up color codes. Previously, color codes like "§L§5" didnt work, this is now fixed. The Playground serves as an demonstration
[Kotlin Playground](https://pl.kotl.in/tzZK5-wVS)


## Changelog Technical Details
+ Fixed ScoreboardData Line formatting with doubled color codes. - j10a1n15

