### PR TITLE
Improvement: Click on Garden Shopping List now uses /viewrecipe instead of /recipe

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
@@ -109,7 +109,7 @@ object GardenVisitorSupercraft {
         if (event.slotId != 31) return
         event.cancel()
         if (lastClick.passedSince() > 0.3.seconds) {
-            HypixelCommands.recipe(lastSuperCraftMaterial)
+            HypixelCommands.viewRecipe(lastSuperCraftMaterial)
             lastClick = SimpleTimeMark.now()
         }
     }


### PR DESCRIPTION
## What

<details>
Saving one click in the supercraft for visitors by using the viewRecipe command instead of the recipe command.

</details>

## Changelog Improvements
+ Reduced one click for supercrafting visitor materials by using `/viewrecipe` instead of `/recipe` when using the Shopping List button. - Miestiek

