### PR TITLE
Fix: ConcurrentModificationException in SeaCreatureManager

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
@@ -125,7 +125,7 @@ object FishingTimer {
     private fun handle() {
         if (lastSeaCreatureFished.passedSince() > 2.seconds) return
         val name = lastNameFished ?: return
-        val mobs = recentMobs.filter { it.name == name && it !in mobDespawnTime }
+        val mobs = recentMobs.toSet().filter { it.name == name && it !in mobDespawnTime }
             .sortedBy { it.baseEntity.distanceToPlayer() }
             .take(mobsToFind).ifEmpty { return }
         mobsToFind -= mobs.size


### PR DESCRIPTION
## What
Fix a ConcurrentModificationException in SeaCreatureManager.
Reported: https://discord.com/channels/997079228510117908/1273199562558935081


<details>
<summary>Stack Trace</summary>

SkyHanni 0.26.Beta.22: Caught an NoSuchElementException in FishingTimer at SeaCreatureFishEvent: null
 
Caused by java.util.NoSuchElementException: null
    at com.google.common.cache.LocalCache$HashIterator.nextEntry(LocalCache.java:4343)
    at com.google.common.cache.LocalCache$KeyIterator.next(LocalCache.java:4362)
    at kotlin.collections.CollectionsKt___CollectionsKt.toSet(_Collections.kt:1347)
    at SH.utils.TimeLimitedSet.toSet(TimeLimitedSet.kt:31)
    at SH.utils.TimeLimitedSet.iterator(TimeLimitedSet.kt:34)
    at SH.features.fishing.FishingTimer.handle(FishingTimer.kt:245)
    at SH.features.fishing.FishingTimer.onSeaCreatureFish(FishingTimer.kt:122)
    at SH.features.fishing.SeaCreatureManager.onChat(SeaCreatureManager.kt:53)
    at SH.data.ChatManager.onChatReceive(ChatManager.kt:130)
    at FML.common.eventhandler.EventBus.post(EventBus.java:140)

</details>

## Changelog Fixes
+ Fixed an error during fishing. - hannibal2