### PR TITLE
Fix: Reputation helper sack update

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.SackChangeEvent
 import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.DailyQuestHelper
 import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.QuestLoader
 import at.hannibal2.skyhanni.features.nether.reputationhelper.kuudra.DailyKuudraBossHelper
@@ -86,6 +87,11 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
             kuudraBossHelper.loadData(it)
             questHelper.load(it)
         }
+    }
+
+    @SubscribeEvent
+    fun onSackChange(event: SackChangeEvent) {
+        dirty = true
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Fixed the reputation helper not updating on a sack update
Reported: https://discord.com/channels/997079228510117908/1279702749147303997

## Changelog Fixes
+ Fixed the reputation helper not updating after a sack update. - hannibal2