### PR TITLE
Fix: /shcommands empty page

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.chat.Text.style
 import at.hannibal2.skyhanni.utils.chat.Text.suggest
 import net.minecraft.util.EnumChatFormatting
 import net.minecraft.util.IChatComponent
+import kotlin.math.ceil
 
 object HelpCommand {
 
@@ -50,7 +51,7 @@ object HelpCommand {
         val filtered = commands.filter {
             it.name.contains(search, ignoreCase = true) || it.description.contains(search, ignoreCase = true)
         }
-        val maxPage = filtered.size / COMMANDS_PER_PAGE + 1
+        val maxPage = ceil(filtered.size.toDouble() / COMMANDS_PER_PAGE).toInt()
         val page = page.coerceIn(1, maxPage)
         val title = if (search.isEmpty()) "§6SkyHanni Commands" else "§6SkyHanni Commands matching '$search'"
 


### PR DESCRIPTION
## What
Fixed additional, empty /shcommands page showing up.
Reported: https://discord.com/channels/997079228510117908/1268398884858630238

## Changelog Fixes
+ Fixed an additional empty /shcommands page from appearing. - hannibal2