### PR TITLE
Fix: Time Tower usage warnings sending excessively

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -57,7 +57,7 @@ object ChocolateFactoryTimeTowerManager {
             }
         }
 
-        if (currentCharges() in 0..maxCharges()) {
+        if (currentCharges() > 0 && currentCharges() < maxCharges()) {
             if (!config.timeTowerWarning || timeTowerActive()) return
             if (!warnAboutNewCharge) return
             ChatUtils.clickableChat(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -22,7 +22,7 @@ object ChocolateFactoryTimeTowerManager {
     private val profileStorage get() = ChocolateFactoryAPI.profileStorage
 
     private var lastTimeTowerWarning = SimpleTimeMark.farPast()
-    private var warnedAboutLatestCharge = false
+    private var warnAboutNewCharge = false
     private var wasTimeTowerRecentlyActive = false
 
     @SubscribeEvent
@@ -53,13 +53,13 @@ object ChocolateFactoryTimeTowerManager {
                 profileStorage.currentTimeTowerUses++
                 nextCharge += ChocolateFactoryAPI.timeTowerChargeDuration()
                 profileStorage.nextTimeTower = nextCharge
-                warnedAboutLatestCharge = false
+                warnAboutNewCharge = true
             }
         }
 
         if (currentCharges() > 0 && currentCharges() < maxCharges()) {
             if (!config.timeTowerWarning || timeTowerActive()) return
-            if (warnedAboutLatestCharge) return
+            if (!warnAboutNewCharge) return
             ChatUtils.clickableChat(
                 "Your Time Tower has an available charge §7(${timeTowerCharges()})§e. " +
                     "Click here to use one.",
@@ -68,7 +68,7 @@ object ChocolateFactoryTimeTowerManager {
             )
             SoundUtils.playBeepSound()
             lastTimeTowerWarning = SimpleTimeMark.now()
-            warnedAboutLatestCharge = true
+            warnAboutNewCharge = false
         }
         checkTimeTowerWarning(false)
     }
@@ -106,7 +106,6 @@ object ChocolateFactoryTimeTowerManager {
         )
         SoundUtils.playBeepSound()
         lastTimeTowerWarning = SimpleTimeMark.now()
-        warnedAboutLatestCharge = true
     }
 
     fun timeTowerCharges(): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -57,7 +57,7 @@ object ChocolateFactoryTimeTowerManager {
             }
         }
 
-        if (currentCharges() < maxCharges()) {
+        if (currentCharges() > 0 && currentCharges() < maxCharges()) {
             if (!config.timeTowerWarning || timeTowerActive()) return
             if (warnedAboutLatestCharge) return
             ChatUtils.clickableChat(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -57,7 +57,7 @@ object ChocolateFactoryTimeTowerManager {
             }
         }
 
-        if (currentCharges() > 0 && currentCharges() < maxCharges()) {
+        if (currentCharges() in 0..maxCharges()) {
             if (!config.timeTowerWarning || timeTowerActive()) return
             if (!warnAboutNewCharge) return
             ChatUtils.clickableChat(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -106,6 +106,7 @@ object ChocolateFactoryTimeTowerManager {
         )
         SoundUtils.playBeepSound()
         lastTimeTowerWarning = SimpleTimeMark.now()
+        warnedAboutLatestCharge = true
     }
 
     fun timeTowerCharges(): String {


### PR DESCRIPTION
## What
Fixes two issues with the Time Tower Usage Warning:
-  sending a message for 0 charges being available when joining skyblock (reported [here](https://discord.com/channels/997079228510117908/1296237205500465172))
- sending after tower expiry (shouldn't happen since the Expiry Reminder is meant for this)

## Changelog Fixes
+ Fixed an issue where the Time Tower Usage Warning would notify you after expiration or when you have 0 charges. - MTOnline
