### PR TITLE
Fix: Last Server Slider

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/LastServersConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/LastServersConfig.java
@@ -17,5 +17,5 @@ public class LastServersConfig {
     @Expose
     @ConfigOption(name = "Notification Time", desc = "Get notified if you rejoin a server within the specified number of seconds.")
     @ConfigEditorSlider(minValue = 5, maxValue = 300, minStep = 1)
-    public Integer warnTime = 60;
+    public int warnTime = 60;
 }


### PR DESCRIPTION
## What
Fixed the Slider just not working at all, [Discord](https://discord.com/channels/997079228510117908/1000669238035497022/1279745942077046909)

## Changelog Fixes
+ Fixed Last Server Time Slider not functioning. - j10a1n15