### PR TITLE
Fix: Hoppity Goal Levels Off-by-One

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyblockSeason
@@ -54,7 +53,7 @@ object ChocolateFactoryAPI {
      */
     private val upgradeLorePattern by patternGroup.pattern(
         "item.lore.upgrade",
-        "§a§l(?:UPGRADE|PROMOTE) §8➜ (?:§7\\[(?<nextlevel>\\d+)§7] )?(?<upgradename>.*?) ?(?<nextlevelalt>[IVXLCDM]*)\$"
+        "§a§l(?:UPGRADE|PROMOTE) §8➜ (?:§7\\[(?<nextlevel>\\d+)§7] )?(?<upgradename>.*?) ?(?<nextlevelalt>[IVXLCDM]*)\$",
     )
 
     /**
@@ -64,7 +63,7 @@ object ChocolateFactoryAPI {
      */
     private val employeeNamePattern by patternGroup.pattern(
         "item.name.employee",
-        "(?<employee>(?:§.+)+Rabbit .*)§8 - §7\\[\\d*§7] .*"
+        "(?<employee>(?:§.+)+Rabbit .*)§8 - §7\\[\\d*§7] .*",
     )
 
     var rabbitSlots = mapOf<Int, Int>()
@@ -180,16 +179,16 @@ object ChocolateFactoryAPI {
         }
     }
 
-    fun getNextLevelName(stack: ItemStack): String? {
-        return upgradeLorePattern.firstMatcher(stack.getLore()) {
+    fun getNextLevelName(stack: ItemStack): String? =
+        upgradeLorePattern.firstMatcher(stack.getLore()) {
             val upgradeName = if (stack.getLore().any { it == "§8Employee" }) employeeNamePattern.matchMatcher(stack.name) {
                 groupOrNull("employee")
             } else groupOrNull("upgradename")
             val nextLevel = groupOrNull("nextlevel") ?: groupOrNull("nextlevelalt")
-            if(upgradeName == null || nextLevel == null) null
+            if (upgradeName == null || nextLevel == null) null
             else "$upgradeName $nextLevel"
         }
-    }
+
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
@@ -67,13 +67,14 @@ object ChocolateFactoryCustomReminder {
         // TODO add support for prestige and for Chocolate Milestone
         val cost = ChocolateFactoryAPI.getChocolateBuyCost(item.getLore()) ?: return
         val duration = ChocolateAmount.CURRENT.timeUntilGoal(cost)
+        val nextLevelName = ChocolateFactoryAPI.getNextLevelName(item) ?: return
 
         // the user has enough chocolate, and just bought something
         if (duration.isNegative()) {
             reset()
             return
         }
-        setReminder(cost, item.name)
+        setReminder(cost, nextLevelName)
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1249247998349807617
Fixes hoppity goal levels being off-by-one, due to using the item name instead of next level data.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/5785875e-d91d-48df-a825-572ed1988fed)

![image](https://github.com/user-attachments/assets/1a39164c-ed43-4e65-abd9-18edc3b40570)

</details>

## Changelog Fixes
+ Fixed Hoppity custom goals being off by one level. - Daveed
