### PR TITLE
Fix: Add delay to Pablo GfS message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/PabloHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/PabloHelper.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.GetFromSackAPI
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -51,10 +52,12 @@ object PabloHelper {
 
         if (InventoryUtils.countItemsInLowerInventory { it.name.contains(itemName) } > 0) return
 
-        GetFromSackAPI.getFromChatMessageSackItems(
-            itemName.asInternalName().makePrimitiveStack(),
-            "Click here to grab an $itemName from sacks!",
-        )
+        DelayedRun.runNextTick {
+            GetFromSackAPI.getFromChatMessageSackItems(
+                itemName.asInternalName().makePrimitiveStack(),
+                "Click here to grab an $itemName from sacks!",
+            )
+        }
 
         lastSentMessage = SimpleTimeMark.now()
     }


### PR DESCRIPTION
## What
Added a delay to Pablo GfS message so it shows up after his messages.

### Before
```
[NPC] Pablo: owoLuna! You've arrived at the perfect moment.
[SkyHanni] Click here to grab an Enchanted Dandelion from sacks!
[NPC] Pablo: I really need an Enchanted Dandelion today, do you have one you could spare?
```

### After
```
[NPC] Pablo: owoLuna! You've arrived at the perfect moment.
[NPC] Pablo: I really need an Enchanted Dandelion today, do you have one you could spare?
[SkyHanni] Click here to grab an Enchanted Dandelion from sacks!
```

## Changelog Fixes
+ Added a delay to the Pablo helper message so it appears after he finishes his dialogue. - Luna