### PR TITLE
Fix: Sound Utils Over-correction

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -20,7 +20,6 @@ object SoundUtils {
 
     fun ISound.playSound() {
         DelayedRun.onThread.execute {
-            if (Minecraft.getMinecraft().soundHandler.isSoundPlaying(this)) return@execute
             val gameSettings = Minecraft.getMinecraft().gameSettings
             val oldLevel = gameSettings.getSoundLevel(SoundCategory.PLAYERS)
             if (!SkyHanniMod.feature.misc.maintainGameVolume) {
@@ -28,19 +27,11 @@ object SoundUtils {
             }
             try {
                 Minecraft.getMinecraft().soundHandler.playSound(this)
+            } catch (e: IllegalArgumentException) {
+                if (e.message?.startsWith("value already present:") == true) return@execute
+                ErrorManager.logErrorWithData(e, "Failed to play a sound", "soundLocation" to this.soundLocation)
             } catch (e: Exception) {
-                if (e is IllegalArgumentException) {
-                    e.message?.let {
-                        if (it.startsWith("value already present:")) {
-                            println("SkyHanni Sound error: $it")
-                            return@execute
-                        }
-                    }
-                }
-                ErrorManager.logErrorWithData(
-                    e, "Failed to play a sound",
-                    "soundLocation" to this.soundLocation,
-                )
+                ErrorManager.logErrorWithData(e, "Failed to play a sound", "soundLocation" to this.soundLocation)
             } finally {
                 if (!SkyHanniMod.feature.misc.maintainGameVolume) {
                     gameSettings.setSoundLevel(SoundCategory.PLAYERS, oldLevel)


### PR DESCRIPTION
## What
In #2431 we over-corrected to solve the issue of a sound error, which is now causing alert sounds to be all sorts of messed up. This PR rolls back those changes, instead nerfing the logging that led to that change in the first place, and tidying up the code.

## Changelog Fixes
+ Fixed warning sounds being stuttered and cutting out. - Daveed

