### PR TITLE
Fix: async map clear

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
@@ -43,14 +43,14 @@ object SuperpairDataDisplay {
     private val emptySuperpairItem = SuperpairItem(-1, "", -1)
 
     private var display = emptyList<String>()
-    private var uncoveredItems = mutableMapOf<Int, SuperpairItem>()
+    private var uncoveredItems = mapOf<Int, SuperpairItem>()
     private val found = mutableMapOf<FoundType, MutableList<FoundData>>()
 
     @SubscribeEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
         display = emptyList()
 
-        uncoveredItems = mutableMapOf()
+        uncoveredItems = emptyMap()
         found.clear()
     }
 
@@ -81,68 +81,70 @@ object SuperpairDataDisplay {
         val clicksItem = InventoryUtils.getItemAtSlotIndex(4)
 
         // TODO add variable name to indicate what is going on here
-        if (uncoveredItems.none { it.value.index == event.slotId && it.key == uncoveredItems.keys.max() }) {
+        val items = uncoveredItems.toMutableMap()
+        if (items.none { it.value.index == event.slotId && it.key == items.keys.max() }) {
             if (clicksItem != null) {
                 remainingClicksPattern.matchMatcher(clicksItem.displayName.removeColor()) { if (group("clicks").toInt() == 0) return }
             }
 
-            handleItem(event.slotId)
+            handleItem(items, event.slotId)
         }
+        uncoveredItems = items
     }
 
-    private fun handleItem(slot: Int) = DelayedRun.runDelayed(200.milliseconds) {
+    private fun handleItem(items: MutableMap<Int, SuperpairItem>, slot: Int) = DelayedRun.runDelayed(200.milliseconds) {
         val itemNow = InventoryUtils.getItemAtSlotIndex(slot) ?: return@runDelayed
         val itemName = itemNow.displayName.removeColor()
         val reward = convertToReward(itemNow)
         val itemData = SuperpairItem(slot, reward, itemNow.itemDamage)
-        val uncovered = uncoveredItems.keys.maxOrNull() ?: -1
+        val uncovered = items.keys.maxOrNull() ?: -1
 
         if (isWaiting(itemName)) return@runDelayed
 
-        if (uncoveredItems.none { it.key == uncovered && it.value.index == slot }) uncoveredItems[uncovered + 1] = itemData
+        if (items.none { it.key == uncovered && it.value.index == slot }) items[uncovered + 1] = itemData
 
         when {
-            isPowerUp(reward) -> handlePowerUp(itemData, uncovered + 1)
-            isReward(itemName) -> handleReward(itemData, uncovered + 1)
+            isPowerUp(reward) -> handlePowerUp(items, itemData, uncovered + 1)
+            isReward(itemName) -> handleReward(items, itemData, uncovered + 1)
         }
 
-        val since = clicksSinceSeparator(uncoveredItems)
+        val since = clicksSinceSeparator(items)
 
-        val lastReward = uncoveredItems.entries.last().value.reward
+        val lastReward = items.entries.last().value.reward
         // TODO use repo patterns for "Instant Find"
-        if ((since >= 2 || (since == -1 && uncoveredItems.size >= 2)) && lastReward != "Instant Find") uncoveredItems[uncovered + 2] =
+        if ((since >= 2 || (since == -1 && items.size >= 2)) && lastReward != "Instant Find") items[uncovered + 2] =
             emptySuperpairItem
 
         display = drawDisplay()
     }
 
-    private fun handlePowerUp(item: SuperpairItem, uncovered: Int) {
+    private fun handlePowerUp(items: MutableMap<Int, SuperpairItem>, item: SuperpairItem, uncovered: Int) {
         // TODO use repo patterns for "Instant Find"
-        if (item.reward != "Instant Find") uncoveredItems.remove(uncovered)
+        if (item.reward != "Instant Find") items.remove(uncovered)
 
         val itemData = FoundData(item = item)
         found.getOrPut(FoundType.POWERUP) { mutableListOf(itemData) }.apply { if (!contains(itemData)) add(itemData) }
     }
 
-    private fun handleReward(item: SuperpairItem, uncovered: Int) {
-        val last = uncoveredItems.getOrDefault(uncovered - 1, item)
+    private fun handleReward(items: MutableMap<Int, SuperpairItem>, item: SuperpairItem, uncovered: Int) {
+        val last = items.getOrDefault(uncovered - 1, item)
 
         if (isWaiting(last.reward)) return
 
         when {
             // TODO use repo patterns for "Instant Find"
-            last.reward == "Instant Find" -> handleInstantFind(item, uncovered)
+            last.reward == "Instant Find" -> handleInstantFind(items, item, uncovered)
             hasFoundPair(item, last) -> handleFoundPair(item, last)
-            hasFoundMatch(item) -> handleFoundMatch(item)
+            hasFoundMatch(items, item) -> handleFoundMatch(items, item)
             else -> handleNormalReward(item)
         }
 
         println(found)
     }
 
-    private fun handleInstantFind(item: SuperpairItem, uncovered: Int) {
-        uncoveredItems[uncovered - 1] = item
-        uncoveredItems[uncovered] = emptySuperpairItem
+    private fun handleInstantFind(items: MutableMap<Int, SuperpairItem>, item: SuperpairItem, uncovered: Int) {
+        items[uncovered - 1] = item
+        items[uncovered] = emptySuperpairItem
 
         handleFoundPair(item, emptySuperpairItem)
     }
@@ -164,9 +166,9 @@ object SuperpairDataDisplay {
         found.getOrPut(FoundType.PAIR) { mutableListOf(pairData) }.apply { if (!contains(pairData)) add(pairData) }
     }
 
-    private fun handleFoundMatch(item: SuperpairItem) {
+    private fun handleFoundMatch(items: MutableMap<Int, SuperpairItem>, item: SuperpairItem) {
         // TODO better name
-        val match = uncoveredItems.values.find { it.index != item.index && it.sameAs(item) } ?: return
+        val match = items.values.find { it.index != item.index && it.sameAs(item) } ?: return
 
         found.entries.forEach {
             when {
@@ -269,8 +271,8 @@ object SuperpairDataDisplay {
     ) = first.index != second.index && first.sameAs(second)
 
     // TODO extract logic greatly
-    private fun hasFoundMatch(firstItem: SuperpairItem) =
-        uncoveredItems.any { it.value.index != firstItem.index && it.value.sameAs(firstItem) } &&
+    private fun hasFoundMatch(items: Map<Int, SuperpairItem>, firstItem: SuperpairItem) =
+        items.any { it.value.index != firstItem.index && it.value.sameAs(firstItem) } &&
             found.entries.none {
                 it.key.isAnyOf(FoundType.PAIR, FoundType.MATCH) &&
                     it.value.any { data ->


### PR DESCRIPTION
## What
only working with a local variable on item click so that the inventory close packet cant interfere.
bug report: https://discord.com/channels/997079228510117908/1299864186272223337

<details>
<summary>Stack trace</summary>

```
SkyHanni 0.28.Beta.7: DelayedRun task crashed while executing
 
Caused by java.util.NoSuchElementException: Collection is empty.
    at kotlin.collections.CollectionsKt___CollectionsKt.last(_Collections.kt:400)
    at SH.features.inventory.experimentationtable.SuperpairDataDisplay.handleItem_1cd6UlU$lambda$3(SuperpairDataDisplay.kt:111)
    at SH.utils.DelayedRun.checkRuns$lambda$0(DelayedRun.kt:32)
    at SH.utils.DelayedRun.checkRuns$lambda$1(DelayedRun.kt:28)
    at java.util.ArrayList.removeIf(ArrayList.java:1415)
    at SH.utils.DelayedRun.checkRuns(DelayedRun.kt:28)
    at SH.data.MinecraftData.onTick(MinecraftData.kt:74)
    at FML.common.eventhandler.EventBus.post(EventBus.java:140)
```

</details>

## Changelog Fixes
+ Fixed a rare error message when using Experimentation Table features. - hannibal2