### PR TITLE
Fix: Dungeon Finder item lore wrong item

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -297,7 +297,7 @@ object DungeonFinderFeatures {
     fun onTooltip(event: LorenzToolTipEvent) {
         if (!isEnabled()) return
         if (!inInventory) return
-        val toolTip = toolTipMap[event.slot.slotIndex]
+        val toolTip = toolTipMap[event.slot.slotNumber]
         if (toolTip.isNullOrEmpty()) return
         // TODO @Thunderblade73 fix that to "event.toolTip = toolTip"
         val oldToolTip = event.toolTip


### PR DESCRIPTION
## What
Fixed showing the dungeon finder item lore on another item in the inventory.

## Changelog Fixes
+ Fixed the dungeon finder item lore displaying on other items in the inventory. - hannibal2