### PR TITLE
Backend: Alter regex to account for Champion XP number

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -41,17 +41,19 @@ object EnchantParser {
     val patternGroup = RepoPattern.group("misc.items.enchantparsing")
     // Pattern to check that the line contains ONLY enchants (and the other bits that come with a valid enchant line)
     /**
+     * REGEX-TEST: §9Champion VI §81.2M
+     * REGEX-TEST: §9Cultivating VII §83,271,717
      * REGEX-TEST: §d§l§d§lWisdom V§9, §9Depth Strider III§9, §9Feather Falling X
      * REGEX-TEST: §9Compact X§9, §9Efficiency V§9, §9Experience IV
      */
     val enchantmentExclusivePattern by patternGroup.pattern(
         "exclusive",
-        "(?:(?:§7§l|§d§l|§9)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:,\\d{3})*))+\$",
+        "(?:(?:§7§l|§d§l|§9)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:[,.]\\d{1,3})*)[kKmMbB]?)+\$",
     )
     // Above regex tests apply to this pattern also
     val enchantmentPattern by patternGroup.pattern(
         "enchants.new",
-        "(§7§l|§d§l|§9)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)(?<stacking>(§r)?§9, |\$| §8\\d{1,3}(,\\d{3})*)",
+        "(§7§l|§d§l|§9)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)(?<stacking>(§r)?§9, |\$| §8\\d{1,3}([,.]\\d{1,3})*[kKmMbB]?)",
     )
     private val grayEnchantPattern by patternGroup.pattern(
         "grayenchants", "^(Respiration|Aqua Affinity|Depth Strider|Efficiency).*",
@@ -280,7 +282,7 @@ object EnchantParser {
                 } catch (e: NumberFormatException) {
                     matcher.group("levelNumeral").romanToDecimal()
                 }
-                val stacking = if (matcher.group("stacking").trimStart().removeColor().matches("[\\d,]+\$".toRegex())) {
+                val stacking = if (matcher.group("stacking").trimStart().removeColor().matches("[\\d,.kKmMbB]+\$".toRegex())) {
                     shouldBeSingleColumn = true
                     matcher.group("stacking")
                 } else "empty"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -53,7 +53,8 @@ object EnchantParser {
     // Above regex tests apply to this pattern also
     val enchantmentPattern by patternGroup.pattern(
         "enchants.new",
-        "(§7§l|§d§l|§9)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)(?<stacking>(§r)?§9, |\$| §8\\d{1,3}([,.]\\d{1,3})*[kKmMbB]?)",
+        "(§7§l|§d§l|§9)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)" +
+            "(?<stacking>(§r)?§9, |\$| §8\\d{1,3}([,.]\\d{1,3})*[kKmMbB]?)",
     )
     private val grayEnchantPattern by patternGroup.pattern(
         "grayenchants", "^(Respiration|Aqua Affinity|Depth Strider|Efficiency).*",


### PR DESCRIPTION
## What
Alters the enchant parsing regexes to account for Champion enchant stacking progress, since Hypixel abbreviates it after 1M, i.e. `§9Champion VI §81.2M`, should also cover the case if Hypixel ever abreviates numbers with kK or bB too. Also adds a couple extra regex tests.

## Changelog Technical Details
+ Handles the number of Champion stacks. - Vixid
