### PR TITLE
Remove: Feature toggle from focus mode

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.config.features.inventory;
 
-import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
@@ -12,7 +11,6 @@ public class FocusModeConfig {
     @Expose
     @ConfigOption(name = "Enabled", desc = "In focus mode you only see the name of the item instead of the whole description.")
     @ConfigEditorBoolean
-    @FeatureToggle
     public boolean enabled = false;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -4,12 +4,14 @@ import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag;
 import org.lwjgl.input.Keyboard;
 
 public class FocusModeConfig {
 
     @Expose
     @ConfigOption(name = "Enabled", desc = "In focus mode you only see the name of the item instead of the whole description.")
+    @SearchTag("compact hide")
     @ConfigEditorBoolean
     public boolean enabled = false;
 


### PR DESCRIPTION
## What
removed the feature toggle from focus mode because people keep turning it on by accident

Also added search tags so people can find it more easily when accidentily enabled


exclude_from_changelog
