### PR TITLE
Fix: Carnival in Garden

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
@@ -53,6 +53,7 @@ object IslandAreas {
         display = null
         targetNode = null
         hasMoved = true
+        updateArea("no_area")
     }
 
     fun nodeMoved() {
@@ -172,11 +173,7 @@ object IslandAreas {
                         addSearchString("§7Not in an area.")
                     }
                 }
-                if (name != currentAreaName) {
-                    val oldArea = currentAreaName
-                    currentAreaName = name
-                    GraphAreaChangeEvent(name, oldArea).post()
-                }
+                updateArea(name)
 
                 addSearchString("§eAreas nearby:")
                 continue
@@ -221,6 +218,14 @@ object IslandAreas {
             } else {
                 addSearchString("§cThere is no $islandName area data avaliable yet!")
             }
+        }
+    }
+
+    private fun updateArea(name: String) {
+        if (name != currentAreaName) {
+            val oldArea = currentAreaName
+            currentAreaName = name
+            GraphAreaChangeEvent(name, oldArea).post()
         }
     }
 


### PR DESCRIPTION
## What
Fixed carnival goal display rarely showing outside of the hub island.
Someone (me) forgot to add an island change check to the graph network area event. This event does not trigger on islands that don't have networks (private island, garden).

## Changelog Fixes
+ Fixed Carnival Goal display rarely showing outside the Hub Island. - hannibal2