### PR TITLE
Improvement: optimal speed for cactus

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/CustomSpeedConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/CustomSpeedConfig.java
@@ -65,7 +65,7 @@ public class CustomSpeedConfig {
 
     @Expose
     @ConfigOption(name = "Cactus", desc = "Suggested farm speed:\n" +
-        "§eYaw 90§7: §f✦ 464 speed\n")
+        "§eYaw 90§7: §f✦ 464 speed")
     @ConfigEditorSlider(minValue = 1, maxValue = 500, minStep = 1)
     public Property<Float> cactus = Property.of(464f);
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/CustomSpeedConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/CustomSpeedConfig.java
@@ -67,7 +67,7 @@ public class CustomSpeedConfig {
     @ConfigOption(name = "Cactus", desc = "Suggested farm speed:\n" +
         "§eYaw 90§7: §f✦ 464 speed\n")
     @ConfigEditorSlider(minValue = 1, maxValue = 500, minStep = 1)
-    public Property<Float> cactus = Property.of(400f);
+    public Property<Float> cactus = Property.of(464f);
 
     // TODO does other speed settings exist?
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/CustomSpeedConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/CustomSpeedConfig.java
@@ -65,9 +65,7 @@ public class CustomSpeedConfig {
 
     @Expose
     @ConfigOption(name = "Cactus", desc = "Suggested farm speed:\n" +
-        "§eNormal§7: §f✦ 400 speed\n" +
-        "§eRacing Helmet§7: §f✦ 464 speed\n" +
-        "§eBlack Cat§7: §f✦ 464 speed")
+        "§eYaw 90§7: §f✦ 464 speed\n")
     @ConfigEditorSlider(minValue = 1, maxValue = 500, minStep = 1)
     public Property<Float> cactus = Property.of(400f);
 


### PR DESCRIPTION
Since the mod before had 3 different 400, 464, 464 for normal, racing helmet and black cat respectively but a couple skyblock updates back they added 500 speed limit when holding a cactus knife so there is no use for having different anymore and 464 can be the default be the only one suggestion in the lore.

## Changelog Improvements
+ Changed suggested cactus speed to 464 again. - DarkDash
    * Since the cactus knife now allows 500 max speed.

