### PR TITLE
Fix: Autopet Rule Detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experiments/GuardianReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experiments/GuardianReminder.kt
@@ -37,9 +37,14 @@ object GuardianReminder {
         "mainmenu",
         "Experimentation Table",
     )
+
+    /**
+     * REGEX-TEST: §dGuardian§e
+     * REGEX-TEST: §6Elephant§e
+     */
     private val petNamePattern by patternGroup.pattern(
         "guardianpet",
-        "§[956d]Guardian",
+        "§[956d]Guardian.*",
     )
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experiments/GuardianReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experiments/GuardianReminder.kt
@@ -39,8 +39,8 @@ object GuardianReminder {
     )
 
     /**
-     * REGEX-TEST: §dGuardian§e
-     * REGEX-TEST: §6Elephant§e
+     * REGEX-TEST: §dGuardian
+     * REGEX-TEST: §9Guardian§e
      */
     private val petNamePattern by patternGroup.pattern(
         "guardianpet",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CurrentPetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CurrentPetDisplay.kt
@@ -35,9 +35,14 @@ object CurrentPetDisplay {
         "chat.despawn",
         "§aYou despawned your §r.*§r§a!"
     )
+
+    /**
+     * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 100] §6Griffin§4 ✦§e! §a§lVIEW RULE
+     * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 100] §6Elephant§e! §a§lVIEW RULE
+     */
     private val chatPetRulePattern by patternGroup.pattern(
         "chat.rule",
-        "§cAutopet §eequipped your §7\\[Lvl .*] (?<pet>.*)! §a§lVIEW RULE"
+        "§cAutopet §eequipped your §7\\[Lvl .*] (?<pet>.*)§e! §a§lVIEW RULE"
     )
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Fix Guardian Reminder Experimentation Table not working with autopet rules.
Reported: https://discord.com/channels/997079228510117908/1279107957396738138

## Changelog Fixes
+ Fixed Guardian Reminder Experimentation Table not working with autopet rules. - hannibal2