### PR TITLE
Fix: Merged enchant books tooltip being overwritten (+ backend)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
@@ -3,13 +3,15 @@ package at.hannibal2.skyhanni.features.misc.items.enchants
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.features.chroma.ChromaManager
 import at.hannibal2.skyhanni.utils.ItemCategory
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
+import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.observer.Property
-import net.minecraft.item.ItemStack
 import java.util.TreeSet
+import net.minecraft.item.ItemStack
 
 open class Enchant : Comparable<Enchant> {
     @Expose
@@ -64,7 +66,8 @@ open class Enchant : Comparable<Enchant> {
         val config = SkyHanniMod.feature.inventory.enchantParsing
 
         val itemCategory = itemStack?.getItemCategoryOrNull()
-        val itemName = itemStack?.itemNameWithoutColor
+        val internalName = itemStack?.getInternalNameOrNull()
+        val itemName = internalName?.itemName?.removeColor()
 
         if (this.nbtName == "efficiency") {
             // If the item is a Stonk, or a non-mining tool with Efficiency 5 (whilst not being a Promising Shovel),

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -19,8 +19,10 @@ import at.hannibal2.skyhanni.utils.ItemUtils.isEnchanted
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getExtraAttributes
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import java.lang.ArithmeticException
 import net.minecraft.event.HoverEvent
 import net.minecraft.item.ItemStack
 import net.minecraft.util.ChatComponentText
@@ -202,7 +204,26 @@ object EnchantParser {
         val insertEnchants: MutableList<String> = mutableListOf()
 
         // Format enchants based on format config option
-        formatEnchants(insertEnchants)
+        try {
+            formatEnchants(insertEnchants)
+        } catch (e: ArithmeticException) {
+            ErrorManager.logErrorWithData(
+                e,
+                "Item has enchants in nbt but none were found?",
+                "item" to currentItem,
+                "loreList" to loreList,
+                "nbt" to currentItem?.getExtraAttributes()
+            )
+            return
+        } catch (e: ConcurrentModificationException) {
+            ErrorManager.logErrorWithData(
+                e,
+                "ConcurrentModificationException whilst formatting enchants",
+                "loreList" to loreList,
+                "format" to config.format.get(),
+                "orderedEnchants" to orderedEnchants
+            )
+        }
 
         // Add our parsed enchants back into the lore
         loreList.addAll(startEnchant, insertEnchants)


### PR DESCRIPTION
## What
Fixes enchanted books with multiple enchants from having their tooltip being overwritten due to not having an internal name.

Also adds better error logging for the enchant parser for an ArithmeticException and ConcurrentModificationException so I can better understand how these errors occur. (Since right now I can't reproduce and don't understand how they even occur)

## Changelog Fixes
+ Fixed merged enchant books tooltip being overwritten. - Vixid

## Changelog Technical Details
+ Improved error logging for enchant parser. - Vixid

