### PR TITLE
Fix: Wrong Slayer alert Bladesoul

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
@@ -125,6 +125,11 @@ object SlayerQuestWarning {
     private fun isSlayerMob(entity: EntityLivingBase): Boolean {
         val slayerType = SlayerAPI.getSlayerTypeForCurrentArea() ?: return false
 
+        // workaround for rift mob that is unrelated to slayer
+        if (entity.name == "Oubliette Guard") return false
+        // workaround for Bladesoul in  Crimson Isle
+        if (LorenzUtils.skyBlockArea == "Stronghold" && entity.name == "Skeleton") return false
+
         val activeSlayer = SlayerAPI.activeSlayer
 
         if (activeSlayer != null) {
@@ -138,8 +143,8 @@ object SlayerQuestWarning {
                 )
             }
         }
-        // workaround for rift mob that is unrelated to slayer
-        val isSlayer = slayerType.clazz.isInstance(entity) && entity.name != "Oubliette Guard"
+
+        val isSlayer = slayerType.clazz.isInstance(entity)
         return (getSlayerData().lastSlayerType == slayerType) && isSlayer
     }
 


### PR DESCRIPTION
## What
Fix showing "wrong slayer alert" when attacking Bladesoul
Report: https://discord.com/channels/997079228510117908/1274321596395421696

## Changelog Fixes
+ Fixed the "wrong slayer" alert being shown when attacking Bladesoul. - hannibal2