### PR TITLE
Improvement: Fewer Tab list chat errors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/storage/PlayerSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/PlayerSpecificStorage.java
@@ -23,6 +23,9 @@ public class PlayerSpecificStorage {
     public Boolean useRomanNumerals = true;
 
     @Expose
+    public Boolean multipleProfiles = false;
+
+    @Expose
     public Integer gardenCommunityUpgrade = -1;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -293,6 +293,7 @@ object HypixelData {
             if (profileName == newProfile) return
             profileName = newProfile
             ProfileJoinEvent(newProfile).postAndCatch()
+            ProfileStorageData.profileJoinMessage()
         }
     }
 


### PR DESCRIPTION
## What
We don't show the "tab list data missing" line if Hypixel has not yet sent us the chat message "you are playing on profile xy". This only shows up for users with multiple profiles. Therefore, we save if the user has ever got this message.

Also, we changed the delay from 3 seconds to 5 seconds for normal checks. This should also reduce false positives. 

## Changelog Improvements
+ Reduced the frequency of "tab list not found" error messages. - hannibal2