### PR TITLE
Backend: Event Objects

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -61,7 +61,7 @@ class SkyHanniMod {
 
         CommandRegistrationEvent.post()
 
-        PreInitFinishedEvent().post()
+        PreInitFinishedEvent.post()
     }
 
     @Mod.EventHandler

--- a/src/main/java/at/hannibal2/skyhanni/api/CollectionAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/CollectionAPI.kt
@@ -60,7 +60,7 @@ object CollectionAPI {
                 val internalName = incorrectCollectionNames[name] ?: NEUInternalName.fromItemName(name)
                 collectionValue[internalName] = counter
             }
-            CollectionUpdateEvent().postAndCatch()
+            CollectionUpdateEvent.post()
         }
 
         if (inventoryName.endsWith(" Collections")) {
@@ -83,7 +83,7 @@ object CollectionAPI {
                     collectionValue[internalName] = counter
                 }
             }
-            CollectionUpdateEvent().postAndCatch()
+            CollectionUpdateEvent.post()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/FmlEventApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/FmlEventApi.kt
@@ -12,7 +12,7 @@ object FmlEventApi {
 
     @SubscribeEvent
     fun onDisconnect(event: FMLNetworkEvent.ClientDisconnectionFromServerEvent) {
-        ClientDisconnectEvent().post()
+        ClientDisconnectEvent.post()
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.events.EntityMoveEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
-import at.hannibal2.skyhanni.events.LorenzWarpEvent
+import at.hannibal2.skyhanni.events.SkyHanniWarpEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
@@ -104,7 +104,7 @@ object EntityMovementData {
         if (!LorenzUtils.inSkyBlock) return
         if (!warpingPattern.matches(event.message)) return
         DelayedRun.runNextTick {
-            LorenzWarpEvent.post()
+            SkyHanniWarpEvent.post()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
@@ -104,7 +104,7 @@ object EntityMovementData {
         if (!LorenzUtils.inSkyBlock) return
         if (!warpingPattern.matches(event.message)) return
         DelayedRun.runNextTick {
-            LorenzWarpEvent().postAndCatch()
+            LorenzWarpEvent.post()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/GardenCropMilestones.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GardenCropMilestones.kt
@@ -51,7 +51,7 @@ object GardenCropMilestones {
                 crop.setCounter(amount)
             }
         }
-        CropMilestoneUpdateEvent().postAndCatch()
+        CropMilestoneUpdateEvent.post()
         GardenCropMilestonesCommunityFix.openInventory(event.inventoryItems)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/GuiData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiData.kt
@@ -24,7 +24,7 @@ object GuiData {
 
     var preDrawEventCancelled = false
 
-    @SubscribeEvent(priority = EventPriority.HIGH)
+    @HandleEvent(priority = HandleEvent.HIGH)
     fun onNeuRenderEvent(event: NEURenderEvent) {
         if (preDrawEventCancelled) event.cancel()
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
@@ -334,7 +334,7 @@ object SackAPI {
         ProfileStorageData.sackProfiles?.sackContents = sackData
         SkyHanniMod.configManager.saveConfig(ConfigFileType.SACKS, "saving-data")
 
-        SackDataUpdateEvent().postAndCatch()
+        SackDataUpdateEvent.post()
     }
 
     data class SackGemstone(

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerAPI.kt
@@ -82,7 +82,7 @@ object SlayerAPI {
         }
 
         if (event.message == "  §r§a§lSLAYER QUEST COMPLETE!") {
-            SlayerQuestCompleteEvent().postAndCatch()
+            SlayerQuestCompleteEvent.post()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/events/CollectionUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/CollectionUpdateEvent.kt
@@ -1,3 +1,5 @@
 package at.hannibal2.skyhanni.events
 
-class CollectionUpdateEvent : LorenzEvent()
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+object CollectionUpdateEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/CropMilestoneUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/CropMilestoneUpdateEvent.kt
@@ -1,3 +1,5 @@
 package at.hannibal2.skyhanni.events
 
-class CropMilestoneUpdateEvent : LorenzEvent()
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+object CropMilestoneUpdateEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/DungeonBossRoomEnterEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/DungeonBossRoomEnterEvent.kt
@@ -1,3 +1,5 @@
 package at.hannibal2.skyhanni.events
 
-class DungeonBossRoomEnterEvent : LorenzEvent()
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+object DungeonBossRoomEnterEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/LorenzWarpEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/LorenzWarpEvent.kt
@@ -1,3 +1,5 @@
 package at.hannibal2.skyhanni.events
 
-class LorenzWarpEvent : LorenzEvent()
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+object LorenzWarpEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/NEURenderEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/NEURenderEvent.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.events
 
-import net.minecraftforge.fml.common.eventhandler.Cancelable
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-@Cancelable
-class NEURenderEvent : LorenzEvent()
+class NEURenderEvent : SkyHanniEvent(), SkyHanniEvent.Cancellable

--- a/src/main/java/at/hannibal2/skyhanni/events/NEURenderEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/NEURenderEvent.kt
@@ -1,5 +1,5 @@
 package at.hannibal2.skyhanni.events
 
-import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.api.event.CancellableSkyHanniEvent
 
-class NEURenderEvent : SkyHanniEvent(), SkyHanniEvent.Cancellable
+class NEURenderEvent : CancellableSkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/SackDataUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/SackDataUpdateEvent.kt
@@ -1,3 +1,5 @@
 package at.hannibal2.skyhanni.events
 
-class SackDataUpdateEvent : LorenzEvent()
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+object SackDataUpdateEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/SkyHanniWarpEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/SkyHanniWarpEvent.kt
@@ -2,4 +2,4 @@ package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-object LorenzWarpEvent : SkyHanniEvent()
+object SkyHanniWarpEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/SlayerQuestCompleteEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/SlayerQuestCompleteEvent.kt
@@ -1,3 +1,5 @@
 package at.hannibal2.skyhanni.events
 
-class SlayerQuestCompleteEvent : LorenzEvent()
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+object SlayerQuestCompleteEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/bingo/BingoCardUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/bingo/BingoCardUpdateEvent.kt
@@ -2,4 +2,4 @@ package at.hannibal2.skyhanni.events.bingo
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-class BingoCardUpdateEvent : SkyHanniEvent()
+object BingoCardUpdateEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestUpdateEvent.kt
@@ -2,4 +2,4 @@ package at.hannibal2.skyhanni.events.garden.pests
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-class PestUpdateEvent : SkyHanniEvent()
+object PestUpdateEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/ClientDisconnectEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/ClientDisconnectEvent.kt
@@ -2,4 +2,4 @@ package at.hannibal2.skyhanni.events.minecraft
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-class ClientDisconnectEvent : SkyHanniEvent()
+object ClientDisconnectEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/utils/PreInitFinishedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/utils/PreInitFinishedEvent.kt
@@ -2,4 +2,4 @@ package at.hannibal2.skyhanni.events.utils
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-class PreInitFinishedEvent : SkyHanniEvent()
+object PreInitFinishedEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardReader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardReader.kt
@@ -96,7 +96,7 @@ object BingoCardReader {
         }
         BingoAPI.lastBingoCardOpenTime = SimpleTimeMark.now()
 
-        BingoCardUpdateEvent().post()
+        BingoCardUpdateEvent.post()
     }
 
     private fun bingoGoalDifference(bingoGoal: BingoGoal, new: Double) {
@@ -163,7 +163,7 @@ object BingoCardReader {
         val goal = BingoAPI.personalGoals.firstOrNull { it.displayName == name } ?: return
         goal.done = true
         BingoGoalReachedEvent(goal).post()
-        BingoCardUpdateEvent().post()
+        BingoCardUpdateEvent.post()
     }
 
     private fun BingoData.getDescriptionLine() = "§7" + note.joinToString(" ")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
@@ -123,7 +123,7 @@ object DungeonAPI {
         val message = rawMessage.removeColor()
         val bossName = message.substringAfter("[BOSS] ").substringBefore(":").trim()
         if ((bossName != "The Watcher") && dungeonFloor != null && checkBossName(bossName) && !inBossRoom) {
-            DungeonBossRoomEnterEvent().postAndCatch()
+            DungeonBossRoomEnterEvent.post()
             inBossRoom = true
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.DungeonBossRoomEnterEvent
@@ -133,7 +134,7 @@ object DungeonCopilot {
         searchForKey = true
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onDungeonBossRoomEnter(event: DungeonBossRoomEnterEvent) {
         changeNextStep("Defeat the boss! Good luck :)")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropSpeedMeter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropSpeedMeter.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.farming
 
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.GardenCropMilestones.getCounter
 import at.hannibal2.skyhanni.events.CropClickEvent
 import at.hannibal2.skyhanni.events.CropMilestoneUpdateEvent
@@ -76,7 +77,7 @@ object CropSpeedMeter {
         return list
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onCropMilestoneUpdate(event: CropMilestoneUpdateEvent) {
         if (!isEnabled()) return
         val counters = mutableMapOf<CropType, Long>()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.farming
 
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.garden.cropmilestones.CropMilestonesConfig.MilestoneTextEntry
 import at.hannibal2.skyhanni.config.features.garden.cropmilestones.CropMilestonesConfig.TimeFormatEntry
@@ -99,7 +100,7 @@ object GardenCropMilestoneDisplay {
         }
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onCropMilestoneUpdate(event: CropMilestoneUpdateEvent) {
         needsInventory = false
         GardenBestCropTime.updateTimeTillNextCrop()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenCropMilestoneInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenCropMilestoneInventory.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.inventory
 
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.GardenCropMilestones
 import at.hannibal2.skyhanni.data.GardenCropMilestones.getCounter
@@ -24,7 +25,7 @@ object GardenCropMilestoneInventory {
     private var average = -1.0
     private val config get() = GardenAPI.config
 
-    @SubscribeEvent
+    @HandleEvent
     fun onCropMilestoneUpdate(event: CropMilestoneUpdateEvent) {
         if (!config.number.averageCropMilestone) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -155,7 +155,7 @@ object PestAPI {
     private fun updatePests() {
         if (!firstScoreboardCheck) return
         fixPests()
-        PestUpdateEvent().post()
+        PestUpdateEvent.post()
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.visitor
 
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.garden.visitor.VisitorConfig.HighlightMode
 import at.hannibal2.skyhanni.data.IslandType
@@ -336,7 +337,7 @@ object GardenVisitorFeatures {
         }
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onSackUpdate(event: SackDataUpdateEvent) {
         update()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.events.LorenzKeyPressEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
-import at.hannibal2.skyhanni.events.LorenzWarpEvent
+import at.hannibal2.skyhanni.events.SkyHanniWarpEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -503,7 +503,7 @@ object TunnelsMaps {
     }
 
     @HandleEvent
-    fun onLorenzWarp(event: LorenzWarpEvent) {
+    fun onWarp(event: SkyHanniWarpEvent) {
         if (!isEnabled()) return
         if (goal != null) {
             DelayedRun.runNextTick {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -502,7 +502,7 @@ object TunnelsMaps {
         }
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onLorenzWarp(event: LorenzWarpEvent) {
         if (!isEnabled()) return
         if (goal != null) {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.slayer
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage
 import at.hannibal2.skyhanni.data.ItemAddManager
@@ -143,7 +144,7 @@ object SlayerProfitTracker {
         }
     }
 
-    @SubscribeEvent
+    @HandleEvent
     fun onQuestComplete(event: SlayerQuestCompleteEvent) {
         getTracker()?.modify {
             it.slayerCompletedCount++

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinNEUOverlay.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinNEUOverlay.java
@@ -12,7 +12,7 @@ public class MixinNEUOverlay {
 
     @Inject(method = "render", at = @At("HEAD"), cancellable = true, remap = false)
     private void render(boolean hoverInv, CallbackInfo ci) {
-        if (new NEURenderEvent().postAndCatch()) {
+        if (new NEURenderEvent().post()) {
             ci.cancel();
         }
     }


### PR DESCRIPTION
## What
Changes SkyHanniEvents without any parameters to be objects instead of classes. It seems like you cannot actually do this with LorenzEvent, ~~so those will be changed at a later date, probably whenever those are migrated to be SkyHanniEvent instead.~~ ended up migrating some of them in the same pr

## Changelog Technical Details
+ Migrated some LorenzEvents without parameters to SkyHanniEvents. - Empa
+ Changed SkyHanniEvents without parameters to be objects. - Empa