### PR TITLE
Fix: Negative price for items with no NPC sell price

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -16,7 +16,7 @@ object ItemPriceUtils {
     fun NEUInternalName.getPrice(
         priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_BUY,
         pastRecipes: List<NeuRecipe> = emptyList(),
-    ) = getPriceOrNull(priceSource, pastRecipes) ?: -1.0
+    ) = getPriceOrNull(priceSource, pastRecipes) ?: 0.0
 
     fun NEUInternalName.getPriceOrNull(
         priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_BUY,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -66,7 +66,7 @@ object ItemPriceUtils {
         .filter { it >= 0 }
         .minOrNull()
 
-    fun NEUInternalName.getNpcPrice(): Double = getNpcPriceOrNull() ?: -1.0
+    fun NEUInternalName.getNpcPrice(): Double = getNpcPriceOrNull() ?: 0.0
 
     fun NEUInternalName.getNpcPriceOrNull(): Double? {
         if (this == NEUInternalName.WISP_POTION) {


### PR DESCRIPTION
## What
Fixed items with no NPC sell price counting as -1 coins instead of 0 coins.

## Changelog Fixes
+ Fixed items with no NPC sell price being counted as -1 coins instead of 0 coins. - Luna
