### PR TITLE
Backend: Make unusable enchants be valid by the enchant parser

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -48,12 +48,12 @@ object EnchantParser {
      */
     val enchantmentExclusivePattern by patternGroup.pattern(
         "exclusive",
-        "(?:(?:§7§l|§d§l|§9)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:[,.]\\d{1,3})*)[kKmMbB]?)+\$",
+        "^(?:(?:§7§l|§d§l|§9|§7)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:[,.]\\d{1,3})*)[kKmMbB]?)+\$",
     )
     // Above regex tests apply to this pattern also
     val enchantmentPattern by patternGroup.pattern(
         "enchants.new",
-        "(§7§l|§d§l|§9)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)" +
+        "(§7§l|§d§l|§9|§7)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)" +
             "(?<stacking>(§r)?§9, |\$| §8\\d{1,3}([,.]\\d{1,3})*[kKmMbB]?)",
     )
     private val grayEnchantPattern by patternGroup.pattern(


### PR DESCRIPTION
## What
Adds `§7` to the enchant regex so locked enchants are still detected by the enchant parser, since they are mistaken for lore lines and get hidden by the Hide Enchant Descriptions option.

At first I thought this would have issues with actual lore lines since lore lines mostly use §7, however I checked and no lore line in the game triggers the enchant regex, some come close with Hardened Mana having a line ending with `§7 for 10` but the space after the §7 saves it from being falsely detected. But obviously there is the potential Hypixel brings out a enchant with a lore line that does trigger the enchant regex, so the enchant exclusive regex was changed to better detect that a line contains only text that matches an enchant by including the beginning token `^` (which should have been added in the first place to be honest), which is checked before the enchant regex. It is still possible Hypixel release an enchant with a lore line that matches both the enchant exclusive regex and enchant regex, but it is far less likely.

## Changelog Technical Details
+ Unusable enchantments are no longer treated as lore lines by the enchant parser. - Vixid

