### PR TITLE
Fix: Powder Tracker not tracking items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -198,7 +198,7 @@ object PowderTracker {
         }
 
         for (reward in PowderChestReward.entries) {
-            if (reward == PowderChestReward.MITHRIL_POWDER || reward == PowderChestReward.GEMSTONE_POWDER) return
+            if (reward == PowderChestReward.MITHRIL_POWDER || reward == PowderChestReward.GEMSTONE_POWDER) continue
             reward.chatPattern.matchMatcher(msg) {
                 tracker.modify {
                     val count = it.rewards[reward] ?: 0


### PR DESCRIPTION
## What
Fixed Powder Tracker not counting items others than powder

## Changelog Fixes
+ Fixed the Powder Tracker not tracking items correctly. - HiZe
