### PR TITLE
Backend: Disallow unnamed capture groups

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -17,6 +17,8 @@ RepoRules:
         active: true
     RepoPatternRegexTest:
         active: true
+    RepoPatternUnnamedGroup:
+        active: true
 
 ImportRules:
     CustomImportOrdering:

--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -62,6 +62,4 @@ class RepoPatternElement private constructor(
             return regexTests to failingRegexTests
         }
     }
-
-
 }

--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -1,0 +1,67 @@
+package at.hannibal2.skyhanni.detektrules
+
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyDelegate
+import org.jetbrains.kotlin.psi.KtStringTemplateEntryWithExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+
+class RepoPatternElement private constructor(
+    val variableName: String,
+    val rawPattern: String,
+    val regexTests: List<String>,
+    val failingRegexTests: List<String>,
+) {
+
+    val pattern by lazy { rawPattern.toPattern() }
+
+    companion object {
+        fun KtPropertyDelegate.asRepoPatternElement(): RepoPatternElement? {
+            val expression = this.expression as? KtDotQualifiedExpression ?: return null
+            val callExpression = expression.selectorExpression as? KtCallExpression ?: return null
+            if (callExpression.valueArguments.size != 2) return null
+
+            val patternArg = callExpression.valueArguments[1].getArgumentExpression() ?: return null
+
+            // We only want to match on plain strings, not string templates
+            if (patternArg !is KtStringTemplateExpression) return null
+            if (patternArg.entries.any { it is KtStringTemplateEntryWithExpression }) return null
+
+            val rawPattern = patternArg.entries.joinToString("") { entry ->
+                when (entry) {
+                    is KtLiteralStringTemplateEntry -> entry.text
+                    is KtEscapeStringTemplateEntry -> entry.unescapedValue
+                    else -> "" // Skip any other types of entries
+                }
+            }.removeSurrounding("\"").replace("\n", "")
+
+            val parent = parent as? KtProperty ?: return null
+            val variableName = parent.name ?: "unknownPattern"
+
+            val (regexTests, failingRegexTests) = findRegexTestInKDoc(parent)
+            return RepoPatternElement(variableName, rawPattern, regexTests, failingRegexTests)
+        }
+
+        private fun findRegexTestInKDoc(property: KtProperty): Pair<List<String>, List<String>> {
+            val kDoc = property.docComment ?: return listOf<String>() to listOf()
+
+            val regexTests = mutableListOf<String>()
+            val failingRegexTests = mutableListOf<String>()
+
+            kDoc.getDefaultSection().getContent().lines().forEach { line ->
+                if (line.contains("REGEX-TEST: ")) {
+                    regexTests.add(line.substringAfter("REGEX-TEST: "))
+                }
+                if (line.contains("REGEX-FAIL: ")) {
+                    failingRegexTests.add(line.substringAfter("REGEX-FAIL: "))
+                }
+            }
+            return regexTests to failingRegexTests
+        }
+    }
+
+
+}

--- a/detekt/src/main/kotlin/SkyHanniRule.kt
+++ b/detekt/src/main/kotlin/SkyHanniRule.kt
@@ -1,0 +1,15 @@
+package at.hannibal2.skyhanni.detektrules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Rule
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+
+abstract class SkyHanniRule(config: Config) : Rule(config) {
+
+    protected fun PsiElement.reportIssue(message: String) {
+        report(CodeSmell(issue, Entity.from(this), message))
+    }
+
+}

--- a/detekt/src/main/kotlin/SkyHanniRule.kt
+++ b/detekt/src/main/kotlin/SkyHanniRule.kt
@@ -11,5 +11,4 @@ abstract class SkyHanniRule(config: Config) : Rule(config) {
     protected fun PsiElement.reportIssue(message: String) {
         report(CodeSmell(issue, Entity.from(this), message))
     }
-
 }

--- a/detekt/src/main/kotlin/formatting/CustomAnnotationSpacing.kt
+++ b/detekt/src/main/kotlin/formatting/CustomAnnotationSpacing.kt
@@ -1,12 +1,12 @@
 package at.hannibal2.skyhanni.detektrules.formatting
 
 import at.hannibal2.skyhanni.detektrules.PreprocessingPattern.Companion.containsPreprocessingPattern
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
  * This rule enforces the default spacing rules for annotations but allows preprocessed comments to be between
  * an annotation and the annotated construct.
  */
