### PR TITLE
Fix: Carnival Area

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/skyblock/AreaChangeEvents.kt
@@ -4,4 +4,4 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
 // Detect area changes by looking at the scoreboard.
 class ScoreboardAreaChangeEvent(val area: String, val previousArea: String?) : SkyHanniEvent()
-class GraphAreaChangeEvent(val area: String, val previousArea: String?) : SkyHanniEvent()
+class GraphAreaChangeEvent(val area: String, val previousArea: String?, val onlyInternal: Boolean) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.repo.RepoManager
 import at.hannibal2.skyhanni.data.repo.RepoManager.Companion.hasDefaultSettings
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.features.misc.IslandAreas
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.OSUtils
@@ -127,7 +128,9 @@ object DebugCommand {
         event.addIrrelevant {
             add("on Hypixel SkyBlock")
             add("skyBlockIsland: ${LorenzUtils.skyBlockIsland}")
-            add("skyBlockArea: '${LorenzUtils.skyBlockArea}'")
+            add("skyBlockArea:")
+            add("  scoreboard: '${LorenzUtils.skyBlockArea}'")
+            add("  graph network: '${IslandAreas.currentAreaName}'")
             add("isOnAlphaServer: '${LorenzUtils.isOnAlphaServer}'")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -43,7 +43,7 @@ object GraphEditorBugFinder {
 
         val nearestArea = mutableMapOf<GraphNode, GraphNode>()
         for (node in nodes) {
-            val pathToNearestArea = GraphUtils.findFastestPath(node) { it.getAreaTag(ignoreConfig = true) != null }?.first
+            val pathToNearestArea = GraphUtils.findFastestPath(node) { it.getAreaTag() != null }?.first
             if (pathToNearestArea == null) {
                 continue
             }
@@ -56,7 +56,7 @@ object GraphEditorBugFinder {
             for (neighbour in node.neighbours.keys) {
                 val neighbouringAreaNode = nearestArea[neighbour]?.name ?: continue
                 if (neighbouringAreaNode == areaNode) continue
-                if ((null == node.getAreaTag(ignoreConfig = true))) {
+                if ((null == node.getAreaTag())) {
                     bugs++
                     errorsInWorld[node] = "§cConflicting areas $areaNode and $neighbouringAreaNode"
                 }


### PR DESCRIPTION
## What
Fixed area detection breaking in small areas when small area is disabled.
Made detecting internal area, and throwing the area event for small areas always, even when disabled.
This only impacted the carnival, the other spots where we use the graph area detection, the area is a big area.

## Changelog Fixes
+ Fixed "in Carnival area" detection not working when "Small Areas" are disabled in the "Area Navigation" config category. - hannibal2