### PR TITLE
Fix: Soopy Spam

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -281,7 +281,7 @@ object ChatFilter {
         "§6§lGOOD CATCH! §r§bYou found a §r§fSpooky Bait§r§b.",
         "§e[NPC] Jacob§f: §rMy contest has started!",
         "§eObtain a §r§6Booster Cookie §r§efrom the community shop in the hub!",
-        "§rUnknown command. Type \"/help\" for help. ('uhfdsolguhkjdjfhgkjhdfdlgkjhldkjhlkjhsldkjfhldshkjf')",
+        "Unknown command. Type \"/help\" for help. ('uhfdsolguhkjdjfhgkjhdfdlgkjhldkjhlkjhsldkjfhldshkjf')",
     )
 
     private val skymallMessages = listOf(


### PR DESCRIPTION
## What
There was an extra §r randomly at the beginning of the message which was causing it to not be blocked. Confirmed that removing it actually does lead to it being blocked now (see images).

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/3394d2fe-1090-43ab-a57d-965f492237c9)


</details>

exclude_from_changelog
