### PR TITLE
Fix: Derpy Perk Name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
@@ -93,7 +93,7 @@ enum class Mayor(
         "Derpy",
         "§d",
         Perk.TURBO_MINIONS,
-        Perk.AH_TAX,
+        Perk.QUAD_TAXES,
         Perk.DOUBLE_MOBS_HP,
         Perk.MOAR_SKILLZ,
     ),
@@ -224,7 +224,7 @@ enum class Perk(val perkName: String) {
 
     // Derpy
     TURBO_MINIONS("TURBO MINIONS!!!"),
-    AH_TAX("MOAR TAX!!!"), // TODO: Change to actual perk name when known
+    QUAD_TAXES("QUAD TAXES!!!"),
     DOUBLE_MOBS_HP("DOUBLE MOBS HP!!!"),
     MOAR_SKILLZ("MOAR SKILLZ!!!"),
     ;


### PR DESCRIPTION
## What
Updated Derpy's extra tax perk to use the correct name.

## Changelog Fixes
+ Updated Derpy's extra tax perk to use the correct name. - Luna