### PR TITLE
Improvement: Slight Touch up for Hoppity Event Summary

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
@@ -231,12 +231,18 @@ object HoppityEventSummary {
         config.eventSummary.statDisplayList.forEach {
             summaryOperationList[it]?.invoke(statsBuilder, stats, eventYear)
         }
+
+        // If no stats are found, display a message
         if (statsBuilder.toString().replace("\n", "").isEmpty()) {
-            statsBuilder.appendHeadedLine("§c§lNothing to show!\n§c§oGo find some eggs!")
+            statsBuilder.appendHeadedLine("§c§lNothing to show!")
+            statsBuilder.appendHeadedLine("§c§oGo find some eggs!")
         }
 
+        // Remove any consecutive empty lines in the stats
+        val statsBuilderString = statsBuilder.toString().replace(Regex("\n{4,}"), "\n".repeat(3))
+
         // Append stats
-        summaryBuilder.append(statsBuilder)
+        summaryBuilder.append(statsBuilderString)
 
         // Footer
         summaryBuilder.append("§d§l${"▬".repeat(64)}")


### PR DESCRIPTION
## What
Fixed a formatting issue, and finally fixed the problem with the empty lines causing unnecessary spacing in the stats card.

## Changelog Improvements
+ Improved the formatting of the Hoppity Event Stats card. - Daveed

