### PR TITLE
Improvement: Add Minister to MayorAPI

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/MayorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/MayorConfig.java
@@ -16,8 +16,7 @@ public class MayorConfig {
     public boolean showTimeTillNextMayor = true;
 
     @Expose
-    // TODO: Same Toggle toggles ministers
-    @ConfigOption(name = "Show Extra Mayor", desc = "Show the Perkpocalypse Mayor without their perks.")
+    @ConfigOption(name = "Show Extra Mayor", desc = "Show the Perkpocalypse Mayor without their perks and the minister with their perk.")
     @ConfigEditorBoolean
     public boolean showExtraMayor = true;
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
@@ -86,6 +86,8 @@ object MayorAPI {
 
     var currentMayor: Mayor? = null
         private set
+    var currentMinister: Mayor? = null
+        private set
     private var lastMayor: Mayor? = null
     var jerryExtraMayor: Pair<Mayor?, SimpleTimeMark> = null to SimpleTimeMark.farPast()
         private set
@@ -216,6 +218,7 @@ object MayorAPI {
             val currentMayorName = data.mayor.name
             if (lastMayor?.name != currentMayorName) {
                 currentMayor = setAssumeMayorJson(currentMayorName, data.mayor.perks)
+                currentMinister = setAssumeMayorJson(data.mayor.minister.name, data.mayor.minister.perk)
             }
         }
     }
@@ -246,6 +249,8 @@ object MayorAPI {
             add("Active Perks: ${currentMayor?.activePerks}")
             add("Last Update: $lastUpdate (${lastUpdate.passedSince()} ago)")
             add("Time Till Next Mayor: ${nextMayorTimestamp.timeUntil()}")
+            add("Current Minister: ${currentMinister?.name ?: "Unknown"}")
+            add("Current Minister Perk: ${currentMinister?.activePerks}")
             if (jerryExtraMayor.first != null) {
                 add("Jerry Mayor: ${jerryExtraMayor.first?.name} expiring at: ${jerryExtraMayor.second.timeUntil()}")
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/MayorJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/MayorJson.kt
@@ -11,6 +11,7 @@ data class MayorInfo(
     @Expose val key: String,
     @Expose val name: String,
     @Expose val perks: List<MayorPerk>,
+    @Expose val minister: Minister,
     @Expose val election: MayorElection,
 )
 
@@ -26,7 +27,14 @@ data class MayorCandidate(
     @Expose val votes: Int,
 )
 
+data class Minister(
+    @Expose val key: String,
+    @Expose val name: String,
+    @Expose val perk: List<MayorPerk>,
+)
+
 data class MayorPerk(
     @Expose val name: String,
     @Expose val description: String,
+    @Expose val minister: Boolean = false,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -747,7 +747,7 @@ private fun getEventsDisplayPair(): List<ScoreboardElementType> = ScoreboardEven
 private fun getEventsShowWhen() = ScoreboardEvent.getEvent().isNotEmpty()
 
 private fun getMayorDisplayPair() = buildList {
-    val currentMayorName = MayorAPI.currentMayor?.mayorName?.let { MayorAPI.mayorNameWithColorCode(it) } ?: "<hidden>"
+    val currentMayorName = MayorAPI.currentMayor?.mayorName?.let { MayorAPI.mayorNameWithColorCode(it) } ?: return@buildList
     val timeTillNextMayor = if (mayorConfig.showTimeTillNextMayor) {
         "§7 (§e${MayorAPI.nextMayorTimestamp.timeUntil().format(maxUnits = 2)}§7)"
     } else {
@@ -763,6 +763,15 @@ private fun getMayorDisplayPair() = buildList {
     }
 
     if (!mayorConfig.showExtraMayor) return@buildList
+    val ministerName = MayorAPI.currentMinister?.mayorName?.let { MayorAPI.mayorNameWithColorCode(it) } ?: return@buildList
+    add(ministerName to HorizontalAlignment.LEFT)
+
+    if (mayorConfig.showMayorPerks) {
+        MayorAPI.currentMinister?.activePerks?.forEach { perk ->
+            add(" §7- §e${perk.perkName}" to HorizontalAlignment.LEFT)
+        }
+    }
+
     val jerryExtraMayor = MayorAPI.jerryExtraMayor
     val extraMayor = jerryExtraMayor.first ?: return@buildList
 
@@ -774,7 +783,6 @@ private fun getMayorDisplayPair() = buildList {
     }
 
     add((extraMayorName + extraTimeTillNextMayor) to HorizontalAlignment.LEFT)
-
 }
 
 private fun getMayorShowWhen() =


### PR DESCRIPTION
## What
Thanks to Thunder for telling me that Hypixel finally added it to the [API](https://api.hypixel.net/v2/resources/skyblock/election).
This Pull Request finally adds the minister to the MayorAPI.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/1f53362c-c249-49db-9aca-ae3b3e10e3bf)

</details>

## Changelog Improvements
+ Added the current Minister's name and perks to the Mayor Display on the Custom Scoreboard. - j10a1n15


## Changelog Technical Details
+ Added Minister data to the MayorAPI. - j10a1n15

