### PR TITLE
Fix: OreMinedEvent bugging out and not being thrown

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -193,7 +193,7 @@ object MiningAPI {
     fun onTick(event: LorenzTickEvent) {
         if (!inCustomMiningIsland()) return
 
-        if (LorenzUtils.lastWorldSwitch.passedSince() < 4.seconds) return
+        if (LorenzUtils.lastWorldSwitch.passedSince() < 50.milliseconds) return
         updateLocation()
 
         if (currentAreaOreBlocks.isEmpty()) return


### PR DESCRIPTION
## What
Fixes OreMinedEvent bugging out and not being thrown when breaking blocks soon after joining a server. (https://discord.com/channels/997079228510117908/1252228681947152494/1252228681947152494)

## Changelog Fixes
+ Fixed OreMinedEvent not being thrown in certain cases. - SuperClash