### PR TITLE
Backend: Add REGEX-FAIL and fix some regex and tests

### DIFF
--- a/.live-plugins/regexr/plugin.kts
+++ b/.live-plugins/regexr/plugin.kts
@@ -21,6 +21,7 @@ val logger =
     Logger.getInstance("SkyHanni")
 
 val regexTestPrefix = "REGEX-TEST: "
+val regexTestFailPrefix = "REGEX-FAIL: "
 
 class RegexInfo(
     val regex: KtValueArgument,
@@ -50,7 +51,7 @@ class RegexInfo(
     }
 
     fun getExamples(): List<String> {
-        val examples = commentText?.filter { it.startsWith(regexTestPrefix) }
+        val examples = commentText?.filter { it.startsWith(regexTestPrefix) || it.startsWith(regexTestFailPrefix) }
             ?.map { it.substring(regexTestPrefix.length) }
         if (examples == null) return listOf()
         return examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ format like "- #821" to illustrate the dependency.
     - **There are valid reasons to deviate from the norm**
         - If you have such a case, either use `@Supress("rule_name")`, or re-build the `baseline.xml` file, using `./gradlew detektBaselineMain`.
       After running detektBaselineMain, you should find a file called `baseline-main.xml` in the `version/1.8.9` folder, rename the file to
-     `baseline.xml` replacing the old one. You also should copy the new contents of this file to the [main baseline file](detekt/baseline.xml)
+     `baseline.xml` replacing the old one.
 - Do not copy features from other mods. Exceptions:
     - Mods that are paid to use.
   - Mods that have reached their end of life. (Rip SBA, Dulkir and Soopy).
@@ -145,6 +145,7 @@ format like "- #821" to illustrate the dependency.
 - Do not use `MinecraftForge.EVENT_BUS.post(event)`, use `event.post()` instead.
 - Do not use `toRegex()` or `toPattern()`, use `RepoPattern` instead.
     - See [RepoPattern.kt](https://github.com/hannibal002/SkyHanni/blob/beta/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPattern.kt)
+    - All repo patterns must be accompanied by a regex test. Look at other patterns for examples.
 for more information and usages.
     - The pattern variables are named in the scheme `variableNamePattern`
 - Please use Regex instead of String comparison when it is likely Hypixel will change the message in the future.

--- a/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BitsAPI.kt
@@ -66,10 +66,10 @@ object BitsAPI {
     // Chat patterns
     private val bitsChatGroup = bitsDataGroup.group("chat")
 
+    @Suppress("MaxLineLength")
     private val bitsFromFameRankUpChatPattern by bitsChatGroup.pattern(
         "rankup.bits",
-        "§eYou gained §3(?<amount>.*) Bits Available §ecompounded from all your " +
-            "§epreviously eaten §6cookies§e! Click here to open §6cookie menu§e!",
+        "§eYou gained §3(?<amount>.*) Bits Available §ecompounded from all your §epreviously eaten §6cookies§e! Click here to open §6cookie menu§e!",
     )
 
     private val fameRankUpPattern by bitsChatGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -127,7 +127,7 @@ object IslandGraphs {
 
     /**
      * REGEX-TEST: Dwarven Base Camp
-     * REGEX-TEST: Forge
+     * REGEX-FAIL: Forge
      * REGEX-TEST: Fossil Research Center
      */
     private val glaciteTunnelsPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -71,8 +71,8 @@ object PlayerChatManager {
     /**
      * REGEX-TEST: To nea89o: lol
      * REGEX-TEST: From nea89o: hiii
-     * REGEX-TEST: From stash: Pufferfish
-     * REGEX-TEST: From stash: Wheat
+     * REGEX-FAIL: From stash: Pufferfish
+     * REGEX-FAIL: From stash: Wheat
      * REGEX-TEST: To [MVP+] Eisengolem: Boop!
      * REGEX-TEST: From [MVP+] Eisengolem: Boop!
      * REGEX-TEST: To [MVP+] Eisengolem: danke
@@ -99,7 +99,7 @@ object PlayerChatManager {
 
     /**
      * REGEX-TEST: ♫ §c[Buddy ツ] §b[MVP§d+§b] lrg89
-     * REGEX-TEST: ℻ §b[MVP§5+§b] Alea1337
+     * REGEX-FAIL: ℻ §b[MVP§5+§b] Alea1337
      */
     private val privateIslandRankPattern by patternGroup.pattern(
         "privateislandrank",
@@ -108,7 +108,7 @@ object PlayerChatManager {
 
     /**
      * REGEX-TEST: ♫ §a[✌] §f[Gamer] §b[MVP§d+§b] lrg89
-     * REGEX-TEST: ℻ §b[MVP§5+§b] Alea1337
+     * REGEX-FAIL: ℻ §b[MVP§5+§b] Alea1337
      * REGEX-TEST: ♫ §a[✌] §c[Buddy ツ] §b[MVP§d+§b] lrg89
      */
     private val privateIslandGuestPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.features.chat.ChatFilter.messagesMap
 import at.hannibal2.skyhanni.features.chat.PowderMiningChatFilter.genericMiningRewardMessage
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.garden.GardenAPI
-import at.hannibal2.skyhanni.features.garden.pests.PestFinder
+import at.hannibal2.skyhanni.features.garden.pests.PestAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrEmpty
@@ -557,7 +557,7 @@ object ChatFilter {
         dungeonConfig.soloClass && DungeonAPI.inDungeon() && message.isPresent("solo_class") -> "solo_class"
         dungeonConfig.soloStats && DungeonAPI.inDungeon() && message.isPresent("solo_stats") -> "solo_stats"
         dungeonConfig.fairy && DungeonAPI.inDungeon() && message.isPresent("fairy") -> "fairy"
-        config.gardenNoPest && GardenAPI.inGarden() && PestFinder.noPestsChatPattern.matches(message) -> "garden_pest"
+        config.gardenNoPest && GardenAPI.inGarden() && PestAPI.noPestsChatPattern.matches(message) -> "garden_pest"
 
         else -> null
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -104,22 +104,22 @@ object PowderMiningChatFilter {
     )
 
     /**
-     * REGEX-TEST:    §r§a§r§aGreen Goblin Egg
-     * REGEX-TEST:    §r§9Goblin Egg
-     * REGEX-TEST:    §r§dDiamond Essence
-     * REGEX-TEST:    §r§dGold Essence
-     * REGEX-TEST:    §r§dGold Essence §r§8x3
-     * REGEX-TEST:    §r§dGemstone Powder §r§8x537
-     * REGEX-TEST:    §r§dDiamond Essence §r§8x2
-     * REGEX-TEST:    §r§2Mithril Powder §r§8x153
-     * REGEX-TEST:    §r§5Treasurite
-     * REGEX-TEST:    §r§f⸕ Rough Amber Gemstone §r§8x24
-     * REGEX-TEST:    §r§f❤ Rough Ruby Gemstone §r§8x24
-     * REGEX-TEST:    §r§f❈ Rough Amethyst Gemstone §r§8x24
-     * REGEX-TEST:    §r§9§r§eYellow Goblin Egg
-     * REGEX-TEST:    §r§a⸕ Flawed Amber Gemstone
-     * REGEX-TEST:    §r§aWishing Compass §r§8x3
-     * REGEX-TEST:    §r§a⸕ Flawed Amber Gemstone §r§8x2
+     * REGEX-TEST:     §r§a§r§aGreen Goblin Egg
+     * REGEX-TEST:     §r§9Goblin Egg
+     * REGEX-TEST:     §r§dDiamond Essence
+     * REGEX-TEST:     §r§dGold Essence
+     * REGEX-TEST:     §r§dGold Essence §r§8x3
+     * REGEX-TEST:     §r§dGemstone Powder §r§8x537
+     * REGEX-TEST:     §r§dDiamond Essence §r§8x2
+     * REGEX-TEST:     §r§2Mithril Powder §r§8x153
+     * REGEX-TEST:     §r§5Treasurite
+     * REGEX-TEST:     §r§f⸕ Rough Amber Gemstone §r§8x24
+     * REGEX-TEST:     §r§f❤ Rough Ruby Gemstone §r§8x24
+     * REGEX-TEST:     §r§f❈ Rough Amethyst Gemstone §r§8x24
+     * REGEX-TEST:     §r§9§r§eYellow Goblin Egg
+     * REGEX-TEST:     §r§a⸕ Flawed Amber Gemstone
+     * REGEX-TEST:     §r§aWishing Compass §r§8x3
+     * REGEX-TEST:     §r§a⸕ Flawed Amber Gemstone §r§8x2
      */
     val genericMiningRewardMessage by patternGroup.pattern(
         "reward.generic",
@@ -256,7 +256,7 @@ object PowderMiningChatFilter {
     @Suppress("MaxLineLength")
     private val gemstonePattern by patternGroup.pattern(
         "reward.gemstone",
-        "§r§[fa9][❤❈☘⸕✎✧❁] (?<tier>Rough|Flawed|Fine|Flawless) (?<gem>Ruby|Amethyst|Jade|Amber|Sapphire|Topaz|Jasper) Gemstone( §r§8x(?<amount>[\\d,]+))?",
+        "§r§[fa95][❤❈☘⸕✎✧❁] (?<tier>Rough|Flawed|Fine|Flawless) (?<gem>Ruby|Amethyst|Jade|Amber|Sapphire|Topaz|Jasper) Gemstone( §r§8x(?<amount>[\\d,]+))?",
     )
 
     @Suppress("CyclomaticComplexMethod")

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -51,8 +51,8 @@ object StashCompact {
     )
 
     /**
-     * REGEX-TEST: §eOne or more items didn't fit in your inventory and were added to your item stash! §6Click here to pick them up!
-     * REGEX-TEST: §eOne or more materials didn't fit in your inventory and were added to your material stash! §6Click here to pick them up!
+     * REGEX-TEST: §eOne or more items didn't fit in your inventory and were added to your item stash! §6Click here §eto pick them up!
+     * REGEX-TEST: §eOne or more materials didn't fit in your inventory and were added to your material stash! §6Click here §eto pick them up!
      */
     @Suppress("MaxLineLength")
     private val genericAddedToStashPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonBossAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonBossAPI.kt
@@ -37,7 +37,7 @@ object DungeonBossAPI {
     private val patternGroup = RepoPattern.group("dungeon.boss.message")
 
     /**
-     * REGEX-TEST: §c[BOSS] Sadan§r§f: So you made it all the way here... Now you wish to defy me\? Sadan\?!
+     * REGEX-TEST: §c[BOSS] Sadan§r§f: So you made it all the way here... Now you wish to defy me? Sadan?!
      */
     private val terracottaStartPattern by patternGroup.pattern(
         "f6.terracotta",

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCleanEnd.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCleanEnd.kt
@@ -27,7 +27,7 @@ object DungeonCleanEnd {
     /**
      * REGEX-TEST: §f                §r§cMaster Mode The Catacombs §r§8- §r§eFloor III
      * REGEX-TEST: §f                        §r§cThe Catacombs §r§8- §r§eFloor VI
-     * REGEX-TEST: §f                §r§cMaster Mode Catacombs §r§8- §r§eFloor II
+     * REGEX-TEST: §f                §r§cMaster Mode The Catacombs §r§8- §r§eFloor II
      */
     private val catacombsPattern by RepoPattern.pattern(
         "dungeon.end.chests.spawned",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -119,7 +119,7 @@ object PestAPI {
         "chat.pestdeath",
         "§eYou received §a(?<amount>[0-9]*)x (?<item>.*) §efor killing an? §6(?<pest>.*)§e!"
     )
-    private val noPestsChatPattern by patternGroup.pattern(
+    val noPestsChatPattern by patternGroup.pattern(
         "chat.nopests",
         "§cThere are not any Pests on your Garden right now! Keep farming!"
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -31,7 +31,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.renderables.Renderable
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -43,10 +42,6 @@ object PestFinder {
     private val config get() = PestAPI.config.pestFinder
 
     private var display = emptyList<Renderable>()
-    val noPestsChatPattern by RepoPattern.pattern(
-        "chat.garden.no.pest",
-        "§cThere are not any Pests on your Garden right now! Keep farming!",
-    )
 
     @HandleEvent
     fun onPestUpdate(event: PestUpdateEvent) {
@@ -175,7 +170,7 @@ object PestFinder {
         if (!GardenAPI.inGarden()) return
         if (!config.noPestTitle) return
 
-        if (noPestsChatPattern.matches(event.message)) LorenzUtils.sendTitle("§eNo pests!", 2.seconds)
+        if (PestAPI.noPestsChatPattern.matches(event.message)) LorenzUtils.sendTitle("§eNo pests!", 2.seconds)
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
@@ -44,8 +44,8 @@ object CarnivalShopHelper {
     private var shopSpecificInfoItemStack: ItemStack? = null
 
     /**
-     * REGEX-TEST: Your Tokens: §a1,234,567
-     * REGEX-TEST: Your Tokens: §a0
+     * REGEX-TEST: §7Your Tokens: §a1,234,567
+     * REGEX-TEST: §7Your Tokens: §a0
      */
     private val currentTokenCountPattern by patternGroup.pattern(
         "carnival.tokens.current",

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorAPI.kt
@@ -27,7 +27,7 @@ object FossilExcavatorAPI {
     /**
      * REGEX-TEST:   §r§6§lEXCAVATION COMPLETE
      */
-    private val startPattern by chatPatternGroup.pattern("start", " {2}§r§6§lEXCAVATION COMPLETE ")
+    private val startPattern by chatPatternGroup.pattern("start", " {2}§r§6§lEXCAVATION COMPLETE ?")
 
     /**
      * REGEX-TEST: §a§l▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -53,10 +53,10 @@ object EnchantParser {
         "^(?:(?:§.)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:[,.]\\d{1,3})*)[kKmMbB]?)+\$",
     )
     // Above regex tests apply to this pattern also
+    @Suppress("MaxLineLength")
     val enchantmentPattern by patternGroup.pattern(
         "enchants.new",
-        "(§7§l|§d§l|§9|§7)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)" +
-            "(?<stacking>(§r)?§9, |\$| §8\\d{1,3}([,.]\\d{1,3})*[kKmMbB]?)",
+        "(§7§l|§d§l|§9|§7)(?<enchant>[A-Za-z][A-Za-z '-]+) (?<levelNumeral>[IVXLCDM]+|[0-9]+)(?<stacking>(§r)?§9, |\$| §8\\d{1,3}([,.]\\d{1,3})*[kKmMbB]?)",
     )
     private val grayEnchantPattern by patternGroup.pattern(
         "grayenchants", "^(Respiration|Aqua Affinity|Depth Strider|Efficiency).*",

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/RiftGunthersRace.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/RiftGunthersRace.kt
@@ -41,7 +41,7 @@ object RiftGunthersRace {
      */
     private val raceFinishedPattern by patternGroup.pattern(
         "finish",
-        "§3§lRIFT RACING §r§eRace finished in \\d+:\\d+.\\d+!.*"
+        "§3§lRIFT RACING §r§eRace finished in (?:§.)*\\d+:\\d+.\\d+(?:§.)*!.*"
     )
 
     /**


### PR DESCRIPTION
## What
Added REGEX-FAIL which indicates this regex test should not match
Fix up regex tests that dont pass
Fix some regex being across 2 lines
Fixed the same regex being in 2 spots
Upated some info in the contributing guide that relates to repo patterns & detekt

## Changelog Technical Details
+ Added `REGEX-FAIL` for regex tests that are expected to fail. - CalMWolfs