### PR TITLE
Improvement: Help finding Rift Guide

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/rift/EnigmaSoulConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/rift/EnigmaSoulConfig.java
@@ -4,15 +4,24 @@ import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 
 public class EnigmaSoulConfig {
 
     @Expose
-    @ConfigOption(name = "Enabled", desc = "Click on Enigma Souls in Rift Guides to highlight their location.")
+    @ConfigOption(name = "Enabled", desc = "Click on an Enigma Soul in §eRift Guide -> Area -> Enigma Souls §7to highlight their location.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = true;
+
+    @ConfigOption(
+        name = "§aRift Guide",
+        desc = "Type §e/riftguide §7in chat or navigate through the SkyBlock Menu to open the §aRift Guide§7. " +
+            "Complete the first quest in the Rift to unlock this Hypixel feature."
+    )
+    @ConfigEditorInfoText
+    public String tutorialHowToOpenRiftGuide = "";
 
     @Expose
     @ConfigOption(name = "Color", desc = "Color of the Enigma Souls.")


### PR DESCRIPTION
## What
Updated the description of the config for Enigma Soul Waypoints description to help find the Rift Guide in the game.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/5a7b1f7e-b49c-4393-be35-0ae9124d9dd7)

</details>

## Changelog Improvements
+ Updated the description of the config for Enigma Soul Waypoints to help find the Rift Guide in the game. - hannibal2