### PR TITLE
Backend: fix pet regex

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/PetAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PetAPI.kt
@@ -23,7 +23,7 @@ object PetAPI {
     )
     private val neuRepoPetItemName by patternGroup.pattern(
         "item.name.neu.format",
-        "(?:§f§f)?§7\\[Lvl 1➡(?:100|200)] (?<name>.*)",
+        "(?:§f§f)?§7\\[Lvl (?:1➡(?:100|200)|\\{LVL})] (?<name>.*)",
     )
 
     private val ignoredPetStrings = listOf(


### PR DESCRIPTION
## What
Fixes pet regex so it doesn't display [Lvl {LVL}] pet name

exclude_from_changelog