### PR TITLE
Fix: MayorAPI not working without Ministers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
@@ -218,7 +218,7 @@ object MayorAPI {
             val currentMayorName = data.mayor.name
             if (lastMayor?.name != currentMayorName) {
                 currentMayor = setAssumeMayorJson(currentMayorName, data.mayor.perks)
-                currentMinister = setAssumeMayorJson(data.mayor.minister.name, listOf(data.mayor.minister.perk))
+                currentMinister = data.mayor.minister?.let { setAssumeMayorJson(it.name, listOf(data.mayor.minister.perk)) }
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
@@ -218,7 +218,7 @@ object MayorAPI {
             val currentMayorName = data.mayor.name
             if (lastMayor?.name != currentMayorName) {
                 currentMayor = setAssumeMayorJson(currentMayorName, data.mayor.perks)
-                currentMinister = data.mayor.minister?.let { setAssumeMayorJson(it.name, listOf(data.mayor.minister.perk)) }
+                currentMinister = data.mayor.minister?.let { setAssumeMayorJson(it.name, listOf(it.perk)) }
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/MayorJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/MayorJson.kt
@@ -11,7 +11,7 @@ data class MayorInfo(
     @Expose val key: String,
     @Expose val name: String,
     @Expose val perks: List<MayorPerk>,
-    @Expose val minister: Minister,
+    @Expose val minister: Minister?,
     @Expose val election: MayorElection,
 )
 

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/MayorJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/MayorJson.kt
@@ -11,6 +11,8 @@ data class MayorInfo(
     @Expose val key: String,
     @Expose val name: String,
     @Expose val perks: List<MayorPerk>,
+    // Ministers won't exist,
+    // when the current mayor is a special mayor
     @Expose val minister: Minister?,
     @Expose val election: MayorElection,
 )


### PR DESCRIPTION
## What
Hypixel stated in the [Better Mayors Update](https://hypixel.net/threads/hypixel-skyblock-patch-notes-0-20-3-better-mayors.5692280/) that ministers wont exist when a special mayor is in Office: "A Minister Perk will not be featured when a Special Mayor is elected as they prefer not to share the spotlight with anyone else."
This Pull Request fixes the MayorAPI not working when this happens.

This is broken on full release, my bad. Didnt notice it earlier


## Changelog Fixes
+ Fixed Mayor Detection failing when Special Mayors are in office. - j10a1n15

