### PR TITLE
Fix: Pity Counter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -164,7 +164,8 @@ object MiningAPI {
     @SubscribeEvent
     fun onBlockChange(event: ServerBlockChangeEvent) {
         if (!inCustomMiningIsland()) return
-        if (event.newState.block != Blocks.air) return
+        if (event.newState.block.let { it != Blocks.air && it != Blocks.bedrock }) return
+        if (event.oldState.block.let { it == Blocks.air || it == Blocks.bedrock }) return
         if (event.oldState.block == Blocks.air) return
         val pos = event.location
         if (pos.distanceToPlayer() > 7) return


### PR DESCRIPTION
## What
Fixed Mineshaft Pity Counter not working with some ore types.
Hypixel has changed not to send air blocks before sending barrier blocks anymore.

## Changelog Fixes
+ Fixed Mineshaft Pity Counter not working with some ore types. - hannibal2