### PR TITLE
Backend Fix: Detekt on Build Failure

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -35,7 +35,7 @@ jobs:
                         echo "exists=false" >> $GITHUB_OUTPUT
                     fi
             -   name: Annotate detekt failures
-                if: ${{ steps.check_sarif.outputs.exists == 'true' }}
+                if: ${{ !cancelled() && steps.check_sarif.outputs.exists == 'true' }}
                 run: |
                     chmod +x .github/scripts/process_detekt_sarif.sh
                     ./.github/scripts/process_detekt_sarif.sh versions/1.8.9/build/reports/detekt/main.sarif | tee detekt_output.txt

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -16,6 +16,8 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+        outputs:
+            sarif_exists: ${{ steps.check_sarif.outputs.exists }}
         steps:
             -   name: Checkout PR code
                 uses: actions/checkout@v4

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -26,13 +26,21 @@ jobs:
             -   name: Run detekt main (w/ typing analysis)
                 run: |
                   ./gradlew detektMain --stacktrace
+            -   name: Check if SARIF file exists
+                id: check_sarif
+                run: |
+                    if [ -f "versions/1.8.9/build/reports/detekt/main.sarif" ]; then
+                        echo "exists=true" >> $GITHUB_OUTPUT
+                    else
+                        echo "exists=false" >> $GITHUB_OUTPUT
+                    fi
             -   name: Annotate detekt failures
-                if: ${{ !cancelled() }}
+                if: ${{ steps.check_sarif.outputs.exists == 'true' }}
                 run: |
                     chmod +x .github/scripts/process_detekt_sarif.sh
                     ./.github/scripts/process_detekt_sarif.sh versions/1.8.9/build/reports/detekt/main.sarif | tee detekt_output.txt
             -   name: Upload detekt output as artifact
-                if: always()
+                if: ${{ steps.check_sarif.outputs.exists == 'true' }}
                 uses: actions/upload-artifact@v4
                 with:
                     name: detekt-output
@@ -42,7 +50,7 @@ jobs:
         name: Comment detekt failures on PR
         runs-on: ubuntu-latest
         needs: detekt
-        if: ${{ failure() }}
+        if: ${{ needs.detekt.outputs.sarif_exists == 'true' && failure() }}
         permissions:
             pull-requests: write
         steps:

--- a/.github/workflows/detekt_beta.yml
+++ b/.github/workflows/detekt_beta.yml
@@ -28,7 +28,7 @@ jobs:
                         echo "exists=false" >> $GITHUB_OUTPUT
                     fi
             -   name: Annotate detekt failures
-                if: ${{ steps.check_sarif.outputs.exists == 'true' }}
+                if: ${{ !cancelled() && steps.check_sarif.outputs.exists == 'true' }}
                 run: |
                     chmod +x .github/scripts/process_detekt_sarif.sh
                     ./.github/scripts/process_detekt_sarif.sh versions/1.8.9/build/reports/detekt/main.sarif

--- a/.github/workflows/detekt_beta.yml
+++ b/.github/workflows/detekt_beta.yml
@@ -19,8 +19,16 @@ jobs:
             -   name: Run detekt main (w/ typing analysis)
                 run: |
                   ./gradlew detektMain --stacktrace
-            -   name: Annotate detekt failures
-                if: ${{ !cancelled() }}
+            -   name: Check if SARIF file exists
+                id: check_sarif
                 run: |
-                  chmod +x .github/scripts/process_detekt_sarif.sh
-                  ./.github/scripts/process_detekt_sarif.sh versions/1.8.9/build/reports/detekt/main.sarif
+                    if [ -f "versions/1.8.9/build/reports/detekt/main.sarif" ]; then
+                        echo "exists=true" >> $GITHUB_OUTPUT
+                    else
+                        echo "exists=false" >> $GITHUB_OUTPUT
+                    fi
+            -   name: Annotate detekt failures
+                if: ${{ steps.check_sarif.outputs.exists == 'true' }}
+                run: |
+                    chmod +x .github/scripts/process_detekt_sarif.sh
+                    ./.github/scripts/process_detekt_sarif.sh versions/1.8.9/build/reports/detekt/main.sarif

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,6 +12,9 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4
+                with:
+                    ref: ${{ github.event.pull_request.head.sha }}
+                    repository: ${{ github.event.pull_request.head.repo.full_name }}
 
             -   uses: ./.github/actions/setup-normal-workspace
 
@@ -67,8 +70,8 @@ jobs:
                         const commentBody = `${test}`
                         
                         github.rest.issues.createComment({
-                          issue_number: context.issue.number,
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          body: commentBody
+                            issue_number: context.issue.number,
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            body: commentBody
                         })

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -39,8 +39,25 @@ jobs:
                     github_token: ${{ secrets.GITHUB_TOKEN }}
                     labels: 'Wrong Title/Changelog'
 
+            -   name: Check if this is the latest workflow run
+                id: check_latest
+                run: |
+                    PR_LATEST_SHA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                        "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
+                        | jq -r '.head.sha')
+
+                    echo "Latest commit SHA from PR: $PR_LATEST_SHA"
+                    echo "Current workflow SHA: ${{ github.event.pull_request.head.sha }}"
+
+                    # Compare the SHAs and set a result variable
+                    if [[ "${PR_LATEST_SHA}" == "${{ github.event.pull_request.head.sha }}" ]]; then
+                        echo "is_latest=true" >> $GITHUB_ENV
+                    else
+                        echo "is_latest=false" >> $GITHUB_ENV
+                    fi
+
             -   name: Add comment to PR if changelog verification fails
-                if: failure()
+                if: ${{ failure() && env.is_latest == 'true' }}
                 uses: actions/github-script@v6
                 with:
                     github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
Fixes the detekt processor(s) incorrectly continuing to run even when the build fails, and the sarif file is not generated.
Also adds the "is this the latest runner" to Cal's PR formatting workflow per a request from him.

exclude_from_changelog