### PR TITLE
Improvement: Add Mining Event Display to Outside Skyblock Features

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/enums/OutsideSbFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/enums/OutsideSbFeature.kt
@@ -20,6 +20,7 @@ enum class OutsideSbFeature(private val displayName: String) {
     HIGHLIGHT_PARTY_MEMBERS("Highlight Party Members"),
     MOVEMENT_SPEED("Movement Speed"),
     CUSTOM_SCOREBOARD("Custom Scoreboard (only on Hypixel)"),
+    MINING_EVENT_DISPLAY("Mining Event Display"),
     ;
 
     override fun toString() = displayName

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventDisplay.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.mining.eventtracker
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.enums.OutsideSbFeature
 import at.hannibal2.skyhanni.config.features.mining.MiningEventConfig
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -122,8 +123,11 @@ object MiningEventDisplay {
         }
     }
 
-    private fun shouldDisplay() =
-        LorenzUtils.inSkyBlock && config.enabled && !(!config.outsideMining && !MiningEventTracker.isMiningIsland())
+    private fun shouldDisplay(): Boolean {
+        val isOnValidMiningLocation = LorenzUtils.inSkyBlock && (config.outsideMining || MiningEventTracker.isMiningIsland())
+
+        return (isOnValidMiningLocation || OutsideSbFeature.MINING_EVENT_DISPLAY.isSelected()) && config.enabled
+    }
 
     @SubscribeEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {


### PR DESCRIPTION
## What
This Pull Request adds the Mining Event Display to the Outside Skyblock draggable list.

## Changelog Improvements
+ Added the Mining Event Display to Outside Skyblock Features. - j10a1n15
