### PR TITLE
Fix: MobDetection Memory Collection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.drainForEach
 import at.hannibal2.skyhanni.utils.CollectionUtils.drainTo
 import at.hannibal2.skyhanni.utils.CollectionUtils.put
@@ -31,6 +32,7 @@ import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.network.play.server.S01PacketJoinGame
 import net.minecraft.network.play.server.S0CPacketSpawnPlayer
 import net.minecraft.network.play.server.S0FPacketSpawnMob
+import net.minecraft.world.World
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
@@ -62,10 +64,44 @@ object MobDetection {
         MobData.currentMobs.map {
             it.createDeSpawnEvent()
         }.forEach { it.postAndCatch() }
+        MobData.retries.clear()
     }
+
+    private fun watchdog() {
+        val world = LorenzUtils.getPlayer()?.worldObj ?: return
+        if (MobData.retries.any { it.value.entity.worldObj != world }) {
+            ChatUtils.chat("Watchdog: Retires")
+        }
+        if (MobData.currentMobs.any { it.watchdogCheck(world) }) {
+            ChatUtils.chat("Watchdog: Current Mobs")
+        }
+        if (MobData.players.any { it.watchdogCheck(world) }) {
+            ChatUtils.chat("Watchdog: Players")
+        }
+        if (MobData.displayNPCs.any { it.watchdogCheck(world) }) {
+            ChatUtils.chat("Watchdog: Display NPCs")
+        }
+        if (MobData.skyblockMobs.any { it.watchdogCheck(world) }) {
+            ChatUtils.chat("Watchdog: SkyBlockMobs")
+        }
+        if (MobData.summoningMobs.any { it.watchdogCheck(world) }) {
+            ChatUtils.chat("Watchdog: Summoning")
+        }
+        if (MobData.special.any { it.watchdogCheck(world) }) {
+            ChatUtils.chat("Watchdog: Special")
+        }
+        if (MobData.notSeenMobs.any { it.watchdogCheck(world) }) {
+            ChatUtils.chat("Watchdog: Not Seen Mobs")
+        }
+    }
+
+    private fun Mob.watchdogCheck(world: World): Boolean =
+        this.baseEntity.worldObj != world || (this.armorStand?.let { it.worldObj != world }
+            ?: false) || this.extraEntities.any { it.worldObj != world }
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
+        watchdog()
         if (shouldClear.get()) { // Needs to work outside skyblock since it needs clearing when leaving skyblock and joining limbo
             mobDetectionReset()
             shouldClear.set(false)

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -101,7 +101,6 @@ object MobDetection {
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
-        watchdog()
         if (shouldClear.get()) { // Needs to work outside skyblock since it needs clearing when leaving skyblock and joining limbo
             mobDetectionReset()
             shouldClear.set(false)


### PR DESCRIPTION
## What
Idk why but dungeon does not resets the retries properly, so I added a clear at world change.

Also I added a simple watchdog to find missbehaved entitys. (Is there for debugging of a dev, that's why it isn't used)

## Changelog Fixes
+ Fixed performance issues with a high number of dungeon runs in one session. - Thunderblade73

