### PR TITLE
Fix: Renderable links in other mods

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -252,6 +252,9 @@ interface Renderable {
             val isInNeuPv = openGui == "io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer"
             val neuFocus = NEUItems.neuHasFocus()
             val isInSkytilsPv = openGui == "gg.skytils.skytilsmod.gui.profile.ProfileGui"
+            val isInSkytilsSettings =
+                openGui.let { it.startsWith("gg.skytils.vigilance.gui.") || it.startsWith("gg.skytils.skytilsmod.gui.") }
+            val isInNeuSettings = openGui.startsWith("io.github.moulberry.notenoughupdates.")
 
             val result = isGuiScreen &&
                 isGuiPositionEditor &&
@@ -260,7 +263,9 @@ interface Renderable {
                 isConfigScreen &&
                 !isInNeuPv &&
                 !isInSkytilsPv &&
-                !neuFocus
+                !neuFocus &&
+                !isInSkytilsSettings &&
+                !isInNeuSettings
 
             if (debug) {
                 if (!result) {
@@ -274,6 +279,8 @@ interface Renderable {
                     if (isInNeuPv) logger.log("isInNeuPv")
                     if (neuFocus) logger.log("neuFocus")
                     if (isInSkytilsPv) logger.log("isInSkytilsPv")
+                    if (isInSkytilsSettings) logger.log("isInSkytilsSettings")
+                    if (isInNeuSettings) logger.log("isInNeuSettings")
                     logger.log("")
                 } else {
                     logger.log("allowed click")


### PR DESCRIPTION
## What
disable renderable links while in other mods screens (neu + skytils for now)
Reported: https://discord.com/channels/997079228510117908/1251518465882193930

## Changelog Fixes
+ Disabled the SkyHanni GUI's hover function while in other mods' screens. - hannibal2