### PR TITLE
Fix: Update radius for Sulphur Skitter to 4 blocks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/SulphurSkitterBox.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/SulphurSkitterBox.kt
@@ -29,7 +29,7 @@ object SulphurSkitterBox {
     private val config get() = SkyHanniMod.feature.fishing.trophyFishing.sulphurSkitterBox
     private var spongeBlocks = listOf<BlockPos>()
     private var closestBlock: BlockPos? = null
-    private const val RADIUS = 8
+    private const val RADIUS = 4
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {


### PR DESCRIPTION
## What
Sulphur Skitter radius was changed from 8 to 4 in SkyBlock 0.20.6. This PR updates the radius in the code.

## Changelog Fixes
+ Fixed Sulphur Skitter Box radius. - Luna
    * Hypixel changed it from 8 to 4 blocks.