### PR TITLE
Fix: double sending locraw

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -35,7 +35,6 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonObject
 import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -400,10 +400,7 @@ object HypixelData {
     private fun sendLocraw() {
         if (LorenzUtils.onHypixel && locrawData == null && lastLocRaw.passedSince() > 15.seconds) {
             lastLocRaw = SimpleTimeMark.now()
-            thread(start = true) {
-                Thread.sleep(1000)
-                HypixelCommands.locraw()
-            }
+            HypixelCommands.locraw()
         }
     }
 


### PR DESCRIPTION
## What
Fixes skyhanni sending locraw after neu does resulting in sending commands too fast


<details>
<summary>Images</summary>

pretend I took one

</details>

## Changelog Fixes
+ Fixed "You are sending commands too fast" error when swapping lobbies. - nopo