### PR TITLE
Fix: Visitor Supercraft use internal name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
@@ -84,7 +84,7 @@ object GardenVisitorSupercraft {
         hasIngredients = true
         for ((key, value) in ingredientReqs) {
             val sackItem = key.asInternalName().getAmountInSacks()
-            lastSuperCraftMaterial = internalName.itemName.removeColor()
+            lastSuperCraftMaterial = internalName.asString()
             if (sackItem < value * amount) {
                 hasIngredients = false
                 break


### PR DESCRIPTION
## What
Fixed broken implementation in #2505. `/viewrecipe` requires internal name, plus it was only using the first word.

exclude_from_changelog