### PR TITLE
Backend Fix: Detekt Comment Processor Todos

### DIFF
--- a/.github/scripts/process_detekt_output.js
+++ b/.github/scripts/process_detekt_output.js
@@ -32,7 +32,7 @@ lines.forEach((line) => {
     const cleanMessage = line.replace(/::.*?::/g, '');
 
     // Append to comment
-    comment += `- [ ] [${fileName}#L${lineNumber}](https://github.com/${GITHUB_REPOSITORY}/blob/${PR_SHA}/${cleanedFilePath}#L${lineNumber}): ${cleanMessage}\n`;
+    comment += `- [${fileName}#L${lineNumber}](https://github.com/${GITHUB_REPOSITORY}/blob/${PR_SHA}/${cleanedFilePath}#L${lineNumber}): ${cleanMessage}\n`;
 });
 
 // Write comment to file

--- a/.github/scripts/process_detekt_output.js
+++ b/.github/scripts/process_detekt_output.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+const PR_SHA = process.env.PR_SHA;
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
+
+// Read detekt_output.txt
+const detektOutput = fs.readFileSync('detekt_output.txt', 'utf8');
+
+let comment = '### One or more Detekt Failures were detected:\n\n';
+
+const lines = detektOutput.split('\n');
+lines.forEach((line) => {
+    if (!line.trim()) return; // Skip empty lines
+
+    // Extract file path and line number
+    const filePathMatch = line.match(/file=([^,]+)/);
+    const lineNumberMatch = line.match(/line=(\d+)/);
+    if (!filePathMatch || !lineNumberMatch) return;
+
+    const filePath = filePathMatch[1];
+    const lineNumber = lineNumberMatch[1];
+
+    // Remove everything before 'src/' in the file path (if it exists)
+    const srcIndex = filePath.indexOf('src/');
+    const cleanedFilePath = srcIndex !== -1 ? filePath.substring(srcIndex) : filePath;
+
+    // Extract file name
+    const fileName = path.basename(cleanedFilePath);
+
+    // Clean up the line to remove everything between '::' and '::' (inclusive)
+    const cleanMessage = line.replace(/::.*?::/g, '');
+
+    // Append to comment
+    comment += `- [ ] [${fileName}#L${lineNumber}](https://github.com/${GITHUB_REPOSITORY}/blob/${PR_SHA}/${cleanedFilePath}#L${lineNumber}): ${cleanMessage}\n`;
+});
+
+// Write comment to file
+fs.writeFileSync('detekt_comment.txt', comment);

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -73,9 +73,6 @@ jobs:
                       "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
                       | jq -r '.head.sha')
                     
-                    echo "Latest commit SHA: $PR_LATEST_SHA"
-                    echo "Current workflow SHA: ${{ github.sha }}"
-                    
                     # Compare the SHAs and set a result variable
                     if [[ "${PR_LATEST_SHA}" == "${{ github.sha }}" ]]; then
                       echo "::set-output name=is_latest::true"

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -70,26 +70,29 @@ jobs:
                 id: check_latest
                 run: |
                     PR_LATEST_SHA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                      "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
-                      | jq -r '.head.sha')
-                    
+                        "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
+                        | jq -r '.head.sha')
+                  
+                    echo "Latest commit SHA from PR: $PR_LATEST_SHA"
+                    echo "Current workflow SHA: ${{ github.event.pull_request.head.sha }}"
+                  
                     # Compare the SHAs and set a result variable
-                    if [[ "${PR_LATEST_SHA}" == "${{ github.sha }}" ]]; then
-                      echo "::set-output name=is_latest::true"
+                    if [[ "${PR_LATEST_SHA}" == "${{ github.event.pull_request.head.sha }}" ]]; then
+                        echo "is_latest=true" >> $GITHUB_ENV
                     else
-                      echo "::set-output name=is_latest::false"
+                        echo "is_latest=false" >> $GITHUB_ENV
                     fi
             -   name: Add comment to PR
-                if: steps.check_latest.outputs.is_latest == 'true'
+                if: env.is_latest == 'true'
                 uses: actions/github-script@v6
                 with:
                     github-token: ${{ secrets.GITHUB_TOKEN }}
                     script: |
-                      const fs = require('fs');
-                      const commentBody = fs.readFileSync('detekt_comment.txt', 'utf8');
-                      github.rest.issues.createComment({
-                        issue_number: context.issue.number,
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        body: commentBody
-                      })
+                        const fs = require('fs');
+                        const commentBody = fs.readFileSync('detekt_comment.txt', 'utf8');
+                        github.rest.issues.createComment({
+                            issue_number: context.issue.number,
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            body: commentBody
+                        })

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -66,7 +66,24 @@ jobs:
                     GITHUB_REPOSITORY: ${{ github.repository }}
                 run: |
                     node .github/scripts/process_detekt_output.js
+            -   name: Check if this is the latest workflow run
+                id: check_latest
+                run: |
+                    PR_LATEST_SHA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                      "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
+                      | jq -r '.head.sha')
+                    
+                    echo "Latest commit SHA: $PR_LATEST_SHA"
+                    echo "Current workflow SHA: ${{ github.sha }}"
+                    
+                    # Compare the SHAs and set a result variable
+                    if [[ "${PR_LATEST_SHA}" == "${{ github.sha }}" ]]; then
+                      echo "::set-output name=is_latest::true"
+                    else
+                      echo "::set-output name=is_latest::false"
+                    fi
             -   name: Add comment to PR
