### PR TITLE
Backend: Pattern Key rename in Carnival

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalGoal.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalGoal.kt
@@ -24,7 +24,7 @@ import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.intellij.lang.annotations.Language
 
-private val repoGroup = RepoPattern.group("carnvial.goals")
+private val patternGroup = RepoPattern.group("event.carnival.goals")
 
 enum class CarnivalGoal(
     private val type: GoalType,
@@ -126,8 +126,8 @@ enum class CarnivalGoal(
 
     private val patternKeyName = name.lowercase().replace("_", ".")
 
-    private val lorePattern by repoGroup.pattern("lore.$patternKeyName", loreLine)
-    private val chatPattern by repoGroup.pattern("chat.$patternKeyName", chatLine)
+    private val lorePattern by patternGroup.pattern("lore.$patternKeyName", loreLine)
+    private val chatPattern by patternGroup.pattern("chat.$patternKeyName", chatLine)
 
     private var isReached: Boolean
         get() {
@@ -161,9 +161,9 @@ enum class CarnivalGoal(
         private val config get() = SkyHanniMod.feature.event.carnival
         private val storage get() = ProfileStorageData.profileSpecific?.carnival
 
-        private val inventoryPattern by repoGroup.pattern("inventory", "Carnival Goals")
+        private val inventoryPattern by patternGroup.pattern("inventory", "Carnival Goals")
 
-        private val completePattern by repoGroup.pattern("complete", "§a§lCOMPLETE")
+        private val completePattern by patternGroup.pattern("complete", "§a§lCOMPLETE")
 
         private var dirty = true
 


### PR DESCRIPTION
## What
fixed typo in pattern group key, only a internal change.

## Changelog Technical Details
+ Fixed a typo in the key of Carnival Repo Patterns. - hannibal2