### PR TITLE
Fix: trophy fish title

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
@@ -96,7 +96,7 @@ object TrophyFishMessages {
     }
 
     private fun sendTitle(displayName: String, displayRarity: String?, amount: Int) {
-        val text = "$displayName\n$displayRarity $amount!"
+        val text = "$displayName $displayRarity §8$amount§c!"
         LorenzUtils.sendTitle(text, 3.seconds, 2.8, 7f)
     }
 


### PR DESCRIPTION
## What
Fixed trophy fish title
Reported: https://discord.com/channels/997079228510117908/1291722302148317194

## Changelog Fixes
+ Fixed the Trophy Fish Title displaying an undefined character in the format. - hannibal2