### PR TITLE
Backend: debug data powder tracker chat error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConfigUtils
@@ -193,9 +194,22 @@ object PowderTracker {
 
         for (reward in PowderChestReward.entries) {
             reward.chatPattern.matchMatcher(msg) {
+                val amountName = groupOrNull("amount")
+                // TODO remove workaround check once we know this chat message
+                //  formatLong failed for '2 §r§awith your §r§cMetal Detector§r§a!'
+                if (amountName?.contains("Metal Detector") ?: false) {
+                    ErrorManager.skyHanniError(
+                        "Powder tracker pattern contains invalid amount",
+                        "msg" to msg,
+                        "amountName" to amountName,
+                        "reward" to reward.name,
+                    )
+                }
+
                 tracker.modify {
                     val count = it.rewards[reward] ?: 0
-                    var amount = groupOrNull("amount")?.formatLong() ?: 1
+                    var amount = amountName?.formatLong() ?: 1
+
                     if ((reward == PowderChestReward.MITHRIL_POWDER || reward == PowderChestReward.GEMSTONE_POWDER) && doublePowder) {
                         amount *= 2
                     }


### PR DESCRIPTION
## What
Added more debug data for powder tracker chat pattern error.
Bug report: https://discord.com/channels/997079228510117908/1262765792420692240

<details>
<summary>Stack Trace</summary>

```
SkyHanni 0.26.Beta.17: Caught an NumberFormatException in PowderTracker at LorenzChatEvent: formatLong failed for '2 with your Metal Detector!'
 
Caused by java.lang.NumberFormatException: formatLong failed for '2 §r§awith your §r§cMetal Detector§r§a!'
    at SH.utils.NumberUtil.formatLong(NumberUtil.kt:213)
    at SH.features.mining.powdertracker.PowderTracker$onChat$5$1.invoke(PowderTracker.kt:165)
    at SH.features.mining.powdertracker.PowderTracker$onChat$5$1.invoke(PowderTracker.kt:163)
    at SH.utils.tracker.SkyHanniTracker$SharedTracker.modify(SkyHanniTracker.kt:163)
    at SH.utils.tracker.SkyHanniTracker.modify(SkyHanniTracker.kt:56)
    at SH.features.mining.powdertracker.PowderTracker.onChat(PowderTracker.kt:163)
    at SH.data.ChatManager.onChatReceive(ChatManager.kt:130)
    at FML.common.eventhandler.EventBus.post(EventBus.java:140)
```

</details>


## Changelog Technical Details
+ Added more debug data for powder tracker chat pattern error. - hannibal2