### PR TITLE
Fix: Chroma Preview text showing in white

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
@@ -3,7 +3,11 @@ package at.hannibal2.skyhanni.mixins.hooks
 import at.hannibal2.skyhanni.features.chroma.ChromaFontRenderer
 import at.hannibal2.skyhanni.features.chroma.ChromaManager
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.ReflectionUtils.getPropertiesWithType
 import at.hannibal2.skyhanni.utils.RenderUtils
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import jdk.nashorn.internal.runtime.regexp.joni.Config
+import kotlin.reflect.KAnnotatedElement
 import net.minecraft.client.renderer.GlStateManager
 
 /**
@@ -27,8 +31,15 @@ object FontRendererHook {
 
     private var currentDrawState: ChromaFontRenderer? = null
     private var previewChroma = false
+    private var chromaPreviewText: String
 
     var cameFromChat = false
+    init {
+        // Get the description text from the ConfigOption annotation from the chromaPreview field to check against
+        val fields = config::class.java.declaredFields
+        val previewField = fields.first { it.name == "chromaPreview" } // Pls no one change the config field name
+        chromaPreviewText = previewField.getAnnotation(ConfigOption::class.java).desc
+    }
 
     /**
      * Setups the [ChromaFontRenderer][at.hannibal2.skyhanni.features.chroma.ChromaFontRenderer] for rendering text
@@ -71,7 +82,7 @@ object FontRendererHook {
             return
         }
 
-        if (text == "§fPlease star the mod on GitHub!") {
+        if (text == chromaPreviewText) {
             previewChroma = true
             setupChromaFont()
         }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
@@ -3,11 +3,8 @@ package at.hannibal2.skyhanni.mixins.hooks
 import at.hannibal2.skyhanni.features.chroma.ChromaFontRenderer
 import at.hannibal2.skyhanni.features.chroma.ChromaManager
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.ReflectionUtils.getPropertiesWithType
 import at.hannibal2.skyhanni.utils.RenderUtils
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
-import jdk.nashorn.internal.runtime.regexp.joni.Config
-import kotlin.reflect.KAnnotatedElement
 import net.minecraft.client.renderer.GlStateManager
 
 /**

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
@@ -31,6 +31,7 @@ object FontRendererHook {
     private var chromaPreviewText: String
 
     var cameFromChat = false
+
     init {
         // Get the description text from the ConfigOption annotation from the chromaPreview field to check against
         val fields = config::class.java.declaredFields


### PR DESCRIPTION
## What
Gets the description text of the ConfigOption annotation on the `chromaPreview` field in the config to check against in `FontRendererHook` programmatically so we don't have to make sure both places are up to date if one changes.

## Changelog Fixes
+ Fixed chroma preview always being white. - Vixid

