### PR TITLE
Fix: Farming Weight Overlay

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -360,12 +360,9 @@ object FarmingWeightDisplay {
         )
     }
 
-    private fun isEnabled() = (
-        config.display && (
-            OutsideSbFeature.FARMING_WEIGHT.isSelected() && !LorenzUtils.inSkyBlock
-            ) ||
-            (LorenzUtils.inSkyBlock && (GardenAPI.inGarden() || config.showOutsideGarden))
-        )
+    private fun isEnabled() = config.display && (outsideEnabled() || inGardenEnabled())
+    private fun outsideEnabled() = OutsideSbFeature.FARMING_WEIGHT.isSelected() && !LorenzUtils.inSkyBlock
+    private fun inGardenEnabled() = (LorenzUtils.inSkyBlock && GardenAPI.inGarden()) || config.showOutsideGarden
 
     private fun isEtaEnabled() = config.overtakeETA
 


### PR DESCRIPTION
## What
isEnabledFunctions and trying to nest these conditions is going to be the death of anything functioning correctly.
Fixes farming weight display not respecting its config option.

## Changelog Fixes
+ Fixed farming weight not disappearing when the config option is off. - Daveed
