### PR TITLE
Improvement: Chroma disabling patchers font renderer for no reason

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.java
@@ -80,7 +80,7 @@ public class ChromaConfig {
     public Runnable resetSettings = ChromaManager::resetChromaSettings;
 
     @Expose
-    @ConfigOption(name = "Everything Chroma", desc = "Render §4§l§oALL §r§7text in chroma. §e(Some enchants may appear white with SBA enchant parsing)")
+    @ConfigOption(name = "Everything Chroma", desc = "Render §4§l§oALL §r§7text in chroma. §e(Disables Patcher's Optimized Font Renderer while enabled)")
     @ConfigEditorBoolean
     public boolean allChroma = false;
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.java
@@ -20,7 +20,7 @@ public class ChromaConfig {
     public boolean chromaPreview = false;
 
     @Expose
-    @ConfigOption(name = "Enabled", desc = "Toggle SkyHanni's chroma. §e(Disables Patcher's Optimized Font Renderer while enabled)")
+    @ConfigOption(name = "Enabled", desc = "Toggle SkyHanni's chroma.")
     @ConfigEditorBoolean
     @FeatureToggle
     public Property<Boolean> enabled = Property.of(false);

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FontRendererHook.kt
@@ -28,7 +28,7 @@ object FontRendererHook {
 
     private var currentDrawState: ChromaFontRenderer? = null
     private var previewChroma = false
-    private var chromaPreviewText: String
+    var chromaPreviewText: String
 
     var cameFromChat = false
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MixinPatcherFontRendererHookHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MixinPatcherFontRendererHookHook.kt
@@ -11,9 +11,15 @@ class MixinPatcherFontRendererHookHook {
         fun overridePatcherFontRenderer(string: String, shadow: Boolean, cir: CallbackInfoReturnable<Boolean>) {
             if (!LorenzUtils.onHypixel) return
 
-            if (ChromaManager.config.enabled.get()) {
-                cir.cancel()
+            if (string.contains("§#§")) {
                 cir.returnValue = false
+                return
+            }
+            if (ChromaManager.config.enabled.get()) {
+                if (string.contains("§z") || string.contains("§Z")) {
+                    cir.returnValue = false
+                    return
+                }
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MixinPatcherFontRendererHookHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MixinPatcherFontRendererHookHook.kt
@@ -11,6 +11,16 @@ class MixinPatcherFontRendererHookHook {
         fun overridePatcherFontRenderer(string: String, shadow: Boolean, cir: CallbackInfoReturnable<Boolean>) {
             if (!LorenzUtils.onHypixel) return
 
+            if (ChromaManager.config.allChroma) {
+                cir.returnValue = false
+                return
+            }
+
+            if (string == FontRendererHook.chromaPreviewText) {
+                cir.returnValue = false
+                return
+            }
+
             if (string.contains("§#§")) {
                 cir.returnValue = false
                 return


### PR DESCRIPTION
## What
now it only disables patchers font renderer for strings that have cool colours in them
![image](https://github.com/user-attachments/assets/1300f6c2-bfd9-4959-b969-50dfbcaa2419)


<details>
<summary>Images</summary>

Before:
![image](https://github.com/user-attachments/assets/cc52ec79-7eee-42a4-af9c-dcda7d0706f5)

After
![image](https://github.com/user-attachments/assets/427d7a69-841f-4175-87b9-2a165b67da5b)

</details>

## Changelog Improvements
+ Greatly improved performance by optimizing SkyHanni Chroma support for Patcher Font Renderer. - nopo