### PR TITLE
Improvement: Option to hide all Tooltips inside of Excavator

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/ExcavatorTooltipHiderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/ExcavatorTooltipHiderConfig.java
@@ -1,0 +1,21 @@
+package at.hannibal2.skyhanni.config.features.mining;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+public class ExcavatorTooltipHiderConfig {
+
+    @Expose
+    @ConfigOption(name = "Hide Excavator Tooltips", desc = "Hides tooltips of the Dirt inside of the Fossil Excavator.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hideExcavatorTooltips = true;
+
+    @Expose
+    @ConfigOption(name = "Hide all Excavator Tooltips", desc = "Hide all tooltips inside inside of the Fossil Excavator.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hideAllExcavatorTooltips = false;
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/ExcavatorTooltipHiderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/ExcavatorTooltipHiderConfig.java
@@ -8,14 +8,14 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 public class ExcavatorTooltipHiderConfig {
 
     @Expose
-    @ConfigOption(name = "Hide Excavator Tooltips", desc = "Hides tooltips of the Dirt inside of the Fossil Excavator.")
+    @ConfigOption(name = "Hide Dirt", desc = "Hides tooltips of the Dirt inside of the Fossil Excavator.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean hideExcavatorTooltips = true;
+    public boolean hideDirt = true;
 
     @Expose
-    @ConfigOption(name = "Hide all Excavator Tooltips", desc = "Hide all tooltips inside inside of the Fossil Excavator.")
+    @ConfigOption(name = "Hide Everything", desc = "Hide all tooltips inside of the Fossil Excavator.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean hideAllExcavatorTooltips = false;
+    public boolean hideEverything = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/FossilExcavatorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/FossilExcavatorConfig.java
@@ -19,6 +19,11 @@ public class FossilExcavatorConfig {
     public ExcavatorProfitTrackerConfig profitTracker = new ExcavatorProfitTrackerConfig();
 
     @Expose
+    @ConfigOption(name = "Excavator Tooltip Hider", desc = "")
+    @Accordion
+    public ExcavatorTooltipHiderConfig tooltipHider = new ExcavatorTooltipHiderConfig();
+
+    @Expose
     @ConfigOption(
         name = "Profit per Excavation",
         desc = "Show profit/loss in chat after each excavation. Also includes breakdown information on hover."
@@ -36,12 +41,4 @@ public class FossilExcavatorConfig {
     @FeatureToggle
     public boolean glacitePowderStack = false;
 
-    @Expose
-    @ConfigOption(
-        name = "Hide Excavator Tooltips",
-        desc = "Hides tooltips of items inside of the Fossil Excavator."
-    )
-    @ConfigEditorBoolean
-    @FeatureToggle
-    public boolean hideExcavatorTooltips = true;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorTooltipHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorTooltipHider.kt
@@ -3,18 +3,27 @@ package at.hannibal2.skyhanni.features.mining.fossilexcavator
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.inventory.ContainerLocalMenu
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
 object ExcavatorTooltipHider {
 
-    private val config get() = SkyHanniMod.feature.mining.fossilExcavator
+    private val config get() = SkyHanniMod.feature.mining.fossilExcavator.tooltipHider
+
+    private val dirtPattern by RepoPattern.pattern(
+        "excavator.dirt.name",
+        "§6Dirt"
+    )
 
     @SubscribeEvent
     fun onTooltip(event: LorenzToolTipEvent) {
         if (!isEnabled()) return
+
         if (event.slot.inventory !is ContainerLocalMenu) return
+        if (!(dirtPattern.matches(event.itemStack.displayName)) && !config.hideAllExcavatorTooltips) return
         event.cancel()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorTooltipHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorTooltipHider.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.mining.fossilexcavator
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.inventory.ContainerLocalMenu
@@ -13,9 +14,12 @@ object ExcavatorTooltipHider {
 
     private val config get() = SkyHanniMod.feature.mining.fossilExcavator.tooltipHider
 
+    /**
+     * REGEX-TEST: §6Dirt
+     */
     private val dirtPattern by RepoPattern.pattern(
         "excavator.dirt.name",
-        "§6Dirt"
+        "§6Dirt",
     )
 
     @SubscribeEvent
@@ -23,9 +27,18 @@ object ExcavatorTooltipHider {
         if (!isEnabled()) return
 
         if (event.slot.inventory !is ContainerLocalMenu) return
-        if (!(dirtPattern.matches(event.itemStack.displayName)) && !config.hideAllExcavatorTooltips) return
-        event.cancel()
+        if (config.hideEverything) {
+            event.cancel()
+            return
+        }
+
+        if (config.hideDirt) {
+            val isDirt = dirtPattern.matches(event.itemStack.name)
+            if (isDirt) {
+                event.cancel()
+            }
+        }
     }
 
-    fun isEnabled() = FossilExcavatorAPI.inInventory && !FossilExcavatorAPI.inExcavatorMenu && config.hideExcavatorTooltips
+    fun isEnabled() = FossilExcavatorAPI.inInventory && !FossilExcavatorAPI.inExcavatorMenu
 }


### PR DESCRIPTION
## What
Adds a config option to hide all tooltips inside of the Excavator instead of only the dirt. 

## Changelog Improvements
+ Added an option to hide all tooltips inside the Fossil Excavator. - Cuz_Im_Clicks