### PR TITLE
Fix: Zombie Shootout Baby Zombie Bounding Box

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -23,6 +23,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.entity.monster.EntityZombie
 import net.minecraft.init.Blocks
 import net.minecraft.item.ItemStack
+import net.minecraft.util.AxisAlignedBB
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.awt.Color
 import kotlin.time.Duration.Companion.seconds
@@ -95,9 +96,21 @@ object CarnivalZombieShootout {
 
         for ((zombie, type) in drawZombies) {
             val entity = EntityUtils.getEntityByID(zombie.entityId) ?: continue
+            val isSmall = (entity as? EntityZombie)?.isChild ?: false
+
+            val boundingBox = entity.entityBoundingBox.let {
+                if (isSmall) {
+                    val widthScale = 0.5
+                    val heightScale = 0.85
+                    val newMin = it.minX + (it.maxX - it.minX) * (1 - widthScale) / 2
+                    val newMax = it.maxX - (it.maxX - it.minX) * (1 - widthScale) / 2
+                    val newHeight = it.minY + (it.maxY - it.minY) * heightScale / 1.75
+                    AxisAlignedBB(newMin, it.minY, it.minZ, newMax, newHeight, it.maxZ)
+                } else it
+            }.expand(0.1, 0.05, 0.0).offset(0.0, 0.05, 0.0)
 
             event.drawHitbox(
-                entity.entityBoundingBox.expand(0.1, 0.05, 0.0).offset(0.0, 0.05, 0.0),
+                boundingBox,
                 lineWidth = 3,
                 type.color,
                 depth = false,


### PR DESCRIPTION
## What
This Pull Request fixes the bounding box of the baby zombies during the Zombie Shootout. entity.entityBoundingBox does not differenciate between child and not child bounding boxes.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/5dfbad64-dd91-499f-bb90-3fdc49ab42b6)

</details>


## Changelog Fixes
+ Fixed the bounding box of baby zombies in Zombie Shootout. - j10a1n15
