### PR TITLE
Fix : Glacite Commissions tunnel map

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.data.model.findShortestPathAsGraphWithDistance
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ItemClickEvent
@@ -193,6 +194,11 @@ object TunnelsMaps {
                 }
             }
         }
+    }
+
+    @SubscribeEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        clickTranslate = mapOf()
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Fix showing "click to show tunnel map" from Glacite mines commission menu in inventory
Reported: https://discord.com/channels/997079228510117908/1282533743306997853

## Changelog Fixes
+ Fixed "click to show tunnel map" from the Glacite Mines commission menu appearing in the inventory. - hannibal2