### PR TITLE
Improvement: Make line width for 'Line to Arachne' & 'Line to Miniboss' configurable 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/MobsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/MobsConfig.java
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features.combat;
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 
 public class MobsConfig {
@@ -62,6 +63,11 @@ public class MobsConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean lineToArachne = false;
+
+    @Expose
+    @ConfigOption(name = "Line to Arachne Width", desc = "The width of the line pointing to where Arachne is at.")
+    @ConfigEditorSlider(minStep = 1, minValue = 1, maxValue = 10)
+    public int lineToArachneWidth = 5;
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.java
@@ -8,6 +8,7 @@ import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.Accordion;
 import io.github.notenoughupdates.moulconfig.annotations.Category;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 
 public class SlayerConfig {
@@ -58,6 +59,11 @@ public class SlayerConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean slayerMinibossLine = false;
+
+    @Expose
+    @ConfigOption(name = "Line to Miniboss Width", desc = "The width of the line pointing to every Slayer Mini-Boss around you.")
+    @ConfigEditorSlider(minStep = 1, minValue = 1, maxValue = 10)
+    public int slayerMinibossLineWidth = 3;
 
     @Expose
     @ConfigOption(name = "Hide Mob Names", desc = "Hide the name of the mobs you need to kill in order for the Slayer boss to spawn. Exclude mobs that are damaged, corrupted, runic or semi rare.")

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -125,7 +125,7 @@ object MobHighlight {
             event.exactPlayerEyeLocation(),
             arachne.getLorenzVec().add(y = 1),
             LorenzColor.RED.toColor(),
-            5,
+            config.lineToArachneWidth,
             true
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
@@ -65,7 +65,7 @@ object SlayerMiniBossFeatures {
                 event.exactPlayerEyeLocation(),
                 mob.getLorenzVec().add(y = 1),
                 LorenzColor.AQUA.toColor(),
-                3,
+                config.slayerMinibossLineWidth,
                 true
             )
         }


### PR DESCRIPTION
## What
This pull request makes the line width for the "Line to Arachne" & "Line to Miniboss" features configurable instead of hard-coded.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/b0ce04e4-2957-4c4a-9caa-cc2c6c3abca0)
![image](https://github.com/user-attachments/assets/9d4d12a5-a568-4598-8b65-78442ab864b1)

</details>

## Changelog Improvements
+ Made the "Line to Arachne" width configurable. - azurejelly
+ Made the "Line to Miniboss" width configurable. - azurejelly

