### PR TITLE
Backend: Detekt Fixes Part 1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -338,7 +338,7 @@ publishing.publications {
 }
 
 // Detekt: TODO: Uncomment this when we're ready to enforce
-/*detekt {
+detekt {
     buildUponDefaultConfig = true // preconfigure defaults
     config.setFrom(rootProject.layout.projectDirectory.file("detekt/detekt.yml")) // point to your custom config defining rules to run, overwriting default behavior
     baseline = file(layout.projectDirectory.file("detekt/baseline.xml")) // a way of suppressing issues before introducing detekt
@@ -361,4 +361,4 @@ tasks.withType<Detekt>().configureEach {
 tasks.withType<DetektCreateBaselineTask>().configureEach {
     jvmTarget = target.minecraftVersion.formattedJavaLanguageVersion
     outputs.cacheIf { false } // Custom rules won't work if cached
-}*/
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -338,7 +338,7 @@ publishing.publications {
 }
 
 // Detekt: TODO: Uncomment this when we're ready to enforce
-detekt {
+/*detekt {
     buildUponDefaultConfig = true // preconfigure defaults
     config.setFrom(rootProject.layout.projectDirectory.file("detekt/detekt.yml")) // point to your custom config defining rules to run, overwriting default behavior
     baseline = file(layout.projectDirectory.file("detekt/baseline.xml")) // a way of suppressing issues before introducing detekt
@@ -361,4 +361,4 @@ tasks.withType<Detekt>().configureEach {
 tasks.withType<DetektCreateBaselineTask>().configureEach {
     jvmTarget = target.minecraftVersion.formattedJavaLanguageVersion
     outputs.cacheIf { false } // Custom rules won't work if cached
-}
+}*/

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiForgeInterop.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiForgeInterop.kt
@@ -12,6 +12,7 @@ import java.io.IOException
 @Suppress("unused")
 class ConfigGuiForgeInterop : IModGuiFactory {
 
+    @Suppress("EmptyFunctionBlock")
     override fun initialize(minecraft: Minecraft) {}
     override fun mainConfigGuiClass() = WrappedSkyHanniConfig::class.java
 

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -182,7 +182,7 @@ class ConfigManager {
                         try {
                             run()
                         } catch (e: Throwable) {
-                            e.printStackTrace()
+                            logger.log(e.stackTraceToString())
                             LorenzUtils.shutdownMinecraft("Config is corrupt inside development environment.")
                         }
                     } else {
@@ -194,7 +194,7 @@ class ConfigManager {
 
                 logger.log("Loaded $fileName from file")
             } catch (e: Exception) {
-                e.printStackTrace()
+                logger.log(e.stackTraceToString())
                 val backupFile = file.resolveSibling("$fileName-${SimpleTimeMark.now().toMillis()}-backup.json")
                 logger.log("Exception while reading $file. Will load blank $fileName and save backup to $backupFile")
                 logger.log("Exception was $e")
@@ -202,7 +202,7 @@ class ConfigManager {
                     file.copyTo(backupFile)
                 } catch (e: Exception) {
                     logger.log("Could not create backup for $fileName file")
-                    e.printStackTrace()
+                    logger.log(e.stackTraceToString())
                 }
             }
         }
@@ -239,7 +239,7 @@ class ConfigManager {
             move(unit, file, reason)
         } catch (e: IOException) {
             logger.log("Could not save $fileName file to $file")
-            e.printStackTrace()
+            logger.log(e.stackTraceToString())
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -57,7 +57,7 @@ class GuiPositionEditor(
     }
 
     override fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
-        //Items aren't drawn due to a bug in neu rendering
+        // Items aren't drawn due to a bug in neu rendering
         drawDefaultBackground()
         if (oldScreen != null) {
             val accessor = oldScreen as AccessorGuiContainer

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -218,7 +218,7 @@ object HypixelData {
     // This code is modified from NEU, and depends on NEU (or another mod) sending /locraw.
     private val jsonBracketPattern = "^\\{.+}".toPattern()
 
-    //todo convert to proper json object
+    // todo convert to proper json object
     fun checkForLocraw(message: String) {
         jsonBracketPattern.matchMatcher(message.removeColor()) {
             try {

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -165,7 +165,6 @@ object MiningAPI {
     fun onBlockClick(event: BlockClickEvent) {
         if (!inCustomMiningIsland()) return
         if (event.clickType != ClickType.LEFT_CLICK) return
-        //println(event.getBlockState.properties)
         if (OreBlock.getByStateOrNull(event.getBlockState) == null) return
         recentClickedBlocks += event.position to SimpleTimeMark.now()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -27,7 +27,7 @@ object ChatFilter {
     private val config get() = SkyHanniMod.feature.chat.filterType
     private val dungeonConfig get() = SkyHanniMod.feature.dungeon.messageFilter
 
-    /// <editor-fold desc="Regex Patterns & Messages">
+    // <editor-fold desc="Regex Patterns & Messages">
     // Lobby Messages
     private val lobbyPatterns = listOf(
         // player join
@@ -89,15 +89,19 @@ object ChatFilter {
     )
 
     // Guild EXP
+    /**
+     * REGEX-TEST: §aYou earned §r§22 GEXP §r§afrom playing SkyBlock!
+     * REGEX-TEST: §aYou earned §r§22 GEXP §r§a+ §r§c210 Event EXP §r§afrom playing SkyBlock!
+     */
     private val guildExpPatterns = listOf(
-        // §aYou earned §r§22 GEXP §r§afrom playing SkyBlock!
-        // §aYou earned §r§22 GEXP §r§a+ §r§c210 Event EXP §r§afrom playing SkyBlock!
         "§aYou earned §r§2.* GEXP (§r§a\\+ §r§.* Event EXP )?§r§afrom playing SkyBlock!".toPattern(),
     )
 
     // Kill Combo
+    /**
+     * REGEX-TEST: §a§l+5 Kill Combo §r§8+§r§b3% §r§b? Magic Find
+     */
     private val killComboPatterns = listOf(
-        //§a§l+5 Kill Combo §r§8+§r§b3% §r§b? Magic Find
         "§.§l\\+(.*) Kill Combo (.*)".toPattern(),
         "§cYour Kill Combo has expired! You reached a (.*) Kill Combo!".toPattern(),
     )
@@ -500,7 +504,7 @@ object ChatFilter {
         "slayer" to slayerMessageStartWith,
         "profile_join" to profileJoinMessageStartsWith,
     )
-    /// </editor-fold>
+    // </editor-fold>
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -275,7 +275,7 @@ object PowderMiningChatFilter {
         // To simplify regex statements, this check is done outside
         val ssMessage = message.takeIf { it.startsWith("    ") }?.substring(4) ?: return null
 
-        //Powder
+        // Powder
         powderRewardPattern.matchMatcher(ssMessage) {
             if (config.powderFilterThreshold == 60000) return "powder_mining_powder"
             val amountStr = groupOrNull("amount") ?: "1"
@@ -286,7 +286,7 @@ object PowderMiningChatFilter {
             }
         }
 
-        //Essence
+        // Essence
         essenceRewardPattern.matchMatcher(ssMessage) {
             if (config.essenceFilterThreshold == 20) return "powder_mining_essence"
             val amountStr = groupOrNull("amount") ?: "1"
@@ -301,11 +301,11 @@ object PowderMiningChatFilter {
         blockGoblinEggs(ssMessage)?.let { return it }
         blockGemstones(ssMessage)?.let { return it }
 
-        //Fallback default
+        // Fallback default
         return null
     }
 
-    var rewardPatterns: Map<Pair<Pattern, PowderMiningFilterConfig.SimplePowderMiningRewardTypes>, String> = emptyMap()
+    private var rewardPatterns: Map<Pair<Pattern, PowderMiningFilterConfig.SimplePowderMiningRewardTypes>, String> = emptyMap()
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     fun onRepoReload(event: RepositoryReloadEvent) {
@@ -339,7 +339,7 @@ object PowderMiningChatFilter {
             if (config.goblinEggs == PowderMiningFilterConfig.GoblinEggFilterEntry.HIDE_ALL) return "powder_mining_goblin_eggs"
 
             return when (val colorStr = groupOrNull("color")?.lowercase()) {
-                //'Colorless', base goblin eggs will never be shown in this code path
+                // 'Colorless', base goblin eggs will never be shown in this code path
                 null -> "powder_mining_goblin_eggs"
                 "green" -> if (config.goblinEggs > PowderMiningFilterConfig.GoblinEggFilterEntry.GREEN_UP) {
                     "powder_mining_goblin_eggs"
@@ -380,7 +380,7 @@ object PowderMiningChatFilter {
                 "amethyst" -> gemstoneConfig.amethystGemstones
                 "jade" -> gemstoneConfig.jadeGemstones
                 "topaz" -> gemstoneConfig.topazGemstones
-                //Failure case that should never be reached
+                // Failure case that should never be reached
                 else -> return "no_filter"
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/GetFromSacksTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/GetFromSacksTabComplete.kt
@@ -19,7 +19,7 @@ object GetFromSacksTabComplete {
         return GetFromSackAPI.sackListNames.map { it.replace(" ", "_") }
     }
 
-    //No subscribe since it needs to be called from the GetFromSackAPI
+    // No subscribe since it needs to be called from the GetFromSackAPI
     fun handleUnderlineReplace(event: MessageSendToServerEvent): MessageSendToServerEvent {
         if (!isEnabled()) return event
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonChatFilter.kt
@@ -16,7 +16,7 @@ object DungeonChatFilter {
 
     private val config get() = SkyHanniMod.feature.chat
 
-    /// <editor-fold desc="Patterns, Messages, and Maps">
+    // <editor-fold desc="Patterns, Messages, and Maps">
     // TODO USE SH-REPO
     private val endPatterns = listOf(
         "(.*) §r§eunlocked §r§d(.*) Essence §r§8x(.*)§r§e!".toPattern(),
@@ -140,9 +140,12 @@ object DungeonChatFilter {
     private val pickupMessages = listOf(
         "§fYou found a §r§dWither Essence§r§f! Everyone gains an extra essence!"
     )
+
+    /**
+     * REGEX-TEST: §a[Berserk] §r§fMelee Damage §r§c48%§r§f -> §r§a88%
+     * REGEX-TEST: §a[Berserk] §r§fWalk Speed §r§c38§r§f -> §r§a68
+     */
     private val startPatterns = listOf(
-        //§a[Berserk] §r§fMelee Damage §r§c48%§r§f -> §r§a88%
-        //§a[Berserk] §r§fWalk Speed §r§c38§r§f -> §r§a68
         "§a(.*) §r§f(.*) §r§c(.*)§r§f -> §r§a(.*)".toPattern()
     )
     private val startMessages = listOf(
@@ -188,7 +191,7 @@ object DungeonChatFilter {
     private val messagesEndsWithMap: Map<MessageTypes, List<String>> = mapOf(
         MessageTypes.END to endMessagesEndWith,
     )
-    /// </editor-fold>
+    // </editor-fold>
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
@@ -34,6 +34,7 @@ object DungeonRankTabListColor {
             val sbLevel = group("sbLevel")
             val rank = groupOrNull("rank") ?: ""
             val playerName = group("playerName")
+            // val symbols = group("symbols")
             val className = group("className")
             val classLevel = group("classLevel")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonRankTabListColor.kt
@@ -34,7 +34,6 @@ object DungeonRankTabListColor {
             val sbLevel = group("sbLevel")
             val rank = groupOrNull("rank") ?: ""
             val playerName = group("playerName")
-            //val symbols = group("symbols")
             val className = group("className")
             val classLevel = group("classLevel")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -61,10 +61,10 @@ object CarnivalZombieShootout {
     )
 
     enum class ZombieType(val points: Int, val helmet: String, val color: Color) {
-        LEATHER(30, "Leather Cap", Color(165, 42, 42)), //Brown
-        IRON(50, "Iron Helmet", Color(192, 192, 192)), //Silver
-        GOLD(80, "Golden Helmet", Color(255, 215, 0)), //Gold
-        DIAMOND(120, "Diamond Helmet", Color(44, 214, 250)) //Diamond
+        LEATHER(30, "Leather Cap", Color(165, 42, 42)), // Brown
+        IRON(50, "Iron Helmet", Color(192, 192, 192)), // Silver
+        GOLD(80, "Golden Helmet", Color(255, 215, 0)), // Gold
+        DIAMOND(120, "Diamond Helmet", Color(44, 214, 250)) // Diamond
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -262,7 +262,7 @@ object HoppityCollectionStats {
                     else -> "" // Never happens
                 }
 
-                //List indexing is weird
+                // List indexing is weird
                 existingLore[replaceIndex - 1] = "§7Obtained by $operationFormat §6$displayAmount"
                 existingLore[replaceIndex] = "§7all-time §6Chocolate."
                 return existingLore

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -372,7 +372,7 @@ object FarmingWeightDisplay {
     private fun isEtaEnabled() = config.overtakeETA
 
     fun addCrop(crop: CropType, addedCounter: Int) {
-        //Prevent div-by-0 errors
+        // Prevent div-by-0 errors
         if (addedCounter == 0) return;
 
         val before = getExactWeight()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -373,7 +373,7 @@ object FarmingWeightDisplay {
 
     fun addCrop(crop: CropType, addedCounter: Int) {
         // Prevent div-by-0 errors
-        if (addedCounter == 0) return;
+        if (addedCounter == 0) return
 
         val before = getExactWeight()
         localCounter[crop] = crop.getLocalCounter() + addedCounter

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
@@ -112,8 +112,8 @@ object CaptureFarmingGear {
         val currentCrop = itemStack.getCropType()
 
         if (currentCrop == null) {
-            //todo better fall back items
-            //todo Daedalus axe
+            // todo better fall back items
+            // todo Daedalus axe
         } else {
             currentCrop.farmingItem.setItem(itemStack)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/pages/OverviewPage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/pages/OverviewPage.kt
@@ -21,7 +21,7 @@ class OverviewPage(sizeX: Int, sizeY: Int, paddingX: Int = 15, paddingY: Int = 7
         update(content, footer)
     }
 
-    //TODO split up this 240 lines function
+    // TODO split up this 240 lines function
     fun getPage(): Pair<List<List<Renderable>>, List<Renderable>> {
         val content = mutableListOf<MutableList<Renderable>>()
         val footer = mutableListOf<Renderable>()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorCompactChat.kt
@@ -82,10 +82,10 @@ object GardenVisitorCompactChat {
             visitorNameFormatted = "$visitorColor$visitorName"
         }
 
-        //If visitor name has not yet been matched, we aren't looking at a visitor accept message, and can ignore this.
+        // If visitor name has not yet been matched, we aren't looking at a visitor accept message, and can ignore this.
         if (visitorNameFormatted.isBlank()) return;
 
-        //Match rewards and transform
+        // Match rewards and transform
         visitorRewardPattern.matchMatcher(transformedMessage) {
             val rewardColor = groupOrNull("rewardcolor")
             val amountColor = groupOrNull("amountcolor")
@@ -105,7 +105,7 @@ object GardenVisitorCompactChat {
                 if (altAmount == null) "" else "$altAmount "
             }
 
-            //Don't add name for copper, farming XP, garden XP, or bits
+            // Don't add name for copper, farming XP, garden XP, or bits
             val rewardString = if (discardRewardNamePattern.matcher(reward).matches()) "" else reward
 
             rewardsList.add(
@@ -127,7 +127,7 @@ object GardenVisitorCompactChat {
     }
 
     private fun sendCompact() {
-        //This prevents commission rewards, crop milestone data, etc. from triggering incorrectly
+        // This prevents commission rewards, crop milestone data, etc. from triggering incorrectly
         if (visitorNameFormatted.isBlank()) return;
 
         if (visitorAcceptedChat.isNotEmpty()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorCompactChat.kt
@@ -83,7 +83,7 @@ object GardenVisitorCompactChat {
         }
 
         // If visitor name has not yet been matched, we aren't looking at a visitor accept message, and can ignore this.
-        if (visitorNameFormatted.isBlank()) return;
+        if (visitorNameFormatted.isBlank()) return
 
         // Match rewards and transform
         visitorRewardPattern.matchMatcher(transformedMessage) {
@@ -128,7 +128,7 @@ object GardenVisitorCompactChat {
 
     private fun sendCompact() {
         // This prevents commission rewards, crop milestone data, etc. from triggering incorrectly
-        if (visitorNameFormatted.isBlank()) return;
+        if (visitorNameFormatted.isBlank()) return
 
         if (visitorAcceptedChat.isNotEmpty()) {
             ChatUtils.hoverableChat(createCompactVisitorMessage(), hover = visitorAcceptedChat, prefix = false)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
@@ -228,7 +228,7 @@ object GardenVisitorDropStatistics {
         return "$amount"
     }
 
-    //todo this should just save when changed not once a second
+    // todo this should just save when changed not once a second
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {
         saveAndUpdate()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -148,7 +148,7 @@ object ItemPickupLog {
 
             if (cursorItem != null) {
                 val hash = cursorItem.hash()
-                //this prevents items inside hypixel guis counting when picked up
+                // this prevents items inside hypixel guis counting when picked up
                 if (oldItemList.contains(hash)) {
                     inventoryItems.add(cursorItem)
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
@@ -379,8 +379,6 @@ object ReforgeHelper {
                 colorReforgeStone(hoverColor, hoveredReforge?.rawReforgeStoneName ?: "Random Basic Reforge")
             } else {
                 inventoryContainer?.getSlot(reforgeItem)?.highlight(hoverColor)
-
-                //?.get(reforgeItem)?. = hoverColor
             }
             hoveredReforge = null
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SackDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SackDisplay.kt
@@ -153,7 +153,7 @@ object SackDisplay {
                             ),
                         )
                     )
-                    //TOOD add cache
+                    // TODO add cache
                     addItemStack("MAGMA_FISH".asInternalName())
                 }
                 if (config.showPrice && price != 0L) addAlignedNumber("§6${format(price)}")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryCustomReminder.kt
@@ -61,6 +61,8 @@ object ChocolateFactoryCustomReminder {
 
     /**
      * REGEX-TEST: §cYou don't have enough Chocolate!
+     * REGEX-TEST: §cYou don't have the required items!
+     * REGEX-TEST: §cYou must collect 300B all-time Chocolate!
      */
     private val chatMessagePattern by patternGroup.list(
         "chat.hide",
@@ -74,11 +76,7 @@ object ChocolateFactoryCustomReminder {
         if (!isEnabled()) return
         if (!ChocolateFactoryAPI.inChocolateFactory) return
         if (configReminder.hideChat) {
-
             if (chatMessagePattern.matches(event.message)) {
-                //§cYou don't have the required items!
-                //§cYou must collect 300B all-time Chocolate!
-//             if (event.message == "§cYou don't have enough Chocolate!") {
                 event.blockedReason = "custom_reminder"
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTracker.kt
@@ -204,14 +204,14 @@ object ChocolateFactoryStrayTracker {
 
         // "Base" strays - Common -> Epic, raw choc only reward.
         strayLorePattern.matchMatcher(loreLine) {
-            //Pretty sure base strays max at Epic, but...
+            // Pretty sure base strays max at Legendary, but...
             val rarity = HoppityAPI.rarityByRabbit(group("rabbit")) ?: return@matchMatcher
             incrementRarity(rarity, group("amount").formatLong())
         }
 
         // Fish the Rabbit
         fishTheRabbitPattern.matchMatcher(loreLine) {
-            //Also fairly sure that Fish maxes out at Rare, but...
+            // Also fairly sure that Fish maxes out at Rare, but...
             val rarity = HoppityAPI.rarityByRabbit(group("color")) ?: return@matchMatcher
             incrementRarity(rarity, group("amount").formatLong())
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -301,11 +301,6 @@ object MineshaftPityDisplay {
 
         GEMSTONE(
             "Gemstone",
-            /*listOf(
-                OreType.RUBY, OreType.AMBER, OreType.AMETHYST, OreType.JADE,
-                OreType.SAPPHIRE, OreType.TOPAZ, OreType.JASPER, OreType.OPAL,
-                OreType.AQUAMARINE, OreType.CITRINE, OreType.ONYX, OreType.PERIDOT,
-            ),*/
             OreType.entries.filter { it.isGemstone() },
             4,
             ItemStack(Blocks.stained_glass, 1, EnumDyeColor.BLUE.metadata),

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -117,7 +117,7 @@ enum class OreBlock(
         checkArea = { inSpidersDen },
     ),
 
-    //END
+    // END
     END_STONE(
         checkBlock = { it.block == Blocks.end_stone },
         checkArea = { inEnd },

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -298,7 +298,7 @@ object MinionFeatures {
             System.currentTimeMillis() - lastClicked
         } ?: return "§cCan't calculate coins/day: No time data available!"
 
-        //§7Held Coins: §b151,389
+        // §7Held Coins: §b151,389
         // TODO use regex
         val coins = line.split(": §b")[1].formatDouble()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -738,7 +738,7 @@ object EstimatedItemValueCalculator {
         var totalPrice = 0.0
         val map = mutableMapOf<String, Double>()
 
-        //todo use repo
+        // todo use repo
         val tieredEnchants = listOf("compact", "cultivating", "champion", "expertise", "hecatomb", "toxophilite")
         val onlyTierOnePrices = listOf("ultimate_chimera", "ultimate_fatal_tempo", "smoldering", "ultimate_flash", "divine_gift")
         val onlyTierFivePrices = listOf("ferocious_mana", "hardened_mana", "mana_vampire", "strong_mana")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
@@ -94,8 +94,7 @@ open class Enchant : Comparable<Enchant> {
         return if (this.isUltimate()) -1 else 1
     }
 
-    class Normal : Enchant() {
-    }
+    class Normal : Enchant()
 
     class Ultimate : Enchant() {
         override fun getFormat(level: Int, itemStack: ItemStack?) = "§d§l"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/FeatureToggleProcessor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/FeatureToggleProcessor.kt
@@ -24,8 +24,8 @@ class FeatureToggleProcessor : ConfigStructureReader {
         latestCategory = Category(name, description)
     }
 
-    override fun endCategory() {
-    }
+    @Suppress("EmptyFunctionBlock")
+    override fun endCategory() {}
 
     override fun beginAccordion(baseObject: Any?, field: Field?, o: ConfigOption?, id: Int) {
         val option = o ?: return
@@ -86,6 +86,6 @@ class FeatureToggleProcessor : ConfigStructureReader {
         )
     }
 
-    override fun emitGuiOverlay(baseObject: Any?, field: Field?, option: ConfigOption?) {
-    }
+    @Suppress("EmptyFunctionBlock")
+    override fun emitGuiOverlay(baseObject: Any?, field: Field?, option: ConfigOption?) {}
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/RiftTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/RiftTimer.kt
@@ -53,7 +53,7 @@ object RiftTimer {
         currentTime = 0.seconds
     }
 
-    //todo use ActionBarValueUpdateEvent
+    // todo use ActionBarValueUpdateEvent
     @SubscribeEvent
     fun onActionBarUpdate(event: ActionBarUpdateEvent) {
         if (!isEnabled()) return

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -137,9 +137,8 @@ object SkyHanniDebugsAndTests {
         }
     }
 
-    private fun asyncTest(args: Array<String>) {
-
-    }
+    @Suppress("EmptyFunctionBlock")
+    private fun asyncTest(args: Array<String>) {}
 
     fun findNullConfig(args: Array<String>) {
         println("start null finder")
@@ -487,8 +486,8 @@ object SkyHanniDebugsAndTests {
     }
 
     @SubscribeEvent
-    fun onChat(event: LorenzChatEvent) {
-    }
+    @Suppress("EmptyFunctionBlock")
+    fun onChat(event: LorenzChatEvent) {}
 
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
@@ -600,7 +600,7 @@ object GraphEditor {
         ghostPosition = null
     }
 
-    private fun prune() { //TODO fix
+    private fun prune() { // TODO fix
         val hasNeighbours = nodes.associateWith { false }.toMutableMap()
         edges.forEach {
             hasNeighbours[it.node1] = true

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzLogger.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzLogger.kt
@@ -43,6 +43,7 @@ class LorenzLogger(filePath: String) {
         return initLogger
     }
 
+    @Suppress("PrintStackTrace")
     private fun initLogger(): Logger {
         val logger = Logger.getLogger("Lorenz-Logger-" + System.nanoTime())
         try {

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -64,6 +64,7 @@ object NEUItems {
             .registerTypeAdapter(
                 HypixelApiTrophyFish::class.java,
                 object : TypeAdapter<HypixelApiTrophyFish>() {
+                    @Suppress("EmptyFunctionBlock")
                     override fun write(out: JsonWriter, value: HypixelApiTrophyFish) {}
 
                     override fun read(reader: JsonReader): HypixelApiTrophyFish {

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUVersionCheck.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUVersionCheck.kt
@@ -52,6 +52,7 @@ object NEUVersionCheck {
     /**
      * Taken and modified from Skytils
      */
+    @Suppress("PrintStackTrace")
     private fun openPopupWindow(errorMessage: String, vararg options: Pair<String, String>) {
         try {
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -270,7 +270,7 @@ object StringUtils {
     }
 
     fun progressBar(percentage: Double, steps: Int = 24): Any {
-        //'§5§o§2§l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §f§l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §r §e348,144.3§6/§e936k'
+        // '§5§o§2§l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §f§l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §l§m §r §e348,144.3§6/§e936k'
         val prefix = "§5§o§2"
         val step = "§l§m "
         val missing = "§f"

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/GuiScreenUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/GuiScreenUtils.kt
@@ -47,7 +47,7 @@ object GuiScreenUtils {
     val mouseY: Int
         get() {
             val height = this.scaledWindowHeight
-            //TODO: in later versions the height - factor is removed, i think
+            // TODO: in later versions the height - factor is removed, i think
             val y = globalMouseY * height / displayHeight
 //#if MC < 1.16
             return height - y - 1

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
@@ -6,5 +6,4 @@ abstract class SkyhanniBaseScreen : GuiScreen(
     //#if MC > 1.12
     //$$ net.minecraft.network.chat.TextComponent.EMPTY
     //#endif
-) {
-}
+)


### PR DESCRIPTION
## What
Oooooh boy, here we go.
Fixes all instances of the following detektions:
- `CustomCommentSpacing`
- `EmptyElseBlock`
- `EmptyClassBlock`
- `EmptyFunctionBlock`
- `PrintStackTrace`

Detektion count down to 981 from 1050 at HEAD.

exclude_from_changelog

