### PR TITLE
Backend: Update pr template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,10 +1,14 @@
-<!-- remove all unused parts -->
+<!-- remove all unused parts 
+
+The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by an ampersand. For example, `Feature & Fix: Add new command and fix bug in command`.
 
 ## PR Reviews
 
 When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).
 
 Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.
+
+-->
 
 ## Dependencies
 - pr_number_or_link_here


### PR DESCRIPTION
Updated this template to show how to properly title your pr. Also hid the pr review text so that i can actually ready the pr description in discord without having to open my browser and ignore 300 words

exclude_from_changelog

