### PR TITLE
Fix: Hoppity Event Stats Resetting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -673,6 +673,7 @@ public class ProfileSpecificStorage {
     @Nullable
     public Integer abiphoneContactAmount = null;
 
+    @Expose
     public Map<Integer, HoppityEventStats> hoppityEventStats = new HashMap<>();
 
     public static class HoppityEventStats {


### PR DESCRIPTION
## What
Adds the `@Expose` annotation back to `hoppityEventStats`

## Changelog Fixes
+ Fixed Hoppity Event stats resetting. - Daveed

