### PR TITLE
Backend: Include PolyPatcher cactus hitbox fix info in Discord FAQ + Installation guide

### DIFF
--- a/docs/DISCORD_FAQ.md
+++ b/docs/DISCORD_FAQ.md
@@ -26,8 +26,8 @@ _Frequently Asked Questions_
 
 > **8: How can I get bigger crop hit boxes?**
 > Use Patcher or PolyPatcher to have 1.12 hit boxes in 1.8.9.
-> - [Sk1erLLC's Patcher](<https://sk1er.club/mods/patcher>)
-> - [Polyfrost's PolyPatcher](<https://modrinth.com/mod/patcher>) (a fork of Patcher with OneConfig, slightly different features, and bug fixes)
+> - [Sk1erLLC's Patcher](<https://sk1er.club/mods/patcher>) (Versions 1.8.8 and after will have broken cactus hitboxes)
+> - [Polyfrost's PolyPatcher](<https://modrinth.com/mod/patcher>) (a fork of Patcher with OneConfig, slightly different features, and bug fixes. Fixes cactus hitboxes.)
 
 > **9: Why does my Item Tracker feature not track this item?**
 > 1. Check if the item goes directly into your sacks. 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -122,7 +122,7 @@ select new installation, under version you need to find Forge for 1.8.9 (most li
 <summary>10. Recommended additional mods (optional)</summary>
 
 [OptiFine](https://optifine.net/adloadx?f=preview_OptiFine_1.8.9_HD_U_M6_pre2.jar)
-and either [Sk1erLLC's Patcher](https://sk1er.club/mods/patcher) or [Polyfrost's PolyPatcher](<https://modrinth.com/mod/patcher>) (a fork of Patcher with OneConfig, slightly different features, and bug fixes)
+and either [Sk1erLLC's Patcher](https://sk1er.club/mods/patcher) or [Polyfrost's PolyPatcher](<https://modrinth.com/mod/patcher>) (a fork of Patcher with OneConfig, slightly different features, and bug fixes, including fixed cactus hitboxes)
 
 Those two mods help you get more FPS in game and let you change many more performance
 settings.


### PR DESCRIPTION
## What
Include that PolyPatcher fixes the smaller cactus hitboxes seen in Patcher 1.8.8 and above

exclude_from_changelog