### PR TITLE
Fix: Compact stash

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
@@ -24,6 +24,11 @@ public class StashConfig {
     public String notice = "";
 
     @Expose
+    @ConfigOption(name = "Hide Added Messages", desc = "Hide the messages when something is added to your stash.")
+    @ConfigEditorBoolean
+    public boolean hideAddedMessages = true;
+
+    @Expose
     @ConfigOption(name = "Hide Duplicate Warnings", desc = "Hide duplicate warnings for previously reported stash counts.")
     @ConfigEditorBoolean
     public boolean hideDuplicateCounts = true;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
@@ -30,7 +30,7 @@ public class StashConfig {
 
     @Expose
     @ConfigOption(name = "Hide Low Warnings", desc = "Hide warnings with a total count below this number.")
-    @ConfigEditorSlider(minValue = 0, maxValue = 1000000, minStep = 100)
+    @ConfigEditorSlider(minValue = 0, maxValue = 1_000_000, minStep = 100)
     public int hideLowWarningsThreshold = 0;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -109,7 +109,8 @@ object StashCompact {
         val action = if (config.useViewStash) "view" else "pickup"
 
         ChatUtils.clickableChat(
-            "${mainColor}You have $accentColor${materialCount.shortFormat()} $mainColor$typeNameFormat in stash$typeStringExtra. " + "${mainColor}Click to $accentColor$action ${mainColor}your stash!",
+            "${mainColor}You have $accentColor${materialCount.shortFormat()} $mainColor$typeNameFormat in stash$typeStringExtra. " +
+                "${mainColor}Click to $accentColor$action ${mainColor}your stash!",
             onClick = {
                 if (config.useViewStash) HypixelCommands.viewStash(type)
                 else HypixelCommands.pickupStash()


### PR DESCRIPTION
## What
Fixes the compact item stash messages not being detected correctly and fixes the color of material messages.
Also shows the amount in stash in compact format e.g. 700000 -> 700k (should I add an option for this?), and some code cleanup.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/e9478e45-b843-4bbd-9bcf-7efaa064ff3d)

</details>

## Changelog Fixes
+ Fixed compact stash messages. - Obsidian
    * Fixed compact item stash messages not being detected correctly.
    * Fixed the color of material messages.