### PR TITLE
Improvement: Added parkour and teleport messages to blockable messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.java
@@ -111,6 +111,12 @@ public class FilterTypesConfig {
     @FeatureToggle
     public boolean hideAlphaAchievements = false;
 
+    @Expose
+    @ConfigOption(name = "Parkour", desc = "Hide parkour messages.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean parkour = false;
+
     //TODO remove
     @Expose
     @ConfigOption(name = "Others", desc = "Hide other annoying messages.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.java
@@ -112,16 +112,16 @@ public class FilterTypesConfig {
     public boolean hideAlphaAchievements = false;
 
     @Expose
-    @ConfigOption(name = "Parkour", desc = "Hide parkour messages.")
+    @ConfigOption(name = "Hide Parkour", desc = "Hide parkour messages (starting, stopping, reaching a milestone).")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean parkour = false;
+    public boolean hideParkour = false;
 
     @Expose
-    @ConfigOption(name = "Teleport pads", desc = "Hide annoying messages from teleport pads.")
+    @ConfigOption(name = "Hide Teleport Pads", desc = "Hide annoying messages when using teleport pads.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean teleport_pads = false;
+    public boolean hideTeleportPads = false;
 
     //TODO remove
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.java
@@ -117,6 +117,12 @@ public class FilterTypesConfig {
     @FeatureToggle
     public boolean parkour = false;
 
+    @Expose
+    @ConfigOption(name = "Teleport pads", desc = "Hide annoying messages from teleport pads.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean teleport_pads = false;
+
     //TODO remove
     @Expose
     @ConfigOption(name = "Others", desc = "Hide other annoying messages.")

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -405,24 +405,38 @@ object ChatFilter {
         "§e§k.§a>> {3}§aAchievement Unlocked: .* {3}<<§e§k.".toPattern(),
     )
 
+    /**
+     * REGEX-TEST: §aStarted parkour cocoa!
+     * REGEX-TEST: §aFinished parkour cocoa in 12:34.567
+     * REGEX-TEST: §aReached checkpoint #4 for parkour cocoa!
+     * REGEX-TEST: §4Wrong checkpoint for parkour cocoa!
+     * REGEX-TEST: §4You haven't reached all checkpoints for parkour cocoa!
+     */
     private val parkourPatterns = listOf(
         "§aStarted parkour (.*)!".toPattern(),
         "§aFinished parkour (.*) in (.*)!".toPattern(),
-        "§aReached checkpoint (.*) for parkour (.*)!".toPattern(),
+        "§aReached checkpoint #(.*) for parkour (.*)!".toPattern(),
         "§4Wrong checkpoint for parkour (.*)!".toPattern(),
-        "§4You havent't reached all checkpoints for parkour (.*)!".toPattern(),
+        "§4You haven't reached all checkpoints for parkour (.*)!".toPattern(),
     )
 
+    /**
+     * REGEX-TEST: §4Cancelled parkour! You cannot fly.
+     * REGEX-TEST: §4Cancelled parkour! You cannot use item abilities.
+     * REGEX-TEST: §4Cancelled parkour!
+     */
     private val parkourCancelMessages = listOf(
         "§4Cancelled parkour! You cannot fly.",
         "§4Cancelled parkour! You cannot use item abilities.",
         "§4Cancelled parkour!",
     )
 
+    // §r§aWarped from the tppadone §r§ato the tppadtwo§r§a!
     private val teleportPadPatterns = listOf(
-        "§aWarped from the (.*) §ato the (.*)§a!".toPattern(),
+        "§aWarped from the (.*) §r§ato the (.*)§r§a!".toPattern(),
     )
 
+    // §r§4This Teleport Pad does not have a destination set!
     private val teleportPadMessages = listOf(
         "§4This Teleport Pad does not have a destination set!"
     )
@@ -477,7 +491,7 @@ object ChatFilter {
     private val messagesContainsMap: Map<String, List<String>> = mapOf(
         "lobby" to lobbyMessagesContains,
     )
-    
+
     private val messagesStartsWithMap: Map<String, List<String>> = mapOf(
         "slayer" to slayerMessageStartWith,
         "profile_join" to profileJoinMessageStartsWith,

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -419,6 +419,14 @@ object ChatFilter {
         "§4Cancelled parkour!",
     )
 
+    private val teleportPadPatterns = listOf(
+        "§aWarped from the (.*) §ato the (.*)§a!".toPattern(),
+    )
+
+    private val teleportPadMessages = listOf(
+        "§4This Teleport Pad does not have a destination set!"
+    )
+
     private val patternsMap: Map<String, List<Pattern>> = mapOf(
         "lobby" to lobbyPatterns,
         "warping" to warpingPatterns,
@@ -442,6 +450,7 @@ object ChatFilter {
         "fairy" to fairyPatterns,
         "achievement_get" to achievementGetPatterns,
         "parkour" to parkourPatterns,
+        "teleport_pads" to teleportPadPatterns,
     )
 
     private val messagesMap: Map<String, List<String>> = mapOf(
@@ -462,11 +471,13 @@ object ChatFilter {
         "event" to eventMessage,
         "skymall" to skymallMessages,
         "parkour" to parkourCancelMessages,
-
+        "teleport_pads" to teleportPadMessages,
     )
+
     private val messagesContainsMap: Map<String, List<String>> = mapOf(
         "lobby" to lobbyMessagesContains,
     )
+    
     private val messagesStartsWithMap: Map<String, List<String>> = mapOf(
         "slayer" to slayerMessageStartWith,
         "profile_join" to profileJoinMessageStartsWith,
@@ -495,6 +506,7 @@ object ChatFilter {
         config.killCombo && message.isPresent("kill_combo") -> "kill_combo"
         config.profileJoin && message.isPresent("profile_join") -> "profile_join"
         config.parkour && message.isPresent("parkour") -> "parkour"
+        config.teleport_pads && message.isPresent("teleport_pads") -> "teleport_pads"
 
         config.hideAlphaAchievements && HypixelData.hypixelAlpha && message.isPresent("achievement_get") -> "achievement_get"
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -519,8 +519,8 @@ object ChatFilter {
         config.guildExp && message.isPresent("guild_exp") -> "guild_exp"
         config.killCombo && message.isPresent("kill_combo") -> "kill_combo"
         config.profileJoin && message.isPresent("profile_join") -> "profile_join"
-        config.parkour && message.isPresent("parkour") -> "parkour"
-        config.teleport_pads && message.isPresent("teleport_pads") -> "teleport_pads"
+        config.hideParkour && message.isPresent("parkour") -> "parkour"
+        config.hideTeleportPads && message.isPresent("teleport_pads") -> "teleport_pads"
 
         config.hideAlphaAchievements && HypixelData.hypixelAlpha && message.isPresent("achievement_get") -> "achievement_get"
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -405,6 +405,10 @@ object ChatFilter {
         "§e§k.§a>> {3}§aAchievement Unlocked: .* {3}<<§e§k.".toPattern(),
     )
 
+    private val parkourPatterns = listOf(
+        "§aStarted parkour".toPattern(), "§aFinished parkour".toPattern(), "§aReach checkpoint".toPattern(), "§4Wrong checkpoint for parkour".toPattern(),
+    )
+
     private val patternsMap: Map<String, List<Pattern>> = mapOf(
         "lobby" to lobbyPatterns,
         "warping" to warpingPatterns,
@@ -427,6 +431,7 @@ object ChatFilter {
         "solo_stats" to soloStatsPatterns,
         "fairy" to fairyPatterns,
         "achievement_get" to achievementGetPatterns,
+        "parkour" to parkourPatterns,
     )
 
     private val messagesMap: Map<String, List<String>> = mapOf(
@@ -477,6 +482,7 @@ object ChatFilter {
         config.guildExp && message.isPresent("guild_exp") -> "guild_exp"
         config.killCombo && message.isPresent("kill_combo") -> "kill_combo"
         config.profileJoin && message.isPresent("profile_join") -> "profile_join"
+        config.parkour && message.isPresent("parkour") -> "parkour"
 
         config.hideAlphaAchievements && HypixelData.hypixelAlpha && message.isPresent("achievement_get") -> "achievement_get"
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -406,7 +406,17 @@ object ChatFilter {
     )
 
     private val parkourPatterns = listOf(
-        "§aStarted parkour".toPattern(), "§aFinished parkour".toPattern(), "§aReach checkpoint".toPattern(), "§4Wrong checkpoint for parkour".toPattern(),
+        "§aStarted parkour (.*)!".toPattern(),
+        "§aFinished parkour (.*) in (.*)!".toPattern(),
+        "§aReached checkpoint (.*) for parkour (.*)!".toPattern(),
+        "§4Wrong checkpoint for parkour (.*)!".toPattern(),
+        "§4You havent't reached all checkpoints for parkour (.*)!".toPattern(),
+    )
+
+    private val parkourCancelMessages = listOf(
+        "§4Cancelled parkour! You cannot fly.",
+        "§4Cancelled parkour! You cannot use item abilities.",
+        "§4Cancelled parkour!",
     )
 
     private val patternsMap: Map<String, List<Pattern>> = mapOf(
@@ -451,6 +461,8 @@ object ChatFilter {
         "fire_sale" to fireSaleMessages,
         "event" to eventMessage,
         "skymall" to skymallMessages,
+        "parkour" to parkourCancelMessages,
+
     )
     private val messagesContainsMap: Map<String, List<String>> = mapOf(
         "lobby" to lobbyMessagesContains,


### PR DESCRIPTION
## What
Hides **parkour** and **teleport pad** messages. I wasn't able to test, **I'M NOT SURE IF IT WORKS**

## Changelog Improvements
+ Added more options to the Chat Hider feature. - not_a_cow
    * Option to block parkour messages and teleport pad messages.