### PR TITLE
Fix: Made it so you can shift click to disable features like it says

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiScreen.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiScreen.java
@@ -8,6 +8,7 @@ import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -32,5 +33,10 @@ public class MixinGuiScreen {
     @Inject(method = "handleKeyboardInput", at = @At("HEAD"), cancellable = true)
     public void handleKeyboardInput(CallbackInfo ci) {
         TextInput.Companion.onGuiInput(ci);
+    }
+
+    @Redirect(method = "handleComponentClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiScreen;isShiftKeyDown()Z"))
+    public boolean handleComponentClick() {
+        return false;
     }
 }


### PR DESCRIPTION
## What
Chat popups said "shift click or control click to disable" however shift clicking never worked
I do make this function always return false but I searched around on github and couldn't really find a mod that used this "Insertion" feature thingy that I'm disabling so I think its fine

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/bddcb6af-81b6-44b5-bbf9-6f4c5a8a10b7)

</details>

## Changelog Fixes
+ Fixed being unable to shift-click on chat messages. - nopo
