### PR TITLE
Feature: Farming Personal Best FF Gain

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.java
@@ -220,7 +220,7 @@ public class GardenConfig {
     @Expose
     @ConfigOption(
         name = "Personal Best Increase FF",
-        desc = "Show mow much more FF you get from farming contest personal best bonus after beating the previous record."
+        desc = "Show in chat how much more FF you get from farming contest personal best bonus after beating the previous record."
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.java
@@ -217,6 +217,15 @@ public class GardenConfig {
     @FeatureToggle
     public boolean jacobContestSummary = true;
 
+    @Expose
+    @ConfigOption(
+        name = "Personal Best Increase FF",
+        desc = "Show mow much more FF you get from farming contest personal best bonus after beating the previous record."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean contestPersonalBestIncreaseFF = true;
+
     // Does not have a config element!
     @Expose
     public Position cropSpeedMeterPos = new Position(278, -236, false, true);

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -274,6 +274,7 @@ public class ProfileSpecificStorage {
         @Expose
         public Map<CropType, Double> latestTrueFarmingFortune = new HashMap<>();
 
+        // TODO use in /ff guide
         @Expose
         public Map<CropType, Double> personalBestFF = new HashMap<>();
 

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -29,7 +29,6 @@ import at.hannibal2.skyhanni.features.garden.pests.PestProfitTracker;
 import at.hannibal2.skyhanni.features.garden.pests.VinylType;
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorReward;
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryStrayTracker;
-import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryUpgrade;
 import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeAPI;
 import at.hannibal2.skyhanni.features.mining.MineshaftPityDisplay;
 import at.hannibal2.skyhanni.features.mining.fossilexcavator.ExcavatorProfitTracker;
@@ -274,6 +273,9 @@ public class ProfileSpecificStorage {
 
         @Expose
         public Map<CropType, Double> latestTrueFarmingFortune = new HashMap<>();
+
+        @Expose
+        public Map<CropType, Double> personalBestFF = new HashMap<>();
 
         @Expose
         @Nullable

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.garden.contest
 
 import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -59,8 +60,13 @@ object FarmingPersonalBestGain {
             checkDelayed()
         }
         newFFPattern.matchMatcher(event.message) {
+            val cropName = group("crop")
             newFF = group("ff").formatDouble()
-            crop = group("crop")
+            crop = cropName
+            val cropType = CropType.getByName(cropName)
+            GardenAPI.storage?.let {
+                it.personalBestFF[cropType] = newFF
+            }
             checkDelayed()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
@@ -82,7 +82,7 @@ object FarmingPersonalBestGain {
         val oldFF = oldCollected / collectionPerFF
         val ffDiff = newFF - oldFF
 
-        ChatUtils.chat("This is §6${ffDiff.round(1)}☘ $crop Fortune §emore than previously!")
+        ChatUtils.chat("This is §6${ffDiff.round(2)}☘ $crop Fortune §emore than previously!")
     }
 
     fun isEnabled() = GardenAPI.inGarden() && config.contestPersonalBestIncreaseFF

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
@@ -1,0 +1,89 @@
+package at.hannibal2.skyhanni.features.garden.contest
+
+import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.features.garden.GardenAPI
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.LorenzUtils.round
+import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object FarmingPersonalBestGain {
+    private val config get() = GardenAPI.config
+    private val patternGroup = RepoPattern.group("garden.contest.personal.best")
+
+    /**
+     * REGEX-TEST: §e[NPC] Jacob§f: §rYou collected §e1,400,694 §fitems! §d§lPERSONAL BEST§f!
+     */
+    private val newPattern by patternGroup.pattern(
+        "collection.new",
+        "§e\\[NPC] Jacob§f: §rYou collected §e(?<collected>.*) §fitems! §d§lPERSONAL BEST§f!",
+    )
+
+    /**
+     * REGEX-TEST: §e[NPC] Jacob§f: §rYour previous Personal Best was §e1,176,372§f.
+     */
+    private val oldPattern by patternGroup.pattern(
+        "collection.old",
+        "§e\\[NPC] Jacob§f: §rYour previous Personal Best was §e(?<collected>.*)§f.",
+    )
+
+    /**
+     * REGEX-TEST: §e[NPC] Jacob§f: §rYour §6Personal Bests §fperk is now granting you §6+46.69☘ Potato Fortune§f!
+     *
+     */
+    private val newFFPattern by patternGroup.pattern(
+        "ff.new",
+        "§e\\[NPC] Jacob§f: §rYour §6Personal Bests §fperk is now granting you §6\\+(?<ff>.*)☘ (?<crop>.*) Fortune§f!",
+    )
+
+    var newCollected: Double? = null
+    var oldCollected: Double? = null
+    var newFF: Double? = null
+    var crop: String? = null
+
+    @SubscribeEvent
+    fun onChat(event: LorenzChatEvent) {
+        if (!isEnabled()) return
+
+        newPattern.matchMatcher(event.message) {
+            newCollected = group("collected").formatDouble()
+            checkDelayed()
+        }
+        oldPattern.matchMatcher(event.message) {
+            oldCollected = group("collected").formatDouble()
+            checkDelayed()
+        }
+        newFFPattern.matchMatcher(event.message) {
+            newFF = group("ff").formatDouble()
+            crop = group("crop")
+            checkDelayed()
+        }
+    }
+
+    private fun checkDelayed() = DelayedRun.runNextTick { check() }
+
+    private fun check() {
+        val newCollected = newCollected ?: return
+        val oldCollected = oldCollected ?: return
+        val newFF = newFF ?: return
+        val crop = crop ?: return
+
+        this.newCollected = null
+        this.oldCollected = null
+        this.newFF = null
+        this.crop = null
+
+        val collectionPerFF = newCollected / newFF
+        val oldFF = oldCollected / collectionPerFF
+        val ffDiff = newFF - oldFF
+
+        ChatUtils.chat("This is §6${ffDiff.round(1)}☘ $crop Fortune §emore than previously!")
+    }
+
+    fun isEnabled() = GardenAPI.inGarden() && config.contestPersonalBestIncreaseFF
+}


### PR DESCRIPTION
## What
Show in chat how much more FF you get from farming contest personal best bonus after beating the previous record.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/61daca02-c7ec-4311-aa79-2307855d5afb)

</details>


## Changelog New Features
+ Added Farming Personal Best FF Gain. - hannibal2
    * Displays in chat how much additional FF you earn from the farming contest personal best bonus after beating your previous record.