### PR TITLE
Fix: Typos

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/waypoints/ChristmasPresentConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/waypoints/ChristmasPresentConfig.java
@@ -8,18 +8,20 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 public class ChristmasPresentConfig {
 
     @Expose
-    @ConfigOption(name = "Present Waypoints", desc = "Show all Present waypoints")
+    @ConfigOption(name = "Present Waypoints", desc = "Show all Present waypoints.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean allWaypoints = false;
 
+    // TODO confirm if this toggle actually does anything, ar there helper waypoints at all?
     @Expose
-    @ConfigOption(name = "Entrance Waypoints", desc = "Show helper waypoints to .")
+    @ConfigOption(name = "Entrance Waypoints", desc = "Show helper waypoints.")
     @ConfigEditorBoolean
     public boolean allEntranceWaypoints = false;
 
+
     @Expose
-    @ConfigOption(name = "Only Closest", desc = "Only show the closest waypoint")
+    @ConfigOption(name = "Only Closest", desc = "Only show the closest waypoint.")
     @ConfigEditorBoolean
     public boolean onlyClosest = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/waypoints/HalloweenBasketConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/waypoints/HalloweenBasketConfig.java
@@ -21,7 +21,7 @@ public class HalloweenBasketConfig {
     public boolean allEntranceWaypoints = false;
 
     @Expose
-    @ConfigOption(name = "Only Closest", desc = "Only show the closest waypoint")
+    @ConfigOption(name = "Only Closest", desc = "Only show the closest waypoint.")
     @ConfigEditorBoolean
     public boolean onlyClosest = true;
 }


### PR DESCRIPTION
## What
Fix typos in event waypoint config category.
Reported: https://discord.com/channels/997079228510117908/1274645369568886784

## Changelog Fixes
+ Fixed typos in the "event waypoint" config category. - hannibal2