### PR TITLE
Fix: Mana Enchants in Estimated Chest Value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -637,7 +637,9 @@ object EstimatedItemValueCalculator {
                     9 -> multiplier = 16
                     10 -> multiplier = 32
                 }
-                level = 5
+                if (multiplier > 1) {
+                    level = 5
+                }
             }
             if (internalName.startsWith("ENCHANTED_BOOK_BUNDLE_")) {
                 multiplier = EstimatedItemValue.bookBundleAmount.getOrDefault(rawName, 5)


### PR DESCRIPTION
## What
Fixed price of mana enchantments tier 1-4 in Estimated Chest value.
Reported: https://discord.com/channels/997079228510117908/1275933115226919045

## Changelog Fixes
+ Fixed the price of mana enchantments tiers 1-4 in Estimated Chest value. - hannibal2