### PR TITLE
Fix: Compact Stash - Item Stash & Empty Line

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features.chat;
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 
@@ -13,6 +14,14 @@ public class StashConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = true;
+
+    @ConfigOption(
+        name = "§cNotice",
+        desc = "Due to Hypixel sending empty messages before and after the stash message, " +
+            "you may see empty lines still. Turn on `/sh empty messages` to solve for this."
+    )
+    @ConfigEditorInfoText
+    public String notice = "";
 
     @Expose
     @ConfigOption(name = "Hide Duplicate Warnings", desc = "Hide duplicate warnings for previously reported stash counts.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
@@ -17,8 +17,8 @@ public class StashConfig {
 
     @ConfigOption(
         name = "§cNotice",
-        desc = "Due to Hypixel sending empty messages before and after the stash message, " +
-            "you may see empty lines still. Turn on `/sh empty messages` to solve for this."
+        desc = "Hypixel sends un-detectable empty messages wrapping the stash message. " +
+            "Enable §e§l/sh empty messages §r§7to hide them."
     )
     @ConfigEditorInfoText
     public String notice = "";

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -120,6 +120,9 @@ object StashCompact {
         )
         lastSentMaterialCount = lastMaterialCount
         lastSentType = lastType
+        // Dirty, but item stash doesn't always have differing materials count,
+        // and we don't compare this value to the last one, so we can reset it here
+        lastDifferingMaterialsCount = 0
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -106,9 +106,9 @@ object StashCompact {
 
     private fun sendCompactedStashMessage() {
         val typeNameFormat = StringUtils.pluralize(lastMaterialCount, lastType)
-        val typeStringExtra =
-            if (lastDifferingMaterialsCount == 0) "."
-            else ", §etotalling §6$lastDifferingMaterialsCount ${StringUtils.pluralize(lastDifferingMaterialsCount, "type")}§6."
+        val typeStringExtra = lastDifferingMaterialsCount.let {
+            if (it == 0) "." else ", §etotalling §6$it ${StringUtils.pluralize(it, "type")}§6."
+        }
 
         ChatUtils.clickableChat(
             "§eYou have §6$lastMaterialCount §e$typeNameFormat in stash§6${typeStringExtra} " +

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -47,7 +47,7 @@ object StashCompact {
      */
     private val pickupStashPattern by patternGroup.pattern(
         "pickup.stash",
-        "§f *§.§l>>> §.§lCLICK HERE§b to pick (?:them|it) up! §.§l<<<.*",
+        "§f *§.§l>>> §.§lCLICK HERE§. to pick (?:them|it) up! §.§l<<<.*",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -70,17 +70,12 @@ object StashCompact {
     private var lastSentMaterialCount = 0
     private var lastSentType = ""
 
-    private var openMessage = false
-
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
         if (!isEnabled()) return
 
-        if(event.message.isEmpty() && openMessage) event.blockedReason = "stash_compact"
-
         genericAddedToStashPattern.matchMatcher(event.message) {
             event.blockedReason = "stash_compact"
-            openMessage = true
         }
 
         materialCountPattern.matchMatcher(event.message) {
@@ -104,7 +99,6 @@ object StashCompact {
             event.blockedReason = "stash_compact"
             if (lastMaterialCount <= config.hideLowWarningsThreshold) return
             if (config.hideDuplicateCounts && lastMaterialCount == lastSentMaterialCount && lastType == lastSentType) return
-            openMessage = false
 
             sendCompactedStashMessage()
         }
@@ -126,9 +120,6 @@ object StashCompact {
         )
         lastSentMaterialCount = lastMaterialCount
         lastSentType = lastType
-        // Dirty, but item stash doesn't always have differing materials count,
-        // and we don't compare this value to the last one, so we can reset it here
-        lastDifferingMaterialsCount = 0
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled


### PR DESCRIPTION
## What
Fixes the fact that the item stash messages were not being detected due to a different color. Also added a notice about the empty lines from the hypixel block not being blocked cause they're in absolutely stupid places, and how to solve for it.

## Changelog Fixes
+ Fixed item stash messages not being compacted correctly. - Daveed
