### PR TITLE
Backend Fix: Detekt Annotations

### DIFF
--- a/.github/scripts/process_detekt_sarif.sh
+++ b/.github/scripts/process_detekt_sarif.sh
@@ -29,7 +29,7 @@ read -r -d '' jq_command <<'EOF'
     ",title=" + (.ruleId) +
     ",col=" + (.l.region.startColumn|tostring) +
     ",endColumn=" + (.l.region.endColumn|tostring) +
-    "::" + (.message.text)
+    "::" + (.message)
 )
 EOF
 


### PR DESCRIPTION
## What
Color me shocked, `.message.text.text` doesn't exist 🥺

exclude_from_changelog


