### PR TITLE
Fix: Garden Guesting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
@@ -22,7 +22,13 @@ object ScoreboardData {
 
     private var sidebarLines: List<String> = emptyList() // TODO rename to raw
     var sidebarLinesRaw: List<String> = emptyList() // TODO delete
-    var objectiveTitle = ""
+    val objectiveTitle: String get() = grabObjectiveTitle()
+
+    fun grabObjectiveTitle(): String {
+        val scoreboard = Minecraft.getMinecraft().theWorld?.scoreboard ?: return ""
+        val objective = scoreboard.getObjectiveInDisplaySlot(1) ?: return ""
+        return objective.displayName
+    }
 
     private var dirty = false
 
@@ -84,7 +90,6 @@ object ScoreboardData {
     private fun fetchScoreboardLines(): List<String> {
         val scoreboard = Minecraft.getMinecraft().theWorld?.scoreboard ?: return emptyList()
         val objective = scoreboard.getObjectiveInDisplaySlot(1) ?: return emptyList()
-        objectiveTitle = objective.displayName
         var scores = scoreboard.getSortedScores(objective)
         val list = scores.filter { input: Score? ->
             input != null && input.playerName != null && !input.playerName.startsWith("#")


### PR DESCRIPTION
## What
`ScoreboardData.objectiveTitle` was not updated immediately after world swap.
Bug report: https://discord.com/channels/997079228510117908/1273595874726907914

## Changelog Fixes
+ Fixed own garden not being detected when swapping islands from a guesting server. - hannibal2