### PR TITLE
Fix: Broodmother countdown when imminent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -150,6 +150,9 @@ object BroodmotherFeatures {
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isCountdownEnabled()) return
         if (display.isEmpty()) return
+        if (broodmotherSpawnTime.isInPast() && !broodmotherSpawnTime.isFarPast()) {
+            display = "§4Broodmother spawning now!"
+        }
 
         config.countdownPosition.renderString(display, posLabel = "Broodmother Countdown")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -70,14 +70,14 @@ object BroodmotherFeatures {
             return
         }
 
+        val lastStage = lastStage ?: return
+        val timeUntilSpawn = currentStage?.minutes?.minutes ?: return
+        broodmotherSpawnTime = SimpleTimeMark.now() + timeUntilSpawn
+
         if (currentStage == StageEntry.IMMINENT && config.imminentWarning) {
             playImminentWarning()
             return
         }
-
-        val lastStage = lastStage ?: return
-        val timeUntilSpawn = currentStage?.minutes?.minutes ?: return
-        broodmotherSpawnTime = SimpleTimeMark.now() + timeUntilSpawn
 
         if (currentStage !in config.stages) return
         if (currentStage == StageEntry.SLAIN) {
@@ -158,10 +158,8 @@ object BroodmotherFeatures {
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!isCountdownEnabled()) return
 
-        if (broodmotherSpawnTime.isFarPast()) {
-            if (lastStage != null && currentStage == StageEntry.ALIVE) {
-                display = "§4Broodmother spawned!"
-            }
+        if (broodmotherSpawnTime.isFarPast() && currentStage == StageEntry.ALIVE) {
+            display = "§4Broodmother spawned!"
         } else {
             val countdown = broodmotherSpawnTime.timeUntil().format()
             display = "§4Broodmother spawning in §b$countdown"

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -50,7 +50,7 @@ object BroodmotherFeatures {
     fun onTabListUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.BROODMOTHER)) return
         val newStage = event.widget.matchMatcherFirstLine { group("stage") } ?: ""
-        if (newStage.isNotEmpty()) {
+        if (newStage.isNotEmpty() && newStage != lastStage.toString()) {
             lastStage = currentStage
             currentStage = StageEntry.valueOf(newStage.replace("!", "").uppercase())
             onStageUpdate()
@@ -60,7 +60,7 @@ object BroodmotherFeatures {
     private fun onStageUpdate() {
         ChatUtils.debug("New Broodmother stage: $currentStage")
 
-        if (lastStage == null && onServerJoin()) return
+        if (onServerJoin()) return
 
         // ignore Hypixel bug where the stage may temporarily revert to Imminent after the Broodmother's death
         if (currentStage == StageEntry.IMMINENT && lastStage == StageEntry.ALIVE) return
@@ -91,9 +91,10 @@ object BroodmotherFeatures {
     }
 
     private fun onServerJoin(): Boolean {
+        if (lastStage != null || !config.stageOnJoin) return false
         // don't send if user has config enabled for either of the alive messages
         // this is so that two messages aren't immediately sent upon joining a server
-        if (config.stageOnJoin && !(currentStage == StageEntry.ALIVE && isAliveMessageEnabled())) {
+        if (!(currentStage == StageEntry.ALIVE && isAliveMessageEnabled())) {
             val pluralize = StringUtils.pluralize(currentStage?.minutes ?: 0, "minute")
             var message = "The Broodmother's current stage in this server is ${currentStage.toString().replace("!", "")}§e."
             if (currentStage?.minutes != 0) {
@@ -101,9 +102,8 @@ object BroodmotherFeatures {
             }
             ChatUtils.chat(message)
             return true
-        } else {
-            return false
         }
+        return false
     }
 
     private fun onBroodmotherSpawn() {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -158,8 +158,10 @@ object BroodmotherFeatures {
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!isCountdownEnabled()) return
 
-        if (broodmotherSpawnTime.isFarPast() && currentStage == StageEntry.ALIVE) {
-            display = "§4Broodmother spawned!"
+        if (broodmotherSpawnTime.isFarPast()) {
+            if (currentStage == StageEntry.ALIVE) {
+                display = "§4Broodmother spawned!"
+            }
         } else {
             val countdown = broodmotherSpawnTime.timeUntil().format()
             display = "§4Broodmother spawning in §b$countdown"


### PR DESCRIPTION
## What
Fixes a simple issue where the Broodmother countdown wouldn't update at the Imminent stage if you had the "Imminent Warning" feature enabled. Also improves onServerJoin() logic and improves the countdown display so that it doesn't show negative seconds.

## Changelog Fixes
+ Fixed a case where the Imminent stage did not update the Broodmother countdown. - MTOnline