### PR TITLE
Fix: Allow clicking Carnival Masks in /equipment

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -298,6 +298,7 @@ object HideNotClickableItems {
 
         val list = listOf(
             "HELMET",
+            "CARNIVAL MASK",
             "CHESTPLATE",
             "LEGGINGS",
             "BOOTS",


### PR DESCRIPTION
## What
Fixed Carnival Masks not being clickable in `/equipment`.

## Changelog Fixes
+ Fixed Carnival Masks not being clickable in `/equipment`. - Luna