### PR TITLE
Improvement: Add Mining Effects to Non God Pot Effect Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
@@ -76,6 +76,10 @@ object NonGodPotEffectDisplay {
         CURSE_OF_GREED("§4Curse of Greed I"),
 
         COLD_RESISTANCE_4("§bCold Resistance IV"),
+
+        POWDER_PUMPKIN("§fPowder Pumpkin I"),
+        FILET_O_FORTUNE("§fFilet O' Fortune I"),
+        CHILLED_PRISTINE_POTATO("§fChilled Pristine Potato I"),
     }
 
     private val effectsCountPattern by RepoPattern.pattern(


### PR DESCRIPTION

## What
Adds the "new" effects to the non god pot display



## Changelog Improvements
+ Added Mining Effects (Powder Pumpkin, Filet O' Fortune, and Chilled Pristine Potato) to the Non-God Effect Display. - jani



