### PR TITLE
Fix: Catch JSON Parse Errors in APIUtils

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/APIUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/APIUtils.kt
@@ -181,9 +181,16 @@ object APIUtils {
 
     private fun readResponse(entity: HttpEntity): JsonObject {
         val retSrc = EntityUtils.toString(entity) ?: return JsonObject()
-        val parsed = parser.parse(retSrc)
-        if (parsed.isJsonNull) return JsonObject()
-        return parsed as JsonObject
+
+        try {
+            val parsed = parser.parse(retSrc)
+            if (parsed.isJsonNull) return JsonObject()
+
+            return parsed as JsonObject
+        } catch (_: Throwable) {
+            // This causes content types that aren't JSON to be ignored
+            return JsonObject()
+        }
     }
 
     fun postJSONIsSuccessful(url: String, body: String, silentError: Boolean = false): Boolean {


### PR DESCRIPTION
## What
This fixes getting errors from syncing contests with elitebot.dev because SkyHanni tries reading a string response as JSON. [See error here](https://discord.com/channels/997079228510117908/1000669238035497022/1299559940251324527).

The "fix" here is to just catch the parse error and return an empty JsonObject when reading the response of a POST request in APIUtils. Because the previous behavior was to error out and the string responses from my API don't need to be looked at, I don't expect this to cause any problems.

**Untested** - This is small change and I honestly don't want to figure out how to get SkyHanni to build since the last time I did a PR, so yeah.

## Changelog Fixes
+ Fixed API error when sending Jacob Contests. - Ke5o