### PR TITLE
Backend Fix: Detekt Artifact not Uploading

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -43,7 +43,7 @@ jobs:
                     chmod +x .github/scripts/process_detekt_sarif.sh
                     ./.github/scripts/process_detekt_sarif.sh versions/1.8.9/build/reports/detekt/main.sarif | tee detekt_output.txt
             -   name: Upload detekt output as artifact
-                if: ${{ steps.check_sarif.outputs.exists == 'true' }}
+                if: ${{ !cancelled() && steps.check_sarif.outputs.exists == 'true' }}
                 uses: actions/upload-artifact@v4
                 with:
                     name: detekt-output


### PR DESCRIPTION
## What
Fixes the detekt runner, again, again. This time it was the Upload Artifact step. It was missing an `always()`-esque condition to make sure it was not skipped when the actual detekt runner failed.

Yap bot is back baby.

Test PR with the fix implemented here:
- https://github.com/DavidArthurCole/SkyHanni/pull/163

exclude_from_changelog

