### PR TITLE
Fix: Incorrect "This item has no attributes" message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -39,6 +39,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.drawBorder
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.hasAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isMuseumDonated
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRiftExportable
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRiftTransferable

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -330,7 +330,7 @@ object HideNotClickableItems {
 
         showGreenLine = true
 
-        if (ItemUtils.hasAttributes(stack)) return false
+        if (stack.hasAttributes()) return false
 
         hideReason = "This item has no attributes!"
         return true

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -14,8 +14,6 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRecombobulated
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
-import com.google.gson.GsonBuilder
-import com.google.gson.JsonObject
 import io.github.moulberry.notenoughupdates.recipes.NeuRecipe
 import net.minecraft.client.Minecraft
 import net.minecraft.init.Items
@@ -76,19 +74,6 @@ object ItemUtils {
             list.add(player.inventory.itemStack)
         }
         return list
-    }
-
-    fun hasAttributes(stack: ItemStack): Boolean {
-        if (!stack.hasTagCompound()) return false
-        val tagCompound = stack.tagCompound
-        if (!tagCompound.hasKey("ExtraAttributes")) return false
-        val extraAttributes = tagCompound.getCompoundTag("ExtraAttributes")
-        try {
-            val json = GsonBuilder().create().fromJson(extraAttributes.toString(), JsonObject::class.java)
-            return json.has("attributes")
-        } catch (_: Exception) {
-            return false
-        }
     }
 
     fun ItemStack.getInternalName() = getInternalNameOrNull() ?: NEUInternalName.NONE

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -151,6 +151,8 @@ object SkyBlockItemModifierUtils {
             }.sortedBy { it.first }
         }
 
+    fun ItemStack.hasAttributes() = getAttributes() != null
+
     fun ItemStack.getReforgeName() = getAttributeString("modifier")?.let {
         when {
             it == "pitchin" -> "pitchin_koi"


### PR DESCRIPTION
## What
Fixed incorrect "This item has no attributes" message in Attribute Fusion menu for some items. It seemed to happen on items with unlocked gemstone slots, for example. The old code was hacky and error-prone and increased an unnecessary back-and-forth JSON conversion, which caused a syntax error with some items.

## Changelog Fixes
+ Fixed the incorrect "This item has no attributes" message appearing in the Attribute Fusion menu for some items. - Luna
