### PR TITLE
Improvement: Warning rancher chat command

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/OptimalSpeedConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/OptimalSpeedConfig.java
@@ -17,7 +17,7 @@ public class OptimalSpeedConfig {
     public boolean showOnHUD = false;
 
     @Expose
-    @ConfigOption(name = "Warning Title", desc = "Warn via title when you don't have the optimal speed.")
+    @ConfigOption(name = "Wrong Speed Warning", desc = "Warn via title and chat message when you don't have the optimal speed.")
     @ConfigEditorBoolean
     public boolean warning = false;
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isRancherSign
@@ -175,7 +176,7 @@ object GardenOptimalSpeed {
         if (speed != currentSpeed && !recentlySwitchedTool && !recentlyStartedSneaking) warn(speed)
     }
 
-    private fun warn(speed: Int) {
+    private fun warn(optimalSpeed: Int) {
         if (!Minecraft.getMinecraft().thePlayer.onGround) return
         if (GardenAPI.onBarnPlot) return
         if (!config.warning) return
@@ -184,11 +185,16 @@ object GardenOptimalSpeed {
         lastWarnTime = SimpleTimeMark.now()
         LorenzUtils.sendTitle("§cWrong speed!", 3.seconds)
         cropInHand?.let {
-            var text = "Wrong speed for ${it.cropName}: §f$currentSpeed"
-            if (sneaking) text += " §7[Sneaking]"
-            text += " §e(§f$speed §eis optimal)"
+            var text = "§cWrong speed while farming ${it.cropName} detected!"
+            text += "\n§eCurrent Speed: §f$currentSpeed§e, Optimal Speed: §f$optimalSpeed §a[Click to change]"
 
-            ChatUtils.chat(text)
+            ChatUtils.clickableChat(
+                text,
+                onClick = {
+                    HypixelCommands.setMaxSpeed()
+                },
+                hover = "§eClick to change the Rancher Boots Speed!",
+            )
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
@@ -9,9 +9,12 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isRancherSign
+import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.asInternalName
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -34,6 +37,7 @@ object GardenOptimalSpeed {
     private var sneakingTime = 0.seconds
     private val sneaking get() = Minecraft.getMinecraft().thePlayer.isSneaking
     private val sneakingPersistent get() = sneakingSince.passedSince() > 5.seconds
+    private val rancherBoots = "RANCHERS_BOOTS".asInternalName()
 
     /**
      * This speed value represents the walking speed, not the speed stat.
@@ -180,11 +184,14 @@ object GardenOptimalSpeed {
         if (!Minecraft.getMinecraft().thePlayer.onGround) return
         if (GardenAPI.onBarnPlot) return
         if (!config.warning) return
+        if (!GardenAPI.isCurrentlyFarming()) return
+        if (InventoryUtils.getBoots()?.getInternalNameOrNull() != rancherBoots) return
         if (lastWarnTime.passedSince() < 20.seconds) return
 
         lastWarnTime = SimpleTimeMark.now()
         LorenzUtils.sendTitle("§cWrong speed!", 3.seconds)
         val cropInHand = cropInHand ?: return
+
         var text = "§cWrong speed while farming ${cropInHand.cropName} detected!"
         text += "\n§eCurrent Speed: §f$currentSpeed§e, Optimal Speed: §f$optimalSpeed"
         ChatUtils.clickToActionOrDisable(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
@@ -184,18 +184,15 @@ object GardenOptimalSpeed {
 
         lastWarnTime = SimpleTimeMark.now()
         LorenzUtils.sendTitle("§cWrong speed!", 3.seconds)
-        cropInHand?.let {
-            var text = "§cWrong speed while farming ${it.cropName} detected!"
-            text += "\n§eCurrent Speed: §f$currentSpeed§e, Optimal Speed: §f$optimalSpeed §a[Click to change]"
-
-            ChatUtils.clickableChat(
-                text,
-                onClick = {
-                    HypixelCommands.setMaxSpeed()
-                },
-                hover = "§eClick to change the Rancher Boots Speed!",
-            )
-        }
+        val cropInHand = cropInHand ?: return
+        var text = "§cWrong speed while farming ${cropInHand.cropName} detected!"
+        text += "\n§eCurrent Speed: §f$currentSpeed§e, Optimal Speed: §f$optimalSpeed §a[Click to change]"
+        ChatUtils.clickToActionOrDisable(
+            text,
+            config::warning,
+            actionName = "change the speed",
+            action = { HypixelCommands.setMaxSpeed() },
+        )
     }
 
     private fun isRancherOverlayEnabled() = GardenAPI.inGarden() && config.signEnabled

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
@@ -186,7 +186,7 @@ object GardenOptimalSpeed {
         LorenzUtils.sendTitle("§cWrong speed!", 3.seconds)
         val cropInHand = cropInHand ?: return
         var text = "§cWrong speed while farming ${cropInHand.cropName} detected!"
-        text += "\n§eCurrent Speed: §f$currentSpeed§e, Optimal Speed: §f$optimalSpeed §a[Click to change]"
+        text += "\n§eCurrent Speed: §f$currentSpeed§e, Optimal Speed: §f$optimalSpeed"
         ChatUtils.clickToActionOrDisable(
             text,
             config::warning,

--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -136,6 +136,11 @@ object HypixelCommands {
         send("pq $quality")
     }
 
+    // Changes the speed of rancher boots in garden
+    fun setMaxSpeed() {
+        send("setmaxspeed")
+    }
+
     fun showRng(major: String? = null, minor: String? = null) = when {
         major == null || minor == null -> send("rng")
         else -> send("rng $major $minor")


### PR DESCRIPTION
## What
Improved wrong rancher speed while farming warning, allows clicking on the message to open the edit sign

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Improvements
+ Improved incorrect Rancher Boots speed warning. - hannibal2
    * Also allows clicking on the message to open the edit sign directly.
    * Now warns only when actually farming and wearing Rancher Boots.