### PR TITLE
Fix: One hoppity page

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -39,9 +39,15 @@ object HoppityCollectionStats {
     private val config get() = ChocolateFactoryAPI.config
 
     private val patternGroup = ChocolateFactoryAPI.patternGroup.group("collection")
+
+    /**
+     * REGEX-TEST: (1/17) Hoppity's Collection
+     * REGEX-TEST: (12/17) Hoppity's Collection
+     * REGEX-TEST: Hoppity's Collection
+     */
     private val pagePattern by patternGroup.pattern(
         "page.current",
-        "\\((?<page>\\d+)/(?<maxPage>\\d+)\\) Hoppity's Collection",
+        "(?:\\((?<page>\\d+)\\/(?<maxPage>\\d+)\\) )?Hoppity's Collection",
     )
     private val duplicatesFoundPattern by patternGroup.pattern(
         "duplicates.found",


### PR DESCRIPTION
## What
Fixed Hoppity Menu not getting detected when only having one page.
Report: https://discord.com/channels/997079228510117908/1274349313438515315

## Changelog Fixes
+ Fixed the Hoppity Menu not being detected when it only had one page. - hannibal2