### PR TITLE
Fix: El Dorado HoppityAPI

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactor
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryStrayTracker
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryStrayTracker.duplicateDoradoStrayPattern
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryStrayTracker.duplicatePseudoStrayPattern
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryStrayTracker.formLoreToSingleLine
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -117,15 +118,17 @@ object HoppityAPI {
                         duplicate = it.stack.getLore().any { line -> duplicatePseudoStrayPattern.matches(line) }
                         attemptFireRabbitFound()
                     }
-                    "El Dorado" -> {
-                        EggFoundEvent(STRAY, it.slotNumber).post()
-                        lastName = "§6El Dorado"
-                        lastMeal = STRAY
-                        duplicate = it.stack.getLore().any { line -> duplicateDoradoStrayPattern.matches(line) }
-                        attemptFireRabbitFound()
-                    }
                     else -> return@matchMatcher
                 }
+            }
+            ChocolateFactoryStrayTracker.strayDoradoPattern.matchMatcher(formLoreToSingleLine(it.stack.getLore())) {
+                // We don't need to do a handleStrayClicked here - the lore from El Dorado is already:
+                // §6§lGolden Rabbit §d§lCAUGHT!
+                // Which will trigger the above matcher. We only need to check name here to fire the found event for Dorado.
+                EggFoundEvent(STRAY, it.slotNumber).post()
+                lastName = "§6El Dorado"
+                lastMeal = STRAY
+                duplicate = it.stack.getLore().any { line -> duplicateDoradoStrayPattern.matches(line) }
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
@@ -129,6 +129,7 @@ object HoppityAPI {
                 lastName = "§6El Dorado"
                 lastMeal = STRAY
                 duplicate = it.stack.getLore().any { line -> duplicateDoradoStrayPattern.matches(line) }
+                attemptFireRabbitFound()
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTracker.kt
@@ -77,7 +77,7 @@ object ChocolateFactoryStrayTracker {
      * REGEX-TEST: §7You caught a stray §6§lGolden Rabbit§7! §7You caught §6El Dorado §7- quite the elusive rabbit!
      * REGEX-TEST: §7You caught a stray §6§lGolden Rabbit§7! §7You caught §6El Dorado§7! Since you §7already have captured him before, §7you gained §6+324,364,585 Chocolate§7.
      */
-    private val strayDoradoPattern by ChocolateFactoryAPI.patternGroup.pattern(
+    val strayDoradoPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "stray.dorado",
         ".*§6El Dorado(?:.*?§6\\+?(?<amount>[\\d,]+) Chocolate)?.*",
     )
@@ -147,7 +147,7 @@ object ChocolateFactoryStrayTracker {
         var goldenTypesCaught: MutableMap<String, Int> = mutableMapOf()
     }
 
-    private fun formLoreToSingleLine(lore: List<String>): String {
+    fun formLoreToSingleLine(lore: List<String>): String {
         val notEmptyLines = lore.filter { it.isNotEmpty() }
         return notEmptyLines.joinToString(" ")
     }


### PR DESCRIPTION
## What
[Info here](https://discord.com/channels/997079228510117908/1295820860707311657).
Fixes an issue where finding El Dorado will not fire an event from the Hoppity API, due to not matching the 'normal' patterns that other strays follow ... god bless Hypixel.
This only should have impacted the Compact Hoppity option, as the stray tracker still takes the click event properly, as it has its own patterns.

## Changelog Fixes
+ Fixed El Dorado not receiving a compacted chat message. - Daveed

