### PR TITLE
Fix: Rare Scoreboard Errors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -101,7 +101,7 @@ object CustomScoreboard {
         if (!isEnabled()) return
 
         // we want to update the scoreboard as soon as we have new data, not 5 ticks delayed
-        var dirty = true
+        var dirty = false
         if (lastScoreboardUpdate.passedSince() > 300.milliseconds) {
             activeLines = mostRecentLines
             lastScoreboardUpdate = SimpleTimeMark.farFuture()

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -100,7 +100,7 @@ object CustomScoreboard {
     fun onTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
 
-        // we want to update the scoreboard as soon as we have new data, not 5 ticks delayed
+        // We want to update the scoreboard as soon as we have new data, not 5 ticks delayed
         var dirty = true
         if (lastScoreboardUpdate.passedSince() > 300.milliseconds) {
             activeLines = mostRecentLines

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -51,7 +51,7 @@ object CustomScoreboard {
     // Cached scoreboard data, only update after no change for 300ms
     var activeLines = emptyList<String>()
 
-    // most recent scoreboard state, not in use until cached
+    // Most recent scoreboard state, not in use until cached
     private var mostRecentLines = emptyList<String>()
     private var lastScoreboardUpdate = SimpleTimeMark.farFuture()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -48,7 +48,7 @@ object CustomScoreboard {
     private var cache = emptyList<ScoreboardElementType>()
     private val guiName = "Custom Scoreboard"
 
-    // cached scoreboard data, only update after no change for 300ms
+    // Cached scoreboard data, only update after no change for 300ms
     var activeLines = emptyList<String>()
 
     // most recent scoreboard state, not in use until cached

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.events.GuiPositionMovedEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
+import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
@@ -26,6 +27,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -34,6 +36,7 @@ import com.google.gson.JsonPrimitive
 import net.minecraftforge.client.GuiIngameForge
 import net.minecraftforge.client.event.RenderGameOverlayEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 typealias ScoreboardElementType = Pair<String, HorizontalAlignment>
@@ -44,6 +47,13 @@ object CustomScoreboard {
     private var display = emptyList<ScoreboardElementType>()
     private var cache = emptyList<ScoreboardElementType>()
     private val guiName = "Custom Scoreboard"
+
+    // cached scoreboard data, only update after no change for 300ms
+    var activeLines = emptyList<String>()
+
+    // most recent scoreboard state, not in use until cached
+    private var mostRecentLines = emptyList<String>()
+    private var lastScoreboardUpdate = SimpleTimeMark.farFuture()
 
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
@@ -90,8 +100,16 @@ object CustomScoreboard {
     fun onTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
 
+        // we want to update the scoreboard as soon as we have new data, not 5 ticks delayed
+        var dirty = true
+        if (lastScoreboardUpdate.passedSince() > 300.milliseconds) {
+            activeLines = mostRecentLines
+            lastScoreboardUpdate = SimpleTimeMark.farFuture()
+            dirty = true
+        }
+
         // Creating the lines
-        if (event.isMod(5)) {
+        if (event.isMod(5) || dirty) {
             display = createLines().removeEmptyLinesFromEdges()
             if (TabListData.fullyLoaded) {
                 cache = display.toList()
@@ -101,6 +119,13 @@ object CustomScoreboard {
         // Remove Known Lines, so we can get the unknown ones
         UnknownLinesHandler.handleUnknownLines()
     }
+
+    @SubscribeEvent
+    fun onScoreboardChange(event: ScoreboardUpdateEvent) {
+        mostRecentLines = event.scoreboard
+        lastScoreboardUpdate = SimpleTimeMark.now()
+    }
+
 
     internal val config get() = SkyHanniMod.feature.gui.customScoreboard
     internal val displayConfig get() = config.display

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardUtils.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.gui.customscoreboard
 import at.hannibal2.skyhanni.config.features.gui.customscoreboard.DisplayConfig
 import at.hannibal2.skyhanni.data.BitsAPI
 import at.hannibal2.skyhanni.data.HypixelData
-import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.features.bingo.BingoAPI
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.displayConfig
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -28,7 +27,7 @@ object CustomScoreboardUtils {
     fun getProfileTypeSymbol() = when {
         HypixelData.ironman -> "§7♲ "
         HypixelData.stranded -> "§a☀ "
-        HypixelData.bingo -> ScoreboardData.sidebarLinesFormatted.firstNotNullOfOrNull {
+        HypixelData.bingo -> CustomScoreboard.activeLines.firstNotNullOfOrNull {
             BingoAPI.getIconFromScoreboard(it)?.plus(" ")
         } ?: "§e❤ "
 
@@ -44,7 +43,7 @@ object CustomScoreboardUtils {
 
     internal fun String.formatNum() = this.formatDouble().formatNum()
 
-    internal fun getMotes() = getGroupFromPattern(ScoreboardData.sidebarLinesFormatted, ScoreboardPattern.motesPattern, "motes")
+    internal fun getMotes() = getGroupFromPattern(CustomScoreboard.activeLines, ScoreboardPattern.motesPattern, "motes")
     internal fun getBank() = getGroupFromPattern(TabListData.getTabList(), ScoreboardPattern.bankPattern, "bank")
 
     internal fun getBits() = BitsAPI.bits.coerceAtLeast(0).formatNum()
@@ -58,15 +57,15 @@ object CustomScoreboardUtils {
     }
 
     internal fun getCopper() =
-        getGroupFromPattern(ScoreboardData.sidebarLinesFormatted, ScoreboardPattern.copperPattern, "copper")
+        getGroupFromPattern(CustomScoreboard.activeLines, ScoreboardPattern.copperPattern, "copper")
 
     internal fun getGems() = getGroupFromPattern(TabListData.getTabList(), ScoreboardPattern.gemsPattern, "gems")
 
     internal fun getHeat() =
-        getGroupFromPattern(ScoreboardData.sidebarLinesFormatted, ScoreboardPattern.heatPattern, "heat")
+        getGroupFromPattern(CustomScoreboard.activeLines, ScoreboardPattern.heatPattern, "heat")
 
     internal fun getNorthStars() =
-        getGroupFromPattern(ScoreboardData.sidebarLinesFormatted, ScoreboardPattern.northstarsPattern, "northstars")
+        getGroupFromPattern(CustomScoreboard.activeLines, ScoreboardPattern.northstarsPattern, "northstars")
 
 
     class UndetectedScoreboardLines(message: String) : Exception(message)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -76,7 +76,7 @@ private fun onRemoval(line: String) {
         "Unknown Lines" to confirmedUnknownLines,
         "Island" to LorenzUtils.skyBlockIsland,
         "Area" to HypixelData.skyBlockArea,
-        "Full Scoreboard" to ScoreboardData.sidebarLinesFormatted,
+        "Full Scoreboard" to CustomScoreboard.activeLines,
         noStackTrace = true,
         betaOnly = true,
     )
@@ -381,7 +381,7 @@ private fun getPurseDisplayPair(): List<ScoreboardElementType> {
     var purse = PurseAPI.currentPurse.formatNum()
 
     if (!displayConfig.hideCoinsDifference) {
-        val earned = getGroupFromPattern(ScoreboardData.sidebarLinesFormatted, PurseAPI.coinsPattern, "earned")
+        val earned = getGroupFromPattern(CustomScoreboard.activeLines, PurseAPI.coinsPattern, "earned")
         if (earned != null) purse += " §7(§e+$earned§7)§6"
     }
 
@@ -484,7 +484,7 @@ private fun getHeatDisplayPair(): List<ScoreboardElementType> {
 }
 
 private fun getHeatShowWhen() = inAnyIsland(IslandType.CRYSTAL_HOLLOWS)
-    && ScoreboardData.sidebarLinesFormatted.any { ScoreboardPattern.heatPattern.matches(it) }
+    && CustomScoreboard.activeLines.any { ScoreboardPattern.heatPattern.matches(it) }
 
 private fun getColdDisplayPair(): List<ScoreboardElementType> {
     val cold = -MiningAPI.cold
@@ -499,7 +499,7 @@ private fun getColdDisplayPair(): List<ScoreboardElementType> {
 }
 
 private fun getColdShowWhen() = inAnyIsland(IslandType.DWARVEN_MINES, IslandType.MINESHAFT) &&
-    ScoreboardData.sidebarLinesFormatted.any { ScoreboardPattern.coldPattern.matches(it) }
+    CustomScoreboard.activeLines.any { ScoreboardPattern.coldPattern.matches(it) }
 
 private fun getNorthStarsDisplayPair(): List<ScoreboardElementType> {
     val northStars = getNorthStars()?.formatNum() ?: "0"
@@ -542,7 +542,7 @@ private fun getIslandDisplayPair() =
 private fun getLocationDisplayPair() = buildList {
     HypixelData.skyBlockAreaWithSymbol?.let { add(it to HorizontalAlignment.LEFT) }
 
-    ScoreboardData.sidebarLinesFormatted.firstOrNull { ScoreboardPattern.plotPattern.matches(it) }
+    CustomScoreboard.activeLines.firstOrNull { ScoreboardPattern.plotPattern.matches(it) }
         ?.let { add(it to HorizontalAlignment.LEFT) }
 }
 
@@ -560,12 +560,12 @@ fun getPlayerAmountDisplayPair() = buildList {
 
 private fun getVisitDisplayPair() =
     listOf(
-        ScoreboardData.sidebarLinesFormatted.first { ScoreboardPattern.visitingPattern.matches(it) } to
+        CustomScoreboard.activeLines.first { ScoreboardPattern.visitingPattern.matches(it) } to
             HorizontalAlignment.LEFT,
     )
 
 private fun getVisitShowWhen() =
-    ScoreboardData.sidebarLinesFormatted.any { ScoreboardPattern.visitingPattern.matches(it) }
+    CustomScoreboard.activeLines.any { ScoreboardPattern.visitingPattern.matches(it) }
 
 private fun getDateDisplayPair() =
     listOf(
@@ -574,7 +574,7 @@ private fun getDateDisplayPair() =
 
 private fun getTimeDisplayPair(): List<ScoreboardElementType> {
     val symbol =
-        getGroupFromPattern(ScoreboardData.sidebarLinesFormatted, ScoreboardPattern.timePattern, "symbol") ?: ""
+        getGroupFromPattern(CustomScoreboard.activeLines, ScoreboardPattern.timePattern, "symbol") ?: ""
     return listOf(
         "§7" + SkyBlockTime.now()
             .formatted(dayAndMonthElement = false, yearElement = false, timeFormat24h = config.display.skyblockTime24hFormat) +
@@ -658,7 +658,7 @@ private fun getCookieShowWhen(): Boolean {
 }
 
 private fun getObjectiveDisplayPair() = buildList {
-    val formattedLines = ScoreboardData.sidebarLinesFormatted
+    val formattedLines = CustomScoreboard.activeLines
     val objective = formattedLines.firstOrNull { ScoreboardPattern.objectivePattern.matches(it) }
     if (objective != null) {
         add(objective to HorizontalAlignment.LEFT)
@@ -677,7 +677,7 @@ private fun getObjectiveDisplayPair() = buildList {
 }
 
 private fun getObjectiveShowWhen(): Boolean =
-    ScoreboardPattern.objectivePattern.anyMatches(ScoreboardData.sidebarLinesFormatted)
+    ScoreboardPattern.objectivePattern.anyMatches(CustomScoreboard.activeLines)
 
 private fun getSlayerDisplayPair(): List<ScoreboardElementType> = buildList {
     add((if (SlayerAPI.hasActiveSlayerQuest()) "Slayer Quest" else "<hidden>") to HorizontalAlignment.LEFT)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvent.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.gui.customscoreboard
 
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.eventsConfig
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardEvent.VOTING
@@ -28,9 +27,7 @@ import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern as 
  * because they are visible for a maximum of like 1 minute every 5 days and ~12 hours.
  */
 
-private fun getSbLines(): List<String> {
-    return ScoreboardData.sidebarLinesFormatted
-}
+private fun getSbLines(): List<String> = CustomScoreboard.activeLines
 
 enum class ScoreboardEvent(
     private val displayLine: () -> List<String>,

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.gui.customscoreboard
 
 import at.hannibal2.skyhanni.data.BitsAPI
 import at.hannibal2.skyhanni.data.PurseAPI
-import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.features.misc.ServerRestartTitle
 import at.hannibal2.skyhanni.features.rift.area.stillgorechateau.RiftBloodEffigies
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -17,7 +16,7 @@ object UnknownLinesHandler {
     internal lateinit var remoteOnlyPatterns: Array<Pattern>
 
     fun handleUnknownLines() {
-        val sidebarLines = ScoreboardData.sidebarLinesFormatted
+        val sidebarLines = CustomScoreboard.activeLines
 
         var unknownLines = sidebarLines
             .map { it.removeResets() }


### PR DESCRIPTION
## What
As seen in the image (created with https://github.com/hannibal002/SkyHanni/pull/2412), hypixel sometimes sends new scoreboard data packets delayed, giving us a invalid state of the current scoreboard for a brief moment in time. sometimes, this happens exactly at the moment when custom scoreboard pulls data. This causes weird/unlogical errors.

The fix is to wait 300ms (time can be varied maybe) after a change, and only then accept this change as valid. if a new change happens in between this time, the timer starts again.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/d6baa103-534c-48bb-ad03-788f1d09dbb8)

</details>

## Changelog Fixes
+ Fixed rare Custom Scoreboard errors. - hannibal2