### PR TITLE
Fix: Scoreboard Error with Barry Protestors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvent.kt
@@ -550,6 +550,8 @@ private fun getRiftLines() = getSbLines().filter { line ->
         || SbPattern.riftAveikxPattern.matches(line)
         || SbPattern.riftHayEatenPattern.matches(line)
         || SbPattern.cluesPattern.matches(line)
+        || SbPattern.barryProtestorsQuestlinePattern.matches(line)
+        || SbPattern.barryProtestorsHandledPattern.matches(line)
 }
 
 private fun getEssenceLines(): List<String> = listOf(getSbLines().first { SbPattern.essencePattern.matches(it) })

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -511,7 +511,7 @@ object ScoreboardPattern {
      */
     val barryProtestorsHandledPattern by riftSb.pattern(
         "protestors.handled",
-        "Protestors handled: §b\\d+/\\d+",
+        "Protestors handled: §b\\d+\\/\\d+",
     )
 
     private val carnivalSb = scoreboardGroup.group("carnival")

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -497,6 +497,23 @@ object ScoreboardPattern {
         "Clues: §.\\d+/\\d+",
     )
 
+    /**
+     * REGEX-TEST: §eFirst Up
+     * REGEX-TEST: Find and talk with Barry
+     */
+    val barryProtestorsQuestlinePattern by riftSb.pattern(
+        "protestors.quest",
+        "§eFirst Up|Find and talk with Barry",
+    )
+
+    /**
+     * REGEX-TEST: Protestors handled: §b5/7
+     */
+    val barryProtestorsHandledPattern by riftSb.pattern(
+        "protestors.handled",
+        "Protestors handled: §b\\d+/\\d+",
+    )
+
     private val carnivalSb = scoreboardGroup.group("carnival")
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -126,6 +126,8 @@ object UnknownLinesHandler {
             SbPattern.riftHayEatenPattern,
             SbPattern.fossilDustPattern,
             SbPattern.cluesPattern,
+            SbPattern.barryProtestorsQuestlinePattern,
+            SbPattern.barryProtestorsHandledPattern,
             SbPattern.carnivalPattern,
             SbPattern.carnivalTasksPattern,
             SbPattern.carnivalTokensPattern,


### PR DESCRIPTION
## What
These are not all lines, just some of them. I dont have any way to get them without starting another rift playthrough on another profile.


## Changelog Fixes
+ Fixed Custom Scoreboard Error during the Barry Protestors Quest. - j10a1n15