### PR TITLE
Fix: Custom Scoreboard Carnival

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardEvent.kt
@@ -534,7 +534,8 @@ private fun getCarnivalLines() = listOf(
         getSbLines().firstOrNull { pattern.matches(it) }
     }
 
-private fun getCarnivalShowWhen(): Boolean = SbPattern.carnivalPattern.anyMatches(getSbLines())
+private fun getCarnivalShowWhen() =
+    listOf(SbPattern.carnivalPattern, SbPattern.carnivalTokensPattern, SbPattern.carnivalTasksPattern).anyMatches(getSbLines())
 
 private fun getRiftLines() = getSbLines().filter { line ->
     RiftBloodEffigies.heartsPattern.matches(line) ||


### PR DESCRIPTION
## What
Hypixel doesn't show the "Carnival: 10:00:00" line while playing on bingo (it does on Ironman though iirc), which broke the detection.


## Changelog Fixes
+ Fixed Custom Scoreboard not showing Carnival Lines on Bingo. - j10a1n15
