### PR TITLE
Improvement: Added option to show the barn fishing timer anywhere.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/BarnTimerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/BarnTimerConfig.java
@@ -23,6 +23,14 @@ public class BarnTimerConfig {
 
     @Expose
     @ConfigOption(
+        name = "Show Anywhere",
+        desc = "Show the Barn Fishing Timer whenever you fish up a sea creature, regardless of location."
+    )
+    @ConfigEditorBoolean
+    public Property<Boolean> showAnywhere = Property.of(true);
+
+    @Expose
+    @ConfigOption(
         name = "Worm Fishing",
         desc = "Show the Barn Fishing Timer in the Crystal Hollows."
     )

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/BarnTimerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/BarnTimerConfig.java
@@ -27,7 +27,7 @@ public class BarnTimerConfig {
         desc = "Show the Barn Fishing Timer whenever you fish up a sea creature, regardless of location."
     )
     @ConfigEditorBoolean
-    public Property<Boolean> showAnywhere = Property.of(false);
+    public boolean showAnywhere = false;
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/BarnTimerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/BarnTimerConfig.java
@@ -27,7 +27,7 @@ public class BarnTimerConfig {
         desc = "Show the Barn Fishing Timer whenever you fish up a sea creature, regardless of location."
     )
     @ConfigEditorBoolean
-    public Property<Boolean> showAnywhere = Property.of(true);
+    public Property<Boolean> showAnywhere = Property.of(false);
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
@@ -180,7 +180,7 @@ object FishingTimer {
             else -> false
         }
         
-        if (config.showAnywhere.get() == true) {
+        if (config.showAnywhere == true) {
             rightLocation = true
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
@@ -179,6 +179,10 @@ object FishingTimer {
             IslandType.PRIVATE_ISLAND -> config.forStranded.get() && LorenzUtils.isStrandedProfile
             else -> false
         }
+        
+        if (config.showAnywhere.get() == true) {
+            rightLocation = true
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
@@ -180,7 +180,7 @@ object FishingTimer {
             else -> false
         }
         
-        if (config.showAnywhere == true) {
+        if (config.showAnywhere) {
             rightLocation = true
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
@@ -65,7 +65,7 @@ object FishingTimer {
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
-        updateLocation()
+        rightLocation = updateLocation()
         if (startTime.passedSince().inWholeSeconds - config.alertTime in 0..3) {
             playSound()
         }
@@ -170,18 +170,16 @@ object FishingTimer {
         display = createDisplay()
     }
 
-    private fun updateLocation() {
-        rightLocation = when (LorenzUtils.skyBlockIsland) {
+    private fun updateLocation(): Boolean {
+        if (config.showAnywhere) return true
+
+        return when (LorenzUtils.skyBlockIsland) {
             IslandType.CRYSTAL_HOLLOWS -> config.crystalHollows.get()
             IslandType.CRIMSON_ISLE -> config.crimsonIsle.get()
             IslandType.WINTER -> config.winterIsland.get()
             IslandType.HUB -> barnLocation.distanceToPlayer() < 50
             IslandType.PRIVATE_ISLAND -> config.forStranded.get() && LorenzUtils.isStrandedProfile
             else -> false
-        }
-        
-        if (config.showAnywhere) {
-            rightLocation = true
         }
     }
 


### PR DESCRIPTION
## What
Adds option to show the barn fishing timer anywhere, regardless of the player's current location.

The code change is simple, a new option which the user can choose to enable or disable. When `updateLocation()` is run, an if statement will check if the setting is enabled, if so it'll override the outcome of the code above it.

## Changelog Improvements
+ Added an option to always display the Barn Fishing Timer anywhere. - NeoNyaa
