### PR TITLE
Fix: Kick Duration not matching certain messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -24,11 +25,21 @@ object SkyBlockKickDuration {
     private var lastKickTime = SimpleTimeMark.farPast()
     private var hasWarned = false
 
+    private val patternGroup = RepoPattern.group("misc.kickduration")
+    private val kickPattern by patternGroup.pattern(
+        "kicked",
+        "§c(?:You were kicked while joining that server!|A kick occurred in your connection, so you were put in the SkyBlock lobby!)",
+    )
+    private val problemJoiningPattern by patternGroup.pattern(
+        "problemjoining",
+        "§cThere was a problem joining SkyBlock, try again in a moment!",
+    )
+
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
         if (!isEnabled()) return
-        if (event.message == "§cYou were kicked while joining that server!") {
 
+        if (kickPattern.matches(event.message) {
             if (LorenzUtils.onHypixel && !LorenzUtils.inSkyBlock) {
                 kickMessage = false
                 showTime = true
@@ -38,7 +49,7 @@ object SkyBlockKickDuration {
             }
         }
 
-        if (event.message == "§cThere was a problem joining SkyBlock, try again in a moment!") {
+        if (problemJoiningPattern.matches(event.message)) {
             kickMessage = false
             showTime = true
             lastKickTime = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
@@ -26,10 +27,19 @@ object SkyBlockKickDuration {
     private var hasWarned = false
 
     private val patternGroup = RepoPattern.group("misc.kickduration")
+
+    /**
+     * REGEX-TEST: §cYou were kicked while joining that server!
+     * REGEX-TEST: §cA kick occurred in your connection, so you were put in the SkyBlock lobby!
+     */
     private val kickPattern by patternGroup.pattern(
         "kicked",
         "§c(?:You were kicked while joining that server!|A kick occurred in your connection, so you were put in the SkyBlock lobby!)",
     )
+
+    /**
+     * REGEX-TEST: §cThere was a problem joining SkyBlock, try again in a moment!
+     */
     private val problemJoiningPattern by patternGroup.pattern(
         "problemjoining",
         "§cThere was a problem joining SkyBlock, try again in a moment!",
@@ -39,7 +49,7 @@ object SkyBlockKickDuration {
     fun onChat(event: LorenzChatEvent) {
         if (!isEnabled()) return
 
-        if (kickPattern.matches(event.message) {
+        if (kickPattern.matches(event.message)) {
             if (LorenzUtils.onHypixel && !LorenzUtils.inSkyBlock) {
                 kickMessage = false
                 showTime = true


### PR DESCRIPTION
## What
Fixed Kick Duration not matching certain kick messages and made it use RepoPatterns.
test

## Changelog Fixes
+ Fixed kick duration not showing with some kick messages. - Luna

## Changelog Technical Details
+ Changed "Kick Duration" to use `RepoPatterns`. - Luna