### PR TITLE
Fix: typo in FarmingWeightDisplay error message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -511,7 +511,7 @@ object FarmingWeightDisplay {
             "Error loading user farming weight\n" +
                 "§eLoading the farming weight data from elitebot.dev failed!\n" +
                 "§eYou can re-enter the garden to try to fix the problem.\n" +
-                "§cIf this message repeats, please report it on Discord!\n",
+                "§cIf this message repeats, please report it on Discord",
             "url" to url,
             "apiResponse" to apiResponse,
             "localProfile" to localProfile,


### PR DESCRIPTION
## What

Removed extra `!\n` in message output, since the [ErrorManager adds a closing dot](../blob/HEAD/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt#L152) to the message already (`"…$message§c. Click here to copy the error into the clipboard.",`)

<details>
<summary>Screenshot of old behavior</summary>

<img width="575" alt="5f3598a7-c9d3-4e8c-83ca-d36beb9bc979" src="https://github.com/user-attachments/assets/0a5fea31-a666-4aa9-8289-a065b669d610">

</details>


## Changelog Fixes
+ Fixed a typo in the Farming Weight Display error message. - aphased