### PR TITLE
Fix: Check line of sight before alerting about rare sea creature

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -39,7 +39,10 @@ object SeaCreatureFeatures {
     @SubscribeEvent
     fun onMobSpawn(event: MobEvent.Spawn.SkyblockMob) {
         if (!isEnabled()) return
+
         val mob = event.mob
+        if (!mob.canBeSeen()) return
+
         val creature = SeaCreatureManager.allFishingMobs[mob.name] ?: return
         if (!creature.rare) return
 


### PR DESCRIPTION
## What
Fixed missing `canBeSeen` check in rare sea creature alert.

## Changelog Fixes
+ Fixed rare sea creature alert not checking if the sea creature can be seen by the player. - Luna