### PR TITLE
Fix: Mineshaft roomId in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningAPI.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.mining.OreMinedEvent
 import at.hannibal2.skyhanni.events.player.PlayerDeathEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonAPI.dungeonRoomPattern
 import at.hannibal2.skyhanni.features.mining.OreBlock
 import at.hannibal2.skyhanni.features.mining.isTitanium
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -152,6 +153,9 @@ object MiningAPI {
     var cold: Int = 0
         private set
 
+    var mineshaftRoomId: String? = null
+        private set
+
     var lastColdUpdate = SimpleTimeMark.farPast()
         private set
     var lastColdReset = SimpleTimeMark.farPast()
@@ -188,6 +192,14 @@ object MiningAPI {
 
     @SubscribeEvent
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {
+        if (!inCustomMiningIsland()) return
+
+        dungeonRoomPattern.firstMatcher(event.added) {
+            mineshaftRoomId = group("roomId")
+        } ?: run {
+            mineshaftRoomId = null
+        }
+
         val newCold = coldPattern.firstMatcher(event.added) {
             group("cold").toInt().absoluteValue
         } ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonAPI.kt
@@ -97,7 +97,7 @@ object DungeonAPI {
     /**
      * REGEX-TEST: §711/15/24 §8m4F 830,-420
      */
-    private val dungeonRoomPattern by patternGroup.pattern(
+    val dungeonRoomPattern by patternGroup.pattern(
         "room",
         "§7\\d+/\\d+/\\d+ §\\w+ (?<roomId>[\\w,-]+)",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.gui.customscoreboard.elements
 
 import at.hannibal2.skyhanni.data.DateFormat
 import at.hannibal2.skyhanni.data.HypixelData
+import at.hannibal2.skyhanni.data.MiningAPI
 import at.hannibal2.skyhanni.features.dungeon.DungeonAPI
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard
 
@@ -9,10 +10,13 @@ import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard
 // update on island change and every second while in dungeons
 object ScoreboardElementLobbyCode : ScoreboardElement() {
     override fun getDisplay() = buildString {
-        if (CustomScoreboard.displayConfig.dateInLobbyCode) append("§7${CustomScoreboard.displayConfig.dateFormat} ")
-        HypixelData.serverId?.let { append("§8$it") }
-        DungeonAPI.roomId?.let { append(" §8$it") }
-    }
+        if (CustomScoreboard.displayConfig.dateInLobbyCode) append("§7${CustomScoreboard.displayConfig.dateFormat}")
+        listOfNotNull(
+            HypixelData.serverId,
+            DungeonAPI.roomId,
+            MiningAPI.mineshaftRoomId,
+        ).forEach { append(" §8$it") }
+    }.trim()
 
     override val configLine = "§7${DateFormat.US_SLASH_MMDDYYYY} §8mega77CK"
 }


### PR DESCRIPTION
## What
This Pull Request fixes the Mineshaft RoomId missing in the Custom Scoreboard LobbyCode element.

## Changelog Fixes
+ Fixed Mineshaft RoomId missing in the Custom Scoreboard. - j10a1n15

## Changelog Technical Details
+ Added Mineshaft roomId to MiningAPI. - j10a1n15

