### PR TITLE
Fix: tab completions for /p [ign] shorthand

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
@@ -55,6 +55,7 @@ object PlayerTabComplete {
                 parent("kick", "demote", "promote", "transfer") { add(partyMembersEntry) }
                 literal("chat", "disband", "kickoffline", "leave", "list", "mute", "poll", "private", "settings", "warp")
             }
+            add(getExcluding(PlayerCategory.PARTY))
         }
 
         parent("w", "msg", "tell", "boop") { add(getExcluding()) }


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by a plus. For example, `Feature + Fix: Add new command and fix bug in command`.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

-->

## What
Fixes PlayerTabComplete not giving player name suggestions for the /p [IGN] or /party [IGN] shorthand (minor regression from https://github.com/hannibal002/SkyHanni/pull/2637).

If both a subcommand and potential player names match, the subcommands come first in the tab completion list, then the matching player names.

<details>
<summary>Images</summary>

<!-- drop images here -->
<img width="325" alt="Screenshot 2024-10-19 at 3 38 27 PM" src="https://github.com/user-attachments/assets/75c56734-f2c8-4ced-b9af-156925d1d300">

</details>

## Changelog Fixes
+ Fixed tab completions for /p [IGN]. - appable

