### PR TITLE
Improvement + Fix: No Rarity on Compacted Dupes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -156,6 +156,12 @@ public class HoppityEggsConfig {
     public boolean compactChat = false;
 
     @Expose
+    @ConfigOption(name = "Compacted Rarity", desc = "Show rarity of found rabbit in Compacted chat messages.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean rarityInCompact = true;
+
+    @Expose
     @ConfigOption(
         name = "Rabbit Pet Warning",
         desc = "Warn when using the Egglocator without a §d§lMythic Rabbit Pet §7equipped. " +

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/HoppityEggsConfig.java
@@ -159,7 +159,26 @@ public class HoppityEggsConfig {
     @ConfigOption(name = "Compacted Rarity", desc = "Show rarity of found rabbit in Compacted chat messages.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean rarityInCompact = true;
+    public CompactRarityTypes rarityInCompact = CompactRarityTypes.NEW;
+
+    public enum CompactRarityTypes {
+        NONE("Neither"),
+        NEW("New Rabbits"),
+        DUPE("Duplicate Rabbits"),
+        BOTH("New & Duplicate Rabbits")
+        ;
+
+        private final String name;
+
+        CompactRarityTypes(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -14,6 +14,8 @@ import at.hannibal2.skyhanni.utils.TimeUtils.format
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
+typealias RarityType = HoppityEggsConfig.CompactRarityTypes
+
 object HoppityEggsCompactChat {
 
     private var hoppityEggChat = mutableListOf<String>()
@@ -67,20 +69,19 @@ object HoppityEggsCompactChat {
         val mealName = lastChatMeal?.coloredName ?: ""
         val mealNameFormatted = if (rabbitBought) "§aBought Rabbit" else "$mealName Egg"
 
+        val rarityConfig = HoppityEggsManager.config.rarityInCompact
         return if (duplicate) {
             val format = lastDuplicateAmount?.shortFormat() ?: "?"
             val timeFormatted = lastDuplicateAmount?.let {
                 ChocolateFactoryAPI.timeUntilNeed(it).format(maxUnits = 2)
             } ?: "?"
 
-            val showDupeRarity = HoppityEggsManager.config.rarityInCompact == HoppityEggsConfig.CompactRarityTypes.BOTH ||
-                HoppityEggsManager.config.rarityInCompact == HoppityEggsConfig.CompactRarityTypes.DUPE
+            val showDupeRarity = rarityConfig.let { it == RarityType.BOTH || it == RarityType.DUPE }
             val timeStr = if (config.showDuplicateTime) ", §a+§b$timeFormatted§7" else ""
-            "$mealNameFormatted! §7Duplicate ${ if(showDupeRarity) "$lastRarity " else ""}$lastName §7(§6+$format Chocolate§7$timeStr)"
+            "$mealNameFormatted! §7Duplicate ${if (showDupeRarity) "$lastRarity " else ""}$lastName §7(§6+$format Chocolate§7$timeStr)"
         } else if (newRabbit) {
-            val showNewRarity = HoppityEggsManager.config.rarityInCompact == HoppityEggsConfig.CompactRarityTypes.BOTH ||
-                HoppityEggsManager.config.rarityInCompact == HoppityEggsConfig.CompactRarityTypes.NEW
-            "$mealNameFormatted! §d§lNEW ${ if(showNewRarity) "$lastRarity " else ""}$lastName §7(${lastProfit}§7)"
+            val showNewRarity = rarityConfig.let { it == RarityType.BOTH || it == RarityType.NEW }
+            "$mealNameFormatted! §d§lNEW ${if (showNewRarity) "$lastRarity " else ""}$lastName §7(${lastProfit}§7)"
         } else "?"
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.event.hoppity
 
+import at.hannibal2.skyhanni.config.features.event.HoppityEggsConfig
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggsManager.getEggType
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
@@ -65,19 +66,21 @@ object HoppityEggsCompactChat {
     private fun createCompactMessage(): String {
         val mealName = lastChatMeal?.coloredName ?: ""
         val mealNameFormatted = if (rabbitBought) "§aBought Rabbit" else "$mealName Egg"
-        val showRarity = HoppityEggsManager.config.rarityInCompact
 
-        val rarityText = if (showRarity) "$lastRarity " else ""
         return if (duplicate) {
             val format = lastDuplicateAmount?.shortFormat() ?: "?"
             val timeFormatted = lastDuplicateAmount?.let {
                 ChocolateFactoryAPI.timeUntilNeed(it).format(maxUnits = 2)
             } ?: "?"
 
+            val showDupeRarity = HoppityEggsManager.config.rarityInCompact == HoppityEggsConfig.CompactRarityTypes.BOTH ||
+                HoppityEggsManager.config.rarityInCompact == HoppityEggsConfig.CompactRarityTypes.DUPE
             val timeStr = if (config.showDuplicateTime) ", §a+§b$timeFormatted§7" else ""
-            "$mealNameFormatted! §7Duplicate $rarityText$lastName §7(§6+$format Chocolate§7$timeStr)"
+            "$mealNameFormatted! §7Duplicate ${ if(showDupeRarity) "$lastRarity " else ""}$lastName §7(§6+$format Chocolate§7$timeStr)"
         } else if (newRabbit) {
-            "$mealNameFormatted! §d§lNEW $rarityText$lastName §7(${lastProfit}§7)"
+            val showNewRarity = HoppityEggsManager.config.rarityInCompact == HoppityEggsConfig.CompactRarityTypes.BOTH ||
+                HoppityEggsManager.config.rarityInCompact == HoppityEggsConfig.CompactRarityTypes.NEW
+            "$mealNameFormatted! §d§lNEW ${ if(showNewRarity) "$lastRarity " else ""}$lastName §7(${lastProfit}§7)"
         } else "?"
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -65,6 +65,7 @@ object HoppityEggsCompactChat {
     private fun createCompactMessage(): String {
         val mealName = lastChatMeal?.coloredName ?: ""
         val mealNameFormatted = if (rabbitBought) "§aBought Rabbit" else "$mealName Egg"
+        val showRarity = HoppityEggsManager.config.rarityInCompact
 
         return if (duplicate) {
             val format = lastDuplicateAmount?.shortFormat() ?: "?"
@@ -73,9 +74,9 @@ object HoppityEggsCompactChat {
             } ?: "?"
 
             val timeStr = if (config.showDuplicateTime) ", §a+§b$timeFormatted§7" else ""
-            "$mealNameFormatted! §7Duplicate $lastRarity $lastName §7(§6+$format Chocolate§7$timeStr)"
+            "$mealNameFormatted! §7Duplicate ${ if(showRarity) "$lastRarity " else ""}$lastName §7(§6+$format Chocolate§7$timeStr)"
         } else if (newRabbit) {
-            "$mealNameFormatted! §d§lNEW $lastRarity $lastName §7(${lastProfit}§7)"
+            "$mealNameFormatted! §d§lNEW ${ if(showRarity) "$lastRarity " else ""}$lastName §7(${lastProfit}§7)"
         } else "?"
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -67,6 +67,7 @@ object HoppityEggsCompactChat {
         val mealNameFormatted = if (rabbitBought) "§aBought Rabbit" else "$mealName Egg"
         val showRarity = HoppityEggsManager.config.rarityInCompact
 
+        val rarityText = if (showRarity) "$lastRarity " else ""
         return if (duplicate) {
             val format = lastDuplicateAmount?.shortFormat() ?: "?"
             val timeFormatted = lastDuplicateAmount?.let {
@@ -74,9 +75,9 @@ object HoppityEggsCompactChat {
             } ?: "?"
 
             val timeStr = if (config.showDuplicateTime) ", §a+§b$timeFormatted§7" else ""
-            "$mealNameFormatted! §7Duplicate ${ if(showRarity) "$lastRarity " else ""}$lastName §7(§6+$format Chocolate§7$timeStr)"
+            "$mealNameFormatted! §7Duplicate $rarityText$lastName §7(§6+$format Chocolate§7$timeStr)"
         } else if (newRabbit) {
-            "$mealNameFormatted! §d§lNEW ${ if(showRarity) "$lastRarity " else ""}$lastName §7(${lastProfit}§7)"
+            "$mealNameFormatted! §d§lNEW $rarityText$lastName §7(${lastProfit}§7)"
         } else "?"
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -73,7 +73,7 @@ object HoppityEggsCompactChat {
             } ?: "?"
 
             val timeStr = if (config.showDuplicateTime) ", §a+§b$timeFormatted§7" else ""
-            "$mealNameFormatted! §7Duplicate $lastName §7(§6+$format Chocolate§7$timeStr)"
+            "$mealNameFormatted! §7Duplicate $lastRarity $lastName §7(§6+$format Chocolate§7$timeStr)"
         } else if (newRabbit) {
             "$mealNameFormatted! §d§lNEW $lastRarity $lastName §7(${lastProfit}§7)"
         } else "?"


### PR DESCRIPTION
## What
Follow-up to #2364 - this adds the rarity for duplicate rabbits as well.
Also adds a config message to turn the rarity-adding off.

## Changelog Improvements
+ Added config option to disable rarity in Compact Hoppity messages. - Daveed

## Changelog Fixes
+ Fixed rabbit rarity not appearing on compacted Duplicate rabbit messages. - Daveed

