### PR TITLE
Fix: Typo

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
@@ -448,7 +448,8 @@ object BestiaryData {
             return true
         } else if (name == "Search Results") {
             val loreList = stack.getLore()
-            if (loreList.size >= 2 && loreList[0].startsWith("§7Query: §a") &&
+            if (loreList.size >= 2 &&
+                loreList[0].startsWith("§7Query: §a") &&
                 loreList[1].startsWith("§7Results: §a")
             ) {
                 return true
@@ -464,7 +465,7 @@ object BestiaryData {
 
     enum class NumberType(val type: String) {
         INT("Normal (1, 2, 3)"),
-        ROMAN("Roman (I, II, III")
+        ROMAN("Roman (I, II, III)")
     }
 
     enum class DisplayType(val type: String) {


### PR DESCRIPTION
## What
Fix non-game breaking typo in Bestiary Display.
Report: https://discord.com/channels/997079228510117908/1296131703785390131

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/a0c39cad-4eaa-414a-b71b-202e448a3a9d)

</details>

## Changelog Fixes
+ Fixed a small typo in Bestiary Display. - hannibal2