### PR TITLE
Improvement: More DateFormatter in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
@@ -140,6 +140,16 @@ public class DisplayConfig {
     public boolean skyblockTimeExactMinutes = true;
 
     @Expose
+    @ConfigOption(name = "Date in Lobby Code", desc = "Show the current date infront of the server name, like Hypixel does.")
+    @ConfigEditorBoolean
+    public boolean dateInLobbyCode = true;
+
+    @Expose
+    @ConfigOption(name = "Use Day-First Date Format", desc = "If enabled, the date will be shown in day-first format (dd/MM/yyyy). Otherwise, it will be shown in month-first format (MM/dd/yyyy).")
+    @ConfigEditorBoolean
+    public boolean useDayFirstDateFormat = false;
+
+    @Expose
     @ConfigOption(name = "Line Spacing", desc = "The amount of space between each line.")
     @ConfigEditorSlider(minValue = 0, maxValue = 20, minStep = 1)
     public int lineSpacing = 10;
@@ -153,11 +163,6 @@ public class DisplayConfig {
     @ConfigOption(name = "Show Profile Name", desc = "Show profile name instead of the type in the profile element.")
     @ConfigEditorBoolean
     public boolean showProfileName = false;
-
-    @Expose
-    @ConfigOption(name = "Date in Lobby Code", desc = "Show the current date infront of the server name, like Hypixel does.")
-    @ConfigEditorBoolean
-    public boolean dateInLobbyCode = true;
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.java
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.features.gui.customscoreboard;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
+import at.hannibal2.skyhanni.data.DateFormat;
 import at.hannibal2.skyhanni.utils.RenderUtils;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.Accordion;
@@ -145,9 +146,9 @@ public class DisplayConfig {
     public boolean dateInLobbyCode = true;
 
     @Expose
-    @ConfigOption(name = "Use Day-First Date Format", desc = "If enabled, the date will be shown in day-first format (dd/MM/yyyy). Otherwise, it will be shown in month-first format (MM/dd/yyyy).")
-    @ConfigEditorBoolean
-    public boolean useDayFirstDateFormat = false;
+    @ConfigOption(name = "Lobby Code Date Format", desc = "Select your preferred date format.")
+    @ConfigEditorDropdown
+    public DateFormat dateFormat = DateFormat.US_SLASH_MMDDYYYY;
 
     @Expose
     @ConfigOption(name = "Line Spacing", desc = "The amount of space between each line.")

--- a/src/main/java/at/hannibal2/skyhanni/data/DateFormat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/DateFormat.kt
@@ -1,0 +1,24 @@
+package at.hannibal2.skyhanni.data
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+enum class DateFormat(pattern: String) {
+    US_SLASH_MMDDYYYY("MM/dd/yyyy"),
+    US_DASH_MMDDYYYY("MM-dd-yyyy"),
+    UK_DDMMYYYY("dd/MM/yyyy"),
+    UK_DASH_DDMMYYYY("dd-MM-yyyy"),
+    ISO_YYYYMMDD("yyyy-MM-dd"),
+    FULL_MONTH_DAY_YEAR("MMMM dd, yyyy"),
+    SHORT_MONTH_DAY_YEAR("MMM dd, yyyy"),
+    YEAR_MONTH_DAY("yyyy/MM/dd"),
+    YEAR_DAY_MONTH("yyyy/dd/MM"),
+    COMPACT_YYYYMMDD("yyyyMMdd"),
+    DAY_MONTH_YEAR("dd MMMM yyyy"),
+    DAY_MONTH_YEAR_SHORT("dd MMM yyyy");
+
+    val formatter = DateTimeFormatter.ofPattern(pattern)
+
+    override fun toString() = LocalDate.now().format(formatter)
+}
+

--- a/src/main/java/at/hannibal2/skyhanni/data/DateFormat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/DateFormat.kt
@@ -17,7 +17,7 @@ enum class DateFormat(pattern: String) {
     DAY_MONTH_YEAR("dd MMMM yyyy"),
     DAY_MONTH_YEAR_SHORT("dd MMM yyyy");
 
-    val formatter = DateTimeFormatter.ofPattern(pattern)
+    private val formatter = DateTimeFormatter.ofPattern(pattern)
 
     override fun toString() = LocalDate.now().format(formatter)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -1,6 +1,5 @@
 /**
  * TODO LIST
- *  - Bank API (actually maybe not, I like the current design)
  *  - countdown events like fishing festival + fiesta when its not on tablist
  *  - improve hide coin difference to also work with bits, motes, etc
  *  - color options in the purse etc lines

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
@@ -9,13 +9,15 @@ import java.time.format.DateTimeFormatter
 // internal
 // update on island change and every second while in dungeons
 object ScoreboardElementLobbyCode : ScoreboardElement() {
-    private val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+    private val dateFormatterMonthFirst = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+    private val dateFormatterDayFirst = DateTimeFormatter.ofPattern("dd/MM/yyyy")
 
     override fun getDisplay() = buildString {
+        val formatter = if (CustomScoreboard.displayConfig.useDayFirstDateFormat) dateFormatterDayFirst else dateFormatterMonthFirst
         if (CustomScoreboard.displayConfig.dateInLobbyCode) append("§7${LocalDate.now().format(formatter)} ")
         HypixelData.serverId?.let { append("§8$it") }
         DungeonAPI.roomId?.let { append(" §8$it") }
     }
 
-    override val configLine = "§710/23/2024 §8mega77CK"
+    override val configLine = "§7${LocalDate.now().format(dateFormatterMonthFirst)} §8mega77CK"
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
@@ -1,23 +1,18 @@
 package at.hannibal2.skyhanni.features.gui.customscoreboard.elements
 
+import at.hannibal2.skyhanni.data.DateFormat
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 // internal
 // update on island change and every second while in dungeons
 object ScoreboardElementLobbyCode : ScoreboardElement() {
-    private val dateFormatterMonthFirst = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-    private val dateFormatterDayFirst = DateTimeFormatter.ofPattern("dd/MM/yyyy")
-
     override fun getDisplay() = buildString {
-        val formatter = if (CustomScoreboard.displayConfig.useDayFirstDateFormat) dateFormatterDayFirst else dateFormatterMonthFirst
-        if (CustomScoreboard.displayConfig.dateInLobbyCode) append("§7${LocalDate.now().format(formatter)} ")
+        if (CustomScoreboard.displayConfig.dateInLobbyCode) append("§7${CustomScoreboard.displayConfig.dateFormat} ")
         HypixelData.serverId?.let { append("§8$it") }
         DungeonAPI.roomId?.let { append(" §8$it") }
     }
 
-    override val configLine = "§7${LocalDate.now().format(dateFormatterMonthFirst)} §8mega77CK"
+    override val configLine = "§7${DateFormat.US_SLASH_MMDDYYYY} §8mega77CK"
 }


### PR DESCRIPTION
## What
[Discord](https://discord.com/channels/997079228510117908/1302536110873776138)

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/5de42e72-e3aa-4502-968b-7b7e55d2fe42)

</details>

## Changelog Improvements
+ Added a dropdown menu to select the Lobby Code date format. - j10a1n15

## Changelog Technical Details
+ Added a `DateFormat` enum that contains various date formats. - j10a1n15
