### PR TITLE
Backend: Remove usages of deprecated color functions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
@@ -9,8 +9,6 @@ import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColorInt
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
@@ -23,6 +21,8 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawSphereWireframeInWorld
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColorInt
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
 import at.hannibal2.skyhanni.utils.getLorenzVec
@@ -170,7 +170,7 @@ object FlareDisplay {
                 FlareType.WARNING -> config.warningColor
                 FlareType.ALERT -> config.alertColor
                 FlareType.SOS -> config.sosColor
-            }.toChromaColor()
+            }.toSpecialColor()
 
             when (config.outlineType) {
                 FlareConfig.OutlineType.FILLED -> {
@@ -200,7 +200,7 @@ object FlareDisplay {
             0,
             minecraft.displayWidth,
             minecraft.displayHeight,
-            (alpha shl 24) or (config.flashColor.toChromaColorInt() and 0xFFFFFF),
+            (alpha shl 24) or (config.flashColor.toSpecialColorInt() and 0xFFFFFF),
         )
         GlStateManager.color(1F, 1F, 1F, 1F)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/cosmetics/ArrowTrail.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/cosmetics/ArrowTrail.kt
@@ -6,12 +6,12 @@ import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.getPrevLorenzVec
 import net.minecraft.client.Minecraft
@@ -55,12 +55,12 @@ object ArrowTrail {
     fun onWorldRender(event: LorenzRenderWorldEvent) {
         if (!isEnabled()) return
         val color = if (config.handlePlayerArrowsDifferently) config.playerArrowColor else config.arrowColor
-        val playerArrowColor = color.toChromaColor()
+        val playerArrowColor = color.toSpecialColor()
         listYourArrow.forEach {
             event.draw3DLine(it.start, it.end, playerArrowColor, config.lineWidth, true)
         }
         if (!config.hideOtherArrows) {
-            val arrowColor = config.arrowColor.toChromaColor()
+            val arrowColor = config.arrowColor.toSpecialColor()
             listAllArrow.forEach {
                 event.draw3DLine(it.start, it.end, arrowColor, config.lineWidth, true)
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/cosmetics/CosmeticFollowingLine.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/cosmetics/CosmeticFollowingLine.kt
@@ -8,13 +8,13 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.RenderUtils.exactLocation
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.awt.Color
@@ -43,7 +43,7 @@ object CosmeticFollowingLine {
         updateClose(event)
 
         val firstPerson = Minecraft.getMinecraft().gameSettings.thirdPersonView == 0
-        val color = config.lineColor.toChromaColor()
+        val color = config.lineColor.toSpecialColor()
 
         renderClose(event, firstPerson, color)
         renderFar(event, firstPerson, color)

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHighlightClickedBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHighlightClickedBlocks.kt
@@ -63,8 +63,7 @@ object DungeonHighlightClickedBlocks {
         }
 
         if (lockedPattern.matches(event.message)) {
-            blocks.lastOrNull { it.value.displayText.contains("Chest") }?.value?.color =
-                config.lockedChestColor.toSpecialColor()
+            blocks.lastOrNull { it.value.displayText.contains("Chest") }?.value?.color = config.lockedChestColor.toSpecialColor()
         }
     }
 
@@ -75,8 +74,7 @@ object DungeonHighlightClickedBlocks {
 
         val type = event.blockType
 
-        val color =
-            if (config.randomColor) getRandomColor().toColor() else getBlockProperties(type).color.toSpecialColor()
+        val color = if (config.randomColor) getRandomColor().toColor() else getBlockProperties(type).color.toSpecialColor()
         val displayText = ExtendedChatColor(color.rgb, false).toString() + "Clicked " + getBlockProperties(type).name
         blocks[event.position] = ClickedBlock(displayText, color)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHighlightClickedBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHighlightClickedBlocks.kt
@@ -8,13 +8,13 @@ import at.hannibal2.skyhanni.events.DungeonBlockClickEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ExtendedChatColor
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.RenderUtils.drawString
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -63,7 +63,8 @@ object DungeonHighlightClickedBlocks {
         }
 
         if (lockedPattern.matches(event.message)) {
-            blocks.lastOrNull { it.value.displayText.contains("Chest") }?.value?.color = config.lockedChestColor.toChromaColor()
+            blocks.lastOrNull { it.value.displayText.contains("Chest") }?.value?.color =
+                config.lockedChestColor.toSpecialColor()
         }
     }
 
@@ -74,7 +75,8 @@ object DungeonHighlightClickedBlocks {
 
         val type = event.blockType
 
-        val color = if (config.randomColor) getRandomColor().toColor() else getBlockProperties(type).color.toChromaColor()
+        val color =
+            if (config.randomColor) getRandomColor().toColor() else getBlockProperties(type).color.toSpecialColor()
         val displayText = ExtendedChatColor(color.rgb, false).toString() + "Clicked " + getBlockProperties(type).name
         blocks[event.position] = ClickedBlock(displayText, color)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
@@ -9,12 +9,12 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.exactPlayerEyeLocation
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.awt.Color
@@ -87,7 +87,7 @@ object DungeonMobManager {
                 event.draw3DLine(
                     it.baseEntity.getLorenzVec().add(y = 0.15),
                     event.exactPlayerEyeLocation(),
-                    fel.colour.get().toChromaColor(),
+                    fel.colour.get().toSpecialColor(),
                     3,
                     true,
                 )
@@ -97,7 +97,7 @@ object DungeonMobManager {
         felOnTheGround.removeIf { mob ->
             event.drawWaypointFilled(
                 mob.baseEntity.getLorenzVec().add(-0.5, -0.23, -0.5),
-                fel.colour.get().toChromaColor(),
+                fel.colour.get().toSpecialColor(),
                 seeThroughBlocks = false,
                 beacon = false,
                 extraSize = -0.2,
@@ -125,7 +125,7 @@ object DungeonMobManager {
         }
     }
 
-    private fun getStarColor(): Color = starredConfig.colour.get().toChromaColor()
+    private fun getStarColor(): Color = starredConfig.colour.get().toSpecialColor()
 
     private fun handleStar0(mob: Mob, colour: Color?) {
         if (mob.isInvisible()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonsRaceGuide.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonsRaceGuide.kt
@@ -9,11 +9,11 @@ import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.ParkourHelper
 import at.hannibal2.skyhanni.utils.RegexUtils.findMatcher
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -78,7 +78,7 @@ object DungeonsRaceGuide {
     private fun updateConfig() {
         parkourHelpers.values.forEach {
             it.rainbowColor = config.rainbowColor.get()
-            it.monochromeColor = config.monochromeColor.get().toChromaColor()
+            it.monochromeColor = config.monochromeColor.get().toSpecialColor()
             it.lookAhead = config.lookAhead.get() + 1
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/HighlightInquisitors.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/HighlightInquisitors.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.diana.InquisitorFoundEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColorInt
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColorInt
 
 @SkyHanniModule
 object HighlightInquisitors {
@@ -18,7 +18,7 @@ object HighlightInquisitors {
 
         val inquisitor = event.inquisitorEntity
 
-        val color = config.color.toChromaColorInt()
+        val color = config.color.toSpecialColorInt()
         RenderLivingEntityHelper.setEntityColorWithNoHurtTime(inquisitor, color) { config.highlightInquisitors }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCallWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCallWarning.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColorInt
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.HypixelCommands
@@ -18,6 +17,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColorInt
 import at.hannibal2.skyhanni.utils.StringUtils.isValidUuid
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
@@ -136,7 +136,7 @@ object HoppityCallWarning {
             minecraft.displayWidth,
             minecraft.displayHeight,
             // Apply the shifted alpha and combine it with the RGB components of flashColor.
-            shiftedRandomAlpha or (config.flashColor.toChromaColorInt() and 0xFFFFFF),
+            shiftedRandomAlpha or (config.flashColor.toSpecialColorInt() and 0xFFFFFF),
         )
         GlStateManager.color(1F, 1F, 1F, 1F)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.events.hoppity.EggFoundEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -30,6 +29,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawLineToEye
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.exactPlayerEyeLocation
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraft.item.ItemStack
 import net.minecraft.util.EnumParticleTypes
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -147,7 +147,7 @@ object HoppityEggLocator {
                     if (eyeLocation.distance(it) > 2) {
                         drawWaypointFilled(
                             it,
-                            config.waypointColor.toChromaColor(),
+                            config.waypointColor.toSpecialColor(),
                             seeThroughBlocks = true,
                         )
                         drawDynamicText(it.up(), "§aGuess", 1.5)
@@ -164,7 +164,7 @@ object HoppityEggLocator {
         val shouldMarkDuplicate = config.highlightDuplicateEggLocations && HoppityEggLocations.hasCollectedEgg(location)
         val possibleDuplicateLabel = if (shouldMarkDuplicate) "$label §c(Duplicate Location)" else label
         if (!shouldMarkDuplicate) {
-            drawWaypointFilled(location, config.waypointColor.toChromaColor(), seeThroughBlocks = true)
+            drawWaypointFilled(location, config.waypointColor.toSpecialColor(), seeThroughBlocks = true)
         } else {
             drawColor(location, LorenzColor.RED.toColor(), false, 0.5f)
         }
@@ -276,7 +276,7 @@ object HoppityEggLocator {
         if (!config.showPathFinder) return
         val location = possibleEggLocations.firstOrNull() ?: return
 
-        val color = config.waypointColor.toChromaColor()
+        val color = config.waypointColor.toSpecialColor()
 
         IslandGraphs.pathFind(location, "Hoppity Egg", color, condition = { config.showPathFinder })
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -22,6 +21,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawSphereInWorld
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSphereWireframeInWorld
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.SoundUtils.playPlingSound
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -91,7 +91,7 @@ object TotemOfCorruption {
         if (!isEffectiveAreaEnabled()) return
         if (totems.isEmpty()) return
 
-        val color = config.color.toChromaColor()
+        val color = config.color.toSpecialColor()
         for (totem in totems) {
             // The center of the totem is the upper part of the armor stand
             when (config.outlineType) {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/RenderBackground.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/RenderBackground.kt
@@ -5,8 +5,8 @@ import at.hannibal2.skyhanni.data.GuiEditManager
 import at.hannibal2.skyhanni.data.GuiEditManager.getAbsX
 import at.hannibal2.skyhanni.data.GuiEditManager.getAbsY
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.backgroundConfig
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.RenderUtils
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraft.util.ResourceLocation
@@ -28,8 +28,8 @@ object RenderBackground {
                 0,
                 backgroundConfig.roundedCornerSmoothness,
                 1,
-                outline.colorTop.toChromaColor().rgb,
-                outline.colorBottom.toChromaColor().rgb,
+                outline.colorTop.toSpecialColor().rgb,
+                outline.colorBottom.toSpecialColor().rgb,
                 outline.thickness,
                 outline.blur,
                 horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
@@ -52,7 +52,7 @@ object RenderBackground {
         } else {
             Renderable.drawInsideRoundedRect(
                 renderable,
-                backgroundConfig.color.toChromaColor(),
+                backgroundConfig.color.toSpecialColor(),
                 borderSize,
                 backgroundConfig.roundedCornerSmoothness,
                 1,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.features.inventory.patternGroup
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.HypixelCommands
@@ -36,6 +35,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraft.inventory.ContainerChest
@@ -66,8 +66,8 @@ object CakeTracker {
     private var cakeRenderables = listOf<Renderable>()
     private var lastKnownCakeDataHash = 0
 
-    private val unobtainedHighlightColor: Color get() = config.unobtainedAuctionHighlightColor.toChromaColor()
-    private val obtainedHighlightColor: Color get() = config.obtainedAuctionHighlightColor.toChromaColor()
+    private val unobtainedHighlightColor: Color get() = config.unobtainedAuctionHighlightColor.toSpecialColor()
+    private val obtainedHighlightColor: Color get() = config.obtainedAuctionHighlightColor.toSpecialColor()
 
     /**
      * REGEX-TEST: §cNew Year Cake (Year 360)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryScreenFlash.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryScreenFlash.kt
@@ -10,11 +10,11 @@ import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactor
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryDataLoader.clickMeGoldenRabbitPattern
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryDataLoader.clickMeRabbitPattern
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColorInt
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColorInt
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
 import net.minecraft.client.renderer.GlStateManager
@@ -64,7 +64,7 @@ object ChocolateFactoryScreenFlash {
             0,
             minecraft.displayWidth,
             minecraft.displayHeight,
-            (alpha shl 24) or (config.rabbitWarning.flashColor.toChromaColorInt() and 0xFFFFFF),
+            (alpha shl 24) or (config.rabbitWarning.flashColor.toSpecialColorInt() and 0xFFFFFF),
         )
         GlStateManager.color(1F, 1F, 1F, 1F)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -17,8 +17,6 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.darker
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColorInt
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.transformIf
 import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
@@ -31,6 +29,8 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColorInt
 import at.hannibal2.skyhanni.utils.compat.getTooltipCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraft.client.Minecraft
@@ -388,7 +388,7 @@ object CustomWardrobe {
                 ),
                 blockBottomHover = false,
             ),
-            config.color.backgroundColor.toChromaColor(),
+            config.color.backgroundColor.toSpecialColor(),
             padding = borderPadding,
         )
 
@@ -525,8 +525,8 @@ object CustomWardrobe {
                 ),
                 hoveredColor,
                 padding = 0,
-                topOutlineColor = config.color.topBorderColor.toChromaColorInt(),
-                bottomOutlineColor = config.color.bottomBorderColor.toChromaColorInt(),
+                topOutlineColor = config.color.topBorderColor.toSpecialColorInt(),
+                bottomOutlineColor = config.color.bottomBorderColor.toSpecialColorInt(),
                 borderOutlineThickness = 2,
                 horizontalAlign = HorizontalAlignment.CENTER,
             ),
@@ -589,7 +589,7 @@ object CustomWardrobe {
         )
 
     private fun WardrobeSlot.getOutlineColor(): Pair<Color, Color> {
-        val (top, bottom) = config.color.topBorderColor.toChromaColor() to config.color.bottomBorderColor.toChromaColor()
+        val (top, bottom) = config.color.topBorderColor.toSpecialColor() to config.color.bottomBorderColor.toSpecialColor()
         return when {
             isEmpty() || locked -> ColorUtils.TRANSPARENT_COLOR to ColorUtils.TRANSPARENT_COLOR
             !isInCurrentPage() -> top.darker(0.5) to bottom.darker(0.5)
@@ -624,8 +624,8 @@ object CustomWardrobe {
             isCurrentSlot() -> equippedColor
             favorite && !config.onlyFavorites -> favoriteColor
             else -> null
-        }?.toChromaColor()?.transformIf({ !isInCurrentPage() }) { darker() }
-            ?: (if (isInCurrentPage()) samePageColor else otherPageColor).toChromaColor()
+        }?.toSpecialColor()?.transformIf({ !isInCurrentPage() }) { darker() }
+            ?: (if (isInCurrentPage()) samePageColor else otherPageColor).toSpecialColor()
                 .transformIf({ locked || isEmpty() }) { darker(0.2) }.addAlpha(100)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
@@ -10,13 +10,13 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.features.nether.ashfang.AshfangFreezeCooldown
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraft.client.Minecraft
 import net.minecraft.util.EnumParticleTypes
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -58,7 +58,7 @@ object FireVeilWandParticles {
         if (config.display != DisplayEntry.LINE) return
         if (lastClick.passedSince() > 5.5.seconds) return
 
-        val color = config.displayColor.toChromaColor()
+        val color = config.displayColor.toSpecialColor()
         RenderUtils.drawCircle(Minecraft.getMinecraft().thePlayer, event.partialTicks, 3.5, color)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/DeepCavernsGuide.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/DeepCavernsGuide.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.render.gui.ReplaceItemEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -24,6 +23,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.ParkourHelper
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.inventory.ContainerLocalMenu
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -89,7 +89,7 @@ object DeepCavernsGuide {
     private fun updateConfig() {
         parkourHelper?.run {
             rainbowColor = config.rainbowColor.get()
-            monochromeColor = config.monochromeColor.get().toChromaColor()
+            monochromeColor = config.monochromeColor.get().toSpecialColor()
             lookAhead = config.lookAhead.get() + 1
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -24,7 +24,6 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.addString
 import at.hannibal2.skyhanni.utils.CollectionUtils.filterNotNullKeys
 import at.hannibal2.skyhanni.utils.ColorUtils.getFirstColorCode
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.GraphUtils
@@ -48,6 +47,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -475,7 +475,7 @@ object TunnelsMaps {
         goal?.name?.getFirstColorCode()?.toLorenzColor()?.takeIf { it != LorenzColor.WHITE }?.toColor()
     } else {
         null
-    } ?: config.pathColour.toChromaColor()
+    } ?: config.pathColour.toSpecialColor()
 
     @SubscribeEvent
     fun onKeyPress(event: LorenzKeyPressEvent) {
@@ -536,5 +536,6 @@ object TunnelsMaps {
 
     private val areas = setOf("Glacite Tunnels", "Dwarven Base Camp", "Great Glacite Lake", "Fossil Research Center")
 
-    private fun isEnabled() = IslandType.DWARVEN_MINES.isInIsland() && config.enable && LorenzUtils.skyBlockArea in areas
+    private fun isEnabled() =
+        IslandType.DWARVEN_MINES.isInIsland() && config.enable && LorenzUtils.skyBlockArea in areas
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -536,6 +536,5 @@ object TunnelsMaps {
 
     private val areas = setOf("Glacite Tunnels", "Dwarven Base Camp", "Great Glacite Lake", "Fossil Research Center")
 
-    private fun isEnabled() =
-        IslandType.DWARVEN_MINES.isInIsland() && config.enable && LorenzUtils.skyBlockArea in areas
+    private fun isEnabled() = IslandType.DWARVEN_MINES.isInIsland() && config.enable && LorenzUtils.skyBlockArea in areas
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/AuctionHousePriceComparison.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/AuctionHousePriceComparison.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.features.inventory.AuctionsHighlighter
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -16,6 +15,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraft.client.player.inventory.ContainerLocalMenu
 import net.minecraft.item.ItemStack
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -77,11 +77,11 @@ object AuctionHousePriceComparison {
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!isEnabled()) return
 
-        val good = config.good.toChromaColor()
-        val veryGood = config.veryGood.toChromaColor()
+        val good = config.good.toSpecialColor()
+        val veryGood = config.veryGood.toSpecialColor()
 
-        val bad = config.bad.toChromaColor()
-        val veryBad = config.veryBad.toChromaColor()
+        val bad = config.bad.toSpecialColor()
+        val veryBad = config.veryBad.toSpecialColor()
 
 
         for (slot in InventoryUtils.getItemsInOpenChest()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.addSearchString
 import at.hannibal2.skyhanni.utils.CollectionUtils.sorted
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.canBeSeen
@@ -27,6 +26,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.buildSearchBox
@@ -278,7 +278,7 @@ object IslandAreas {
         targetNode = node
         val tag = node.getAreaTag() ?: return
         val displayName = tag.color.getChatColor() + node.name
-        val color = config.pathfinder.color.get().toChromaColor()
+        val color = config.pathfinder.color.get().toSpecialColor()
         node.pathFind(
             displayName,
             color,

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherSendCoordinates.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PatcherSendCoordinates.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -18,6 +17,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.RenderUtils.drawString
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -73,7 +73,7 @@ object PatcherSendCoordinates {
             val formattedDistance = distance.toInt().addSeparators()
 
             event.drawColor(location, LorenzColor.DARK_GREEN, alpha = 1f)
-            event.drawWaypointFilled(location, config.color.toChromaColor(), true, true)
+            event.drawWaypointFilled(location, config.color.toSpecialColor(), true, true)
             event.drawString(location.blockCenter(), beacon.name + " §e[${formattedDistance}m]", true, LorenzColor.DARK_BLUE.toColor())
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
@@ -8,12 +8,12 @@ import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.CopyNearbyEntitiesCommand.getMobInfo
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.RenderUtils.drawFilledBoundingBoxNea
 import at.hannibal2.skyhanni.utils.RenderUtils.exactPlayerEyeLocation
 import at.hannibal2.skyhanni.utils.RenderUtils.expandBlock
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import java.util.TreeSet
@@ -53,13 +53,13 @@ object MatriarchHelper {
     fun onRender(event: LorenzRenderWorldEvent) {
         if (!isEnabled()) return
         if (config.highlight) {
-            val color = config.highlightColor.toChromaColor()
+            val color = config.highlightColor.toSpecialColor()
             pearlList.forEach {
                 event.drawFilledBoundingBoxNea(it.boundingBox.expandBlock(), color, 1.0f)
             }
         }
         if (config.line) {
-            val color = config.lineColor.toChromaColor()
+            val color = config.lineColor.toSpecialColor()
             var prePoint = event.exactPlayerEyeLocation()
             for (mob in pearlList) {
                 val point = mob.baseEntity.getLorenzVec().up(1.2)

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangHighlights.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangHighlights.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.getExtendedColorCode
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -21,6 +20,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawString
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.exactLocation
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -58,7 +58,7 @@ object AshfangHighlights {
         if (!AshfangManager.active) return
 
         if (config.blazingSouls.enabled) {
-            val color = config.blazingSouls.color.toChromaColor()
+            val color = config.blazingSouls.color.toSpecialColor()
             blazingSouls.forEach {
                 val location = event.exactLocation(it)
                 event.drawWaypointFilled(location.add(-0.5, 1.25, -0.5), color, extraSize = -0.15)
@@ -67,7 +67,7 @@ object AshfangHighlights {
         }
 
         if (config.gravityOrbs.enabled) {
-            val color = config.gravityOrbs.color.toChromaColor()
+            val color = config.gravityOrbs.color.toSpecialColor()
             gravityOrbs.forEach {
                 val location = event.exactLocation(it)
                 event.drawCylinderInWorld(color, location.add(-0.5, -2.0, -0.5), 3.5f, 4.5f)

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
@@ -19,7 +19,6 @@ import at.hannibal2.skyhanni.features.rift.everywhere.EnigmaSoulWaypoints.soulLo
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.LocationUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
@@ -27,6 +26,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.block.BlockButtonWood
 import net.minecraft.init.Blocks
@@ -99,7 +99,7 @@ object WoodenButtonsHelper {
                 IslandGraphs.pathFind(
                     it.position,
                     "Button Spot",
-                    config.color.toChromaColor(),
+                    config.color.toSpecialColor(),
                     condition = { config.showPathFinder && config.showButtonsHelper },
                 )
             }
@@ -161,7 +161,7 @@ object WoodenButtonsHelper {
             IslandGraphs.pathFind(
                 it,
                 "Buttons Enigma Soul",
-                config.color.toChromaColor(),
+                config.color.toSpecialColor(),
                 condition = { config.showPathFinder },
             )
         }
@@ -181,7 +181,7 @@ object WoodenButtonsHelper {
         val spotName = "${spot.name}:${spot.position}"
         buttonLocations[spotName]?.forEach { button ->
             if (!hitButtons.contains(button)) {
-                event.drawWaypointFilled(button, config.color.toChromaColor(), inverseAlphaScale = true)
+                event.drawWaypointFilled(button, config.color.toSpecialColor(), inverseAlphaScale = true)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isAtFullHealth
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
@@ -20,6 +19,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.drawLineToEye
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.exactLocation
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.util.EnumParticleTypes
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -169,7 +169,7 @@ object LivingCaveDefenseBlocks {
         }
     }
 
-    private val color get() = config.color.get().toChromaColor()
+    private val color get() = config.color.get().toSpecialColor()
 
     fun isEnabled() = RiftAPI.inRift() && config.enabled && RiftAPI.inLivingCave()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveLivingMetalHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveLivingMetalHelper.kt
@@ -10,10 +10,10 @@ import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.TitleReceivedEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
@@ -99,7 +99,7 @@ object LivingCaveLivingMetalHelper {
         }
     }
 
-    val color get() = config.color.get().toChromaColor()
+    val color get() = config.color.get().toSpecialColor()
 
     fun isEnabled() = RiftAPI.inRift() && (RiftAPI.inLivingCave() || RiftAPI.inLivingStillness()) && config.enabled
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/RiftLavaMazeParkour.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/RiftLavaMazeParkour.kt
@@ -8,9 +8,9 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ParkourHelper
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
@@ -63,7 +63,7 @@ object RiftLavaMazeParkour {
     private fun updateConfig() {
         parkourHelper?.run {
             rainbowColor = config.rainbowColor.get()
-            monochromeColor = config.monochromeColor.get().toChromaColor()
+            monochromeColor = config.monochromeColor.get().toSpecialColor()
             lookAhead = config.lookAhead.get() + 1
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/RiftUpsideDownParkour.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/RiftUpsideDownParkour.kt
@@ -8,9 +8,9 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ParkourHelper
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
@@ -62,7 +62,7 @@ object RiftUpsideDownParkour {
     private fun updateConfig() {
         parkourHelper?.run {
             rainbowColor = config.rainbowColor.get()
-            monochromeColor = config.monochromeColor.get().toChromaColor()
+            monochromeColor = config.monochromeColor.get().toSpecialColor()
             lookAhead = config.lookAhead.get() + 1
             outline = config.outline
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/TubulatorParkour.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/TubulatorParkour.kt
@@ -7,10 +7,10 @@ import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.isPlayerInside
 import at.hannibal2.skyhanni.utils.ParkourHelper
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraft.util.AxisAlignedBB
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -55,7 +55,7 @@ object TubulatorParkour {
     private fun updateConfig() {
         parkourHelper?.run {
             rainbowColor = config.rainbowColor.get()
-            monochromeColor = config.monochromeColor.get().toChromaColor()
+            monochromeColor = config.monochromeColor.get().toSpecialColor()
             lookAhead = config.lookAhead.get() + 1
             outline = config.outline
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/RiftGunthersRace.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/RiftGunthersRace.kt
@@ -10,11 +10,11 @@ import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
 import at.hannibal2.skyhanni.utils.ParkourHelper
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -86,7 +86,7 @@ object RiftGunthersRace {
     private fun updateConfig() {
         parkourHelper?.run {
             rainbowColor = config.rainbowColor.get()
-            monochromeColor = config.monochromeColor.get().toChromaColor()
+            monochromeColor = config.monochromeColor.get().toSpecialColor()
             lookAhead = config.lookAhead.get() + 1
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
@@ -14,6 +13,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.TimeLimitedSet
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
@@ -40,7 +40,7 @@ object VerminHighlighter {
             checkedEntities.add(id)
 
             if (!isVermin(entity)) continue
-            val color = config.color.get().toChromaColor().addAlpha(60)
+            val color = config.color.get().toSpecialColor().addAlpha(60)
             RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, color) { isEnabled() }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftLarva.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftLarva.kt
@@ -5,13 +5,13 @@ import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.EntityUtils.getEntities
 import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -46,7 +46,7 @@ object RiftLarva {
             if (stand.wearingSkullTexture(LARVA_SKULL_TEXTURE)) {
                 RenderLivingEntityHelper.setEntityColor(
                     stand,
-                    config.highlightColor.toChromaColor().addAlpha(1),
+                    config.highlightColor.toSpecialColor().addAlpha(1),
                 ) { isEnabled() && hasHookInHand }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftOdonata.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftOdonata.kt
@@ -5,13 +5,13 @@ import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.EntityUtils.getEntities
 import at.hannibal2.skyhanni.utils.EntityUtils.holdingSkullTexture
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -45,7 +45,7 @@ object RiftOdonata {
             if (stand.holdingSkullTexture(ODONATA_SKULL_TEXTURE)) {
                 RenderLivingEntityHelper.setEntityColor(
                     stand,
-                    config.highlightColor.toChromaColor().addAlpha(1),
+                    config.highlightColor.toSpecialColor().addAlpha(1),
                 ) { isEnabled() && hasBottleInHand }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/EnigmaSoulWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/EnigmaSoulWaypoints.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.features.rift.area.dreadfarm.WoodenButtonsHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.InventoryUtils.getAllItems
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -25,6 +24,7 @@ import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.player.inventory.ContainerLocalMenu
@@ -123,7 +123,7 @@ object EnigmaSoulWaypoints {
                         IslandGraphs.pathFind(
                             it,
                             "$name Enigma Soul",
-                            config.color.toChromaColor(),
+                            config.color.toSpecialColor(),
                             condition = { config.showPathFinder }
                         )
                     }
@@ -162,7 +162,7 @@ object EnigmaSoulWaypoints {
         if (!isEnabled()) return
         for (soul in trackedSouls) {
             soulLocations[soul]?.let {
-                event.drawWaypointFilled(it, config.color.toChromaColor(), seeThroughBlocks = true, beacon = true)
+                event.drawWaypointFilled(it, config.color.toSpecialColor(), seeThroughBlocks = true, beacon = true)
                 event.drawDynamicText(it.up(), "§5${soul.removeSuffix(" Soul")} Soul", 1.5)
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
@@ -29,6 +28,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.entity.AbstractClientPlayer
@@ -143,7 +143,7 @@ object PunchcardHighlight {
     }
 
     private fun colorPlayer(entity: EntityLivingBase) {
-        val color = config.color.get().toChromaColor()
+        val color = config.color.get().toSpecialColor()
         val alpha = when (color.alpha) {
             0 -> 0
             255 -> 1

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
@@ -36,6 +35,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.exactLocation
 import at.hannibal2.skyhanni.utils.RenderUtils.exactPlayerEyeLocation
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityOtherPlayerMP
@@ -90,7 +90,8 @@ object VampireSlayerFeatures {
                 val isIchor = stand.hasSkullTexture(BLOOD_ICHOR_TEXTURE)
                 if (isIchor || stand.hasSkullTexture(KILLER_SPRING_TEXTURE)) {
                     val color =
-                        (if (isIchor) configBloodIchor.color else configKillerSpring.color).toChromaColor().addAlpha(config.withAlpha)
+                        (if (isIchor) configBloodIchor.color else configKillerSpring.color).toSpecialColor()
+                            .addAlpha(config.withAlpha)
                     if (distance <= 15) {
                         RenderLivingEntityHelper.setEntityColor(
                             stand,
@@ -201,7 +202,7 @@ object VampireSlayerFeatures {
     }
 
     private fun String.color(): Color {
-        return toChromaColor().addAlpha(config.withAlpha)
+        return this.toSpecialColor().addAlpha(config.withAlpha)
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
@@ -271,7 +272,7 @@ object VampireSlayerFeatures {
                 if (vec.distanceToPlayer() < 15) {
                     event.drawLineToEye(
                         vec.up(1.54),
-                        config.lineColor.toChromaColor(),
+                        config.lineColor.toSpecialColor(),
                         config.lineWidth,
                         true,
                     )
@@ -285,7 +286,8 @@ object VampireSlayerFeatures {
             val isIchor = stand.hasSkullTexture(BLOOD_ICHOR_TEXTURE)
             val isSpring = stand.hasSkullTexture(KILLER_SPRING_TEXTURE)
             if (!(isIchor && config.bloodIchor.highlight) && !(isSpring && config.killerSpring.highlight)) continue
-            val color = (if (isIchor) configBloodIchor.color else configKillerSpring.color).toChromaColor().addAlpha(config.withAlpha)
+            val color = (if (isIchor) configBloodIchor.color else configKillerSpring.color).toSpecialColor()
+                .addAlpha(config.withAlpha)
             if (distance <= 15) {
                 RenderLivingEntityHelper.setEntityColor(
                     stand,
@@ -293,7 +295,7 @@ object VampireSlayerFeatures {
                 ) { isEnabled() }
 
                 val linesColorStart =
-                    (if (isIchor) configBloodIchor.linesColor else configKillerSpring.linesColor).toChromaColor()
+                    (if (isIchor) configBloodIchor.linesColor else configKillerSpring.linesColor).toSpecialColor()
                 val text = if (isIchor) "§4Ichor" else "§4Spring"
                 event.drawColor(
                     stand.position.toLorenzVec().up(2.0),
@@ -321,7 +323,7 @@ object VampireSlayerFeatures {
             if (configBloodIchor.renderBeam && isIchor && stand.isEntityAlive) {
                 event.drawWaypointFilled(
                     event.exactLocation(stand).add(0, y = -2, 0),
-                    configBloodIchor.color.toChromaColor(),
+                    configBloodIchor.color.toSpecialColor(),
                     beacon = true,
                 )
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -90,8 +90,7 @@ object VampireSlayerFeatures {
                 val isIchor = stand.hasSkullTexture(BLOOD_ICHOR_TEXTURE)
                 if (isIchor || stand.hasSkullTexture(KILLER_SPRING_TEXTURE)) {
                     val color =
-                        (if (isIchor) configBloodIchor.color else configKillerSpring.color).toSpecialColor()
-                            .addAlpha(config.withAlpha)
+                        (if (isIchor) configBloodIchor.color else configKillerSpring.color).toSpecialColor().addAlpha(config.withAlpha)
                     if (distance <= 15) {
                         RenderLivingEntityHelper.setEntityColor(
                             stand,
@@ -286,8 +285,7 @@ object VampireSlayerFeatures {
             val isIchor = stand.hasSkullTexture(BLOOD_ICHOR_TEXTURE)
             val isSpring = stand.hasSkullTexture(KILLER_SPRING_TEXTURE)
             if (!(isIchor && config.bloodIchor.highlight) && !(isSpring && config.killerSpring.highlight)) continue
-            val color = (if (isIchor) configBloodIchor.color else configKillerSpring.color).toSpecialColor()
-                .addAlpha(config.withAlpha)
+            val color = (if (isIchor) configBloodIchor.color else configKillerSpring.color).toSpecialColor().addAlpha(config.withAlpha)
             if (distance <= 15) {
                 RenderLivingEntityHelper.setEntityColor(
                     stand,

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
@@ -31,6 +30,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.exactLocation
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
+import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.compat.getStandHelmet
 import at.hannibal2.skyhanni.utils.getLorenzVec
@@ -71,7 +71,7 @@ object EndermanSlayerFeatures {
                     flyingBeacons.add(entity)
                     RenderLivingEntityHelper.setEntityColor(
                         entity,
-                        beaconConfig.beaconColor.toChromaColor().addAlpha(1),
+                        beaconConfig.beaconColor.toSpecialColor().addAlpha(1),
                     ) {
                         beaconConfig.highlightBeacon
                     }
@@ -107,7 +107,7 @@ object EndermanSlayerFeatures {
             endermenWithBeacons.removeIf { it.isDead || !hasBeaconInHand(it) }
 
             for (location in endermenWithBeacons.map { it.getLorenzVec().add(-0.5, 0.2, -0.5) }) {
-                event.drawColor(location, beaconConfig.beaconColor.toChromaColor(), alpha = 0.5f)
+                event.drawColor(location, beaconConfig.beaconColor.toSpecialColor(), alpha = 0.5f)
             }
         }
 
@@ -154,7 +154,7 @@ object EndermanSlayerFeatures {
                 val beaconLocation = event.exactLocation(beacon)
                 event.drawLineToEye(
                     beaconLocation.add(0.5, 1.0, 0.5),
-                    beaconConfig.lineColor.toChromaColor(),
+                    beaconConfig.lineColor.toSpecialColor(),
                     beaconConfig.lineWidth,
                     true,
                 )
@@ -168,7 +168,7 @@ object EndermanSlayerFeatures {
             if (beaconConfig.showLine) {
                 event.drawLineToEye(
                     location.add(0.5, 1.0, 0.5),
-                    beaconConfig.lineColor.toChromaColor(),
+                    beaconConfig.lineColor.toSpecialColor(),
                     beaconConfig.lineWidth,
                     true,
                 )
@@ -177,8 +177,8 @@ object EndermanSlayerFeatures {
             if (beaconConfig.highlightBeacon) {
                 val duration = 5.seconds - time.passedSince()
                 val durationFormat = duration.format(showMilliSeconds = true)
-                event.drawColor(location, beaconConfig.beaconColor.toChromaColor(), alpha = 1f)
-                event.drawWaypointFilled(location, beaconConfig.beaconColor.toChromaColor(), true, true)
+                event.drawColor(location, beaconConfig.beaconColor.toSpecialColor(), alpha = 1f)
+                event.drawWaypointFilled(location, beaconConfig.beaconColor.toSpecialColor(), true, true)
                 event.drawDynamicText(location.add(y = 1), "§4Beacon §b$durationFormat", 1.8)
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SpecialColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SpecialColor.kt
@@ -9,13 +9,11 @@ import java.awt.Color
 object SpecialColor {
     private const val MIN_CHROMA_SECS = 1
     private const val MAX_CHROMA_SECS = 60
-    private var startTime = SimpleTimeMark.farPast()
+    private val startTime = SimpleTimeMark.now()
 
     fun String.toSpecialColor() = Color(toSpecialColorInt(), true)
 
     fun String.toSpecialColorInt(): Int {
-        if (startTime.isFarPast()) startTime = SimpleTimeMark.now()
-
         val (chroma, alpha, red, green, blue) = decompose(this)
         val (hue, sat, bri) = Color.RGBtoHSB(red, green, blue, null)
 


### PR DESCRIPTION
## What
Switched to using non deprecated colour functions, will leave the old functions in for a little bit before removing them

## Changelog Technical Details
+ Switched to using non-deprecated color functions. - CalMWolfs
