### PR TITLE
Fix: Flawless Gemstones in Powder Filter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 52
+    const val CONFIG_VERSION = 53
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningGemstoneFilterConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningGemstoneFilterConfig.java
@@ -15,38 +15,38 @@ public class PowderMiningGemstoneFilterConfig {
     @Expose
     @ConfigOption(name = "Ruby", desc = "Hide Ruby gemstones under a certain quality.")
     @ConfigEditorDropdown
-    public GemstoneFilterEntry rubyGemstones = GemstoneFilterEntry.FINE_ONLY;
+    public GemstoneFilterEntry rubyGemstones = GemstoneFilterEntry.FINE_UP;
 
     @Expose
     @ConfigOption(name = "Sapphire", desc = "Hide Sapphire gemstones under a certain quality.")
     @ConfigEditorDropdown
-    public GemstoneFilterEntry sapphireGemstones = GemstoneFilterEntry.FINE_ONLY;
+    public GemstoneFilterEntry sapphireGemstones = GemstoneFilterEntry.FINE_UP;
 
     @Expose
     @ConfigOption(name = "Amber", desc = "Hide Amber gemstones under a certain quality.")
     @ConfigEditorDropdown
-    public GemstoneFilterEntry amberGemstones = GemstoneFilterEntry.FINE_ONLY;
+    public GemstoneFilterEntry amberGemstones = GemstoneFilterEntry.FINE_UP;
 
     @Expose
     @ConfigOption(name = "Amethyst", desc = "Hide Amethyst gemstones under a certain quality.")
     @ConfigEditorDropdown
-    public GemstoneFilterEntry amethystGemstones = GemstoneFilterEntry.FINE_ONLY;
+    public GemstoneFilterEntry amethystGemstones = GemstoneFilterEntry.FINE_UP;
 
     @Expose
     @ConfigOption(name = "Jade", desc = "Hide Jade gemstones under a certain quality.")
     @ConfigEditorDropdown
-    public GemstoneFilterEntry jadeGemstones = GemstoneFilterEntry.FINE_ONLY;
+    public GemstoneFilterEntry jadeGemstones = GemstoneFilterEntry.FINE_UP;
 
     @Expose
     @ConfigOption(name = "Topaz", desc = "Hide Topaz gemstones under a certain quality.")
     @ConfigEditorDropdown
-    public GemstoneFilterEntry topazGemstones = GemstoneFilterEntry.FINE_ONLY;
+    public GemstoneFilterEntry topazGemstones = GemstoneFilterEntry.FINE_UP;
 
     public enum GemstoneFilterEntry {
         SHOW_ALL("Show All"),
         HIDE_ALL("Hide all"),
         FLAWED_UP("Show §aFlawed §7or higher"),
-        FINE_ONLY("Show §9Fine §7or higher"),
+        FINE_UP("Show §9Fine §7or higher"),
         FLAWLESS_ONLY("Show §5Flawless §7only");
 
         private final String str;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningGemstoneFilterConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningGemstoneFilterConfig.java
@@ -46,7 +46,8 @@ public class PowderMiningGemstoneFilterConfig {
         SHOW_ALL("Show All"),
         HIDE_ALL("Hide all"),
         FLAWED_UP("Show §aFlawed §7or higher"),
-        FINE_ONLY("Show §9Fine §7only");
+        FINE_ONLY("Show §9Fine §7or higher"),
+        FLAWLESS_ONLY("Show §5Flawless §7only");
 
         private final String str;
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -8,12 +8,15 @@ import at.hannibal2.skyhanni.features.chat.PowderMiningChatFilter.genericMiningR
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import com.google.gson.JsonPrimitive
+import io.github.moulberry.notenoughupdates.util.toJsonArray
 import net.minecraft.util.ChatComponentText
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.regex.Pattern
@@ -576,5 +579,12 @@ object ChatFilter {
         event.move(3, "chat.profileJoin", "chat.filterType.profileJoin")
         event.move(3, "chat.others", "chat.filterType.others")
         event.move(52, "chat.filterType.powderMining", "chat.filterType.powderMiningFilter.enabled")
+        event.transform(53, "chat.filterType.powderMiningFilter.gemstoneFilterConfig") { element ->
+            element.asJsonObject.apply {
+                entrySet().forEach { (key, value) ->
+                    if (value.asString == "FINE_ONLY") addProperty(key, "FINE_UP")
+                }
+            }
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -8,15 +8,12 @@ import at.hannibal2.skyhanni.features.chat.PowderMiningChatFilter.genericMiningR
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import com.google.gson.JsonPrimitive
-import io.github.moulberry.notenoughupdates.util.toJsonArray
 import net.minecraft.util.ChatComponentText
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.regex.Pattern

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -232,10 +232,11 @@ object PowderMiningChatFilter {
      * REGEX-TEST: §r§f❈ Rough Amethyst Gemstone §r§8x24
      * REGEX-TEST: §r§a❈ Flawed Amethyst Gemstone §r§8x4
      * REGEX-TEST: §r§9⸕ Fine Amber Gemstone
+     * REGEX-TEST: §r§5⸕ Flawless Amber Gemstone
      */
     private val gemstonePattern by patternGroup.pattern(
         "reward.gemstone",
-        "§r§[fa9][❤❈☘⸕✎✧] (?<tier>Rough|Flawed|Fine) (?<gem>Ruby|Amethyst|Jade|Amber|Sapphire|Topaz) Gemstone( §r§8x(?<amount>[\\d,]+))?",
+        "§r§[fa9][❤❈☘⸕✎✧] (?<tier>Rough|Flawed|Fine|Flawless) (?<gem>Ruby|Amethyst|Jade|Amber|Sapphire|Topaz) Gemstone( §r§8x(?<amount>[\\d,]+))?",
     )
 
     fun block(message: String): String? {
@@ -316,8 +317,7 @@ object PowderMiningChatFilter {
             if (config.goblinEggs == PowderMiningFilterConfig.GoblinEggFilterEntry.SHOW_ALL) return "no_filter"
             if (config.goblinEggs == PowderMiningFilterConfig.GoblinEggFilterEntry.HIDE_ALL) return "powder_mining_goblin_eggs"
 
-            val colorStr = groupOrNull("color")?.lowercase()
-            return when (colorStr) {
+            return when (val colorStr = groupOrNull("color")?.lowercase()) {
                 //'Colorless', base goblin eggs will never be shown in this code path
                 null -> "powder_mining_goblin_eggs"
                 "green" -> if (config.goblinEggs > PowderMiningFilterConfig.GoblinEggFilterEntry.GREEN_UP) {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -372,9 +372,12 @@ object PowderMiningChatFilter {
                 "flawed" -> if (gemSpecificFilterEntry > GemstoneFilterEntry.FLAWED_UP) {
                     "powder_mining_gemstones"
                 } else "no_filter"
-                // FINE_ONLY enum not explicitly used in comparison, as the only
+                "fine" -> if (gemSpecificFilterEntry > GemstoneFilterEntry.FINE_ONLY) {
+                    "powder_mining_gemstones"
+                } else "no_filter"
+                // FLAWLESS_ONLY enum not explicitly used in comparison, as the only
                 // case that will block it is HIDE_ALL, which is covered above
-                "fine" -> "no_filter"
+                "flawless" -> "no_filter"
                 // This should not be reachable
                 else -> "no_filter"
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -372,7 +372,7 @@ object PowderMiningChatFilter {
                 "flawed" -> if (gemSpecificFilterEntry > GemstoneFilterEntry.FLAWED_UP) {
                     "powder_mining_gemstones"
                 } else "no_filter"
-                "fine" -> if (gemSpecificFilterEntry > GemstoneFilterEntry.FINE_ONLY) {
+                "fine" -> if (gemSpecificFilterEntry > GemstoneFilterEntry.FINE_UP) {
                     "powder_mining_gemstones"
                 } else "no_filter"
                 // FLAWLESS_ONLY enum not explicitly used in comparison, as the only


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1268045402394067114
Fixed the fact that Flawless gemstones were not included in the pattern.

## Changelog Fixes
+ Fixed Flawless Gemstones not being formatted correctly when the Powder Mining filter is enabled. - Daveed

