### PR TITLE
Feature: Ultimate Enchant Star

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -232,6 +232,12 @@ public class InventoryConfig {
     public boolean itemStars = false;
 
     @Expose
+    @ConfigOption(name = "Ultimate Enchant Star", desc = "Show a star on Enchanted Books with an Ultimate Enchant.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean ultimateEnchantStar = false;
+
+    @Expose
     @ConfigOption(name = "Missing Tasks", desc = "Highlight missing tasks in the SkyBlock Level Guide inventory.")
     // TODO move( , "inventory.highlightMissingSkyBlockLevelGuide", "inventory.skyblockGuideConfig.highlightMissingSkyBlockLevelGuide")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/UltimateEnchantStar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/UltimateEnchantStar.kt
@@ -1,0 +1,28 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.RenderItemTipEvent
+import at.hannibal2.skyhanni.events.RenderObject
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
+import net.minecraft.init.Items
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object UltimateEnchantStar {
+
+    private val config get() = SkyHanniMod.feature.inventory
+
+    @SubscribeEvent
+    fun onRenderItemTip(event: RenderItemTipEvent) {
+        if (!isEnabled()) return
+        if (event.stack.item != Items.enchanted_book) return
+        val enchants = event.stack.getEnchantments() ?: return
+        if (enchants.size != 1 || !enchants.keys.first().startsWith("ultimate_")) return
+        event.renderObjects += RenderObject("§d✦", -10, -10)
+    }
+
+    private fun isEnabled() = LorenzUtils.inSkyBlock && config.ultimateEnchantStar
+
+}


### PR DESCRIPTION
## What
Adds a pink star to enchanted books of ultimate enchants.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/b5bdcd66-a673-470d-a7c9-25f261b86626)

</details>

## Changelog New Features
+ Added Ultimate Enchant Star. - Empa
    * Shows a star on Enchanted Books with an Ultimate Enchant.