### PR TITLE
Fix: Obfuscated and Shard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
@@ -218,7 +218,7 @@ object TrophyFishDisplay {
 
     private fun getItemName(rawName: String): String {
         val name = getInternalName(rawName).itemName
-        return name.split(" ").dropLast(1).joinToString(" ").replace("§k", "")
+        return name.split(" ").dropLast(1).joinToString(" ")
     }
 
     private fun getInternalName(name: String): NEUInternalName {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.ReforgeAPI
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.sortedDesc
+import at.hannibal2.skyhanni.utils.ItemUtils.getAttributeFromShard
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -128,16 +129,8 @@ object EstimatedItemValueCalculator {
         if (isKuudraSet(internalName)) {
             genericName = kuudraSets.fold(internalName) { acc, part -> acc.replace(part, "GENERIC_KUUDRA") }
         }
-        if (internalName == "ATTRIBUTE_SHARD" && attributes.size == 1) {
-            val price = getPriceOrCompositePriceForAttribute(
-                "ATTRIBUTE_SHARD+ATTRIBUTE_" + attributes[0].first,
-                attributes[0].second,
-            )
-            if (price != null) {
-                val name = attributes[0].first.fixMending().allLettersFirstUppercase()
-                list.add("§7Attribute §9$name ${attributes[0].second}§7: (§6${price.shortFormat()}§7)")
-                return price
-            }
+        stack.getAttributeFromShard()?.let {
+            return 0.0
         }
         if (attributes.size != 2) return 0.0
         val basePrice = internalName.asInternalName().getPriceOrNull() ?: 0.0
@@ -546,6 +539,16 @@ object EstimatedItemValueCalculator {
 
     private fun addBaseItem(stack: ItemStack, list: MutableList<String>): Double {
         val internalName = removeKuudraArmorPrefix(stack.getInternalName().asString()).asInternalName()
+
+        stack.getAttributeFromShard()?.let {
+            val price = it.getAttributePrice()
+            if (price != null) {
+                val name = it.getAttributeName()
+                list.add("§7Base item: $name §7(§6" + price.shortFormat() + "§7)")
+                return price
+            }
+        }
+
         var price = internalName.getPrice()
         if (price == -1.0) {
             price = 0.0
@@ -771,4 +774,15 @@ object EstimatedItemValueCalculator {
     private fun NEUInternalName.getPriceOrNull(): Double? {
         return getPriceOrNull(config.priceSource.get())
     }
+
+    fun Pair<String, Int>.getAttributeName(): String {
+        val name = first.fixMending().allLettersFirstUppercase()
+        return "§9$name ${second}"
+    }
+
+    fun Pair<String, Int>.getAttributePrice(): Double? =
+        EstimatedItemValueCalculator.getPriceOrCompositePriceForAttribute(
+            "ATTRIBUTE_SHARD+ATTRIBUTE_" + first,
+            second,
+        )
 }

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -497,7 +497,7 @@ object SkyHanniDebugsAndTests {
             event.toolTip.add("Item name: no item.")
             return
         }
-        val name = internalName.itemName
+        val name = itemStack.itemName
         event.toolTip.add("Item name: '$name§7'")
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.data.PetAPI
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator.getAttributeName
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
@@ -12,6 +13,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.cachedData
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRecombobulated
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -343,7 +345,20 @@ object ItemUtils {
 
     // use when showing the item name to the user (in guis, chat message, etc.), not for comparing
     val ItemStack.itemName: String
-        get() = getInternalName().itemName
+        get() {
+            getAttributeFromShard()?.let {
+                return it.getAttributeName()
+            }
+            return getInternalName().itemName
+        }
+
+
+    fun ItemStack.getAttributeFromShard(): Pair<String, Int>? {
+        if (getInternalName().asString() != "ATTRIBUTE_SHARD") return null
+        val attributes = getAttributes() ?: return null
+        return attributes.firstOrNull()
+    }
+
 
     val ItemStack.itemNameWithoutColor: String get() = itemName.removeColor()
 
@@ -380,6 +395,11 @@ object ItemUtils {
         }
         if (name.endsWith("Enchanted Book Bundle")) {
             return name.replace("Enchanted Book", itemStack.getLore()[0].removeColor())
+        }
+
+        // obfuscated trophy fish
+        if (name.contains("§kObfuscated")) {
+            return name.replace("§kObfuscated", "Obfuscated")
         }
 
         // hide pet level


### PR DESCRIPTION
## What
Fix obfuscated trophy fish and attribute shard names.
Reported: https://discord.com/channels/997079228510117908/1274263829748125707

## Changelog Fixes
+ Fixed Attribute Shards not displaying their names in the Chest Value feature. - hannibal2
+ Fixed obfuscated trophy fish names being unreadable in the Fishing Profit Tracker. - hannibal2