### PR TITLE
Fix: NEUInternalName string comparison

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
@@ -53,7 +53,11 @@ class NEUInternalName private constructor(private val internalName: String) {
 
     fun asString() = internalName
 
-    override fun equals(other: Any?) = other is NEUInternalName && internalName == other.internalName
+    override fun equals(other: Any?) = when (other) {
+        is NEUInternalName -> internalName == other.internalName
+        is String -> internalName == other
+        else -> false
+    }
 
     override fun toString(): String = "internalName:$internalName"
 


### PR DESCRIPTION
## What
Fixed a regression causing comparisons between `NEUInternalName` and `String` to always returning false.

## Changelog Fixes
+ Fixed some features not working correctly because of a bug in the code. - Luna
    * This includes, but is likely not limited to, the "Merge Seeds" option for Crop Profit Display.