### PR TITLE
Fix: grab item name none

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -370,7 +370,7 @@ object ItemUtils {
             getAttributeFromShard()?.let {
                 return it.getAttributeName()
             }
-            return getInternalName().itemName
+            return getInternalNameOrNull()?.itemName ?: "<null>"
         }
 
     fun ItemStack.getAttributeFromShard(): Pair<String, Int>? {


### PR DESCRIPTION
## What
Fixes a logic error in `ItemUtils.getItemName` that causes issues in multiple different features

<details>
<summary>Stack Trace</summary>

Caught an IllegalStateException in x at x: NEUInternalName.NONE has no name!
 
Caused by java.lang.IllegalStateException: NEUInternalName.NONE has no name!
    at SH.utils.ItemUtils.grabItemName(ItemUtils.kt:402)
    at SH.utils.ItemUtils.getItemName(ItemUtils.kt:390)
    at SH.utils.ItemUtils.getItemName(ItemUtils.kt:377)
    at SH.utils.ItemUtils.getItemNameWithoutColor(ItemUtils.kt:386)

</details>

## Changelog Fixes
+ Fixed an internal bug with `getItemName` that caused the `NEUInternalName.NONE has no name!` error messages to appear. - hannibal2