### PR TITLE
Backend: AreaChangeEvent and Islands in HandleEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
@@ -130,6 +130,13 @@ class EventHandler<T : SkyHanniEvent> private constructor(val name: String, priv
         val invoker: Consumer<Any>,
         val options: HandleEvent,
         val generic: Class<*>?,
-        val onlyOnIslandTypes: Set<IslandType> = options.onlyOnIslands.toSet(),
-    )
+    ) {
+        val onlyOnIslandTypes: Set<IslandType> = getIslands(options)
+
+        companion object {
+            private fun getIslands(options: HandleEvent): Set<IslandType> =
+                if (options.onlyOnIslands.isEmpty()) setOf(options.onlyOnIsland)
+                else options.onlyOnIslands.toSet()
+        }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
@@ -12,8 +12,15 @@ annotation class HandleEvent(
 
     /**
      * If the event should only be received while on a specific skyblock island.
+     * To specify multiple islands, use [onlyOnIslands] instead.
      */
-    vararg val onlyOnIslands: IslandType = [IslandType.ANY],
+    val onlyOnIsland: IslandType = IslandType.ANY,
+
+    /**
+     * If the event should only be received while being on specific skyblock islands.
+     * To specify only one island, use [onlyOnIsland] instead.
+     */
+    vararg val onlyOnIslands: IslandType = [],
 
     /**
      * The priority of when the event will be called, lower priority will be called first, see the companion object.

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
-import at.hannibal2.skyhanni.events.skyblock.AreaChangeEvent
+import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.bingo.BingoAPI
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.rift.RiftAPI
@@ -325,7 +325,7 @@ object HypixelData {
                     if (area != skyBlockArea) {
                         val previousArea = skyBlockArea
                         skyBlockArea = area
-                        AreaChangeEvent(area, previousArea).post()
+                        ScoreboardAreaChangeEvent(area, previousArea).post()
                     }
                     break@loop
                 }

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
+import at.hannibal2.skyhanni.events.skyblock.AreaChangeEvent
 import at.hannibal2.skyhanni.features.bingo.BingoAPI
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.rift.RiftAPI
@@ -319,8 +320,13 @@ object HypixelData {
             loop@ for (line in ScoreboardData.sidebarLinesFormatted) {
                 skyblockAreaPattern.matchMatcher(line) {
                     val originalLocation = group("area").removeColor()
-                    skyBlockArea = LocationFixData.fixLocation(skyBlockIsland) ?: originalLocation
+                    val area = LocationFixData.fixLocation(skyBlockIsland) ?: originalLocation
                     skyBlockAreaWithSymbol = line.trim()
+                    if (area != skyBlockArea) {
+                        val previousArea = skyBlockArea
+                        skyBlockArea = area
+                        AreaChangeEvent(area, previousArea).post()
+                    }
                     break@loop
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/LocationFixData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/LocationFixData.kt
@@ -11,9 +11,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 @SkyHanniModule
 object LocationFixData {
 
-    private var locationFixes = mutableListOf<LocationFix>()
+    private var locationFixes = mutableMapOf<IslandType, List<LocationFix>>()
 
-    class LocationFix(val island: IslandType, val area: AxisAlignedBB, val realLocation: String)
+    private data class LocationFix(val area: AxisAlignedBB, val realLocation: String)
 
     // priority set to low so that IslandType can load their island names from repo earlier
     @SubscribeEvent(priority = EventPriority.LOW)
@@ -26,11 +26,16 @@ object LocationFixData {
             val area = fix.a.axisAlignedTo(fix.b)
             val realLocation = fix.realLocation
 
-            locationFixes.add(LocationFix(island, area, realLocation))
+            val list = locationFixes[island]
+
+            if (list == null) locationFixes[island] = listOf(LocationFix(area, realLocation))
+            else locationFixes[island] = list + LocationFix(area, realLocation)
         }
     }
 
-    fun fixLocation(skyBlockIsland: IslandType) = locationFixes
-        .firstOrNull { skyBlockIsland == it.island && it.area.isPlayerInside() }
-        ?.realLocation
+    fun fixLocation(skyBlockIsland: IslandType): String? =
+        locationFixes[skyBlockIsland]
+            ?.find { it.area.isPlayerInside() }
+            ?.realLocation
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/LocationFixData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/LocationFixData.kt
@@ -28,8 +28,10 @@ object LocationFixData {
 
             val list = locationFixes[island]
 
-            if (list == null) locationFixes[island] = listOf(LocationFix(area, realLocation))
-            else locationFixes[island] = list + LocationFix(area, realLocation)
+            val locationFix = LocationFix(area, realLocation)
+
+            if (list == null) locationFixes[island] = listOf(locationFix)
+            else locationFixes[island] = list + locationFix
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.ColdUpdateEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
@@ -215,6 +216,11 @@ object MiningAPI {
     @HandleEvent
     fun onAreaChange(event: AreaChangeEvent) {
         if (!inCustomMiningIsland()) return
+        updateLocation()
+    }
+
+    @SubscribeEvent
+    fun onIslandChange(event: IslandChangeEvent) {
         updateLocation()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -13,12 +13,11 @@ import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.mining.OreMinedEvent
 import at.hannibal2.skyhanni.events.player.PlayerDeathEvent
-import at.hannibal2.skyhanni.events.skyblock.AreaChangeEvent
+import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
 import at.hannibal2.skyhanni.features.mining.OreBlock
 import at.hannibal2.skyhanni.features.mining.isTitanium
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.countBy
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -33,7 +32,6 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import io.netty.util.internal.ConcurrentSet
 import net.minecraft.init.Blocks
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import java.awt.geom.Area
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.math.absoluteValue
 import kotlin.time.Duration.Companion.milliseconds
@@ -219,7 +217,7 @@ object MiningAPI {
     }
 
     @HandleEvent
-    fun onAreaChange(event: AreaChangeEvent) {
+    fun onAreaChange(event: ScoreboardAreaChangeEvent) {
         if (!inCustomMiningIsland()) return
         updateLocation()
     }

--- a/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvent.kt
@@ -1,5 +1,0 @@
-package at.hannibal2.skyhanni.events.skyblock
-
-import at.hannibal2.skyhanni.api.event.SkyHanniEvent
-
-class AreaChangeEvent(val area: String, val previousArea: String?) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvent.kt
@@ -1,0 +1,5 @@
+package at.hannibal2.skyhanni.events.skyblock
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+class AreaChangeEvent(val area: String, val previousArea: String?) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvents.kt
@@ -1,0 +1,6 @@
+package at.hannibal2.skyhanni.events.skyblock
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+// Detect area changes by looking at the scoreboard.
+class ScoreboardAreaChangeEvent(val area: String, val previousArea: String?) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneSpawnTimer.kt
@@ -80,7 +80,7 @@ object ArachneSpawnTimer {
         }
     }
 
-    @HandleEvent(onlyOnIslands = [IslandType.SPIDER_DEN], priority = HandleEvent.LOW, receiveCancelled = true)
+    @HandleEvent(onlyOnIsland = IslandType.SPIDER_DEN, priority = HandleEvent.LOW, receiveCancelled = true)
     fun onPacketReceive(event: PacketReceivedEvent) {
         if (!saveNextTickParticles) return
         if (searchTime.passedSince() < 3.seconds) return

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonShadowAssassinNotification.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonShadowAssassinNotification.kt
@@ -16,7 +16,7 @@ object DungeonShadowAssassinNotification {
 
     private val config get() = SkyHanniMod.feature.dungeon
 
-    @HandleEvent(onlyOnIslands = [IslandType.CATACOMBS])
+    @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
     fun onWorldBorderChange(event: PacketReceivedEvent) {
         if (!isEnabled()) return
         if (DungeonAPI.dungeonFloor?.contains("3") == true && DungeonAPI.inBossRoom) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -58,7 +58,7 @@ object GriffinBurrowParticleFinder {
         }
     }
 
-    @HandleEvent(onlyOnIslands = [IslandType.HUB], priority = HandleEvent.LOW, receiveCancelled = true)
+    @HandleEvent(onlyOnIsland = IslandType.HUB, priority = HandleEvent.LOW, receiveCancelled = true)
     fun onPacketReceive(event: PacketReceivedEvent) {
         if (!isEnabled()) return
         if (!config.burrowsSoopyGuess) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -222,7 +222,7 @@ object InquisitorWaypointShare {
         HypixelCommands.partyChat("x: $x, y: $y, z: $z ")
     }
 
-    @HandleEvent(onlyOnIslands = [IslandType.HUB], priority = HandleEvent.LOW, receiveCancelled = true)
+    @HandleEvent(onlyOnIsland = IslandType.HUB, priority = HandleEvent.LOW, receiveCancelled = true)
     fun onFirstChatEvent(event: PacketReceivedEvent) {
         if (!isEnabled()) return
         val packet = event.packet

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -90,7 +90,7 @@ object GardenAPI {
         "BINGHOE",
     )
 
-    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onSendPacket(event: PacketSentEvent) {
         if (event.packet !is C09PacketHeldItemChange) return
         checkItemInHand()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -158,7 +158,7 @@ object PestAPI {
         PestUpdateEvent().post()
     }
 
-    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onPestSpawn(event: PestSpawnEvent) {
         PestSpawnTimer.lastSpawnTime = SimpleTimeMark.now()
         val plotNames = event.plotNames

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -121,7 +121,7 @@ object PestParticleWaypoint {
         ++particles
     }
 
-    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onFireWorkSpawn(event: PacketReceivedEvent) {
         if (event.packet !is S0EPacketSpawnObject) return
         if (!config.hideParticles) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
@@ -56,7 +56,7 @@ object VisitorListener {
     }
 
     // TODO make event
-    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onSendEvent(event: PacketSentEvent) {
         val packet = event.packet
         if (packet !is C02PacketUseEntity) return
@@ -136,7 +136,7 @@ object VisitorListener {
         inventory.handleMouseClick_skyhanni(slot, slot.slotIndex, 0, 0)
     }
 
-    @HandleEvent(onlyOnIslands = [IslandType.GARDEN])
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onTooltip(event: ItemHoverEvent) {
         if (!GardenAPI.onBarnPlot) return
         if (!VisitorAPI.inInventory) return


### PR DESCRIPTION
## What
Adds AreaChangeEvent and uses it in MiningAPI, and changes some stuff in LocationFixData to use a map.
Also reverts the changes for the onlyOnIsland argument in the HandleEvent annotation in #2502 , and adds a separate argument to use when using multiple IslandType.
For checking a single IslandType, use `onlyOnIsland`, and for multiple use `onlyOnIslands`.

## Changelog Technical Details
+ Added `AreaChangeEvent`. - Empa
+ Updated `HandleEvent` to allow `onlyOnIsland` usage for a single island without brackets. - Empa
