### PR TITLE
Fix: Custom Scoreboard Printing Class Name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementParty.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementParty.kt
@@ -18,7 +18,7 @@ object ScoreboardElementParty : ScoreboardElement() {
         add(if (PartyAPI.partyMembers.isEmpty()) "§9§lParty" else "§9§lParty (${PartyAPI.partyMembers.size})")
 
         if (partyConfig.showPartyLeader && PartyAPI.partyLeader != null) {
-            add(" §7- §f$PartyAPI.partyLeader §e♚")
+            add(" §7- §f${PartyAPI.partyLeader} §e♚")
         }
 
         if (partyConfig.showPartyLeader) {


### PR DESCRIPTION
## What
[Reported here](https://discord.com/channels/997079228510117908/1297726116655529997).
Fixes an issue where the class name of `PartyAPI` was being printed instead of the value it was meant to reference.

## Changelog Fixes
+ Fixed party leader not displaying correctly in the Custom Scoreboard. - Daveed
