### PR TITLE
Fix: IllegalStateException from Pest Traps

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -123,10 +123,6 @@ object PestAPI {
         "chat.pestdeath",
         "§eYou received §a(?<amount>[0-9]*)x (?<item>.*) §efor killing an? §2(?<pest>.*)§e!",
     )
-
-    /**
-     * REGEX-TEST: §cThere are not any Pests on your Garden right now! Keep farming!
-     */
     val noPestsChatPattern by patternGroup.pattern(
         "chat.nopests",
         "§cThere are not any Pests on your Garden right now! Keep farming!",
@@ -136,7 +132,7 @@ object PestAPI {
      * REGEX-TEST: §eMouse Trap #1§r
      * REGEX-TEST: §eMouse Trap #2§r
      * REGEX-TEST: §eMouse Trap #3§r
-     * REGEX-TEST: §aPest Trap #3
+     * REGEX-TEST: §aPest Trap #3§r
      */
     private val pestTrapPattern by patternGroup.pattern(
         "entity.pesttrap",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -25,9 +25,11 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
+import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
@@ -36,6 +38,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.entity.item.EntityArmorStand
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.lwjgl.input.Keyboard
 import kotlin.time.Duration.Companion.seconds
@@ -120,9 +123,24 @@ object PestAPI {
         "chat.pestdeath",
         "§eYou received §a(?<amount>[0-9]*)x (?<item>.*) §efor killing an? §2(?<pest>.*)§e!",
     )
+
+    /**
+     * REGEX-TEST: §cThere are not any Pests on your Garden right now! Keep farming!
+     */
     val noPestsChatPattern by patternGroup.pattern(
         "chat.nopests",
         "§cThere are not any Pests on your Garden right now! Keep farming!",
+    )
+
+    /**
+     * REGEX-TEST: §eMouse Trap #1§r
+     * REGEX-TEST: §eMouse Trap #2§r
+     * REGEX-TEST: §eMouse Trap #3§r
+     * REGEX-TEST: §aPest Trap #3
+     */
+    private val pestTrapPattern by patternGroup.pattern(
+        "entity.pesttrap",
+        "(?:§.)+(?:Pest|Mouse) Trap(?: #\\d+)?(?:§.)+"
     )
 
     var gardenJoinTime = SimpleTimeMark.farPast()
@@ -281,6 +299,10 @@ object PestAPI {
 
     fun getNearestInfestedPlot() = getInfestedPlots().minByOrNull { it.middle.distanceSqToPlayer() }
 
+    fun isNearPestTrap() = EntityUtils.getAllEntities().filterIsInstance<EntityArmorStand>().any {
+        it.distanceToPlayer() < 10 && pestTrapPattern.matches(it.displayName.formattedText)
+    }
+
     private fun removePests(removedPests: Int) {
         if (removedPests < 1) return
         repeat(removedPests) {
@@ -290,7 +312,10 @@ object PestAPI {
 
     private fun removeNearestPest() {
         val plot = getNearestInfestedPlot()
-            ?: ErrorManager.skyHanniError("Can not remove nearest pest: No infested plots detected.")
+            ?: run {
+                if (isNearPestTrap()) return
+                else ErrorManager.skyHanniError("Can not remove nearest pest: No infested plots detected.")
+            }
 
         if (!plot.isPestCountInaccurate) plot.pests--
         scoreboardPests--

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -307,11 +307,10 @@ object PestAPI {
     }
 
     private fun removeNearestPest() {
-        val plot = getNearestInfestedPlot()
-            ?: run {
-                if (isNearPestTrap()) return
-                else ErrorManager.skyHanniError("Can not remove nearest pest: No infested plots detected.")
-            }
+        val plot = getNearestInfestedPlot() ?: run {
+            if (isNearPestTrap()) return
+            else ErrorManager.skyHanniError("Can not remove nearest pest: No infested plots detected.")
+        }
 
         if (!plot.isPestCountInaccurate) plot.pests--
         scoreboardPests--


### PR DESCRIPTION
## What
Fixes an issue where pests from traps may not update the tablist/scoreboard fast enough, leading to an exception being thrown.

## Changelog Fixes
+ Fixed an occasional error when killing pests shortly after releasing them from pest traps. - Daveed

