### PR TITLE
Fix: Item Pickup Log null items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -229,13 +229,9 @@ object ItemPickupLog {
     }
 
     private fun isBannedItem(item: ItemStack): Boolean {
-        if (item.getInternalNameOrNull()?.startsWith("MAP") == true) {
-            return true
-        }
-
-        if (bannedItemsConverted.contains(item.getInternalNameOrNull())) {
-            return true
-        }
+        val internalName = item.getInternalNameOrNull() ?: return true
+        if (internalName.startsWith("MAP") == true) return true
+        if (internalName in bannedItemsConverted) return true
 
         if (item.getExtraAttributes()?.hasKey("quiver_arrow") == true) {
             return true


### PR DESCRIPTION
## What
Fix item pickup log detecting items without an internal name.
Reported: https://discord.com/channels/997079228510117908/1272204215200124938

## Changelog Fixes
+ Fixed the Item Pickup Log detecting "Magical Map" in dungeons when using Skytils. - hannibal2