### PR TITLE
Fix: MP Reset in Dungeons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -273,11 +273,11 @@ object MaxwellAPI {
             if (noPowerSelectedPattern.matches(line)) currentPower = NO_POWER
 
             inventoryMPPattern.matchMatcher(line) {
+                foundMagicalPower = true
                 // MagicalPower is boosted in catacombs
                 if (DungeonAPI.inDungeon()) return@matchMatcher
 
                 magicalPower = group("mp").formatInt()
-                foundMagicalPower = true
             }
 
             inventoryPowerPattern.matchMatcher(line) {


### PR DESCRIPTION
## What
That var got never set to true because it of the Catacombs check, which set it back to 0.


## Changelog Fixes
+ Fixed Magical Power resetting to 0 when opening "Your Bags" in the Catacombs. - j10a1n15
