### PR TITLE
Fix: Estimated Item Value OpenGL Error & Data Dump NBT

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.isRune
@@ -204,22 +203,21 @@ object EstimatedItemValue {
         this.getInternalNameOrNull()?.let { internalName ->
             val name = this.name
             return (
-                name == "§6☘ Category: Item Ability (Passive)" ||
-                name.contains("Salesperson") ||
-                (
-                    !InventoryUtils.isSlotInPlayerInventory(this) &&
-                    InventoryUtils.openInventoryName() == "Choose a wardrobe slot"
-                    ) ||
-                internalName.startsWith("ULTIMATE_ULTIMATE_") ||
                 this.item == Items.enchanted_book ||
-                internalName.startsWith("CATACOMBS_PASS_") ||
-                internalName.startsWith("MASTER_CATACOMBS_PASS_") ||
-                internalName.startsWith("MAP-") ||
-                internalName.isRune() ||
-                internalName.contains("UNIQUE_RUNE") ||
-                internalName.contains("WISP_POTION")
-            )
-
+                    name.contains("Salesperson") ||
+                    name == "§6☘ Category: Item Ability (Passive)" ||
+                    internalName.isRune() ||
+                    internalName.startsWith("ULTIMATE_ULTIMATE_") ||
+                    internalName.startsWith("CATACOMBS_PASS_") ||
+                    internalName.startsWith("MASTER_CATACOMBS_PASS_") ||
+                    internalName.startsWith("MAP-") ||
+                    internalName.contains("UNIQUE_RUNE") ||
+                    internalName.contains("WISP_POTION") ||
+                    (
+                        !InventoryUtils.isSlotInPlayerInventory(this) &&
+                            InventoryUtils.openInventoryName() == "Choose a wardrobe slot"
+                        )
+                )
         } ?: return true
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -106,6 +106,7 @@ object EstimatedItemValue {
         } catch (ex: RuntimeException) {
             // "No OpenGL context found in the current thread." - caused indiscriminately by any other mod
             // that tries to over-render the tooltip, and is not explicitly something we can solve here?
+            // TODO start a deep sea activity: read mixin dumps, pinpoint the culprit, write over engineered workaround
             if (ex.message?.contains("No OpenGL context found in the current thread.") == true) return
             ErrorManager.logErrorWithData(
                 ex, "Error in Estimated Item Value renderer",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -199,6 +199,8 @@ object EstimatedItemValue {
         lastToolTipTime = System.currentTimeMillis()
     }
 
+    // TODO: Refactor this code to not return listOf() 20 times
+    @Suppress("ReturnCount")
     private fun draw(stack: ItemStack): List<Renderable> {
         val internalName = stack.getInternalNameOrNull() ?: return listOf()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -255,10 +255,7 @@ object EstimatedItemValueCalculator {
                         "internal name" to stack.getInternalName(),
                         "itemRarity" to itemRarity,
                         "item name" to stack.name,
-                        "item nbt" to {
-                            stack.tagCompound?.getReadableNBTDump(includeLore = true)?.joinToString("\n")
-                                ?: "no tag compound"
-                        }
+                        "item nbt" to stack.readNbtDump(),
                     )
                     return null
                 }
@@ -275,10 +272,7 @@ object EstimatedItemValueCalculator {
                 "internal name" to stack.getInternalName(),
                 "item name" to stack.name,
                 "reforgeStone" to reforgeStone,
-                "item nbt" to {
-                    stack.tagCompound?.getReadableNBTDump(includeLore = true)?.joinToString("\n")
-                        ?: "no tag compound"
-                }
+                "item nbt" to stack.readNbtDump(),
             )
             null
         }
@@ -855,6 +849,9 @@ object EstimatedItemValueCalculator {
         return totalPrice
     }
 
+    private fun ItemStack.readNbtDump() = tagCompound?.getReadableNBTDump(includeLore = true)?.joinToString("\n")
+    ?: "no tag compound"
+
     private fun addGemstoneSlotUnlockCost(stack: ItemStack, list: MutableList<String>): Double {
         val internalName = stack.getInternalName()
 
@@ -874,10 +871,7 @@ object EstimatedItemValueCalculator {
                 "internal name" to internalName,
                 "gemstoneUnlockCosts" to EstimatedItemValue.gemstoneUnlockCosts,
                 "item name" to stack.name,
-                "item nbt" to {
-                    stack.tagCompound?.getReadableNBTDump(includeLore = true)?.joinToString("\n")
-                        ?: "no tag compound"
-                }
+                "item nbt" to stack.readNbtDump(),
             )
             return 0.0
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.getReadableNBTDump
 import at.hannibal2.skyhanni.utils.ItemUtils.isRune
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
@@ -865,6 +866,10 @@ object EstimatedItemValueCalculator {
                 "internal name" to internalName,
                 "gemstoneUnlockCosts" to EstimatedItemValue.gemstoneUnlockCosts,
                 "item name" to stack.name,
+                "item nbt" to {
+                    stack.tagCompound?.getReadableNBTDump(includeLore = true)?.joinToString("\n")
+                        ?: "no tag compound"
+                }
             )
             return 0.0
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -255,6 +255,10 @@ object EstimatedItemValueCalculator {
                         "internal name" to stack.getInternalName(),
                         "itemRarity" to itemRarity,
                         "item name" to stack.name,
+                        "item nbt" to {
+                            stack.tagCompound?.getReadableNBTDump(includeLore = true)?.joinToString("\n")
+                                ?: "no tag compound"
+                        }
                     )
                     return null
                 }
@@ -271,6 +275,10 @@ object EstimatedItemValueCalculator {
                 "internal name" to stack.getInternalName(),
                 "item name" to stack.name,
                 "reforgeStone" to reforgeStone,
+                "item nbt" to {
+                    stack.tagCompound?.getReadableNBTDump(includeLore = true)?.joinToString("\n")
+                        ?: "no tag compound"
+                }
             )
             null
         }

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.getReadableNBTDump
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getMinecraftId
 import net.minecraft.item.ItemStack
