### PR TITLE
Fix: Efficient Miner on Ore Mined Event

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -147,7 +147,6 @@ object MiningAPI {
     fun onPlaySound(event: PlaySoundEvent) {
         if (!inCustomMiningIsland()) return
         if (event.soundName !in allowedSoundNames) return
-        println("Sound: ${event.soundName} ${event.pitch} ${event.location.roundLocationToBlock().toCleanString()}")
         if (waitingForInitSound) {
             if (event.soundName != "random.orb" && event.pitch == 0.7936508f) {
                 val pos = event.location.roundLocationToBlock()

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -48,12 +48,7 @@ object MiningAPI {
         "§6The warmth of the campfire reduced your §r§b❄ Cold §r§6to §r§a0§r§6!|§c ☠ §r§7You froze to death§r§7.",
     )
 
-    private data class MinedBlock(
-        val ore: OreBlock,
-        var confirmed: Boolean,
-        val time: SimpleTimeMark = SimpleTimeMark.now(),
-        val isFirst: Boolean = false,
-    )
+    private data class MinedBlock(val ore: OreBlock, var confirmed: Boolean, val time: SimpleTimeMark = SimpleTimeMark.now())
 
     private var lastInitSound = SimpleTimeMark.farPast()
 

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -165,19 +165,21 @@ object MiningAPI {
     @SubscribeEvent
     fun onBlockChange(event: ServerBlockChangeEvent) {
         if (!inCustomMiningIsland()) return
-        val oldBlock = event.oldState.block
-        val newBlock = event.newState.block
+        val oldState = event.oldState
+        val newState = event.newState
+        val oldBlock = oldState.block
+        val newBlock = newState.block
 
-        if (event.oldState == event.newState) return
+        if (oldState == newState) return
         if (oldBlock == Blocks.air || oldBlock == Blocks.bedrock) return
-        if (newBlock != Blocks.air && newBlock != Blocks.bedrock && !isTitanium(event.newState)) return
+        if (newBlock != Blocks.air && newBlock != Blocks.bedrock && !isTitanium(newState)) return
 
         val pos = event.location
         if (pos.distanceToPlayer() > 7) return
 
         if (lastInitSound.passedSince() > 100.milliseconds) return
 
-        val ore = OreBlock.getByStateOrNull(event.oldState) ?: return
+        val ore = OreBlock.getByStateOrNull(oldState) ?: return
 
         if (initBlockPos == pos) {
             surroundingMinedBlocks += MinedBlock(ore, true) to pos

--- a/src/main/java/at/hannibal2/skyhanni/events/ServerBlockChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/ServerBlockChangeEvent.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.block.state.IBlockState
 import net.minecraft.util.BlockPos
 
-class ServerBlockChangeEvent(private val blockPos: BlockPos, private val blockState: IBlockState) : LorenzEvent() {
+class ServerBlockChangeEvent(blockPos: BlockPos, blockState: IBlockState) : LorenzEvent() {
 
     val location by lazy { blockPos.toLorenzVec() }
     val old by lazy { location.getBlockAt().toString().getName() }
@@ -17,7 +17,7 @@ class ServerBlockChangeEvent(private val blockPos: BlockPos, private val blockSt
 
     companion object {
 
-        val pattern = "Block\\{minecraft:(?<name>.*)}".toPattern()
+        private val pattern = "Block\\{minecraft:(?<name>.*)}".toPattern()
 
         private fun String.getName() = pattern.matchMatcher(this) {
             group("name")

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -252,7 +252,7 @@ private fun isHighTierMithril(state: IBlockState): Boolean {
     return (state.block == Blocks.wool && state.getValue(BlockColored.COLOR) == EnumDyeColor.LIGHT_BLUE)
 }
 
-private fun isTitanium(state: IBlockState): Boolean {
+fun isTitanium(state: IBlockState): Boolean {
     return (state.block == Blocks.stone && state.getValue(BlockStone.VARIANT) == BlockStone.EnumType.DIORITE_SMOOTH)
 }
 


### PR DESCRIPTION
## What
This pr fixes efficient miner not working in the ore mined event. this happened because hypixel made it so that the block change packet of block you originally mined gets sent after all the blocks mined by efficient miner.

For some reason in alpha they still have the old behavior, not sure if we want to merge this rn or wait until the changes in alpha get merged to make sure the current behavior stays, as this doesn't work rn in alpha.

## Changelog Fixes
+ Fixed blocks mined by Efficient Miner not being detected. - Empa