### PR TITLE
Fix: Patcher Breaking Lines

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -218,6 +218,15 @@ public class MiscConfig {
 
     @Expose
     @ConfigOption(
+        name = "Fix Patcher Lines",
+        desc = "Suggest in chat to disable Patcher's `parallax fix` that breaks SkyHanni's line from middle of player to somewhere else."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean fixPatcherLines = true;
+
+    @Expose
+    @ConfigOption(
         name = "Time In Limbo",
         desc = "Show the time since you entered the limbo.")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
@@ -26,10 +26,10 @@ object PatcherFixes {
         lastChatMessage = SimpleTimeMark.now()
 
         ChatUtils.clickToActionOrDisable(
-            "§cPatcher's Parallax Fix breaks SkyHanni's line rendering!", config::fixPatcherLines, "disable this option in Patcher",
-            action = {
-                tryFix()
-            },
+            "§cPatcher's Parallax Fix breaks SkyHanni's line rendering!",
+            config::fixPatcherLines,
+            "disable this option in Patcher",
+            action = { tryFix() },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
@@ -39,7 +39,7 @@ object PatcherFixes {
             patcher.setBoolean("parallaxFix", false)
             ChatUtils.chat("§aDisabled Patcher's Parallax Fix! SkyHanni's lines should now work correctly.")
         } else {
-            ChatUtils.userError("Patcher's Patcher's Parallax is already disabled!")
+            ChatUtils.userError("Patcher's Parallax is already disabled!")
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
@@ -1,0 +1,58 @@
+package at.hannibal2.skyhanni.features.misc
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.OtherModsSettings
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+object PatcherFixes {
+    private val config get() = SkyHanniMod.feature.misc
+
+    private var lastCheck = SimpleTimeMark.farPast()
+    private var lastChatMessage = SimpleTimeMark.farPast()
+
+    fun onPlayerEyeLine() {
+        if (!isEnabled()) return
+        if (lastCheck.passedSince() < 5.seconds) return
+        lastCheck = SimpleTimeMark.now()
+
+        val patcher = OtherModsSettings.patcher()
+        if (!patcher.getBoolean("parallaxFix")) return
+
+        if (lastChatMessage.passedSince() < 3.minutes) return
+        lastChatMessage = SimpleTimeMark.now()
+
+        ChatUtils.clickToActionOrDisable(
+            "§cPatcher's Parallax Fix breaks SkyHanni's line rendering.", config::fixPatcherLines, "disable this option in Patcher",
+            action = {
+                tryFix()
+            },
+        )
+    }
+
+    private fun tryFix() {
+        val patcher = OtherModsSettings.patcher()
+        if (patcher.getBoolean("parallaxFix")) {
+            patcher.setBoolean("parallaxFix", false)
+            ChatUtils.chat("§aDisabled Patcher's Parallax Fix! SkyHanni's lines should now work correctly.")
+        } else {
+            ChatUtils.userError("Patcher's Patcher's Parallax is already disabled!")
+        }
+    }
+
+    private fun tryFix2() {
+        OtherModsSettings.patcher().let {
+            if (it.getBoolean("parallaxFix")) {
+                it.setBoolean("parallaxFix", false)
+                ChatUtils.chat("Disabled Patcher's Parallax Fix! SkyHanni's lines should now work again.")
+            } else {
+                ChatUtils.userError("Patcher's Patcher's Parallax is already disabled!")
+            }
+        }
+    }
+
+    private fun isEnabled() = LorenzUtils.inSkyBlock && config.fixPatcherLines
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
@@ -26,7 +26,7 @@ object PatcherFixes {
         lastChatMessage = SimpleTimeMark.now()
 
         ChatUtils.clickToActionOrDisable(
-            "§cPatcher's Parallax Fix breaks SkyHanni's line rendering.", config::fixPatcherLines, "disable this option in Patcher",
+            "§cPatcher's Parallax Fix breaks SkyHanni's line rendering!", config::fixPatcherLines, "disable this option in Patcher",
             action = {
                 tryFix()
             },
@@ -40,17 +40,6 @@ object PatcherFixes {
             ChatUtils.chat("§aDisabled Patcher's Parallax Fix! SkyHanni's lines should now work correctly.")
         } else {
             ChatUtils.userError("Patcher's Parallax is already disabled!")
-        }
-    }
-
-    private fun tryFix2() {
-        OtherModsSettings.patcher().let {
-            if (it.getBoolean("parallaxFix")) {
-                it.setBoolean("parallaxFix", false)
-                ChatUtils.chat("Disabled Patcher's Parallax Fix! SkyHanni's lines should now work again.")
-            } else {
-                ChatUtils.userError("Patcher's Patcher's Parallax is already disabled!")
-            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/OtherModsSettings.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/OtherModsSettings.kt
@@ -1,0 +1,25 @@
+package at.hannibal2.skyhanni.utils
+
+import java.lang.reflect.Field
+
+class OtherModsSettings(val modConfigPath: String) {
+
+    companion object {
+        fun patcher(): OtherModsSettings = getModPath("club.sk1er.patcher.config.PatcherConfig")
+
+        private fun getModPath(modConfigPath: String): OtherModsSettings = OtherModsSettings(modConfigPath)
+    }
+
+    fun getBoolean(optionPath: String): Boolean = getOption(optionPath)?.get(null) as? Boolean ?: false
+
+    fun setBoolean(optionPath: String, value: Boolean) {
+        getOption(optionPath)?.set(null, value)
+    }
+
+    private fun getOption(optionPath: String): Field? =
+        try {
+            Class.forName(modConfigPath).getField(optionPath)
+        } catch (e: Throwable) {
+            null
+        }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiRenderItemEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.RenderGuiItemOverlayEvent
+import at.hannibal2.skyhanni.features.misc.PatcherFixes
 import at.hannibal2.skyhanni.features.misc.RoundedRectangleOutlineShader
 import at.hannibal2.skyhanni.features.misc.RoundedRectangleShader
 import at.hannibal2.skyhanni.features.misc.RoundedTextureShader
@@ -1132,6 +1133,7 @@ object RenderUtils {
     fun LorenzRenderWorldEvent.exactPlayerEyeLocation(): LorenzVec {
         val player = Minecraft.getMinecraft().thePlayer
         val add = if (player.isSneaking) LorenzVec(0.0, 1.54, 0.0) else LorenzVec(0.0, 1.62, 0.0)
+        PatcherFixes.onPlayerEyeLine()
         return exactLocation(player) + add
     }
 


### PR DESCRIPTION
## What
Patcher has an option called `Parallax Fix`. This option changes the rendering in a way that breaks SkyHanni's `LorenzRenderWorldEvent.exactPlayerEyeLocation()` logic.
This PR is no actual fix to the problem, we just suggest in chat that users can disable the patcher option.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/59cc23e0-ac75-461e-89a0-3bc7f729d1d3)

</details>

## Changelog Fixes
+ Added a chat option to disable a Patcher setting that breaks SkyHanni's line from the center of the player to something else. - hannibal2
    * E.g. Diana guesses, Slayer Mini Bosses, etc.