### PR TITLE
Fix: New Visitor Ping sent too late while farming

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -157,11 +157,12 @@ object GardenVisitorTimer {
             else -> "e"
         }
 
+        val adjustedMillis = if (GardenAPI.isCurrentlyFarming()) millis / 3 else millis
         val extraSpeed = if (GardenAPI.isCurrentlyFarming()) {
-            val duration = (millis / 3) * (GardenCropSpeed.getRecentBPS() / 20)
+            val duration = adjustedMillis * (GardenCropSpeed.getRecentBPS() / 20)
             "§7/§$formatColor" + duration.format()
         } else ""
-        if (config.newVisitorPing && millis < 10.seconds) {
+        if (config.newVisitorPing && adjustedMillis < 10.seconds) {
             SoundUtils.playBeepSound()
         }
 


### PR DESCRIPTION
## What
Fixed New Visitor Ping triggering too late if the player is actively farming.

## Changelog Fixes
+ Fixed New Visitor Ping triggering too late if the player is actively farming. - Luna

