### PR TITLE
Feature: Mask Shop carnival token profit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/CarnivalConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/CarnivalConfig.java
@@ -16,6 +16,11 @@ public class CarnivalConfig {
     public ZombieShootoutConfig zombieShootout = new ZombieShootoutConfig();
 
     @Expose
+    @ConfigOption(name = "Mask Shop Price", desc = "")
+    @Accordion
+    public MaskShopPriceConfig maskShopPrice = new MaskShopPriceConfig();
+
+    @Expose
     @ConfigOption(name = "Reminder Daily Tickets", desc = "Reminds you when tickets can be claimed from the carnival leader.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/MaskShopPriceConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/MaskShopPriceConfig.java
@@ -1,0 +1,27 @@
+package at.hannibal2.skyhanni.config.features.event.carnival;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import at.hannibal2.skyhanni.config.core.config.Position;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+public class MaskShopPriceConfig {
+
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Show carnival token to coin prices inside the Mask Shop inventory.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean enabled = true;
+
+    @Expose
+    @ConfigLink(owner = CarnivalConfig.class, field = "maskShopPrice")
+    public Position position = new Position(200, 150, false, true);
+
+    @Expose
+    @ConfigOption(name = "Item Scale", desc = "Change the size of the items.")
+    @ConfigEditorSlider(minValue = 0.3f, maxValue = 3, minStep = 0.1f)
+    public double itemScale = 0.6;
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/MaskShopPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/MaskShopPrice.kt
@@ -38,8 +38,12 @@ object MaskShopPrice {
 
     val patternGroup = RepoPattern.group("carnival.shop")
     private val tokenAmountPattern by patternGroup.pattern(
-        "amount",
+        "tokencost",
         "(?<amount>[\\d,]+) Carnival Tokens",
+    )
+    private val inventoryPattern by patternGroup.pattern(
+        "mask.inventoryname",
+        "Carnival Masks"
     )
 
     @SubscribeEvent
@@ -52,7 +56,7 @@ object MaskShopPrice {
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
-        if (event.inventoryName != "Carnival Masks") return
+        if (!inventoryPattern.matches(event.inventoryName)) return
         inInventory = true
         inventoryItems = event.inventoryItems
         update()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/MaskShopPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/MaskShopPrice.kt
@@ -1,0 +1,144 @@
+package at.hannibal2.skyhanni.features.event.carnival
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
+import at.hannibal2.skyhanni.utils.DisplayTableEntry
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.itemName
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NEUInternalName
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
+import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.UtilsPatterns
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.item.ItemStack
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object MaskShopPrice {
+    private val config get() = SkyHanniMod.feature.event.carnival.maskShopPrice
+
+    private var display = emptyList<Renderable>()
+    private var products = emptyList<Product>()
+
+    private var inInventory = false
+    private var inventoryItems = emptyMap<Int, ItemStack>()
+
+    val patternGroup = RepoPattern.group("carnival.shop")
+    private val tokenAmountPattern by patternGroup.pattern(
+        "amount",
+        "(?<amount>[\\d,]+) Carnival Tokens",
+    )
+
+    @SubscribeEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
+        if (inInventory) {
+            update()
+        }
+    }
+
+    @SubscribeEvent
+    fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+        if (!isEnabled()) return
+        if (event.inventoryName != "Carnival Masks") return
+        inInventory = true
+        inventoryItems = event.inventoryItems
+        update()
+    }
+
+    private fun updateProducts() {
+        val newProducts = mutableListOf<Product>()
+        for ((slot, item) in inventoryItems) {
+            val lore = item.getLore()
+
+            val carnivalTokens = getTokenBuyCost(lore) ?: continue
+            val internalName = item.getInternalName()
+            val itemPrice = internalName.getPriceOrNull() ?: continue
+
+            newProducts.add(Product(slot, item.itemName, internalName, carnivalTokens, itemPrice))
+        }
+        products = newProducts
+    }
+
+    private fun update() {
+        updateProducts()
+
+        val multiplier = 100
+        val table = mutableListOf<DisplayTableEntry>()
+
+        for (product in products) {
+            val factor = (product.itemPrice / product.carnivalTokens) * multiplier
+            val perFormat = factor.shortFormat()
+
+            val hover = buildList {
+                add(product.name)
+
+                add("")
+                add("§7Item price: §6${product.itemPrice.shortFormat()} ")
+                add("§7Carnival Token cost: §c${product.carnivalTokens.shortFormat()} ")
+                add("§7Profit per 100 Carnival Tokens: §6$perFormat ")
+                add("")
+            }
+            table.add(
+                DisplayTableEntry(
+                    "${product.name}§f:",
+                    "§6§l$perFormat",
+                    factor,
+                    product.item,
+                    hover,
+                    highlightsOnHoverSlots = product.slot?.let { listOf(it) } ?: emptyList(),
+                ),
+            )
+        }
+
+        display = buildList {
+            add(Renderable.string("§e§lCoins per 100 Carnival Tokens§f:"))
+            add(LorenzUtils.fillTable(table, padding = 5, itemScale = config.itemScale))
+        }
+    }
+
+    private fun getTokenBuyCost(lore: List<String>): Long? {
+        val nextLine = lore.nextAfter({ UtilsPatterns.costLinePattern.matches(it) }) ?: return null
+        return tokenAmountPattern.matchMatcher(nextLine.removeColor()) {
+            group("amount").formatLong()
+        }
+    }
+
+    @SubscribeEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        inInventory = false
+    }
+
+    @SubscribeEvent
+    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+        if (inInventory) {
+            config.position.renderRenderables(
+                display,
+                extraSpace = 5,
+                posLabel = "Mask Shop Price",
+            )
+        }
+    }
+
+    private fun isEnabled() = LorenzUtils.skyBlockArea == "Carnival" && config.enabled
+
+    private data class Product(
+        var slot: Int?,
+        val name: String,
+        val item: NEUInternalName,
+        val carnivalTokens: Long,
+        val itemPrice: Double,
+    )
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/MaskShopPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/MaskShopPrice.kt
@@ -76,6 +76,7 @@ object MaskShopPrice {
         updateProducts()
 
         val multiplier = 100
+        // TODO merge core with SkyMartCopperPrice into a utils
         val table = mutableListOf<DisplayTableEntry>()
 
         for (product in products) {
@@ -84,12 +85,10 @@ object MaskShopPrice {
 
             val hover = buildList {
                 add(product.name)
-
                 add("")
                 add("§7Item price: §6${product.itemPrice.shortFormat()} ")
                 add("§7Carnival Token cost: §c${product.carnivalTokens.shortFormat()} ")
                 add("§7Profit per 100 Carnival Tokens: §6$perFormat ")
-                add("")
             }
             table.add(
                 DisplayTableEntry(


### PR DESCRIPTION
## What
Adds a display in the Carnival Mask Shop for the best items to buy in terms of coins to 100 carnival tokens.
Very similar to SkyMart and Chocolate Factory equivalents.

<details>
<summary>Image</summary>

![image](https://github.com/user-attachments/assets/ade76e13-6b3f-4603-94dc-4cf45f2047f6)
</details>

## Changelog New Features
+ Added a coins to carnival tokens display for the Carnival Mask Shop. - MTOnline
    * Uses coins per hundred tokens.

