### PR TITLE
Fix: empty list in compact experiment rewards

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactExperimentRewards.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactExperimentRewards.kt
@@ -21,7 +21,7 @@ object CompactExperimentRewards {
 
     private val config get() = SkyHanniMod.feature.chat
 
-    private var gainedRewards = mutableListOf<String>()
+    private val gainedRewards = mutableListOf<String>()
     private var lastTimeTableOpened = SimpleTimeMark.farPast()
     private var currentMessage = ""
 
@@ -89,7 +89,7 @@ object CompactExperimentRewards {
     }
 
     private fun sendMessage(reward: String?) {
-        if (gainedRewards.last() != reward || currentMessage == "") return
+        if (gainedRewards.lastOrNull() != reward || currentMessage == "") return
 
         val expList = mutableListOf<String>().apply {
             gainedRewards.forEach { add("§8+$it") }


### PR DESCRIPTION
## What
Fixed an NoSuchElementException
Report: https://discord.com/channels/997079228510117908/1293485111056011294
 
<details>
<summary>Stack Trace</summary>

```
Caused by java.util.NoSuchElementException: List is empty.
    at kotlin.collections.CollectionsKt___CollectionsKt.last(_Collections.kt:418)
    at SH.features.chat.CompactExperimentRewards.sendMessage(CompactExperimentRewards.kt:92)
    at SH.features.chat.CompactExperimentRewards.onChat$lambda$2$lambda$1(CompactExperimentRewards.kt:86)
    at SH.utils.DelayedRun.checkRuns$lambda$0(DelayedRun.kt:31)
    at SH.utils.DelayedRun.checkRuns$lambda$1(DelayedRun.kt:27)
    at java.util.ArrayList.removeIf(ArrayList.java:1415)
    at SH.utils.DelayedRun.checkRuns(DelayedRun.kt:27)
    at SH.data.MinecraftData.onTick(MinecraftData.kt:74)
    at FML.common.eventhandler.EventBus.post(EventBus.java:140)
```
</details>

## Changelog Fixes
+ Fixed an error with compact experiment rewards chat messages. - hannibal2