### PR TITLE
Improvement: Focus Mode Options

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -10,7 +10,7 @@ import org.lwjgl.input.Keyboard;
 public class FocusModeConfig {
 
     @Expose
-    @ConfigOption(name = "Enabled", desc = "In focus mode you only see the name of the item instead of the whole description.")
+    @ConfigOption(name = "Enabled", desc = "In focus mode you only see the name of the item instead of the whole description. §eSet a Toggle key below to use.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = false;
@@ -19,4 +19,14 @@ public class FocusModeConfig {
     @ConfigOption(name = "Toggle Key", desc = "Key to toggle the focus mode on and off.")
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     public int toggleKey = Keyboard.KEY_NONE;
+
+    @Expose
+    @ConfigOption(name = "Disable Hint", desc = "Disable the line in item tooltips that show how to enable or disable this feature via key press.")
+    @ConfigEditorBoolean
+    public boolean disableHint = false;
+
+    @Expose
+    @ConfigOption(name = "Always Enabled", desc = "Ignore the keybind and enable this feature all the time.")
+    @ConfigEditorBoolean
+    public boolean alwaysEnabled = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -5,12 +5,14 @@ import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag;
 import org.lwjgl.input.Keyboard;
 
 public class FocusModeConfig {
 
     @Expose
     @ConfigOption(name = "Enabled", desc = "In focus mode you only see the name of the item instead of the whole description. §eSet a Toggle key below to use.")
+    @SearchTag("compact hide")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -15,20 +16,35 @@ object FocusMode {
 
     private val config get() = SkyHanniMod.feature.inventory.focusMode
 
-    private var toggle = true
+    private var active = false
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     fun onLorenzToolTip(event: LorenzToolTipEvent) {
-        if (!isEnabled() || !toggle) return
+        if (!isEnabled()) return
         if (event.toolTip.isEmpty()) return
-        event.toolTip = mutableListOf(event.toolTip.first())
+        val keyName = KeyboardManager.getKeyName(config.toggleKey)
+
+        val hint = !config.disableHint && !config.alwaysEnabled && keyName != "NONE"
+        if (active || config.alwaysEnabled) {
+            event.toolTip = buildList {
+                add(event.toolTip.first())
+                if (hint) {
+                    add("§7Focus Mode from SkyHanni active! (Press $keyName to disable)")
+                }
+            }.toMutableList()
+        } else {
+            if (hint) {
+                event.toolTip.add(1, "§7Press $keyName to enable Focus Mode from SkyHanni!")
+            }
+        }
     }
 
     @SubscribeEvent
     fun onLorenzTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
+        if (config.alwaysEnabled) return
         if (!config.toggleKey.isKeyClicked()) return
-        toggle = !toggle
+        active = !active
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && InventoryUtils.inContainer() && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
@@ -29,7 +29,8 @@ object FocusMode {
             event.toolTip = buildList {
                 add(event.toolTip.first())
                 if (hint) {
-                    add("§7Focus Mode from SkyHanni active! (Press $keyName to disable)")
+                    add("§7Focus Mode from SkyHanni active!")
+                    add("Press $keyName to disable!")
                 }
             }.toMutableList()
         } else {


### PR DESCRIPTION
## What
This PR replaces
- #2797

Helps users understand how this feature works by not being instantly enabled even when enabled via config.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/6dc813dd-bb58-4929-b195-46a32753286c)
![image](https://github.com/user-attachments/assets/18ec602f-f5e3-4d95-b8d1-4a24d779341e)
![image](https://github.com/user-attachments/assets/88c3d3f1-68ae-4106-ae52-ac895e234752)


</details>

## Changelog Improvements
+ Added more options to Focus Mode to avoid hiding the item lore unintentionally. - hannibal2
    * Even when enabled in config, focus mode is now inactive on game start and needs to get enabled via toggle mode.
    * Show a hint in the item lore how to enable/disable focus mode (with a config option to hide this hint).
    * Option to enable focus mode all the time, ignoring the keybind.