+                if: steps.check_latest.outputs.is_latest == 'true'
                 uses: actions/github-script@v6
                 with:
                     github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -29,14 +29,14 @@ jobs:
             -   name: Annotate detekt failures
                 if: ${{ !cancelled() }}
                 run: |
-                  chmod +x .github/scripts/process_detekt_sarif.sh
-                  ./.github/scripts/process_detekt_sarif.sh versions/1.8.9/build/reports/detekt/main.sarif
-            -   name: Upload SARIF file as artifact
+                    chmod +x .github/scripts/process_detekt_sarif.sh
+                    ./.github/scripts/process_detekt_sarif.sh versions/1.8.9/build/reports/detekt/main.sarif | tee detekt_output.txt
+            -   name: Upload detekt output as artifact
                 if: always()
                 uses: actions/upload-artifact@v4
                 with:
-                    name: detekt-sarif-report
-                    path: versions/1.8.9/build/reports/detekt/main.sarif
+                    name: detekt-output
+                    path: detekt_output.txt
 
     detekt_comment:
         name: Comment detekt failures on PR
@@ -51,73 +51,21 @@ jobs:
                 with:
                     ref: ${{ github.event.pull_request.head.sha }}
                     repository: ${{ github.event.pull_request.head.repo.full_name }}
-            -   name: Download SARIF file
+            -   name: Download detekt output
                 uses: actions/download-artifact@v4
                 with:
-                    name: detekt-sarif-report
+                    name: detekt-output
                     path: .
-            -   name: Process detekt SARIF and create comment
-                shell: bash
+            -   name: Set up Node.js
+                uses: actions/setup-node@v4
+                with:
+                    node-version: '>=21'
+            -   name: Process detekt output and create comment
                 env:
                     PR_SHA: ${{ github.event.pull_request.head.sha }}
                     GITHUB_REPOSITORY: ${{ github.repository }}
                 run: |
-                    set -e  # Exit on errors
-                    set -x  # Print each command for debugging
-                    
-                    # Ensure the SARIF file exists in the project root
-                    if [ ! -f main.sarif ]; then
-                        echo "SARIF file not found!"
-                        exit 1
-                    fi
-        
-                    chmod +x .github/scripts/process_detekt_sarif.sh
-                    
-                    # Process the SARIF file
-                    ./.github/scripts/process_detekt_sarif.sh main.sarif > detekt_output.txt
-                    
-                    # Check if the detekt_output.txt file was created
-                    if [ ! -s detekt_output.txt ]; then
-                        echo "detekt_output.txt is empty or missing!"
-                        exit 1
-                    fi
-        
-                    DETEKT_OUTPUT=$(cat detekt_output.txt)
-        
-                    COMMENT="### One or more Detekt Failures were detected:\n\n"
-        
-                    while read -r line; do
-                        echo "Processing line: $line"
-                        
-                        # Extract the full file path and line number using regex
-                        FILE_PATH=$(echo "$line" | grep -oP '(?<=file=)[^,]+')
-                        LINE_NUMBER=$(echo "$line" | grep -oP '(?<=line=)\d+')
-                      
-                        # Check if extraction worked
-                        if [ -z "$FILE_PATH" ] || [ -z "$LINE_NUMBER" ]; then
-                            echo "Failed to extract file path or line number from: $line"
-                            continue
-                        fi
-                        
-                        echo "Original file path: $FILE_PATH, Line number: $LINE_NUMBER"
-                        
-                        # Remove everything before 'src/' in the file path (if it exists)
-                        CLEANED_FILE_PATH=$(echo "$FILE_PATH" | sed 's/.*\(src\/.*\)/\1/')
-                        echo "Cleaned file path: $CLEANED_FILE_PATH"
-                        
-                        # Extract just the file name from the file path
-                        FILE_NAME=$(basename "$CLEANED_FILE_PATH")
-                        echo "File name: $FILE_NAME"
-                        
-                        # Clean up the line to remove everything between '::' and '::' (inclusive)
-                        CLEAN_MESSAGE=$(echo "$line" | sed 's/::.*:://g')
-                        echo "Clean message: $CLEAN_MESSAGE"
-                        
-                        # Append the comment with the cleaned-up message, using PR_SHA
-                        COMMENT+="- [ ] [$FILE_NAME#L$LINE_NUMBER](https://github.com/${GITHUB_REPOSITORY}/blob/${PR_SHA}/$CLEANED_FILE_PATH#L$LINE_NUMBER): $CLEAN_MESSAGE\n"
-                    done <<< "$DETEKT_OUTPUT"
-                    
-                    echo -e "$COMMENT" > detekt_comment.txt
+                    node .github/scripts/process_detekt_output.js
             -   name: Add comment to PR
                 uses: actions/github-script@v6
                 with:


### PR DESCRIPTION
## What
Converts the 60 lines of in-workflow bash to a Node script, and solves for the duplication of annotations being caused by piping things strangely. Artifact between steps was changed to a text file that's being tee-d out, which I hope works.

Test PR on my repo here:
- https://github.com/DavidArthurCole/SkyHanni/pull/120

Second PR testing sequential commits, making sure that the bot does not over-post:
- https://github.com/DavidArthurCole/SkyHanni/pull/122

exclude_from_changelog