### PR TITLE
Fix: Config Typo

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogConfig.java
@@ -35,7 +35,7 @@ public class ItemPickupLogConfig {
     public boolean shorten = false;
 
     @Expose
-    @ConfigOption(name = "Sacks", desc = "Show items added and removed from stacks.")
+    @ConfigOption(name = "Sacks", desc = "Show items added and removed from sacks.")
     @ConfigEditorBoolean
     public boolean sack = false;
 


### PR DESCRIPTION
## What
Fixed a typo in item pickup log config.
Reported at: https://discord.com/channels/997079228510117908/1267226895783821416

## Changelog Fixes
+ Fixed a typo in the Item Pickup Log config. - hannibal2