### PR TITLE
Fix: github source checking

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
+++ b/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
@@ -1,7 +1,5 @@
 package at.hannibal2.skyhanni.tweaker;
 
-import at.hannibal2.skyhanni.SkyHanniMod;
-
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -16,7 +14,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DownloadSourceChecker {
 
-    private static final String GITHUB_REPO_TEXT = "repo_id=511310721";
+    private static final String GITHUB_REPO = "511310721";
+    private static final String GITHUB_REPO_TEXT = "repo_id=" + GITHUB_REPO;
     private static final String MODRINTH_URL = "/data/byNkmv5G/";
     private static final String THE_PASSWORD = "danger";
 
@@ -96,11 +95,12 @@ public class DownloadSourceChecker {
             }
         ));
 
-        String version = SkyHanniMod.Companion.getVersion();
+        // TODO FIX THIS CAUSING CLASS LOADING AND CRASHING
+        //String version = SkyHanniMod.Companion.getVersion();
         JOptionPane.showOptionDialog(
             frame,
             String.format(String.join("\n", SECURITY_POPUP), uriToSimpleString(host)),
-            "SkyHanni " + version + " Security Error",
+            "SkyHanni Security Error",
             JOptionPane.DEFAULT_OPTION,
             JOptionPane.ERROR_MESSAGE,
             null,
@@ -124,8 +124,12 @@ public class DownloadSourceChecker {
             URI host = getHost(file);
             if (host == null) return null;
 
-            if (host.getHost().equals("objects.githubusercontent.com") && host.getQuery().contains(GITHUB_REPO_TEXT)) {
-                return null;
+            if (host.getHost().equals("objects.githubusercontent.com")) {
+                if (host.getQuery().contains(GITHUB_REPO_TEXT)) {
+                    return null;
+                } else if (host.getPath().contains("/" + GITHUB_REPO + "/")) {
+                    return null;
+                }
             } else if (host.getHost().equals("cdn.modrinth.com") && host.getPath().startsWith(MODRINTH_URL)) {
                 return null;
             }


### PR DESCRIPTION
## What
This PR fixes GitHub changing the url of downloads. This also comments out a change made in https://github.com/hannibal002/SkyHanni/pull/2400 because it causes a class loading error.

## Changelog Fixes
+ Fixed direct GitHub downloads triggering the source checker. - ThatGravyBoat
