### PR TITLE
Fix: Stop CF Screen Flash on Stray Found

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryScreenFlash.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryScreenFlash.kt
@@ -1,8 +1,11 @@
 package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.inventory.chocolatefactory.ChocolateFactoryRabbitWarningConfig.FlashScreenTypeEntry
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.hoppity.RabbitFoundEvent
+import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggType
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI.specialRabbitTextures
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryDataLoader.clickMeGoldenRabbitPattern
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryDataLoader.clickMeRabbitPattern
@@ -23,7 +26,7 @@ import kotlin.math.sin
 object ChocolateFactoryScreenFlash {
 
     private val config get() = ChocolateFactoryAPI.config
-    var flashScreen = false
+    private var flashScreen = false
 
     @SubscribeEvent
     fun onTick(event: SecondPassedEvent) {
@@ -39,6 +42,12 @@ object ChocolateFactoryScreenFlash {
                 FlashScreenTypeEntry.NONE -> false
             }
         }
+    }
+
+    @HandleEvent
+    fun onRabbitFound(event: RabbitFoundEvent) {
+        if (event.eggType != HoppityEggType.STRAY) return
+        flashScreen = false
     }
 
     private fun isSpecial(slot: Slot) =


### PR DESCRIPTION
## What
Fix the hoppity 'rare stray' screen flashing staying past when it actually should. This mainly affects side dish eggs, where the game opens a separate GUI, and the user gets flashbanged the next time they open CF.

God bless HoppityAPI for a +10 fix here.

## Changelog Fixes
+ Fixed Choc Factory screen flashing not disappearing in a timely manner after clicking some strays. - Daveed

