### PR TITLE
Fix: Composter Overlay no data

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -55,7 +55,7 @@ object ComposterDisplay {
 
     @SubscribeEvent
     fun onTabListUpdate(event: WidgetUpdateEvent) {
-        if (!(config.displayEnabled && GardenAPI.inGarden())) return
+        if (!GardenAPI.inGarden()) return
         if (!event.isWidget(TabWidget.COMPOSTER)) return
 
         readData(event.lines)
@@ -68,6 +68,7 @@ object ComposterDisplay {
     }
 
     private fun updateDisplay() {
+        if (!config.displayEnabled) return
         val newDisplay = mutableListOf<List<Any>>()
         newDisplay.addAsSingletonList("§bComposter")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.features.garden.composter.ComposterConfig.Re
 import at.hannibal2.skyhanni.data.SackAPI.getAmountInSacksOrNull
 import at.hannibal2.skyhanni.data.jsonobjects.repo.GardenJson
 import at.hannibal2.skyhanni.data.model.ComposterUpgrade
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -174,8 +175,8 @@ object ComposterOverlay {
                 Collections.singletonList(
                     listOf(
                         "§cSkyHanni composter error:", "§cRepo data not loaded!",
-                        "§7(organicMatterFactors is empty)"
-                    )
+                        "§7(organicMatterFactors is empty)",
+                    ),
                 )
             return
         }
@@ -184,8 +185,8 @@ object ComposterOverlay {
                 Collections.singletonList(
                     listOf(
                         "§cSkyHanni composter error:", "§cRepo data not loaded!",
-                        "§7(fuelFactors is empty)"
-                    )
+                        "§7(fuelFactors is empty)",
+                    ),
                 )
             return
         }
@@ -310,7 +311,7 @@ object ComposterOverlay {
             onChange = {
                 currentTimeType = it
                 update()
-            }
+            },
         )
 
         val list = mutableListOf<Any>()
@@ -405,10 +406,12 @@ object ComposterOverlay {
 
         val first: NEUInternalName? = calculateFirst(map, testOffset, factors, missing, onClick, bigList)
         if (testOffset != 0) {
-            bigList.addAsSingletonList(Renderable.link("testOffset = $testOffset") {
-                ComposterOverlay.testOffset = 0
-                update()
-            })
+            bigList.addAsSingletonList(
+                Renderable.link("testOffset = $testOffset") {
+                    ComposterOverlay.testOffset = 0
+                    update()
+                },
+            )
         }
 
         return first ?: error("First is empty!")
@@ -475,7 +478,7 @@ object ComposterOverlay {
                     lastAttemptTime = SimpleTimeMark.now()
                     retrieveMaterials(internalName, itemName, itemsNeeded.toInt())
                 }
-            }
+            },
         )
     }
 
@@ -524,7 +527,8 @@ object ComposterOverlay {
             if (LorenzUtils.noTradeMode) {
                 ChatUtils.chat("You're out of $itemName §ein your sacks!")
             } else {
-                ChatUtils.clickableChat( // TODO Add this as a separate feature, and then don't send any msg if the feature is disabled
+                ChatUtils.clickableChat(
+                    // TODO Add this as a separate feature, and then don't send any msg if the feature is disabled
                     "You're out of $itemName §ein your sacks! Click here to buy more on the Bazaar!",
                     onClick = { HypixelCommands.bazaar(itemName.removeColor()) },
                     "§eClick find on the bazaar!",
@@ -559,7 +563,7 @@ object ComposterOverlay {
         } catch (e: Exception) {
             ErrorManager.logErrorWithData(
                 e, "Failed to calculate composter overlay data",
-                "organicMatter" to organicMatter
+                "organicMatter" to organicMatter,
             )
         }
     }
@@ -597,11 +601,11 @@ object ComposterOverlay {
         if (inInventory) {
             config.overlayOrganicMatterPos.renderStringsAndItems(
                 organicMatterDisplay,
-                posLabel = "Composter Overlay Organic Matter"
+                posLabel = "Composter Overlay Organic Matter",
             )
             config.overlayFuelExtrasPos.renderStringsAndItems(
                 fuelExtraDisplay,
-                posLabel = "Composter Overlay Fuel Extras"
+                posLabel = "Composter Overlay Fuel Extras",
             )
         }
     }
@@ -622,6 +626,32 @@ object ComposterOverlay {
         event.move(3, "garden.composterRoundDown", "garden.composters.roundDown")
         event.transform(15, "garden.composters.retrieveFrom") { element ->
             ConfigUtils.migrateIntToEnum(element, RetrieveFromEntry::class.java)
+        }
+    }
+
+    @SubscribeEvent
+    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+        event.title("Garden Composter")
+
+        event.addIrrelevant {
+            add("currentOrganicMatterItem: $currentOrganicMatterItem")
+            add("currentFuelItem: $currentFuelItem")
+
+            println(" ")
+            val composterUpgrades = ComposterAPI.composterUpgrades
+            if (composterUpgrades == null) {
+                println("composterUpgrades is null")
+            } else {
+                for ((a, b) in composterUpgrades) {
+                    println("upgrade $a: $b")
+                }
+            }
+
+            println(" ")
+            val tabListData = ComposterAPI.tabListData
+            for ((a, b) in tabListData) {
+                println("tabListData $a: $b")
+            }
         }
     }
 }


### PR DESCRIPTION
## What
Composter Overlay required Composter Display to properly work, since the tab list data are only getting detected from there.
Also added Composter Overlay debug data
Fixed Composter Overlay calculating wrongly while Composter Display is not enabled.

## Changelog Fixes
+ Fixed Composter Overlay calculating incorrectly while Composter Display is disabled. - hannibal2