### PR TITLE
Improvement: Turn on Private Island Ability Block & Terminal Waypoints by default

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.java
@@ -142,7 +142,7 @@ public class DungeonConfig {
     @ConfigOption(name = "Terminal Waypoints", desc = "Displays Waypoints in the F7/M7 Goldor Phase.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean terminalWaypoints = false;
+    public boolean terminalWaypoints = true;
 
     @Expose
     @ConfigOption(name = "Dungeon Races Guide", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningConfig.java
@@ -99,7 +99,7 @@ public class MiningConfig {
     @ConfigOption(name = "Private Island Ability Block", desc = "Block the mining ability when on private island.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean privateIslandNoPickaxeAbility = false;
+    public boolean privateIslandNoPickaxeAbility = true;
 
     @Expose
     @ConfigOption(name = "Highlight your Golden Goblin", desc = "Highlight golden goblins you have spawned in green.")


### PR DESCRIPTION
## What
Turns on Private island mining ability block by default (and terminal waypoints)
These are generally not harmful for the experience and will improve some peoples quality of life, I have an island build and i have holes in it due to Pickonimbus


exclude_from_changelog