### PR TITLE
Backend: Update build gradle to allow launching 1.21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,6 @@ jobs:
     preprocess:
         runs-on: ubuntu-latest
         name: "Build multi version"
-        env:
-            SKIP_DETEKT: "true"
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -384,7 +384,7 @@ detekt {
 
 tasks.withType<Detekt>().configureEach {
     onlyIf {
-        System.getenv("SKIP_DETEKT") != "true"
+        target == ProjectTarget.MAIN
     }
 
     reports {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,6 +152,9 @@ dependencies {
         annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT")
         annotationProcessor("com.google.code.gson:gson:2.10.1")
         annotationProcessor("com.google.guava:guava:17.0")
+    } else if (target == ProjectTarget.MODERN)  {
+        modCompileOnly("net.fabricmc:fabric-loader:0.16.7")
+        modCompileOnly("net.fabricmc.fabric-api:fabric-api:0.102.0+1.21")
     }
 
     implementation(kotlin("stdlib-jdk8"))
@@ -159,7 +162,8 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin")
     }
 
-    modRuntimeOnly("me.djtheredstoner:DevAuth-forge-legacy:1.1.0")
+    if (target.isForge) modRuntimeOnly("me.djtheredstoner:DevAuth-forge-legacy:1.2.1")
+    else modRuntimeOnly("me.djtheredstoner:DevAuth-fabric:1.2.1")
 
     modCompileOnly("com.github.hannibal002:notenoughupdates:4957f0b:all") {
         exclude(module = "unspecified")
@@ -251,6 +255,10 @@ if (target == ProjectTarget.MAIN) {
     }
 }
 
+tasks.withType<KotlinCompile> {
+    compilerOptions.jvmTarget.set(JvmTarget.fromTarget(target.minecraftVersion.formattedJavaLanguageVersion))
+}
+
 if (target.parent == ProjectTarget.MAIN) {
     val mainRes = project(ProjectTarget.MAIN.projectPath).tasks.getAt("processResources")
     tasks.named("processResources") {
@@ -331,7 +339,8 @@ if (!MultiVersionStage.activeState.shouldCompile(target)) {
 
 preprocess {
     vars.put("MC", target.minecraftVersion.versionNumber)
-    vars.put("FORGE", if (target.forgeDep != null) 1 else 0)
+    vars.put("FORGE", if (target.isForge) 1 else 0)
+    vars.put("FABRIC", if (target.isFabric) 1 else 0)
     vars.put("JAVA", target.minecraftVersion.javaVersion)
     patternAnnotation.set("at.hannibal2.skyhanni.utils.compat.Pattern")
 }

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -2,7 +2,7 @@ import at.skyhanni.sharedvariables.ProjectTarget
 import com.replaymod.gradle.preprocess.Node
 
 plugins {
-    id("dev.deftu.gradle.preprocess") version "0.6.1"
+    id("dev.deftu.gradle.preprocess") version "0.7.1"
     id("net.kyori.blossom") version "1.3.2" apply false
     id("gg.essential.loom") version "1.6.+" apply false
     kotlin("jvm") version "2.0.0" apply false


### PR DESCRIPTION
Update dev auth which in theory should mean that we have to authenticate less due to this commit 
https://github.com/DJtheRedstoner/DevAuth/commit/dc6641fda9edad6553aaa4be972877309190fbb5

- Adds fabric loader and fabric api when launching the game on a modern version
- Uses fabric version of devauth when on fabric
- Uses the correct java version to compile kotlin code when on a modern version
- Adds an if fabric preprocessing directive
- Make detekt not run on gradle builds unless you are building 1.8.9
- Update pre-processor to most recent version

This doesnt directly allow the 1.21 run client task to work as obviously all of our code is still for 1.8.9 but if you know what you are doing this is needed


exclude_from_changelog