### PR TITLE
Fix: Hard Stone in Crystal Hollows misdetected as Mithril

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -30,7 +30,7 @@ enum class OreBlock(
     // MITHRIL
     LOW_TIER_MITHRIL(
         checkBlock = ::isLowTierMithril,
-        checkArea = { inDwarvenMines || inCrystalHollows || inGlacite },
+        checkArea = { inDwarvenMines || inGlacite },
     ),
     MID_TIER_MITHRIL(
         checkBlock = { it.block == Blocks.prismarine },


### PR DESCRIPTION
## What
Fixed Gray Wool and Cyan Hardened Clay in the Crystal Hollows being misdetected as Low Tier Mithril instead of Hard Stone.

## Changelog Fixes
+ Fixed some blocks in the Crystal Hollows being detected as Mithril instead of Hard Stone. - Luna
