### PR TITLE
Improvement: Armor Stack Display 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ActionBarStatsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ActionBarStatsData.kt
@@ -30,6 +30,10 @@ enum class ActionBarStatsData(@Language("RegExp") rawPattern: String) {
         // language=RegExp
         ".*(§b\\+\\d+ SkyBlock XP §.\\([^()]+\\)§b \\(\\d+/\\d+\\)).*"
     ),
+    ARMOR_STACK(
+        // language=RegExp
+        " (?:§6§l|§6)(?<stack>\\d+)(?<symbol>[ᝐ⁑|҉Ѫ⚶])"
+    ),
     ;
 
     private val repoKey = name.replace("_", ".").lowercase()

--- a/src/main/java/at/hannibal2/skyhanni/data/ActionBarStatsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ActionBarStatsData.kt
@@ -32,7 +32,7 @@ enum class ActionBarStatsData(@Language("RegExp") rawPattern: String) {
     ),
     ARMOR_STACK(
         // language=RegExp
-        " (?:§6§l|§6)(?<stack>\\d+)(?<symbol>[ᝐ⁑|҉Ѫ⚶])"
+        ".*(?:§6§l|§6)(?<stack>\\d+)(?<symbol>[ᝐ⁑|҉Ѫ⚶]).*"
     ),
     ;
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ArmorStackDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ArmorStackDisplay.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.combat
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.ActionBarStatsData
 import at.hannibal2.skyhanni.events.ActionBarUpdateEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -13,30 +14,26 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 @SkyHanniModule
 object ArmorStackDisplay {
     private val config get() = SkyHanniMod.feature.combat.stackDisplayConfig
-    private var display = ""
-
-    /**
-     * REGEX-TEST: §66,171/4,422❤  §6§l10ᝐ§r     §a1,295§a❈ Defense     §b525/1,355✎ §3400ʬ
-     * REGEX-TEST: §66,171/4,422❤  §65ᝐ     §b-150 Mana (§6Wither Impact§b)     §b1,016/1,355✎ §3400ʬ
-     */
-    private val armorStackPattern by RepoPattern.pattern(
-        "combat.armorstack.actionbar",
-        " (?:§6|§6§l)(?<stack>\\d+[ᝐ⁑|҉Ѫ⚶])"
-    )
+    private var stackCount = 0
+    private var stackSymbol = ""
 
     @SubscribeEvent
     fun onActionBar(event: ActionBarUpdateEvent) {
         if (!isEnabled()) return
-        val stacks = armorStackPattern.findMatcher(event.actionBar) {
-            "§6§l" + group("stack")
-        } ?: ""
-        display = stacks
+        val actionBarText = event.actionBar
+        val stackPattern = ActionBarStatsData.ARMOR_STACK.pattern
+
+        stackSymbol = stackPattern.findMatcher(actionBarText) { group("symbol") } ?: ""
+        stackCount = (stackPattern.findMatcher(actionBarText) { group("stack") } ?: "0").toInt()
+
+        val updatedActionBarText = actionBarText.replace(Regex("\\s*$stackPattern"), "").trim()
+        event.changeActionBar(updatedActionBarText)
     }
 
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!isEnabled()) return
-        config.position.renderString(display, posLabel = "Armor Stack Display")
+        if (!isEnabled() || stackCount == 0) return
+        config.position.renderString("§6§l$stackCount$stackSymbol", posLabel = "Armor Stack Display")
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ArmorStackDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ArmorStackDisplay.kt
@@ -26,7 +26,7 @@ object ArmorStackDisplay {
         stackSymbol = stackPattern.findMatcher(actionBarText) { group("symbol") } ?: ""
         stackCount = (stackPattern.findMatcher(actionBarText) { group("stack") } ?: "0").toInt()
 
-        val updatedActionBarText = actionBarText.replace(Regex("\\s*$stackPattern"), "").trim()
+        val updatedActionBarText = actionBarText.replace(Regex("\\$stackPattern?"), "").trim()
         event.changeActionBar(updatedActionBarText)
     }
 


### PR DESCRIPTION
## What
[Discord Post](https://discordapp.com/channels/997079228510117908/1271756488175779891) Hides Crimson armor stacks from action bar when "Armor Stack Display" is enabled.
also separated stackSymbol for later use making detection of armor type easier.


## Changelog Improvements
+ Hides armor stacks from action bar  when "Armor Stack Display" is enabled. - Ovi_1

