### PR TITLE
Fix: Bingo found by

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/BingoJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/BingoJson.kt
@@ -11,5 +11,5 @@ data class BingoData(
     @Expose val difficulty: String,
     @Expose val note: List<String>,
     @Expose val guide: List<String>,
-    @Expose val found: String,
+    @Expose val found: String?,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardTips.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardTips.kt
@@ -81,7 +81,9 @@ object BingoCardTips {
         for (line in bingoTip.guide) {
             toolTip.add(index++, " $line")
         }
-        toolTip.add(index++, "§7Found by: §e${bingoTip.found}")
+        bingoTip.found?.let {
+            toolTip.add(index++, "§7Found by: §e$it")
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Fixed the found by line

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/a28fd0cb-3784-4917-9e7f-f4eb7841edb0)

</details>

## Changelog Fixes
+ Fixed the "found by" line in bingo showing up accidentally. - hannibal2