### PR TITLE
Backend: No unknown lines after changes are declared

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,5 +13,5 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("com.github.SkyHanniStudios:SkyHanniChangelogBuilder:1.0.1")
+    implementation("com.github.SkyHanniStudios:SkyHanniChangelogBuilder:1.0.2")
 }


### PR DESCRIPTION
By request of hannibal2, disallow unknown lines after changes are declared

exclude_from_changelog