### PR TITLE
Fix: Contributor nametag flicker Patcher

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -23,16 +23,15 @@ import net.minecraft.entity.item.EntityItem
 import net.minecraft.entity.item.EntityItemFrame
 import net.minecraft.entity.item.EntityXPOrb
 import net.minecraft.network.play.server.S1CPacketEntityMetadata
-import net.minecraft.util.IChatComponent
+import net.minecraft.util.ChatComponentText
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
 object EntityData {
 
     private val maxHealthMap = mutableMapOf<EntityLivingBase, Int>()
-    private val nametagCache = TimeLimitedCache<Entity, IChatComponent>(50.milliseconds)
+    private val nametagCache = TimeLimitedCache<Entity, ChatComponentText>(50.milliseconds)
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
@@ -95,11 +94,11 @@ object EntityData {
     }
 
     @JvmStatic
-    fun getDisplayName(entity: Entity, ci: CallbackInfoReturnable<IChatComponent>) {
-        ci.returnValue = postRenderNametag(entity, ci.returnValue)
+    fun getDisplayName(entity: Entity, oldValue: ChatComponentText): ChatComponentText {
+        return postRenderNametag(entity, oldValue)
     }
 
-    private fun postRenderNametag(entity: Entity, chatComponent: IChatComponent) = nametagCache.getOrPut(entity) {
+    private fun postRenderNametag(entity: Entity, chatComponent: ChatComponentText) = nametagCache.getOrPut(entity) {
         val event = EntityDisplayNameEvent(entity, chatComponent)
         event.postAndCatch()
         event.chatComponent

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityDisplayNameEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityDisplayNameEvent.kt
@@ -2,6 +2,6 @@ package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.events.LorenzEvent
 import net.minecraft.entity.Entity
-import net.minecraft.util.IChatComponent
+import net.minecraft.util.ChatComponentText
 
-class EntityDisplayNameEvent(val entity: Entity, var chatComponent: IChatComponent) : LorenzEvent()
+class EntityDisplayNameEvent(val entity: Entity, var chatComponent: ChatComponentText) : LorenzEvent()

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntity.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntity.java
@@ -2,17 +2,19 @@ package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.data.EntityData;
 import net.minecraft.entity.Entity;
-import net.minecraft.util.IChatComponent;
+import net.minecraft.util.ChatComponentText;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(Entity.class)
 public abstract class MixinEntity {
 
-    @Inject(method = "getDisplayName", at = @At("RETURN"), cancellable = true)
-    public void getDisplayName(CallbackInfoReturnable<IChatComponent> ci) {
-        EntityData.getDisplayName((Entity) (Object) this, ci);
+    @ModifyVariable(
+        method = "getDisplayName",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/util/ChatStyle;setInsertion(Ljava/lang/String;)Lnet/minecraft/util/ChatStyle;", shift = At.Shift.AFTER)
+    )
+    public ChatComponentText getDisplayName(ChatComponentText value) {
+        return EntityData.getDisplayName((Entity) (Object) this, value);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityPlayer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntityPlayer.java
@@ -2,17 +2,20 @@ package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.data.EntityData;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IChatComponent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(EntityPlayer.class)
 public class MixinEntityPlayer {
 
-    @Inject(method = "getDisplayName", at = @At("RETURN"), cancellable = true)
-    public void getDisplayName(CallbackInfoReturnable<IChatComponent> ci) {
-        EntityData.getDisplayName((EntityPlayer) (Object) this, ci);
+    @ModifyVariable(
+        method = "getDisplayName",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/util/ChatStyle;setInsertion(Ljava/lang/String;)Lnet/minecraft/util/ChatStyle;", shift = At.Shift.AFTER)
+    )
+    public IChatComponent getDisplayName(IChatComponent value) {
+        return EntityData.getDisplayName((EntityPlayer) (Object) this, (ChatComponentText) value);
     }
 }


### PR DESCRIPTION
## What
Nea fixed the contributor name tag being sometimes (1-2 frames a second) disabled because of a mixin thingy with Patcher
Report: https://discord.com/channels/997079228510117908/1248249463445786624

## Changelog Fixes
+ Fixed Contributor name tag flickering when using Patcher. - nea