### PR TITLE
Feature: Excavator Tooltip Hider

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/FossilExcavatorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/FossilExcavatorConfig.java
@@ -36,4 +36,14 @@ public class FossilExcavatorConfig {
     @FeatureToggle
     public boolean glacitePowderStack = false;
 
+    @Expose
+    @ConfigOption(
+        name = "Hide Excavator Tooltips",
+        desc = "Hides tooltips of items inside of the excavator."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hideExcavatorTooltips = false;
+
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/FossilExcavatorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/FossilExcavatorConfig.java
@@ -39,11 +39,9 @@ public class FossilExcavatorConfig {
     @Expose
     @ConfigOption(
         name = "Hide Excavator Tooltips",
-        desc = "Hides tooltips of items inside of the excavator."
+        desc = "Hides tooltips of items inside of the Fossil Excavator."
     )
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean hideExcavatorTooltips = false;
-
-
+    public boolean hideExcavatorTooltips = true;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -213,6 +213,6 @@ object HarpFeatures {
         if (!config.hideMelodyTooltip) return
         if (!isHarpGui(InventoryUtils.openInventoryName())) return
         if (event.slot.inventory !is ContainerLocalMenu) return
-            event.cancel()
+        event.cancel()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorTooltipHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorTooltipHider.kt
@@ -1,0 +1,22 @@
+package at.hannibal2.skyhanni.features.mining.fossilexcavator
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import net.minecraft.client.player.inventory.ContainerLocalMenu
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object ExcavatorTooltipHider {
+
+    private val config get() = SkyHanniMod.feature.mining.fossilExcavator
+
+    @SubscribeEvent
+    fun onTooltip(event: LorenzToolTipEvent) {
+        if (!isEnabled()) return
+        if (event.slot.inventory !is ContainerLocalMenu) return
+        event.cancel()
+    }
+
+    fun isEnabled() = FossilExcavatorAPI.inInventory && !FossilExcavatorAPI.inExcavatorMenu && config.hideExcavatorTooltips
+}


### PR DESCRIPTION
<!-- remove all unused parts -->

## What
Hides tooltips while in the digging inventory of the fossil excavator.

## Changelog New Features
+ Hides tooltips of items inside the Fossil Excavator in Glacite Tunnels. - Cuz_Im_Clicks