### PR TITLE
Fix: Hoppity > max

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -103,6 +103,9 @@ public class ProfileSpecificStorage {
         public long currentChocolate = 0;
 
         @Expose
+        public long maxChocolate = 0;
+
+        @Expose
         public long chocolateThisPrestige = 0;
 
         @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateAmount.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateAmount.kt
@@ -31,6 +31,7 @@ enum class ChocolateAmount(val chocolate: () -> Long) {
 
     companion object {
         fun chocolateSinceUpdate(): Long {
+            if (ChocolateFactoryAPI.isMax()) return 0L
             val lastUpdate = profileStorage?.lastDataSave ?: return 0
             val currentTime = SimpleTimeMark.now()
             val secondsSinceUpdate = (currentTime - lastUpdate).inWholeSeconds

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -239,4 +239,8 @@ object ChocolateFactoryAPI {
             it.rabbit.removeColor() == rabbitName.removeColor()
         }
     }
+
+    fun isMax(): Boolean = profileStorage?.let {
+        it.maxChocolate == it.currentChocolate
+    } ?: false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -51,6 +51,14 @@ object ChocolateFactoryDataLoader {
         "chocolate.thisprestige",
         "§7Chocolate this Prestige: §6(?<amount>[\\d,]+)",
     )
+
+    /**
+     * REGEX-TEST: §7Max Chocolate: §660B
+     */
+    private val maxChocolatePattern by ChocolateFactoryAPI.patternGroup.pattern(
+        "chocolate.max",
+        "§7Max Chocolate: §6(?<max>.*)",
+    )
     private val chocolateForPrestigePattern by ChocolateFactoryAPI.patternGroup.pattern(
         "chocolate.forprestige",
         "§7§cRequires (?<amount>\\w+) Chocolate this.*",
@@ -229,6 +237,9 @@ object ChocolateFactoryDataLoader {
         for (line in item.getLore()) {
             chocolateThisPrestigePattern.matchMatcher(line) {
                 profileStorage.chocolateThisPrestige = group("amount").formatLong()
+            }
+            maxChocolatePattern.matchMatcher(line) {
+                profileStorage.maxChocolate = group("max").formatLong()
             }
             chocolateForPrestigePattern.matchMatcher(line) {
                 ChocolateFactoryAPI.chocolateForPrestige = group("amount").formatLong()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
@@ -76,7 +76,10 @@ object ChocolateFactoryStats {
         val map = buildMap<ChocolateFactoryStat, String> {
             put(ChocolateFactoryStat.HEADER, "§6§lChocolate Factory ${ChocolateFactoryAPI.currentPrestige.toRoman()}")
 
-            put(ChocolateFactoryStat.CURRENT, "§eCurrent Chocolate: §6${ChocolateAmount.CURRENT.formatted}")
+            val maxSuffix = if (ChocolateFactoryAPI.isMax()) {
+                " §cMax!"
+            } else ""
+            put(ChocolateFactoryStat.CURRENT, "§eCurrent Chocolate: §6${ChocolateAmount.CURRENT.formatted}$maxSuffix")
             put(ChocolateFactoryStat.THIS_PRESTIGE, "§eThis Prestige: §6${ChocolateAmount.PRESTIGE.formatted}")
             put(ChocolateFactoryStat.ALL_TIME, "§eAll-time: §6${ChocolateAmount.ALL_TIME.formatted}")
 


### PR DESCRIPTION
## What
This PR reads the "max chcocolate" line from the item on cf menu open, compares it against the current chocolate number in the API function `isMax()', shows a red "max!" Text behind the number (see image below), and stops updating the numbers in inventories that aren't the main menu.

Reported: https://discord.com/channels/997079228510117908/1291834946574618687

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/e1b9b5b0-e176-42d7-87ae-3d2fa977554c)

</details>

## Changelog Improvements
+ Indicate in the CF menu when the chocolate amount has reached its cap and production is halted. - hannibal2

## Changelog Fixes
+ Fixed the chocolate count increasing in other menus even when production is halted. - hannibal2