### PR TITLE
Fix: Brave Downloads Cutting `host`

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
+++ b/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
@@ -87,7 +87,8 @@ public class DownloadSourceChecker {
         // Check if the host is empty (Brave is cutting everything past .com/ from the host)
         String cutHostMessage = "";
         if (matcher.find()) {
-            cutHostMessage = "\n\nYour browser MAY have interfered with the download process.\nTry downloading the file using a different browser (Microsoft Edge, Google Chrome, etc.).";
+            cutHostMessage = "\n\nYour browser MAY have interfered with the download process.\n" +
+                "Try downloading the file using a different browser (Microsoft Edge, Google Chrome, etc.).";
         }
 
         JOptionPane.showOptionDialog(

--- a/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
+++ b/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
@@ -81,7 +81,7 @@ public class DownloadSourceChecker {
         ));
 
         // Compile the regex pattern for matching an empty host
-        Pattern pattern = Pattern.compile("https:\\/\\/.*.com\\/$");
+        Pattern pattern = Pattern.compile("https:\\/\\/.*.com\\/$|about:internet");
         Matcher matcher = pattern.matcher(host.getHost());
 
         // Check if the host is empty (Brave is cutting everything past .com/ from the host)

--- a/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
+++ b/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
@@ -13,6 +13,8 @@ import java.io.FileReader;
 import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class DownloadSourceChecker {
 
@@ -78,9 +80,19 @@ public class DownloadSourceChecker {
             }
         ));
 
+        // Compile the regex pattern for matching an empty host
+        Pattern pattern = Pattern.compile("https:\\/\\/.*.com\\/$");
+        Matcher matcher = pattern.matcher(host.getHost());
+
+        // Check if the host is empty (Brave is cutting everything past .com/ from the host)
+        String cutHostMessage = "";
+        if (matcher.find()) {
+            cutHostMessage = "\n\nYour browser MAY have interfered with the download process.\nTry downloading the file using a different browser (Microsoft Edge, Google Chrome, etc.).";
+        }
+
         JOptionPane.showOptionDialog(
             frame,
-            String.format(String.join("\n", SECURITY_POPUP), uriToSimpleString(host)),
+            String.format(String.join("\n", SECURITY_POPUP), uriToSimpleString(host)) + cutHostMessage,
             "SkyHanni " + MOD_VERSION + " Security Error",
             JOptionPane.DEFAULT_OPTION,
             JOptionPane.ERROR_MESSAGE,

--- a/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
+++ b/src/main/java/at/hannibal2/skyhanni/tweaker/DownloadSourceChecker.java
@@ -82,7 +82,7 @@ public class DownloadSourceChecker {
 
         // Compile the regex pattern for matching an empty host
         Pattern pattern = Pattern.compile("https:\\/\\/.*.com\\/$|about:internet");
-        Matcher matcher = pattern.matcher(host.getHost());
+        Matcher matcher = pattern.matcher(uriToSimpleString(host));
 
         // Check if the host is empty (Brave is cutting everything past .com/ from the host)
         String cutHostMessage = "";


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1000669238035497022/1296878161015083119
That message and down - Brave browser is cutting the `host` of the download past `.com/`, which is false flagging the security checker. This just adds a notice to the users about that, as there's not much we can do to actually fix the false flag, without nerfing it heavily.

exclude_from_changelog

