### PR TITLE
Fix: Kuudra armor always showing as starred

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -528,7 +528,7 @@ object EstimatedItemValueCalculator {
                 return kuudraUpgradeTiers.indexOf(tier)
             }
         }
-        return 0
+        return -1
     }
 //     private fun getKuudraTier(internalName: NEUInternalName): Int? =
 //         kuudraUpgradeTiers.firstOrNull { it in internalName.toString() }?.let { kuudraUpgradeTiers.indexOf(it) }


### PR DESCRIPTION
## What
Fixed `getKuudraTier` returning hot tier for base tier Kuudra armor, messing up star calculation.

(I can't test this right now, but it should work.)

## Changelog Fixes
+ Fixed Estimated Item Value incorrectly showing all Kuudra armor as starred. - Luna