### PR TITLE
Improvement + Fix: Don't Show Last-Spawned Hoppity Eggs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -78,7 +78,9 @@ object HoppityEggDisplayManager {
 
         val displayList: List<String> = buildList {
             add("§bUnclaimed Eggs:")
-            HoppityEggType.resettingEntries.let { entries ->
+            HoppityEggType.resettingEntries.filter {
+                it.hasRemainingSpawns() // Only show eggs that have future spawns
+            }.let { entries ->
                 if (config.unclaimedEggsOrder == SOONEST_FIRST) entries.sortedBy { it.timeUntil() }
                 else entries
             }.forEach { add("§7 - ${it.formattedName} ${it.timeUntil().format()}") }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
@@ -65,6 +65,14 @@ enum class HoppityEggType(
         return now.hour < resetsAt
     }
 
+    fun hasRemainingSpawns(): Boolean {
+        val hoppityEndMark = HoppityAPI.getEventEndMark() ?: return false
+        // If it's before the last two days of the event, we can assume there are more spawns
+        if (hoppityEndMark.toMillis() > SkyBlockTime.SKYBLOCK_DAY_MILLIS * 2) return true
+        // Otherwise we have to check if the next spawn is after the end of the event
+        return timeUntil() < hoppityEndMark.timeUntil()
+    }
+
     fun isClaimed() = claimed || hasNotSpawnedFirstDay()
     val isResetting get() = resettingEntries.contains(this)
     val formattedName get() = "${if (isClaimed()) "§7§m" else mealColor}$mealName:$mealColor"

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
@@ -59,10 +59,10 @@ enum class HoppityEggType(
         claimed = false
     }
 
-    private fun hasNotSpawnedFirstDay(): Boolean {
+    private fun hasNotFirstSpawnedYet(): Boolean {
         val now = SkyBlockTime.now()
-        if (now.month > 4 || altDay && now.day > 2 || !altDay && now.day > 1) return false
-        return now.hour < resetsAt
+        if (now.month > 4 || (altDay && now.day > 2) || (!altDay && now.day > 1)) return false
+        return (altDay && now.day < 2) || now.hour < resetsAt
     }
 
     fun hasRemainingSpawns(): Boolean {
@@ -73,7 +73,7 @@ enum class HoppityEggType(
         return timeUntil() < hoppityEndMark.timeUntil()
     }
 
-    fun isClaimed() = claimed || hasNotSpawnedFirstDay()
+    fun isClaimed() = claimed || hasNotFirstSpawnedYet()
     val isResetting get() = resettingEntries.contains(this)
     val formattedName get() = "${if (isClaimed()) "§7§m" else mealColor}$mealName:$mealColor"
     val coloredName get() = "$mealColor$mealName"


### PR DESCRIPTION
## What
On the last spawn cycle of Hoppity, hide the eggs that will not have another spawn cycle before the event ends.

## Changelog Improvements
+ The Hoppity Unclaimed Eggs display is now more accurate at the end of events. - Daveed

## Changelog Fixes
+ Fixed an issue where Meal Eggs were incorrectly marked as available on Day 1. - Daveed

