### PR TITLE
Fix: Cactus/Sugar Cane Money Per Hour

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -168,8 +168,7 @@ object CropMoneyDisplay {
             }
 
             if (config.armor) {
-                val amountPerHour =
-                    it.multiplier * GardenCropSpeed.getRecentBPS() * ArmorDropTracker.getDropsPerHour(it)
+                val amountPerHour = GardenCropSpeed.getRecentBPS() * ArmorDropTracker.getDropsPerHour(it)
                 extraArmorCoins = amountPerHour * it.specialDropType.toInternalName().getNpcPrice()
             }
         }


### PR DESCRIPTION
## What
Fixed money per hour from Fermento drops for Cactus and Sugar Cane.

> Fixed an issue causing Sugar Cane and Cactus to roll twice for pests/rare crops/dyes when harvested.
https://hypixel.net/threads/hypixel-skyblock-0-20-8-pesthunters-wares-chocolate-factory-additions-and-more.5804948/

## Changelog Fixes
+ Fixed money per hour calculations from Fermento drops for Cactus and Sugar Cane. - Luna
    * Hypixel fixed the issue where Fermento drops were being given twice as much.