### PR TITLE
Fix: Draft PRs having PR checks run on them

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,11 +2,11 @@ name: "PR Changelog Verification"
 
 on:
     pull_request_target:
-        types: [ opened, edited ]
+        types: [ opened, edited, ready_for_review ]
 
 jobs:
     verify-changelog:
-        if: github.event.pull_request.state == 'open' && '511310721' == github.repository_id
+        if: github.event.pull_request.state == 'open' && '511310721' == github.repository_id && github.event.pull_request.draft == false
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
## What
Changes the PR check action to only run when a PR is not a draft as to not spam drafts that shouldnt have pretty much any actions of reviewing or checking done to them until marked as ready.

exclude_from_changelog