### PR TITLE
Fix: Old mayor perks not being marked as inactive

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/Mayors.kt
@@ -146,6 +146,7 @@ enum class Mayor(
 
         fun Mayor.addPerks(perks: List<Perk>) {
             perks.forEach { it.isActive = false }
+            activePerks.forEach { it.isActive = false }
             activePerks.clear()
             for (perk in perks.filter { perks.contains(it) }) {
                 perk.isActive = true


### PR DESCRIPTION
## What
Fixed the old mayor perks not being marked as inactive when the mayor changes.

## Changelog Fixes
+ Fixed old mayor perks not being marked as inactive when the mayor changes. - Luna
