### PR TITLE
Fix: Hotm wrong max Powder if disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -36,7 +36,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.math.ceil
 import kotlin.math.pow
 
-
 private fun calculatePeakOfTheMountainLoot(level: Int): Map<HotmReward, Double> = buildMap {
     for (i in 1..level) {
         when (i) {
@@ -51,7 +50,6 @@ private fun calculatePeakOfTheMountainLoot(level: Int): Map<HotmReward, Double> 
         }
     }
 }
-
 
 enum class HotmData(
     val guiName: String,
@@ -359,17 +357,22 @@ enum class HotmData(
 
     val printName = name.allLettersFirstUppercase()
 
+    /** Level which are actually paid with powder (does exclude [blueEgg]*/
     val rawLevel: Int
         get() = storage?.perks?.get(this.name)?.level ?: 0
 
+    /** Level for which the effect that is present (considers [enabled] and [blueEgg])*/
     var activeLevel: Int
-        get() = if (enabled) storage?.perks?.get(this.name)?.level?.plus(blueEgg()) ?: 0 else 0
+        get() = if (enabled) effectivLevel else 0
         private set(value) {
             storage?.perks?.computeIfAbsent(this.name) { HotmTree.HotmPerk() }?.level = value.minus(blueEgg())
         }
 
+    /** Level that considering [blueEgg]*/
+    val effectivLevel: Int get() = storage?.perks?.get(this.name)?.level?.plus(blueEgg()) ?: 0
+
     val isMaxLevel: Boolean
-        get() = activeLevel >= maxLevel // >= to account for +1 from Blue Cheese
+        get() = effectivLevel >= maxLevel // >= to account for +1 from Blue Cheese
 
     private fun blueEgg() = if (this != PEAK_OF_THE_MOUNTAIN && maxLevel != 1 && HotmAPI.isBlueEggActive) 1 else 0
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/PowderPerHotmPerk.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/PowderPerHotmPerk.kt
@@ -40,19 +40,19 @@ object PowderPerHotmPerk {
         if (indexOfCost == -1) return
 
         val powderFor10Levels =
-            perk.calculateTotalCost(perk.activeLevel + 10) - perk.calculateTotalCost(perk.activeLevel)
+            perk.calculateTotalCost(perk.rawLevel + 10) - perk.calculateTotalCost(perk.rawLevel)
 
         event.toolTip.add(indexOfCost + 2, "§7Powder for 10 levels: §e${powderFor10Levels.addSeparators()}")
     }
 
     private fun handlePowderSpend(perk: HotmData): String {
-        val currentPowderSpend = perk.calculateTotalCost(perk.activeLevel)
+        val currentPowderSpend = perk.calculateTotalCost(perk.rawLevel)
         val maxPowderNeeded = perk.totalCostMaxLevel
         val percentage = (currentPowderSpend.fractionOf(maxPowderNeeded) * 100).round(2)
 
         return when (config.powderSpentDesign) {
             PowderSpentDesign.NUMBER -> {
-                if (perk.activeLevel == perk.maxLevel) {
+                if (perk.rawLevel == perk.maxLevel) {
                     "§7Powder spent: §e${maxPowderNeeded.addSeparators()} §7(§aMax level§7)"
                 } else {
                     "§7Powder spent: §e${currentPowderSpend.addSeparators()}§7 / §e${maxPowderNeeded.addSeparators()}"
@@ -60,7 +60,7 @@ object PowderPerHotmPerk {
             }
 
             PowderSpentDesign.PERCENTAGE -> {
-                if (perk.activeLevel == perk.maxLevel) {
+                if (perk.rawLevel == perk.maxLevel) {
                     "§7Powder spent: §e$percentage% §7(§aMax level§7)"
                 } else {
                     "§7Powder spent: §e$percentage%§7 of max"
@@ -68,7 +68,7 @@ object PowderPerHotmPerk {
             }
 
             PowderSpentDesign.NUMBER_AND_PERCENTAGE -> {
-                if (perk.activeLevel == perk.maxLevel) {
+                if (perk.rawLevel == perk.maxLevel) {
                     "§7Powder spent: §e${maxPowderNeeded.addSeparators()} §7(§aMax level§7)"
                 } else {
                     "§7Powder spent: §e${currentPowderSpend.addSeparators()}§7/§e${maxPowderNeeded.addSeparators()}§7 (§e$percentage%§7)"


### PR DESCRIPTION
## What
The diffrent level values got confused. Added clarifying descriptions to the values.

## Discord
https://discord.com/channels/997079228510117908/1260214278959661096

## Changelog Fixes
+ Fixed incorrect maximum Powder value on HotM perks when disabled. - Thunderblade73


