### PR TITLE
Improvement: Added cancel carnival game item to the item pickup log blacklist

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -100,6 +100,7 @@ object ItemPickupLog {
         "MAXOR_ENERGY_CRYSTAL",
         "ELLE_SUPPLIES",
         "ELLE_FUEL_CELL",
+        "LEAVE_GAME_BUTTON",
     )
     private val bannedItemsConverted = bannedItemsPattern.map { it.toString().asInternalName() }
 


### PR DESCRIPTION
## What
Adds the LEAVE_GAME_BUTTON item ID to the item pickup log blacklist to prevent the cancel carnival game button from showing up in the item pickup log

## Changelog Improvements
+ Added cancel carnival game item to the item pickup log blacklist. - NeoNyaa