### PR TITLE
Fix: Master Mode Stack Sizes in Mort #2316

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -97,11 +97,11 @@ object DungeonFinderFeatures {
 
     /**
      * REGEX-TEST: Master Mode The Catacombs
-     * REGEX-TEST: The Catacombs
+     * REGEX-TEST: MM The Catacombs
      */
     private val masterModeFloorPattern by patternGroup.pattern(
         "floor.mastermode",
-        "(MM .*)|(.*Master Mode The Catacombs)"
+        "(MM|.*Master Mode) The Catacombs.*"
     )
     private val dungeonFloorPattern by patternGroup.pattern(
         "floor.dungeon",

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -60,11 +60,11 @@ object DungeonFinderFeatures {
 
     /**
      * REGEX-TEST: The Catacombs
-     * REGEX-TEST: Master Mode The Catacombs
+     * REGEX-TEST: MM The Catacombs
      */
     private val floorTypePattern by patternGroup.pattern(
         "floor.type",
-        "(The Catacombs).*|.*(Master Mode The Catacombs).*",
+        "(The Catacombs).*|.*(MM The Catacombs).*",
     )
     private val checkIfPartyPattern by patternGroup.pattern(
         "check.if.party",

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -101,7 +101,7 @@ object DungeonFinderFeatures {
      */
     private val masterModeFloorPattern by patternGroup.pattern(
         "floor.mastermode",
-        "(MM )|(.*Master Mode The Catacombs)"
+        "(MM .*)|(.*Master Mode The Catacombs)"
     )
     private val dungeonFloorPattern by patternGroup.pattern(
         "floor.dungeon",


### PR DESCRIPTION
Fixes erroneous Regex that broke Master Mode Stack Size change made in #2316 

## Changelog Fixes
+ Fixed Master Mode dungeon Stack size within Mort menu. - Fazfoxy
