### PR TITLE
Improvement: Click CF block message to open pets

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.features.event.hoppity.MythicRabbitPetWarning
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -39,10 +40,13 @@ object ChocolateFactoryBlockOpen {
 
         commandSentTimer = SimpleTimeMark.now()
         event.cancel()
-        ChatUtils.chatAndOpenConfig(
-            "Blocked opening the Chocolate Factory without a §dMythic Rabbit Pet §eequipped. Click here to disable!",
+        ChatUtils.clickToActionOrDisable(
+            "§cBlocked opening the Chocolate Factory without a §dMythic Rabbit Pet §cequipped!",
             config::mythicRabbitRequirement,
-        )
+            "open pets menu",
+        ) {
+            HypixelCommands.pet()
+        }
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.mythicRabbitRequirement

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -257,4 +257,19 @@ object ChatUtils {
         }
         return this
     }
+
+    fun clickToActionOrDisable(message: String, option: KMutableProperty0<*>, actionName: String, action: () -> Unit) {
+        ChatUtils.clickableChat(
+            "$message\n§e[CLICK to $actionName or disable this feature]",
+            onClick = {
+                if (KeyboardManager.isShiftKeyDown() || KeyboardManager.isModifierKeyDown()) {
+                    option.jumpToEditor()
+                } else {
+                    action()
+                }
+            },
+            hover = "§eClick to $actionName!\n" +
+                "§eShift-Click to disable this feature!",
+        )
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -68,6 +68,10 @@ object HypixelCommands {
         send("cf")
     }
 
+    fun pet() {
+        send("pet")
+    }
+
     fun openBaker() {
         send("openbaker")
     }


### PR DESCRIPTION
## What
Click on the chat message when you try to open /cf without rabbit pet to open /pets.
Suggested: https://discord.com/channels/997079228510117908/1272447363981639702

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/83e1f99c-3c9d-48ec-89a2-f99c80f9231d)

</details>

## Changelog Improvements
+ Clicking on the chat message when you try to open /cf without a rabbit pet will now open /pets. - hannibal2