### PR TITLE
Fix: buy from bazaar supercraft on overflowed inventory names

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialsFromBazaar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialsFromBazaar.kt
@@ -29,10 +29,6 @@ object CraftMaterialsFromBazaar {
     private val config get() = SkyHanniMod.feature.inventory.bazaar
 
     private val materialSlots = listOf(10, 11, 12, 19, 20, 21, 28, 29, 30)
-    private val inventoryPattern by RepoPattern.pattern(
-        "inventory.recipe.title",
-        ".* Recipe"
-    )
 
     private var inRecipeInventory = false
     private var purchasing = false
@@ -43,11 +39,11 @@ object CraftMaterialsFromBazaar {
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
-        val correctInventoryName = inventoryPattern.matches(event.inventoryName)
         val items = event.inventoryItems
         val correctItem = items[23]?.name == "§aCrafting Table"
+        val correctSuperCraftItem = items[32]?.name == "§aSupercraft"
 
-        inRecipeInventory = correctInventoryName && correctItem && !purchasing
+        inRecipeInventory = correctSuperCraftItem && correctItem &&  !purchasing
         if (!inRecipeInventory) return
 
         val recipeName = items[25]?.itemName ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialsFromBazaar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialsFromBazaar.kt
@@ -17,10 +17,8 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.makePrimitiveStack
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.renderables.Renderable
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
@@ -43,7 +41,7 @@ object CraftMaterialsFromBazaar {
         val correctItem = items[23]?.name == "§aCrafting Table"
         val correctSuperCraftItem = items[32]?.name == "§aSupercraft"
 
-        inRecipeInventory = correctSuperCraftItem && correctItem &&  !purchasing
+        inRecipeInventory = correctSuperCraftItem && correctItem && !purchasing
         if (!inRecipeInventory) return
 
         val recipeName = items[25]?.itemName ?: return


### PR DESCRIPTION
## What
Changes from a Chest name regex to an item check to fix https://discord.com/channels/997079228510117908/1293528556097376336.

## Changelog Fixes
+ Fixed Craft Materials Bazaar not working with long item names. - Fazfoxy
