### PR TITLE
Fix: Mining Stats Reforge

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -43,7 +43,14 @@ enum class SkyblockStat(val icon: String) {
     PRISTINE("§5✧"),
     FORAGING_FORTUNE("§☘"),
     FARMING_FORTUNE("§6☘"),
+
+    MINING_SPREAD("§e▚"),
     MINING_FORTUNE("§6☘"),
+    ORE_FORTUNE("§6☘"),
+    DWARVEN_METAL_FORTUNE("§6☘"),
+    BLOCK_FORTUNE("§6☘"),
+    GEMSTONE_FORTUNE("§6☘"),
+
     FEAR("§a☠"),
     HEAT_RESISTANCE("§c♨"),
     ;


### PR DESCRIPTION
## What
Added the new mining stats to SkyblockStat enum

## Changelog Fixes
+ Fixed reforge display not working with new mining stats. - hannibal2