### PR TITLE
Fix: Tps Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -68,7 +68,6 @@ import at.hannibal2.skyhanni.features.misc.CarryTracker
 import at.hannibal2.skyhanni.features.misc.CollectionTracker
 import at.hannibal2.skyhanni.features.misc.LockMouseLook
 import at.hannibal2.skyhanni.features.misc.MarkedPlayerManager
-import at.hannibal2.skyhanni.features.misc.TpsCounter
 import at.hannibal2.skyhanni.features.misc.discordrpc.DiscordRPCManager
 import at.hannibal2.skyhanni.features.misc.limbo.LimboTimeTracker
 import at.hannibal2.skyhanni.features.misc.massconfiguration.DefaultConfigFeatures
@@ -302,11 +301,6 @@ object Commands {
             @Suppress("AvoidBritishSpelling")
             aliases = listOf("shcolor", "shcolours", "shcolour")
             callback { ColorFormattingHelper.printColorCodeList() }
-        }
-        event.register("shtps") {
-            description = "Informs in chat about the server ticks per second (TPS)."
-            category = CommandCategory.USERS_ACTIVE
-            callback { TpsCounter.tpsCommand() }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -520,13 +520,12 @@ object RenderUtils {
     }
 
     fun Position.renderString(string: String?, offsetX: Int = 0, offsetY: Int = 0, posLabel: String) {
-        if (string == null) return
-        if (string == "") return
+        if (string.isNullOrBlank()) return
         val x = renderString0(string, offsetX, offsetY, isCenter)
         GuiEditManager.add(this, posLabel, x, 10)
     }
 
-    private fun Position.renderString0(string: String?, offsetX: Int = 0, offsetY: Int = 0, centered: Boolean): Int {
+    private fun Position.renderString0(string: String, offsetX: Int = 0, offsetY: Int = 0, centered: Boolean): Int {
         val display = "§f$string"
         GlStateManager.pushMatrix()
         transform()


### PR DESCRIPTION
## What
Fixes TPS display not working outside of skyblock when its selected in the show outside skyblock config, and refactor it to use secondpassedevent and tick event like it said in the todo.

## Changelog Fixes
+ Fixed TPS display not working outside Skyblock. - Empa