### PR TITLE
Fix: Dyes being modified when "Re-Color Missing Rabbit Dyes" is off 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -223,7 +223,7 @@ object HoppityCollectionStats {
                     LorenzRarity.SPECIAL -> 1 // Rose Red - Covering bases for future (?)
                     else -> return
                 },
-            ) else ItemStack(Items.dye, 8)
+            ) else stack
 
             newItemStack.setLore(buildDescriptiveMilestoneLore(stack))
             newItemStack.setStackDisplayName(stack.displayName)


### PR DESCRIPTION
## What
Fixes an issue where turning off the default enabled "Re-Color Missing Rabbit Dyes" option would modify the dyes into Ink Sacs and add a stack size of 8.

<details>
<summary>Images</summary>

**Before:**
![image](https://github.com/user-attachments/assets/d6bfa65d-88d5-4a79-ab9a-9009da2b82b7)
**After:**
![image](https://github.com/user-attachments/assets/9d4a2e84-61ed-4037-922b-e9654bbcdbf2)
</details>

## Changelog Fixes
+ Fixed dyes being incorrectly modified in Hoppity's Collection after disabling "Re-Color Missing Rabbit Dyes". - MTOnline
