### PR TITLE
Fix: Flare Display negative values in chat with lag

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
@@ -100,7 +100,7 @@ object FlareDisplay {
                     }
                 }
             }
-            if (remainingTime > 5.seconds) continue
+            if (remainingTime > 5.seconds || remainingTime < 0.seconds) continue
             val message = "$name §eexpires in: §b${remainingTime.inWholeSeconds}s"
             when (config.alertType) {
                 FlareConfig.AlertType.CHAT -> {
@@ -194,7 +194,6 @@ object FlareDisplay {
         SOS("§5SOS Flare", "+125%"),
         ALERT("§9Alert Flare", "+50%"),
         WARNING("§aWarning Flare", null),
-        ;
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
@@ -101,7 +101,7 @@ object FlareDisplay {
                     }
                 }
             }
-            if (remainingTime > 5.seconds || remainingTime.isNegative()) continue
+            if (remainingTime !in 5.seconds..0.seconds) continue
             val message = "$name §eexpires in: §b${remainingTime.inWholeSeconds}s"
             when (config.alertType) {
                 FlareConfig.AlertType.CHAT -> {
@@ -195,7 +195,6 @@ object FlareDisplay {
         SOS("§5SOS Flare", "+125%"),
         ALERT("§9Alert Flare", "+50%"),
         WARNING("§aWarning Flare", null),
-        ;
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
@@ -48,7 +48,7 @@ object FlareDisplay {
         "ewogICJ0aW1lc3RhbXAiIDogMTY0NjY4NzMyNjQzMiwKICAicHJvZmlsZUlkIiA6ICI0MWQzYWJjMmQ3NDk0MDBjOTA5MGQ1NDM0ZDAzODMxYiIsCiAgInByb2ZpbGVOYW1lIiA6ICJNZWdha2xvb24iLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOWQyYmY5ODY0NzIwZDg3ZmQwNmI4NGVmYTgwYjc5NWM0OGVkNTM5YjE2NTIzYzNiMWYxOTkwYjQwYzAwM2Y2YiIKICAgIH0KICB9Cn0="
             to FlareType.ALERT,
         "ewogICJ0aW1lc3RhbXAiIDogMTY0NjY4NzM0NzQ4OSwKICAicHJvZmlsZUlkIiA6ICI0MWQzYWJjMmQ3NDk0MDBjOTA5MGQ1NDM0ZDAzODMxYiIsCiAgInByb2ZpbGVOYW1lIiA6ICJNZWdha2xvb24iLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzAwNjJjYzk4ZWJkYTcyYTZhNGI4OTc4M2FkY2VmMjgxNWI0ODNhMDFkNzNlYTg3YjNkZjc2MDcyYTg5ZDEzYiIKICAgIH0KICB9Cn0="
-            to FlareType.SOS
+            to FlareType.SOS,
     )
 
     @SubscribeEvent
@@ -92,7 +92,8 @@ object FlareDisplay {
             val name = type.displayName
             if (newDisplay == null) {
                 newDisplay = buildList {
-                    add(Renderable.string("$name: §b${remainingTime.format()}"))
+                    val displayTime = if (remainingTime.isNegative()) "§eSoon" else "§b${remainingTime.format()}"
+                    add(Renderable.string("$name: $displayTime"))
                     if (config.showManaBuff) {
                         type.manaBuff?.let {
                             add(Renderable.string(" §b$it §7mana regen"))
@@ -100,7 +101,7 @@ object FlareDisplay {
                     }
                 }
             }
-            if (remainingTime > 5.seconds || remainingTime <= 0.seconds) continue
+            if (remainingTime > 5.seconds || remainingTime.isNegative()) continue
             val message = "$name §eexpires in: §b${remainingTime.inWholeSeconds}s"
             when (config.alertType) {
                 FlareConfig.AlertType.CHAT -> {
@@ -125,7 +126,7 @@ object FlareDisplay {
     private fun getRemainingTime(flare: Flare): Duration {
         val entity = flare.entity
         val aliveTime = entity.ticksExisted.ticks
-        val remainingTime = (MAX_FLARE_TIME - aliveTime).coerceAtLeast(Duration.ZERO)
+        val remainingTime = (MAX_FLARE_TIME - aliveTime)
         return remainingTime
     }
 
@@ -194,6 +195,7 @@ object FlareDisplay {
         SOS("§5SOS Flare", "+125%"),
         ALERT("§9Alert Flare", "+50%"),
         WARNING("§aWarning Flare", null),
+        ;
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
@@ -100,7 +100,7 @@ object FlareDisplay {
                     }
                 }
             }
-            if (remainingTime > 5.seconds || remainingTime < 0.seconds) continue
+            if (remainingTime > 5.seconds || remainingTime <= 0.seconds) continue
             val message = "$name §eexpires in: §b${remainingTime.inWholeSeconds}s"
             when (config.alertType) {
                 FlareConfig.AlertType.CHAT -> {
@@ -125,7 +125,7 @@ object FlareDisplay {
     private fun getRemainingTime(flare: Flare): Duration {
         val entity = flare.entity
         val aliveTime = entity.ticksExisted.ticks
-        val remainingTime = (MAX_FLARE_TIME - aliveTime)
+        val remainingTime = (MAX_FLARE_TIME - aliveTime).coerceAtLeast(Duration.ZERO)
         return remainingTime
     }
 


### PR DESCRIPTION
## What
Fixes flare display spamming chat with negative with Negative numbers, now will stop at 0

<details>
<summary>Images</summary>

<!-- drop images here -->
![image](https://github.com/user-attachments/assets/9b7d75d9-b69f-40d0-bf75-bb26ae5cdddf)

</details>

## Changelog Fixes
+ Fixed Flare Display spamming chat with negative values when the server is lagging. - Stella