### PR TITLE
Fix: Mining Commission Blocks Color and Connected Textures

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinOptifineConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinOptifineConfig.java
@@ -1,0 +1,23 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.features.mining.MiningCommissionsBlocksColor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Pseudo
+@Mixin(targets = "Config", remap = false)
+public class MixinOptifineConfig {
+
+    @Inject(method = "isConnectedTextures", at = @At("HEAD"), cancellable = true)
+    private static void isConnectedTextures(CallbackInfoReturnable<Boolean> cir) {
+        if (MiningCommissionsBlocksColor.INSTANCE.getActive()) cir.setReturnValue(false);
+    }
+
+    @Inject(method = "isConnectedTexturesFancy", at = @At("HEAD"), cancellable = true)
+    private static void isConnectedTexturesFancy(CallbackInfoReturnable<Boolean> cir) {
+        if (MiningCommissionsBlocksColor.INSTANCE.getActive()) cir.setReturnValue(false);
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinOptifineConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinOptifineConfig.java
@@ -11,13 +11,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(targets = "Config", remap = false)
 public class MixinOptifineConfig {
 
-    @Inject(method = "isConnectedTextures", at = @At("HEAD"), cancellable = true)
+    @Inject(method = {"isConnectedTextures", "isConnectedTexturesFancy"}, at = @At("HEAD"), cancellable = true)
     private static void isConnectedTextures(CallbackInfoReturnable<Boolean> cir) {
-        if (MiningCommissionsBlocksColor.INSTANCE.getActive()) cir.setReturnValue(false);
-    }
-
-    @Inject(method = "isConnectedTexturesFancy", at = @At("HEAD"), cancellable = true)
-    private static void isConnectedTexturesFancy(CallbackInfoReturnable<Boolean> cir) {
         if (MiningCommissionsBlocksColor.INSTANCE.getActive()) cir.setReturnValue(false);
     }
 }


### PR DESCRIPTION
## What
Fixed the Mining Commission Blocks Color feature not working properly when Optifine Connected Textures are enabled, by just temporarily disabling ctm while the feature is active.

[Original Bug Report](https://discord.com/channels/997079228510117908/1239346110770708550)

## Changelog Fixes
+ Fixed Mining Commission Blocks Color not working properly with Connected Textures. - Empa