### PR TITLE
Improvement + Fix: Profile Type in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
@@ -152,7 +152,7 @@ public class DisplayConfig {
     @Expose
     @ConfigOption(name = "Show Profile Name", desc = "Show profile name instead of the type in the profile element.")
     @ConfigEditorBoolean
-    public boolean showProfileName = true;
+    public boolean showProfileName = false;
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
@@ -150,6 +150,11 @@ public class DisplayConfig {
     public RenderUtils.HorizontalAlignment textAlignment = RenderUtils.HorizontalAlignment.LEFT;
 
     @Expose
+    @ConfigOption(name = "Show Profile Name", desc = "Show profile name instead of the type in the profile element.")
+    @ConfigEditorBoolean
+    public boolean showProfileName = true;
+
+    @Expose
     @ConfigOption(
         name = "Cache Scoreboard on Island Switch",
         desc = "Will stop the Scoreboard from updating while switching islands.\n" +

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementProfile.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementProfile.kt
@@ -22,7 +22,7 @@ object ScoreboardElementProfile : ScoreboardElement() {
         }
     }
 
-    override val configLine = "§7♲ Blueberry"
+    override val configLine = "§7♲ Ironman"
 }
 
 // click: does a command for profile management exist?

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementProfile.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementProfile.kt
@@ -1,13 +1,26 @@
 package at.hannibal2.skyhanni.features.gui.customscoreboard.elements
 
 import at.hannibal2.skyhanni.data.HypixelData
+import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 
 // internal and scoreboard
 // island change event
 object ScoreboardElementProfile : ScoreboardElement() {
-    override fun getDisplay() = CustomScoreboardUtils.getProfileTypeSymbol() + HypixelData.profileName.firstLetterUppercase()
+    override fun getDisplay() = buildString {
+        append(CustomScoreboardUtils.getProfileTypeSymbol())
+        if (CustomScoreboard.displayConfig.showProfileName) {
+            append(HypixelData.profileName.firstLetterUppercase())
+        } else {
+            when {
+                HypixelData.ironman -> append("Ironman")
+                HypixelData.stranded -> append("Stranded")
+                HypixelData.bingo -> append("Bingo")
+                else -> append("Normal")
+            }
+        }
+    }
 
     override val configLine = "§7♲ Blueberry"
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventBroodmother.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventBroodmother.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 // scoreboard
 // widget update event
 object ScoreboardEventBroodmother : ScoreboardEvent() {
-    override fun getDisplay() = TabWidget.BROODMOTHER.lines
+    override fun getDisplay() = TabWidget.BROODMOTHER.lines.map { it.trim() }
 
     override val configLine = "Broodmother§7: §eDormant"
 


### PR DESCRIPTION
## What
Added an option to show the profile type instead of profile name, like Hypixel does


## Changelog Improvements
+ Added an option to display the profile type instead of the name in the Custom Scoreboard. - j10a1n15

## Changelog Fixes
+ Fixed the Broodmother line in the Custom Scoreboard having a leading space. - j10a1n15