### PR TITLE
Feature: Dungeon Secret Chime

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.java
@@ -16,6 +16,11 @@ public class DungeonConfig {
     public HighlightClickedBlocksConfig clickedBlocks = new HighlightClickedBlocksConfig();
 
     @Expose
+    @ConfigOption(name = "Secret Chime", desc = "Play a sound effect when levers, chests, and wither essence are clicked in dungeons.")
+    @Accordion
+    public SecretChimeConfig secretChime = new SecretChimeConfig();
+
+    @Expose
     @ConfigOption(name = "Milestones Display", desc = "Show the current milestone in Dungeons.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/SecretChimeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/SecretChimeConfig.java
@@ -1,0 +1,39 @@
+package at.hannibal2.skyhanni.config.features.dungeon;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import at.hannibal2.skyhanni.features.dungeon.DungeonSecretChime;
+import at.hannibal2.skyhanni.utils.OSUtils;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+public class SecretChimeConfig {
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Play a sound effect when levers, chests, and wither essence are clicked in dungeons.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean enabled = false;
+
+    @Expose
+    @ConfigOption(name = "Secret Chime Sound", desc = "The sound played for the secret chime.")
+    @ConfigEditorText
+    public String name = "random.orb";
+
+    @Expose
+    @ConfigOption(name = "Pitch", desc = "The pitch of the secret chime sound.")
+    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.0f, minStep = 0.1f)
+    public float pitch = 1.0f;
+
+
+    @ConfigOption(name = "Sounds", desc = "Click to open the list of available sounds.")
+    @ConfigEditorButton(buttonText = "OPEN")
+    public Runnable sounds = () -> OSUtils.openBrowser("https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/mapping-and-modding-tutorials/2213619-1-8-all-playsound-sound-arguments");
+
+
+    @ConfigOption(name = "Play Sound", desc = "Plays current secret chime sound.")
+    @ConfigEditorButton(buttonText = "Play")
+    public Runnable checkSound = DungeonSecretChime::playSound;
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/SecretChimeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/SecretChimeConfig.java
@@ -20,18 +20,16 @@ public class SecretChimeConfig {
     @Expose
     @ConfigOption(name = "Secret Chime Sound", desc = "The sound played for the secret chime.")
     @ConfigEditorText
-    public String name = "random.orb";
+    public String soundName  = "random.orb";
 
     @Expose
     @ConfigOption(name = "Pitch", desc = "The pitch of the secret chime sound.")
     @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.0f, minStep = 0.1f)
-    public float pitch = 1.0f;
+    public float soundPitch = 1.0f;
 
-
-    @ConfigOption(name = "Sounds", desc = "Click to open the list of available sounds.")
+    @ConfigOption(name = "Sounds", desc = "Click to open the list of available sounds. \n§l§cWarning: Clicking this will open a webpage in your browser.")
     @ConfigEditorButton(buttonText = "OPEN")
-    public Runnable sounds = () -> OSUtils.openBrowser("https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/mapping-and-modding-tutorials/2213619-1-8-all-playsound-sound-arguments");
-
+    public Runnable soundsListURL = () -> OSUtils.openBrowser("https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/mapping-and-modding-tutorials/2213619-1-8-all-playsound-sound-arguments");
 
     @ConfigOption(name = "Play Sound", desc = "Plays current secret chime sound.")
     @ConfigEditorButton(buttonText = "Play")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/SecretChimeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/SecretChimeConfig.java
@@ -20,14 +20,17 @@ public class SecretChimeConfig {
     @Expose
     @ConfigOption(name = "Secret Chime Sound", desc = "The sound played for the secret chime.")
     @ConfigEditorText
-    public String soundName  = "random.orb";
+    public String soundName = "random.orb";
 
     @Expose
     @ConfigOption(name = "Pitch", desc = "The pitch of the secret chime sound.")
     @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.0f, minStep = 0.1f)
     public float soundPitch = 1.0f;
 
-    @ConfigOption(name = "Sounds", desc = "Click to open the list of available sounds. \n§l§cWarning: Clicking this will open a webpage in your browser.")
+    @ConfigOption(name = "Sounds",
+        desc = "Click to open the list of available sounds.\n" +
+        "§l§cWarning: Clicking this will open a webpage in your browser."
+    )
     @ConfigEditorButton(buttonText = "OPEN")
     public Runnable soundsListURL = () -> OSUtils.openBrowser("https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/mapping-and-modding-tutorials/2213619-1-8-all-playsound-sound-arguments");
 

--- a/src/main/java/at/hannibal2/skyhanni/data/ClickedBlockType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ClickedBlockType.kt
@@ -1,0 +1,8 @@
+package at.hannibal2.skyhanni.data
+
+enum class ClickedBlockType {
+    LEVER,
+    CHEST,
+    TRAPPED_CHEST,
+    WITHER_ESSENCE
+}

--- a/src/main/java/at/hannibal2/skyhanni/events/DungeonClickedBlockEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/DungeonClickedBlockEvent.kt
@@ -4,4 +4,4 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.ClickedBlockType
 import at.hannibal2.skyhanni.utils.LorenzVec
 
-class DungeonBlockClickEvent(val position: LorenzVec, val blockType: ClickedBlockType)  : SkyHanniEvent()
+class DungeonBlockClickEvent(val position: LorenzVec, val blockType: ClickedBlockType) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/DungeonClickedBlockEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/DungeonClickedBlockEvent.kt
@@ -1,0 +1,7 @@
+package at.hannibal2.skyhanni.events
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.data.ClickedBlockType
+import at.hannibal2.skyhanni.utils.LorenzVec
+
+class DungeonBlockClickEvent(val position: LorenzVec, val blockType: ClickedBlockType)  : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
@@ -44,13 +44,10 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 object DungeonAPI {
 
     private val floorPattern = " §7⏣ §cThe Catacombs §7\\((?<floor>.*)\\)".toPattern()
-    private val uniqueClassBonus =
-        "^Your ([A-Za-z]+) stats are doubled because you are the only player using this class!$".toRegex()
+    private val uniqueClassBonus = "^Your ([A-Za-z]+) stats are doubled because you are the only player using this class!$".toRegex()
 
-    private val bossPattern =
-        "View all your (?<name>\\w+) Collection".toPattern()
-    private val levelPattern =
-        " +(?<kills>\\d+).*".toPattern()
+    private val bossPattern = "View all your (?<name>\\w+) Collection".toPattern()
+    private val levelPattern = " +(?<kills>\\d+).*".toPattern()
     private val killPattern = " +☠ Defeated (?<boss>\\w+).*".toPattern()
     private val totalKillsPattern = "§7Total Kills: §e(?<kills>.*)".toPattern()
 
@@ -65,7 +62,8 @@ object DungeonAPI {
     val bossStorage: MutableMap<DungeonFloor, Int>? get() = ProfileStorageData.profileSpecific?.dungeons?.bosses
 
     private val patternGroup = RepoPattern.group("dungeon")
-    private const val WITHER_ESSENCE_TEXTURE = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzRkYjRhZGZhOWJmNDhmZjVkNDE3MDdhZTM0ZWE3OGJkMjM3MTY1OWZjZDhjZDg5MzQ3NDlhZjRjY2U5YiJ9fX0="
+    private const val WITHER_ESSENCE_TEXTURE =
+        "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzRkYjRhZGZhOWJmNDhmZjVkNDE3MDdhZTM0ZWE3OGJkMjM3MTY1OWZjZDhjZDg5MzQ3NDlhZjRjY2U5YiJ9fX0="
 
     /**
      * REGEX-TEST: Time Elapsed: §a01m 17s
@@ -181,10 +179,9 @@ object DungeonAPI {
             }
         }
         if (dungeonFloor != null && playerClass == null) {
-            val playerTeam =
-                TabListData.getTabList().firstOrNull {
-                    it.contains(LorenzUtils.getPlayerName())
-                }?.removeColor() ?: ""
+            val playerTeam = TabListData.getTabList().firstOrNull {
+                it.contains(LorenzUtils.getPlayerName())
+            }?.removeColor() ?: ""
 
             for (dungeonClass in DungeonClass.entries) {
                 if (playerTeam.contains("(${dungeonClass.scoreboardName} ")) {
@@ -363,7 +360,6 @@ object DungeonAPI {
         }
     }
 
-
     @SubscribeEvent
     fun onBlockClick(event: BlockClickEvent) {
         if (!inDungeon() || event.clickType != ClickType.RIGHT_CLICK) return
@@ -381,6 +377,7 @@ object DungeonAPI {
                     return
                 }
             }
+
             else -> return
         }
         DungeonBlockClickEvent(position, blockType).post()

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHighlightClickedBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHighlightClickedBlocks.kt
@@ -1,14 +1,13 @@
 package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.ClickType
-import at.hannibal2.skyhanni.events.BlockClickEvent
+import at.hannibal2.skyhanni.data.ClickedBlockType
+import at.hannibal2.skyhanni.events.DungeonBlockClickEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.BlockUtils
-import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ExtendedChatColor
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -18,7 +17,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.RenderUtils.drawString
 import at.hannibal2.skyhanni.utils.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.init.Blocks
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.awt.Color
 import kotlin.time.Duration.Companion.seconds
@@ -40,7 +38,7 @@ object DungeonHighlightClickedBlocks {
 
     private val blocks = TimeLimitedCache<LorenzVec, ClickedBlock>(3.seconds)
     private var colorIndex = 0
-    val undesirableColors = listOf(
+    private val undesirableColors = listOf(
         LorenzColor.BLACK,
         LorenzColor.WHITE,
         LorenzColor.CHROMA,
@@ -69,45 +67,27 @@ object DungeonHighlightClickedBlocks {
         }
     }
 
-    @SubscribeEvent
-    fun onBlockClick(event: BlockClickEvent) {
+    @HandleEvent
+    fun onDungeonClickedBlock(event: DungeonBlockClickEvent) {
         if (!isEnabled()) return
-        if (event.clickType != ClickType.RIGHT_CLICK) return
+        val isWaterRoom = DungeonAPI.getRoomID() == "-60,-60"
+        if (isWaterRoom && event.blockType == ClickedBlockType.LEVER) return
 
-        val position = event.position
-        if (blocks.containsKey(position)) return
+        val type = event.blockType
 
-        val type: ClickedBlockType = when (position.getBlockAt()) {
-            Blocks.chest -> ClickedBlockType.CHEST
-            Blocks.trapped_chest -> ClickedBlockType.TRAPPED_CHEST
-            Blocks.lever -> ClickedBlockType.LEVER
-            Blocks.skull -> ClickedBlockType.WITHER_ESSENCE
-            else -> return
-        }
+        val color = if (config.randomColor) getRandomColor().toColor() else getBlockProperties(type).color.toChromaColor()
+        val displayText = ExtendedChatColor(color.rgb, false).toString() + "Clicked " + getBlockProperties(type).name
+        blocks[event.position] = ClickedBlock(displayText, color)
 
-        if (type == ClickedBlockType.WITHER_ESSENCE) {
-            val text = BlockUtils.getTextureFromSkull(position.toBlockPos())
-            if (text != "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQ" +
-                "ubmV0L3RleHR1cmUvYzRkYjRhZGZhOWJmNDhmZjVkNDE3M" +
-                "DdhZTM0ZWE3OGJkMjM3MTY1OWZjZDhjZDg5MzQ3NDlhZjRjY2U5YiJ9fX0="
-            ) {
-                return
-            }
-        }
-
-        val inWaterRoom = DungeonAPI.getRoomID() == "-60,-60"
-        if (inWaterRoom && type == ClickedBlockType.LEVER) return
-
-        val color = if (config.randomColor) getRandomColor().toColor() else type.color().toChromaColor()
-        val displayText = ExtendedChatColor(color.rgb, false).toString() + "Clicked " + type.display
-        blocks[position] = ClickedBlock(displayText, color)
     }
 
-    enum class ClickedBlockType(val display: String, val color: () -> String) {
-        LEVER("Lever", { config.leverColor }),
-        CHEST("Chest", { config.chestColor }),
-        TRAPPED_CHEST("Trapped Chest", { config.trappedChestColor }),
-        WITHER_ESSENCE("Wither Essence", { config.witherEssenceColor }),
+    private fun getBlockProperties(type: ClickedBlockType): BlockProperties {
+        return when (type) {
+            ClickedBlockType.LEVER -> BlockProperties("Lever", config.leverColor)
+            ClickedBlockType.CHEST -> BlockProperties("Chest", config.chestColor)
+            ClickedBlockType.TRAPPED_CHEST -> BlockProperties("Trapped Chest", config.trappedChestColor)
+            ClickedBlockType.WITHER_ESSENCE -> BlockProperties("Wither Essence", config.witherEssenceColor)
+        }
     }
 
     @SubscribeEvent
@@ -128,6 +108,7 @@ object DungeonHighlightClickedBlocks {
     }
 
     class ClickedBlock(val displayText: String, var color: Color)
+    class BlockProperties(val name: String, val color: String)
 
     fun isEnabled() = !DungeonAPI.inBossRoom && DungeonAPI.inDungeon() && config.enabled
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
@@ -1,0 +1,36 @@
+package at.hannibal2.skyhanni.features.dungeon
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.ClickedBlockType
+import at.hannibal2.skyhanni.events.DungeonBlockClickEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.SoundUtils.playSound
+
+@SkyHanniModule
+object DungeonSecretChime {
+    private val config get() = SkyHanniMod.feature.dungeon.secretChime
+
+    @HandleEvent
+    fun onDungeonClickedBlock(event: DungeonBlockClickEvent) {
+        if (!isEnabled()) return
+        val isWaterRoom = DungeonAPI.getRoomID() == "-60,-60"
+        if (isWaterRoom && event.blockType == ClickedBlockType.LEVER) return
+
+        val type = event.blockType
+        when (type) {
+            ClickedBlockType.CHEST, ClickedBlockType.TRAPPED_CHEST, ClickedBlockType.LEVER, ClickedBlockType.WITHER_ESSENCE -> playSound()
+        }
+    }
+
+    fun isEnabled() = !DungeonAPI.inBossRoom && DungeonAPI.inDungeon() && config.enabled
+
+    @JvmStatic
+    fun playSound() {
+        with(config) {
+            SoundUtils.createSound(name, pitch, 100f)
+                .playSound()
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
@@ -29,7 +29,7 @@ object DungeonSecretChime {
     @JvmStatic
     fun playSound() {
         with(config) {
-            SoundUtils.createSound(name, pitch, 100f)
+            SoundUtils.createSound(soundName, soundPitch, 100f)
                 .playSound()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
@@ -18,9 +18,12 @@ object DungeonSecretChime {
         val isWaterRoom = DungeonAPI.getRoomID() == "-60,-60"
         if (isWaterRoom && event.blockType == ClickedBlockType.LEVER) return
 
-        val type = event.blockType
-        when (type) {
-            ClickedBlockType.CHEST, ClickedBlockType.TRAPPED_CHEST, ClickedBlockType.LEVER, ClickedBlockType.WITHER_ESSENCE -> playSound()
+        when (event.blockType) {
+            ClickedBlockType.CHEST,
+            ClickedBlockType.TRAPPED_CHEST,
+            ClickedBlockType.LEVER,
+            ClickedBlockType.WITHER_ESSENCE,
+            -> playSound()
         }
     }
 
@@ -29,8 +32,7 @@ object DungeonSecretChime {
     @JvmStatic
     fun playSound() {
         with(config) {
-            SoundUtils.createSound(soundName, soundPitch, 100f)
-                .playSound()
+            SoundUtils.createSound(soundName, soundPitch, 100f).playSound()
         }
     }
 }


### PR DESCRIPTION
## What

Added a Secret Chime to dungeons with adjustable pitch and sound. Created a `ClickBlockType` enum for block types. Added a `DungeonBlockClickEvent` class to manage dungeon block clicks and updated `DungeonHighlightClickedBlocks` to work with this new event class.

Hopefully, I’ve fixed all the issues as requested.

I made a mistake in the previous pull request, so here is a new one and Im a new contributor.

## Changelog New Features
+ Added a Secret Chime for Dungeons with adjustable pitch and sound. - Ovi_1
    * The sound and pitch of chimes in dungeons are customizable.

## Changelog Technical Details
+ Created a `ClickBlockType` enum and a `DungeonBlockClickEvent` class. - Ovi_1
    * Added a new enum for block types and a class to handle click events on dungeon blocks.
+ Updated `DungeonHighlightClickedBlocks` to use the new `DungeonBlockClickEvent` class. - Ovi_1

