### PR TITLE
Fix: Unlock mouse on barn tp

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
@@ -8,9 +8,9 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.features.garden.SensitivityReducer
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
@@ -39,7 +39,6 @@ object LockMouseLook {
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
-        println(!unlockMousePattern.matches(event.message))
         if (!unlockMousePattern.matches(event.message)) return
         if (lockedMouse) toggleLock()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
@@ -9,11 +9,18 @@ import at.hannibal2.skyhanni.features.garden.SensitivityReducer
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
 object LockMouseLook {
+
+    private val unlockMousePattern by RepoPattern.pattern(
+        "unlockmouse",
+        "§aTeleported you to (.*)",
+    )
 
     private val config get() = SkyHanniMod.feature.misc
     private val storage get() = SkyHanniMod.feature.storage
@@ -32,7 +39,8 @@ object LockMouseLook {
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
-        if (!event.message.startsWith("§aTeleported you to §r§aPlot")) return
+        println(!unlockMousePattern.matches(event.message))
+        if (!unlockMousePattern.matches(event.message)) return
         if (lockedMouse) toggleLock()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/LockMouseLook.kt
@@ -17,9 +17,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 @SkyHanniModule
 object LockMouseLook {
 
-    private val unlockMousePattern by RepoPattern.pattern(
-        "unlockmouse",
-        "§aTeleported you to (.*)",
+    private val gardenTeleportPattern by RepoPattern.pattern(
+        "chat.garden.teleport",
+        "§aTeleported you to .*",
     )
 
     private val config get() = SkyHanniMod.feature.misc
@@ -39,7 +39,7 @@ object LockMouseLook {
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
-        if (!unlockMousePattern.matches(event.message)) return
+        if (!gardenTeleportPattern.matches(event.message)) return
         if (lockedMouse) toggleLock()
     }
 


### PR DESCRIPTION
## What
Will now unlock mouse when tping to barn (`/plottp barn`) instead of just for plots


## Changelog Fixes
+ Fixed the mouse not unlocking when teleporting to the Barn. - not_a_cow
