### PR TITLE
Fix: Baby Zombie Carnival Size

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -23,7 +23,6 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.entity.monster.EntityZombie
 import net.minecraft.init.Blocks
 import net.minecraft.item.ItemStack
-import net.minecraft.util.AxisAlignedBB
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.awt.Color
 import kotlin.time.Duration.Companion.seconds
@@ -98,19 +97,11 @@ object CarnivalZombieShootout {
             val entity = EntityUtils.getEntityByID(zombie.entityId) ?: continue
             val isSmall = (entity as? EntityZombie)?.isChild ?: false
 
-            val boundingBox = entity.entityBoundingBox.let {
-                if (isSmall) {
-                    val widthScale = 0.5
-                    val heightScale = 0.85
-                    val newMin = it.minX + (it.maxX - it.minX) * (1 - widthScale) / 2
-                    val newMax = it.maxX - (it.maxX - it.minX) * (1 - widthScale) / 2
-                    val newHeight = it.minY + (it.maxY - it.minY) * heightScale / 1.75
-                    AxisAlignedBB(newMin, it.minY, it.minZ, newMax, newHeight, it.maxZ)
-                } else it
-            }.expand(0.1, 0.05, 0.0).offset(0.0, 0.05, 0.0)
+            val boundingBox = if (isSmall) entity.entityBoundingBox.expand(0.0, -0.4, 0.0).offset(0.0, -0.4, 0.0)
+            else entity.entityBoundingBox
 
             event.drawHitbox(
-                boundingBox,
+                boundingBox.expand(0.1, 0.05, 0.0).offset(0.0, 0.05, 0.0),
                 lineWidth = 3,
                 type.color,
                 depth = false,


### PR DESCRIPTION
## What
Improved the Baby Zombie Size a bit more


<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/bd937d8e-288a-409b-860c-b7928d63feb3)

</details>

exclude_from_changelog

