### PR TITLE
Improvement: chocolate factory wording

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -62,7 +62,7 @@ object ChocolateFactoryTimeTowerManager {
             if (!warnAboutNewCharge) return
             ChatUtils.clickableChat(
                 "Your Time Tower has an available charge §7(${timeTowerCharges()})§e. " +
-                    "Click here to use one.",
+                    "Click here to open the Chocolate Factory menu.",
                 onClick = { HypixelCommands.chocolateFactory() },
                 HOVER_TEXT,
             )
@@ -78,7 +78,8 @@ object ChocolateFactoryTimeTowerManager {
         if (!isTimeTowerActive && wasTimeTowerRecentlyActive && config.timeTowerReminder && currentCharges() > 0) {
             val charges = StringUtils.pluralize(currentCharges(), "charge", "charges", withNumber = true)
             ChatUtils.clickableChat(
-                "§cYour Time Tower just expired and has $charges remaining. Click here to use one.",
+                "§cYour Time Tower just expired and has $charges remaining."
+                    + "§cClick here to open the Chocolate Factory Menu.",
                 onClick = {
                     HypixelCommands.chocolateFactory()
                 },
@@ -99,7 +100,8 @@ object ChocolateFactoryTimeTowerManager {
         if (lastTimeTowerWarning.passedSince() < warningSeparation) return
 
         ChatUtils.clickToActionOrDisable(
-            "§cYour Time Tower is full §7(${timeTowerCharges()})§c, Use one to avoid wasting time tower usages!",
+            "§cYour Time Tower is full §7(${timeTowerCharges()})§c, Use one to avoid wasting time tower usages!" +
+            "§cClick here to open the Chocolate Factory menu.",
             config::timeTowerWarning,
             actionName = "open Chocolate Factory",
             action = { HypixelCommands.chocolateFactory() },

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -100,7 +100,7 @@ object ChocolateFactoryTimeTowerManager {
         if (lastTimeTowerWarning.passedSince() < warningSeparation) return
 
         ChatUtils.clickToActionOrDisable(
-            "§cYour Time Tower is full §7(${timeTowerCharges()})§c, Use one to avoid wasting time tower usages!" +
+            "§cYour Time Tower is full §7(${timeTowerCharges()})§c, Use one to avoid wasting time tower usages! " +
                 "§cClick here to open the Chocolate Factory menu.",
             config::timeTowerWarning,
             actionName = "open Chocolate Factory",

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -101,7 +101,7 @@ object ChocolateFactoryTimeTowerManager {
 
         ChatUtils.clickToActionOrDisable(
             "§cYour Time Tower is full §7(${timeTowerCharges()})§c, Use one to avoid wasting time tower usages! " +
-                "§cClick here to open the Chocolate Factory menu.",
+                "Click here to open the Chocolate Factory menu.",
             config::timeTowerWarning,
             actionName = "open Chocolate Factory",
             action = { HypixelCommands.chocolateFactory() },

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -79,7 +79,7 @@ object ChocolateFactoryTimeTowerManager {
             val charges = StringUtils.pluralize(currentCharges(), "charge", "charges", withNumber = true)
             ChatUtils.clickableChat(
                 "§cYour Time Tower just expired and has $charges remaining. " +
-                    "§cClick here to open the Chocolate Factory Menu.",
+                    "Click here to open the Chocolate Factory Menu.",
                 onClick = {
                     HypixelCommands.chocolateFactory()
                 },

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -78,8 +78,8 @@ object ChocolateFactoryTimeTowerManager {
         if (!isTimeTowerActive && wasTimeTowerRecentlyActive && config.timeTowerReminder && currentCharges() > 0) {
             val charges = StringUtils.pluralize(currentCharges(), "charge", "charges", withNumber = true)
             ChatUtils.clickableChat(
-                "§cYour Time Tower just expired and has $charges remaining."
-                    + "§cClick here to open the Chocolate Factory Menu.",
+                "§cYour Time Tower just expired and has $charges remaining." +
+                        "§cClick here to open the Chocolate Factory Menu.",
                 onClick = {
                     HypixelCommands.chocolateFactory()
                 },

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -78,7 +78,7 @@ object ChocolateFactoryTimeTowerManager {
         if (!isTimeTowerActive && wasTimeTowerRecentlyActive && config.timeTowerReminder && currentCharges() > 0) {
             val charges = StringUtils.pluralize(currentCharges(), "charge", "charges", withNumber = true)
             ChatUtils.clickableChat(
-                "§cYour Time Tower just expired and has $charges remaining." +
+                "§cYour Time Tower just expired and has $charges remaining. " +
                     "§cClick here to open the Chocolate Factory Menu.",
                 onClick = {
                     HypixelCommands.chocolateFactory()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -79,7 +79,7 @@ object ChocolateFactoryTimeTowerManager {
             val charges = StringUtils.pluralize(currentCharges(), "charge", "charges", withNumber = true)
             ChatUtils.clickableChat(
                 "§cYour Time Tower just expired and has $charges remaining." +
-                        "§cClick here to open the Chocolate Factory Menu.",
+                    "§cClick here to open the Chocolate Factory Menu.",
                 onClick = {
                     HypixelCommands.chocolateFactory()
                 },
@@ -101,7 +101,7 @@ object ChocolateFactoryTimeTowerManager {
 
         ChatUtils.clickToActionOrDisable(
             "§cYour Time Tower is full §7(${timeTowerCharges()})§c, Use one to avoid wasting time tower usages!" +
-            "§cClick here to open the Chocolate Factory menu.",
+                "§cClick here to open the Chocolate Factory menu.",
             config::timeTowerWarning,
             actionName = "open Chocolate Factory",
             action = { HypixelCommands.chocolateFactory() },


### PR DESCRIPTION

## What
Minor changes to wording, changes "Click here to use one" to "Click here to open the Chocolate Factory menu", and adds a bit of consistency to the other messages



exclude_from_changelog