### PR TITLE
Fix: Item category detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -20,14 +20,14 @@ object UtilsPatterns {
      **/
     val rarityLoreLinePattern by patternGroup.pattern(
         "item.lore.rarity.line",
-        "^(?:§.){2,3}(?:.§. (?:§.){4})?(?:SHINY )?(?<rarity>" +
+        "^(?:§.){2,3}(?:.§. (?:§.){2})?(?:SHINY )?(?<rarity>" +
             enumJoinToPattern<LorenzRarity> { it.name.replace("_", " ") } +
-            ") ?(?:DUNGEON )?(?<itemCategory>[^§]*)(?: (?:§.){3}.)?$"
+            ") ?(?:DUNGEON )?(?<itemCategory>[^§]*)(?: (?:§.){3}.)?$",
     )
 
     val abiPhonePattern by patternGroup.pattern(
         "item.name.abiphone",
-        ".{2}Abiphone .*"
+        ".{2}Abiphone .*",
     )
 
     /**
@@ -36,17 +36,17 @@ object UtilsPatterns {
      */
     val enchantedBookPattern by patternGroup.pattern(
         "item.name.enchanted.book",
-        "(?:§.)+Enchanted Book"
+        "(?:§.)+Enchanted Book",
     )
 
     val baitPattern by patternGroup.pattern(
         "item.name.bait",
-        "^(Obfuscated.*|.* Bait)$"
+        "^(Obfuscated.*|.* Bait)$",
     )
 
     val enchantmentNamePattern by patternGroup.pattern(
         "item.neuitems.enchantmentname",
-        "^(?<format>(?:§.)*)(?<name>[^§]+) (?<level>[IVXL]+)(?: Book)?$"
+        "^(?<format>(?:§.)*)(?<name>[^§]+) (?<level>[IVXL]+)(?: Book)?$",
     )
 
     /**
@@ -56,61 +56,61 @@ object UtilsPatterns {
      */
     val cleanEnchantedNamePattern by patternGroup.pattern(
         "item.enchantment.clean.name",
-        "(?i)(?<name>.*) (?<level>[IVXL]+|[0-9]+)"
+        "(?i)(?<name>.*) (?<level>[IVXL]+|[0-9]+)",
     )
 
     val potionPattern by patternGroup.pattern(
         "item.name.potion",
-        ".*Potion"
+        ".*Potion",
     )
     val readAmountBeforePattern by patternGroup.pattern(
         "item.amount.front",
-        "(?: +§8(?:\\+§.)?(?<amount>[\\d.,]+[km]?)x? )?(?<name>.*)"
+        "(?: +§8(?:\\+§.)?(?<amount>[\\d.,]+[km]?)x? )?(?<name>.*)",
     )
     val readAmountAfterPattern by patternGroup.pattern(
         "item.amount.behind",
-        "(?<name>(?:§.)*(?:[^§] ?)+)(?:§8x(?<amount>[\\d,]+))?"
+        "(?<name>(?:§.)*(?:[^§] ?)+)(?:§8x(?<amount>[\\d,]+))?",
     )
     val costLinePattern by patternGroup.pattern(
         "item.cost.line",
-        "(?:§5§o)?§7Cost.*"
+        "(?:§5§o)?§7Cost.*",
     )
 
     val timeAmountPattern by patternGroup.pattern(
         "time.amount",
-        "(?:(?<y>\\d+) ?y(?:\\w* ?)?)?(?:(?<d>\\d+) ?d(?:\\w* ?)?)?(?:(?<h>\\d+) ?h(?:\\w* ?)?)?(?:(?<m>\\d+) ?m(?:\\w* ?)?)?(?:(?<s>\\d+) ?s(?:\\w* ?)?)?"
+        "(?:(?<y>\\d+) ?y(?:\\w* ?)?)?(?:(?<d>\\d+) ?d(?:\\w* ?)?)?(?:(?<h>\\d+) ?h(?:\\w* ?)?)?(?:(?<m>\\d+) ?m(?:\\w* ?)?)?(?:(?<s>\\d+) ?s(?:\\w* ?)?)?",
     )
 
     val playerChatPattern by patternGroup.pattern(
         "string.playerchat",
-        "(?<important>.*?)(?:§[f7r])*: .*"
+        "(?<important>.*?)(?:§[f7r])*: .*",
     )
     val chatUsernamePattern by patternGroup.pattern(
         "string.chatusername",
-        "^(?:§\\w\\[§\\w\\d+§\\w] )?(?:(?:§\\w)+\\S )?(?<rankedName>(?:§\\w\\[\\w.+] )?(?:§\\w)?(?<username>\\w+))(?: (?:§\\w)?\\[.+?])?"
+        "^(?:§\\w\\[§\\w\\d+§\\w] )?(?:(?:§\\w)+\\S )?(?<rankedName>(?:§\\w\\[\\w.+] )?(?:§\\w)?(?<username>\\w+))(?: (?:§\\w)?\\[.+?])?",
     )
     val isRomanPattern by RepoPattern.pattern(
         "string.isroman",
-        "^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})"
+        "^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})",
     )
 
     val sackPattern by patternGroup.pattern(
         "item.sack",
-        ".*Sack"
+        ".*Sack",
     )
 
     val seasonPattern by patternGroup.pattern(
         "skyblocktime.season",
-        "(?:Early |Late )?(?<season>Spring|Summer|Autumn|Winter)"
+        "(?:Early |Late )?(?<season>Spring|Summer|Autumn|Winter)",
     )
 
     val tabListProfilePattern by patternGroup.pattern(
         "tablist.profile",
-        "(?:§.)+Profile: §r§a(?<profile>[\\w\\s]+[^ §]).*"
+        "(?:§.)+Profile: §r§a(?<profile>[\\w\\s]+[^ §]).*",
     )
 
     val shopOptionsPattern by patternGroup.pattern(
         "inventory.shopoptions",
-        "Shop Trading Options"
+        "Shop Trading Options",
     )
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -10,9 +10,9 @@ object UtilsPatterns {
     private val patternGroup = RepoPattern.group("utils")
 
     /** Examples:
-    §d§l§ka§r §d§l§d§lMYTHIC ACCESSORY §d§l§ka
-    §d§l§ka§r §d§l§d§lSHINY MYTHIC DUNGEON CHESTPLATE §d§l§ka
-    §c§l§ka§r §c§l§c§lVERY SPECIAL HATCESSORY §c§l§ka
+    §d§l§ka§r §d§lMYTHIC ACCESSORY §d§l§ka
+    §d§l§ka§r §d§lSHINY MYTHIC DUNGEON CHESTPLATE §d§l§ka
+    §c§l§ka§r §c§lVERY SPECIAL HATCESSORY §c§l§ka
     §6§lSHINY LEGENDARY DUNGEON BOOTS
     §6§lLEGENDARY DUNGEON BOOTS
     §5§lEPIC BOOTS


### PR DESCRIPTION
## What
After much anticipation, Hypixel has addressed a long-standing issue by fixing the redundant color code formatting present in recombobulated items. This fix effectively streamlines the item lore formatting, reducing unnecessary repetitions of color codes that were previously part of the item descriptions. However, this update inadvertently impacts the current detection mechanisms that rely on these redundant formatting sequences. As a result, the existing pattern matching and detection logic for item parsing is now broken.

This pull request (PR) aims to resolve the issue by adapting the detection algorithm to account for the new, cleaner formatting. The adjustments made in this PR will ensure that item rarity and category detection continues to work accurately, even with the more efficient color coding introduced by the Hypixel update. By implementing these changes, we maintain compatibility with the updated system while eliminating reliance on the now-removed redundant formatting elements.

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fixed item category detection for recombobulated items. - minhperry
