### PR TITLE
Fix: Mining Commissions Blocks Color connected textures v2

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinOptifineConnectedTextures.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinOptifineConnectedTextures.java
@@ -16,8 +16,8 @@ public class MixinOptifineConnectedTextures {
         return OptifineConnectedTexturesHookKt.modifyConnectedTexturesBlockState(state);
     }
 
-    @ModifyArg(method = "getConnectedTexture", at = @At(value = "INVOKE", target = "skipConnectedTexture"))
-    private static IBlockState modifySkipConnectedTexture(IBlockState state) {
+    @ModifyArg(method = "isNeighbour", at = @At(value = "INVOKE", target = "isNeighbour"), index = 4)
+    private static IBlockState modifyIsNeighbour(IBlockState state) {
         return OptifineConnectedTexturesHookKt.modifyConnectedTexturesBlockState(state);
     }
 }


### PR DESCRIPTION
## What
Make it so you can have your connected textures and this colouring feature

## Changelog Fixes
+ Fixed "Mining Commissions Block Color" causing OptiFine connected textures not to connect properly. - nopo