### PR TITLE
Fix: Garden BPS Underestimation Bug

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
@@ -105,9 +105,9 @@ object GardenCropSpeed {
                 }
             }
             averageBlocksPerSecond = if (blocksSpeedList.size > 5) {
-                blocksSpeedList.drop(3).average()
+                blocksSpeedList.drop(3).average().coerceAtMost(20.0)
             } else if (blocksSpeedList.size > 1) {
-                blocksSpeedList.drop(1).average()
+                blocksSpeedList.drop(1).average().coerceAtMost(20.0)
             } else 0.0
             GardenAPI.getCurrentlyFarmedCrop()?.let {
                 val heldTool = InventoryUtils.getItemInHand()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
@@ -83,7 +83,7 @@ object GardenCropSpeed {
     }
 
     private fun checkSpeed() {
-        val blocksBroken = blocksBroken.coerceAtMost(20)
+        val blocksBroken = blocksBroken
         this.blocksBroken = 0
 
         if (blocksBroken == 0) {


### PR DESCRIPTION
## What
Fixes a small bps underestimation bug in GardenCropSpeed caused by capping the blocks broken per second at 20 every second. It's possible to break 21 blocks one second and 19 the next due to lag. This instead caps the average blocks per second calculation at 20. 

## Changelog Fixes
+ Fixed a bug that sometimes caused BPS to be underestimated while farming in the Garden. - Chissl

