### PR TITLE
Fix: Github Actions Artifact path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
                 name: Upload development build
                 with:
                     name: "Development Build"
-                    path: versions/1.8.9/build/libs/*.jar
+                    path: build/libs/*.jar
             -   name: Test with Gradle
                 run: ./gradlew test
             -   uses: actions/upload-artifact@v3


### PR DESCRIPTION
## What
GitHub Actions are not providing the download build as an artifact. This PR fixes the changed build paths.

## Changelog Fixes
+ Fixed incorrect Build Path in GitHub actions. - nea

exclude_from_changelog