### PR TITLE
Fix: Personal Compactor Skull Sizes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/RenderableInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/RenderableInventory.kt
@@ -93,6 +93,7 @@ object RenderableInventory {
                             scale,
                             0,
                             0,
+                            false,
                         )
                     } ?: Renderable.placeholder((16 * scale).toInt(), (16 * scale).toInt())).also { index++ }
                 } else Renderable.placeholder(0, 0)


### PR DESCRIPTION
## What
Fixes skulls inside the personal compactor overlay being too big.

## Changelog Fixes
+ Fixed skull sizes inside the Personal Compactor Overlay. - Empa