### PR TITLE
Feature: Hoppity Collection Dye Recolor

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -193,6 +193,11 @@ public class ChocolateFactoryConfig {
     ));
 
     @Expose
+    @ConfigOption(name = "Re-color Missing Rabbit Dyes", desc = "Replace the gray dye in Hoppity's Collection with a color for the rarity of the rabbit.")
+    @ConfigEditorBoolean
+    public boolean rarityDyeRecolor = true;
+
+    @Expose
     @ConfigOption(
         name = "Show Missing Location Rabbits",
         desc = "Show the locations you have yet to find enough egg locations for in order to unlock the rabbit for that location."


### PR DESCRIPTION
## What
Adds an option for changing the color of the dye in Hoppity's Collection to match the rarity of the missing rabbit.

<details>
<summary>Images</summary>

Before:
![image](https://github.com/user-attachments/assets/c44e45a6-335e-4298-a594-204c1b7d8457)

After:
![image](https://github.com/user-attachments/assets/da84db52-2f7b-42a4-ba8e-c4e9e0e0a8d6)

</details>

## Changelog New Features
+ Added the ability to change the color of missing rabbit dyes in Hoppity's Collection to reflect rabbit rarity. - Daveed


