### PR TITLE
Fix: Broodmother countdown wrong in singular case

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -60,9 +60,7 @@ object BroodmotherFeatures {
     private fun onStageUpdate() {
         ChatUtils.debug("New Broodmother stage: $currentStage")
 
-        if (lastStage == null) {
-            if (onServerJoin()) return
-        }
+        if (lastStage == null && onServerJoin()) return
 
         // ignore Hypixel bug where the stage may temporarily revert to Imminent after the Broodmother's death
         if (currentStage == StageEntry.IMMINENT && lastStage == StageEntry.ALIVE) return
@@ -72,22 +70,24 @@ object BroodmotherFeatures {
             return
         }
 
-        val timeUntilSpawn = currentStage?.minutes?.minutes
-        broodmotherSpawnTime = SimpleTimeMark.now() + timeUntilSpawn!!
-
         if (currentStage == StageEntry.IMMINENT && config.imminentWarning) {
             playImminentWarning()
             return
         }
 
-        if (config.stages.contains(currentStage) && lastStage != null) {
-            if (currentStage == StageEntry.SLAIN) {
-                onBroodmotherSlain()
-            } else {
-                val pluralize = StringUtils.pluralize(timeUntilSpawn.toInt(DurationUnit.MINUTES), "minute")
-                ChatUtils.chat(
-                    "Broodmother: $lastStage §e-> $currentStage§e. §b${timeUntilSpawn.inWholeMinutes} $pluralize §euntil it spawns!"
-                )
+        if (lastStage != null) {
+            val timeUntilSpawn = currentStage?.minutes?.minutes
+            broodmotherSpawnTime = SimpleTimeMark.now() + timeUntilSpawn!!
+
+            if (config.stages.contains(currentStage)) {
+                if (currentStage == StageEntry.SLAIN) {
+                    onBroodmotherSlain()
+                } else {
+                    val pluralize = StringUtils.pluralize(timeUntilSpawn.toInt(DurationUnit.MINUTES), "minute")
+                    ChatUtils.chat(
+                        "Broodmother: $lastStage §e-> $currentStage§e. §b${timeUntilSpawn.inWholeMinutes} $pluralize §euntil it spawns!"
+                    )
+                }
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -75,20 +75,18 @@ object BroodmotherFeatures {
             return
         }
 
-        if (lastStage != null) {
-            val timeUntilSpawn = currentStage?.minutes?.minutes
-            broodmotherSpawnTime = SimpleTimeMark.now() + timeUntilSpawn!!
+        val lastStage = lastStage ?: return
+        val timeUntilSpawn = currentStage?.minutes?.minutes ?: return
+        broodmotherSpawnTime = SimpleTimeMark.now() + timeUntilSpawn
 
-            if (config.stages.contains(currentStage)) {
-                if (currentStage == StageEntry.SLAIN) {
-                    onBroodmotherSlain()
-                } else {
-                    val pluralize = StringUtils.pluralize(timeUntilSpawn.toInt(DurationUnit.MINUTES), "minute")
-                    ChatUtils.chat(
-                        "Broodmother: $lastStage §e-> $currentStage§e. §b${timeUntilSpawn.inWholeMinutes} $pluralize §euntil it spawns!"
-                    )
-                }
-            }
+        if (currentStage !in config.stages) return
+        if (currentStage == StageEntry.SLAIN) {
+            onBroodmotherSlain()
+        } else {
+            val pluralize = StringUtils.pluralize(timeUntilSpawn.toInt(DurationUnit.MINUTES), "minute")
+            ChatUtils.chat(
+                "Broodmother: $lastStage §e-> $currentStage§e. §b${timeUntilSpawn.inWholeMinutes} $pluralize §euntil it spawns!"
+            )
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -99,7 +99,7 @@ object BroodmotherFeatures {
             val pluralize = StringUtils.pluralize(currentStage?.minutes ?: 0, "minute")
             var message = "The Broodmother's current stage in this server is ${currentStage.toString().replace("!", "")}§e."
             if (currentStage?.minutes != 0) {
-                message += " It will spawn within §b${currentStage?.minutes} $pluralize§e."
+                message += " It will spawn §bwithin ${currentStage?.minutes} $pluralize§e."
             }
             ChatUtils.chat(message)
             return true
@@ -161,7 +161,7 @@ object BroodmotherFeatures {
         if (!isCountdownEnabled()) return
 
         if (broodmotherSpawnTime.isFarPast()) {
-            if (lastStage != null) {
+            if (lastStage != null && currentStage == StageEntry.ALIVE) {
                 display = "§4Broodmother spawned!"
             }
         } else {


### PR DESCRIPTION
## What
Fixed an issue where, if you had "Stage on Server Join" off, the Broodmother countdown would instantly show upon joining the Spider's Den - which in most cases caused it to be pretty significantly off.
Also two minor improvements.

## Changelog Fixes
+ Fixed a case where the Broodmother countdown could be wildly inaccurate. - MTOnline