### PR TITLE
Fix: ScoreboardData and splitting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
@@ -35,8 +35,14 @@ object ScoreboardData {
 
             val lastColor = start.lastColorCode() ?: ""
 
-            if (end.startsWith(lastColor)) {
-                end = end.removePrefix(lastColor)
+            // Determine the longest prefix of "end" that matches any suffix of "lastColor"
+            val colorSuffixes = generateSequence(lastColor) { it.dropLast(2) }
+                .takeWhile { it.isNotEmpty() }
+                .toList()
+
+            val matchingPrefix = colorSuffixes.find { end.startsWith(it) } ?: ""
+            if (matchingPrefix.isNotEmpty()) {
+                end = end.removePrefix(matchingPrefix)
             }
 
             add(start + end)


### PR DESCRIPTION
## What
Its hard to explain, basically, the current System worked fine on "§a111<split>§a222" and "§a§a111<split>§a§a222", but didnt work on "§a§a111<split>§a222", which caused this error. Look I assume this fixes it, I cant test it because it's Spring 4th.



## Changelog Fixes
+ Fixed a Custom Scoreboard error during the Winter Event. - j10a1n15

