### PR TITLE
Fix: Scoreboard Error during M7 Dragons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
@@ -51,16 +51,13 @@ object ScoreboardData {
             val lastColor = start.lastColorCode() ?: ""
 
             // Generate the list of color suffixes
-            val colorSuffixes = generateSequence(lastColor) { it.dropLast(2) }
-                .takeWhile { it.isNotEmpty() }
-                .toMutableList()
+            val colorSuffixes = lastColor.chunked(2).toMutableList()
 
             // Iterate through the colorSuffixes to remove matching prefixes from 'end'
             for (suffix in colorSuffixes.toList()) {
                 if (end.startsWith(suffix)) {
                     end = end.removePrefix(suffix)
                     colorSuffixes.remove(suffix)
-                    break
                 }
             }
 


### PR DESCRIPTION
## What
Fixed the Color Prefix removal not working because the colorSuffixes list contained [§c§a, §a] instead of [§c, §a].


## Changelog Fixes
+ Fixed a Custom Scoreboard error during M7 Dragons. - j10a1n15
