### PR TITLE
Fix: Goblin Mining Event Render Issue

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUItems.kt
@@ -210,11 +210,7 @@ object NEUItems {
         AdjustStandardItemLighting.adjust() // Compensate for z scaling
 
         try {
-            // TODO remove workaround once rendering goblin raid textures doesnt cause errors
-//             if (item.name != "Goblin" || Minecraft.getMinecraft().thePlayer.isSneaking) {
-            if (item.name != "Goblin") {
-                Minecraft.getMinecraft().renderItem.renderItemIntoGUI(item, 0, 0)
-            }
+            Minecraft.getMinecraft().renderItem.renderItemIntoGUI(item, 0, 0)
         } catch (e: Exception) {
             if (lastWarn.passedSince() > 1.seconds) {
                 lastWarn = SimpleTimeMark.now()


### PR DESCRIPTION
## What
Fixed the issue where the Goblin Raid event renderable was causing funny stuff to happen. Also removed the temporary workaround that was put in place to solve for this.
Addressed a couple TODOs while I was here as well.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/3fe1f281-8fba-404e-8dbb-9ee4580d772a)

</details>

## Changelog Fixes
+ Fixed Mining Event display glitching with Goblin Raid. - Daveed

