### PR TITLE
Fix: Potm always disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -565,7 +565,7 @@ enum class HotmData(
             }
 
             if (entry == PEAK_OF_THE_MOUNTAIN) {
-                entry.enabled = entry.activeLevel != 0
+                entry.enabled = entry.rawLevel != 0
                 return
             }
             entry.enabled = lore.any { enabledPattern.matches(it) }


### PR DESCRIPTION
<!-- remove all unused parts -->
## What
The activeLevel changed in a Pr which included the enabled state. So it would only get enabled if it has a rawLevel>0 and being enabled. Which is a deadlock. 

## Changelog Fixes
+ Fixed Peak of the Mountain always being disabled. - Thunderblade73



