### PR TITLE
Fix: dicer gemstone fortune in ffguide

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FFStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FFStats.kt
@@ -77,7 +77,7 @@ object FFStats {
             in dicerCrops -> {
                 FortuneStats.SUNDER.set(FarmingFortuneDisplay.getSunderFortune(tool), 75.0)
                 FortuneStats.REFORGE.set(FarmingFortuneDisplay.reforgeFortune, 20.0)
-                FortuneStats.GEMSTONE.set(FarmingFortuneDisplay.gemstoneFortune, 20.0)
+                FortuneStats.GEMSTONE.set(FarmingFortuneDisplay.gemstoneFortune, 30.0)
             }
 
             CropType.MUSHROOM -> {


### PR DESCRIPTION
## What
fixed the max gemstone fortune for dicers from 20 -> 30
(1 character changed, i might be the goat)

[bug fix post](https://discord.com/channels/997079228510117908/1283320562634194954)

## Changelog Fixes
+ Fixed outdated Dicer gemstone fortune in FF guide. - Not_a_cow