@@ -20,21 +21,6 @@ object CopyItemCommand {
         copyItemToClipboard(itemStack)
     }
 
-    private fun recurseTag(compound: NBTTagCompound, text: String, list: MutableList<String>) {
-        for (s in compound.keySet) {
-            if (s == "Lore") continue
-            val tag = compound.getTag(s)
-
-            if (tag !is NBTTagCompound) {
-                list.add("$text$s: $tag")
-            } else {
-                val element = compound.getCompoundTag(s)
-                list.add("$text$s:")
-                recurseTag(element, "$text  ", list)
-            }
-        }
-    }
-
     fun copyItemToClipboard(itemStack: ItemStack) {
         val resultList = mutableListOf<String>()
         resultList.add(itemStack.getInternalName().toString())
@@ -46,10 +32,9 @@ object CopyItemCommand {
         }
         resultList.add("")
         resultList.add("getTagCompound")
-        if (itemStack.hasTagCompound()) {
-            val tagCompound = itemStack.tagCompound
-            recurseTag(tagCompound, "  ", resultList)
-        }
+        itemStack.tagCompound?.let {
+            resultList.addAll(it.getReadableNBTDump())
+        } ?: resultList.add("no tag compound")
 
         val string = resultList.joinToString("\n")
         OSUtils.copyToClipboard(string)

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getReadableNBTDump
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getMinecraftId
 import net.minecraft.item.ItemStack
-import net.minecraft.nbt.NBTTagCompound
 
 object CopyItemCommand {
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -61,6 +61,24 @@ object ItemUtils {
         return list
     }
 
+    fun NBTTagCompound?.getReadableNBTDump(initSeparator: String = "  ", includeLore: Boolean = false): List<String> {
+        this ?: return emptyList()
+        val tagList = mutableListOf<String>()
+        for (s in this.keySet) {
+            if (s == "Lore" && !includeLore) continue
+            val tag = this.getTag(s)
+
+            if (tag !is NBTTagCompound) {
+                tagList.add("$initSeparator$s: $tag")
+            } else {
+                val element = this.getCompoundTag(s)
+                tagList.add("$initSeparator$s:")
+                tagList.addAll(element.getReadableNBTDump("$initSeparator  ", includeLore))
+            }
+        }
+        return tagList
+    }
+
     fun getDisplayName(compound: NBTTagCompound?): String? {
         compound ?: return null
         val name = compound.getCompoundTag("display").getString("Name")


### PR DESCRIPTION
## What
Reported in so so so so many different places. Latest [here](https://discord.com/channels/997079228510117908/1297974849964212264).

'Fixes' (nerfed the message) an issue where conflicting rendering on an item throws an OpenGL error at the user.
If this message _shouldn't_ be nerfed, and if we want to get to the root cause of this, I'm open to suggestions/changes to the catch section, however this issue appears to be broadly caused by any other mod (SBE, ST, SBA, etc.), and hunting that down sounds awful!
Also ports the `EstimatedItemValue` to use Renderable(s) for its display construction, instead of `List<List<Any>>`.

This also adds item NBT data to the dump when a cost fails to calculate.

## Changelog Fixes
+ Fixed an issue with Estimated Item Value erroring when multiple mods affect the same item. - Daveed

## Changelog Technical Details
+ Added a method to retrieve a readable dump of an item's NBT tag(s). - Daveed
   + `ItemUtils.getReadableNBTDump`
