### PR TITLE
Backend: Amend enchant exclusive regex

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -47,10 +47,11 @@ object EnchantParser {
      * REGEX-TEST: §5§o§d§l§d§lChimera V§9, §9Champion X§9, §9Cleave VI
      * REGEX-TEST: §d§l§d§lWisdom V§9, §9Depth Strider III§9, §9Feather Falling X
      * REGEX-TEST: §9Compact X§9, §9Efficiency V§9, §9Experience IV
+     * REGEX_TEST: §r§d§lUltimate Wise V§r§9, §r§9Champion X§r§9, §r§9Cleave V
      */
     val enchantmentExclusivePattern by patternGroup.pattern(
         "exclusive",
-        "^(?:(?:§.)+[A-Za-z][A-Za-z '-]+ (?:[IVXLCDM]+|[0-9]+)(?:[§r]?§9, |\$| §8\\d{1,3}(?:[,.]\\d{1,3})*)[kKmMbB]?)+\$",
+        "^(?:(?:§.)+[A-Za-z][A-Za-z '-]+ (?:[IVXLCDM]+|[0-9]+)(?:(?:§r)?§9, |\$| §8\\d{1,3}(?:[,.]\\d{1,3})*)[kKmMbB]?)+\$",
     )
     // Above regex tests apply to this pattern also
     @Suppress("MaxLineLength")


### PR DESCRIPTION
## What
Fixes the enchant parsing not parsing chat tooltips correctly by fixing the enchant exclusive regex to have the `§r` that appears before commas in chat tooltips be in a capturing group `()` rather than a character class `[]`. Not sure how I did this since for the actual enchant regex it is a capturing group, and none of the regex tests caught it, so I added another test.

One day there will be enough regex tests to catch all potential errors... surely...

## Changelog Technical Details
+ Updated the enchant-exclusive regex to restore chat tooltip functionality. - Vixid

