### PR TITLE
Improvement + Fix: onNextTeleport

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.events.EntityMoveEvent
+import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWarpEvent
@@ -8,27 +9,75 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.entity.Entity
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object EntityMovementData {
 
     private val warpingPattern by RepoPattern.pattern(
         "data.entity.warping",
-        "§7(?:Warping|Warping you to your SkyBlock island|Warping using transfer token|Finding player|Sending a visit request)\\.\\.\\."
+        "§7(?:Warping|Warping you to your SkyBlock island|Warping using transfer token|Finding player|Sending a visit request)\\.\\.\\.",
     )
+
+    private var nextTeleport: OnNextTeleport? = null
+
+    fun onNextTeleport(island: IslandType, action: () -> Unit) {
+        nextTeleport = OnNextTeleport(island, action)
+    }
+
+    class OnNextTeleport(val island: IslandType, val action: () -> Unit) {
+        val startTime: SimpleTimeMark = SimpleTimeMark.now()
+    }
 
     private val entityLocation = mutableMapOf<Entity, LorenzVec>()
 
     fun addToTrack(entity: Entity) {
         if (entity !in entityLocation) {
             entityLocation[entity] = entity.getLorenzVec()
+        }
+    }
+
+    @SubscribeEvent
+    fun onIslandChange(event: IslandChangeEvent) {
+        val nextData = nextTeleport ?: return
+        if (nextData.island != event.newIsland) return
+        val passedSince = nextData.startTime.passedSince()
+        if (passedSince > 5.seconds) {
+            nextTeleport = null
+            return
+        }
+
+        DelayedRun.runDelayed(100.milliseconds) {
+            nextData.action()
+        }
+        nextTeleport = null
+    }
+
+    @SubscribeEvent
+    fun onPlayerMove(event: EntityMoveEvent) {
+        if (!LorenzUtils.inSkyBlock || event.entity != Minecraft.getMinecraft().thePlayer) return
+
+        val nextData = nextTeleport ?: return
+
+        val passedSince = nextData.startTime.passedSince()
+        if (passedSince > 5.seconds) {
+            nextTeleport = null
+            return
+        }
+        if (passedSince > 50.milliseconds && nextData.island.isInIsland()) {
+            nextData.action()
+            nextTeleport = null
+            return
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalReminder.kt
@@ -1,6 +1,9 @@
 package at.hannibal2.skyhanni.features.event.carnival
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.EntityMovementData
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.LorenzChatEvent
@@ -11,6 +14,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
@@ -90,6 +94,9 @@ object CarnivalReminder {
                 "warp to The Carnival",
             ) {
                 HypixelCommands.warp("carnival")
+                EntityMovementData.onNextTeleport(IslandType.HUB) {
+                    IslandGraphs.pathFind(LorenzVec(-89.5, 71.0, -18.7), "§aCarnival Tickets", condition = { config.reminderDailyTickets })
+                }
             }
             nextCheckTime = 5.0.minutes.fromNow()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityNpc.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityNpc.kt
@@ -1,5 +1,8 @@
 package at.hannibal2.skyhanni.features.event.hoppity
 
+import at.hannibal2.skyhanni.data.EntityMovementData
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -15,6 +18,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
@@ -60,7 +64,12 @@ object HoppityNpc {
             actionName = "warp to hub",
             action = {
                 HypixelCommands.warp("hub")
-                //afterNextIslandwarpTtp hub: IslandGraphs.pathFind(hoppity)
+                EntityMovementData.onNextTeleport(IslandType.HUB) {
+                    IslandGraphs.pathFind(
+                        LorenzVec(6.4, 70.0, 7.4),
+                        "§aHoppity's Shop",
+                        condition = { config.hoppityShopReminder })
+                }
             },
         )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -2,6 +2,9 @@ package at.hannibal2.skyhanni.features.fame
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.EntityMovementData
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -20,6 +23,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
@@ -79,7 +83,16 @@ object CityProjectFeatures {
             "Daily City Project Reminder!",
             config::dailyReminder,
             actionName = "warp to Hub",
-            action = { HypixelCommands.warp("hub") },
+            action = {
+                HypixelCommands.warp("hub")
+                EntityMovementData.onNextTeleport(IslandType.HUB) {
+                    IslandGraphs.pathFind(
+                        LorenzVec(9.3, 72.0, -103.4),
+                        "§aCity Project",
+                        condition = { config.dailyReminder },
+                    )
+                }
+            },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
@@ -2,6 +2,9 @@ package at.hannibal2.skyhanni.features.fame
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.EntityMovementData
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
@@ -13,6 +16,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -162,7 +166,16 @@ object UpgradeReminder {
                 "The §a$name §eupgrade has completed!",
                 config::accountUpgradeReminder,
                 actionName = "warp to Hub",
-                action = { HypixelCommands.warp("hub") },
+                action = {
+                    HypixelCommands.warp("hub")
+                    EntityMovementData.onNextTeleport(IslandType.HUB) {
+                        IslandGraphs.pathFind(
+                            LorenzVec(-2.6, 73.0, -101.6),
+                            "§eCommunity Shop",
+                            condition = { config.accountUpgradeReminder },
+                        )
+                    }
+                },
             )
         }
 


### PR DESCRIPTION
## What
Added auto path finding logic for some reminders


## Changelog Improvements
+ Automatically starts pathfinding after clicking on SkyHanni reminder chat messages about Carnival Reminder, Hoppity NPC, City Project, and account/profile upgrades. - hannibal2

## Changelog Technical Details
+ Added `EntityMovementData.onNextTeleport()` logic, which triggers a runnable after the world has changed or the player has teleported. - hannibal2