### PR TITLE
Feature: Chocolate Factory Booster Cookie Blocker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -233,6 +233,12 @@ public class ChocolateFactoryConfig {
     public boolean mythicRabbitRequirement = false;
 
     @Expose
+    @ConfigOption(name = "Booster Cookie", desc = "Blocks running /cf without a §6§lBooster Cookie §7active.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean boosterCookieRequirement = false;
+
+    @Expose
     @ConfigOption(name = "Stray Tracker", desc = "Track stray rabbits found in the Chocolate Factory menu.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -1,6 +1,9 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.EntityMovementData
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.features.event.hoppity.MythicRabbitPetWarning
@@ -8,6 +11,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -54,8 +58,13 @@ object ChocolateFactoryBlockOpen {
                 ChatUtils.clickToActionOrDisable(
                     "§cBlocked opening the Chocolate Factory without a §dBooster Cookie §cactive!",
                     config::boosterCookieRequirement,
-                    actionName = "open bazaar",
-                    action = { HypixelCommands.bazaar("Booster Cookie") },
+                    actionName = "warp to hub",
+                    action = {
+                        HypixelCommands.warp("hub")
+                        EntityMovementData.onNextTeleport(IslandType.HUB) {
+                            IslandGraphs.pathFind(LorenzVec(-32.5, 71.0, -76.5), "§aBazaar", condition = { true })
+                        }
+                    },
                 )
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -28,7 +28,7 @@ object ChocolateFactoryBlockOpen {
      */
     private val commandPattern by RepoPattern.pattern(
         "inventory.chocolatefactory.opencommand",
-        "\\/(?:cf|(?:chocolate)?factory)(?: .*)?",
+        "/(?:cf|(?:chocolate)?factory)(?: .*)?",
     )
 
     private var commandSentTimer = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -52,7 +52,7 @@ object ChocolateFactoryBlockOpen {
                 if (it.timeUntil() > 0.seconds) return
                 event.cancelOpen()
                 ChatUtils.clickToActionOrDisable(
-                    "§cBlocked opening the Chocolate Factory without a §dBooster Cookie §cequipped!",
+                    "§cBlocked opening the Chocolate Factory without a §dBooster Cookie §cactive!",
                     config::boosterCookieRequirement,
                     actionName = "open bazaar",
                     action = { HypixelCommands.bazaar("Booster Cookie") },


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1293985352754794556
Adds config option for blocking `/cf` when no Booster Cookie is active.

## Changelog New Features
+ Added the ability to block opening the Chocolate Factory when Booster Cookie is inactive. - Daveed

