### PR TITLE
Fix: Powder Tracker IndexOutOfBoundsException 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestReward.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestReward.kt
@@ -115,6 +115,8 @@ enum class PowderChestReward(val displayName: String, pattern: String) {
         "§9FTX 3070",
         " {4}§r§9FTX 3070(?: §r§8x(?<amount>.*))?",
     ),
+
+    // TODO: Fix typo
     ELECTRON_TRANSIMTTER(
         "§9Electron Transmitter",
         " {4}§r§9Electron Transmitter(?: §r§8x(?<amount>.*))?",

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -140,8 +140,7 @@ object PowderTracker {
         }
     }
 
-    private val tracker =
-        SkyHanniTracker("Powder Tracker", { Data() }, { it.powderTracker }) { formatDisplay(drawDisplay(it)) }
+    private val tracker = SkyHanniTracker("Powder Tracker", { Data() }, { it.powderTracker }) { formatDisplay(drawDisplay(it)) }
 
     class Data : TrackerData() {
 
@@ -316,13 +315,11 @@ object PowderTracker {
         addSearchString("§d${data.totalChestPicked.addSeparators()} Total Chests Picked §7($chestPerHour/h)")
         addSearchString("§bDouble Powder: ${if (doublePowder) "§aActive! §7($powderTimer)" else "§cInactive!"}")
 
-        val entries = PowderChestReward.entries
         val rewards = data.rewards
-        addPerHour(rewards, entries[0], mithrilInfo)
-        addPerHour(rewards, entries[1], gemstoneInfo)
+        addPerHour(rewards, PowderChestReward.GEMSTONE_POWDER, gemstoneInfo)
         addSearchString("")
-        addPerHour(rewards, entries[46], diamondEssenceInfo)
-        addPerHour(rewards, entries[47], goldEssenceInfo)
+        addPerHour(rewards, PowderChestReward.DIAMOND_ESSENCE, diamondEssenceInfo)
+        addPerHour(rewards, PowderChestReward.GOLD_ESSENCE, goldEssenceInfo)
         addSearchString("")
         val hardStonePerHour = format(hardStoneInfo.perHour)
         addSearchString("§b${data.totalHardStoneCompacted.addSeparators()} §fHard Stone §bCompacted §7($hardStonePerHour/h)", "Hard Stone")
@@ -347,7 +344,14 @@ object PowderTracker {
         }
 
         var totalParts = 0L
-        for (reward in entries.subList(26, 32)) { // robots part
+        for (reward in listOf(
+            PowderChestReward.FTX_3070,
+            PowderChestReward.ELECTRON_TRANSIMTTER,
+            PowderChestReward.ROBOTRON_REFLECTOR,
+            PowderChestReward.SUPERLITE_MOTOR,
+            PowderChestReward.CONTROL_SWITCH,
+            PowderChestReward.SYNTHETIC_HEART,
+        )) {
             val count = rewards.getOrDefault(reward, 0)
             totalParts += count
             val name = reward.displayName
@@ -362,7 +366,17 @@ object PowderTracker {
         val blueEgg = rewards.getOrDefault(PowderChestReward.BLUE_GOBLIN_EGG, 0)
         addSearchString("§3$blueEgg§7-§c$redEgg§7-§e$yellowEgg§f-§a$greenEgg§f-§9$goblinEgg §fGoblin Egg")
 
-        for (reward in entries.subList(37, 46)) {
+        for (reward in listOf(
+            PowderChestReward.WISHING_COMPASS,
+            PowderChestReward.SLUDGE_JUICE,
+            PowderChestReward.ASCENSION_ROPE,
+            PowderChestReward.TREASURITE,
+            PowderChestReward.JUNGLE_HEART,
+            PowderChestReward.PICKONIMBUS_2000,
+            PowderChestReward.YOGGIE,
+            PowderChestReward.PREHISTORIC_EGG,
+            PowderChestReward.OIL_BARREL,
+        )) {
             val count = rewards.getOrDefault(reward, 0).addSeparators()
             val name = reward.displayName
             addSearchString("§b$count $name", name)


### PR DESCRIPTION
## What
Fixes the Powder Tracker getting enum entries using ids instead of the entry itself, causing this bug.



## Changelog Fixes
+ Fixed an error in Powder Tracker. - j10a1n15


