### PR TITLE
Backend: Mixin Plugin Packages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
@@ -77,7 +77,8 @@ public class SkyhanniMixinPlugin implements IMixinConfigPlugin {
     public void walkDir(Path file) {
         System.out.println("Trying to find mixins from directory");
         try (Stream<Path> classes = Files.walk(file.resolve(mixinBaseDir))) {
-            classes.map(it -> file.relativize(it).toString())
+            classes.filter(Files::isRegularFile)
+                .map(it -> file.relativize(it).toString())
                 .forEach(this::tryAddMixinClass);
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Stops the mixin plugin from trying to add packages as mixins.

exclude_from_changelog
