### PR TITLE
Fix: Include Maeve as one of the exceptions in the visitor hide chat config description

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.java
@@ -90,7 +90,7 @@ public class VisitorConfig {
     public boolean hypixelArrivedMessage = true;
 
     @Expose
-    @ConfigOption(name = "Hide Chat", desc = "Hide chat messages from the visitors in the garden. (Except Beth and Spaceman)")
+    @ConfigOption(name = "Hide Chat", desc = "Hide chat messages from the visitors in the garden. (Except Beth, Maeve, and Spaceman)")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean hideChat = true;


### PR DESCRIPTION
## What
Specifies that Maeve is also one of the visitors whose dialogue isn't blocked in the description for the hide visitor chat config option. This was changed in version 25 but was never added to the config description. 

## Changelog Fixes
+ Specified in visitor config that Maeve's dialogue is not hidden in the "Hide Chat" option. - Chissl

