### PR TITLE
Fix: Millennia-Aged Blaze not getting highlighted by the Area Boss Highlight feature

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AreaMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AreaMiniBossFeatures.kt
@@ -100,7 +100,7 @@ object AreaMiniBossFeatures {
             LorenzVec(-573, 51, -353),
         ),
         MILLENNIA_AGED_BLAZE(
-            "Millenia-Aged Blaze", LorenzColor.DARK_RED, 60,
+            "Millennia-Aged Blaze", LorenzColor.DARK_RED, 60,
             LorenzVec(-292, 97, -999),
             LorenzVec(-232, 77, -951),
             LorenzVec(-304, 73, -952),


### PR DESCRIPTION
## What
Fixes millennia highlight not working


## Changelog Fixes
+ Fixed Millennia-Aged Blaze not being highlighted by the Area Boss Highlight feature. - jani

