### PR TITLE
Fix: ! Crash

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
@@ -44,7 +44,7 @@ public class SkyhanniMixinPlugin implements IMixinConfigPlugin {
         String string = classUrl.toString();
         if (classUrl.getProtocol().equals("jar")) {
             try {
-                return new URL(string.substring(4).split("!")[0]);
+                return new URL(string.substring(4, string.lastIndexOf('!')));
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
## What
Fix skyhanni not working with an "!" in the game directory path.

## Changelog Fixes
+ Fixed the mod crashing on startup when the game directory path contains a "!". - hannibal2