### PR TITLE
Fix: Flare expire warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
@@ -101,7 +101,7 @@ object FlareDisplay {
                     }
                 }
             }
-            if (remainingTime !in 5.seconds..0.seconds) continue
+            if (remainingTime !in 0.seconds..5.seconds) continue
             val message = "$name §eexpires in: §b${remainingTime.inWholeSeconds}s"
             when (config.alertType) {
                 FlareConfig.AlertType.CHAT -> {


### PR DESCRIPTION
## What
Fixed flare expire warning not showing in chat or as title

## Changelog Fixes
+ Fixed Flare Expiration warnings not appearing in chat or as a title. - hannibal2