### PR TITLE
Fix: Guardian warn text

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableAPI.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.inventory.experimentationtable
 
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.PetAPI
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -169,8 +170,10 @@ object ExperimentationTableAPI {
      * REGEX-TEST: §dGuardian
      * REGEX-TEST: §9Guardian§e
      */
-    val petNamePattern by patternGroup.pattern(
+    private val petNamePattern by patternGroup.pattern(
         "guardianpet",
         "§[956d]Guardian.*",
     )
+
+    fun hasGuardianPet(): Boolean = petNamePattern.matches(PetAPI.currentPet)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/GuardianReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/GuardianReminder.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.inventory.experimentationtable
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.PetAPI
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -12,7 +11,6 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
@@ -31,7 +29,6 @@ object GuardianReminder {
 
     private val config get() = SkyHanniMod.feature.inventory.experimentationTable
     private var lastInventoryOpen = SimpleTimeMark.farPast()
-    private var lastWarn = SimpleTimeMark.farPast()
     private var lastErrorSound = SimpleTimeMark.farPast()
 
     @SubscribeEvent
@@ -44,10 +41,7 @@ object GuardianReminder {
     }
 
     private fun warn() {
-        if (ExperimentationTableAPI.petNamePattern.matches(PetAPI.currentPet)) return
-
-        if (lastWarn.passedSince() < 5.seconds) return
-        lastWarn = SimpleTimeMark.now()
+        if (ExperimentationTableAPI.hasGuardianPet()) return
 
         ChatUtils.clickToActionOrDisable(
             "Use a §9§lGuardian Pet §efor more Exp in the Experimentation Table.",
@@ -62,6 +56,7 @@ object GuardianReminder {
         if (!isEnabled()) return
         if (InventoryUtils.openInventoryName() != "Experimentation Table") return
         if (lastInventoryOpen.passedSince() > 2.seconds) return
+        if (ExperimentationTableAPI.hasGuardianPet()) return
         val gui = Minecraft.getMinecraft().currentScreen as? GuiContainer ?: return
 
         sendTitle(gui.width, gui.height)


### PR DESCRIPTION
## What
Fixed guardian warn text.
Removed time check since chat messages are stacked already
Reported: https://discord.com/channels/997079228510117908/1294079215401963540

## Changelog Fixes
+ Fixed displaying the Guardian warning text in the Experimentation Table even when using a Guardian Pet. - hannibal2