### PR TITLE
Fix: Corpse Tracker not being modifed by /shdefaultoptions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/CorpseTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/CorpseTrackerConfig.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.features.mining;
 
+import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
@@ -11,6 +12,7 @@ public class CorpseTrackerConfig {
     @Expose
     @ConfigOption(name = "Enabled", desc = "Enable the Corpse Tracker overlay for Glacite Mineshafts.")
     @ConfigEditorBoolean
+    @FeatureToggle
     public boolean enabled = false;
 
     @Expose


### PR DESCRIPTION

## What
CorpseTracker had no FeatureToggle so it did not get modifed. And i dont think its worth the changelog line

exclude_from_changelog