### PR TITLE
Fix: Rev Viscera Multi-Drop Pattern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -164,6 +164,7 @@ object ChatFilter {
     @Suppress("MaxLineLength")
     private val slayerDropPatterns = listOf(
         // Zombie
+        "§b§lRARE DROP! §r§7\\(§r§f§r§7(.*)x §9Revenant Viscera§r§7\\) (.*)".toPattern(),
         "§b§lRARE DROP! §r§7\\(§r§f§r§9Revenant Viscera§r§7\\) (.*)".toPattern(),
         "§b§lRARE DROP! §r§7\\(§r§f§r§7(.*)x §r§f§r§9Foul Flesh§r§7\\) (.*)".toPattern(),
         "§b§lRARE DROP! §r§7\\(§r§f§r§9Foul Flesh§r§7\\) (.*)".toPattern(),


### PR DESCRIPTION
## What
Adds the multiple drop pattern for rev viscera for the slayer_drop filter (see image).

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/401f89b1-5722-41c4-a075-2384f89b37b1)

![image](https://github.com/user-attachments/assets/da13bcac-f30e-4b16-9892-ae0d7d57ea09)


</details>

exclude_from_changelog

