### PR TITLE
Fix: Crafting Room Rounding

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.HolographicEntities
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.isInside
+import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RenderUtils.drawString
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.client.entity.EntityOtherPlayerMP
@@ -65,7 +66,7 @@ object CraftRoomHolographicMob {
                     append("§a$mobName ")
                 }
                 if (config.showHealth) {
-                    append("§c${theMob.health}♥")
+                    append("§c${theMob.health.roundTo(1)}♥")
                 }
             }.trim()
 


### PR DESCRIPTION
## What
Fixed holographic mob wrong health format in Rift's Crafting Room
Reported: https://discord.com/channels/997079228510117908/1300199371400413245

## Changelog Fixes
+ Fixed incorrect health format for holographic mobs in Rift's Crafting Room. - hannibal2