### PR TITLE
Improvement: Make Default GfS always on

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackAPI.kt
@@ -173,8 +173,6 @@ object GetFromSackAPI {
         // The last parameter could be "2*3". This does not support ending with ")", but it is good enough
         val argsNull = !args.last().last().isDigit()
         val arguments = if (argsNull) {
-            if (!config.defaultGFS) return CommandResult.WRONG_ARGUMENT to null
-
             args + config.defaultAmountGFS.toString()
         } else args
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.java
@@ -26,11 +26,6 @@ public class GetFromSackConfig {
     public boolean superCraftGFS = true;
 
     @Expose
-    @ConfigOption(name = "Default GfS", desc = "If you don't provide an amount, a default one will be used instead. Queued GfS needs to be on in order for this to work.")
-    @ConfigEditorBoolean
-    public boolean defaultGFS = false;
-
-    @Expose
     @ConfigOption(name = "Default Amount GfS", desc = "The default amount of items used when an amount isn't provided.")
     @ConfigEditorSlider(minValue = 1, maxValue = 64, minStep = 1)
     public int defaultAmountGFS = 1;


### PR DESCRIPTION
## What
Default GfS is now always on. Hypixel added this to their `/gfs` command, so it makes sense for us to do so too.

## Changelog Improvements
+ Queued GfS will now always fall back to a default amount if one is not specified. - Luna

