### PR TITLE
Fix: Heavy Pearls sometimes not detected

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -121,7 +121,7 @@ object IslandExceptions {
         armorStand: EntityArmorStand?,
         nextEntity: EntityLivingBase?,
     ) = when {
-        baseEntity is EntitySlime && armorStand?.name == "§f§lCOLLECT!" ->
+        baseEntity is EntitySlime && MobFilter.heavyPearlPattern.matches(armorStand?.name) ->
             MobData.MobResult.found(
                 MobFactories.special(baseEntity, "Heavy Pearl"),
             )

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -103,6 +103,10 @@ object MobFilter {
         "pattern.summon.owner",
         ".*Spawned by: (?<name>.*).*",
     )
+    val heavyPearlPattern by repoGroup.pattern(
+        "pattern.heavypearl.collect",
+        "§.§lCOLLECT!",
+    )
 
     /**
      * REGEX-TEST: §8[§7Lv1§8] §5Horse


### PR DESCRIPTION
## What
(Hopefully) fixed Heavy Pearls sometimes not getting highlighted due to Hypixel alternating the color on the armor stand between `§f` and `§e`. It works so far, but due to limited attempts per day I can't know for sure if it still breaks sometimes or not.

## Changelog Fixes
+ Fixed Heavy Pearls sometimes not being highlighted. - Luna
