### PR TITLE
Feature: Inventory Focus Mode

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -1,0 +1,22 @@
+package at.hannibal2.skyhanni.config.features.inventory;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import org.lwjgl.input.Keyboard;
+
+public class FocusModeConfig {
+
+    @Expose
+    @ConfigOption(name = "Enable", desc = "In focus mode you only see the name of the item instead of the whole description.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean enable = false;
+
+    @Expose
+    @ConfigOption(name = "Toggle Key", desc = "Key to toggle the focus mode on and off.")
+    @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
+    public int toggleKey = Keyboard.KEY_NONE;
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -10,10 +10,10 @@ import org.lwjgl.input.Keyboard;
 public class FocusModeConfig {
 
     @Expose
-    @ConfigOption(name = "Enable", desc = "In focus mode you only see the name of the item instead of the whole description.")
+    @ConfigOption(name = "Enabled", desc = "In focus mode you only see the name of the item instead of the whole description.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean enable = false;
+    public boolean enabled = false;
 
     @Expose
     @ConfigOption(name = "Toggle Key", desc = "Key to toggle the focus mode on and off.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -85,7 +85,7 @@ public class InventoryConfig {
     public PersonalCompactorConfig personalCompactor = new PersonalCompactorConfig();
 
     @Expose
-    @ConfigOption(name = "Focus Mode",desc="")
+    @ConfigOption(name = "Focus Mode", desc="")
     @Accordion
     public FocusModeConfig focusMode = new FocusModeConfig();
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -85,6 +85,11 @@ public class InventoryConfig {
     public PersonalCompactorConfig personalCompactor = new PersonalCompactorConfig();
 
     @Expose
+    @ConfigOption(name = "Focus Mode",desc="")
+    @Accordion
+    public FocusModeConfig focusMode = new FocusModeConfig();
+
+    @Expose
     @ConfigOption(name = "RNG Meter", desc = "")
     @Accordion
     public RngMeterConfig rngMeter = new RngMeterConfig();

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
@@ -31,5 +31,5 @@ object FocusMode {
         toggle = !toggle
     }
 
-    fun isEnabled() = LorenzUtils.inSkyBlock && InventoryUtils.inContainer() && config.enable
+    fun isEnabled() = LorenzUtils.inSkyBlock && InventoryUtils.inContainer() && config.enabled
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraftforge.fml.common.eventhandler.EventPriority
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object FocusMode {
+
+    private val config get() = SkyHanniMod.feature.inventory.focusMode
+
+    private var toggle = true
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    fun onLorenzToolTip(event: LorenzToolTipEvent) {
+        if (!isEnabled() || !toggle) return
+        if(event.toolTip.isEmpty()) return
+        event.toolTip = mutableListOf(event.toolTip.first())
+    }
+
+    @SubscribeEvent
+    fun onLorenzTick(event: LorenzTickEvent) {
+        if (!isEnabled()) return
+        if (!config.toggleKey.isKeyClicked()) return
+        toggle = !toggle
+    }
+
+    fun isEnabled() = LorenzUtils.inSkyBlock && InventoryUtils.inContainer() && config.enable
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -41,6 +41,8 @@ object InventoryUtils {
 
     fun inInventory() = Minecraft.getMinecraft().currentScreen is GuiChest
 
+    fun inContainer() = Minecraft.getMinecraft().currentScreen is GuiContainer
+
     fun ContainerChest.getInventoryName() = this.lowerChestInventory.displayName.unformattedText.trim()
 
     fun getWindowId(): Int? = (Minecraft.getMinecraft().currentScreen as? GuiChest)?.inventorySlots?.windowId


### PR DESCRIPTION
## What
Only show the name of the item when in focus mode.

## Discord
https://discord.com/channels/997079228510117908/1292289101340344453

## Changelog New Features
+ Added Focus Mode. - Thunderblade73
    * In Focus Mode, only the name of the item is displayed instead of the full description.
