### PR TITLE
Fix: Supercraft Spelling

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
@@ -34,11 +34,11 @@ object GardenVisitorSupercraft {
         val neuItem = "GOLD_PICKAXE".toInternalName().getItemStack()
         ItemUtils.createItemStack(
             neuItem.item,
-            "§bSuper Craft",
+            "§bSupercraft",
             "§8(From SkyHanni)",
             "",
-            "§7You have the items to craft",
-            "§7Click me to open the super crafter!",
+            "§7You have the items to craft.",
+            "§7Click me to open the supercrafter!",
         )
     }
 


### PR DESCRIPTION
## What
Fixed spelling of "Supercraft" in Garden visitor menu to match Hypixel's spelling.

## Changelog Fixes
+ Fixed the spelling of "Supercraft" in the Garden visitor menu. - Luna
