### PR TITLE
Fix: TunnelMaps area and missing stats for reforge helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -44,7 +44,8 @@ enum class SkyblockStat(val icon: String) {
     FORAGING_FORTUNE("§☘"),
     FARMING_FORTUNE("§6☘"),
     MINING_FORTUNE("§6☘"),
-    FEAR("§a☠")
+    FEAR("§a☠"),
+    HEAT_RESISTANCE("§c♨"),
     ;
 
     val capitalizedName = name.lowercase().allLettersFirstUppercase()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -524,7 +524,7 @@ object TunnelsMaps {
         goal = getNext()
     }
 
-    private val areas = setOf("Glacite Tunnels", "Dwarven Base Camp", "Glacite Lake", "Fossil Research Center")
+    private val areas = setOf("Glacite Tunnels", "Dwarven Base Camp", "Great Glacite Lake", "Fossil Research Center")
 
     private fun isEnabled() = IslandType.DWARVEN_MINES.isInIsland() && config.enable && LorenzUtils.skyBlockArea in areas
 }


### PR DESCRIPTION
## What
They changed "Glacial Lake" to "Great Glacial Lake".

Also reforges can now give heat resitance and since the StatsAPI is not merged yet, it needs to be fixed this way.


exclude_from_changelog

