### PR TITLE
Fix: Strays Wrongly Counting as Unique

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
@@ -108,12 +108,14 @@ object HoppityAPI {
                         EggFoundEvent(STRAY, it.slotNumber).post()
                         lastName = "§9Fish the Rabbit"
                         lastMeal = STRAY
+                        duplicate = it.stack.getLore().any { line -> line.contains("You have already found")}
                         attemptFireRabbitFound()
                     }
                     "El Dorado" -> {
                         EggFoundEvent(STRAY, it.slotNumber).post()
                         lastName = "§6El Dorado"
                         lastMeal = STRAY
+                        duplicate = it.stack.getLore().any { line -> line.contains("You have already found")}
                         attemptFireRabbitFound()
                     }
                     else -> return@matchMatcher

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
@@ -115,7 +115,7 @@ object HoppityAPI {
                         EggFoundEvent(STRAY, it.slotNumber).post()
                         lastName = "§6El Dorado"
                         lastMeal = STRAY
-                        duplicate = it.stack.getLore().any { line -> line.contains("You have already found")}
+                        duplicate = it.stack.getLore().any { line -> line.contains("already have captured him")}
                         attemptFireRabbitFound()
                     }
                     else -> return@matchMatcher

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
@@ -14,6 +14,8 @@ import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggsManager.eggFoundP
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggsManager.getEggType
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryStrayTracker
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryStrayTracker.duplicateDoradoStrayPattern
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryStrayTracker.duplicatePseudoStrayPattern
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -24,6 +26,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getMinecraftId
 import at.hannibal2.skyhanni.utils.SkyblockSeason
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -108,14 +111,14 @@ object HoppityAPI {
                         EggFoundEvent(STRAY, it.slotNumber).post()
                         lastName = "§9Fish the Rabbit"
                         lastMeal = STRAY
-                        duplicate = it.stack.getLore().any { line -> line.contains("You have already found")}
+                        duplicate = it.stack.getLore().any { line -> duplicatePseudoStrayPattern.matches(line)}
                         attemptFireRabbitFound()
                     }
                     "El Dorado" -> {
                         EggFoundEvent(STRAY, it.slotNumber).post()
                         lastName = "§6El Dorado"
                         lastMeal = STRAY
-                        duplicate = it.stack.getLore().any { line -> line.contains("already have captured him")}
+                        duplicate = it.stack.getLore().any { line -> duplicateDoradoStrayPattern.matches(line)}
                         attemptFireRabbitFound()
                     }
                     else -> return@matchMatcher

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTracker.kt
@@ -100,12 +100,29 @@ object ChocolateFactoryStrayTracker {
         "§7You caught a stray §6§lGolden Rabbit§7! §7You gained §6\\+5 Chocolate §7until the §7end of the SkyBlock year!",
     )
 
+    // TODO: Fix this pattern so it doesn't only match duplicates.
     /**
      * REGEX-TEST: §7You caught a stray §9Fish the Rabbit§7! §7You have already found §9Fish the §9Rabbit§7, so you received §655,935,257 §6Chocolate§7!
      */
     private val fishTheRabbitPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "stray.fish",
         "§7You caught a stray (?<color>§.)Fish the Rabbit§7! §7You have already found (?:§.)?Fish the (?:§.)?Rabbit§7, so you received §6(?<amount>[\\d,]*) (?:§6)?Chocolate§7!",
+    )
+
+    /**
+     * REGEX-TEST: §7You have already found §9Fish the
+     */
+    val duplicatePseudoStrayPattern by ChocolateFactoryAPI.patternGroup.pattern(
+        "stray.pseudoduplicate",
+        "(?:§.)*You have already found.*",
+    )
+
+    /**
+     * REGEX-TEST: §7already have captured him before
+     */
+    val duplicateDoradoStrayPattern by ChocolateFactoryAPI.patternGroup.pattern(
+        "stray.doradoduplicate",
+        "(?:§.)*already have captured him before.*",
     )
 
     private val tracker = SkyHanniTracker("Stray Tracker", { Data() }, { it.chocolateFactory.strayTracker })


### PR DESCRIPTION
## What
`duplicate` was not being set at all during the stray section of the Hoppity API. This fixes that.

## Changelog Fixes
+ Fixed Fish the Rabbit and El Dorado incorrectly counting as unique rabbits during Hoppity's Hunt. - Daveed

