### PR TITLE
Fix: Diamond/Golden heads + Master Skulls using Name not ID causing an incompatibility with NEURenamed items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -66,15 +66,11 @@ object ItemDisplayOverlayFeatures {
     private val config get() = SkyHanniMod.feature.inventory
 
     private val patternGroup = RepoPattern.group("inventory.item.overlay")
-    private val masterSkullPattern by patternGroup.pattern(
-        "masterskull",
-        "(.*)Master Skull - Tier .",
-    )
     private val masterSkullIDPattern by patternGroup.pattern(
         "masterskull.id",
         "MASTER_SKULL_TIER_(?<tier>\\d)",
     )
-    private val gardenVacuumPatterm by patternGroup.pattern(
+    private val gardenVacuumPattern by patternGroup.pattern(
         "vacuum",
         "§7Vacuum Bag: §6(?<amount>\\d*) Pests?",
     )
@@ -256,7 +252,7 @@ object ItemDisplayOverlayFeatures {
         }
 
         if (VACUUM_GARDEN.isSelected() && internalName in PestAPI.vacuumVariants && isOwnItem(lore)) {
-            lore.matchFirst(gardenVacuumPatterm) {
+            lore.matchFirst(gardenVacuumPattern) {
                 val pests = group("amount").formatLong()
                 return if (config.vacuumBagCap) {
                     if (pests > 39) "§640+" else "$pests"

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -70,6 +70,10 @@ object ItemDisplayOverlayFeatures {
         "masterskull",
         "(.*)Master Skull - Tier .",
     )
+    private val masterSkullIDPattern by patternGroup.pattern(
+        "masterskull.id",
+        "MASTER_SKULL_TIER_(?<tier>\\d)",
+    )
     private val gardenVacuumPatterm by patternGroup.pattern(
         "vacuum",
         "§7Vacuum Bag: §6(?<amount>\\d*) Pests?",
@@ -131,20 +135,20 @@ object ItemDisplayOverlayFeatures {
         }
 
         if (MASTER_SKULL_TIER.isSelected()) {
-            masterSkullPattern.matchMatcher(itemName) {
-                return itemName.substring(itemName.length - 1)
+            masterSkullIDPattern.matchMatcher(internalName.asString()) {
+                return group("tier")
             }
         }
 
-        if (DUNGEON_HEAD_FLOOR_NUMBER.isSelected() && (itemName.contains("Golden ") || itemName.contains("Diamond "))) {
+        if (DUNGEON_HEAD_FLOOR_NUMBER.isSelected() && (internalName.contains("GOLD_") || internalName.contains("DIAMOND_"))) {
             when {
-                itemName.contains("Bonzo") -> return "1"
-                itemName.contains("Scarf") -> return "2"
-                itemName.contains("Professor") -> return "3"
-                itemName.contains("Thorn") -> return "4"
-                itemName.contains("Livid") -> return "5"
-                itemName.contains("Sadan") -> return "6"
-                itemName.contains("Necron") -> return "7"
+                internalName.contains("BONZO") -> return "1"
+                internalName.contains("SCARF") -> return "2"
+                internalName.contains("PROFESSOR") -> return "3"
+                internalName.contains("THORN") -> return "4"
+                internalName.contains("LIVID") -> return "5"
+                internalName.contains("SADAN") -> return "6"
+                internalName.contains("NECRON") -> return "7"
             }
         }
 


### PR DESCRIPTION
## What
Fixes an incompatibility with NEURename with how SH gets the data for D/G heads and Master Skulls.

## Changelog Fixes
+ Fixed an issue where the item stack size on Diamond/Golden Heads and Master Skulls could be incorrect. - Fazfoxy

