### PR TITLE
Fix: SplatterHearts ConcurrentModificationException

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/stillgorechateau/SplatterHearts.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/stillgorechateau/SplatterHearts.kt
@@ -27,7 +27,7 @@ object SplatterHearts {
         if (event.count != 3 || event.speed != 0f) return
 
         if (lastHearts.passedSince() > 50.milliseconds) {
-            shownHearts = currentHearts
+            shownHearts = currentHearts.toSet()
             currentHearts.clear()
         }
         lastHearts = SimpleTimeMark.now()


### PR DESCRIPTION
## What
Fixes a ConcurrentModificationException in SplatterHearts.kt

Report: https://discord.com/channels/997079228510117908/1273425543814975508

<details>
<summary>Stack Trace</summary>

SkyHanni 0.26.Beta.23: Caught an ConcurrentModificationException in SplatterHearts at LorenzRenderWorldEvent: null
 
Caused by java.util.ConcurrentModificationException: null
    at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:711)
    at java.util.LinkedHashMap$LinkedKeyIterator.next(LinkedHashMap.java:734)
    at SH.features.rift.area.stillgorechateau.SplatterHearts.onRenderWorld(SplatterHearts.kt:51)
    at kr.syeyoung.dungeonsguide.launcher.events.OwnerAwareASMEventHandler_1761_SplatterHearts_onRenderWorld_LorenzRenderWorldEvent.invoke(.dynamic)
    at kr.syeyoung.dungeonsguide.launcher.events.OwnerAwareASMEventHandler.invoke(OwnerAwareASMEventHandler.java:65)
    at SH.data.RenderData.onRenderWorld(RenderData.kt:62)
    at kr.syeyoung.dungeonsguide.launcher.events.OwnerAwareASMEventHandler_453_RenderData_onRenderWorld_RenderWorldLastEvent.invoke(.dynamic)
    at kr.syeyoung.dungeonsguide.launcher.events.OwnerAwareASMEventHandler.invoke(OwnerAwareASMEventHandler.java:65)
    at FML.common.eventhandler.EventBus.post(EventBus.java:140)

</details>

## Changelog Fixes
+ Fixed an error when killing Splatter Cruxes in the Rift. - hannibal2