### PR TITLE
Backend: Deleted duplicate function in Crop Milestone Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -245,15 +245,6 @@ object GardenCropMilestoneDisplay {
             }
         }
 
-        if (overflowConfig.chat) {
-            if (currentTier > 46 && currentTier == previousNext &&
-                nextRealTier == currentTier + 1 && lastWarnedLevel != currentTier
-            ) {
-                GardenCropMilestones.onOverflowLevelUp(crop, currentTier - 1, nextRealTier - 1)
-                lastWarnedLevel = currentTier
-            }
-        }
-
         if (GardenAPI.mushroomCowPet && crop != CropType.MUSHROOM) {
             addMushroomCowData()
         }


### PR DESCRIPTION
## What
Deleted duplicate function in Crop Milestone Display

## Changelog Technical Details
+ Deleted an unnecessary function in Garden Crop Milestone. - notafrogo
