### PR TITLE
Fix: Rounded Shaders not working with a scale less than 1

### DIFF
--- a/src/main/resources/assets/skyhanni/shaders/rounded_rect.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_rect.fsh
@@ -22,7 +22,7 @@ void main() {
     vec2 newHalfSize = vec2(halfSize.x * xScale, halfSize.y * yScale);
 
     float newCenterPosY = centerPos.y;
-    if (yScale > 1.0) {
+    if (yScale != 1.0) {
         newCenterPosY = centerPos.y - (halfSize.y * (yScale - 1));
     }
 

--- a/src/main/resources/assets/skyhanni/shaders/rounded_rect_outline.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_rect_outline.fsh
@@ -26,7 +26,7 @@ void main() {
     vec2 newHalfSize = vec2(halfSize.x * xScale, halfSize.y * yScale);
 
     float newCenterPosY = centerPos.y;
-    if (yScale > 1.0) {
+    if (yScale != 1.0) {
         newCenterPosY = centerPos.y - (halfSize.y * (yScale - 1));
     }
 

--- a/src/main/resources/assets/skyhanni/shaders/rounded_texture.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_texture.fsh
@@ -25,7 +25,7 @@ void main() {
     vec2 newHalfSize = vec2(halfSize.x * xScale, halfSize.y * yScale);
 
     float newCenterPosY = centerPos.y;
-    if (yScale > 1.0) {
+    if (yScale != 1.0) {
         newCenterPosY = centerPos.y - (halfSize.y * (yScale - 1));
     }
 


### PR DESCRIPTION
## Changelog Fixes
+ Fixed rounded rectangles not working with a scale less than 1. - Thunderblade73
    * E.g. Custom Scoreboard Background.