### PR TITLE
Fix: Pesterminator & Bestiary Fortune

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -331,7 +331,7 @@ object FarmingFortuneDisplay {
     fun getSunderFortune(tool: ItemStack?) = (tool?.getEnchantments()?.get("sunder") ?: 0) * 12.5
     fun getHarvestingFortune(tool: ItemStack?) = (tool?.getEnchantments()?.get("harvesting") ?: 0) * 12.5
     fun getCultivatingFortune(tool: ItemStack?) = (tool?.getEnchantments()?.get("cultivating") ?: 0) * 2.0
-    fun getPesterminatorFortune(tool: ItemStack?) = (tool?.getEnchantments()?.get("pesterminator") ?: 0) * 1.0
+    fun getPesterminatorFortune(tool: ItemStack?) = (tool?.getEnchantments()?.get("pesterminator") ?: 0) * 2.0
 
     fun getAbilityFortune(item: ItemStack?) = item?.let {
         getAbilityFortune(it.getInternalName(), it.getLore())

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FFInfos.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FFInfos.kt
@@ -63,7 +63,7 @@ internal enum class FFInfos(
         from = { FarmingItems.currentArmor?.getFFData() ?: FFStats.armorTotalFF },
         what = FFTypes.ENCHANT,
         x4 = { FarmingItems.currentArmor == null },
-        max = 5,
+        max = 12,
     ),
     GEMSTONE_ARMOR(
         TOTAL_ARMOR, { FarmingItems.currentArmor?.getFFData() ?: FFStats.armorTotalFF }, FFTypes.GEMSTONE,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FFInfos.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FFInfos.kt
@@ -21,7 +21,7 @@ internal enum class FFInfos(
         },
     ),
     FARMING_LEVEL(UNIVERSAL, { FFStats.baseFF }, FFTypes.FARMING_LVL, 240),
-    BESTIARY(UNIVERSAL, { FFStats.baseFF }, FFTypes.BESTIARY, 60),
+    BESTIARY(UNIVERSAL, { FFStats.baseFF }, FFTypes.BESTIARY, 66),
     GARDEN_PLOTS(UNIVERSAL, { FFStats.baseFF }, FFTypes.PLOTS, 72),
     ANITA_BUFF(UNIVERSAL, { FFStats.baseFF }, FFTypes.ANITA, 60),
     COMMUNITY_SHOP(UNIVERSAL, { FFStats.baseFF }, FFTypes.COMMUNITY_SHOP, 40),


### PR DESCRIPTION
## What
Updated Armor Enchantment Farming Fortune for Pesterminator changes. 

## Changelog Fixes
+ Updated Farming Fortune calculation to use 2 FF per Pesterminator level. - Luna
+ Updated the maximum possible Farming Fortune from the Pesterminator armor enchantment from 5 to 12 per piece. - Luna
+ Updated maximum Farming Fortune from the Pest Bestiary from 60 to 66. - Luna