### PR TITLE
Fix: TunnelMaps Deadlock

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -488,6 +488,7 @@ object TunnelsMaps {
         closedNote = null
         clearPath()
         cooldowns.clear()
+        goalReached = false
     }
 
     private var nextSpotDelay = SimpleTimeMark.farPast()


### PR DESCRIPTION
## What
I forgot to reset the goalReached which leads to a deadlock since 

## Changelog Fixes
+ Fixed an issue where TunnelMaps could stop functioning. - Thunderblade73

