### PR TITLE
Fix: Scoreboard Hiding

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -39,8 +39,6 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.renderables.Renderable
-import net.minecraftforge.client.GuiIngameForge
-import net.minecraftforge.client.event.RenderGameOverlayEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -58,6 +56,8 @@ object CustomScoreboard {
     private const val GUI_NAME = "Custom Scoreboard"
 
     private var nextScoreboardUpdate = SimpleTimeMark.farFuture()
+
+    private var dirty = false
 
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
@@ -181,32 +181,8 @@ object CustomScoreboard {
         takeIf { !informationFilteringConfig.hideEmptyLinesAtTopAndBottom }
             ?: dropWhile { it.display.isBlank() }.dropLastWhile { it.display.isBlank() }
 
-    private var dirty = false
-
-    // The ElementType for the Vanilla Scoreboard is called HELMET
-    // Thanks to APEC for showing this
-    @SubscribeEvent
-    fun onRenderScoreboard(event: RenderGameOverlayEvent.Post) {
-        if (event.type == RenderGameOverlayEvent.ElementType.HELMET) {
-            if (isHideVanillaScoreboardEnabled()) {
-                GuiIngameForge.renderObjective = false
-            }
-            if (dirty) {
-                GuiIngameForge.renderObjective = true
-                dirty = false
-            }
-        }
-    }
-
     @SubscribeEvent
     fun onConfigLoad(event: ConfigLoadEvent) {
-        ConditionalUtils.onToggle(
-            config.enabled,
-            displayConfig.hideVanillaScoreboard,
-            SkyHanniMod.feature.misc.showOutsideSB,
-        ) {
-            if (!isHideVanillaScoreboardEnabled()) dirty = true
-        }
         ConditionalUtils.onToggle(
             config.scoreboardEntries,
             eventsConfig.eventEntries,
@@ -268,5 +244,6 @@ object CustomScoreboard {
     private fun isEnabled() =
         (LorenzUtils.inSkyBlock || (OutsideSbFeature.CUSTOM_SCOREBOARD.isSelected() && LorenzUtils.onHypixel)) && config.enabled.get()
 
-    private fun isHideVanillaScoreboardEnabled() = isEnabled() && displayConfig.hideVanillaScoreboard.get()
+    @JvmStatic
+    fun isHideVanillaScoreboardEnabled() = isEnabled() && displayConfig.hideVanillaScoreboard.get()
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiIngame.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiIngame.java
@@ -1,0 +1,18 @@
+package at.hannibal2.skyhanni.mixins.transformers.gui;
+
+import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard;
+import net.minecraft.client.gui.GuiIngame;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.scoreboard.ScoreObjective;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiIngame.class)
+public class MixinGuiIngame {
+    @Inject(method = "renderScoreboard", at = @At("HEAD"), cancellable = true)
+    public void renderScoreboard(ScoreObjective objective, ScaledResolution scaledRes, CallbackInfo ci) {
+        if (CustomScoreboard.isHideVanillaScoreboardEnabled()) ci.cancel();
+    }
+}


### PR DESCRIPTION
## What
This Pull Request improves/fixes the vanilla scoreboard hiding to use a mixin, instead of the other render method.
~~Wasn't able to test this yet because it doesn't build rn (com.gradleup.shadow is down or smth idfk)~~ Ran it using the GitHub build, works really well (even with Apec) 
I hope it has a better spec combat, because rn it still [flickers](https://discord.com/channels/728271316276215918/1293302756807016580) apparently (awesome how this didn't get reported on SkyHanni)


## Changelog Fixes
+ Fixed scoreboard flickering when using Apec and Custom Scoreboard. - j10a1n15
