### PR TITLE
Backend: /shdebugscoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.data.GardenCropMilestonesCommunityFix
 import at.hannibal2.skyhanni.data.GuiEditManager
 import at.hannibal2.skyhanni.data.PartyAPI
 import at.hannibal2.skyhanni.data.SackAPI
+import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.bazaar.HypixelBazaarFetcher
 import at.hannibal2.skyhanni.features.bingo.card.BingoCardDisplay
@@ -453,6 +454,10 @@ object Commands {
             "Sets the current skyblock island for testing purposes.",
         ) { SkyBlockIslandTest.onCommand(it) }
         registerCommand("shdebugprice", "Debug different price sources for an item.") { ItemPriceUtils.debugItemPrice(it) }
+        registerCommand(
+            "shdebugscoreboard",
+            "Monitors the scoreboard changes: Prints the raw scoreboard lines in the console after each update, with time since last update.",
+        ) { ScoreboardData.toggleMonitor() }
     }
 
     private fun developersCodingHelp() {

--- a/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
@@ -6,7 +6,10 @@ import at.hannibal2.skyhanni.events.RawScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.lastColorCode
+import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraft.client.Minecraft
 import net.minecraft.network.play.server.S3CPacketUpdateScore
 import net.minecraft.network.play.server.S3EPacketTeams
@@ -70,19 +73,41 @@ object ScoreboardData {
         if (event.packet is S3CPacketUpdateScore) {
             if (event.packet.objectiveName == "update") {
                 dirty = true
+                monitor()
             }
         }
         if (event.packet is S3EPacketTeams) {
             if (event.packet.name.startsWith("team_")) {
                 dirty = true
+                monitor()
             }
         }
+    }
+
+    private var monitor = false
+    private var lastMonitorState = emptyList<String>()
+    private var lastChangeTime = SimpleTimeMark.farPast()
+
+    private fun monitor() {
+        if (!monitor) return
+        val currentList = fetchScoreboardLines()
+        if (lastMonitorState != currentList) {
+            val time = lastChangeTime.passedSince()
+            lastChangeTime = SimpleTimeMark.now()
+            println("Scoreboard Monitor: (new change after ${time.format(showMilliSeconds = true)})")
+            for (s in currentList) {
+                println("'$s'")
+            }
+        }
+        lastMonitorState = currentList
+        println(" ")
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     fun onTick(event: LorenzTickEvent) {
         if (!dirty) return
         dirty = false
+        monitor()
 
         val list = fetchScoreboardLines().reversed()
         val semiFormatted = list.map { cleanSB(it) }
@@ -97,6 +122,13 @@ object ScoreboardData {
             ScoreboardUpdateEvent(new).postAndCatch()
             sidebarLinesFormatted = new
         }
+    }
+
+    fun toggleMonitor() {
+        monitor = !monitor
+        val action = if (monitor) "Enabled" else "Disabled"
+        ChatUtils.chat("$action scoreboard monitoring in the console.")
+
     }
 
     private fun cleanSB(scoreboard: String): String {


### PR DESCRIPTION
## What
This debug featue was used to confirm the custom scoreboard bug fixed with https://github.com/hannibal002/SkyHanni/pull/2411

## Changelog Technical Details
+ Added /shdebugscoreboard to monitor scoreboard changes. - hannibal2
    * Prints the raw scoreboard lines in the console after each update, with the time since the last update.