-class CustomAnnotationSpacing(config: Config) : Rule(config) {
+class CustomAnnotationSpacing(config: Config) : SkyHanniRule(config) {
     override val issue = Issue(
         "CustomAnnotationSpacing",
         Severity.Style,
@@ -38,13 +38,7 @@ class CustomAnnotationSpacing(config: Config) : Rule(config) {
         }
 
         if (hasInvalidSpacing) {
-            report(
-                CodeSmell(
-                    issue,
-                    Entity.from(annotationEntry),
-                    "Annotations should occur immediately before the annotated construct"
-                )
-            )
+            annotationEntry.reportIssue("Annotations should occur immediately before the annotated construct.")
         }
         super.visitAnnotationEntry(annotationEntry)
     }

--- a/detekt/src/main/kotlin/formatting/CustomCommentSpacing.kt
+++ b/detekt/src/main/kotlin/formatting/CustomCommentSpacing.kt
@@ -1,19 +1,19 @@
 package at.hannibal2.skyhanni.detektrules.formatting
 
 import at.hannibal2.skyhanni.detektrules.PreprocessingPattern.Companion.containsPreprocessingPattern
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 
 /**
  * This rule enforces the default spacing rules for comments but ignores preprocessed comments.
  */
-class CustomCommentSpacing(config: Config) : Rule(config) {
+class CustomCommentSpacing(config: Config) : SkyHanniRule(config) {
     override val issue = Issue(
         "CustomCommentSpacing",
         Severity.Style,
@@ -24,13 +24,7 @@ class CustomCommentSpacing(config: Config) : Rule(config) {
     override fun visitComment(comment: PsiComment) {
         if (comment.text.containsPreprocessingPattern()) return
         if (!commentRegex.matches(comment.text)) {
-            report(
-                CodeSmell(
-                    issue,
-                    Entity.from(comment),
-                    "Expected space after opening comment."
-                )
-            )
+            comment.reportIssue("Expected space after opening comment.")
         }
 
         // Fallback to super (ostensibly a no-check)

--- a/detekt/src/main/kotlin/grammar/AvoidBritishSpelling.kt
+++ b/detekt/src/main/kotlin/grammar/AvoidBritishSpelling.kt
@@ -1,11 +1,11 @@
 package at.hannibal2.skyhanni.detektrules.grammar
 
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtStringTemplateExpression
  * This rule reports all usages of the british spelling over the american spelling in the codebase,
  * this will ignore any type annotations, i.e., `@ConfigEditorColour` will not be reported.
  */
-class AvoidBritishSpelling(config: Config) : Rule(config) {
+class AvoidBritishSpelling(config: Config) : SkyHanniRule(config) {
     override val issue = Issue(
         "AvoidBritishSpelling",
         Severity.Style,
@@ -32,13 +32,7 @@ class AvoidBritishSpelling(config: Config) : Rule(config) {
 
         for (word in scannedWords) {
             if (text.contains(word.key, ignoreCase = true)) {
-                report(
-                    CodeSmell(
-                        issue,
-                        Entity.from(expression),
-                        "Avoid using the word '${word.key}' in code, '${word.value}' is preferred instead.",
-                    ),
-                )
+                expression.reportIssue("Avoid using the word '${word.key}' in code, '${word.value}' is preferred instead.")
             }
         }
         super.visitStringTemplateExpression(expression)

--- a/detekt/src/main/kotlin/imports/CustomImportOrdering.kt
+++ b/detekt/src/main/kotlin/imports/CustomImportOrdering.kt
@@ -2,12 +2,10 @@ package at.hannibal2.skyhanni.detektrules.imports
 
 import at.hannibal2.skyhanni.detektrules.PreprocessingPattern
 import at.hannibal2.skyhanni.detektrules.PreprocessingPattern.Companion.containsPreprocessingPattern
-import io.gitlab.arturbosch.detekt.api.CodeSmell
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtImportList
@@ -15,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtImportList
 /**
  * This rule enforces correct import ordering, while ignoring preprocessed comments and imports that are in a preprocessed block.
  */
-class CustomImportOrdering(config: Config) : Rule(config) {
+class CustomImportOrdering(config: Config) : SkyHanniRule(config) {
     override val issue = Issue(
         "CustomImportOrdering",
         Severity.Style,
@@ -98,17 +96,12 @@ class CustomImportOrdering(config: Config) : Rule(config) {
         val importsCorrect = isImportsCorrectlyOrdered(importList.imports, rawText.lines())
 
         if (!importsCorrect) {
-            report(
-                CodeSmell(
-                    issue,
-                    Entity.from(importList),
-                    "Imports must be ordered in lexicographic order without any empty lines in-between " +
-                        "with \"java\", \"javax\", \"kotlin\" and aliases in the end. This should then be followed by " +
-                        "pre-processed imports.",
-                ),
+            importList.reportIssue(
+                "Imports must be ordered in lexicographic order without any empty lines in-between " +
+                    "with \"java\", \"javax\", \"kotlin\" and aliases in the end. This should then be followed by " +
+                    "pre-processed imports.",
             )
         }
-
         super.visitImportList(importList)
     }
 }

--- a/detekt/src/main/kotlin/repo/RepoPatternRegexTest.kt
+++ b/detekt/src/main/kotlin/repo/RepoPatternRegexTest.kt
@@ -1,19 +1,12 @@
 package at.hannibal2.skyhanni.detektrules.repo
 
+import at.hannibal2.skyhanni.detektrules.RepoPatternElement.Companion.asRepoPatternElement
 import at.hannibal2.skyhanni.detektrules.SkyHanniRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Severity
-import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry
-import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
-import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyDelegate
-import org.jetbrains.kotlin.psi.KtStringTemplateEntryWithExpression
-import org.jetbrains.kotlin.psi.KtStringTemplateExpression
-import java.util.regex.PatternSyntaxException
 
 class RepoPatternRegexTest(config: Config) : SkyHanniRule(config) {
     override val issue = Issue(
@@ -26,72 +19,28 @@ class RepoPatternRegexTest(config: Config) : SkyHanniRule(config) {
     override fun visitPropertyDelegate(delegate: KtPropertyDelegate) {
         super.visitPropertyDelegate(delegate)
 
-        val expression = delegate.expression as? KtDotQualifiedExpression ?: return
-        if (!expression.text.contains(".pattern(")) return
-        val callExpression = expression.selectorExpression as? KtCallExpression ?: return
-        if (callExpression.valueArguments.size != 2) return
-
-        val patternArg = callExpression.valueArguments[1].getArgumentExpression() ?: return
-
-        // We only want to match on plain strings, not string templates
-        if (patternArg !is KtStringTemplateExpression) return
-        if (patternArg.entries.any { it is KtStringTemplateEntryWithExpression }) return
-
-        val rawPattern = patternArg.entries.joinToString("") { entry ->
-            when (entry) {
-                is KtLiteralStringTemplateEntry -> entry.text
-                is KtEscapeStringTemplateEntry -> entry.unescapedValue
-                else -> "" // Skip any other types of entries
-            }
-        }.removeSurrounding("\"").replace("\n", "")
+        val repoPatternElement = delegate.asRepoPatternElement() ?: return
+        val variableName = repoPatternElement.variableName
+        val rawPattern = repoPatternElement.rawPattern
 
         if (!rawPattern.needsRegexTest()) return
 
-        val parent = delegate.parent as? KtProperty ?: return
-        val variableName = parent.name ?: "unknownPattern"
-
-        val (regexTests, failingRegexTests) = findRegexTestInKDoc(parent)
-
-        if (regexTests.isEmpty()) {
-            delegate.reportIssue("Repo pattern `$variableName` must have a regex test.")
+        if (repoPatternElement.regexTests.isEmpty()) {
+            delegate.reportIssue("Repo pattern `${variableName}` must have a regex test.")
             return
         }
 
-        val pattern = try {
-            rawPattern.toPattern()
-        } catch (e: PatternSyntaxException) {
-            delegate.reportIssue("Repo pattern `$variableName` has an invalid regex: `$rawPattern`.")
-            return
-        }
-
-        regexTests.forEach { test ->
-            if (!pattern.matcher(test).find()) {
+        repoPatternElement.regexTests.forEach { test ->
+            if (!repoPatternElement.pattern.matcher(test).find()) {
                 delegate.reportIssue("Repo pattern `$variableName` failed regex test: `$test` pattern: `$rawPattern`.")
             }
         }
 
-        failingRegexTests.forEach { test ->
-            if (pattern.matcher(test).find()) {
+        repoPatternElement.failingRegexTests.forEach { test ->
+            if (repoPatternElement.pattern.matcher(test).find()) {
                 delegate.reportIssue("Repo pattern `$variableName` passed regex test: `$test` pattern: `$rawPattern` even though it was set to fail.")
             }
         }
-    }
-
-    private fun findRegexTestInKDoc(property: KtProperty): Pair<List<String>, List<String>> {
-        val kDoc = property.docComment ?: return listOf<String>() to listOf()
-
-        val regexTests = mutableListOf<String>()
-        val failingRegexTests = mutableListOf<String>()
-
-        kDoc.getDefaultSection().getContent().lines().forEach { line ->
-            if (line.contains("REGEX-TEST: ")) {
-                regexTests.add(line.substringAfter("REGEX-TEST: "))
-            }
-            if (line.contains("REGEX-FAIL: ")) {
-                failingRegexTests.add(line.substringAfter("REGEX-FAIL: "))
-            }
-        }
-        return regexTests to failingRegexTests
     }
 
     private fun String.needsRegexTest(): Boolean {

--- a/detekt/src/main/kotlin/repo/RepoPatternRegexTest.kt
+++ b/detekt/src/main/kotlin/repo/RepoPatternRegexTest.kt
@@ -1,11 +1,9 @@
 package at.hannibal2.skyhanni.detektrules.repo
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
@@ -17,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtStringTemplateEntryWithExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import java.util.regex.PatternSyntaxException
 
-class RepoPatternRegexTest(config: Config) : Rule(config) {
+class RepoPatternRegexTest(config: Config) : SkyHanniRule(config) {
     override val issue = Issue(
         "RepoPatternRegexTest",
         Severity.Style,
@@ -55,50 +53,26 @@ class RepoPatternRegexTest(config: Config) : Rule(config) {
         val (regexTests, failingRegexTests) = findRegexTestInKDoc(parent)
 
         if (regexTests.isEmpty()) {
-            report(
-                CodeSmell(
-                    issue,
-                    Entity.from(delegate),
-                    "Repo pattern `$variableName` must have a regex test.",
-                ),
-            )
+            delegate.reportIssue("Repo pattern `$variableName` must have a regex test.")
             return
         }
 
         val pattern = try {
             rawPattern.toPattern()
         } catch (e: PatternSyntaxException) {
-            report(
-                CodeSmell(
-                    issue,
-                    Entity.from(delegate),
-                    "Repo pattern `$variableName` has an invalid regex: `$rawPattern`.",
-                ),
-            )
+            delegate.reportIssue("Repo pattern `$variableName` has an invalid regex: `$rawPattern`.")
             return
         }
 
         regexTests.forEach { test ->
             if (!pattern.matcher(test).find()) {
-                report(
-                    CodeSmell(
-                        issue,
-                        Entity.from(delegate),
-                        "Repo pattern `$variableName` failed regex test: `$test` pattern: `$rawPattern`.",
-                    ),
-                )
+                delegate.reportIssue("Repo pattern `$variableName` failed regex test: `$test` pattern: `$rawPattern`.")
             }
         }
 
         failingRegexTests.forEach { test ->
             if (pattern.matcher(test).find()) {
-                report(
-                    CodeSmell(
-                        issue,
-                        Entity.from(delegate),
-                        "Repo pattern `$variableName` passed regex test: `$test` pattern: `$rawPattern` even though it was set to fail.",
-                    ),
-                )
+                delegate.reportIssue("Repo pattern `$variableName` passed regex test: `$test` pattern: `$rawPattern` even though it was set to fail.")
             }
         }
     }

--- a/detekt/src/main/kotlin/repo/RepoPatternUnnamedGroup.kt
+++ b/detekt/src/main/kotlin/repo/RepoPatternUnnamedGroup.kt
@@ -24,7 +24,6 @@ class RepoPatternUnnamedGroup(config: Config) : SkyHanniRule(config) {
         if (repoPatternElement.rawPattern.hasUnnamedGroup()) {
             delegate.reportIssue("Repo pattern `${repoPatternElement.variableName}` must not contain unnamed capture groups.")
         }
-
     }
 
     private fun String.hasUnnamedGroup(): Boolean {
@@ -34,5 +33,4 @@ class RepoPatternUnnamedGroup(config: Config) : SkyHanniRule(config) {
     companion object {
         val unnamedGroup = Regex("""(?<!\\)\((?!\?)""")
     }
-
 }

--- a/detekt/src/main/kotlin/repo/RepoPatternUnnamedGroup.kt
+++ b/detekt/src/main/kotlin/repo/RepoPatternUnnamedGroup.kt
@@ -1,0 +1,38 @@
+package at.hannibal2.skyhanni.detektrules.repo
+
+import at.hannibal2.skyhanni.detektrules.RepoPatternElement.Companion.asRepoPatternElement
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtPropertyDelegate
+
+class RepoPatternUnnamedGroup(config: Config) : SkyHanniRule(config) {
+    override val issue = Issue(
+        "RepoPatternUnnamedGroup",
+        Severity.Style,
+        "All repo patterns must not contain unnamed groups.",
+        Debt.FIVE_MINS,
+    )
+
+    override fun visitPropertyDelegate(delegate: KtPropertyDelegate) {
+        super.visitPropertyDelegate(delegate)
+
+        val repoPatternElement = delegate.asRepoPatternElement() ?: return
+
+        if (repoPatternElement.rawPattern.hasUnnamedGroup()) {
+            delegate.reportIssue("Repo pattern `${repoPatternElement.variableName}` must not contain unnamed capture groups.")
+        }
+
+    }
+
+    private fun String.hasUnnamedGroup(): Boolean {
+        return unnamedGroup.containsMatchIn(this)
+    }
+
+    companion object {
+        val unnamedGroup = Regex("""(?<!\\)\((?!\?)""")
+    }
+
+}

--- a/detekt/src/main/kotlin/repo/RepoRuleSetProvider.kt
+++ b/detekt/src/main/kotlin/repo/RepoRuleSetProvider.kt
@@ -15,6 +15,7 @@ class RepoRuleSetProvider : RuleSetProvider {
             listOf(
                 SkullTexturesUseRepo(config),
                 RepoPatternRegexTest(config),
+                RepoPatternUnnamedGroup(config),
             ),
         )
     }

--- a/detekt/src/main/kotlin/repo/SkullTexturesUseRepo.kt
+++ b/detekt/src/main/kotlin/repo/SkullTexturesUseRepo.kt
@@ -1,18 +1,18 @@
 package at.hannibal2.skyhanni.detektrules.repo
 
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
 /**
  * This rule reports all instances of hard-coded skull textures in the codebase.
  */
-class SkullTexturesUseRepo(config: Config) : Rule(config) {
+class SkullTexturesUseRepo(config: Config) : SkyHanniRule(config) {
     override val issue = Issue(
         "SkullTexturesUseRepo",
         Severity.Style,
@@ -22,7 +22,7 @@ class SkullTexturesUseRepo(config: Config) : Rule(config) {
 
     private val scannedTextureStarts = listOf(
         "ewogICJ0aW1l",
-        "eyJ0ZXh0dXJl"
+        "eyJ0ZXh0dXJl",
     )
 
     override fun visitStringTemplateExpression(expression: KtStringTemplateExpression) {
@@ -31,13 +31,7 @@ class SkullTexturesUseRepo(config: Config) : Rule(config) {
 
         for (textureStarters in scannedTextureStarts) {
             if (text.startsWith(textureStarters)) {
-                report(
-                    CodeSmell(
-                        issue,
-                        Entity.from(expression),
-                        "Avoid hard-coding skull texture text in strings.",
-                    ),
-                )
+                expression.reportIssue("Avoid hard-coding skull texture text in strings.")
             }
         }
         super.visitStringTemplateExpression(expression)

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -301,6 +301,103 @@
     <ID>RepoPatternRegexTest:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "string.playerchat", "(?&lt;important&gt;.*?)(?:§[f7r])*: .*", )</ID>
     <ID>RepoPatternRegexTest:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "time.amount", "(?:(?&lt;y&gt;\\d+) ?y(?:\\w* ?)?)?(?:(?&lt;d&gt;\\d+) ?d(?:\\w* ?)?)?(?:(?&lt;h&gt;\\d+) ?h(?:\\w* ?)?)?(?:(?&lt;m&gt;\\d+) ?m(?:\\w* ?)?)?(?:(?&lt;s&gt;\\d+) ?s(?:\\w* ?)?)?", )</ID>
     <ID>RepoPatternRegexTest:VisitorListener.kt$VisitorListener$by RepoPattern.pattern( "garden.visitor.offersaccepted", "§7Offers Accepted: §a(?&lt;offersAccepted&gt;\\d+)", )</ID>
+    <ID>RepoPatternUnnamedGroup:ArmorDropTracker.kt$ArmorDropTracker$by RepoPattern.pattern( "garden.armordrops.armor", "(FERMENTO|CROPIE|SQUASH|MELON)_(LEGGINGS|CHESTPLATE|BOOTS|HELMET)", )</ID>
+    <ID>RepoPatternUnnamedGroup:BasketWaypoints.kt$BasketWaypoints$by patternGroup.pattern( "basket", "^((?:§.)+You found a Candy Basket! (?:(?:§.)+\\((?:§.)+(?&lt;current&gt;\\d+)(?:§.)+/(?:§.)+(?&lt;max&gt;\\d+)(?:§.)+\\))?|(?:§.)+You already found this Candy Basket!)\$" )</ID>
+    <ID>RepoPatternUnnamedGroup:BestiaryData.kt$BestiaryData$by patternGroup.pattern( "title", "^(?:\\(\\d+/\\d+\\) )?(Bestiary|.+) ➜ (.+)\$" )</ID>
+    <ID>RepoPatternUnnamedGroup:BitsAPI.kt$BitsAPI$by bitsGuiGroup.pattern( "availablemenu", "§7Bits Available: §b(?&lt;toClaim&gt;[\\d,]+)(§3.+)?", )</ID>
+    <ID>RepoPatternUnnamedGroup:BitsAPI.kt$BitsAPI$by bitsGuiGroup.pattern( "cookiemenucookieactive", "(§7§cYou do not currently have a|§cBooster Cookie active!)", )</ID>
+    <ID>RepoPatternUnnamedGroup:BitsAPI.kt$BitsAPI$by bitsGuiGroup.pattern( "famerankmenuname", "^(Community Shop|Booster Cookie)$", )</ID>
+    <ID>RepoPatternUnnamedGroup:BitsAPI.kt$BitsAPI$by bitsGuiGroup.pattern( "famerankmenustack", "^(§aCommunity Shop|§eFame Rank)$", )</ID>
+    <ID>RepoPatternUnnamedGroup:BlazeSlayerDaggerHelper.kt$BlazeSlayerDaggerHelper$by RepoPattern.pattern( "slayer.blaze.dagger.attunement", "§cStrike using the §r(.+) §r§cattunement on your dagger!" )</ID>
+    <ID>RepoPatternUnnamedGroup:CakeTracker.kt$CakeTracker$by patternGroup.pattern( "cake.container", "Ender Chest \\(\\d{1,2}/\\d{1,2}\\)|.*Backpack(?:§r)? \\(Slot #\\d{1,2}\\)|New Year Cake Bag|(Large )?Chest", )</ID>
+    <ID>RepoPatternUnnamedGroup:ChatFilter.kt$ChatFilter$by RepoPattern.pattern( "chat.skymall.perk", "§eNew buff§r§r§r:(.*)", )</ID>
+    <ID>RepoPatternUnnamedGroup:DianaProfitTracker.kt$DianaProfitTracker$by patternGroup.pattern( "burrow.dug", "(§eYou dug out a Griffin Burrow!|§eYou finished the Griffin burrow chain!) .*", )</ID>
+    <ID>RepoPatternUnnamedGroup:DicerRngDropTracker.kt$DicerRngDropTracker$by melonPatternGroup.pattern( "crazyrare", "§d§lCRAZY RARE DROP! §r§eDicer dropped §r§[a|9](\\d+)x §r§[a|9]Enchanted Melon(?: Block)?§r§e!", )</ID>
+    <ID>RepoPatternUnnamedGroup:DicerRngDropTracker.kt$DicerRngDropTracker$by melonPatternGroup.pattern( "rare", "§9§lRARE DROP! §r§eDicer dropped §r§a(\\d+)x §r§aEnchanted Melon§r§e!", )</ID>
+    <ID>RepoPatternUnnamedGroup:DicerRngDropTracker.kt$DicerRngDropTracker$by melonPatternGroup.pattern( "rngesus", "§5§lPRAY TO RNGESUS DROP! §r§eDicer dropped §r§9(\\d+)x §r§9Enchanted Melon Block§r§e!", )</ID>
+    <ID>RepoPatternUnnamedGroup:DicerRngDropTracker.kt$DicerRngDropTracker$by melonPatternGroup.pattern( "uncommon", "§a§lUNCOMMON DROP! §r§eDicer dropped §r§a(\\d+)x §r§aEnchanted Melon§r§e!", )</ID>
+    <ID>RepoPatternUnnamedGroup:DicerRngDropTracker.kt$DicerRngDropTracker$by pumpkinPatternGroup.pattern( "crazyrare", "§d§lCRAZY RARE DROP! §r§eDicer dropped §r§a(\\d+)x §r§aEnchanted Pumpkin§r§e!", )</ID>
+    <ID>RepoPatternUnnamedGroup:DicerRngDropTracker.kt$DicerRngDropTracker$by pumpkinPatternGroup.pattern( "rare", "§9§lRARE DROP! §r§eDicer dropped §r§a(\\d+)x §r§aEnchanted Pumpkin§r§e!", )</ID>
+    <ID>RepoPatternUnnamedGroup:DicerRngDropTracker.kt$DicerRngDropTracker$by pumpkinPatternGroup.pattern( "rngesus", "§5§lPRAY TO RNGESUS DROP! §r§eDicer dropped §r§[a|9](\\d+)x §r§(aEnchanted|9Polished) Pumpkin§r§e!", )</ID>
+    <ID>RepoPatternUnnamedGroup:DicerRngDropTracker.kt$DicerRngDropTracker$by pumpkinPatternGroup.pattern( "uncommon", "§a§lUNCOMMON DROP! §r§eDicer dropped §r§a(\\d+)x §r§aEnchanted Pumpkin§r§e!", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonCleanEnd.kt$DungeonCleanEnd$by RepoPattern.pattern( "dungeon.end.chests.spawned", "(?:§f)?( *)§r§c(Master Mode )?The Catacombs §r§8- §r§eFloor (.*)", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonCopilot.kt$DungeonCopilot$by patternGroup.pattern( "countdown", "(.*) has started the dungeon countdown. The dungeon will begin in 1 minute.", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonCopilot.kt$DungeonCopilot$by patternGroup.pattern( "wither.door", "(.*) opened a §r§8§lWITHER §r§adoor!", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "carry", "(?i).*(CARRY|CARY|CARRIES|CARIES|COMP|TO CATA [0-9]{2}).*", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "entrance", "(.*Entrance)", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "floor", "(Floor .*)", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "floor.dungeon", "(Dungeon: .*)", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "floor.mastermode", "(MM|.*Master Mode) The Catacombs.*", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "floor.pattern", "(Floor: .*)", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "floor.type", "(The Catacombs).*|.*(MM The Catacombs).*", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "ineligible", "§c(Requires .*$|You don't meet the requirement!|Complete previous floor first!$)", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "nonpug", "(?i).*(PERM|VC|DISCORD).*", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "price", "(?i).*([0-9]{2,3}K|[0-9]{1,3}M|[0-9]+\\.[0-9]M|[0-9] ?MIL).*", )</ID>
+    <ID>RepoPatternUnnamedGroup:DungeonRankTabListColor.kt$DungeonRankTabListColor$by patternGroup.pattern( "rank", "^(?:§.)*(?&lt;sbLevel&gt;\\[(?:§.)*\\d+(?:§.)*]) (?&lt;rank&gt;(?:§.)*\\[(?:§.)*[^]]+(?:§.)*])? ?(?&lt;playerName&gt;\\S+) (?&lt;symbols&gt;[^(]*)\\((?:§.)*(?&lt;className&gt;\\S+) (?&lt;classLevel&gt;[CLXVI]+)(?:§.)*\\)(?:§.)*$" )</ID>
+    <ID>RepoPatternUnnamedGroup:EnchantParser.kt$EnchantParser$by patternGroup.pattern( "enchants.new", "(§7§l|§d§l|§9|§7)(?&lt;enchant&gt;[A-Za-z][A-Za-z '-]+) (?&lt;levelNumeral&gt;[IVXLCDM]+|[0-9]+)(?&lt;stacking&gt;(§r)?§9, |\$| §8\\d{1,3}([,.]\\d{1,3})*[kKmMbB]?)", )</ID>
+    <ID>RepoPatternUnnamedGroup:EnchantParser.kt$EnchantParser$by patternGroup.pattern( "exclusive", "^(?:(?:§.)+([A-Za-z][A-Za-z '-]+) (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:[,.]\\d{1,3})*)[kKmMbB]?)+\$", )</ID>
+    <ID>RepoPatternUnnamedGroup:EnchantParser.kt$EnchantParser$by patternGroup.pattern( "grayenchants", "^(Respiration|Aqua Affinity|Depth Strider|Efficiency).*", )</ID>
+    <ID>RepoPatternUnnamedGroup:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "armorability", "Tiered Bonus: .* [(](?&lt;pieces&gt;.*)/4[)]", )</ID>
+    <ID>RepoPatternUnnamedGroup:FishingAPI.kt$FishingAPI$by RepoPattern.pattern( "fishing.trophyfishing.armor", "(BRONZE|SILVER|GOLD|DIAMOND)_HUNTER_(HELMET|CHESTPLATE|LEGGINGS|BOOTS)", )</ID>
+    <ID>RepoPatternUnnamedGroup:GardenNextJacobContest.kt$GardenNextJacobContest$by patternGroup.pattern( "crop", "§(e○|6☘) §7(?&lt;crop&gt;.*)" )</ID>
+    <ID>RepoPatternUnnamedGroup:GardenVisitorCompactChat.kt$GardenVisitorCompactChat$by patternGroup.pattern( "disregardrewardname", "^(Copper|Farming XP|Farming Experience|Garden Experience|Bits)\$", )</ID>
+    <ID>RepoPatternUnnamedGroup:GardenVisitorDropStatistics.kt$GardenVisitorDropStatistics$by patternGroup.pattern( "accept", "OFFER ACCEPTED with (?&lt;visitor&gt;.*) [(](?&lt;rarity&gt;.*)[)]", )</ID>
+    <ID>RepoPatternUnnamedGroup:HoppityCollectionStats.kt$HoppityCollectionStats$by patternGroup.pattern( "rabbit.requirement.location", "Find 15 unique egg locations in (the )?(?&lt;location&gt;.*)\\..*", )</ID>
+    <ID>RepoPatternUnnamedGroup:HoppityEggsManager.kt$HoppityEggsManager$by ChocolateFactoryAPI.patternGroup.pattern( "egg.bought", "§aYou bought §r(?&lt;rabbitname&gt;.*?) §r§afor §r§6((\\d|,)*) Coins§r§a!", )</ID>
+    <ID>RepoPatternUnnamedGroup:HoppityEggsManager.kt$HoppityEggsManager$by ChocolateFactoryAPI.patternGroup.pattern( "rabbit.found.new", "§d§lNEW RABBIT! (?:((§6\\+(?&lt;chocolate&gt;.*) Chocolate §7and )?§6\\+(?&lt;perSecond&gt;.*)x Chocolate §7per second!)|(?&lt;other&gt;.*))", )</ID>
+    <ID>RepoPatternUnnamedGroup:HotmData.kt$HotmData.Companion$by patternGroup.pattern( "perk.enable", "§a§lENABLED|(§.)*SELECTED", )</ID>
+    <ID>RepoPatternUnnamedGroup:HotmData.kt$HotmData.Companion$by patternGroup.pattern( "perk.notunlocked", "(§.)*Requires.*|.*Mountain!|(§.)*Click to unlock!|", )</ID>
+    <ID>RepoPatternUnnamedGroup:HypixelData.kt$HypixelData$by patternGroup.pattern( "islandname", "(?:§.)*(Area|Dungeon): (?:§.)*(?&lt;island&gt;.*)", )</ID>
+    <ID>RepoPatternUnnamedGroup:InGameDateDisplay.kt$InGameDateDisplay$by patternGroup.pattern( "date", ".*((Early|Late) )?(Winter|Spring|Summer|Autumn) [0-9]{1,2}(nd|rd|th|st)?.*", )</ID>
+    <ID>RepoPatternUnnamedGroup:InGameDateDisplay.kt$InGameDateDisplay$by patternGroup.pattern( "symbols", "([☀☽࿇])", )</ID>
+    <ID>RepoPatternUnnamedGroup:IslandGraphs.kt$IslandGraphs$by patternGroup.pattern( "glacitetunnels", "(Glacite Tunnels|Dwarven Base Camp|Great Glacite Lake|Fossil Research Center)", )</ID>
+    <ID>RepoPatternUnnamedGroup:ItemAbilityCooldown.kt$ItemAbilityCooldown$by patternGroup.pattern( "alignedother", "§eYou aligned §r§a.* §r§eother player(s)?!", )</ID>
+    <ID>RepoPatternUnnamedGroup:ItemAddManager.kt$ItemAddManager$by RepoPattern.pattern( "data.itemmanager.diceroll", "§eYour §r§(5|6High Class )Archfiend Dice §r§erolled a §r§.(?&lt;number&gt;.)§r§e! Bonus: §r§.(?&lt;hearts&gt;.*)❤", )</ID>
+    <ID>RepoPatternUnnamedGroup:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$by patternGroup.pattern( "bingogoalrank", "(§.)*You were the (§.)*(?&lt;rank&gt;[\\w]+)(?&lt;ordinal&gt;(st|nd|rd|th)) (§.)*to", )</ID>
+    <ID>RepoPatternUnnamedGroup:LimboPlaytime.kt$LimboPlaytime$by patternGroup.pattern( "hours", "§5§o§b([\\d.,]+) hours.+\$" )</ID>
+    <ID>RepoPatternUnnamedGroup:LimboPlaytime.kt$LimboPlaytime$by patternGroup.pattern( "minutes", "§5§o§a([\\d.,]+) minutes.+\$" )</ID>
+    <ID>RepoPatternUnnamedGroup:MagicalPowerDisplay.kt$MagicalPowerDisplay$by RepoPattern.pattern( "inv.acceptable", "^(Accessory Bag(?: \\(\\d+\\/\\d+\\))?|Auctions Browser|Manage Auctions|Auctions: \".*\"?)$", )</ID>
+    <ID>RepoPatternUnnamedGroup:MaxwellAPI.kt$MaxwellAPI$by patternGroup.pattern( "chat.power", "§eYou selected the §a(?&lt;power&gt;.*) §e(power )?for your §aAccessory Bag§e!", )</ID>
+    <ID>RepoPatternUnnamedGroup:MinionFeatures.kt$MinionFeatures$by patternGroup.pattern( "chat.coin", "§aYou received §r§6(.*) coins§r§a!" )</ID>
+    <ID>RepoPatternUnnamedGroup:PlayerChatManager.kt$PlayerChatManager$by patternGroup.pattern( "privateislandrank", "(?&lt;prefix&gt;.*?)(?&lt;privateIslandRank&gt;§.\\[(?!MVP(§.\\++)?§.]|VIP\\+*|YOU§.TUBE|ADMIN|MOD|GM)[^]]+\\]) (?&lt;suffix&gt;.*)" )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.ascensionrope", "§r§9Ascension Rope( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.essence", "§r§d(?:Gold|Diamond) Essence( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.gemstone", "§r§[fa95][❤❈☘⸕✎✧❁] (?&lt;tier&gt;Rough|Flawed|Fine|Flawless) (?&lt;gem&gt;Ruby|Amethyst|Jade|Amber|Sapphire|Topaz|Jasper) Gemstone( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.goblineggs", "(?:§.)*(?&lt;color&gt;[a-zA-Z]+)? ?Goblin Egg( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.jungleheart", "§r§6Jungle Heart( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.oilbarrel", "§r§aOil Barrel( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.pickonimbus", "§r§5Pickonimbus 2000( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.powder", "§r§[d2](?:Gemstone|Mithril) Powder( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.prehistoricegg", "§r§fPrehistoric Egg( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.robotparts", "§r§9(?:FTX 3070|Synthetic Heart|Control Switch|Robotron Reflector|Electron Transmitter|Superlite Motor)( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.sludgejuice", "§r§aSludge Juice( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.treasurite", "§r§5Treasurite( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.wishingcompass", "§r§aWishing Compass( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:PowderMiningChatFilter.kt$PowderMiningChatFilter$by patternGroup.pattern( "reward.yoggie", "§r§aYoggie( §r§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternUnnamedGroup:QuiverAPI.kt$QuiverAPI$by group.pattern("fakebows", "^(BOSS_SPIRIT_BOW|CRYPT_BOW)$")</ID>
+    <ID>RepoPatternUnnamedGroup:RareDropMessages.kt$RareDropMessages$by chatGroup.pattern( "pet.oringopattern", "(?&lt;start&gt;§e\\[NPC] Oringo§f: §b✆ §f§r§8• )§(?&lt;rarityColor&gt;.)(?&lt;petName&gt;[^§(.]+)(?&lt;end&gt; Pet)" )</ID>
+    <ID>RepoPatternUnnamedGroup:RareDropMessages.kt$RareDropMessages$by chatGroup.pattern( "pet.petclaimedmessage", "(?&lt;start&gt;(?:§.)*You claimed a )(?:§.)*§(?&lt;rarityColor&gt;.)(?&lt;petName&gt;[^§(.]+)(?&lt;end&gt;.*You can manage your Pets.*)" )</ID>
+    <ID>RepoPatternUnnamedGroup:RareDropMessages.kt$RareDropMessages$by chatGroup.pattern( "pet.petdroppedmessage", "(?&lt;start&gt;(?:§.)*PET DROP! )(?:§.)*§(?&lt;rarityColor&gt;.)(?&lt;petName&gt;[^§(.]+)(?&lt;end&gt; .*)" )</ID>
+    <ID>RepoPatternUnnamedGroup:RareDropMessages.kt$RareDropMessages$by chatGroup.pattern( "pet.petfishedmessage", "(?&lt;start&gt;(?:§.)*GREAT CATCH! (?:§.)*You found a (?:§.)*\\[Lvl 1] )(?:§.)*§(?&lt;rarityColor&gt;.)(?&lt;petName&gt;[^§(.]+)(?&lt;end&gt;.*)" )</ID>
+    <ID>RepoPatternUnnamedGroup:RareDropMessages.kt$RareDropMessages$by chatGroup.pattern( "pet.petobtainedmessage", "(?&lt;start&gt;.*has obtained (?:§.)*\\[Lvl 1] )(?:§.)*§(?&lt;rarityColor&gt;.)(?&lt;petName&gt;[^§(.]+)(?&lt;end&gt;.*)" )</ID>
+    <ID>RepoPatternUnnamedGroup:RiftBloodEffigies.kt$RiftBloodEffigies$by patternGroup.pattern( "heart", "Effigies: (?&lt;hearts&gt;((§[7c])?⧯)*)" )</ID>
+    <ID>RepoPatternUnnamedGroup:SackAPI.kt$SackAPI$by patternGroup.pattern( "sack", "^(.* Sack|Enchanted .* Sack)\$", )</ID>
+    <ID>RepoPatternUnnamedGroup:ScoreboardPattern.kt$ScoreboardPattern$by dungeonSb.pattern( "teammates", "(?:§.)*(?&lt;classAbbv&gt;\\[\\w]) (?:§.)*(?&lt;username&gt;\\w{2,16}) ((?:§.)*(?&lt;classLevel&gt;\\[Lvl?(?&lt;level&gt;[\\w,.]+)?]?)|(?:§.)*(?&lt;health&gt;[\\w,.]+)(?:§.)*.?)", )</ID>
+    <ID>RepoPatternUnnamedGroup:ScoreboardPattern.kt$ScoreboardPattern$by farmingSb.pattern( "medals", "§[6fc]§l(GOLD|SILVER|BRONZE) §fmedals: §[6fc][\\d.,]+", )</ID>
+    <ID>RepoPatternUnnamedGroup:ScoreboardPattern.kt$ScoreboardPattern$by miningSb.pattern( "raffletickets", "Tickets: §a\\d+ §7\\(\\d+(\\.\\d)?%\\)", )</ID>
+    <ID>RepoPatternUnnamedGroup:ScoreboardPattern.kt$ScoreboardPattern$by miscSb.pattern( "flightduration", "^\\s*Flight Duration: §a(:?\\d{1,3})*$", )</ID>
+    <ID>RepoPatternUnnamedGroup:ScoreboardPattern.kt$ScoreboardPattern$by multiUseSb.pattern( "timeelapsed", "(?:§.)*Time Elapsed: (?:§.)*(?&lt;time&gt;(\\w+[ydhms] ?)+)", )</ID>
+    <ID>RepoPatternUnnamedGroup:SummoningMobManager.kt$SummoningMobManager$by patternGroup.pattern( "seraphrecall", "§cThe Seraph recalled your (\\d+) summoned allies!", )</ID>
+    <ID>RepoPatternUnnamedGroup:SummoningMobManager.kt$SummoningMobManager$by patternGroup.pattern( "spawn", "§aYou have spawned your (.+) §r§asoul! §r§d\\((\\d+) Mana\\)", )</ID>
+    <ID>RepoPatternUnnamedGroup:TabListReader.kt$TabListReader$by patternGroup.pattern( "cookie", "Cookie Buff(?:§.)*(?:\\n(§.)*§7.+)*" )</ID>
+    <ID>RepoPatternUnnamedGroup:TabListReader.kt$TabListReader$by patternGroup.pattern( "dungeonbuff", "Dungeon Buffs(?:§.)*(?:\\n(§.)*§7.+)*" )</ID>
+    <ID>RepoPatternUnnamedGroup:TabListReader.kt$TabListReader$by patternGroup.pattern( "winterpowerups", "Active Power Ups(?:§.)*(?:\\n(§.)*§7.+)*" )</ID>
+    <ID>RepoPatternUnnamedGroup:TabWidgetSettings.kt$TabWidgetSettings$by patternGroup.pattern( "click.disable", ".*(disable!)", )</ID>
+    <ID>RepoPatternUnnamedGroup:TabWidgetSettings.kt$TabWidgetSettings$by patternGroup.pattern( "gui", "(Widgets in.*|Widgets on.*)", )</ID>
+    <ID>RepoPatternUnnamedGroup:TheGreatSpook.kt$TheGreatSpook$by patternGroup.pattern( "chat.speaking", "§4\\[FEAR] Public Speaking Demon§r§f: (Speak|Say something interesting) (?&lt;name&gt;.*)!", )</ID>
+    <ID>RepoPatternUnnamedGroup:UniqueGiftingOpportunitiesFeatures.kt$UniqueGiftingOpportunitiesFeatures$by patternGroup.pattern( "gifted", "§6\\+1 Unique Gift given! To ([^§]+)§r§6!", )</ID>
+    <ID>RepoPatternUnnamedGroup:UtilsPatterns.kt$UtilsPatterns$by RepoPattern.pattern( "string.isroman", "^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})", )</ID>
+    <ID>RepoPatternUnnamedGroup:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "item.name.bait", "^(Obfuscated.*|.* Bait)$", )</ID>
     <ID>ReturnCount:AnitaMedalProfit.kt$AnitaMedalProfit$private fun readItem(slot: Int, item: ItemStack, table: MutableList&lt;DisplayTableEntry&gt;)</ID>
     <ID>ReturnCount:BingoNextStepHelper.kt$BingoNextStepHelper$private fun readDescription(description: String): NextStep?</ID>
     <ID>ReturnCount:BroodmotherFeatures.kt$BroodmotherFeatures$private fun onStageUpdate()</ID>


### PR DESCRIPTION
## What
Cleaned up the logic for adding code issues in detekt
Made a method for finding repo patterns in the code

Disallowed the use of making repo patterns that have unnamed capture groups as this is bad.


## Changelog Technical Details
+ Disallowed repo patterns from having unnamed capture groups. - CalMWolfs