### PR TITLE
Improvement: Focus Mode hide menu

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -33,7 +33,7 @@ public class FocusModeConfig {
     public boolean alwaysEnabled = false;
 
     @Expose
-    @ConfigOption(name = "Hide Menu Items", desc = "Also hide the item lore of no real SkyBlock items in menus.")
+    @ConfigOption(name = "Hide Menu Items", desc = "Also hide the lore of non-SkyBlock items in menus.")
     @ConfigEditorBoolean
     public boolean hideMenuItems = true;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -10,7 +10,7 @@ import org.lwjgl.input.Keyboard;
 public class FocusModeConfig {
 
     @Expose
-    @ConfigOption(name = "Enabled", desc = "In focus mode you only see the name of the item instead of the whole description.")
+    @ConfigOption(name = "Enabled", desc = "In focus mode you only see the name of the item instead of the whole description. §eSet a Toggle key below to use.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = false;
@@ -19,4 +19,14 @@ public class FocusModeConfig {
     @ConfigOption(name = "Toggle Key", desc = "Key to toggle the focus mode on and off.")
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     public int toggleKey = Keyboard.KEY_NONE;
+
+    @Expose
+    @ConfigOption(name = "Disable Hint", desc = "Disable the line in item tooltips that show how to enable or disable this feature via key press.")
+    @ConfigEditorBoolean
+    public boolean disableHint = false;
+
+    @Expose
+    @ConfigOption(name = "Always Enabled", desc = "Ignore the keybind and enable this feature all the time.")
+    @ConfigEditorBoolean
+    public boolean alwaysEnabled = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -23,7 +23,7 @@ public class FocusModeConfig {
     public int toggleKey = Keyboard.KEY_NONE;
 
     @Expose
-    @ConfigOption(name = "Disable Hint", desc = "Disable the line in item tooltips that show how to enable or disable this feature via key press.")
+    @ConfigOption(name = "Disable Hint", desc = "Disable the line in item tooltips that shows how to enable or disable this feature via key press.")
     @ConfigEditorBoolean
     public boolean disableHint = false;
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -31,4 +31,9 @@ public class FocusModeConfig {
     @ConfigOption(name = "Always Enabled", desc = "Ignore the keybind and enable this feature all the time.")
     @ConfigEditorBoolean
     public boolean alwaysEnabled = false;
+
+    @Expose
+    @ConfigOption(name = "Hide Menu Items", desc = "Also hide the item lore of no real SkyBlock items in menus.")
+    @ConfigEditorBoolean
+    public boolean hideMenuItems = true;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/FocusModeConfig.java
@@ -5,12 +5,14 @@ import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag;
 import org.lwjgl.input.Keyboard;
 
 public class FocusModeConfig {
 
     @Expose
     @ConfigOption(name = "Enabled", desc = "In focus mode you only see the name of the item instead of the whole description. §eSet a Toggle key below to use.")
+    @SearchTag("compact hide")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -15,20 +16,35 @@ object FocusMode {
 
     private val config get() = SkyHanniMod.feature.inventory.focusMode
 
-    private var toggle = true
+    private var active = false
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     fun onLorenzToolTip(event: LorenzToolTipEvent) {
-        if (!isEnabled() || !toggle) return
+        if (!isEnabled()) return
         if (event.toolTip.isEmpty()) return
-        event.toolTip = mutableListOf(event.toolTip.first())
+        val keyName = KeyboardManager.getKeyName(config.toggleKey)
+
+        val hint = !config.disableHint && !config.alwaysEnabled && keyName != "NONE"
+        if (active || config.alwaysEnabled) {
+            event.toolTip = buildList {
+                add(event.toolTip.first())
+                if (hint) {
+                    add("§7Focus Mode from SkyHanni active! (Press $keyName to disable)")
+                }
+            }.toMutableList()
+        } else {
+            if (hint) {
+                event.toolTip.add(1, "§7Press $keyName to enable Focus Mode from SkyHanni!")
+            }
+        }
     }
 
     @SubscribeEvent
     fun onLorenzTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
+        if (config.alwaysEnabled) return
         if (!config.toggleKey.isKeyClicked()) return
-        toggle = !toggle
+        active = !active
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && InventoryUtils.inContainer() && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
@@ -29,7 +29,8 @@ object FocusMode {
             event.toolTip = buildList {
                 add(event.toolTip.first())
                 if (hint) {
-                    add("§7Focus Mode from SkyHanni active! (Press $keyName to disable)")
+                    add("§7Focus Mode from SkyHanni active!")
+                    add("Press $keyName to disable!")
                 }
             }.toMutableList()
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
@@ -1,13 +1,19 @@
 package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.CollectionUtils.sublistAfter
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.InventoryUtils.isTopInventory
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -17,11 +23,20 @@ object FocusMode {
     private val config get() = SkyHanniMod.feature.inventory.focusMode
 
     private var active = false
+    private var inAuctionHouse = false
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     fun onLorenzToolTip(event: LorenzToolTipEvent) {
         if (!isEnabled()) return
         if (event.toolTip.isEmpty()) return
+        if (config.hideMenuItems) {
+            event.itemStack.getInternalNameOrNull().let {
+                if (it == null || it == "SKYBLOCK_MENU".toInternalName()) return
+            }
+            val inBazaar = BazaarApi.inBazaarInventory && event.slot.isTopInventory()
+            if (inBazaar) return
+        }
+
         val keyName = KeyboardManager.getKeyName(config.toggleKey)
 
         val hint = !config.disableHint && !config.alwaysEnabled && keyName != "NONE"
@@ -31,6 +46,12 @@ object FocusMode {
                 if (hint) {
                     add("§7Focus Mode from SkyHanni active!")
                     add("Press $keyName to disable!")
+                }
+                val separator = "§5§o§8§m-----------------"
+                if (inAuctionHouse && event.toolTip.contains(separator)) {
+                    val ahLore = event.toolTip.sublistAfter(separator, amount = 20)
+                    add(separator)
+                    addAll(ahLore)
                 }
             }.toMutableList()
         } else {
@@ -46,6 +67,11 @@ object FocusMode {
         if (config.alwaysEnabled) return
         if (!config.toggleKey.isKeyClicked()) return
         active = !active
+    }
+
+    @SubscribeEvent
+    fun onInventoryOpen(event: InventoryOpenEvent) {
+        inAuctionHouse = event.inventoryName.startsWith("Auctions")
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && InventoryUtils.inContainer() && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -7,6 +7,7 @@ import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.gui.inventory.GuiInventory
+import net.minecraft.client.player.inventory.ContainerLocalMenu
 import net.minecraft.entity.player.InventoryPlayer
 import net.minecraft.inventory.ContainerChest
 import net.minecraft.inventory.Slot
@@ -132,4 +133,6 @@ object InventoryUtils {
         val controller = Minecraft.getMinecraft().playerController
         controller.windowClick(windowId, slot, 0, 0, Minecraft.getMinecraft().thePlayer)
     }
+
+    fun Slot.isTopInventory() = inventory is ContainerLocalMenu
 }


### PR DESCRIPTION
## Dependencies
- #2844

## What
added option to hide focus mode in menus.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/819fa547-95fa-4b8f-a7f0-fc95d2a3ed90)

</details>

## Changelog Improvements
+ Added an option for Focus Mode to ignore Menu Items. - hannibal2
+ Focus Mode no longer hides the seller information in the Auction House. - hannibal2