### PR TITLE
Fix: Lore on books with Compressed format + Regex Fix

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -38,7 +38,7 @@ object EnchantParser {
 
     val patternGroup = RepoPattern.group("misc.items.enchantparsing")
     val enchantmentPattern by patternGroup.pattern(
-        "enchants", "(?<enchant>[A-Za-z][A-Za-z -]+) (?<levelNumeral>[IVXLCDM]+)(?<stacking>, |\$| \\d{1,3}(,\\d{3})*)"
+        "enchants", "(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+)(?<stacking>, |\$| \\d{1,3}(,\\d{3})*)"
     )
     private val grayEnchantPattern by patternGroup.pattern(
         "grayenchants", "^(Respiration|Aqua Affinity|Depth Strider|Efficiency).*"
@@ -315,11 +315,18 @@ object EnchantParser {
             val comma = if (commaFormat == CommaFormat.COPY_ENCHANT) ", " else "§9, "
 
             builder.append(orderedEnchant.getFormattedString())
-            if (i % 3 != 2) {
-                builder.append(comma)
-            } else {
+
+            if (itemIsBook() && maxEnchantsPerLine == 1) {
                 insertEnchants.add(builder.toString())
+                insertEnchants.addAll(orderedEnchant.getLore())
                 builder = StringBuilder()
+            } else {
+                if (i % 3 != 2) {
+                    builder.append(comma)
+                } else {
+                    insertEnchants.add(builder.toString())
+                    builder = StringBuilder()
+                }
             }
         }
 


### PR DESCRIPTION
## What
Fixes lore not showing on enchanted books when compressed format is on, only shows lore on books with 1 enchant as books with more than 1 enchant with be compressed as usual. Plus fix enchant pattern regex to fix Bobbin' Time not being detected correctly.

## Changelog Fixes
+ Fixed Bobbin' Time not being detected correctly. - Vixid
+ Fixed lore not showing on enchanted books with compressed format. - Vixid
