### PR TITLE
Fix: Revert Gauntlet item category change

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ReforgeAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ReforgeAPI.kt
@@ -75,7 +75,7 @@ object ReforgeAPI {
         fun isValid(itemCategory: ItemCategory?, internalName: NEUInternalName) = when (type) {
             ReforgeType.SWORD -> setOf(
                 ItemCategory.SWORD,
-                ItemCategory.PICKAXE_AND_SWORD,
+                ItemCategory.GAUNTLET,
                 ItemCategory.LONGSWORD,
                 ItemCategory.FISHING_WEAPON,
             ).contains(itemCategory)
@@ -98,7 +98,7 @@ object ReforgeAPI {
             ReforgeType.PICKAXE ->
                 itemCategory == ItemCategory.PICKAXE ||
                     itemCategory == ItemCategory.DRILL ||
-                    itemCategory == ItemCategory.PICKAXE_AND_SWORD
+                    itemCategory == ItemCategory.GAUNTLET
 
             ReforgeType.EQUIPMENT -> setOf(
                 ItemCategory.CLOAK,
@@ -111,7 +111,7 @@ object ReforgeAPI {
             ReforgeType.ROD -> itemCategory == ItemCategory.FISHING_ROD || itemCategory == ItemCategory.FISHING_WEAPON
             ReforgeType.SWORD_AND_ROD -> setOf(
                 ItemCategory.SWORD,
-                ItemCategory.PICKAXE_AND_SWORD,
+                ItemCategory.GAUNTLET,
                 ItemCategory.LONGSWORD,
                 ItemCategory.FISHING_ROD,
                 ItemCategory.FISHING_WEAPON,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
@@ -12,7 +12,7 @@ enum class ItemCategory {
     FISHING_WEAPON,
     FISHING_ROD,
     AXE,
-    PICKAXE_AND_SWORD,
+    GAUNTLET,
     HOE,
     PICKAXE,
     SHOVEL,
@@ -66,7 +66,7 @@ enum class ItemCategory {
         fun Collection<ItemCategory>.containsItem(stack: ItemStack?) =
             stack?.getItemCategoryOrNull()?.let { this.contains(it) } ?: false
 
-        val miningTools = listOf(PICKAXE, DRILL, PICKAXE_AND_SWORD)
+        val miningTools = listOf(PICKAXE, DRILL, GAUNTLET)
 
         val armor = setOf(HELMET, CHESTPLATE, LEGGINGS, BOOTS)
     }


### PR DESCRIPTION

## What
Reverted "GAUNTLET" -> "PICKAXE AND SWORD" item category change. Hypixel reverted this change before the update went on the main server and we didn't check properly.

## Changelog Fixes
+ Fixed Gemstone Gauntlet item category. - Luna
