### PR TITLE
Fix: Mining Crash workaround

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.features.mining.MiningCommissionsBlocksColor
 import at.hannibal2.skyhanni.features.mining.MiningCommissionsBlocksColor.CommissionBlock.Companion.onColor
 import at.hannibal2.skyhanni.features.mining.MiningCommissionsBlocksColor.replaceBlocksMapCache
 import at.hannibal2.skyhanni.features.mining.OreType.Companion.isOreType
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.block.state.IBlockState
 import net.minecraft.client.renderer.BlockRendererDispatcher
@@ -25,12 +26,16 @@ fun modifyGetModelFromBlockState(
 
     if (!LorenzUtils.inSkyBlock) return
 
-    if (MiningCommissionsBlocksColor.enabled && MiningCommissionsBlocksColor.active) {
-        returnState = replaceBlocksMapCache.getOrPut(state) {
-            MiningCommissionsBlocksColor.CommissionBlock.entries.firstOrNull {
-                state.isOreType(it.oreType)
-            }?.onColor(state) ?: state
+    try {
+        if (MiningCommissionsBlocksColor.enabled && MiningCommissionsBlocksColor.active) {
+            returnState = replaceBlocksMapCache.getOrPut(state) {
+                MiningCommissionsBlocksColor.CommissionBlock.entries.firstOrNull {
+                    state.isOreType(it.oreType)
+                }?.onColor(state) ?: state
+            }
         }
+    } catch (e: Exception) {
+        ErrorManager.logErrorWithData(e, "Error in MiningCommissionsBlocksColor")
     }
 
     if (returnState !== state) {


### PR DESCRIPTION
## What
Added a try catch block around `MiningCommissionsBlocksColor` so that we no longer crash but rather only show an error.

<details>
<summary>Stack Trace</summary>

```
java.lang.ClassCastException: java.util.LinkedHashMap$Entry cannot be cast to java.util.HashMap$TreeNode
at java.util.HashMap$TreeNode.moveRootToFront(HashMap.java:1859)
at java.util.HashMap$TreeNode.treeify(HashMap.java:1975)
at java.util.HashMap.treeifyBin(HashMap.java:773)
at java.util.HashMap.putVal(HashMap.java:645)
at java.util.HashMap.put(HashMap.java:613)
at at.hannibal2.skyhanni.mixins.hooks.BlockRendererDispatcherHookKt.modifyGetModelFromBlockState(BlockRendererDispatcherHook.kt:46)
at net.minecraft.client.renderer.BlockRendererDispatcher.handler$bpp001$modifyGetModelFromBlockState(BlockRendererDispatcher.java:1520)
at net.minecraft.client.renderer.BlockRendererDispatcher.getModelFromBlockState(BlockRendererDispatcher.java:155)
at net.minecraft.client.renderer.BlockRendererDispatcher.renderBlock(BlockRendererDispatcher.java:93)
at net.minecraft.client.renderer.chunk.RenderChunk.rebuildChunk(RenderChunk.java:316)
at net.minecraft.client.renderer.chunk.ChunkRenderWorker.processTask(SourceFile:78)
at net.minecraft.client.renderer.chunk.ChunkRenderWorker.run(SourceFile:38)
at java.lang.Thread.run(Thread.java:750)
```

</details>

## Changelog Fixes
+ Fixed a rare crash occurring on a mining island. - hannibal2