### PR TITLE
Fix: Remove Empty Strings in Powder Filter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.StringUtils.removeSFormattingCode
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -275,6 +274,7 @@ object PowderMiningChatFilter {
         // All powder and loot chest rewards start with 4 spaces
         // To simplify regex statements, this check is done outside
         val ssMessage = message.takeIf { it.startsWith("    ") }?.substring(4) ?: return null
+
         //Powder
         powderRewardPattern.matchMatcher(ssMessage) {
             if (config.powderFilterThreshold == 60000) return "powder_mining_powder"

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -19,6 +19,8 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.StringUtils.removeSFormattingCode
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -48,6 +50,14 @@ object PowderMiningChatFilter {
     private val successfulPickPattern by patternGroup.pattern(
         "warning.successpick",
         "§6You have successfully picked the lock on this chest!",
+    )
+
+    /**
+     * REGEX-TEST: §cThis chest has already been looted.
+     */
+    private val alreadyLootedPattern by patternGroup.pattern(
+        "warning.alreadylooted",
+        "§cThis chest has already been looted."
     )
 
     /**
@@ -247,6 +257,7 @@ object PowderMiningChatFilter {
         // Generic "you uncovered a chest" message
         if (uncoverChestPattern.matches(message)) return "powder_mining_chest"
         if (successfulPickPattern.matches(message)) return "powder_mining_picked"
+        if (alreadyLootedPattern.matches(message)) return "powder_mining_dupe"
         // Breaking power warning
         if (breakingPowerPattern.matches(message) && gemstoneConfig.strongerToolMessages) return "stronger_tool"
         // Closing or opening a reward 'loop' with the spam of ▬
@@ -256,6 +267,7 @@ object PowderMiningChatFilter {
         }
 
         if (!unclosedRewards) return null
+        if (message.removeColor().trim() == "") return "powder_mining_empty"
         if (lockPickedPattern.matches(message)) return "powder_chest_lockpicked"
         if (lootChestCollectedPattern.matches(message)) return "loot_chest_opened"
         if (rewardHeaderPattern.matches((message))) return "powder_reward_header"
@@ -263,7 +275,6 @@ object PowderMiningChatFilter {
         // All powder and loot chest rewards start with 4 spaces
         // To simplify regex statements, this check is done outside
         val ssMessage = message.takeIf { it.startsWith("    ") }?.substring(4) ?: return null
-
         //Powder
         powderRewardPattern.matchMatcher(ssMessage) {
             if (config.powderFilterThreshold == 60000) return "powder_mining_powder"

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -56,7 +56,7 @@ object PowderMiningChatFilter {
      */
     private val alreadyLootedPattern by patternGroup.pattern(
         "warning.alreadylooted",
-        "§cThis chest has already been looted."
+        "§cThis chest has already been looted\\.",
     )
 
     /**
@@ -266,7 +266,7 @@ object PowderMiningChatFilter {
         }
 
         if (!unclosedRewards) return null
-        if (message.removeColor().trim() == "") return "powder_mining_empty"
+        if (StringUtils.isEmpty(message)) return "powder_mining_empty"
         if (lockPickedPattern.matches(message)) return "powder_chest_lockpicked"
         if (lootChestCollectedPattern.matches(message)) return "loot_chest_opened"
         if (rewardHeaderPattern.matches((message))) return "powder_reward_header"
@@ -393,6 +393,7 @@ object PowderMiningChatFilter {
                 "flawed" -> if (gemSpecificFilterEntry > GemstoneFilterEntry.FLAWED_UP) {
                     "powder_mining_gemstones"
                 } else "no_filter"
+
                 "fine" -> if (gemSpecificFilterEntry > GemstoneFilterEntry.FINE_UP) {
                     "powder_mining_gemstones"
                 } else "no_filter"


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1269454294537470124
In case a user doesn't have the `Hide Empty Lines` filter enabled, explicitly remove the empty line in the powder filter.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/93031436-9210-4643-92d0-2c526893c212)

</details>

## Changelog Fixes
+ Fixed empty lines not being blocked by the Powder Mining filter. - Daveed

