### PR TITLE
Fix: Unknown Perkpocalypse Mayor Chat Spam

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorAPI.kt
@@ -170,7 +170,7 @@ object MayorAPI {
             } ?: false
         } ?: return
 
-        val perk = stack.getLore().nextAfter({ perkpocalypsePerksPattern.matches(it) }) ?: return
+        val perk = stack.getLore().nextAfter({ perkpocalypsePerksPattern.matches(it) }, 2) ?: return
         // This is the first Perk of the Perkpocalypse Mayor
         val jerryMayor = getMayorFromPerk(getPerkFromName(perk.removeColor()) ?: return)?.addAllPerks() ?: return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardElements.kt
@@ -784,6 +784,11 @@ private fun getMayorDisplayPair() = buildList {
     }
 
     if (!mayorConfig.showExtraMayor) return@buildList
+    addAll(addMinister())
+    addAll(addPerkpocalypseMayor())
+}
+
+private fun addMinister() = buildList {
     val ministerName = MayorAPI.currentMinister?.mayorName?.let { MayorAPI.mayorNameWithColorCode(it) } ?: return@buildList
     add(ministerName to HorizontalAlignment.LEFT)
 
@@ -792,7 +797,9 @@ private fun getMayorDisplayPair() = buildList {
             add(" §7- §e${perk.perkName}" to HorizontalAlignment.LEFT)
         }
     }
+}
 
+private fun addPerkpocalypseMayor() = buildList {
     val jerryExtraMayor = MayorAPI.jerryExtraMayor
     val extraMayor = jerryExtraMayor.first ?: return@buildList
 


### PR DESCRIPTION
## What
Hypixel decided to add a cool seperator between "Perkpocalypse Perks:" and the actual perks, making this not work


## Changelog Fixes
+ Fixed unknown Perkpocalypse Mayor chat spam. - j10a1n15
+ Fixed Custom Scoreboard not showing the Perkpocalypse Mayor. - j10a1n15

