### PR TITLE
Backend: Make HandleEvent Islands take in a vararg

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.inAnyIsland
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.chat.Text
 import java.lang.invoke.LambdaMetafactory
 import java.lang.invoke.MethodHandles
@@ -131,6 +130,6 @@ class EventHandler<T : SkyHanniEvent> private constructor(val name: String, priv
         val invoker: Consumer<Any>,
         val options: HandleEvent,
         val generic: Class<*>?,
-        val onlyOnIslandTypes: Set<IslandType> = options.onlyOnIsland.toSet(),
+        val onlyOnIslandTypes: Set<IslandType> = options.onlyOnIslands.toSet(),
     )
 }

--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.inAnyIsland
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.chat.Text
 import java.lang.invoke.LambdaMetafactory
@@ -113,7 +114,7 @@ class EventHandler<T : SkyHanniEvent> private constructor(val name: String, priv
     private fun shouldInvoke(event: SkyHanniEvent, listener: Listener): Boolean {
         if (SkyHanniEvents.isDisabledInvoker(listener.name)) return false
         if (listener.options.onlyOnSkyblock && !LorenzUtils.inSkyBlock) return false
-        if (listener.options.onlyOnIsland != IslandType.ANY && !listener.options.onlyOnIsland.isInIsland()) return false
+        if (IslandType.ANY !in listener.onlyOnIslandTypes && !inAnyIsland(listener.onlyOnIslandTypes)) return false
         if (event.isCancelled && !listener.options.receiveCancelled) return false
         if (
             event is GenericSkyHanniEvent<*> &&
@@ -129,6 +130,7 @@ class EventHandler<T : SkyHanniEvent> private constructor(val name: String, priv
         val name: String,
         val invoker: Consumer<Any>,
         val options: HandleEvent,
-        val generic: Class<*>?
+        val generic: Class<*>?,
+        val onlyOnIslandTypes: Set<IslandType> = options.onlyOnIsland.toSet(),
     )
 }

--- a/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
@@ -13,7 +13,7 @@ annotation class HandleEvent(
     /**
      * If the event should only be received while on a specific skyblock island.
      */
-    vararg val onlyOnIsland: IslandType = [IslandType.ANY],
+    vararg val onlyOnIslands: IslandType = [IslandType.ANY],
 
     /**
      * The priority of when the event will be called, lower priority will be called first, see the companion object.

--- a/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
@@ -13,7 +13,7 @@ annotation class HandleEvent(
     /**
      * If the event should only be received while on a specific skyblock island.
      */
-    val onlyOnIsland: IslandType = IslandType.ANY,
+    vararg val onlyOnIsland: IslandType = [IslandType.ANY],
 
     /**
      * The priority of when the event will be called, lower priority will be called first, see the companion object.

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneSpawnTimer.kt
@@ -80,7 +80,7 @@ object ArachneSpawnTimer {
         }
     }
 
-    @HandleEvent(onlyOnIsland = [IslandType.SPIDER_DEN], priority = HandleEvent.LOW, receiveCancelled = true)
+    @HandleEvent(onlyOnIslands = [IslandType.SPIDER_DEN], priority = HandleEvent.LOW, receiveCancelled = true)
     fun onPacketReceive(event: PacketReceivedEvent) {
         if (!saveNextTickParticles) return
         if (searchTime.passedSince() < 3.seconds) return

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneSpawnTimer.kt
@@ -80,7 +80,7 @@ object ArachneSpawnTimer {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.SPIDER_DEN, priority = HandleEvent.LOW, receiveCancelled = true)
+    @HandleEvent(onlyOnIsland = [IslandType.SPIDER_DEN], priority = HandleEvent.LOW, receiveCancelled = true)
     fun onPacketReceive(event: PacketReceivedEvent) {
         if (!saveNextTickParticles) return
         if (searchTime.passedSince() < 3.seconds) return

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonShadowAssassinNotification.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonShadowAssassinNotification.kt
@@ -16,7 +16,7 @@ object DungeonShadowAssassinNotification {
 
     private val config get() = SkyHanniMod.feature.dungeon
 
-    @HandleEvent(onlyOnIsland = [IslandType.CATACOMBS])
+    @HandleEvent(onlyOnIslands = [IslandType.CATACOMBS])
     fun onWorldBorderChange(event: PacketReceivedEvent) {
         if (!isEnabled()) return
         if (DungeonAPI.dungeonFloor?.contains("3") == true && DungeonAPI.inBossRoom) return

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonShadowAssassinNotification.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonShadowAssassinNotification.kt
@@ -16,7 +16,7 @@ object DungeonShadowAssassinNotification {
 
     private val config get() = SkyHanniMod.feature.dungeon
 
-    @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
+    @HandleEvent(onlyOnIsland = [IslandType.CATACOMBS])
     fun onWorldBorderChange(event: PacketReceivedEvent) {
         if (!isEnabled()) return
         if (DungeonAPI.dungeonFloor?.contains("3") == true && DungeonAPI.inBossRoom) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -58,7 +58,7 @@ object GriffinBurrowParticleFinder {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.HUB, priority = HandleEvent.LOW, receiveCancelled = true)
+    @HandleEvent(onlyOnIsland = [IslandType.HUB], priority = HandleEvent.LOW, receiveCancelled = true)
     fun onPacketReceive(event: PacketReceivedEvent) {
         if (!isEnabled()) return
         if (!config.burrowsSoopyGuess) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -58,7 +58,7 @@ object GriffinBurrowParticleFinder {
         }
     }
 
-    @HandleEvent(onlyOnIsland = [IslandType.HUB], priority = HandleEvent.LOW, receiveCancelled = true)
+    @HandleEvent(onlyOnIslands = [IslandType.HUB], priority = HandleEvent.LOW, receiveCancelled = true)
     fun onPacketReceive(event: PacketReceivedEvent) {
         if (!isEnabled()) return
         if (!config.burrowsSoopyGuess) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -222,7 +222,7 @@ object InquisitorWaypointShare {
         HypixelCommands.partyChat("x: $x, y: $y, z: $z ")
     }
 
-    @HandleEvent(onlyOnIsland = [IslandType.HUB], priority = HandleEvent.LOW, receiveCancelled = true)
+    @HandleEvent(onlyOnIslands = [IslandType.HUB], priority = HandleEvent.LOW, receiveCancelled = true)
     fun onFirstChatEvent(event: PacketReceivedEvent) {
         if (!isEnabled()) return
         val packet = event.packet

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -222,7 +222,7 @@ object InquisitorWaypointShare {
         HypixelCommands.partyChat("x: $x, y: $y, z: $z ")
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.HUB, priority = HandleEvent.LOW, receiveCancelled = true)
+    @HandleEvent(onlyOnIsland = [IslandType.HUB], priority = HandleEvent.LOW, receiveCancelled = true)
     fun onFirstChatEvent(event: PacketReceivedEvent) {
         if (!isEnabled()) return
         val packet = event.packet

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -87,10 +87,10 @@ object GardenAPI {
         "BASIC_GARDENING_AXE",
         "ADVANCED_GARDENING_HOE",
         "ROOKIE_HOE",
-        "BINGHOE"
+        "BINGHOE",
     )
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
     fun onSendPacket(event: PacketSentEvent) {
         if (event.packet !is C09PacketHeldItemChange) return
         checkItemInHand()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -90,7 +90,7 @@ object GardenAPI {
         "BINGHOE",
     )
 
-    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
     fun onSendPacket(event: PacketSentEvent) {
         if (event.packet !is C09PacketHeldItemChange) return
         checkItemInHand()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -158,7 +158,7 @@ object PestAPI {
         PestUpdateEvent().post()
     }
 
-    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
     fun onPestSpawn(event: PestSpawnEvent) {
         PestSpawnTimer.lastSpawnTime = SimpleTimeMark.now()
         val plotNames = event.plotNames

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -158,7 +158,7 @@ object PestAPI {
         PestUpdateEvent().post()
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
     fun onPestSpawn(event: PestSpawnEvent) {
         PestSpawnTimer.lastSpawnTime = SimpleTimeMark.now()
         val plotNames = event.plotNames

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -121,7 +121,7 @@ object PestParticleWaypoint {
         ++particles
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
     fun onFireWorkSpawn(event: PacketReceivedEvent) {
         if (event.packet !is S0EPacketSpawnObject) return
         if (!config.hideParticles) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -121,7 +121,7 @@ object PestParticleWaypoint {
         ++particles
     }
 
-    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
     fun onFireWorkSpawn(event: PacketReceivedEvent) {
         if (event.packet !is S0EPacketSpawnObject) return
         if (!config.hideParticles) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
@@ -56,7 +56,7 @@ object VisitorListener {
     }
 
     // TODO make event
-    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
     fun onSendEvent(event: PacketSentEvent) {
         val packet = event.packet
         if (packet !is C02PacketUseEntity) return
@@ -136,7 +136,7 @@ object VisitorListener {
         inventory.handleMouseClick_skyhanni(slot, slot.slotIndex, 0, 0)
     }
 
-    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
     fun onTooltip(event: ItemHoverEvent) {
         if (!GardenAPI.onBarnPlot) return
         if (!VisitorAPI.inInventory) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
@@ -56,7 +56,7 @@ object VisitorListener {
     }
 
     // TODO make event
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
     fun onSendEvent(event: PacketSentEvent) {
         val packet = event.packet
         if (packet !is C02PacketUseEntity) return
@@ -136,7 +136,7 @@ object VisitorListener {
         inventory.handleMouseClick_skyhanni(slot, slot.slotIndex, 0, 0)
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    @HandleEvent(onlyOnIsland = [IslandType.GARDEN])
     fun onTooltip(event: ItemHoverEvent) {
         if (!GardenAPI.onBarnPlot) return
         if (!VisitorAPI.inInventory) return

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -300,7 +300,8 @@ object LorenzUtils {
 
     fun IslandType.isInIsland() = inSkyBlock && skyBlockIsland == this
 
-    fun inAnyIsland(vararg islandTypes: IslandType) = inSkyBlock && islandTypes.any { it.isInIsland() }
+    fun inAnyIsland(vararg islandTypes: IslandType) = inSkyBlock && HypixelData.skyBlockIsland in islandTypes
+    fun inAnyIsland(islandTypes: Collection<IslandType>) = inSkyBlock && HypixelData.skyBlockIsland in islandTypes
 
     fun GuiContainerEvent.SlotClickEvent.makeShiftClick() {
         if (this.clickedButton == 1 && slot?.stack?.getItemCategoryOrNull() == ItemCategory.SACK) return
@@ -315,6 +316,7 @@ object LorenzUtils {
             this.cancel()
         }
     }
+
     // TODO move into mayor api
     val isDerpy by RecalculatingValue(1.seconds) { Perk.DOUBLE_MOBS_HP.isActive }
 


### PR DESCRIPTION
## What
This PR changes the HandleEvent Annotation to make the onlyOnIslands option take in a vararg of islands instead of just one.
This also changes the internal Listener class to have a set of these islands for checking against.
The funny brackets are sadly needed though.


## Changelog Technical Details
+ Updated HandleEvent onlyOnIslands to handle multiple islands. - j10a1n15