### PR TITLE
Fix: "null" in Custom Scoreboard LobbyCode

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
@@ -13,8 +13,8 @@ object ScoreboardElementLobbyCode : ScoreboardElement() {
 
     override fun getDisplay() = buildString {
         if (CustomScoreboard.displayConfig.dateInLobbyCode) append("§7${LocalDate.now().format(formatter)} ")
-        append(HypixelData.serverId?.let { "§8$it" })
-        append(DungeonAPI.getRoomID()?.let { " §8$it" })
+        HypixelData.serverId?.let { append("a§8$it") }
+        DungeonAPI.getRoomID()?.let { append(" b§8$it") }
     }
 
     override val configLine = "§710/23/2024 §8mega77CK"

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
@@ -13,8 +13,8 @@ object ScoreboardElementLobbyCode : ScoreboardElement() {
 
     override fun getDisplay() = buildString {
         if (CustomScoreboard.displayConfig.dateInLobbyCode) append("§7${LocalDate.now().format(formatter)} ")
-        HypixelData.serverId?.let { append("a§8$it") }
-        DungeonAPI.getRoomID()?.let { append(" b§8$it") }
+        HypixelData.serverId?.let { append("§8$it") }
+        DungeonAPI.getRoomID()?.let { append(" §8$it") }
     }
 
     override val configLine = "§710/23/2024 §8mega77CK"


### PR DESCRIPTION
## What
How did I not notice this while testing before :(


## Changelog Fixes
+ Fixed "null" appearing in the LobbyCode element of the Custom Scoreboard. - j10a1n15
