### PR TITLE
Backend: Better Enchant Detection and Error Logging

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -40,10 +40,15 @@ object EnchantParser {
 
     val patternGroup = RepoPattern.group("misc.items.enchantparsing")
     // Pattern to check that the line contains ONLY enchants (and the other bits that come with a valid enchant line)
+    /**
+     * REGEX-TEST: §d§l§d§lWisdom V§9, §9Depth Strider III§9, §9Feather Falling X
+     * REGEX-TEST: §9Compact X§9, §9Efficiency V§9, §9Experience IV
+     */
     val enchantmentExclusivePattern by patternGroup.pattern(
         "exclusive",
         "(?:(?:§7§l|§d§l|§9)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:,\\d{3})*))+\$",
     )
+    // Above regex tests apply to this pattern also
     val enchantmentPattern by patternGroup.pattern(
         "enchants.new",
         "(§7§l|§d§l|§9)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)(?<stacking>(§r)?§9, |\$| §8\\d{1,3}(,\\d{3})*)",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -39,6 +39,11 @@ object EnchantParser {
     private val config get() = SkyHanniMod.feature.inventory.enchantParsing
 
     val patternGroup = RepoPattern.group("misc.items.enchantparsing")
+    // Pattern to check that the line contains ONLY enchants (and the other bits that come with a valid enchant line)
+    val enchantmentExclusivePattern by patternGroup.pattern(
+        "exclusive",
+        "(?:(?:§7§l|§d§l|§9)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:,\\d{3})*))+\$",
+    )
     val enchantmentPattern by patternGroup.pattern(
         "enchants.new",
         "(§7§l|§d§l|§9)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)(?<stacking>(§r)?§9, |\$| §8\\d{1,3}(,\\d{3})*)",
@@ -186,20 +191,6 @@ object EnchantParser {
             return
         }
 
-        // Remove enchantment lines so we can insert ours
-        try {
-            loreList.subList(startEnchant, endEnchant + 1).clear()
-        } catch (e: IndexOutOfBoundsException) {
-            ErrorManager.logErrorWithData(
-                e,
-                "Error parsing enchantment info from item",
-                "loreList" to loreList,
-                "startEnchant" to startEnchant,
-                "endEnchant" to endEnchant,
-            )
-            return
-        }
-
         val insertEnchants: MutableList<String> = mutableListOf()
 
         // Format enchants based on format config option
@@ -220,8 +211,22 @@ object EnchantParser {
                 "ConcurrentModificationException whilst formatting enchants",
                 "loreList" to loreList,
                 "format" to config.format.get(),
-                "orderedEnchants" to orderedEnchants
+                "orderedEnchants" to orderedEnchants.toString()
             )
+        }
+
+        // Remove enchantment lines so we can insert ours
+        try {
+            loreList.subList(startEnchant, endEnchant + 1).clear()
+        } catch (e: IndexOutOfBoundsException) {
+            ErrorManager.logErrorWithData(
+                e,
+                "Error parsing enchantment info from item",
+                "loreList" to loreList,
+                "startEnchant" to startEnchant,
+                "endEnchant" to endEnchant,
+            )
+            return
         }
 
         // Add our parsed enchants back into the lore

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantsJson.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.misc.items.enchants
 
+import at.hannibal2.skyhanni.features.misc.items.enchants.EnchantParser.enchantmentExclusivePattern
 import at.hannibal2.skyhanni.features.misc.items.enchants.EnchantParser.enchantmentPattern
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
@@ -27,15 +28,20 @@ class EnchantsJson {
     }
 
     fun containsEnchantment(enchants: Map<String, Int>, line: String): Boolean {
+        val exclusiveMatch = enchantmentExclusivePattern.matcher(line)
+        if (!exclusiveMatch.find()) return false // This is the case that the line is not exclusively enchants
+
         val matcher = enchantmentPattern.matcher(line)
         while (matcher.find()) {
             val enchant = this.getFromLore(matcher.group("enchant"))
             if (enchants.isNotEmpty()) {
                 if (enchants.containsKey(enchant.nbtName)) return true
             } else {
-                if (normal.containsKey(enchant.loreName.lowercase())) return true
-                if (ultimate.containsKey(enchant.loreName.lowercase())) return true
-                if (stacking.containsKey(enchant.loreName.lowercase())) return true
+                if (normal.containsKey(enchant.loreName.lowercase()) ||
+                    ultimate.containsKey(enchant.loreName.lowercase()) ||
+                    stacking.containsKey(enchant.loreName.lowercase())
+                )
+                    return true
             }
         }
         return false

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantsJson.kt
@@ -1,7 +1,5 @@
 package at.hannibal2.skyhanni.features.misc.items.enchants
 
-import at.hannibal2.skyhanni.features.misc.items.enchants.EnchantParser.enchantmentExclusivePattern
-import at.hannibal2.skyhanni.features.misc.items.enchants.EnchantParser.enchantmentPattern
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 
@@ -28,18 +26,19 @@ class EnchantsJson {
     }
 
     fun containsEnchantment(enchants: Map<String, Int>, line: String): Boolean {
-        val exclusiveMatch = enchantmentExclusivePattern.matcher(line)
+        val exclusiveMatch = EnchantParser.enchantmentExclusivePattern.matcher(line)
         if (!exclusiveMatch.find()) return false // This is the case that the line is not exclusively enchants
 
-        val matcher = enchantmentPattern.matcher(line)
+        val matcher = EnchantParser.enchantmentPattern.matcher(line)
         while (matcher.find()) {
             val enchant = this.getFromLore(matcher.group("enchant"))
             if (enchants.isNotEmpty()) {
                 if (enchants.containsKey(enchant.nbtName)) return true
             } else {
-                if (normal.containsKey(enchant.loreName.lowercase()) ||
-                    ultimate.containsKey(enchant.loreName.lowercase()) ||
-                    stacking.containsKey(enchant.loreName.lowercase())
+                val key = enchant.loreName.lowercase()
+                if (normal.containsKey(key) ||
+                    ultimate.containsKey(key) ||
+                    stacking.containsKey(key)
                 )
                     return true
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FormattedEnchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FormattedEnchant.kt
@@ -25,4 +25,8 @@ class FormattedEnchant(
 
         return if (!stacking.contains("empty")) builder.append(stacking).toString() else builder.toString()
     }
+
+    override fun toString(): String {
+        return "FormattedEnchant[enchant: " + enchant.nbtName + ", level: " + level + ", isRoman: " + isRoman + "]"
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FormattedEnchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FormattedEnchant.kt
@@ -3,14 +3,12 @@ package at.hannibal2.skyhanni.features.misc.items.enchants
 import at.hannibal2.skyhanni.utils.NumberUtil.toRoman
 import net.minecraft.item.ItemStack
 
-class FormattedEnchant(
+data class FormattedEnchant(
     private val enchant: Enchant,
     private val level: Int,
-    stacking: String,
+    private val stacking: String,
     private val isRoman: Boolean,
 ) : Comparable<FormattedEnchant> {
-    private val stacking: String = stacking
-        get() = "§8$field"
     private val loreDescription: MutableList<String> = mutableListOf()
 
     fun addLore(lineOfLore: String) = loreDescription.add(lineOfLore)
@@ -23,10 +21,6 @@ class FormattedEnchant(
         val builder = StringBuilder()
         builder.append(enchant.getFormattedName(level, itemStack)).append(" ").append(if (isRoman) level.toRoman() else level)
 
-        return if (!stacking.contains("empty")) builder.append(stacking).toString() else builder.toString()
-    }
-
-    override fun toString(): String {
-        return "FormattedEnchant[enchant: " + enchant.nbtName + ", level: " + level + ", isRoman: " + isRoman + "]"
+        return if (!stacking.contains("empty")) builder.append("§8$stacking").toString() else builder.toString()
     }
 }


### PR DESCRIPTION
## What
Adds a regex pattern to check that a line contains only enchants (and anything else expected in a legitimate enchant line) so miscellaneous strings from elsewhere in the mod or from other mods are not messed with incorrectly. Also fixes and improves the error logging in enchant parser for some still unexplained errors.
test

## Changelog Technical Details
+ Improved enchant detection and enchant parser error logging. - Vixid