### PR TITLE
Improvement: Click on chat

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -336,7 +336,7 @@ object Commands {
         ) { LimboTimeTracker.printStats() }
         registerCommand(
             "shlanedetection",
-            "Detect a farming lane in garden",
+            "Detect a farming lane in the Garden",
         ) { FarmingLaneCreator.commandLaneDetection() }
         registerCommand(
             "shignore",

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/composter/ComposterConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/composter/ComposterConfig.java
@@ -91,6 +91,7 @@ public class ComposterConfig {
         desc = "Warn when the Composter gets close to empty, even outside Garden."
     )
     @ConfigEditorBoolean
+    // TODO rename to warnAlmostEmpty
     public boolean warnAlmostClose = false;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -251,19 +251,17 @@ object HoppityEggsManager {
         val amount = HoppityEggType.resettingEntries.size
         val message = "All $amount Hoppity Eggs are ready to be found!"
         if (config.warpUnclaimedEggs) {
-            if (LorenzUtils.inSkyBlock) {
-                ChatUtils.clickableChat(
-                    message,
-                    onClick = { HypixelCommands.warp(config.warpDestination) },
-                    "§eClick to ${"/warp ${config.warpDestination}".trim()}!",
-                )
+            val (action, actionName) = if (LorenzUtils.inSkyBlock) {
+                { HypixelCommands.warp(config.warpDestination) } to "${"warp to ${config.warpDestination}".trim()}"
             } else {
-                ChatUtils.clickableChat(
-                    message,
-                    onClick = { HypixelCommands.skyblock() },
-                    "§eClick to join /skyblock!",
-                )
+                { HypixelCommands.skyblock() } to "join /skyblock!"
             }
+            ChatUtils.clickToActionOrDisable(
+                message,
+                config::warpUnclaimedEggs,
+                actionName = actionName,
+                action = action,
+            )
         } else ChatUtils.chat(message)
         LorenzUtils.sendTitle("§e$amount Hoppity Eggs!", 5.seconds)
         SoundUtils.repeatSound(100, 10, SoundUtils.plingSound)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityNpc.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityNpc.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -53,13 +54,11 @@ object HoppityNpc {
         if (!HoppityAPI.isHoppityEvent()) return
         if (lastReminderSent.passedSince() <= 2.minutes) return
 
-        ChatUtils.clickableChat(
-            "New rabbits are available at §aHoppity's Shop§e! §c(Click to disable this reminder)",
-            onClick = {
-                disableReminder()
-                ChatUtils.chat("§eHoppity's Shop reminder disabled.")
-            },
-            oneTimeClick = true,
+        ChatUtils.clickToActionOrDisable(
+            "New rabbits are available at §aHoppity's Shop§e!",
+            config::hoppityShopReminder,
+            actionName = "warp to hub",
+            action = { HypixelCommands.warp("hub") },
         )
 
         lastReminderSent = SimpleTimeMark.now()
@@ -103,9 +102,5 @@ object HoppityNpc {
     private fun clear() {
         inShop = false
         slotsToHighlight.clear()
-    }
-
-    private fun disableReminder() {
-        config.hoppityShopReminder = false
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/NewYearCakeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/NewYearCakeReminder.kt
@@ -24,7 +24,7 @@ object NewYearCakeReminder {
     private val config get() = SkyHanniMod.feature.event.winter
     private val sidebarDetectionPattern by RepoPattern.pattern(
         "event.winter.newyearcake.reminder.sidebar",
-        "§dNew Year Event!§f (?<time>.*)"
+        "§dNew Year Event!§f (?<time>.*)",
     )
     private var lastReminderSend = SimpleTimeMark.farPast()
 
@@ -63,11 +63,11 @@ object NewYearCakeReminder {
 
         if (lastReminderSend.passedSince() < 30.seconds) return
         lastReminderSend = SimpleTimeMark.now()
-
-        ChatUtils.clickableChat(
+        ChatUtils.clickToActionOrDisable(
             "Reminding you to grab the free New Year Cake. Click here to open the baker menu!",
-            onClick = { HypixelCommands.openBaker() },
-            "§eClick to run /openbaker!",
+            config::newYearCakeReminder,
+            actionName = "open the baker menu",
+            action = { HypixelCommands.openBaker() },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -53,17 +54,12 @@ object CityProjectFeatures {
     private val patternGroup = RepoPattern.group("fame.projects")
     private val contributeAgainPattern by patternGroup.pattern(
         "contribute",
-        "§7Contribute again: §e(?<time>.*)"
+        "§7Contribute again: §e(?<time>.*)",
     )
     private val completedPattern by patternGroup.pattern(
         "completed",
-        "§aProject is (?:being built|released)!"
+        "§aProject is (?:being built|released)!",
     )
-
-    fun disable() {
-        config.dailyReminder = false
-        ChatUtils.chat("Disabled city project reminder messages!")
-    }
 
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {
@@ -79,11 +75,11 @@ object CityProjectFeatures {
         if (lastReminderSend.passedSince() < 30.seconds) return
         lastReminderSend = SimpleTimeMark.now()
 
-        ChatUtils.clickableChat(
-            "Daily City Project Reminder! (Click here to disable this reminder)",
-            onClick = { disable() },
-            "§eClick to disable!",
-            oneTimeClick = true
+        ChatUtils.clickToActionOrDisable(
+            "Daily City Project Reminder!",
+            config::dailyReminder,
+            actionName = "warp to Hub",
+            action = { HypixelCommands.warp("hub") },
         )
     }
 
@@ -166,8 +162,8 @@ object CityProjectFeatures {
                         } else {
                             BazaarApi.searchForBazaarItem(name, amount)
                         }
-                    }
-                ) { inInventory && !NEUItems.neuHasFocus() }
+                    },
+                ) { inInventory && !NEUItems.neuHasFocus() },
             )
 
             val price = internalName.getPrice() * amount

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
@@ -27,31 +28,33 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object UpgradeReminder {
+    private val config get() = SkyHanniMod.feature.misc
+
     private val patternGroup = RepoPattern.group("fame.upgrades")
 
     private val accountUpgradePattern by patternGroup.pattern(
         "account",
-        "§8Account Upgrade"
+        "§8Account Upgrade",
     )
     private val profileUpgradePattern by patternGroup.pattern(
         "profile",
-        "§8Profile Upgrade"
+        "§8Profile Upgrade",
     )
     private val upgradeDurationPattern by patternGroup.pattern(
         "duration",
-        "§8Duration: (?<duration>.+)"
+        "§8Duration: (?<duration>.+)",
     )
     private val upgradeStartedPattern by patternGroup.pattern(
         "started",
-        "§eYou started the §r§a(?<upgrade>.+) §r§eupgrade!"
+        "§eYou started the §r§a(?<upgrade>.+) §r§eupgrade!",
     )
     private val upgradeClaimedPattern by patternGroup.pattern(
         "claimed",
-        "§eYou claimed the §r§a(?<upgrade>.+) §r§eupgrade!"
+        "§eYou claimed the §r§a(?<upgrade>.+) §r§eupgrade!",
     )
     private val upgradePattern by patternGroup.pattern(
         "upgrade",
-        "§eClick to start upgrade!"
+        "§eClick to start upgrade!",
     )
 
     private var currentProfileUpgrade: CommunityShopUpgrade?
@@ -74,7 +77,6 @@ object UpgradeReminder {
     // TODO: (for 0.27) merge this logic with reminder manager
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!isEnabled()) return
         if (ReminderUtils.isBusy()) return
         if (inInventory || LorenzUtils.skyBlockArea == "Community Center") return
@@ -127,28 +129,26 @@ object UpgradeReminder {
         }
     }
 
-    private fun isEnabled() = SkyHanniMod.feature.misc.accountUpgradeReminder
-
-    fun disable() {
-        SkyHanniMod.feature.misc.accountUpgradeReminder = false
-    }
+    private fun isEnabled() = LorenzUtils.inSkyBlock && config.accountUpgradeReminder
 
     @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
-        event.move(49,
+        event.move(
+            49,
             "#player.currentAccountUpgrade",
-            "#player.communityShopAccountUpgrade.name"
+            "#player.communityShopAccountUpgrade.name",
         )
 
-        event.move(49,
+        event.move(
+            49,
             "#player.nextAccountUpgradeCompletionTime",
-            "#player.communityShopAccountUpgrade.completionTime"
+            "#player.communityShopAccountUpgrade.completionTime",
         )
     }
 
     class CommunityShopUpgrade(
         @Expose val name: String?,
-        @Expose var completionTime: SimpleTimeMark = SimpleTimeMark.farFuture()
+        @Expose var completionTime: SimpleTimeMark = SimpleTimeMark.farFuture(),
     ) {
         private var duration: Duration = Duration.ZERO
 
@@ -158,10 +158,11 @@ object UpgradeReminder {
 
         fun sendReminderIfClaimable() {
             if (this.name == null || this.completionTime.isInFuture()) return
-            ChatUtils.clickableChat(
-                "The §a$name §eupgrade has completed! §c(Click to disable these reminders)", onClick = {
-                    disable()
-                }, oneTimeClick = true
+            ChatUtils.clickToActionOrDisable(
+                "The §a$name §eupgrade has completed!",
+                config::accountUpgradeReminder,
+                actionName = "warp to Hub",
+                action = { HypixelCommands.warp("hub") },
             )
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -198,7 +198,7 @@ object ComposterDisplay {
             ChatUtils.clickToActionOrDisable(
                 warningMessage,
                 config::warnAlmostClose,
-                actionName = "warp to the garden",
+                actionName = "warp to the Garden",
                 action = { HypixelCommands.warp("garden") },
             )
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -195,12 +195,11 @@ object ComposterDisplay {
         if (IslandType.GARDEN.isInIsland()) {
             ChatUtils.chat(warningMessage)
         } else {
-            ChatUtils.clickableChat(
+            ChatUtils.clickToActionOrDisable(
                 warningMessage,
-                onClick = {
-                    HypixelCommands.warp("garden")
-                },
-                "§eClick to warp to the garden!",
+                config::warnAlmostClose,
+                actionName = "warp to the garden",
+                action = { HypixelCommands.warp("garden") },
             )
         }
         LorenzUtils.sendTitle("§eComposter Warning!", 3.seconds)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -43,10 +43,9 @@ object ChocolateFactoryBlockOpen {
         ChatUtils.clickToActionOrDisable(
             "§cBlocked opening the Chocolate Factory without a §dMythic Rabbit Pet §cequipped!",
             config::mythicRabbitRequirement,
-            "open pets menu",
-        ) {
-            HypixelCommands.pet()
-        }
+            actionName = "open pets menu",
+            action = { HypixelCommands.pet() },
+        )
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.mythicRabbitRequirement

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
@@ -196,12 +196,11 @@ object ChocolateFactoryCustomReminder {
         if (configUpgradeWarnings.upgradeWarningSound) {
             SoundUtils.playBeepSound()
         }
-        ChatUtils.clickableChat(
+        ChatUtils.clickToActionOrDisable(
             "You can now purchase §f$targetName §ein Chocolate factory!",
-            onClick = {
-                HypixelCommands.chocolateFactory()
-            },
-            "§eClick to run /cf!",
+            configReminder::enabled,
+            actionName = "open Chocolate Factory",
+            action = { HypixelCommands.chocolateFactory() },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -92,11 +92,11 @@ object ChocolateFactoryTimeTowerManager {
         val warningSeparation = if (inInventory) 30.seconds else 5.minutes
         if (lastTimeTowerWarning.passedSince() < warningSeparation) return
 
-        ChatUtils.clickableChat(
-            "§cYour Time Tower is full §7(${timeTowerCharges()})§c, " +
-                "Use one to avoid wasting time tower usages!",
-            onClick = { HypixelCommands.chocolateFactory() },
-            HOVER_TEXT,
+        ChatUtils.clickToActionOrDisable(
+            "§cYour Time Tower is full §7(${timeTowerCharges()})§c, Use one to avoid wasting time tower usages!",
+            config::timeTowerWarning,
+            actionName = "open Chocolate Factory",
+            action = { HypixelCommands.chocolateFactory() },
         )
         SoundUtils.playBeepSound()
         lastTimeTowerWarning = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
@@ -44,10 +44,11 @@ object ChocolateFactoryUpgradeWarning {
             SoundUtils.playBeepSound()
         }
         if (ChocolateFactoryAPI.inChocolateFactory) return
-        ChatUtils.clickableChat(
+        ChatUtils.clickToActionOrDisable(
             "You have a Chocolate factory upgrade available to purchase!",
-            onClick = { HypixelCommands.chocolateFactory() },
-            "§eClick to run /cf!"
+            config::upgradeWarning,
+            actionName = "open Chocolate Factory",
+            action = { HypixelCommands.chocolateFactory() },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experiments/GuardianReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experiments/GuardianReminder.kt
@@ -51,11 +51,9 @@ object GuardianReminder {
         lastInventoryOpen = SimpleTimeMark.now()
         ChatUtils.clickToActionOrDisable(
             "Use a §9§lGuardian Pet §efor more Exp in the Experimentation Table.",
-            option = config::guardianReminder,
+            config::guardianReminder,
             actionName = "open pets menu",
-            action = {
-                HypixelCommands.pet()
-            },
+            action = { HypixelCommands.pet() },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherFixes.kt
@@ -28,7 +28,7 @@ object PatcherFixes {
         ChatUtils.clickToActionOrDisable(
             "§cPatcher's Parallax Fix breaks SkyHanni's line rendering!",
             config::fixPatcherLines,
-            "disable this option in Patcher",
+            actionName = "disable this option in Patcher",
             action = { tryFix() },
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -258,6 +258,7 @@ object ChatUtils {
         return this
     }
 
+
     fun clickToActionOrDisable(message: String, option: KMutableProperty0<*>, actionName: String, action: () -> Unit) {
         ChatUtils.clickableChat(
             "$message\n§e[CLICK to $actionName or disable this feature]",
@@ -269,7 +270,7 @@ object ChatUtils {
                 }
             },
             hover = "§eClick to $actionName!\n" +
-                "§eShift-Click to disable this feature!",
+                "§eShift-Click or Control-Click to disable this feature!",
         )
     }
 }


### PR DESCRIPTION
## What
Reworked chat click on upgrade reminder, Hoppity cake reminder, new year Hoppity NPC reminder, new year cake reminder, city project reminder, garden composter empty warning, cf custom goal reached message, time tower warning, cf upgrade warning

## Changelog Improvements
+ Reworked the chat formatting for reminders and warnings across multiple features. - hannibal2
    * They now all allow performing an action on click (e.g., warping you somewhere or opening a menu) and can be disabled in the config via shift-click or control-click on the chat message.
    * Changed chat messages: Account/Profile Upgrade reminder, Hoppity Cake reminder, New Year Hoppity NPC reminder, New Year Cake reminder, City Project reminder, Garden Composter empty warning, CF Custom Goal reached message, Time Tower warning, CF upgrade warning.