### PR TITLE
Improvement: Stop Time Tower Usage Warning spam

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -22,6 +22,7 @@ object ChocolateFactoryTimeTowerManager {
     private val profileStorage get() = ChocolateFactoryAPI.profileStorage
 
     private var lastTimeTowerWarning = SimpleTimeMark.farPast()
+    private var warnedAboutLatestCharge = false
     private var wasTimeTowerRecentlyActive = false
 
     @SubscribeEvent
@@ -52,12 +53,13 @@ object ChocolateFactoryTimeTowerManager {
                 profileStorage.currentTimeTowerUses++
                 nextCharge += ChocolateFactoryAPI.timeTowerChargeDuration()
                 profileStorage.nextTimeTower = nextCharge
+                warnedAboutLatestCharge = false
             }
         }
 
         if (currentCharges() < maxCharges()) {
             if (!config.timeTowerWarning || timeTowerActive()) return
-            if (lastTimeTowerWarning.passedSince() < 5.minutes) return
+            if (warnedAboutLatestCharge) return
             ChatUtils.clickableChat(
                 "Your Time Tower has an available charge §7(${timeTowerCharges()})§e. " +
                     "Click here to use one.",
@@ -66,7 +68,7 @@ object ChocolateFactoryTimeTowerManager {
             )
             SoundUtils.playBeepSound()
             lastTimeTowerWarning = SimpleTimeMark.now()
-            return
+            warnedAboutLatestCharge = true
         }
         checkTimeTowerWarning(false)
     }


### PR DESCRIPTION
## What
Improves the logic of the "Time Tower Usage Warning" feature so that it only sends one message at a time.

For example, previously if you went offline with no charges and returned with three charges available, it would notify you for each charge and then warn about the timer tower being full. Now, it will _only_ give the warning.
<details>
<summary>Image</summary>

![image](https://github.com/user-attachments/assets/a452002d-5ea8-4560-b7f0-4b4eb3ce9e2d)
</details>

I had to test by changing my config manually since my time tower is empty at the moment.

## Changelog Improvements
+ Improved the Time Tower Usage Warning so it doesn't spam messages. - MTOnline