### PR TITLE
Fix: Hypixel error negative magma cubes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -438,9 +438,14 @@ object ScoreboardPattern {
         "wintereventwave",
         "(§.)*Wave \\d+$",
     )
+
+    /**
+     * REGEX-TEST: Magma Cubes Left: §c-4
+     * REGEX-TEST: Magma Cubes Left: §c3
+     */
     val winterMagmaLeftPattern by eventsSb.pattern(
         "wintereventmagmaleft",
-        "(§.)*Magma Cubes Left: §.\\d+$",
+        "(§.)*Magma Cubes Left: §.-?\\d+$",
     )
     val winterTotalDmgPattern by eventsSb.pattern(
         "wintereventtotaldmg",


### PR DESCRIPTION
## What
Fixed Hypixel error when magma cubed left is negative.
Report: https://discord.com/channels/997079228510117908/1265832080164655185

## Changelog Fixes
+ Fixed a scoreboard error message when a Hypixel bug shows a negative number of magma cubes remaining in the scoreboard. - hannibal2