### PR TITLE
Backend: `messageHistory` Length Config Option

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
@@ -36,6 +36,15 @@ public class DevConfig {
     public int logExpiryTime = 14;
 
     @Expose
+    @ConfigOption(
+        name = "Chat History Length",
+        desc = "The number of messages to keep in chat history.\n" +
+            "§cExcessively large values may cause memory allocation issues."
+    )
+    @ConfigEditorSlider(minValue = 100, maxValue = 5000, minStep = 10)
+    public int chatHistoryLength = 100;
+
+    @Expose
     @ConfigOption(name = "Slot Number", desc = "Show slot number in inventory while pressing this key.")
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     public int showSlotNumberKey = Keyboard.KEY_NONE;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
@@ -38,7 +38,7 @@ public class DevConfig {
     @Expose
     @ConfigOption(
         name = "Chat History Length",
-        desc = "The number of messages to keep in chat history.\n" +
+        desc = "The number of messages to keep in memory for §e/shchathistory§7.\n" +
             "§cExcessively large values may cause memory allocation issues."
     )
     @ConfigEditorSlider(minValue = 100, maxValue = 5000, minStep = 10)

--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -31,6 +31,8 @@ import java.lang.invoke.MethodHandles
 @SkyHanniModule
 object ChatManager {
 
+    private val config get() = SkyHanniMod.feature.dev
+
     private val loggerAll = LorenzLogger("chat/all")
     private val loggerFiltered = LorenzLogger("chat/blocked")
     private val loggerAllowed = LorenzLogger("chat/allowed")
@@ -41,7 +43,7 @@ object ChatManager {
             override fun removeEldestEntry(
                 eldest: MutableMap.MutableEntry<IdentityCharacteristics<IChatComponent>, MessageFilteringResult>?,
             ): Boolean {
-                return size > 100
+                return size > config.chatHistoryLength
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -43,7 +43,7 @@ object ChatManager {
             override fun removeEldestEntry(
                 eldest: MutableMap.MutableEntry<IdentityCharacteristics<IChatComponent>, MessageFilteringResult>?,
             ): Boolean {
-                return size > config.chatHistoryLength
+                return size > config.chatHistoryLength.coerceAtLeast(0)
             }
         }
 


### PR DESCRIPTION
## What
Adds a dev config option to allow expanding the length of chat history that is kept in `messageHistory`.

## Changelog Technical Details
+ Added dev config option for expanding Chat History length. - Daveed
   + Careful with large values :)

