### PR TITLE
Fix: Superpair Experimentation data always visible

### DIFF
--- a/.idea/dictionaries/default_user.xml
+++ b/.idea/dictionaries/default_user.xml
@@ -193,6 +193,8 @@
       <w>pling</w>
       <w>pocalypse</w>
       <w>polarvoid</w>
+      <w>powerup</w>
+      <w>powerups</w>
       <w>preinitialization</w>
       <w>procs</w>
       <w>prospection</w>
@@ -251,6 +253,7 @@
       <w>supercraft</w>
       <w>supercrafting</w>
       <w>superlite</w>
+      <w>superpair</w>
       <w>superpairs</w>
       <w>tablist</w>
       <w>terracottas</w>

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentationTableConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentationTableConfig.java
@@ -21,7 +21,7 @@ public class ExperimentationTableConfig {
     public ExperimentsDryStreakConfig dryStreak = new ExperimentsDryStreakConfig();
 
     @Expose
-    @ConfigOption(name = "Superpair Data", desc = "Shows a display with useful information while doing the Superpair experiment.")
+    @ConfigOption(name = "Superpair Data", desc = "Displays useful data while doing the Superpair experiment.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean superpairDisplay = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
@@ -60,8 +60,8 @@ object SuperpairDataDisplay {
         if (InventoryUtils.openInventoryName() == "Experimentation Table") {
             // Render here so they can move it around.
             config.superpairDisplayPosition.renderString("§6Superpair Experimentation Data", posLabel = "Superpair Experimentation Data")
-            return
         }
+        if (ExperimentationTableAPI.getCurrentExperiment() == null) return
 
         if (display.isEmpty()) display = drawDisplay()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.isAnyOf
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraft.item.ItemStack
@@ -56,14 +57,21 @@ object SuperpairDataDisplay {
     @SubscribeEvent
     fun onChestGuiOverlayRendered(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
+        if (ExperimentationTableAPI.getCurrentExperiment() == null) {
+            // Render here so they can move it around.
+            config.superpairDisplayPosition.renderString("§6Superpair Experimentation Data", posLabel = "Superpair Experimentation Data")
+        }
+
         if (display.isEmpty()) display = drawDisplay()
 
-        config.superpairDisplayPosition.renderStrings(display, posLabel = "Superpair Experiment Information")
+        config.superpairDisplayPosition.renderStrings(display, posLabel = "Superpair Experimentation Data")
     }
 
     @SubscribeEvent
     fun onSlotClick(event: SlotClickEvent) {
         if (!isEnabled()) return
+        if (ExperimentationTableAPI.getCurrentExperiment() == null) return
+
         val currentExperiment = ExperimentationTableAPI.getCurrentExperiment() ?: return
 
         val item = event.item ?: return
@@ -286,6 +294,5 @@ object SuperpairDataDisplay {
 
     private fun SuperpairItem?.sameAs(other: SuperpairItem) = this?.reward == other.reward && this?.damage == other.damage
 
-    private fun isEnabled() =
-        IslandType.PRIVATE_ISLAND.isInIsland() && config.superpairDisplay && ExperimentationTableAPI.getCurrentExperiment() != null
+    private fun isEnabled() = IslandType.PRIVATE_ISLAND.isInIsland() && config.superpairDisplay
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
@@ -57,9 +57,10 @@ object SuperpairDataDisplay {
     @SubscribeEvent
     fun onChestGuiOverlayRendered(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
-        if (ExperimentationTableAPI.getCurrentExperiment() == null) {
+        if (InventoryUtils.openInventoryName() == "Experimentation Table") {
             // Render here so they can move it around.
             config.superpairDisplayPosition.renderString("§6Superpair Experimentation Data", posLabel = "Superpair Experimentation Data")
+            return
         }
 
         if (display.isEmpty()) display = drawDisplay()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/solver/FossilSolverDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/solver/FossilSolverDisplay.kt
@@ -188,7 +188,7 @@ object FossilSolverDisplay {
 
         if (inExcavatorMenu) {
             // Render here so they can move it around. As if you press key while doing the excavator you lose the scrap
-            config.position.renderString("§eExcavator solver gui", posLabel = "Fossil Excavator Solver")
+            config.position.renderString("§eExcavator solver GUI", posLabel = "Fossil Excavator Solver")
             return
         }
 


### PR DESCRIPTION
## What
Allows moving the Superpair Experimentation Data display around while not inside the experiment.
Reported: https://discord.com/channels/997079228510117908/1289323995212288020

## Changelog Fixes
+ Enabled the movement of the Superpair Experimentation Data display even when not inside the experiment. - hannibal2