### PR TITLE
Fix: brewing stand shift click close button

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
@@ -11,6 +11,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
 object ShiftClickBrewing {
+    private val closeButtonIndex = 49
 
     @SubscribeEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
@@ -19,7 +20,7 @@ object ShiftClickBrewing {
 
         if (event.gui !is GuiChest) return
 
-        if (event.slot == null || event.slotId == 49) return
+        if (event.slot == null || event.slotId == closeButtonIndex) return
 
         val chestName = InventoryUtils.openInventoryName()
         if (!chestName.startsWith("Brewing Stand")) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
@@ -19,7 +19,7 @@ object ShiftClickBrewing {
 
         if (event.gui !is GuiChest) return
 
-        if (event.slot == null) return
+        if (event.slot == null || event.slotId == 49) return
 
         val chestName = InventoryUtils.openInventoryName()
         if (!chestName.startsWith("Brewing Stand")) return


### PR DESCRIPTION
## What
Can't close brewing stand using close button when Shift Click Brewing ("change normal clicks to shift clicks in Brewing Stand inventories)

fixed by checking if the slot is the close button and returning

Bug reported in discord: https://discord.com/channels/997079228510117908/1297607870166335623

## Changelog Fixes
+ Fixed being unable to use the "Close" button when "Change all clicks to shift clicks in brewing stands" is enabled. - phoebe

