### PR TITLE
Fix: Jasper Gemstones not in Powder Mining Filter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningGemstoneFilterConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningGemstoneFilterConfig.java
@@ -42,6 +42,11 @@ public class PowderMiningGemstoneFilterConfig {
     @ConfigEditorDropdown
     public GemstoneFilterEntry topazGemstones = GemstoneFilterEntry.FINE_UP;
 
+    @Expose
+    @ConfigOption(name = "Jasper", desc = "Hide Jasper gemstones under a certain quality.")
+    @ConfigEditorDropdown
+    public GemstoneFilterEntry jasperGemstones = GemstoneFilterEntry.FINE_UP;
+
     public enum GemstoneFilterEntry {
         SHOW_ALL("Show All"),
         HIDE_ALL("Hide all"),

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -246,10 +246,13 @@ object PowderMiningChatFilter {
      * REGEX-TEST: §r§a❈ Flawed Amethyst Gemstone §r§8x4
      * REGEX-TEST: §r§9⸕ Fine Amber Gemstone
      * REGEX-TEST: §r§5⸕ Flawless Amber Gemstone
+     * REGEX-TEST: §r§f❁ Rough Jasper Gemstone §r§8x24
+     * REGEX-TEST: §r§a❁ Flawed Jasper Gemstone
      */
+    @Suppress("MaxLineLength")
     private val gemstonePattern by patternGroup.pattern(
         "reward.gemstone",
-        "§r§[fa9][❤❈☘⸕✎✧] (?<tier>Rough|Flawed|Fine|Flawless) (?<gem>Ruby|Amethyst|Jade|Amber|Sapphire|Topaz) Gemstone( §r§8x(?<amount>[\\d,]+))?",
+        "§r§[fa9][❤❈☘⸕✎✧❁] (?<tier>Rough|Flawed|Fine|Flawless) (?<gem>Ruby|Amethyst|Jade|Amber|Sapphire|Topaz|Jasper) Gemstone( §r§8x(?<amount>[\\d,]+))?",
     )
 
     @Suppress("CyclomaticComplexMethod")
@@ -381,6 +384,7 @@ object PowderMiningChatFilter {
                 "amethyst" -> gemstoneConfig.amethystGemstones
                 "jade" -> gemstoneConfig.jadeGemstones
                 "topaz" -> gemstoneConfig.topazGemstones
+                "jasper" -> gemstoneConfig.jasperGemstones
                 // Failure case that should never be reached
                 else -> return "no_filter"
             }


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1289370641543467099

## Changelog Fixes
+ Fixed Jasper gemstones not being addressed in the Powder Mining filter. - Daveed

