### PR TITLE
Fix: Rabbit the Fish detection in middle slot

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityRabbitTheFishChecker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityRabbitTheFishChecker.kt
@@ -64,7 +64,7 @@ object HoppityRabbitTheFishChecker {
         if (!isEnabled() || !mealEggInventoryPattern.matches(event.inventoryName)) return
 
         rabbitTheFishIndex = event.inventoryItems.filter {
-            it.value.hasDisplayName()
+            it.value.hasDisplayName() && it.key != 22
         }.entries.firstOrNull {
             rabbitTheFishItemPattern.matches(it.value.displayName)
         }?.key


### PR DESCRIPTION
## What
Stops the highlighter from detecting the middle slot where the other rabbits appear, since this caused some issues if it showed up during the roulette animation.

https://discord.com/channels/997079228510117908/1301623747089793145

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fixed the Rabbit the Fish highlighter sometimes causing softlocks. - martimavocado

