### PR TITLE
Fix: Stray Rabbit Requirement Pattern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -122,11 +122,11 @@ object HoppityCollectionStats {
     )
 
     /**
-     * REGEX-TEST: §7§7Obtained by finding the §aStray Rabbit
+     * REGEX-TEST: §7§7Obtained by finding a §6Golden Stray
      */
     private val strayRabbit by RepoPattern.pattern(
         "rabbit.requirement.stray",
-        "§7§7Obtained by finding the §aStray Rabbit",
+        "(?:§.)+Obtained by finding a §6Golden Stray",
     )
 
     /**


### PR DESCRIPTION
## What
Seemingly a while back, Hypixel changed the "stray rabbit" requirement text, which broke the color highlighting for El Dorado and Fish the Rabbit in Hoppity's Collection. See images.

Also to note, Fish the Rabbit states it comes from a golden stray right now, which just is not true, so I don't expect this pattern to work forever ...

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/f476988f-c80b-47e0-aca6-fcbaa8d2ad23)

![image](https://github.com/user-attachments/assets/a64794c8-50d5-47b1-9df2-1e9fe0f67ce4)

</details>

## Changelog Fixes
+ Fixed El Dorado and Fish the Rabbit not being correctly highlighted in the Hoppity Collection Stats. - Daveed
