### PR TITLE
Fix: Typo in mob detection config

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.java
@@ -74,7 +74,7 @@ public class DebugMobConfig {
         public HowToShow special = HowToShow.OFF;
 
         @Expose
-        @ConfigOption(name = "Show Invisible", desc = "Shows the mob even though they are invisible (do to invisibility effect) if looked at directly.")
+        @ConfigOption(name = "Show Invisible", desc = "Shows invisible mobs (due to invisibility effect) if looked at directly.")
         @ConfigEditorBoolean
         public boolean showInvisible = false;
     }


### PR DESCRIPTION
## What
Fixed minor spelling mistake in config
Report: https://discord.com/channels/997079228510117908/1281878574579585147

## Changelog Fixes
+ Fixed a typo in mob detection config. - hannibal2