### PR TITLE
Fix: repo getting redownloaded on the same commit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -36,7 +36,7 @@ class RepoManager(private val configLocation: File) {
     private var latestRepoCommit: String? = null
     val repoLocation: File = File(configLocation, "repo")
     private var error = false
-    private var lastRepoUpdate = SimpleTimeMark.farPast()
+    private var lastRepoUpdate = SimpleTimeMark.now()
 
     companion object {
 


### PR DESCRIPTION
## What
Makes the github traffic go down

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/96b30dbf-de83-4826-a135-1e0e7dfdc2fd)

</details>


## Changelog Fixes
+ Fixed SkyHanni re-downloading the repository on every launch. - nopo