### PR TITLE
Improvement: Guardian Pet Experimentation Table

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experiments/GuardianReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experiments/GuardianReminder.kt
@@ -30,6 +30,7 @@ object GuardianReminder {
 
     private val config get() = SkyHanniMod.feature.inventory.helper.enchanting
     private var lastInventoryOpen = SimpleTimeMark.farPast()
+    private var lastWarn = SimpleTimeMark.farPast()
     private var lastErrorSound = SimpleTimeMark.farPast()
 
     private val patternGroup = RepoPattern.group("data.enchanting.inventory.experimentstable")
@@ -54,6 +55,9 @@ object GuardianReminder {
         if (petNamePattern.matches(PetAPI.currentPet)) return
 
         lastInventoryOpen = SimpleTimeMark.now()
+
+        if (lastWarn.passedSince() < 5.seconds) return
+        lastWarn = SimpleTimeMark.now()
         ChatUtils.clickToActionOrDisable(
             "Use a §9§lGuardian Pet §efor more Exp in the Experimentation Table.",
             config::guardianReminder,


### PR DESCRIPTION
## What
Added cooldown between experimentation table guardian pet warnings in chat.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/e4682cb2-faa0-4fb0-956b-30b363756b45)

</details>

## Changelog Improvements
+ Added a short cooldown between Experimentation Table Guardian Pet chat warnings. - hannibal2