### PR TITLE
Fix: Race Condition in Hoppity Duplicate Number & Stray no-fire

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
@@ -106,11 +106,13 @@ object HoppityAPI {
                 when (groupOrNull("name") ?: return@matchMatcher) {
                     "Fish the Rabbit" -> {
                         EggFoundEvent(STRAY, it.slotNumber, null).post()
+                        lastName = "§9Fish the Rabbit"
                         lastMeal = STRAY
                         attemptFireRabbitFound()
                     }
                     "El Dorado" -> {
                         EggFoundEvent(STRAY, it.slotNumber, null).post()
+                        lastName = "§6El Dorado"
                         lastMeal = STRAY
                         attemptFireRabbitFound()
                     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.events.hoppity.RabbitFoundEvent
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggType.CHOCOLATE_FACTORY_MILESTONE
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggType.CHOCOLATE_SHOP_MILESTONE
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggType.SIDE_DISH
+import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggType.STRAY
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggsManager.eggFoundPattern
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggsManager.getEggType
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
@@ -103,8 +104,16 @@ object HoppityAPI {
             ChocolateFactoryStrayTracker.strayCaughtPattern.matchMatcher(it.stack.displayName) {
                 ChocolateFactoryStrayTracker.handleStrayClicked(it)
                 when (groupOrNull("name") ?: return@matchMatcher) {
-                    "Fish the Rabbit" -> EggFoundEvent(HoppityEggType.STRAY, it.slotNumber, null).post()
-                    "El Dorado" -> EggFoundEvent(HoppityEggType.STRAY, it.slotNumber, null).post()
+                    "Fish the Rabbit" -> {
+                        EggFoundEvent(STRAY, it.slotNumber, null).post()
+                        lastMeal = STRAY
+                        attemptFireRabbitFound()
+                    }
+                    "El Dorado" -> {
+                        EggFoundEvent(STRAY, it.slotNumber, null).post()
+                        lastMeal = STRAY
+                        attemptFireRabbitFound()
+                    }
                     else -> return@matchMatcher
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -95,7 +95,7 @@ object HoppityEggsCompactChat {
             } ?: "?"
 
             val dupeNumberFormat = if (eventConfig.showDuplicateNumber) {
-                (HoppityCollectionStats.getRabbitCount(this.lastName) - 1).takeIf { it > 1}?.let {
+                (HoppityCollectionStats.getRabbitCount(this.lastName)).takeIf { it > 0 }?.let {
                     " §7(§b#$it§7)"
                 } ?: ""
             } else ""

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -25,6 +25,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.now
 import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.regex.Matcher
 import kotlin.time.Duration.Companion.minutes
@@ -120,9 +121,11 @@ object HoppityEggsManager {
         lastNote = event.note
     }
 
-    @HandleEvent
+    @HandleEvent(priority = HandleEvent.LOWEST)
     fun onRabbitFound(event: RabbitFoundEvent) {
-        HoppityCollectionStats.incrementRabbitCount(event.rabbitName)
+        DelayedRun.runDelayed(1.seconds) {
+            HoppityCollectionStats.incrementRabbitCount(event.rabbitName)
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBarnManager.kt
@@ -62,7 +62,7 @@ object ChocolateFactoryBarnManager {
             HoppityAPI.attemptFireRabbitFound(lastDuplicateAmount = amount)
 
             if (hoppityConfig.showDuplicateNumber && !hoppityConfig.compactChat) {
-                (HoppityCollectionStats.getRabbitCount(HoppityAPI.getLastRabbit()) - 1).takeIf { it > 1 }?.let {
+                (HoppityCollectionStats.getRabbitCount(HoppityAPI.getLastRabbit())).takeIf { it > 0 }?.let {
                     event.chatComponent = ChatComponentText(
                         event.message.replace("§7§lDUPLICATE RABBIT!", "§7§lDUPLICATE RABBIT! §7(Duplicate §b#$it§7)§r"),
                     )


### PR DESCRIPTION
## What
Because both incrementing the stats number, and editing of chat messages both rely on the HoppityAPI for their driving logic, there was a seemingly indeterminate race condition that would cause these numbers to be off-by-one at random.

[Here](https://discord.com/channels/997079228510117908/1234043917792579604/1288567689131986986) and down is a conversation where it's pretty consistently off-by-one, but I could not replicate this issue, and the config numbers were "right", but the chat message wasn't 🤷

Just delaying the increment by a second, and removing the `-1` on the get that's called, which should absolutely ensure it's at least using the latest stats. It could still be wrong if the stats are out of sync, but it now should be _consistently wrong_, if wrong at all.

This PR also fixes the fact that Stray rabbits would not fire a `RabbitFoundEvent()`, which would cause the Hoppity stats for Fish the Rabbit and El Dorado to go out of sync.

## Changelog Fixes
+ Fixed inconsistencies in Hoppity Duplicate Number counts. - Daveed

