### PR TITLE
Fix: update dungeon potion regex

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -80,7 +80,7 @@ object ItemDisplayOverlayFeatures {
     )
     private val dungeonPotionPattern by patternGroup.pattern(
         "dungeonpotion",
-        "Dungeon (?<level>.*) Potion",
+        "Dungeon (?<level>.*) Potion(?: x1)?",
     )
     private val bingoGoalRankPattern by patternGroup.pattern(
         "bingogoalrank",

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -78,6 +78,11 @@ object ItemDisplayOverlayFeatures {
         "harvest",
         "§7§7You may harvest §6(?<amount>.).*",
     )
+
+    /**
+     * REGEX-TEST: Dungeon VII Potion
+     * REGEX-TEST: Dungeon VII Potion x1
+     */
     private val dungeonPotionPattern by patternGroup.pattern(
         "dungeonpotion",
         "Dungeon (?<level>.*) Potion(?: x1)?",


### PR DESCRIPTION
## What
Update the dungeon potion regex as hypixel adds a x1 onto the end when in a menu where the potion is able to be sold.

bug reported in discord: https://discord.com/channels/997079228510117908/1296714423301312532

## Changelog Fixes
+ Fixed "Dungeon Potion level as stack size" not working in shop menus. - phoebe
