### PR TITLE
Fix: Wiki keybind searching for <null>

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/BetterWikiCommandConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/BetterWikiCommandConfig.java
@@ -53,7 +53,7 @@ public class BetterWikiCommandConfig {
     public boolean menuOpenWiki = false;
 
     @Expose
-    @ConfigOption(name = "Fandom Wiki Key", desc = "Search for an item on Wiki with this keybind.\n" +
+    @ConfigOption(name = "Wiki Key", desc = "Search for an item's wiki page with this keybind.\n" +
         "§cFor an optimal experience, do §lNOT §cbind this to a mouse button.")
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     public int wikiKeybind = Keyboard.KEY_NONE;

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
-import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUItems
@@ -70,7 +69,7 @@ object WikiManager {
 
     private fun wikiTheItem(item: ItemStack, autoOpen: Boolean, useFandom: Boolean = config.useFandom) {
         val itemDisplayName =
-            item.itemName.replace("§a✔ ", "").replace("§c✖ ", "")
+            item.displayName.replace("§a✔ ", "").replace("§c✖ ", "")
         val internalName = item.getInternalName().asString()
         val wikiUrlSearch = if (internalName != "NONE") internalName else itemDisplayName.removeColor()
 


### PR DESCRIPTION
## What
Fixes an issue where using the wiki keybind on an item with no internal name searched for `<null>` instead of that item's display name. Also rewords the wiki keybind's config option since it's not exclusive to the Fandom Wiki.

## Changelog Fixes
+ Fixed the wiki keybind searching for "null" on items with no internal name. - MTOnline