### PR TITLE
Backend: Remove Deprecated Color.withAlpha

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.EntityUtils.hasNameTagWith
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -40,7 +40,7 @@ object MobHighlight {
         if (config.corruptedMobHighlight && event.health == baseMaxHealth * 3) {
             RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                 entity,
-                LorenzColor.DARK_PURPLE.toColor().withAlpha(127)
+                LorenzColor.DARK_PURPLE.toColor().addAlpha(127),
             ) { config.corruptedMobHighlight }
         }
     }
@@ -54,14 +54,14 @@ object MobHighlight {
         if (config.arachneKeeperHighlight && (maxHealth == 3_000 || maxHealth == 12_000) && entity is EntityCaveSpider) {
             RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                 entity,
-                LorenzColor.DARK_BLUE.toColor().withAlpha(127)
+                LorenzColor.DARK_BLUE.toColor().addAlpha(127),
             ) { config.arachneKeeperHighlight }
         }
 
         if (config.corleoneHighlighter && maxHealth == 1_000_000 && entity is EntityOtherPlayerMP && entity.name == "Team Treasurite") {
             RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                 entity,
-                LorenzColor.DARK_PURPLE.toColor().withAlpha(127)
+                LorenzColor.DARK_PURPLE.toColor().addAlpha(127),
             ) { config.corleoneHighlighter }
         }
 
@@ -73,17 +73,17 @@ object MobHighlight {
                 if (isZealot || isBruiser) {
                     RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                         entity,
-                        LorenzColor.DARK_AQUA.toColor().withAlpha(127)
+                        LorenzColor.DARK_AQUA.toColor().addAlpha(127),
                     ) { config.zealotBruiserHighlighter }
                 }
             }
 
             if (config.chestZealotHighlighter) {
-                val isHoldingChest = (entity as? EntityEnderman)?.getBlockInHand()?.block == Blocks.ender_chest
+                val isHoldingChest = entity.getBlockInHand()?.block == Blocks.ender_chest
                 if ((isZealot || isBruiser) && isHoldingChest) {
                     RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                         entity,
-                        LorenzColor.GREEN.toColor().withAlpha(127)
+                        LorenzColor.GREEN.toColor().addAlpha(127),
                     ) { config.chestZealotHighlighter }
                 }
             }
@@ -92,7 +92,7 @@ object MobHighlight {
             if (config.specialZealotHighlighter && maxHealth.ignoreDerpy() == 2_000) {
                 RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                     entity,
-                    LorenzColor.DARK_RED.toColor().withAlpha(50)
+                    LorenzColor.DARK_RED.toColor().addAlpha(50),
                 ) { config.specialZealotHighlighter }
             }
         }
