### PR TITLE
Fix: Slayer Mini Boss Walls

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
@@ -10,8 +10,8 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.hasMaxHealth
-import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawLineToEye
@@ -60,7 +60,7 @@ object SlayerMiniBossFeatures {
         for (mob in miniBosses) {
             if (mob.health <= 0) continue
             if (mob.isDead) continue
-            if (mob.distanceToPlayer() > 10) continue
+            if (!mob.canBeSeen(10)) continue
 
             event.drawLineToEye(
                 mob.getLorenzVec().up(),


### PR DESCRIPTION
## What
Fixed Line to slayer Miniboss not checking for walls.

## Changelog Fixes
+ Fixed `Line to Slayer Miniboss` not checking for walls. - hannibal2