### PR TITLE
Improvement: Updated Carnival Diamond Zombie Color

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -64,7 +64,7 @@ object CarnivalZombieShootout {
         LEATHER(30, "Leather Cap", Color(165, 42, 42)), //Brown
         IRON(50, "Iron Helmet", Color(192, 192, 192)), //Silver
         GOLD(80, "Golden Helmet", Color(255, 215, 0)), //Gold
-        DIAMOND(120, "Diamond Helmet", Color(185, 242, 255)) //Diamond
+        DIAMOND(120, "Diamond Helmet", Color(44, 214, 250)) //Diamond
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Made the diamond Zombie Color more blue, 

<details>
<summary>difference</summary>

new:
![image](https://github.com/user-attachments/assets/b6617c1d-d8aa-4f1d-8c4d-cfa1020036ae)
old:
![image](https://github.com/user-attachments/assets/7033b5af-64c8-45f3-905c-748f2eb5d9fd)

</details>


## Changelog Improvements
+ Updated the Zombie Shootout Diamond color to be a deeper blue. - j10a1n15


