### PR TITLE
Improvement: Directly set optimal speed

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
@@ -198,7 +198,7 @@ object GardenOptimalSpeed {
             text,
             config::warning,
             actionName = "change the speed",
-            action = { HypixelCommands.setMaxSpeed() },
+            action = { HypixelCommands.setMaxSpeed(optimalSpeed) },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -142,9 +142,10 @@ object HypixelCommands {
         send("pq $quality")
     }
 
-    // Changes the speed of rancher boots in garden
-    fun setMaxSpeed() {
-        send("setmaxspeed")
+    // Changes the speed of Rancher's Boots in The Garden
+    fun setMaxSpeed(speed: Int? = null) = when {
+        speed == null -> send("setmaxspeed")
+        else -> send("setmaxspeed $speed")
     }
 
     fun showRng(major: String? = null, minor: String? = null) = when {

--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -142,7 +142,7 @@ object HypixelCommands {
         send("pq $quality")
     }
 
-    // Changes the speed of Rancher's Boots in The Garden
+    // Changes the speed of Rancher's Boots
     fun setMaxSpeed(speed: Int? = null) = when {
         speed == null -> send("setmaxspeed")
         else -> send("setmaxspeed $speed")


### PR DESCRIPTION
## What
Directly set optimal speed when clicking on wrong speed message in chat instead of opening sign GUI.

Hypixel made this possible in SkyBlock 0.20.8.

## Changelog Improvements
+ The optimal speed for Rancher's Boots is now automatically set when clicking on the wrong speed message in chat, eliminating the need to enter it manually. - Luna