### PR TITLE
Fix: Fishing Bait Error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingBaitWarnings.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingBaitWarnings.kt
@@ -69,7 +69,7 @@ object FishingBaitWarnings {
 
     private fun checkBait() {
         val bobber = FishingAPI.bobber ?: return
-        val bait = baitEntities.filter { it.distanceTo(bobber) < 8 }.minByOrNull { it.distanceTo(bobber) }?.name
+        val bait = baitEntities.toSet().filter { it.distanceTo(bobber) < 8 }.minByOrNull { it.distanceTo(bobber) }?.name
         baitEntities.clear()
 
         if (bait == null) {


### PR DESCRIPTION
## What
Maybe fixed the error message in FishingBaitWarnings when using TimeLimitedSet.
Reported: https://discord.com/channels/997079228510117908/1274350250043379752

<details>
<summary>Stack Trace</summary>

```
SkyHanni 0.26.Beta.24: DelayedRun task crashed while executing
 
Caused by java.util.NoSuchElementException: null
    at com.google.common.cache.LocalCache$HashIterator.nextEntry(LocalCache.java:4343)
    at com.google.common.cache.LocalCache$KeyIterator.next(LocalCache.java:4362)
    at kotlin.collections.CollectionsKt___CollectionsKt.toSet(_Collections.kt:1347)
    at SH.utils.TimeLimitedSet.toSet(TimeLimitedSet.kt:31)
    at SH.utils.TimeLimitedSet.iterator(TimeLimitedSet.kt:34)
    at SH.features.fishing.FishingBaitWarnings.checkBait(FishingBaitWarnings.kt:107)
    at SH.features.fishing.FishingBaitWarnings.onBobberInWater$lambda$0(FishingBaitWarnings.kt:54)
    at SH.utils.DelayedRun.checkRuns$lambda$0(DelayedRun.kt:29)
    at SH.utils.DelayedRun.checkRuns$lambda$1(DelayedRun.kt:25)
    at java.util.ArrayList.removeIf(Unknown Source)
    at SH.utils.DelayedRun.checkRuns(DelayedRun.kt:25)
    at SH.data.MinecraftData.onTick(MinecraftData.kt:74)
    at kr.syeyoung.dungeonsguide.launcher.events.OwnerAwareASMEventHandler_368_MinecraftData_onTick_ClientTickEvent.invoke(.dynamic)
    at kr.syeyoung.dungeonsguide.launcher.events.OwnerAwareASMEventHandler.invoke(OwnerAwareASMEventHandler.java:65)
    at FML.common.eventhandler.EventBus.post(EventBus.java:140)
```

</details>

## Changelog Fixes
+ Maybe fixed the fishing bait error message. - hannibal2