### PR TITLE
Backend: Allow enchants be prefixed by any combination of colour codes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -48,7 +48,7 @@ object EnchantParser {
      */
     val enchantmentExclusivePattern by patternGroup.pattern(
         "exclusive",
-        "^(?:(?:§7§l|§d§l|§9|§7)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:[,.]\\d{1,3})*)[kKmMbB]?)+\$",
+        "^(?:(?:§.)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:[,.]\\d{1,3})*)[kKmMbB]?)+\$",
     )
     // Above regex tests apply to this pattern also
     val enchantmentPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -43,6 +43,8 @@ object EnchantParser {
     /**
      * REGEX-TEST: §9Champion VI §81.2M
      * REGEX-TEST: §9Cultivating VII §83,271,717
+     * REGEX-TEST: §5§o§9Compact X
+     * REGEX-TEST: §5§o§d§l§d§lChimera V§9, §9Champion X§9, §9Cleave VI
      * REGEX-TEST: §d§l§d§lWisdom V§9, §9Depth Strider III§9, §9Feather Falling X
      * REGEX-TEST: §9Compact X§9, §9Efficiency V§9, §9Experience IV
      */


### PR DESCRIPTION
## What
Fixes the issue with enchant parser being broken by having the enchant exclusive regex allow the start of enchant lines be prefixed by any combination of colour codes since Hypixel just adds random colour codes in every different place imaginable. The actual enchant regex still only checks for the certain colours since it doesn't need to match from the very start like the enchant exclusive regex.

Also adds more regex tests that previously would have failed.

## Changelog Technical Details
+ Enchantment-exclusive regex now allows any combination of prefixed colour codes. - Vixid
