### PR TITLE
Improvement: Add per election year diana trackers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -44,6 +44,7 @@ import at.hannibal2.skyhanni.utils.LorenzRarity;
 import at.hannibal2.skyhanni.utils.LorenzVec;
 import at.hannibal2.skyhanni.utils.NEUInternalName;
 import at.hannibal2.skyhanni.utils.SimpleTimeMark;
+import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker;
 import com.google.gson.annotations.Expose;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -647,8 +648,14 @@ public class ProfileSpecificStorage {
         public DianaProfitTracker.Data dianaProfitTracker = new DianaProfitTracker.Data();
 
         @Expose
+        public Map<Integer, DianaProfitTracker.Data> dianaProfitTrackerPerElectionSeason = new HashMap<>();
+
+        @Expose
         // TODO rename
         public MythologicalCreatureTracker.Data mythologicalMobTracker = new MythologicalCreatureTracker.Data();
+
+        @Expose
+        public Map<Integer, MythologicalCreatureTracker.Data> mythologicalMobTrackerPerElectionSeason = new HashMap<>();
     }
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -44,7 +44,6 @@ import at.hannibal2.skyhanni.utils.LorenzRarity;
 import at.hannibal2.skyhanni.utils.LorenzVec;
 import at.hannibal2.skyhanni.utils.NEUInternalName;
 import at.hannibal2.skyhanni.utils.SimpleTimeMark;
-import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker;
 import com.google.gson.annotations.Expose;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
@@ -186,17 +186,21 @@ object MayorAPI {
         jerryExtraMayor = jerryMayor to expireTime
     }
 
