### PR TITLE
Improvement: Repo Errors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -171,23 +171,19 @@ object ComposterOverlay {
             return
         }
         if (organicMatterFactors.isEmpty()) {
-            organicMatterDisplay =
-                Collections.singletonList(
-                    listOf(
-                        "§cSkyHanni composter error:", "§cRepo data not loaded!",
-                        "§7(organicMatterFactors is empty)",
-                    ),
-                )
+            organicMatterDisplay = listOf(
+                Collections.singletonList("§cSkyHanni composter error:"),
+                Collections.singletonList("§cRepo data not loaded!"),
+                Collections.singletonList("§7(organicMatterFactors is empty)"),
+            )
             return
         }
         if (fuelFactors.isEmpty()) {
-            organicMatterDisplay =
-                Collections.singletonList(
-                    listOf(
-                        "§cSkyHanni composter error:", "§cRepo data not loaded!",
-                        "§7(fuelFactors is empty)",
-                    ),
-                )
+            organicMatterDisplay = listOf(
+                Collections.singletonList("§cSkyHanni composter error:"),
+                Collections.singletonList("§cRepo data not loaded!"),
+                Collections.singletonList("§7(fuelFactors is empty)"),
+            )
             return
         }
         if (currentOrganicMatterItem.let { it !in organicMatterFactors.keys && it != NONE }) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/GardenComposterInventoryFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/GardenComposterInventoryFeatures.kt
@@ -57,14 +57,7 @@ object GardenComposterInventoryFeatures {
                     )
                     continue
                 }
