### PR TITLE
Fix: Custom Scoreboard Party Leader

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementParty.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementParty.kt
@@ -13,15 +13,18 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.inAnyIsland
 object ScoreboardElementParty : ScoreboardElement() {
     override fun getDisplay() = buildList {
         if (PartyAPI.partyMembers.isEmpty() && informationFilteringConfig.hideEmptyLines) return@buildList
-        add(if (PartyAPI.partyMembers.isEmpty()) "§9§lParty" else "§9§lParty (${PartyAPI.partyMembers.size})")
-        if (partyConfig.showPartyLeader) PartyAPI.partyLeader?.let { leader -> add(" §7- §f$leader §e♚") }
 
-        PartyAPI.partyMembers
-            .take(partyConfig.maxPartyList.get())
-            .apply { if (partyConfig.showPartyLeader) remove(PartyAPI.partyLeader) }
-            .forEach {
-                add(" §7- §f$it")
-            }
+        add(if (PartyAPI.partyMembers.isEmpty()) "§9§lParty" else "§9§lParty (${PartyAPI.partyMembers.size})")
+
+        if (partyConfig.showPartyLeader && PartyAPI.partyLeader != null) {
+            add(" §7- §f$PartyAPI.partyLeader §e♚")
+        }
+
+        if (partyConfig.showPartyLeader) {
+            PartyAPI.partyMembers.filter { it != PartyAPI.partyLeader }
+        } else {
+            PartyAPI.partyMembers
+        }.take(partyConfig.maxPartyList.get()).forEach { add(" §7- §f$it") }
     }
 
     override fun showWhen() =


### PR DESCRIPTION
## What
This Pull Request fixes the Party leader showing twice on the Custom Scoreboard display.

## Changelog Fixes
+ Fixed Custom Scoreboard duplicating the Party Leader. - j10a1n15
