### PR TITLE
Improvement: Replace same message for New Year Cake Reminder

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/NewYearCakeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/NewYearCakeReminder.kt
@@ -68,6 +68,7 @@ object NewYearCakeReminder {
             config::newYearCakeReminder,
             actionName = "open the baker menu",
             action = { HypixelCommands.openBaker() },
+            replaceSameMessage = true,
         )
     }
 


### PR DESCRIPTION
## What
Added `replaceSameMessage = true` to New Year Cake Reminder.

## Changelog Improvements
+ Previous reminders for New Year Cake are now replaced instead of spamming the chat. - Luna