-                val internalName = NEUInternalName.fromItemNameOrNull(itemName) ?: run {
-                    ErrorManager.logErrorStateWithData(
-                        "Error reading internal name for item: $itemName",
-                        "could not find internal name for",
-                        "itemName" to itemName
-                    )
-                    continue
-                }
+                val internalName = NEUInternalName.fromItemName(itemName)
                 val lowestBin = internalName.getPrice()
                 val price = lowestBin * amount
                 fullPrice += price

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.item.ItemHoverEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -25,7 +24,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
-import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
@@ -202,12 +200,6 @@ object EstimatedItemValue {
         if (internalName.isRune()) return listOf()
         if (internalName.contains("UNIQUE_RUNE")) return listOf()
         if (internalName.contains("WISP_POTION")) return listOf()
-
-
-        if (internalName.getItemStackOrNull() == null) {
-            ChatUtils.debug("Estimated Item Value is null for: '$internalName'")
-            return listOf()
-        }
 
         val list = mutableListOf<String>()
         list.add("§aEstimated Item Value:")

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorColorNames
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.getBazaarData
 import at.hannibal2.skyhanni.features.mining.OreBlock
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -32,7 +31,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
-import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -366,12 +364,9 @@ object SkyHanniDebugsAndTests {
             return
         }
 
-        val internalName = hand.getInternalNameOrNull()
-            ?: ErrorManager.skyHanniError("Internal name is null for item ${hand.name}")
-
-        val rawInternalName = internalName.asString()
-        OSUtils.copyToClipboard(rawInternalName)
-        ChatUtils.chat("§eCopied internal name §7$rawInternalName §eto the clipboard!")
+        val internalName = hand.getInternalName().asString()
+        OSUtils.copyToClipboard(internalName)
+        ChatUtils.chat("§eCopied internal name §7$internalName §eto the clipboard!")
     }
 
     fun toggleRender() {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -272,7 +272,7 @@ object ItemUtils {
      */
     var ItemStack.name: String
         get() = this.displayName ?: ErrorManager.skyHanniError(
-            "Could not get name if ItemStack",
+            "Could not get name of ItemStack",
             "itemStack" to this,
             "displayName" to displayName,
             "internal name" to getInternalNameOrNull(),

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.data.PetAPI
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
@@ -14,7 +16,9 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRecombobulated
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
+import com.google.common.collect.Lists
 import io.github.moulberry.notenoughupdates.recipes.NeuRecipe
+import io.github.moulberry.notenoughupdates.util.NotificationHandler
 import net.minecraft.client.Minecraft
 import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
@@ -22,13 +26,17 @@ import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.nbt.NBTTagList
 import net.minecraft.nbt.NBTTagString
 import net.minecraftforge.common.util.Constants
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.LinkedList
 import java.util.regex.Matcher
 import kotlin.time.Duration.Companion.seconds
 
+@SkyHanniModule
 object ItemUtils {
 
     private val itemNameCache = mutableMapOf<NEUInternalName, String>() // internal name -> item name
+
+    private val missingRepoItems = mutableSetOf<String>()
 
     fun ItemStack.cleanName() = this.displayName.removeColor()
 
@@ -360,7 +368,11 @@ object ItemUtils {
         }
 
         val itemStack = getItemStackOrNull()
-        val name = itemStack?.name ?: error("Could not find item name for $this")
+        val name = itemStack?.name ?: run {
+            val name = toString()
+            addMissingRepoItem(name, "Could not find item name for $name")
+            return "§c$name"
+        }
 
         // show enchanted book name
         if (itemStack.getItemCategoryOrNull() == ItemCategory.ENCHANTED_BOOK) {
@@ -411,4 +423,39 @@ object ItemUtils {
             it.key.getPrice(pastRecipes = pastRecipes) * it.value
         }.sum()
 
+    @SubscribeEvent
+    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+        event.title("Missing Repo Items")
+
+        if (missingRepoItems.isNotEmpty()) {
+            event.addData {
+                add("Detected ${missingRepoItems.size} missing items:")
+                for (itemName in missingRepoItems) {
+                    add(" - $itemName")
+                }
+            }
+        } else {
+            event.addIrrelevant("No Repo Item fails detected.")
+        }
+    }
+
+    fun addMissingRepoItem(name: String, message: String) {
+        if (!missingRepoItems.add(name)) return
+        ChatUtils.debug(message)
+//         showRepoWarning()
+    }
+
+    // Running NEU's function `Utils.showOutdatedRepoNotification()` caused a NoSuchMethodError in dev env.
+    // Therefore we run NotificationHandler.displayNotification directly
+    private fun showRepoWarning() {
+        NotificationHandler.displayNotification(
+            Lists.newArrayList(
+                "§c§lMissing repo data",
+                "§cData used for some SkyHanni features is not up to date, this should normally not be the case.",
+                "§cYou can try §l/neuresetrepo§r§c and restart your game to see if that fixes the issue.",
+                "§cIf the problem persists please join the SkyHanni Discord and message in §l#support§r§c to get support.",
+            ),
+            true, true,
+        )
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
@@ -1,7 +1,5 @@
 package at.hannibal2.skyhanni.utils
 
-import at.hannibal2.skyhanni.test.command.ErrorManager
-
 class NEUInternalName private constructor(private val internalName: String) {
 
     companion object {
@@ -24,11 +22,11 @@ class NEUInternalName private constructor(private val internalName: String) {
         fun fromItemNameOrNull(itemName: String): NEUInternalName? =
             ItemNameResolver.getInternalNameOrNull(itemName.removeSuffix(" Pet"))
 
-        fun fromItemName(itemName: String): NEUInternalName =
-            fromItemNameOrNull(itemName) ?: ErrorManager.skyHanniError(
-                "NEUInternalName is null for item name: '$itemName'",
-                "inventoryName" to InventoryUtils.openInventoryName()
-            )
+        fun fromItemName(itemName: String): NEUInternalName = fromItemNameOrNull(itemName) ?: run {
+            val name = "itemName:$itemName"
+            ItemUtils.addMissingRepoItem(name, "Could not find internal name for $name")
+            return NEUInternalName.MISSING_ITEM
+        }
     }
 
     fun asString() = internalName

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -197,14 +197,9 @@ object NEUItems {
         getItemStackOrNull() ?: run {
             getPriceOrNullNew() ?: return@run fallbackItem
             if (ignoreItemsFilter.match(this.asString())) return@run fallbackItem
-            ErrorManager.logErrorWithData(
-                IllegalStateException("Something went wrong!"),
-                "Encountered an error getting the item for §7$this§c. " +
-                    "This may be because your NEU repo is outdated. Please ask in the SkyHanni " +
-                    "Discord if this is the case.",
-                "Item name" to this.asString(),
-                "repo commit" to manager.latestRepoCommit,
-            )
+
+            val name = this.toString()
+            ItemUtils.addMissingRepoItem(name, "Could not create item stack for $name")
             fallbackItem
         }
 


### PR DESCRIPTION
## What
This PR tries to remove all repo item error related chat messages for users.
This should reduce the amount of bug reports on discord.
Instead, the item names for unknown items will now show in red the internal name, and item stacks will show as barriers.

Optionally, we will also show the "missing neu repo" error popup from NEU. I'm not sure if we want to include this, though. (the function call is currently commented out).

Additionally, the debug mode will show the errors in chat, and /shdebug will also keep track of all failed items.

To test this PR, simply remove some/many/all item files from your local repo folder and see what happens (don't forget to restart, caches exist)

<details>
<summary>/shdebug example</summary>

```
= Debug Information for SkyHanni 0.26.Beta.22 =

no search specified, only showing interesting stuff:

== Item Repo Data ==
 Missing repo items: 33
  - itemname:Carrot
  - internalName:ASPECT_OF_THE_VOID
  - itemname:Melon
  - internalName:IMPLOSION_SCROLL
  - internalName:FLAWLESS_SAPPHIRE_GEM
  - internalName:PERFECT_JASPER_GEM
  - internalName:DARK_CLAYMORE
  - internalName:ARROW_SWAPPER
  - internalName:ICE_SPRAY_WAND
  - internalName:BONZO_MASK
  - internalName:HEARTFIRE_DAGGER
  - internalName:OPAL_POWER_SCROLL
  - internalName:FIRE_VEIL_WAND
  - internalName:KUUDRA_SHOP_ITEM
  - internalName:DAEDALUS_AXE
  - internalName:HYPERION
  - internalName:ANCESTRAL_SPADE
```

</details>

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/4c6d236f-23da-46b4-b5c4-2d1573a13d0d)
![image](https://github.com/user-attachments/assets/137400ed-cd05-4b6f-9d03-e409e52e88c1)
![image](https://github.com/user-attachments/assets/5c537d26-a5a9-4028-8e06-b83d37e4a515)

![image](https://github.com/user-attachments/assets/2bb0bd24-fe6a-48da-9e79-dfadfa912696)

</details>

## Changelog Improvements
+ Hide repository errors in chat. - hannibal2
    * Errors will be displayed directly in the GUI when necessary, making them less intrusive.
## Changelog Technical Details
+ Removed repository item errors. - hannibal2
    * Instead of stack traces for "no item name for internal name", "no item stack for internal name", and "no internal name for item stack", we now return the internal name in red, the internal name `MISSING_ITEM`, or a barrier item instead.
    * Command /shdebug lists all failed item names.
    * Debug chat still logs the errors.
    * Shows a popup (currently disabled).