### PR TITLE
Fix: Remove color codes from hoppity eggs share message 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getMinecraftId
 import at.hannibal2.skyhanni.utils.SkyblockSeason
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -111,14 +112,14 @@ object HoppityAPI {
                         EggFoundEvent(STRAY, it.slotNumber).post()
                         lastName = "§9Fish the Rabbit"
                         lastMeal = STRAY
-                        duplicate = it.stack.getLore().any { line -> duplicatePseudoStrayPattern.matches(line)}
+                        duplicate = it.stack.getLore().any { line -> duplicatePseudoStrayPattern.matches(line) }
                         attemptFireRabbitFound()
                     }
                     "El Dorado" -> {
                         EggFoundEvent(STRAY, it.slotNumber).post()
                         lastName = "§6El Dorado"
                         lastMeal = STRAY
-                        duplicate = it.stack.getLore().any { line -> duplicateDoradoStrayPattern.matches(line)}
+                        duplicate = it.stack.getLore().any { line -> duplicateDoradoStrayPattern.matches(line) }
                         attemptFireRabbitFound()
                     }
                     else -> return@matchMatcher
@@ -165,7 +166,8 @@ object HoppityAPI {
         eggFoundPattern.matchMatcher(event.message) {
             resetRabbitData()
             lastMeal = getEggType(event)
-            lastMeal?.let { EggFoundEvent(it, note = groupOrNull("note")).post() }
+            val note = groupOrNull("note")?.removeColor()
+            lastMeal?.let { EggFoundEvent(it, note = note).post() }
             attemptFireRabbitFound()
         }
 


### PR DESCRIPTION
## What
this was probably unintentional
`[SkyHanni] Lunch Chocolate Egg located at x: -38, y: 193, z: 35 (on the second highest rbMountain rdpeak)`
i'm not good enough at regex to know if this is fixable with a new pattern

## Changelog Fixes
+ Fixed the chocolate egg share message sometimes displaying the wrong location name. - martimavocado