### PR TITLE
Backend: No labels on prs without milestones

### DIFF
--- a/.github/workflows/assign-relevant-labels.yml
+++ b/.github/workflows/assign-relevant-labels.yml
@@ -4,7 +4,7 @@ on:
         types: [ opened, edited ]
 jobs:
     assign-label:
-        if: github.event.pull_request.state == 'open'
+        if: github.event.pull_request.state == 'open' && github.event.pull_request.milestone
         runs-on: ubuntu-latest
         permissions:
             issues: write
@@ -18,7 +18,7 @@ jobs:
                     LABEL_BACKEND: Backend
                 uses: actions/github-script@v7
                 with:
-                    github-token: ${{ secrets.GITHUB_TOKEN}}
+                    github-token: ${{ secrets.GITHUB_TOKEN }}
                     script: |
                         const labelsToAdd = [];
                         const labelsToRemove = [];

--- a/.github/workflows/assign-relevant-labels.yml
+++ b/.github/workflows/assign-relevant-labels.yml
@@ -1,7 +1,9 @@
 name: "Assign relevant labels"
 on:
     pull_request_target:
-        types: [ opened, edited ]
+        types: [ opened, edited, reopened, synchronize, closed ]
+    milestone:
+        types: [ created, closed, deleted, edited ]
 jobs:
     assign-label:
         if: github.event.pull_request.state == 'open' && github.event.pull_request.milestone


### PR DESCRIPTION
## What
To avoid adding labels on new PRs, ones that aren't yet moved to a milestone, we will not add labels until the milestone is set.

exclude_from_changelog