### PR TITLE
Fix: Personal Compactor Hypixel Id

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/PersonalCompactorOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/PersonalCompactorOverlay.kt
@@ -12,11 +12,9 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.NEUItems.getInternalNameFromHypixelId
 import at.hannibal2.skyhanni.utils.NEUItems.getInternalNameFromHypixelIdOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
-import at.hannibal2.skyhanni.utils.RegexUtils.matchGroups
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAttributeString

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/PersonalCompactorOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/PersonalCompactorOverlay.kt
@@ -13,8 +13,10 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUItems.getInternalNameFromHypixelId
+import at.hannibal2.skyhanni.utils.NEUItems.getInternalNameFromHypixelIdOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
+import at.hannibal2.skyhanni.utils.RegexUtils.matchGroups
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAttributeString
@@ -75,7 +77,7 @@ object PersonalCompactorOverlay {
             val slots = slotsMap[tier] ?: return
             val itemList = (0 until slots).map { slot ->
                 val skyblockId = itemStack.getAttributeString(prefix + slot)
-                skyblockId?.let { getInternalNameFromHypixelId(it) }?.getItemStack()
+                skyblockId?.let { getInternalNameFromHypixelIdOrNull(it) }?.getItemStack()
             }
 
             RenderableInventory.fakeInventory(itemList, MAX_ITEMS_PER_ROW, 1.0)

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -114,7 +114,7 @@ object NEUItems {
 
     fun getInternalNameFromHypixelIdOrNull(hypixelId: String): NEUInternalName? {
         val internalName = hypixelId.replace(':', '-')
-        return internalName.asInternalName().takeIf { it.getItemStackOrNull()?.getItemId() == internalName }
+        return internalName.toInternalName().takeIf { it.getItemStackOrNull()?.getItemId() == internalName }
     }
 
     fun getInternalNameFromHypixelId(hypixelId: String): NEUInternalName =


### PR DESCRIPTION
## What
Makes Personal Compactor Overlay not show error if hypixel id doesnt match internal name.

## Changelog Fixes
+ Fixed an error in the Personal Compactor Overlay. - Empa