### PR TITLE
Fix: Great Glacite Lake detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -41,7 +41,7 @@ import kotlin.time.Duration.Companion.seconds
 object MiningAPI {
 
     private val group = RepoPattern.group("data.miningapi")
-    private val glaciteAreaPattern by group.pattern("area.glacite", "Glacite Tunnels|Glacite Lake")
+    private val glaciteAreaPattern by group.pattern("area.glacite", "Glacite Tunnels|Great Glacite Lake")
     private val dwarvenBaseCampPattern by group.pattern("area.basecamp", "Dwarven Base Camp")
 
     // TODO rename to include suffix "pattern", add regex test

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordLocationKey.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordLocationKey.kt
@@ -159,7 +159,7 @@ object DiscordLocationKey {
 
         "Dwarven Base Camp" to "glacite-tunnels",
         "Fossil Research Center" to "glacite-tunnels",
-        "Glacite Lake" to "glacite-tunnels",
+        "Great Glacite Lake" to "glacite-tunnels",
         "Glacite Mineshafts" to "glacite-tunnels",
     ) // maps sublocations to their broader image
 


### PR DESCRIPTION
## What
Fixes 2 instances of "Glacite Lake" being used instead of "Great Glacite Lake" (was renamed in the Modernized Mining update).

## Changelog Fixes
+ Fixed the Great Glacite Lake not being recognized as the Glacite Tunnels. - MTOnline

