### PR TITLE
Fix: Remove leftover debug line from Estimated Item Value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -445,7 +445,6 @@ object EstimatedItemValueCalculator {
         var totalStars = stack.getDungeonStarCount() ?: stack.getStarCount() ?: 0
 
         starChange.takeIf { it != 0 }?.let {
-            list.add("change: $it")
             totalStars += it
         }
 


### PR DESCRIPTION
## What
Removed a debug line that must have been accidentally left in Estimated Item Value.

## Changelog Fixes
+ Removed a testing line mistakenly left in Estimated Item Value. - Luna
