### PR TITLE
Fix: Colored Month in Discord RPC

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
@@ -167,9 +167,11 @@ enum class DiscordStatus(private val displayMessageSupplier: (() -> String?)) {
         } ?: "No item in hand"
     }),
 
-    TIME({
-        SkyBlockTime.now().formatted()
-    }),
+    TIME(
+        {
+            SkyBlockTime.now().formatted().removeColor()
+        },
+    ),
 
     PROFILE({
         val sbLevel = AdvancedPlayerList.tabPlayerData[LorenzUtils.getPlayerName()]?.sbLevel?.toString() ?: "?"


### PR DESCRIPTION
## What
This Pull Request fixes the colored month option also applying to the Discord RPC

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/d840657b-25c5-4300-b0c5-8a5af9b8293a)

</details>


## Changelog Fixes
+ Fixed Discord RPC using the colored month option. - j10a1n15
