### PR TITLE
Improvement: Hide Beacon on bingo

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
+import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -28,19 +29,19 @@ object BeaconPower {
     // TODO add regex tests
     private val deactivatedPattern by group.pattern(
         "deactivated",
-        "§7Beacon Deactivated §8- §cNo Power Remaining"
+        "§7Beacon Deactivated §8- §cNo Power Remaining",
     )
     private val timeRemainingPattern by group.pattern(
         "time",
-        "§7Power Remaining: §e(?<time>.+)"
+        "§7Power Remaining: §e(?<time>.+)",
     )
     private val boostedStatPattern by group.pattern(
         "stat",
-        "§7Current Stat: (?<stat>.+)"
+        "§7Current Stat: (?<stat>.+)",
     )
     private val noBoostedStatPattern by group.pattern(
         "nostat",
-        "TODO"
+        "TODO",
     )
 
     private var expiryTime: SimpleTimeMark
@@ -55,7 +56,7 @@ object BeaconPower {
             storage?.boostedStat = value
         }
 
-    private var display: String? = null
+    private var display = ""
 
     private val BEACON_POWER_SLOT = 22
     private val STATS_SLOT = 23
@@ -97,8 +98,7 @@ object BeaconPower {
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
-        val string = display ?: return
-        config.beaconPowerPosition.renderString(string, posLabel = "Beacon Power")
+        config.beaconPowerPosition.renderString(display, posLabel = "Beacon Power")
     }
 
     @SubscribeEvent
@@ -117,5 +117,10 @@ object BeaconPower {
         }
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.beaconPower
+    @SubscribeEvent
+    fun onProfileJoin(event: ProfileJoinEvent) {
+        display = ""
+    }
+
+    private fun isEnabled() = LorenzUtils.inSkyBlock && config.beaconPower && !LorenzUtils.isBingoProfile
 }


### PR DESCRIPTION
## What
Hide Beacon Power display while on a bingo profile.
Suggested: https://discord.com/channels/997079228510117908/1268434277587095644

Also reset the display on profile switch for an even quicker reset, also using empty string instead of null for the display.

## Changelog Improvements
+ Hide Beacon Power display while on a Bingo profile. - hannibal2