### PR TITLE
Fix: Allow backspace in various editable fields on macOS

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.StringUtils.insert
 import kotlinx.coroutines.runBlocking
 import net.minecraft.client.settings.KeyBinding
+import org.apache.commons.lang3.SystemUtils
 import org.lwjgl.input.Keyboard
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
@@ -156,6 +157,19 @@ class TextInput {
                 } else {
                     textBox.dropLast(1)
                 }
+
+                Char(127) -> if (SystemUtils.IS_OS_MAC) {
+                    if (carriage != null) {
+                        if (carriage == 0) {
+                            textBox.substring(1)
+                        } else {
+                            this.carriage = carriage.minus(1)
+                            textBox.removeRange(carriage - 1, carriage)
+                        }
+                    } else {
+                        textBox.dropLast(1)
+                    }
+                } else {textBox}
 
                 else -> if (carriage != null) {
                     this.carriage = carriage + 1

--- a/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
@@ -169,7 +169,9 @@ class TextInput {
                     } else {
                         textBox.dropLast(1)
                     }
-                } else {textBox}
+                } else {
+                    textBox
+                }
 
                 else -> if (carriage != null) {
                     this.carriage = carriage + 1

--- a/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
@@ -147,28 +147,9 @@ class TextInput {
             val char = Keyboard.getEventCharacter()
             textBox = when (char) {
                 Char(0) -> return
-                '\b' -> if (carriage != null) {
-                    if (carriage == 0) {
-                        textBox.substring(1)
-                    } else {
-                        this.carriage = carriage.minus(1)
-                        textBox.removeRange(carriage - 1, carriage)
-                    }
-                } else {
-                    textBox.dropLast(1)
-                }
-
+                '\b' -> onRemove()
                 Char(127) -> if (SystemUtils.IS_OS_MAC) {
-                    if (carriage != null) {
-                        if (carriage == 0) {
-                            textBox.substring(1)
-                        } else {
-                            this.carriage = carriage.minus(1)
-                            textBox.removeRange(carriage - 1, carriage)
-                        }
-                    } else {
-                        textBox.dropLast(1)
-                    }
+                    onRemove()
                 } else {
                     textBox
                 }
@@ -182,6 +163,15 @@ class TextInput {
             }
             updated()
         }
+
+        private fun onRemove(): String = carriage?.let {
+            if (it == 0) {
+                textBox.substring(1)
+            } else {
+                this.carriage = it.minus(1)
+                textBox.removeRange(it - 1, it)
+            }
+        } ?: textBox.dropLast(1)
 
         private fun moveCarriageRight(carriage: Int) = carriage + 1
 


### PR DESCRIPTION
## What
This pull request fixes text deletion for all usages of the TextInput on macOS (namely in the trackers). This doesn't fix the issue of repeated inputs on macOS, this is most likely a LWJGL2 issue, or an issue with isKeyClicked. It fixes the issue that PR #2868 aims to fix but failed to do so.

## Changelog Fixes
+ Fixed the inability to delete characters when searching on trackers on Mac (again). - 0xDoge
