### PR TITLE
Fix: Ghost Counter area detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghostcounter/GhostCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghostcounter/GhostCounter.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.PurseChangeCause
 import at.hannibal2.skyhanni.events.PurseChangeEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -24,6 +25,7 @@ import at.hannibal2.skyhanni.features.combat.ghostcounter.GhostUtil.isUsingCTGho
 import at.hannibal2.skyhanni.features.combat.ghostcounter.GhostUtil.preFormat
 import at.hannibal2.skyhanni.features.combat.ghostcounter.GhostUtil.prettyTime
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.getBazaarData
+import at.hannibal2.skyhanni.features.misc.IslandAreas
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ChatUtils.chat
@@ -332,13 +334,17 @@ object GhostCounter {
             }
         }
 
-        inMist = LorenzUtils.skyBlockArea == "The Mist"
         update()
 
         if (event.repeatSeconds(2)) {
             calculateXP()
             calculateETA()
         }
+    }
+
+    @SubscribeEvent
+    fun onTick(event: LorenzTickEvent) {
+        inMist = IslandAreas.currentAreaName == "The Mist"
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
@@ -276,5 +276,5 @@ object IslandAreas {
         hasMoved = true
     }
 
-    fun isEnabled() = LorenzUtils.inSkyBlock && config.let { it.pathfinder.enabled || it.enterTitle || it.inWorld }
+    fun isEnabled() = LorenzUtils.inSkyBlock
 }


### PR DESCRIPTION
## What
Using Graph area instead of scoreboard area for more precise detection
Reported: https://discord.com/channels/997079228510117908/1293234947125153852

## Changelog Fixes
+ Fixed Ghost Counter display appearing while in incorrect areas on the map. - hannibal2