### PR TITLE
Fix: Garden Color in Messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotAPI.kt
@@ -72,6 +72,11 @@ object GardenPlotAPI {
         "spray.target",
         "§a§lSPRAYONATOR! §r§7You sprayed §r§aPlot §r§7- §r§b(?<plot>.*) §r§7with §r§a(?<spray>.*)§r§7!"
     )
+
+    /**
+     * REGEX-TEST: §9§lSPLASH! §r§6Your §r§aGarden §r§6was cleared of all active §r§aSprayonator §r§6effects!
+     * REGEX-TEST: §9§lSPLASH! §r§6Your §r§bGarden §r§6was cleared of all active §r§aSprayonator §r§6effects!
+     */
     private val portableWasherPattern by patternGroup.pattern(
         "spray.cleared.portablewasher",
         "§9§lSPLASH! §r§6Your §r§[b|a]Garden §r§6was cleared of all active §r§aSprayonator §r§6effects!"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotAPI.kt
@@ -74,7 +74,7 @@ object GardenPlotAPI {
     )
     private val portableWasherPattern by patternGroup.pattern(
         "spray.cleared.portablewasher",
-        "§9§lSPLASH! §r§6Your §r§bGarden §r§6was cleared of all active §r§aSprayonator §r§6effects!"
+        "§9§lSPLASH! §r§6Your §r§[b|a]Garden §r§6was cleared of all active §r§aSprayonator §r§6effects!"
     )
 
     var plots = listOf<Plot>()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotAPI.kt
@@ -79,7 +79,7 @@ object GardenPlotAPI {
      */
     private val portableWasherPattern by patternGroup.pattern(
         "spray.cleared.portablewasher",
-        "§9§lSPLASH! §r§6Your §r§[b|a]Garden §r§6was cleared of all active §r§aSprayonator §r§6effects!"
+        "§9§lSPLASH! §r§6Your §r§[ba]Garden §r§6was cleared of all active §r§aSprayonator §r§6effects!"
     )
 
     var plots = listOf<Plot>()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -80,9 +80,14 @@ object GardenVisitorFeatures {
     private var display = emptyList<List<Any>>()
 
     private val patternGroup = RepoPattern.group("garden.visitor")
+
+    /**
+     * REGEX-TEST: §a§r§aBanker Broadjaw §r§ehas arrived on your §r§aGarden§r§e!
+     * REGEC-TEST: §a§r§aBanker Broadjaw §r§ehas arrived on your §r§bGarden§r§e!
+     */
     private val visitorArrivePattern by patternGroup.pattern(
         "visitorarrive",
-        ".* §r§ehas arrived on your §r§bGarden§r§e!",
+        ".* §r§ehas arrived on your §r§[b|a]Garden§r§e!",
     )
     private val copperPattern by patternGroup.pattern(
         "copper",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -83,7 +83,7 @@ object GardenVisitorFeatures {
 
     /**
      * REGEX-TEST: §a§r§aBanker Broadjaw §r§ehas arrived on your §r§aGarden§r§e!
-     * REGEC-TEST: §a§r§aBanker Broadjaw §r§ehas arrived on your §r§bGarden§r§e!
+     * REGEX-TEST: §a§r§aBanker Broadjaw §r§ehas arrived on your §r§bGarden§r§e!
      */
     private val visitorArrivePattern by patternGroup.pattern(
         "visitorarrive",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -87,7 +87,7 @@ object GardenVisitorFeatures {
      */
     private val visitorArrivePattern by patternGroup.pattern(
         "visitorarrive",
-        ".* §r§ehas arrived on your §r§[b|a]Garden§r§e!",
+        ".* §r§ehas arrived on your §r§[ba]Garden§r§e!",
     )
     private val copperPattern by patternGroup.pattern(
         "copper",


### PR DESCRIPTION
## What
Garden was standardized to be `§a` in all messages with today's update - this fixes a couple regex patterns to do with garden.

## Changelog Fixes
+ Fixed some garden messages not being blocked. - Daveed
+ Fixed active sprays not being removed from the GUI when using a washer. - Daveed
