### PR TITLE
Fix: Minister not resetting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
@@ -152,6 +152,7 @@ object MayorAPI {
         if (electionOverPattern.matches(event.message)) {
             lastMayor = currentMayor
             currentMayor = Mayor.UNKNOWN
+            currentMinister = null
         }
     }
 


### PR DESCRIPTION
## What
This Pull Request fixes the minister not resetting on election close. 
Setting it to null is better than setting it to Unknown here. 


## Changelog Fixes
+ Fixed Minister not resetting after the election closed. - j10a1n15