### PR TITLE
Backend: Remove deprecated Regex Methods

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/CollectionAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/CollectionAPI.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -54,7 +54,7 @@ object CollectionAPI {
         val inventoryName = event.inventoryName
         if (inventoryName.endsWith(" Collection")) {
             val stack = event.inventoryItems[4] ?: return
-            stack.getLore().matchFirst(singleCounterPattern) {
+            singleCounterPattern.firstMatcher(stack.getLore()) {
                 val counter = group("amount").formatLong()
                 val name = inventoryName.split(" ").dropLast(1).joinToString(" ")
                 val internalName = incorrectCollectionNames[name] ?: NEUInternalName.fromItemName(name)
@@ -78,7 +78,7 @@ object CollectionAPI {
                 }
 
                 val internalName = incorrectCollectionNames[name] ?: NEUInternalName.fromItemName(name)
-                lore.matchFirst(counterPattern) {
+                counterPattern.firstMatcher(lore) {
                     val counter = group("amount").formatLong()
                     collectionValue[internalName] = counter
                 }

--- a/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -223,7 +223,7 @@ object BitsAPI {
             }
 
             val lore = cookieStack.getLore()
-            lore.matchFirst(bitsAvailableMenuPattern) {
+            bitsAvailableMenuPattern.firstMatcher<Unit>(lore) {
                 val amount = group("toClaim").formatInt()
                 if (bitsAvailable != amount) {
                     bitsAvailable = amount
@@ -235,11 +235,11 @@ object BitsAPI {
                     }
                 }
             }
-            lore.matchFirst(cookieDurationPattern) {
+            cookieDurationPattern.firstMatcher<Unit>(lore) {
                 val duration = TimeUtils.getDuration(group("time"))
                 cookieBuffTime = SimpleTimeMark.now() + duration
             }
-            lore.matchFirst(noCookieActiveSBMenuPattern) {
+            noCookieActiveSBMenuPattern.firstMatcher<Unit>(lore) {
                 val cookieTime = cookieBuffTime
                 if (cookieTime == null || cookieTime.isInFuture()) cookieBuffTime = SimpleTimeMark.farPast()
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
@@ -223,7 +223,7 @@ object BitsAPI {
             }
 
             val lore = cookieStack.getLore()
-            bitsAvailableMenuPattern.firstMatcher<Unit>(lore) {
+            bitsAvailableMenuPattern.firstMatcher(lore) {
                 val amount = group("toClaim").formatInt()
                 if (bitsAvailable != amount) {
                     bitsAvailable = amount
@@ -235,11 +235,11 @@ object BitsAPI {
                     }
                 }
             }
-            cookieDurationPattern.firstMatcher<Unit>(lore) {
+            cookieDurationPattern.firstMatcher(lore) {
                 val duration = TimeUtils.getDuration(group("time"))
                 cookieBuffTime = SimpleTimeMark.now() + duration
             }
-            noCookieActiveSBMenuPattern.firstMatcher<Unit>(lore) {
+            noCookieActiveSBMenuPattern.firstMatcher(lore) {
                 val cookieTime = cookieBuffTime
                 if (cookieTime == null || cookieTime.isInFuture()) cookieBuffTime = SimpleTimeMark.farPast()
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/GardenCropMilestones.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GardenCropMilestones.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils.chat
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -33,7 +33,7 @@ object GardenCropMilestones {
     private val config get() = GardenAPI.config.cropMilestones
 
     fun getCropTypeByLore(itemStack: ItemStack): CropType? {
-        itemStack.getLore().matchFirst(cropPattern) {
+        cropPattern.firstMatcher(itemStack.getLore()) {
             val name = group("name")
             return CropType.getByNameOrNull(name)
         }
@@ -46,7 +46,7 @@ object GardenCropMilestones {
 
         for ((_, stack) in event.inventoryItems) {
             val crop = getCropTypeByLore(stack) ?: continue
-            stack.getLore().matchFirst(totalPattern) {
+            totalPattern.firstMatcher(stack.getLore()) {
                 val amount = group("name").formatLong()
                 crop.setCounter(amount)
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/GardenCropUpgrades.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GardenCropUpgrades.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -47,7 +47,7 @@ object GardenCropUpgrades {
 
         for (item in event.inventoryItems.values) {
             val crop = CropType.getByNameOrNull(item.name.removeColor()) ?: continue
-            item.getLore().matchFirst(tierPattern) {
+            tierPattern.firstMatcher(item.getLore()) {
                 val level = group("level").formatInt()
                 crop.setUpgradeLevel(level)
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -24,7 +24,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -51,6 +51,7 @@ object HypixelData {
         "servername.scoreboard",
         "§e(?<prefix>.+\\.)?hypixel\\.net",
     )
+
     @Suppress("UnusedPrivateProperty")
     private val islandNamePattern by patternGroup.pattern(
         "islandname",
@@ -169,7 +170,7 @@ object HypixelData {
             return
         }
 
-        ScoreboardData.sidebarLinesFormatted.matchFirst(serverIdScoreboardPattern) {
+        serverIdScoreboardPattern.firstMatcher(ScoreboardData.sidebarLinesFormatted) {
             val serverType = if (group("servertype") == "M") "mega" else "mini"
             serverId = "$serverType${group("serverid")}"
             lastSuccessfulServerIdFetchTime = SimpleTimeMark.now()
@@ -243,7 +244,7 @@ object HypixelData {
     }
 
     fun getMaxPlayersForCurrentServer(): Int {
-        ScoreboardData.sidebarLinesFormatted.matchFirst(scoreboardVisitingAmountPattern) {
+        scoreboardVisitingAmountPattern.firstMatcher(ScoreboardData.sidebarLinesFormatted) {
             return group("maxamount").toInt()
         }
 
@@ -415,7 +416,7 @@ object HypixelData {
     private fun checkProfileName() {
         if (profileName.isNotEmpty()) return
 
-        TabListData.getTabList().matchFirst(UtilsPatterns.tabListProfilePattern) {
+        UtilsPatterns.tabListProfilePattern.firstMatcher(TabListData.getTabList()) {
             profileName = group("profile").lowercase()
             ProfileJoinEvent(profileName).postAndCatch()
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellAPI.kt
@@ -14,8 +14,8 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -247,7 +247,7 @@ object MaxwellAPI {
 
     private fun loadThaumaturgyMagicalPower(inventoryItems: Map<Int, ItemStack>) {
         val item = inventoryItems[48] ?: return
-        item.getLore().matchFirst(thaumaturgyMagicalPowerPattern) {
+        thaumaturgyMagicalPowerPattern.firstMatcher(item.getLore()) {
             magicalPower = group("mp").formatInt()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
@@ -24,8 +24,8 @@ import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getPrice
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchAll
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -49,11 +49,13 @@ object SackAPI {
         "sack",
         "^(.* Sack|Enchanted .* Sack)\$",
     )
+
     @Suppress("MaxLineLength")
     private val numPattern by patternGroup.pattern(
         "number",
         "(?:(?:§[0-9a-f](?<level>I{1,3})§7:)?|(?:§7Stored:)?) (?<color>§[0-9a-f])(?<stored>[0-9.,kKmMbB]+)§7/(?<total>\\d+(?:[0-9.,]+)?[kKmMbB]?)",
     )
+
     @Suppress("MaxLineLength")
     private val gemstonePattern by patternGroup.pattern(
         "gemstone",
@@ -132,7 +134,7 @@ object SackAPI {
 
             if (isGemstoneSack) {
                 val gem = SackGemstone()
-                lore.matchAll(gemstonePattern) {
+                gemstonePattern.matchAll<Unit>(lore) {
                     val rarity = group("gemrarity")
                     val stored = group("stored").formatInt()
                     gem.internalName = gemstoneMap[name.removeColor()] ?: NEUInternalName.NONE
@@ -193,7 +195,7 @@ object SackAPI {
                 }
             } else {
                 // normal sack
-                lore.matchFirst(numPattern) {
+                numPattern.firstMatcher(lore) {
                     val item = SackOtherItem()
                     val stored = group("stored").formatInt()
                     val internalName = stack.getInternalName()

--- a/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
@@ -134,7 +134,7 @@ object SackAPI {
 
             if (isGemstoneSack) {
                 val gem = SackGemstone()
-                gemstonePattern.matchAll<Unit>(lore) {
+                gemstonePattern.matchAll(lore) {
                     val rarity = group("gemrarity")
                     val stored = group("stored").formatInt()
                     gem.internalName = gemstoneMap[name.removeColor()] ?: NEUInternalName.NONE

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/UniqueGiftCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/UniqueGiftCounter.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -24,7 +24,7 @@ object UniqueGiftCounter {
 
     private val giftedAmountPattern by RepoPattern.pattern(
         "event.winter.uniqugifts.counter.amount",
-        "§7Unique Players Gifted: §a(?<amount>.*)"
+        "§7Unique Players Gifted: §a(?<amount>.*)",
     )
 
     private var display = ""
@@ -36,7 +36,7 @@ object UniqueGiftCounter {
 
         val storage = storage ?: return
 
-        item.getLore().matchFirst(giftedAmountPattern) {
+        giftedAmountPattern.firstMatcher(item.getLore()) {
             val amount = group("amount").formatInt()
             storage.amountGifted = amount
             update()
@@ -70,7 +70,7 @@ object UniqueGiftCounter {
 
         config.position.renderString(
             display,
-            posLabel = "Unique Gift Counter"
+            posLabel = "Unique Gift Counter",
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -30,7 +30,7 @@ import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.NEUItems.getPrice
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
@@ -128,9 +128,9 @@ object CityProjectFeatures {
                 val lore = item.getLore()
                 val completed = lore.lastOrNull()?.let { completedPattern.matches(it) } ?: false
                 if (completed) continue
-                lore.matchFirst(contributeAgainPattern) {
+                contributeAgainPattern.firstMatcher(lore) {
                     val rawTime = group("time")
-                    if (!rawTime.contains("Soon!")) return@matchFirst
+                    if (!rawTime.contains("Soon!")) return
                     val duration = TimeUtils.getDuration(rawTime)
                     val endTime = now + duration
                     if (endTime < nextTime) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
@@ -18,7 +18,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -56,6 +56,7 @@ object UpgradeReminder {
         "claimed",
         "§eYou claimed the §r§a(?<upgrade>.+) §r§eupgrade!",
     )
+
     @Suppress("UnusedPrivateProperty")
     private val upgradePattern by patternGroup.pattern(
         "upgrade",
@@ -215,7 +216,7 @@ object UpgradeReminder {
                 val name = item.displayName
                 val lore = item.getLore()
                 val upgrade = CommunityShopUpgrade(name)
-                upgrade.duration = lore.matchFirst(upgradeDurationPattern) {
+                upgrade.duration = upgradeDurationPattern.firstMatcher(lore) {
                     val durationStr = group("duration")
                     if (durationStr == "Instant!") return null
                     TimeUtils.getDuration(durationStr)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropMilestoneFix.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenCropMilestoneFix.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -32,11 +32,11 @@ object GardenCropMilestoneFix {
     @Suppress("MaxLineLength")
     private val tabListPattern by patternGroup.pattern(
         "tablist",
-        " (?<crop>Wheat|Carrot|Potato|Pumpkin|Sugar Cane|Melon|Cactus|Cocoa Beans|Mushroom|Nether Wart) (?<tier>\\d+): §r§a(?<percentage>.*)%"
+        " (?<crop>Wheat|Carrot|Potato|Pumpkin|Sugar Cane|Melon|Cactus|Cocoa Beans|Mushroom|Nether Wart) (?<tier>\\d+): §r§a(?<percentage>.*)%",
     )
     private val levelUpPattern by patternGroup.pattern(
         "levelup",
-        " {2}§r§b§lGARDEN MILESTONE §3(?<crop>.*) §8.*➜§3(?<tier>.*)"
+        " {2}§r§b§lGARDEN MILESTONE §3(?<crop>.*) §8.*➜§3(?<tier>.*)",
     )
 
     /**
@@ -44,7 +44,7 @@ object GardenCropMilestoneFix {
      */
     private val pestRareDropPattern by patternGroup.pattern(
         "pests.raredrop",
-        "§6§lRARE DROP! (?:§.)*(?<item>.+) §6\\(§6\\+.*☘\\)"
+        "§6§lRARE DROP! (?:§.)*(?<item>.+) §6\\(§6\\+.*☘\\)",
     )
 
     private val tabListCropProgress = mutableMapOf<CropType, Long>()
@@ -69,7 +69,7 @@ object GardenCropMilestoneFix {
             val cropType = CropType.getByNameOrNull(rawName) ?: return
 
             cropType.setCounter(
-                cropType.getCounter() + (amount * primitiveStack.amount)
+                cropType.getCounter() + (amount * primitiveStack.amount),
             )
             GardenCropMilestoneDisplay.update()
         }
@@ -81,7 +81,7 @@ object GardenCropMilestoneFix {
             val cropType = CropType.getByNameOrNull(rawName) ?: return
 
             cropType.setCounter(
-                cropType.getCounter() + primitiveStack.amount
+                cropType.getCounter() + primitiveStack.amount,
             )
             GardenCropMilestoneDisplay.update()
         }
@@ -90,7 +90,7 @@ object GardenCropMilestoneFix {
     @SubscribeEvent
     fun onTabListUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.CROP_MILESTONE)) return
-        event.lines.matchFirst(tabListPattern) {
+        tabListPattern.firstMatcher(event.lines) {
             val tier = group("tier").toInt()
             val percentage = group("percentage").toDouble()
             val cropName = group("crop")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterInventoryNumbers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterInventoryNumbers.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -19,11 +20,11 @@ object ComposterInventoryNumbers {
     private val patternGroup = RepoPattern.group("garden.composter.inventory.numbers")
     private val valuePattern by patternGroup.pattern(
         "value",
-        ".* §e(?<having>.*)§6/(?<total>.*)"
+        ".* §e(?<having>.*)§6/(?<total>.*)",
     )
     private val amountPattern by patternGroup.pattern(
         "amount",
-        "§7§7Compost Available: §a(?<amount>.*)"
+        "§7§7Compost Available: §a(?<amount>.*)",
     )
 
     @SubscribeEvent
@@ -39,7 +40,7 @@ object ComposterInventoryNumbers {
 
         // Composts Available
         if (slotNumber == 13) {
-            stack.getLore().matchFirst(amountPattern) {
+            amountPattern.firstMatcher(stack.getLore()) {
                 val total = group("amount").formatInt()
                 event.offsetY = -2
                 event.offsetX = -20

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterInventoryNumbers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterInventoryNumbers.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -51,7 +50,7 @@ object ComposterInventoryNumbers {
 
         // Organic Matter or Fuel
         if (slotNumber == 46 || slotNumber == 52) {
-            stack.getLore().matchFirst(valuePattern) {
+            valuePattern.firstMatcher(stack.getLore()) {
                 val having = group("having").removeColor().formatInt()
                 val havingFormat = having.shortFormat()
                 val total = group("total").removeColor()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestAPI.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isAnyOf
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -31,15 +32,15 @@ object FarmingContestAPI {
     private val patternGroup = RepoPattern.group("garden.farming.contest")
     private val timePattern by patternGroup.pattern(
         "time",
-        "§a(?<month>.*) (?<day>.*)(?:rd|st|nd|th), Year (?<year>.*)"
+        "§a(?<month>.*) (?<day>.*)(?:rd|st|nd|th), Year (?<year>.*)",
     )
     private val cropPattern by patternGroup.pattern(
         "crop",
-        "§8(?<crop>.*) Contest"
+        "§8(?<crop>.*) Contest",
     )
     private val sidebarCropPattern by patternGroup.pattern(
         "sidebarcrop",
-        "\\s*(?:§e○|§6☘) §f(?<crop>.*) §a.*"
+        "\\s*(?:§e○|§6☘) §f(?<crop>.*) §a.*",
     )
 
     private val contests = mutableMapOf<Long, FarmingContest>()
@@ -48,7 +49,7 @@ object FarmingContestAPI {
         get() = internalContest && LorenzUtils.skyBlockIsland.isAnyOf(
             IslandType.GARDEN,
             IslandType.HUB,
-            IslandType.THE_FARMING_ISLANDS
+            IslandType.THE_FARMING_ISLANDS,
         )
     var contestCrop: CropType? = null
     private var startTime = SimpleTimeMark.farPast()
@@ -132,7 +133,7 @@ object FarmingContestAPI {
     private fun createContest(time: Long, item: ItemStack): FarmingContest {
         val lore = item.getLore()
 
-        val crop = lore.matchFirst(cropPattern) {
+        val crop = cropPattern.firstMatcher(lore) {
             CropType.getByName(group("crop"))
         } ?: error("Crop not found in lore!")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestAPI.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isAnyOf
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
@@ -139,7 +138,7 @@ object FarmingContestAPI {
 
         val brackets = buildMap {
             for (bracket in ContestBracket.entries) {
-                val amount = lore.matchFirst(bracket.bracketPattern) {
+                val amount = bracket.bracketPattern.firstMatcher(lore) {
                     group("amount").formatInt()
                 } ?: continue
                 put(bracket, amount)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
@@ -118,7 +118,7 @@ object CaptureFarmingGear {
             currentCrop.farmingItem.setItem(itemStack)
         }
 
-        TabListData.getTabList().matchFirst(strengthPattern) {
+        strengthPattern.firstMatcher(TabListData.getTabList()) {
             GardenAPI.storage?.fortune?.farmingStrength = group("strength").toInt()
         }
     }
@@ -216,7 +216,7 @@ object CaptureFarmingGear {
             if (item.displayName.contains("Extra Farming Fortune")) {
                 level = 0
 
-                item.getLore().matchFirst(anitaMenuPattern) {
+                anitaMenuPattern.firstMatcher(item.getLore()) {
                     level = group("level").toInt() / 4
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenInventoryNumbers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenInventoryNumbers.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -23,7 +23,7 @@ object GardenInventoryNumbers {
 
     private val upgradeTierPattern by RepoPattern.pattern(
         "garden.inventory.numbers.upgradetier",
-        "§7Current Tier: §[ea](?<tier>.*)§7/§a.*"
+        "§7Current Tier: §[ea](?<tier>.*)§7/§a.*",
     )
 
     @SubscribeEvent
@@ -43,7 +43,7 @@ object GardenInventoryNumbers {
         if (InventoryUtils.openInventoryName() == "Crop Upgrades") {
             if (!config.cropUpgrades) return
 
-            event.stack.getLore().matchFirst(upgradeTierPattern) {
+            upgradeTierPattern.firstMatcher(event.stack.getLore()) {
                 event.stackTip = group("tier")
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -57,10 +57,10 @@ object LogBookStats {
             var timesVisited = 0L
             var timesAccepted = 0L
             val lore = item.getLore()
-            lore.matchFirst(visitedPattern) {
+            visitedPattern.firstMatcher(lore) {
                 timesVisited += group("timesVisited").formatLong()
             }
-            lore.matchFirst(acceptedPattern) {
+            acceptedPattern.firstMatcher(lore) {
                 timesAccepted += group("timesAccepted").formatLong()
             }
 
@@ -112,8 +112,8 @@ object LogBookStats {
         }
         for (item in event.inventoryItems.values) {
             if (item.displayName != "§aNext Page") continue
-            item.getLore().matchFirst(pagePattern) {
-                currentPage = group("page").toInt() - 1
+            pagePattern.firstMatcher(item.getLore()) {
+                this@LogBookStats.currentPage = group("page").toInt() - 1
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -30,7 +30,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -71,7 +71,7 @@ object PestAPI {
     private val patternGroup = RepoPattern.group("garden.pestsapi")
     private val pestsInScoreboardPattern by patternGroup.pattern(
         "scoreboard.pests",
-        " §7⏣ §[ac]The Garden §4§lൠ§7 x(?<pests>.*)"
+        " §7⏣ §[ac]The Garden §4§lൠ§7 x(?<pests>.*)",
     )
 
     /**
@@ -80,7 +80,7 @@ object PestAPI {
      */
     private val noPestsInScoreboardPattern by patternGroup.pattern(
         "scoreboard.nopests",
-        " §7⏣ §a(?:The Garden|Plot §7- §b.+)$"
+        " §7⏣ §a(?:The Garden|Plot §7- §b.+)$",
     )
 
     /**
@@ -88,7 +88,7 @@ object PestAPI {
      */
     private val pestsInPlotScoreboardPattern by patternGroup.pattern(
         "scoreboard.plot.pests",
-        "\\s*(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.+) (?:§.)*ൠ(?:§.)* x(?<pests>\\d+)"
+        "\\s*(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.+) (?:§.)*ൠ(?:§.)* x(?<pests>\\d+)",
     )
 
     /**
@@ -96,11 +96,11 @@ object PestAPI {
      */
     private val noPestsInPlotScoreboardPattern by patternGroup.pattern(
         "scoreboard.plot.nopests",
-        "\\s*(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.{1,3})$"
+        "\\s*(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.{1,3})$",
     )
     private val pestInventoryPattern by patternGroup.pattern(
         "inventory",
-        "§4§lൠ §cThis plot has §6(?<amount>\\d) Pests?§c!"
+        "§4§lൠ §cThis plot has §6(?<amount>\\d) Pests?§c!",
     )
 
     /**
@@ -108,7 +108,7 @@ object PestAPI {
      */
     private val infectedPlotsTablistPattern by patternGroup.pattern(
         "tablist.infectedplots",
-        "\\sPlots: (?<plots>.*)"
+        "\\sPlots: (?<plots>.*)",
     )
 
     /**
@@ -117,11 +117,11 @@ object PestAPI {
      */
     val pestDeathChatPattern by patternGroup.pattern(
         "chat.pestdeath",
-        "§eYou received §a(?<amount>[0-9]*)x (?<item>.*) §efor killing an? §6(?<pest>.*)§e!"
+        "§eYou received §a(?<amount>[0-9]*)x (?<item>.*) §efor killing an? §6(?<pest>.*)§e!",
     )
     private val noPestsChatPattern by patternGroup.pattern(
         "chat.nopests",
-        "§cThere are not any Pests on your Garden right now! Keep farming!"
+        "§cThere are not any Pests on your Garden right now! Keep farming!",
     )
 
     var gardenJoinTime = SimpleTimeMark.farPast()
@@ -196,7 +196,7 @@ object PestAPI {
             plot.pests = 0
             plot.isPestCountInaccurate = false
             val item = event.inventoryItems[plot.inventorySlot] ?: continue
-            item.getLore().matchFirst(pestInventoryPattern) {
+            pestInventoryPattern.firstMatcher(item.getLore()) {
                 plot.pests = group("amount").toInt()
             }
         }
@@ -312,7 +312,7 @@ object PestAPI {
             "scoreboardPests" to scoreboardPests,
             "plots" to getInfestedPlots().map { "id: ${it.id} pests: ${it.pests} isInaccurate: ${it.isPestCountInaccurate}" },
             noStackTrace = true,
-            betaOnly = true
+            betaOnly = true,
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
@@ -83,7 +83,7 @@ object GardenVisitorTimer {
         var millis = visitorInterval
         var queueFull = false
 
-        TabListData.getTabList().matchFirst(timePattern) {
+        timePattern.firstMatcher(TabListData.getTabList()) {
             val timeInfo = group("info").removeColor()
             if (timeInfo == "Not Unlocked!") {
                 display = Renderable.string("§cVisitors not unlocked!")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.gui.inventory.GuiChest
@@ -54,7 +54,7 @@ object AuctionsHighlighter {
                 continue
             }
             if (config.highlightAuctionsUnderbid) {
-                lore.matchFirst(buyItNowPattern) {
+                buyItNowPattern.firstMatcher<Unit>(lore) {
                     val coins = group("coins").formatLong()
                     val totalPrice = EstimatedItemValueCalculator.getTotalPrice(stack)
                     if (coins > totalPrice) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
@@ -54,7 +54,7 @@ object AuctionsHighlighter {
                 continue
             }
             if (config.highlightAuctionsUnderbid) {
-                buyItNowPattern.firstMatcher<Unit>(lore) {
+                buyItNowPattern.firstMatcher(lore) {
                     val coins = group("coins").formatLong()
                     val totalPrice = EstimatedItemValueCalculator.getTotalPrice(stack)
                     if (coins > totalPrice) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/DojoRankDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/DojoRankDisplay.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -27,11 +27,11 @@ object DojoRankDisplay {
     private val patternGroup = RepoPattern.group("inventory.dojo.rankdisplay")
     private val testNamePattern by patternGroup.pattern(
         "name",
-        "(?<color>§\\w)Test of (?<name>.*)"
+        "(?<color>§\\w)Test of (?<name>.*)",
     )
     private val testRankPattern by patternGroup.pattern(
         "rank",
-        "(?:§\\w)+Your Rank: (?<rank>§\\w.) §8\\((?<score>\\d+)\\)"
+        "(?:§\\w)+Your Rank: (?<rank>§\\w.) §8\\((?<score>\\d+)\\)",
     )
     private var belts = mapOf<String, Int>()
 
@@ -54,7 +54,7 @@ object DojoRankDisplay {
             testNamePattern.matchMatcher(name) {
                 val testColor = group("color")
                 val testName = group("name")
-                stack.getLore().matchFirst(testRankPattern) {
+                testRankPattern.firstMatcher(stack.getLore()) {
                     val rank = group("rank")
                     val score = group("score").toInt()
                     val color = if (score in 0..99) "§c" else "§a"

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -47,7 +47,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getBottleOfJyrreSeconds
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEdition
@@ -236,7 +235,7 @@ object ItemDisplayOverlayFeatures {
         }
 
         if (LARVA_HOOK.isSelected() && internalName == "LARVA_HOOK".toInternalName()) {
-            harvestPattern.firstMatcher<Nothing>(lore) {
+            harvestPattern.firstMatcher(lore) {
                 val amount = group("amount").toInt()
                 return when {
                     amount > 4 -> "§a$amount"
@@ -258,7 +257,7 @@ object ItemDisplayOverlayFeatures {
         }
 
         if (VACUUM_GARDEN.isSelected() && internalName in PestAPI.vacuumVariants && isOwnItem(lore)) {
-            lore.matchFirst(gardenVacuumPattern) {
+            gardenVacuumPattern.firstMatcher(lore) {
                 val pests = group("amount").formatLong()
                 return if (config.vacuumBagCap) {
                     if (pests > 39) "§640+" else "$pests"
@@ -292,14 +291,14 @@ object ItemDisplayOverlayFeatures {
         }
 
         if (BINGO_GOAL_RANK.isSelected() && chestName == "Bingo Card" && lore.lastOrNull() == "§aGOAL REACHED") {
-            lore.matchFirst(bingoGoalRankPattern) {
+            bingoGoalRankPattern.firstMatcher(lore) {
                 val rank = group("rank").formatLong()
                 if (rank < 10000) return "§6${rank.shortFormat()}"
             }
         }
 
         if (SKYBLOCK_LEVEL.isSelected() && chestName == "SkyBlock Menu" && itemName == "SkyBlock Leveling") {
-            lore.matchFirst(skyblockLevelPattern) {
+            skyblockLevelPattern.firstMatcher(lore) {
                 return group("level")
             }
         }
@@ -311,7 +310,7 @@ object ItemDisplayOverlayFeatures {
                 it.contains("Deaths: ")
             }
         ) {
-            lore.matchFirst(bestiaryStackPattern) {
+            bestiaryStackPattern.firstMatcher(lore) {
                 val tier = (group("tier").romanToDecimalIfNecessary() - 1)
                 return tier.toString()
             } ?: run {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -46,6 +46,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getBottleOfJyrreSeconds
@@ -235,7 +236,7 @@ object ItemDisplayOverlayFeatures {
         }
 
         if (LARVA_HOOK.isSelected() && internalName == "LARVA_HOOK".toInternalName()) {
-            lore.matchFirst(harvestPattern) {
+            harvestPattern.firstMatcher<Nothing>(lore) {
                 val amount = group("amount").toInt()
                 return when {
                     amount > 4 -> "§a$amount"

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/MaxPurseItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/MaxPurseItems.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
@@ -23,19 +24,19 @@ object MaxPurseItems {
     private val patternGroup = RepoPattern.group("inventory.maxpurse")
     private val orderPattern by patternGroup.pattern(
         "order",
-        ".*§6(?<coins>[\\d.,]+) coins §7each.*"
+        ".*§6(?<coins>[\\d.,]+) coins §7each.*",
     )
     private val instantPattern by patternGroup.pattern(
         "instant",
-        ".*Price per unit: §6(?<coins>[\\d.,]+) coins.*"
+        ".*Price per unit: §6(?<coins>[\\d.,]+) coins.*",
     )
     private val createOrderPattern by patternGroup.pattern(
         "createorder",
-        "§aCreate Buy Order"
+        "§aCreate Buy Order",
     )
     private val createInstantPattern by patternGroup.pattern(
         "createinstant",
-        "§aBuy Instantly"
+        "§aBuy Instantly",
     )
 
     private var buyOrderPrice: Double? = null
@@ -54,7 +55,7 @@ object MaxPurseItems {
                 }
             }
             createInstantPattern.matchMatcher(name) {
-                item.getLore().matchFirst(instantPattern) {
+                instantPattern.firstMatcher(item.getLore()) {
                     instantBuyPrice = group("coins").formatDouble()
                 }
             }
@@ -87,9 +88,9 @@ object MaxPurseItems {
             listOf(
                 "§7Max items with purse",
                 "§7Buy order +0.1: §e${buyOrders.addSeparators()}x",
-                "§7Instant buy: §e${buyInstant.addSeparators()}x"
+                "§7Instant buy: §e${buyInstant.addSeparators()}x",
             ),
-            posLabel = "Max Items With Purse"
+            posLabel = "Max Items With Purse",
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/MaxPurseItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/MaxPurseItems.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -46,7 +45,7 @@ object MaxPurseItems {
         for (item in Minecraft.getMinecraft().thePlayer.openContainer.inventory) {
             val name = item?.displayName ?: continue
             createOrderPattern.matchMatcher(name) {
-                item.getLore().matchFirst(orderPattern) {
+                orderPattern.firstMatcher(item.getLore()) {
                     // +0.1 because I expect people to use the gold nugget option
                     buyOrderPrice = group("coins").formatDouble() + 0.1
                     // If we get to this point, we have the instant price because instant is earlier in the list of items

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -26,7 +26,7 @@ object StatsTuning {
 
     private val statPointsPattern by RepoPattern.pattern(
         "inventory.statstuning.points",
-        "§7Stat has: §e(?<amount>\\d+) points?"
+        "§7Stat has: §e(?<amount>\\d+) points?",
     )
 
     @SubscribeEvent
@@ -38,7 +38,7 @@ object StatsTuning {
         if (config.templateStats && inventoryName == "Stats Tuning") if (templateStats(stack, event)) return
         if (config.selectedStats && MaxwellAPI.isThaumaturgyInventory(inventoryName) && renderTunings(
                 stack,
-                event
+                event,
             )
         ) return
         if (config.points && inventoryName == "Stats Tuning") points(stack, event)
@@ -90,7 +90,7 @@ object StatsTuning {
     }
 
     private fun points(stack: ItemStack, event: RenderInventoryItemTipEvent) {
-        stack.getLore().matchFirst(statPointsPattern) {
+        statPointsPattern.firstMatcher(stack.getLore()) {
             val points = group("amount")
             event.stackTip = points
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseCopyUnderbidPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseCopyUnderbidPrice.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.NEUItems.getPrice
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.OSUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -29,11 +29,11 @@ object AuctionHouseCopyUnderbidPrice {
     private val patternGroup = RepoPattern.group("auctions.underbid")
     private val auctionPricePattern by patternGroup.pattern(
         "price",
-        "§7(?:Buy it now|Starting bid|Top bid): §6(?<coins>[0-9,]+) coins"
+        "§7(?:Buy it now|Starting bid|Top bid): §6(?<coins>[0-9,]+) coins",
     )
     private val allowedInventoriesPattern by patternGroup.pattern(
         "allowedinventories",
-        "Auctions Browser|Manage Auctions|Auctions: \".*\"?"
+        "Auctions Browser|Manage Auctions|Auctions: \".*\"?",
     )
 
     @SubscribeEvent
@@ -64,7 +64,7 @@ object AuctionHouseCopyUnderbidPrice {
         if (!allowedInventoriesPattern.matches(InventoryUtils.openInventoryName())) return
         val stack = event.guiContainer.slotUnderMouse?.stack ?: return
 
-        stack.getLore().matchFirst(auctionPricePattern) {
+        auctionPricePattern.firstMatcher(stack.getLore()) {
             val underbid = group("coins").formatLong() - 1
             OSUtils.copyToClipboard("$underbid")
             ChatUtils.chat("Copied ${underbid.addSeparators()} to clipboard.")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.OSUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -64,7 +64,7 @@ object BazaarCancelledBuyOrderClipboard {
         if (!stack.name.contains("Cancel Order")) return
 
         val lore = stack.getLore()
-        lore.matchFirst(lastAmountPattern) {
+        lastAmountPattern.firstMatcher(lore) {
             latestAmount = group("amount").formatInt()
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -258,7 +259,7 @@ object ChocolateFactoryDataLoader {
     private fun processProductionItem(item: ItemStack) {
         val profileStorage = profileStorage ?: return
 
-        item.getLore().matchFirst(chocolateMultiplierPattern) {
+        chocolateMultiplierPattern.firstMatcher(item.getLore()) {
             val currentMultiplier = group("amount").formatDouble()
             profileStorage.chocolateMultiplier = currentMultiplier
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -167,7 +166,7 @@ object ChocolateFactoryDataLoader {
                 ChatUtils.clickableChat(
                     "Could not determine your current statistics to get next upgrade. Open CF to fix this!",
                     onClick = { HypixelCommands.chocolateFactory() },
-                    "§eClick to run /cf!"
+                    "§eClick to run /cf!",
                 )
             }
         }
@@ -288,7 +287,7 @@ object ChocolateFactoryDataLoader {
     private fun processBarnItem(item: ItemStack) {
         val profileStorage = profileStorage ?: return
 
-        item.getLore().matchFirst(barnAmountPattern) {
+        barnAmountPattern.firstMatcher(item.getLore()) {
             profileStorage.currentRabbits = group("rabbits").formatInt()
             profileStorage.maxRabbits = group("max").formatInt()
             ChocolateFactoryBarnManager.trySendBarnFullMessage(inventory = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSlotText
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -18,7 +18,7 @@ object ChocolateFactoryInventory {
 
     private val unclaimedRewardsPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "unclaimedrewards",
-        "§7§aYou have \\d+ unclaimed rewards?!"
+        "§7§aYou have \\d+ unclaimed rewards?!",
     )
 
     @SubscribeEvent
@@ -63,7 +63,7 @@ object ChocolateFactoryInventory {
                 slot highlight LorenzColor.RED
             }
             if (slotIndex == ChocolateFactoryAPI.milestoneIndex) {
-                slot.stack?.getLore()?.matchFirst(unclaimedRewardsPattern) {
+                unclaimedRewardsPattern.firstMatcher(slot.stack?.getLore().orEmpty()) {
                     slot highlight LorenzColor.RED
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTooltipStray.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -20,7 +20,7 @@ object ChocolateFactoryTooltipStray {
      */
     private val chocolateGainedPattern by ChocolateFactoryAPI.patternGroup.pattern(
         "rabbit.stray",
-        "(?:§.)*(?:Rabbit§7, so )?(?:[Yy]ou )?(?:gained |received )?§6\\+?(?<amount>[\\d,]+)(?: Chocolate§7!)?"
+        "(?:§.)*(?:Rabbit§7, so )?(?:[Yy]ou )?(?:gained |received )?§6\\+?(?<amount>[\\d,]+)(?: Chocolate§7!)?",
     )
 
     @SubscribeEvent(priority = EventPriority.HIGH)
@@ -30,7 +30,7 @@ object ChocolateFactoryTooltipStray {
         if (event.slot.slotNumber > 26 || event.slot.slotNumber == ChocolateFactoryAPI.infoIndex) return
 
         val tooltip = event.toolTip
-        tooltip.matchFirst(chocolateGainedPattern) {
+        chocolateGainedPattern.firstMatcher(tooltip) {
             val amount = group("amount").formatLong()
             val format = ChocolateFactoryAPI.timeUntilNeed(amount + 1).format(maxUnits = 2)
             tooltip[tooltip.lastIndex] += " §7(§a+§b$format §aof production§7)"

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateShopPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateShopPrice.kt
@@ -19,8 +19,8 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.million
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
@@ -93,7 +93,7 @@ object ChocolateShopPrice {
             val lore = item.getLore()
 
             if (slot == MILESTONE_INDEX) {
-                lore.matchFirst(chocolateSpentPattern) {
+                chocolateSpentPattern.firstMatcher(lore) {
                     chocolateSpent = group("amount").formatLong()
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -40,7 +40,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DPathWithWaypoint
@@ -167,7 +167,7 @@ object TunnelsMaps {
             val lore = item.getLore()
             if (!glacitePattern.anyMatches(lore)) return@mapNotNull null
             if (completedPattern.anyMatches(lore)) return@mapNotNull null
-            val type = lore.matchFirst(collectorCommissionPattern) {
+            val type = collectorCommissionPattern.firstMatcher(lore) {
                 group("what")
             } ?: return@mapNotNull null
             if (invalidGoalPattern.matches(type)) return@mapNotNull null

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ServerRestartTitle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ServerRestartTitle.kt
@@ -31,7 +31,7 @@ object ServerRestartTitle {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.serverRestartTitle) return
 
-        restartingPattern.firstMatcher<Unit>(ScoreboardData.sidebarLinesFormatted) {
+        restartingPattern.firstMatcher(ScoreboardData.sidebarLinesFormatted) {
             val minutes = group("minutes").toInt().minutes
             val seconds = group("seconds").toInt().seconds
             val totalTime = minutes + seconds

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ServerRestartTitle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ServerRestartTitle.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -19,11 +19,11 @@ object ServerRestartTitle {
     private val patternGroup = RepoPattern.group("features.misc.serverrestart")
     private val restartingPattern by patternGroup.pattern(
         "time",
-        "§cServer closing: (?<minutes>\\d+):(?<seconds>\\d+) ?§8.*"
+        "§cServer closing: (?<minutes>\\d+):(?<seconds>\\d+) ?§8.*",
     )
     val restartingGreedyPattern by patternGroup.pattern(
         "greedy",
-        "§cServer closing.*"
+        "§cServer closing.*",
     )
 
     @SubscribeEvent
@@ -31,7 +31,7 @@ object ServerRestartTitle {
         if (!LorenzUtils.inSkyBlock) return
         if (!config.serverRestartTitle) return
 
-        ScoreboardData.sidebarLinesFormatted.matchFirst(restartingPattern) {
+        restartingPattern.firstMatcher<Unit>(ScoreboardData.sidebarLinesFormatted) {
             val minutes = group("minutes").toInt().minutes
             val seconds = group("seconds").toInt().seconds
             val totalTime = minutes + seconds

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pets/CurrentPetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pets/CurrentPetDisplay.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
@@ -25,15 +25,15 @@ object CurrentPetDisplay {
     private val patternGroup = RepoPattern.group("misc.currentpet")
     private val inventorySelectedPetPattern by patternGroup.pattern(
         "inventory.selected",
-        "§7§7Selected pet: (?<pet>.*)"
+        "§7§7Selected pet: (?<pet>.*)",
     )
     private val chatSpawnPattern by patternGroup.pattern(
         "chat.spawn",
-        "§aYou summoned your §r(?<pet>.*)§r§a!"
+        "§aYou summoned your §r(?<pet>.*)§r§a!",
     )
     private val chatDespawnPattern by patternGroup.pattern(
         "chat.despawn",
-        "§aYou despawned your §r.*§r§a!"
+        "§aYou despawned your §r.*§r§a!",
     )
 
     /**
@@ -42,7 +42,7 @@ object CurrentPetDisplay {
      */
     private val chatPetRulePattern by patternGroup.pattern(
         "chat.rule",
-        "§cAutopet §eequipped your §7\\[Lvl .*] (?<pet>.*)§e! §a§lVIEW RULE"
+        "§cAutopet §eequipped your §7\\[Lvl .*] (?<pet>.*)§e! §a§lVIEW RULE",
     )
 
     @SubscribeEvent
@@ -74,7 +74,7 @@ object CurrentPetDisplay {
         if (!PetAPI.isPetMenu(event.inventoryName)) return
 
         val lore = event.inventoryItems[4]?.getLore() ?: return
-        lore.matchFirst(inventorySelectedPetPattern) {
+        inventorySelectedPetPattern.firstMatcher(lore) {
             val newPet = group("pet")
             PetAPI.currentPet = if (newPet != "§cNone") newPet else ""
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/FirePillarDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/FirePillarDisplay.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
-import at.hannibal2.skyhanni.utils.RegexUtils.matchFirst
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.entity.item.EntityArmorStand
@@ -23,7 +23,7 @@ object FirePillarDisplay {
      */
     private val entityNamePattern by RepoPattern.pattern(
         "slayer.blaze.firepillar.entityname",
-        "§6§l(?<seconds>.*)s §c§l8 hits"
+        "§6§l(?<seconds>.*)s §c§l8 hits",
     )
 
     private var display = ""
@@ -32,11 +32,7 @@ object FirePillarDisplay {
     fun onTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
 
-        val seconds = EntityUtils.getEntities<EntityArmorStand>()
-            .map { it.name }
-            .matchFirst<String?>(entityNamePattern) {
-                group("seconds")
-            }
+        val seconds = entityNamePattern.firstMatcher(EntityUtils.getEntities<EntityArmorStand>().map { it.name }) { group("seconds") }
 
         display = seconds?.let {
             "§cFire Pillar: §b${seconds}s"

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/FirePillarDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/FirePillarDisplay.kt
@@ -32,7 +32,12 @@ object FirePillarDisplay {
     fun onTick(event: LorenzTickEvent) {
         if (!isEnabled()) return
 
-        val seconds = entityNamePattern.firstMatcher(EntityUtils.getEntities<EntityArmorStand>().map { it.name }) { group("seconds") }
+        val entityNames = EntityUtils.getEntities<EntityArmorStand>().map {
+            it.name
+        }
+        val seconds = entityNamePattern.firstMatcher(entityNames) {
+            group("seconds")
+        }
 
         display = seconds?.let {
             "§cFire Pillar: §b${seconds}s"

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -10,10 +10,6 @@ object RegexUtils {
     inline fun <T> Pattern.findMatcher(text: String, consumer: Matcher.() -> T) =
         matcher(text).let { if (it.find()) consumer(it) else null }
 
-    @Deprecated("", ReplaceWith("pattern.firstMatcher(this) { consumer() }"))
-    inline fun <T> Sequence<String>.matchFirst(pattern: Pattern, consumer: Matcher.() -> T): T? =
-        pattern.firstMatcher(this, consumer)
-
     inline fun <T> Pattern.firstMatcher(sequence: Sequence<String>, consumer: Matcher.() -> T): T? {
         for (line in sequence) {
             matcher(line).let { if (it.matches()) return consumer(it) }
@@ -35,9 +31,6 @@ object RegexUtils {
 
     inline fun <T> Pattern.firstMatcherWithIndex(list: List<String>, consumer: Matcher.(Int) -> T): T? =
         firstMatcherWithIndex(list.asSequence(), consumer)
-
-    @Deprecated("", ReplaceWith("pattern.matchAll(this) { consumer() }"))
-    inline fun <T> List<String>.matchAll(pattern: Pattern, consumer: Matcher.() -> T): T? = pattern.matchAll(this, consumer)
 
     inline fun <T> Pattern.matchAll(list: List<String>, consumer: Matcher.() -> T): T? {
         for (line in list) {


### PR DESCRIPTION
## What
Removed 3 deprecated regexutils methods.
This gets rid of like 40-50 warnings.
These methods have been deprecated for around 3-4 months now.


## Changelog Technical Details
+ Removed deprecated regex utils methods. - j10a1n15

