### PR TITLE
Fix: Glacite Powder being counted as an item in CorpseTracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseTracker.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
@@ -65,9 +66,10 @@ object CorpseTracker {
     private fun addLootedCorpse(type: CorpseType) = tracker.modify { it.corpsesLooted.addOrPut(type, 1) }
 
     @SubscribeEvent
-    fun onCorpseLoot(event: CorpseLootedEvent) {
+    fun onCorpseLooted(event: CorpseLootedEvent) {
         addLootedCorpse(event.corpseType)
         for ((itemName, amount) in event.loot) {
+            if (itemName.removeColor().trim() == "Glacite Powder") continue
             NEUInternalName.fromItemNameOrNull(itemName)?.let { item ->
                 tracker.modify {
                     it.addItem(event.corpseType, item, amount)

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/ProfitPerMineshaftCorpse.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/ProfitPerMineshaftCorpse.kt
@@ -18,7 +18,7 @@ object ProfitPerMineshaftCorpse {
     private val config get() = SkyHanniMod.feature.mining.mineshaft
 
     @SubscribeEvent
-    fun onFossilExcavation(event: CorpseLootedEvent) {
+    fun onCorpseLooted(event: CorpseLootedEvent) {
         if (!config.profitPerCorpseLoot) return
         val loot = event.loot
 


### PR DESCRIPTION
## What
Reported [here](https://discord.com/channels/997079228510117908/1285621391630008403)
Glacite powder was being tracked as `Glacite` in the Corpse Tracker. This PR fixes that.

## Changelog Fixes
+ Fixed Glacite powder being tracked as Glacite in Corpse Tracker. - Daveed
