### PR TITLE
Improvement: Reduce chance of getting muted by random string generator

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -334,7 +334,7 @@ object StringUtils {
 
     fun generateRandomId() = UUID.randomUUID().toString()
 
-    private const val CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    private const val CHARS = "BCDFGHJMPQRTVWXYbcdfghjmpqrtvwxy"
     fun generateRandomString(length: Int): String {
         var res: String = ""
         repeat(length) { res += CHARS.random() }


### PR DESCRIPTION
## What

While it's unlikely, the `generateRandomString(length)` function used in the public speaking (primal fear) solver could lead to… offenses against Hypixel rules when sending a string to all chat.

Even just removing all vowels from the possible output set is already a big improvement, but not sufficient on Hypixel – see screenshot below from a bot I run for a real-world example of this. The "string randomizer" in this case actually lead to having the output _blocked entirely_, but IMO that is the preferable outcome over getting potentially reported by another player from an all chat message.

That means the real issue is messages that get past Hypixel's fairly basic filter, but which are still problematic enough to potentially result in a punishment upon staff review of the `/report`.

<details>
<summary>Example screenshot</summary>

<img width="1098" alt="SCR-20241029-olyo" src="https://github.com/user-attachments/assets/db929ec7-ca9c-43d2-8731-8b9fb340215b">

Hypixel blocking the message – _luckily_

(This is with a string generator we had in use which consisted of letters + numbers)

</details>

Considered alternatives to using [A-Za-z] could be:
- a subset + extension to the letter-only alphabet like using hexadecimal characters, e.g. in form of a (shortened) UUID, or 
- what Microsoft does (https://stackoverflow.com/a/36294356), omitting the following characters from their product keys:
`0 1 2 5    A E I O U    L N S Z`

So, I suggest the following set:
```diff
- "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+ "BCDFGHJMPQRTVWXYbcdfghjmpqrtvwxy"
```
This implements the "Microsoft list" which removes vowels and `L N S Z`, in addition to removing `K`.

Thus leaving enough randomness to comfortably bypass Hypixel's anti-spam rules, but drastically reducing the odds of anything legible (as well as offensive) being produced.

Also posted in #suggestions [here](https://discord.com/channels/997079228510117908/1300863160240181349).

## Changelog Improvements
+ Improved public speaking solver to prevent slim chance of getting muted. - aphased

## Changelog Technical Details
+ StringUtils: reduce CHARS string to a subset of the latin alphabet. - aphased