+    fun SkyBlockTime.getElectionYear(): Int {
+        var mayorYear = year
+
+        // Check if this year's election has not happened yet
+        if (month < ELECTION_END_MONTH || (day < ELECTION_END_DAY && month == ELECTION_END_MONTH)) {
+            // If so, the current mayor is still from last year's election
+            mayorYear--
+        }
+        return mayorYear
+    }
+
     private fun calculateNextMayorTime(): SimpleTimeMark {
         val now = SkyBlockTime.now()
-        var mayorYear = now.year
 
-        // Check if either the month is already over or the day after 27th in the third month
-        if (now.month > ELECTION_END_MONTH || (now.day >= ELECTION_END_DAY && now.month == ELECTION_END_MONTH)) {
-            // If so, the next mayor will be in the next year
-            mayorYear++
-        }
-
-        return SkyBlockTime(mayorYear, ELECTION_END_MONTH, day = ELECTION_END_DAY).asTimeMark()
+        return SkyBlockTime(now.getElectionYear() + 1, ELECTION_END_MONTH, day = ELECTION_END_DAY).asTimeMark()
     }
 
     private fun getTimeTillNextMayor() {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
@@ -50,8 +50,11 @@ object DianaProfitTracker {
         "Diana Profit Tracker",
         { Data() },
         { it.diana.dianaProfitTracker },
-        SkyHanniTracker.DisplayMode.MAYOR to { it.diana.dianaProfitTrackerPerElectionSeason.getOrPut(
-            SkyBlockTime.now().getElectionYear(), ::Data) },
+        SkyHanniTracker.DisplayMode.MAYOR to {
+            it.diana.dianaProfitTrackerPerElectionSeason.getOrPut(
+                SkyBlockTime.now().getElectionYear(), ::Data,
+            )
+        },
     ) { drawDisplay(it) }
 
     class Data : ItemTrackerData() {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.ItemAddManager
+import at.hannibal2.skyhanni.data.MayorAPI.getElectionYear
 import at.hannibal2.skyhanni.data.jsonobjects.repo.DianaDropsJson
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
@@ -18,12 +19,14 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
+import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import com.google.gson.annotations.Expose
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -47,6 +50,8 @@ object DianaProfitTracker {
         "Diana Profit Tracker",
         { Data() },
         { it.diana.dianaProfitTracker },
+        SkyHanniTracker.DisplayMode.MAYOR to { it.diana.dianaProfitTrackerPerElectionSeason.getOrPut(
+            SkyBlockTime.now().getElectionYear(), ::Data) },
     ) { drawDisplay(it) }
 
     class Data : ItemTrackerData() {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
@@ -55,12 +55,14 @@ object MythologicalCreatureTracker {
         ".* §r§eYou dug out a §r§2Minos Inquisitor§r§e!",
     )
 
-    private val tracker =
-        SkyHanniTracker(
-            "Mythological Creature Tracker", { Data() }, { it.diana.mythologicalMobTracker },
-            SkyHanniTracker.DisplayMode.MAYOR to
-                { it.diana.mythologicalMobTrackerPerElectionSeason.getOrPut(SkyBlockTime.now().getElectionYear(), ::Data) },
-        ) { drawDisplay(it) }
+    private val tracker = SkyHanniTracker(
+        "Mythological Creature Tracker", { Data() }, { it.diana.mythologicalMobTracker },
+        SkyHanniTracker.DisplayMode.MAYOR to {
+            it.diana.mythologicalMobTrackerPerElectionSeason.getOrPut(
+                SkyBlockTime.now().getElectionYear(), ::Data,
+            )
+        },
+    ) { drawDisplay(it) }
 
     class Data : TrackerData() {
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.MayorAPI.getElectionYear
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
@@ -13,6 +14,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
@@ -54,7 +56,11 @@ object MythologicalCreatureTracker {
     )
 
     private val tracker =
-        SkyHanniTracker("Mythological Creature Tracker", { Data() }, { it.diana.mythologicalMobTracker }) { drawDisplay(it) }
+        SkyHanniTracker(
+            "Mythological Creature Tracker", { Data() }, { it.diana.mythologicalMobTracker },
+            SkyHanniTracker.DisplayMode.MAYOR to
+                { it.diana.mythologicalMobTrackerPerElectionSeason.getOrPut(SkyBlockTime.now().getElectionYear(), ::Data) },
+        ) { drawDisplay(it) }
 
     class Data : TrackerData() {
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/CollectionUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/CollectionUtils.kt
@@ -334,9 +334,17 @@ object CollectionUtils {
         getName: (T) -> String,
         isCurrent: (T) -> Boolean,
         crossinline onChange: (T) -> Unit,
+    ) = buildSelector(prefix, getName, isCurrent, onChange, enumValues<T>())
+
+    inline fun <T> buildSelector(
+        prefix: String,
+        getName: (T) -> String,
+        isCurrent: (T) -> Boolean,
+        crossinline onChange: (T) -> Unit,
+        universe: Array<T>
     ) = buildList<Renderable> {
         addString(prefix)
-        for (entry in enumValues<T>()) {
+        for (entry in universe) {
             val display = getName(entry)
             if (isCurrent(entry)) {
                 addString("§a[$display]")

--- a/src/main/java/at/hannibal2/skyhanni/utils/CollectionUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/CollectionUtils.kt
@@ -15,28 +15,22 @@ import kotlin.math.ceil
 object CollectionUtils {
 
     inline fun <reified T : Queue<E>, reified E> T.drainForEach(action: (E) -> Unit): T {
-        while (true)
-            action(this.poll() ?: break)
+        while (true) action(this.poll() ?: break)
         return this
     }
 
     inline fun <reified T : Queue<E>, reified E> T.drain(amount: Int): T {
-        for (i in 1..amount)
-            this.poll() ?: break
+        for (i in 1..amount) this.poll() ?: break
         return this
     }
 
-    inline fun <reified E, reified K, reified L : MutableCollection<K>>
-        Queue<E>.drainTo(list: L, action: (E) -> K): L {
-        while (true)
-            list.add(action(this.poll() ?: break))
+    inline fun <reified E, reified K, reified L : MutableCollection<K>> Queue<E>.drainTo(list: L, action: (E) -> K): L {
+        while (true) list.add(action(this.poll() ?: break))
         return list
     }
 
-    inline fun <reified E, reified L : MutableCollection<E>>
-        Queue<E>.drainTo(list: L): L {
-        while (true)
-            list.add(this.poll() ?: break)
+    inline fun <reified E, reified L : MutableCollection<E>> Queue<E>.drainTo(list: L): L {
+        while (true) list.add(this.poll() ?: break)
         return list
     }
 
@@ -155,11 +149,9 @@ object CollectionUtils {
      */
     fun List<String>.addIfNotNull(element: String?) = element?.let { plus(it) } ?: this
 
-    fun <K, V> Map<K, V>.editCopy(function: MutableMap<K, V>.() -> Unit) =
-        toMutableMap().also { function(it) }.toMap()
+    fun <K, V> Map<K, V>.editCopy(function: MutableMap<K, V>.() -> Unit) = toMutableMap().also { function(it) }.toMap()
 
-    fun <T> List<T>.editCopy(function: MutableList<T>.() -> Unit) =
-        toMutableList().also { function(it) }.toList()
+    fun <T> List<T>.editCopy(function: MutableList<T>.() -> Unit) = toMutableList().also { function(it) }.toList()
 
     fun <K, V> Map<K, V>.moveEntryToTop(matcher: (Map.Entry<K, V>) -> Boolean): Map<K, V> {
         val entry = entries.find(matcher)
@@ -171,8 +163,7 @@ object CollectionUtils {
         return this
     }
 
-    operator fun IntRange.contains(range: IntRange): Boolean =
-        range.first in this && range.last in this
+    operator fun IntRange.contains(range: IntRange): Boolean = range.first in this && range.last in this
 
     fun <E> MutableList<List<E>>.addAsSingletonList(text: E) {
         add(Collections.singletonList(text))
@@ -262,12 +253,10 @@ object CollectionUtils {
     } else false
 
     @Suppress("UNCHECKED_CAST")
-    fun <T> Iterable<T?>.takeIfAllNotNull(): Iterable<T>? =
-        takeIf { null !in this } as? Iterable<T>
+    fun <T> Iterable<T?>.takeIfAllNotNull(): Iterable<T>? = takeIf { null !in this } as? Iterable<T>
 
     @Suppress("UNCHECKED_CAST")
-    fun <T> List<T?>.takeIfAllNotNull(): List<T>? =
-        takeIf { null !in this } as? List<T>
+    fun <T> List<T?>.takeIfAllNotNull(): List<T>? = takeIf { null !in this } as? List<T>
 
     // TODO add cache
     fun MutableList<Renderable>.addString(
@@ -341,7 +330,7 @@ object CollectionUtils {
         getName: (T) -> String,
         isCurrent: (T) -> Boolean,
         crossinline onChange: (T) -> Unit,
-        universe: Array<T>
+        universe: Array<T>,
     ) = buildList<Renderable> {
         addString(prefix)
         for (entry in universe) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
@@ -39,8 +39,7 @@ class SkyHanniItemTracker<Data : ItemTrackerData>(
         }
         getSharedTracker()?.let { sharedData ->
             val isHidden = sharedData.get(DisplayMode.TOTAL).items[internalName]?.hidden
-            if (isHidden != null)
-                sharedData.modify { it.items[internalName]?.hidden = isHidden }
+            if (isHidden != null) sharedData.modify { it.items[internalName]?.hidden = isHidden }
         }
 
         if (command) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
@@ -25,8 +25,9 @@ class SkyHanniItemTracker<Data : ItemTrackerData>(
     name: String,
     createNewSession: () -> Data,
     getStorage: (ProfileSpecificStorage) -> Data,
+    vararg extraStorage: Pair<DisplayMode, (ProfileSpecificStorage) -> Data>,
     drawDisplay: (Data) -> List<Searchable>,
-) : SkyHanniTracker<Data>(name, createNewSession, getStorage, drawDisplay) {
+) : SkyHanniTracker<Data>(name, createNewSession, getStorage, *extraStorage, drawDisplay = drawDisplay) {
 
     companion object {
         val SKYBLOCK_COIN = NEUInternalName.SKYBLOCK_COIN
@@ -37,9 +38,9 @@ class SkyHanniItemTracker<Data : ItemTrackerData>(
             it.addItem(internalName, amount, command)
         }
         getSharedTracker()?.let { sharedData ->
-            sharedData.get(DisplayMode.TOTAL).items[internalName]?.let { data ->
-                sharedData.get(DisplayMode.SESSION).items[internalName]!!.hidden = data.hidden
-            }
+            val isHidden = sharedData.get(DisplayMode.TOTAL).items[internalName]?.hidden
+            if (isHidden != null)
+                sharedData.modify { it.items[internalName]?.hidden = isHidden }
         }
 
         if (command) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -64,7 +64,7 @@ open class SkyHanniTracker<Data : TrackerData>(
     }
 
     fun modify(mode: DisplayMode, modifyFunction: (Data) -> Unit) {
-        val sharedTracker = getSharedTracker()?: return
+        val sharedTracker = getSharedTracker() ?: return
         sharedTracker.modify(mode, modifyFunction)
         update()
     }
@@ -135,13 +135,17 @@ open class SkyHanniTracker<Data : TrackerData>(
                 storedTrackers[name] = it
                 update()
             },
-            universe = availableTrackers
+            universe = availableTrackers,
         ),
     )
 
     protected fun getSharedTracker() = ProfileStorageData.profileSpecific?.let { ps ->
-        SharedTracker(mapOf(DisplayMode.TOTAL to ps.getTotal(), DisplayMode.SESSION to ps.getCurrentSession())
-                          + extraDisplayModes.mapValues { it.value(ps) })
+        SharedTracker(
+            mapOf(
+                DisplayMode.TOTAL to ps.getTotal(),
+                DisplayMode.SESSION to ps.getCurrentSession(),
+            ) + extraDisplayModes.mapValues { it.value(ps) },
+        )
     }
 
     private fun ProfileSpecificStorage.getCurrentSession() = currentSessions.getOrPut(this) { createNewSession() }
@@ -180,11 +184,12 @@ open class SkyHanniTracker<Data : TrackerData>(
             entries.values.forEach(modifyFunction)
         }
 
-        fun get(displayMode: DisplayMode) = entries[displayMode]
-            ?: ErrorManager.skyHanniError("Unregistered display mode accessed on tracker",
-                                          "tracker" to name,
-                                          "displayMode" to displayMode,
-                                          "availableModes" to entries.keys)
+        fun get(displayMode: DisplayMode) = entries[displayMode] ?: ErrorManager.skyHanniError(
+            "Unregistered display mode accessed on tracker",
+            "tracker" to name,
+            "displayMode" to displayMode,
+            "availableModes" to entries.keys,
+        )
     }
 
     enum class DisplayMode(val displayName: String) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.TrackerManager
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
@@ -24,9 +25,11 @@ open class SkyHanniTracker<Data : TrackerData>(
     val name: String,
     private val createNewSession: () -> Data,
     private val getStorage: (ProfileSpecificStorage) -> Data,
+    vararg extraStorage: Pair<DisplayMode, (ProfileSpecificStorage) -> Data>,
     private val drawDisplay: (Data) -> List<Searchable>,
 ) {
 
+    private val extraDisplayModes = extraStorage.toMap()
     private var inventoryOpen = false
     private var displayMode: DisplayMode? = null
     private val currentSessions = mutableMapOf<ProfileSpecificStorage, Data>()
@@ -61,12 +64,8 @@ open class SkyHanniTracker<Data : TrackerData>(
     }
 
     fun modify(mode: DisplayMode, modifyFunction: (Data) -> Unit) {
-        val storage = ProfileStorageData.profileSpecific ?: return
-        val data: Data = when (mode) {
-            DisplayMode.TOTAL -> storage.getTotal()
-            DisplayMode.SESSION -> storage.getCurrentSession()
-        }
-        modifyFunction(data)
+        val sharedTracker = getSharedTracker()?: return
+        sharedTracker.modify(mode, modifyFunction)
         update()
     }
 
@@ -124,6 +123,8 @@ open class SkyHanniTracker<Data : TrackerData>(
         },
     )
 
+    private val availableTrackers = arrayOf(DisplayMode.TOTAL, DisplayMode.SESSION) + extraDisplayModes.keys
+
     private fun buildDisplayModeView() = Renderable.horizontalContainer(
         CollectionUtils.buildSelector<DisplayMode>(
             "§7Display Mode: ",
@@ -134,11 +135,13 @@ open class SkyHanniTracker<Data : TrackerData>(
                 storedTrackers[name] = it
                 update()
             },
+            universe = availableTrackers
         ),
     )
 
-    protected fun getSharedTracker() = ProfileStorageData.profileSpecific?.let {
-        SharedTracker(it.getTotal(), it.getCurrentSession())
+    protected fun getSharedTracker() = ProfileStorageData.profileSpecific?.let { ps ->
+        SharedTracker(mapOf(DisplayMode.TOTAL to ps.getTotal(), DisplayMode.SESSION to ps.getCurrentSession())
+                          + extraDisplayModes.mapValues { it.value(ps) })
     }
 
     private fun ProfileSpecificStorage.getCurrentSession() = currentSessions.getOrPut(this) { createNewSession() }
@@ -165,22 +168,29 @@ open class SkyHanniTracker<Data : TrackerData>(
         }
     }
 
-    class SharedTracker<Data : TrackerData>(private val total: Data, private val currentSession: Data) {
+    inner class SharedTracker<Data : TrackerData>(
+        private val entries: Map<DisplayMode, Data>,
+    ) {
+
+        fun modify(mode: DisplayMode, modifyFunction: (Data) -> Unit) {
+            get(mode).let(modifyFunction)
+        }
 
         fun modify(modifyFunction: (Data) -> Unit) {
-            modifyFunction(total)
-            modifyFunction(currentSession)
+            entries.values.forEach(modifyFunction)
         }
 
-        fun get(displayMode: DisplayMode) = when (displayMode) {
-            DisplayMode.TOTAL -> total
-            DisplayMode.SESSION -> currentSession
-        }
+        fun get(displayMode: DisplayMode) = entries[displayMode]
+            ?: ErrorManager.skyHanniError("Unregistered display mode accessed on tracker",
+                                          "tracker" to name,
+                                          "displayMode" to displayMode,
+                                          "availableModes" to entries.keys)
     }
 
     enum class DisplayMode(val displayName: String) {
         TOTAL("Total"),
         SESSION("This Session"),
+        MAYOR("This Mayor"),
         ;
     }
 


### PR DESCRIPTION
<!-- remove all unused parts -->

## What

Adds per election season diana trackers

## Changelog Improvements
+ Added per-election season Diana Trackers. - !nea
    * This includes the Diana Profit Tracker and the Mythological Creature Tracker.
    * The data is stored moving forward, but there is currently no way to view anything other than the current year.


## Changelog Technical Details
+ Added the ability to add more optional display modes to trackers. - !nea
    * These extra trackers still need to provide their own storage.
