### PR TITLE
Fix: Finnegan Perks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
@@ -45,10 +45,10 @@ enum class Mayor(
     FINNEGAN(
         "Finnegan",
         "§c",
-        Perk.FARMING_SIMULATOR,
         Perk.PELT_POCALYPSE,
         Perk.GOATED,
         Perk.BLOOMING_BUSINESS,
+        Perk.PEST_ERADICATOR,
     ),
     FOXY(
         "Foxy",
@@ -189,10 +189,10 @@ enum class Perk(val perkName: String) {
     LONG_TERM_INVESTMENT("Long Term Investment"),
 
     // Finnegan
-    FARMING_SIMULATOR("Farming Simulator"),
     PELT_POCALYPSE("Pelt-pocalypse"),
     GOATED("GOATed"),
     BLOOMING_BUSINESS("Blooming Business"),
+    PEST_ERADICATOR("Pest Eradicator"),
 
     // Foxy
     SWEET_BENEVOLENCE("Sweet Benevolence"),
@@ -224,9 +224,7 @@ enum class Perk(val perkName: String) {
 
     // Derpy
     TURBO_MINIONS("TURBO MINIONS!!!"),
-    AH_TAX("MOAR TAX!!!"),
-
-    // I don't know what the perk is actually gonna be named
+    AH_TAX("MOAR TAX!!!"), // TODO: Change to actual perk name when known
     DOUBLE_MOBS_HP("DOUBLE MOBS HP!!!"),
     MOAR_SKILLZ("MOAR SKILLZ!!!"),
     ;

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -120,13 +120,7 @@ object GardenCropMilestoneDisplay {
                 val addedCounter = (counter - old).toInt()
                 FarmingWeightDisplay.addCrop(crop, addedCounter)
                 update()
-                // Farming Simulator: There is a 25% chance for Mathematical Hoes and the Cultivating Enchantment to count twice.
-                // 0.8 = 1 / 1.25
-                crop.setCounter(
-                    crop.getCounter() + if (GardenCropSpeed.finneganPerkActive()) {
-                        (addedCounter.toDouble() * 0.8).toInt()
-                    } else addedCounter
-                )
+                crop.setCounter(crop.getCounter() + addedCounter)
             }
             cultivatingData[crop] = counter
         } catch (e: Throwable) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
@@ -177,8 +177,6 @@ object GardenCropSpeed {
         secondsStopped = 0
     }
 
-    fun finneganPerkActive() = Perk.FARMING_SIMULATOR.isActive
-
     fun isEnabled() = GardenAPI.inGarden()
 
     fun CropType.getSpeed() = cropsPerSecond?.get(this)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.misc.TrevorTheTrapperConfig.TrackerEntry
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
@@ -144,7 +145,7 @@ object TrevorFeatures {
         }
 
         trapperPattern.matchMatcher(formattedMessage) {
-            timeUntilNextReady = if (GardenCropSpeed.finneganPerkActive()) 16 else 21
+            timeUntilNextReady = if (Perk.PELT_POCALYPSE.isActive) 16 else 21
             currentStatus = TrapperStatus.ACTIVE
             currentLabel = "§cActive Quest"
             trapperReady = false

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
-import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha


### PR DESCRIPTION
## What
Fixed Finnegan having the wrong perks, and the trapper helper checking for the wrong perk.

## Changelog Fixes
+ Fixed Finnegan still having the Farming Simulator perk and missing the Pest Eradicator perk. - Luna
+ Fixed the Trapper Helper checking for the wrong Finnegan perk. - Luna