### PR TITLE
Fix: Detekt Tag Compound FB

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -850,7 +850,7 @@ object EstimatedItemValueCalculator {
     }
 
     private fun ItemStack.readNbtDump() = tagCompound?.getReadableNBTDump(includeLore = true)?.joinToString("\n")
-    ?: "no tag compound"
+        ?: "no tag compound"
 
     private fun addGemstoneSlotUnlockCost(stack: ItemStack, list: MutableList<String>): Double {
         val internalName = stack.getInternalName()


### PR DESCRIPTION
## What
Fix detekt screaming at compound tag.

exclude_from_changelog