### PR TITLE
Fix: NPE in CorpseLocator

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseLocator.kt
@@ -48,7 +48,7 @@ object CorpseLocator {
                 entity.showArms && entity.hasNoBasePlate() && !entity.isInvisible
             }
             .forEach { entity ->
-                val helmetName = entity.getCurrentArmor(3).getInternalName()
+                val helmetName = entity.getCurrentArmor(3)?.getInternalName() ?: return
                 val corpseType = MineshaftWaypointType.getByHelmetOrNull(helmetName) ?: return
 
                 val canSee = entity.getLorenzVec().canBeSeen(-1..3)


### PR DESCRIPTION
## What

Fixed an NullPointerException when using `EntityArmorStand.getCurrentArmor`
Reported here: https://discord.com/channels/997079228510117908/1265062036857946182

<details>
<summary>Stack Trace</summary>

```
SkyHanni 0.26.Beta.18: Caught an NullPointerException in CorpseLocator at SecondPassedEvent: getCurrentArmor(...) must not be null
 
Caused by java.lang.NullPointerException: getCurrentArmor(...) must not be null
    at SH.features.mining.glacitemineshaft.CorpseLocator.findCorpse(CorpseLocator.kt:51)
    at SH.features.mining.glacitemineshaft.CorpseLocator.onSecondPassed(CorpseLocator.kt:93)
    at SH.data.FixedRateTimerManager$1$1.run(FixedRateTimerManager.kt:17)
    at MC.util.Util.func_181617_a(Util.java:19)
    at MC.client.Minecraft.func_71411_J(Minecraft.java:1014)
    at MC.client.Minecraft.handler$bpc000$run(Minecraft.java:3250)
    at MC.client.Minecraft.func_99999_d(Minecraft.java)
    at MC.client.main.Main.main(SourceFile:124)
```

</details>

## Changelog Fixes
+ Fixed a rare error when detecting corpses in the Mineshaft. - hannibal2