@@ -147,14 +147,14 @@ object MobHighlight {
     private fun markArachneMinis(entity: EntityLivingBase) {
         RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
             entity,
-            LorenzColor.GOLD.toColor().withAlpha(50)
+            LorenzColor.GOLD.toColor().addAlpha(50),
         ) { config.arachneBossHighlighter }
     }
 
     private fun markArachne(entity: EntityLivingBase) {
         RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
             entity,
-            LorenzColor.RED.toColor().withAlpha(50)
+            LorenzColor.RED.toColor().addAlpha(50),
         ) { config.arachneBossHighlighter }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -181,7 +181,7 @@ object DungeonHideItems {
             movingSkeletonSkulls[entity] = System.currentTimeMillis()
             RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                 entity,
-                LorenzColor.GOLD.toColor().withAlpha(60)
+                LorenzColor.GOLD.toColor().addAlpha(60),
             ) { shouldColorMovingSkull(entity) }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.features.event.winter.UniqueGiftCounter
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -38,11 +38,11 @@ object UniqueGiftingOpportunitiesFeatures {
     private val patternGroup = RepoPattern.group("event.winter.uniquegifts")
     private val giftedPattern by patternGroup.pattern(
         "gifted",
-        "§6\\+1 Unique Gift given! To ([^§]+)§r§6!"
+        "§6\\+1 Unique Gift given! To ([^§]+)§r§6!",
     )
     private val giftNamePattern by patternGroup.pattern(
         "giftname",
-        "(?:WHITE|RED|GREEN)_GIFT\$"
+        "(?:WHITE|RED|GREEN)_GIFT\$",
     )
 
     private var holdingGift = false
@@ -90,7 +90,7 @@ object UniqueGiftingOpportunitiesFeatures {
 
             RenderLivingEntityHelper.setEntityColor(
                 entity,
-                LorenzColor.DARK_GREEN.toColor().withAlpha(127)
+                LorenzColor.DARK_GREEN.toColor().addAlpha(127),
             ) { isEnabled() && !hasGiftedPlayer(entity) }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.passive.EntityVillager
@@ -24,7 +24,7 @@ object HighlightJerries {
         LorenzColor.BLUE,
         LorenzColor.DARK_PURPLE,
         LorenzColor.GOLD,
-        LorenzColor.LIGHT_PURPLE
+        LorenzColor.LIGHT_PURPLE,
     )
 
     @SubscribeEvent
@@ -36,7 +36,7 @@ object HighlightJerries {
         val maxHealth = event.maxHealth
 
         if (entity is EntityVillager && maxHealth in 3..6) {
-            val color = listOfLorenzColors[maxHealth].toColor().withAlpha(20)
+            val color = listOfLorenzColors[maxHealth].toColor().addAlpha(20)
             RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, color) { config.highlightJerries }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.features.fishing.FishingAPI.isLavaRod
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils
@@ -130,7 +130,7 @@ object GoldenFishTimer {
             val entity = confirmedGoldenFishEntity ?: return
             if (config.highlight) RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                 entity,
-                LorenzColor.GREEN.toColor().withAlpha(100)
+                LorenzColor.GREEN.toColor().addAlpha(100),
             ) { true }
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -594,7 +594,8 @@ object GardenVisitorFeatures {
                         entity,
                         color,
                     ) { config.highlightStatus == HighlightMode.COLOR || config.highlightStatus == HighlightMode.BOTH }
-                } else if (color == null || !GardenAPI.inGarden()) {
+                }
+                if (color == null || !GardenAPI.inGarden()) {
                     // Haven't gotten either of the known effected visitors (Vex and Leo) so can't test for sure
                     RenderLivingEntityHelper.removeEntityColor(entity)
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -589,14 +589,15 @@ object GardenVisitorFeatures {
                 entity is EntityLivingBase
             ) {
                 val color = visitor.status.color
-                if (color != -1) {
+                if (color != null) {
                     RenderLivingEntityHelper.setEntityColor(
                         entity,
                         color,
                     ) { config.highlightStatus == HighlightMode.COLOR || config.highlightStatus == HighlightMode.BOTH }
+                } else if (color == null || !GardenAPI.inGarden()) {
+                    // Haven't gotten either of the known effected visitors (Vex and Leo) so can't test for sure
+                    RenderLivingEntityHelper.removeEntityColor(entity)
                 }
-                // Haven't gotten either of the known effected visitors (Vex and Leo) so can't test for sure
-                if (color == -1 || !GardenAPI.inGarden()) RenderLivingEntityHelper.removeEntityColor(entity)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/HighlightVisitorsOutsideOfGarden.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/HighlightVisitorsOutsideOfGarden.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.getSkinTexture
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -38,7 +38,7 @@ object HighlightVisitorsOutsideOfGarden {
     @SubscribeEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         visitorJson = event.getConstant<GardenJson>(
-            "Garden", GardenJson::class.java
+            "Garden", GardenJson::class.java,
         ).visitors.values.groupBy {
             it.mode
         }
@@ -70,7 +70,7 @@ object HighlightVisitorsOutsideOfGarden {
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!config.highlightVisitors) return
-        val color = LorenzColor.DARK_RED.toColor().withAlpha(50)
+        val color = LorenzColor.DARK_RED.toColor().addAlpha(50)
         EntityUtils.getEntities<EntityLivingBase>()
             .filter { it !is EntityArmorStand && isVisitor(it) }
             .forEach {
@@ -102,7 +102,7 @@ object HighlightVisitorsOutsideOfGarden {
             if (packet.action == C02PacketUseEntity.Action.INTERACT) {
                 ChatUtils.chatAndOpenConfig(
                     "Blocked you from interacting with a visitor. Sneak to bypass or click here to change settings.",
-                    GardenAPI.config.visitors::blockInteracting
+                    GardenAPI.config.visitors::blockInteracting,
                 )
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzLogger
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.isInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.item.ItemStack
+import java.awt.Color
 
 @SkyHanniModule
 object VisitorAPI {
@@ -35,11 +36,11 @@ object VisitorAPI {
     val patternGroup = RepoPattern.group("garden.visitor.api")
     val visitorCountPattern by patternGroup.pattern(
         "visitor.count",
-        "§b§lVisitors: §r§f\\((?<info>.*)\\)"
+        "§b§lVisitors: §r§f\\((?<info>.*)\\)",
     )
     private val visitorNamePattern by patternGroup.pattern(
         "visitor.name",
-        " (?:§.)+(?<name>§.[^§]+).*"
+        " (?:§.)+(?<name>§.[^§]+).*",
     )
 
     fun getVisitorsMap() = visitors
@@ -156,12 +157,12 @@ object VisitorAPI {
         }
     }
 
-    enum class VisitorStatus(val displayName: String, val color: Int) {
-        NEW("§eNew", LorenzColor.YELLOW.toColor().withAlpha(100)),
-        WAITING("Waiting", -1),
-        READY("§aItems Ready", LorenzColor.GREEN.toColor().withAlpha(80)),
-        ACCEPTED("§7Accepted", LorenzColor.DARK_GRAY.toColor().withAlpha(80)),
-        REFUSED("§cRefused", LorenzColor.RED.toColor().withAlpha(60)),
+    enum class VisitorStatus(val displayName: String, val color: Color?) {
+        NEW("§eNew", LorenzColor.YELLOW.toColor().addAlpha(100)),
+        WAITING("Waiting", null),
+        READY("§aItems Ready", LorenzColor.GREEN.toColor().addAlpha(80)),
+        ACCEPTED("§7Accepted", LorenzColor.DARK_GRAY.toColor().addAlpha(80)),
+        REFUSED("§cRefused", LorenzColor.RED.toColor().addAlpha(60)),
     }
 
     fun visitorsInTabList(tabList: List<String>): List<String> {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/GuardianReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/GuardianReminder.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -72,7 +71,7 @@ object GuardianReminder {
         GlStateManager.translate(0f, -150f, 500f)
         Renderable.drawInsideRoundedRect(
             Renderable.string("§cWrong Pet equipped!", 1.5),
-            Color(Color.DARK_GRAY.withAlpha(0), true),
+            Color.DARK_GRAY,
             horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
             verticalAlign = RenderUtils.VerticalAlignment.CENTER,
         ).renderXYAligned(0, 125, width, height)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/UltraRareBookAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/UltraRareBookAlert.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.features.inventory.experimentationtable.Experimenta
 import at.hannibal2.skyhanni.features.inventory.experimentationtable.ExperimentationTableAPI.ultraRarePattern
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -54,7 +53,7 @@ object UltraRareBookAlert {
 
         Renderable.drawInsideRoundedRect(
             Renderable.string("§d§kXX§5 ULTRA-RARE BOOK! §d§kXX", 1.5),
-            Color(Color.DARK_GRAY.withAlpha(0), true),
+            Color.DARK_GRAY,
             horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
             verticalAlign = RenderUtils.VerticalAlignment.CENTER,
         ).renderXYAligned(0, 125, gui.width, gui.height)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -19,7 +19,6 @@ import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.darker
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColorInt
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.transformIf
 import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
@@ -276,7 +275,7 @@ object CustomWardrobe {
 
         val playerColor = if (!slot.isInCurrentPage()) {
             scale *= 0.9
-            Color.GRAY.withAlpha(100)
+            Color.GRAY.addAlpha(100)
         } else null
 
         return Renderable.fakePlayer(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.hasMaxHealth
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -65,7 +65,7 @@ object HighlightMiningCommissionMobs {
             if (type.isMob(entity)) {
                 RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                     entity,
-                    LorenzColor.YELLOW.toColor().withAlpha(127)
+                    LorenzColor.YELLOW.toColor().addAlpha(127),
                 ) { isEnabled() && type in active }
             }
         }
@@ -96,7 +96,7 @@ object HighlightMiningCommissionMobs {
             if (type.isMob(entity)) {
                 RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                     entity,
-                    LorenzColor.YELLOW.toColor().withAlpha(127)
+                    LorenzColor.YELLOW.toColor().addAlpha(127),
                 ) { isEnabled() && type in active }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -71,8 +71,8 @@ object MarkedPlayerManager {
     private fun EntityOtherPlayerMP.setColor() {
         RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
             this,
-            config.entityColor.get().toColor().withAlpha(127),
-            ::isEnabled
+            config.entityColor.get().toColor().addAlpha(127),
+            ::isEnabled,
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
@@ -218,7 +218,7 @@ object TrevorFeatures {
         var found = false
         var active = false
         val previousLocation = TrevorSolver.mobLocation
-        // TODO work wioth trapper widget, widget api, repo patterns, when not found, warn in chat and dont update
+        // TODO work with trapper widget, widget api, repo patterns, when not found, warn in chat and dont update
         for (line in TabListData.getTabList()) {
             val formattedLine = line.removeColor().drop(1)
             if (formattedLine.startsWith("Time Left: ")) {
@@ -345,7 +345,7 @@ object TrevorFeatures {
         ACTIVE(LorenzColor.DARK_RED),
         ;
 
-        val color = baseColor.toColor().withAlpha(75)
+        val color = baseColor.toColor().addAlpha(75)
         val colorCode = baseColor.getChatColor()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BlobbercystsHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BlobbercystsHighlight.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.client.entity.EntityOtherPlayerMP
@@ -26,7 +26,7 @@ object BlobbercystsHighlight {
     fun onTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
         if (!event.isMod(5)) return
-        val color = Color.RED.withAlpha(80)
+        val color = Color.RED.addAlpha(80)
         for (player in EntityUtils.getEntities<EntityOtherPlayerMP>()) {
             if (player.name == BLOBBER_NAME) {
                 RenderLivingEntityHelper.setEntityColorWithNoHurtTime(player, color) { isEnabled() }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
@@ -9,8 +9,8 @@ import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isAtFullHealth
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
@@ -118,7 +118,7 @@ object LivingCaveDefenseBlocks {
                 add(DefenseBlock(entity, location))
                 RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                     entity,
-                    color.withAlpha(50)
+                    color.addAlpha(50),
                 ) { isEnabled() && staticBlocks.any { it.entity == entity } }
             }
         }
@@ -169,7 +169,7 @@ object LivingCaveDefenseBlocks {
         }
     }
 
-    val color get() = config.color.get().toChromaColor()
+    private val color get() = config.color.get().toChromaColor()
 
     fun isEnabled() = RiftAPI.inRift() && config.enabled && RiftAPI.inLivingCave()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
@@ -5,8 +5,8 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
@@ -40,7 +40,7 @@ object VerminHighlighter {
             checkedEntities.add(id)
 
             if (!isVermin(entity)) continue
-            val color = config.color.get().toChromaColor().withAlpha(60)
+            val color = config.color.get().toChromaColor().addAlpha(60)
             RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, color) { isEnabled() }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftLarva.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftLarva.kt
@@ -4,8 +4,8 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.getEntities
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -46,7 +46,7 @@ object RiftLarva {
             if (stand.hasSkullTexture(LARVA_SKULL_TEXTURE)) {
                 RenderLivingEntityHelper.setEntityColor(
                     stand,
-                    config.highlightColor.toChromaColor().withAlpha(1)
+                    config.highlightColor.toChromaColor().addAlpha(1),
                 ) { isEnabled() && hasHookInHand }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftOdonata.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftOdonata.kt
@@ -4,8 +4,8 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.getEntities
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -45,7 +45,7 @@ object RiftOdonata {
             if (stand.hasSkullTexture(ODONATA_SKULL_TEXTURE)) {
                 RenderLivingEntityHelper.setEntityColor(
                     stand,
-                    config.highlightColor.toChromaColor().withAlpha(1)
+                    config.highlightColor.toChromaColor().addAlpha(1),
                 ) { isEnabled() && hasBottleInHand }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
@@ -16,8 +16,8 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
@@ -149,7 +149,7 @@ object PunchcardHighlight {
             255 -> 1
             else -> 255 - color.alpha
         }
-        RenderLivingEntityHelper.setEntityColor(entity, color.withAlpha(alpha)) { IslandType.THE_RIFT.isInIsland() }
+        RenderLivingEntityHelper.setEntityColor(entity, color.addAlpha(alpha)) { IslandType.THE_RIFT.isInIsland() }
     }
 
     private fun removePlayerColor(entity: EntityLivingBase) {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -15,8 +15,8 @@ import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
@@ -46,6 +46,7 @@ import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.util.EnumParticleTypes
 import net.minecraftforge.event.entity.living.LivingDeathEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.awt.Color
 import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
@@ -88,12 +89,12 @@ object VampireSlayerFeatures {
                 val distance = start.distance(vec)
                 val isIchor = stand.hasSkullTexture(BLOOD_ICHOR_TEXTURE)
                 if (isIchor || stand.hasSkullTexture(KILLER_SPRING_TEXTURE)) {
-                    val color = (if (isIchor) configBloodIchor.color else configKillerSpring.color)
-                        .toChromaColor().withAlpha(config.withAlpha)
+                    val color =
+                        (if (isIchor) configBloodIchor.color else configKillerSpring.color).toChromaColor().addAlpha(config.withAlpha)
                     if (distance <= 15) {
                         RenderLivingEntityHelper.setEntityColor(
                             stand,
-                            color
+                            color,
                         ) { isEnabled() }
                         if (isIchor)
                             entityList.add(stand)
@@ -140,7 +141,7 @@ object VampireSlayerFeatures {
                         LorenzUtils.sendTitle(
                             "§6§lTWINCLAWS",
                             (1750 - config.twinclawsDelay).milliseconds,
-                            2.6
+                            2.6,
                         )
                         nextClawSend = System.currentTimeMillis() + 5_000
                     }
@@ -176,7 +177,7 @@ object VampireSlayerFeatures {
                 otherBoss -> configOtherBoss.highlightColor.color()
                 coopBoss -> configCoopBoss.highlightColor.color()
 
-                else -> 0
+                else -> Color.BLACK
             }
 
             val shouldSendSteakTitle =
@@ -199,8 +200,8 @@ object VampireSlayerFeatures {
         return entityList.contains(this) || taggedEntityList.contains(entityId)
     }
 
-    private fun String.color(): Int {
-        return toChromaColor().withAlpha(config.withAlpha)
+    private fun String.color(): Color {
+        return toChromaColor().addAlpha(config.withAlpha)
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
@@ -284,12 +285,11 @@ object VampireSlayerFeatures {
             val isIchor = stand.hasSkullTexture(BLOOD_ICHOR_TEXTURE)
             val isSpring = stand.hasSkullTexture(KILLER_SPRING_TEXTURE)
             if (!(isIchor && config.bloodIchor.highlight) && !(isSpring && config.killerSpring.highlight)) continue
-            val color = (if (isIchor) configBloodIchor.color else configKillerSpring.color)
-                .toChromaColor().withAlpha(config.withAlpha)
+            val color = (if (isIchor) configBloodIchor.color else configKillerSpring.color).toChromaColor().addAlpha(config.withAlpha)
             if (distance <= 15) {
                 RenderLivingEntityHelper.setEntityColor(
                     stand,
-                    color
+                    color,
                 ) { isEnabled() }
 
                 val linesColorStart =
@@ -304,7 +304,7 @@ object VampireSlayerFeatures {
                     stand.position.toLorenzVec().add(0.5, 2.5, 0.5),
                     text,
                     1.5,
-                    ignoreBlocks = false
+                    ignoreBlocks = false,
                 )
                 for ((player, stand2) in standList) {
                     if ((configBloodIchor.showLines && isIchor) || (configKillerSpring.showLines && isSpring))
@@ -322,7 +322,7 @@ object VampireSlayerFeatures {
                 event.drawWaypointFilled(
                     event.exactLocation(stand).add(0, y = -2, 0),
                     configBloodIchor.color.toChromaColor(),
-                    beacon = true
+                    beacon = true,
                 )
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.EntityLiving
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -30,7 +30,7 @@ object HellionShieldHelper {
             hellionShieldMobs[this] = shield
             RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
                 this,
-                shield.color.toColor().withAlpha(80)
+                shield.color.toColor().addAlpha(80),
             ) { LorenzUtils.inSkyBlock && SkyHanniMod.feature.slayer.blazes.hellion.coloredMobs }
         } else {
             hellionShieldMobs.remove(this)

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -11,8 +11,8 @@ import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
@@ -70,7 +70,7 @@ object EndermanSlayerFeatures {
                     flyingBeacons.add(entity)
                     RenderLivingEntityHelper.setEntityColor(
                         entity,
-                        beaconConfig.beaconColor.toChromaColor().withAlpha(1),
+                        beaconConfig.beaconColor.toChromaColor().addAlpha(1),
                     ) {
                         beaconConfig.highlightBeacon
                     }
@@ -89,7 +89,7 @@ object EndermanSlayerFeatures {
                 nukekubiSkulls.add(entity)
                 RenderLivingEntityHelper.setEntityColor(
                     entity,
-                    LorenzColor.GOLD.toColor().withAlpha(1),
+                    LorenzColor.GOLD.toColor().addAlpha(1),
                 ) { config.highlightNukekebi }
                 logger.log("Added Nukekubi skulls at ${entity.getLorenzVec()}")
             }
@@ -139,7 +139,7 @@ object EndermanSlayerFeatures {
                     skullLocation.up(),
                     LorenzColor.GOLD.toColor(),
                     3,
-                    true
+                    true,
                 )
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import net.minecraft.entity.EntityLivingBase
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.awt.Color
 
 @SkyHanniModule
 object RenderLivingEntityHelper {
@@ -32,6 +33,10 @@ object RenderLivingEntityHelper {
         entityColorCondition[entity] = condition
     }
 
+    fun <T : EntityLivingBase> setEntityColor(entity: T, color: Color, condition: () -> Boolean) {
+        setEntityColor(entity, color.rgb, condition)
+    }
+
     fun <T : EntityLivingBase> setNoHurtTime(entity: T, condition: () -> Boolean) {
         entityNoHurtTimeCondition[entity] = condition
     }
@@ -39,6 +44,10 @@ object RenderLivingEntityHelper {
     fun <T : EntityLivingBase> setEntityColorWithNoHurtTime(entity: T, color: Int, condition: () -> Boolean) {
         setEntityColor(entity, color, condition)
         setNoHurtTime(entity, condition)
+    }
+
+    fun <T : EntityLivingBase> setEntityColorWithNoHurtTime(entity: T, color: Color, condition: () -> Boolean) {
+        setEntityColorWithNoHurtTime(entity, color.rgb, condition)
     }
 
     fun <T : EntityLivingBase> removeNoHurtTime(entity: T) {

--- a/src/main/java/at/hannibal2/skyhanni/test/WorldEdit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/WorldEdit.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ClipboardUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.withAlpha
+import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.expandBlock
@@ -79,22 +79,22 @@ object WorldEdit {
             RenderUtils.drawWireframeBoundingBoxNea(
                 funAABB(l, l).expandBlock(),
                 Color.RED,
-                event.partialTicks
+                event.partialTicks,
             )
         }
         rightPos?.let { r ->
             RenderUtils.drawWireframeBoundingBoxNea(
                 funAABB(r, r).expandBlock(),
                 Color.BLUE,
-                event.partialTicks
+                event.partialTicks,
             )
         }
         aabb?.let {
             RenderUtils.drawFilledBoundingBoxNea(
                 it.expandBlock(),
-                Color(Color.CYAN.withAlpha(60), true),
+                Color.CYAN.addAlpha(60),
                 partialTicks = event.partialTicks,
-                renderRelativeToCamera = false
+                renderRelativeToCamera = false,
             )
         }
     }
@@ -108,7 +108,7 @@ object WorldEdit {
             null, "help" -> {
                 ChatUtils.chat(
                     "Use a wood axe and left/right click to select a region in the world. " +
-                        "Then use /shworldedit copy or /shworldedit reset."
+                        "Then use /shworldedit copy or /shworldedit reset.",
                 )
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ColorUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ColorUtils.kt
@@ -36,9 +36,6 @@ object ColorUtils {
 
     val TRANSPARENT_COLOR = Color(0, 0, 0, 0)
 
-    @Deprecated("Don't use int colors", ReplaceWith("this.addAlpha()"))
-    fun Color.withAlpha(alpha: Int): Int = (alpha.coerceIn(0, 255) shl 24) or (rgb and 0x00ffffff)
-
     fun Color.addAlpha(alpha: Int): Color = Color(red, green, blue, alpha)
 
     fun getColorFromHex(hex: String): Int = runCatching { Color(Integer.decode(hex)) }.getOrNull()?.rgb ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -1373,7 +1373,7 @@ interface Renderable {
             height: Int = 100,
             entityScale: Int = 30,
             padding: Int = 5,
-            color: Int? = null,
+            color: Color? = null,
             colorCondition: () -> Boolean = { true },
         ) = object : Renderable {
             override val width = width + 2 * padding


### PR DESCRIPTION
## What
Removes ~32 deprecation messages if I counted correctly
Also can this method just please stay removed ty


## Changelog Technical Details
+ Removed deprecated `Color.withAlpha` method in favor of `Color.addAlpha`. - j10a1n15
