### PR TITLE
Fix: Use URLEncoder in AH Price Website feature

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseOpenPriceWebsite.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseOpenPriceWebsite.kt
@@ -43,8 +43,9 @@ object AuctionHouseOpenPriceWebsite {
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
+        // TODO get search from search sign (slot 48) since it can be cut off in title
         ahSearchPattern.matchMatcher(event.inventoryName) {
-            searchTerm = URLEncoder.encode(group("searchTerm").removeSuffix("\""), "UTF-8")
+            searchTerm = URLEncoder.encode(group("searchTerm").removeSuffix("\""), "UTF-8").replace("+", "%20")
             displayItem = createDisplayItem()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseOpenPriceWebsite.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseOpenPriceWebsite.kt
@@ -18,6 +18,7 @@ import net.minecraft.entity.player.InventoryPlayer
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.net.URLEncoder
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -43,7 +44,7 @@ object AuctionHouseOpenPriceWebsite {
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
         ahSearchPattern.matchMatcher(event.inventoryName) {
-            searchTerm = group("searchTerm").removeSuffix("\"").replace(" ", "%20")
+            searchTerm = URLEncoder.encode(group("searchTerm").removeSuffix("\""), "UTF-8")
             displayItem = createDisplayItem()
         }
     }


### PR DESCRIPTION
## What
Fixes the AH Price Website feature that opens a page on sky.coflnet.com
Currently untested in game, but tested in kotlin playground

## Changelog Fixes
+ Fixed AH Price Website feature not URL encoding the search. - Obsidian