### PR TITLE
Fix: UninitializedPropertyAccessException in UnknownLinesHandler

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -27,7 +27,7 @@ object UnknownLinesHandler {
         /**
          * Remove known lines with patterns
          **/
-        val patternsToExclude = listOf(
+        val patternsToExclude = mutableListOf(
             PurseAPI.coinsPattern,
             SbPattern.motesPattern,
             BitsAPI.bitsScoreboardPattern,
@@ -134,8 +134,11 @@ object UnknownLinesHandler {
             SbPattern.carnivalCatchStreakPattern,
             SbPattern.carnivalAccuracyPattern,
             SbPattern.carnivalKillsPattern,
-            *remoteOnlyPatterns,
         )
+
+        if (!::remoteOnlyPatterns.isInitialized) {
+            patternsToExclude.addAll(remoteOnlyPatterns)
+        }
 
         unknownLines = unknownLines.filterNot { line ->
             patternsToExclude.any { pattern -> pattern.matches(line) }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -136,7 +136,7 @@ object UnknownLinesHandler {
             SbPattern.carnivalKillsPattern,
         )
 
-        if (!::remoteOnlyPatterns.isInitialized) {
+        if (::remoteOnlyPatterns.isInitialized) {
             patternsToExclude.addAll(remoteOnlyPatterns)
         }
 


### PR DESCRIPTION
## What
This Pull Request fixes the UninitializedPropertyAccessException that occurs in the UnknownLinesHandler, if the repository event never fired.

<details>
<summary>Stacktrace</summary>

SkyHanni 0.27.Beta.1: Caught an UninitializedPropertyAccessException in CustomScoreboard at LorenzTickEvent: lateinit property remoteOnlyPatterns has not been initialized
 
Caused by kotlin.UninitializedPropertyAccessException: lateinit property remoteOnlyPatterns has not been initialized
    at SH.features.gui.customscoreboard.UnknownLinesHandler.getRemoteOnlyPatterns$1_8_9(UnknownLinesHandler.kt:17)
    at SH.features.gui.customscoreboard.UnknownLinesHandler.handleUnknownLines(UnknownLinesHandler.kt:137)
    at SH.features.gui.customscoreboard.CustomScoreboard.onTick(CustomScoreboard.kt:102)
    at SH.data.MinecraftData.onTick(MinecraftData.kt:76)
    at FML.common.eventhandler.EventBus.post(EventBus.java:140)

</details>


## Changelog Fixes
+ Fixed Custom Scoreboard Error when no repository exists. - j10a1n15


