### PR TITLE
Fix: Item Pickup Log icons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -318,7 +318,7 @@ object HypixelData {
         if (LorenzUtils.onHypixel && LorenzUtils.inSkyBlock) {
             loop@ for (line in ScoreboardData.sidebarLinesFormatted) {
                 skyblockAreaPattern.matchMatcher(line) {
-                    val originalLocation = group("area")
+                    val originalLocation = group("area").removeColor()
                     skyBlockArea = LocationFixData.fixLocation(skyBlockIsland) ?: originalLocation
                     skyBlockAreaWithSymbol = line.trim()
                     break@loop

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -318,7 +318,7 @@ object HypixelData {
         if (LorenzUtils.onHypixel && LorenzUtils.inSkyBlock) {
             loop@ for (line in ScoreboardData.sidebarLinesFormatted) {
                 skyblockAreaPattern.matchMatcher(line) {
-                    val originalLocation = group("area").removeColor()
+                    val originalLocation = group("area")
                     skyBlockArea = LocationFixData.fixLocation(skyBlockIsland) ?: originalLocation
                     skyBlockAreaWithSymbol = line.trim()
                     break@loop

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -137,6 +137,11 @@ object NEUItems {
         val map = mutableMapOf<String, NEUInternalName>()
         for (rawInternalName in allNeuRepoItems().keys) {
             var name = manager.createItem(rawInternalName).displayName.lowercase()
+
+            // we ignore all builder blocks from the item name -> internal name cache
+            // because builder blocks can have the same display name as normal items.
+            if (rawInternalName.startsWith("BUILDER_")) continue
+
             val internalName = rawInternalName.asInternalName()
 
             // TODO remove all except one of them once neu is consistent


### PR DESCRIPTION
## What
Fixed Item Pickup Log showing wrong icons for some items when collected via sacks.
The cache `item name -> internal name` now ignores all builder blocks. this should not matter at all, as those blocks gets mapped to their normal block id anyway. `builder block ids -> item stack` works unaffected by this.
Report: https://discord.com/channels/997079228510117908/1274369437969027163

## Changelog Fixes
+ Fixed the Item Pickup Log showing incorrect icons for some items when collected via sacks. - hannibal2