### PR TITLE
Fix: shtps command printing nothing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -73,6 +73,7 @@ object TpsCounter {
     }
 
     fun tpsCommand() {
+        if (display.isEmpty()) return
         ChatUtils.chat(display)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -73,7 +73,10 @@ object TpsCounter {
     }
 
     fun tpsCommand() {
-        if (display.isEmpty()) return
+        if (display.isEmpty()) {
+            ChatUtils.chat("§cNo tps data available, make sure you have the setting on.")
+            return
+        }
         ChatUtils.chat(display)
     }
 


### PR DESCRIPTION
## What
Fixed /shtps printing nothing if tps display was currently showing nothing.

## Changelog Fixes
+ Fixed the command `/shtps` printing nothing if the TPS display was currently showing nothing. - CalMWolfs


