### PR TITLE
Fix: Pet detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -89,6 +89,7 @@ object PestProfitTracker {
             val internalName = NEUInternalName.fromItemNameOrNull(group("item")) ?: return
 
             tracker.addItem(internalName, 1)
+            addKill()
             // pests always have guaranteed loot, therefore there's no need to add kill here
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -139,8 +139,9 @@ object NEUItems {
             var name = manager.createItem(rawInternalName).displayName.lowercase()
             val internalName = rawInternalName.asInternalName()
 
-            // TODO remove one of them once neu is consistent
+            // TODO remove all except one of them once neu is consistent
             name = name.removePrefix("§f§f§7[lvl 1➡100] ")
+            name = name.removePrefix("§f§f§7[lvl {lvl}] ")
             name = name.removePrefix("§7[lvl 1➡100] ")
 
             if (name.contains("[lvl 1➡100]")) {


### PR DESCRIPTION
## What
I am not sure why exactly, but with newer versions of NEU, the SkyHanni pet detection fails again.
It does not look like this is related to different NEU-REPO versions. On the outdated NEU version in Dev Env it worked, in production with NEU 2.3.3 it did not. This PR fixes this.

## Changelog Fixes
+ Fixed pet detection with newer NEU versions. - hannibal2