### PR TITLE
Backend: Stop sound errors in console

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -20,6 +20,7 @@ object SoundUtils {
 
     fun ISound.playSound() {
         Minecraft.getMinecraft().addScheduledTask {
+            if (Minecraft.getMinecraft().soundHandler.isSoundPlaying(this)) return@addScheduledTask
             val gameSettings = Minecraft.getMinecraft().gameSettings
             val oldLevel = gameSettings.getSoundLevel(SoundCategory.PLAYERS)
             if (!SkyHanniMod.feature.misc.maintainGameVolume) {
@@ -38,7 +39,7 @@ object SoundUtils {
                 }
                 ErrorManager.logErrorWithData(
                     e, "Failed to play a sound",
-                    "soundLocation" to this.soundLocation
+                    "soundLocation" to this.soundLocation,
                 )
             } finally {
                 if (!SkyHanniMod.feature.misc.maintainGameVolume) {


### PR DESCRIPTION
## What
This fix from Daveed (https://discord.com/channels/997079228510117908/1279100784490971226/1279104782321192990) should prevent the annoying console messages `value already present:` that show up in the console output when playing multiple sounds via the SkyHanni sound API.

## Changelog Technical Details
+ Fixed Sound Errors in the console. - Daveed