### PR TITLE
Backend: Detekt Concurrency

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -14,12 +14,14 @@ jobs:
     detekt:
         name: Run detekt
         runs-on: ubuntu-latest
+        concurrency:
+            group: detekt-${{ github.event.pull_request.number }}
+            cancel-in-progress: true
         permissions:
             contents: read
             pull-requests: write
         outputs:
             sarif_exists: ${{ steps.check_sarif.outputs.exists }}
-            is_latest: ${{ env.is_latest }}
         steps:
             -   name: Checkout PR code
                 uses: actions/checkout@v4
@@ -40,31 +42,14 @@ jobs:
                         echo "exists=false" >> $GITHUB_OUTPUT
                     fi
 
-            -   name: Check if this is the latest workflow run
-                id: check_latest
-                run: |
-                    PR_LATEST_SHA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                        "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
-                        | jq -r '.head.sha')
-                    
-                    echo "Latest commit SHA from PR: $PR_LATEST_SHA"
-                    echo "Current workflow SHA: ${{ github.event.pull_request.head.sha }}"
-                    
-                    # Compare the SHAs and set a result variable
-                    if [[ "${PR_LATEST_SHA}" == "${{ github.event.pull_request.head.sha }}" ]]; then
-                        echo "is_latest=true" >> $GITHUB_ENV
-                    else
-                        echo "is_latest=false" >> $GITHUB_ENV
-                    fi
-
             -   name: Add label if detekt fails
-                if: ${{ failure() && env.is_latest == 'true' && steps.check_sarif.outputs.exists == 'true' }}
+                if: ${{ failure() && steps.check_sarif.outputs.exists == 'true' }}
                 uses: actions-ecosystem/action-add-labels@v1
                 with:
                     github_token: ${{ secrets.GITHUB_TOKEN }}
                     labels: 'Detekt'
             -   name: Remove label if detekt passes
-                if: ${{ success() && env.is_latest == 'true' }}
+                if: success()
                 uses: actions-ecosystem/action-remove-labels@v1
                 with:
                     github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,8 +70,11 @@ jobs:
     detekt_comment:
         name: Comment detekt failures on PR
         runs-on: ubuntu-latest
+        concurrency:
+            group: detekt-comment-${{ github.event.pull_request.number }}
+            cancel-in-progress: true
         needs: detekt
-        if: ${{ needs.detekt.outputs.sarif_exists == 'true' && failure() && needs.detekt.outputs.is_latest == 'true' }}
+        if: ${{ needs.detekt.outputs.sarif_exists == 'true' && failure() }}
         permissions:
             pull-requests: write
         steps:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -44,26 +44,8 @@ jobs:
                     github_token: ${{ secrets.GITHUB_TOKEN }}
                     labels: 'Wrong Title/Changelog'
 
-            -   name: Check if this is the latest workflow run
-                if: failure()
-                id: check_latest
-                run: |
-                    PR_LATEST_SHA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                        "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
-                        | jq -r '.head.sha')
-
-                    echo "Latest commit SHA from PR: $PR_LATEST_SHA"
-                    echo "Current workflow SHA: ${{ github.event.pull_request.head.sha }}"
-
-                    # Compare the SHAs and set a result variable
-                    if [[ "${PR_LATEST_SHA}" == "${{ github.event.pull_request.head.sha }}" ]]; then
-                        echo "is_latest=true" >> $GITHUB_ENV
-                    else
-                        echo "is_latest=false" >> $GITHUB_ENV
-                    fi
-
             -   name: Add comment to PR if changelog verification fails
-                if: ${{ failure() && env.is_latest == 'true' }}
+                if: failure()
                 uses: actions/github-script@v6
                 with:
                     github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,7 +8,9 @@ jobs:
     verify-changelog:
         if: github.event.pull_request.state == 'open' && '511310721' == github.repository_id && github.event.pull_request.draft == false
         runs-on: ubuntu-latest
-
+        concurrency:
+            group: verify-changelog-${{ github.event.pull_request.number }}
+            cancel-in-progress: true
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4


### PR DESCRIPTION
## What
Per recommendation from nea (ty), replaces the `is_latest` checks with `concurrency:` in the detekt gh action workflows.
Per Cal's request, also added this for the pr-check wf

exclude_from_changelog

