### PR TITLE
Fix: Discord RPC dynamic off-by-one

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
@@ -239,9 +239,9 @@ enum class DiscordStatus(private val displayMessageSupplier: (() -> String?)) {
             }
         }
         if (autoReturn == "") { // if we didn't find any useful information, display the fallback
-            val statusNoAuto = DiscordStatus.entries.toMutableList()
-            statusNoAuto.remove(AUTO)
-            autoReturn = statusNoAuto[DiscordRPCManager.config.auto.get().ordinal].getDisplayString()
+            val fallbackID = DiscordRPCManager.config.auto.get().ordinal
+            if (fallbackID == 10) autoReturn = NONE.getDisplayString() // 10 is this (DiscordStatus.AUTO); prevents an infinite loop
+            else autoReturn = DiscordStatus.entries[DiscordRPCManager.config.auto.get().ordinal].getDisplayString()
         }
         autoReturn
     }),

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
@@ -226,25 +226,30 @@ enum class DiscordStatus(private val displayMessageSupplier: (() -> String?)) {
         DiscordRPCManager.config.customText.get() // custom field in the config
     }),
 
-    AUTO({
-        var autoReturn = ""
-        for (statusID in DiscordRPCManager.config.autoPriority) { // for every dynamic that the user wants to see...
-            // TODO, change functionality to use enum rather than ordinals
-            val autoStatus = AutoStatus.entries[statusID.ordinal]
-            val result =
-                autoStatus.correspondingDiscordStatus.getDisplayString() // get what would happen if we were to display it
-            if (result != autoStatus.placeholderText) { // if that value is useful, display it
-                autoReturn = result
-                break
+    AUTO(
+        {
+            var autoReturn = ""
+            for (statusID in DiscordRPCManager.config.autoPriority) { // for every dynamic that the user wants to see...
+                // TODO, change functionality to use enum rather than ordinals
+                val autoStatus = AutoStatus.entries[statusID.ordinal]
+                val result =
+                    autoStatus.correspondingDiscordStatus.getDisplayString() // get what would happen if we were to display it
+                if (result != autoStatus.placeholderText) { // if that value is useful, display it
+                    autoReturn = result
+                    break
+                }
             }
-        }
-        if (autoReturn == "") { // if we didn't find any useful information, display the fallback
-            val fallbackID = DiscordRPCManager.config.auto.get().ordinal
-            if (fallbackID == 10) autoReturn = NONE.getDisplayString() // 10 is this (DiscordStatus.AUTO); prevents an infinite loop
-            else autoReturn = DiscordStatus.entries[DiscordRPCManager.config.auto.get().ordinal].getDisplayString()
-        }
-        autoReturn
-    }),
+            if (autoReturn == "") { // if we didn't find any useful information, display the fallback
+                val fallbackID = DiscordRPCManager.config.auto.get().ordinal
+                autoReturn = if (fallbackID == 10) {
+                    NONE.getDisplayString() // 10 is this (DiscordStatus.AUTO); prevents an infinite loop
+                } else {
+                    DiscordStatus.entries[fallbackID].getDisplayString()
+                }
+            }
+            autoReturn
+        },
+    ),
 
     CROP_MILESTONES({ getCropMilestoneDisplay() }),
 


### PR DESCRIPTION
## What
Fixes an off-by-one error introduced when changing the config system that caused the dynamic fallback to show the wrong message if the user selected one of the affected options.

## Changelog Fixes
+ Fixed Discord Rich Presence dynamic fallback. - NetheriteMiner
    * Placeholder messages that should not be visible will no longer appear.