### PR TITLE
Improvement: Force locale for Number Formatting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
@@ -7,6 +7,7 @@ import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.Accordion;
 import io.github.notenoughupdates.moulconfig.annotations.Category;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
@@ -107,6 +108,13 @@ public class DevConfig {
         desc = "Mark SBA Contributors the same way as SkyHanni contributors.")
     @ConfigEditorBoolean
     public boolean fancySbaContributors = false;
+
+    @Expose
+    @ConfigOption(
+        name = "Number Format Override",
+        desc = "Forces the number format to use the en_US locale.")
+    @ConfigEditorBoolean
+    public boolean numberFormatOverride = false;
 
     @Expose
     @Category(name = "Minecraft Console", desc = "Minecraft Console Settings")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
@@ -7,7 +7,6 @@ import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.Accordion;
 import io.github.notenoughupdates.moulconfig.annotations.Category;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
-import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;

--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -1,13 +1,17 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.utils.LorenzUtils.round
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import java.text.NumberFormat
+import java.util.Locale
 import java.util.TreeMap
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
 object NumberUtil {
+
+    private val config get() = SkyHanniMod.feature
 
     private val suffixes = TreeMap<Long, String>().apply {
         this[1000L] = "k"
@@ -109,7 +113,10 @@ object NumberUtil {
         return this.toString() + this.ordinal()
     }
 
-    fun Number.addSeparators() = NumberFormat.getNumberInstance().format(this)
+    fun Number.addSeparators(): String {
+        return if (!config.dev.numberFormatOverride) NumberFormat.getNumberInstance().format(this)
+        else NumberFormat.getNumberInstance(Locale.US).format(this)
+    }
 
     fun String.romanToDecimalIfNecessary() = toIntOrNull() ?: romanToDecimal()
 


### PR DESCRIPTION
## What
adds a toggle to force en_us locale for number formatting

## Changelog Improvements
+ Added a toggle to force the `en_US` locale for number formatting. - martimavocado
