### PR TITLE
Improvement: Allow turning off exact minutes on custom scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
@@ -130,6 +130,11 @@ public class DisplayConfig {
     public boolean skyblockTime24hFormat = false;
 
     @Expose
+    @ConfigOption(name = "SkyBlock Time Exact Minutes", desc = "Display the exact minutes in the SkyBlock time, rather than only 10 minute increments.")
+    @ConfigEditorBoolean
+    public boolean skyblockTimeExactMinutes = true;
+
+    @Expose
     @ConfigOption(name = "Line Spacing", desc = "The amount of space between each line.")
     @ConfigEditorSlider(minValue = 0, maxValue = 20, minStep = 1)
     public int lineSpacing = 10;

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -577,7 +577,12 @@ private fun getTimeDisplayPair(): List<ScoreboardElementType> {
         getGroupFromPattern(CustomScoreboard.activeLines, ScoreboardPattern.timePattern, "symbol") ?: ""
     return listOf(
         "§7" + SkyBlockTime.now()
-            .formatted(dayAndMonthElement = false, yearElement = false, timeFormat24h = config.display.skyblockTime24hFormat) +
+            .formatted(
+                dayAndMonthElement = false,
+                yearElement = false,
+                timeFormat24h = config.display.skyblockTime24hFormat,
+                exactMinutes = config.display.skyblockTimeExactMinutes,
+            ) +
             " $symbol" to HorizontalAlignment.LEFT,
     )
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -105,12 +105,15 @@ object TimeUtils {
         yearElement: Boolean = true,
         hoursAndMinutesElement: Boolean = true,
         timeFormat24h: Boolean = false,
+        exactMinutes: Boolean = true,
     ): String {
         val hour = if (timeFormat24h) this.hour else (this.hour + 11) % 12 + 1
         val timeOfDay = if (!timeFormat24h) {
             if (this.hour > 11) "pm" else "am"
         } else ""
-        val minute = this.minute.toString().padStart(2, '0')
+        val minute = this.minute.let {
+            if (exactMinutes) it else it - (it % 10)
+        }.toString().padStart(2, '0')
         val month = SkyBlockTime.monthName(this.month)
         val day = this.day
         val daySuffix = SkyBlockTime.daySuffix(day)


### PR DESCRIPTION
## What
Made showing exact minutes for SkyBlock time on the custom scoreboard (as opposed to only 10 minute increments like the vanilla scoreboard) an option (which is on by default).

## Changelog Improvements
+ Added an option to show SkyBlock time on the custom scoreboard rounded to 10 minutes, similar to the vanilla scoreboard. - Luna