### PR TITLE
Backend Fix: Detekt Runner

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -29,6 +29,7 @@ jobs:
                 run: |
                   ./gradlew detektMain --stacktrace
             -   name: Check if SARIF file exists
+                if: always()
                 id: check_sarif
                 run: |
                     if [ -f "versions/1.8.9/build/reports/detekt/main.sarif" ]; then


### PR DESCRIPTION
## What
See images. The `Check if SARIF exists` needed an `if: always()`

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/5006e6a1-3a33-4e10-9d62-1c3b3be607ca)

</details>

exclude_from_changelog
