### PR TITLE
Improvement: Add ignored crops for lane features

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/FarmingLaneConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/FarmingLaneConfig.java
@@ -2,12 +2,17 @@ package at.hannibal2.skyhanni.config.features.garden.laneswitch;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;
+import at.hannibal2.skyhanni.features.garden.CropType;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.Accordion;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class FarmingLaneConfig {
 
@@ -37,4 +42,11 @@ public class FarmingLaneConfig {
     @FeatureToggle
     public boolean cornerWaypoints = false;
 
+    @Expose
+    @ConfigOption(
+        name = "Ignored Crops",
+        desc = "Add the crops you wish to not setup a lane for."
+    )
+    @ConfigEditorDraggableList()
+    public List<CropType> ignoredCrops = new ArrayList<>();
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneAPI.kt
@@ -43,6 +43,7 @@ object FarmingLaneAPI {
 
     private fun warnNoLane(crop: CropType?) {
         if (crop == null || currentLane != null) return
+        if (crop in config.ignoredCrops) return
         if (!GardenAPI.hasFarmingToolInHand()) return
         if (FarmingLaneCreator.detection) return
         if (!config.distanceDisplay && !config.laneSwitchNotification.enabled) return


### PR DESCRIPTION
## What
lets people not be yelled at for not having a lane for a specific crop

[discord suggestion](https://canary.discord.com/channels/997079228510117908/1290111629236899913)

## Changelog Improvements
+ Added ignored crops for the Farming Lane feature. - martimavocado