### PR TITLE
Improvement: Make pest middle waypoint optional

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestWaypointConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestWaypointConfig.java
@@ -35,6 +35,14 @@ public class PestWaypointConfig {
 
     @Expose
     @ConfigOption(
+        name = "Show Middle",
+        desc = "Also show a waypoint to the middle of a plot. This can help determine if the tracker is pointing to the middle instead of a pest."
+    )
+    @ConfigEditorBoolean
+    public boolean showMiddle = false;
+
+    @Expose
+    @ConfigOption(
         name = "Show For Seconds",
         desc = "The waypoint will disappear after this number of seconds."
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleLine.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleLine.kt
@@ -94,6 +94,7 @@ object PestParticleLine {
     }
 
     private fun showMiddle(event: LorenzRenderWorldEvent) {
+        if (!config.showMiddle) return
         if (locations.size <= 0) return
         val plot = GardenPlotAPI.getCurrentPlot() ?: return
         val middle = plot.middle.copy(y = LocationUtils.playerLocation().y)


### PR DESCRIPTION
## What
Added a toggle for pest middle waypoint (off by default). This was added without much thought and is not really useful in most cases, it's just visual clutter. There's better ways we could add to indicate if the waypoint is likely inaccurate, but I'm leaving in a toggle in case someone wants it for testing purposes or other reasons.

## Changelog Improvements
+ Made the waypoint to the middle of the plot for Pest Waypoint optional (off by default). - Luna