### PR TITLE
Fix: Custom Scoreboard in Kuudra

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -11,6 +11,7 @@ package at.hannibal2.skyhanni.features.gui.customscoreboard
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.enums.OutsideSbFeature
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
@@ -199,7 +200,7 @@ object CustomScoreboard {
 
     @SubscribeEvent
     fun onIslandChange(event: IslandChangeEvent) {
-        updateIslandEntries()
+        if (event.newIsland != IslandType.NONE) updateIslandEntries()
     }
 
     private fun updateIslandEntries() {
@@ -215,10 +216,10 @@ object CustomScoreboard {
                 add("Custom Scoreboard disabled.")
             } else {
                 add("Custom Scoreboard Lines:")
-                addAll(formatEntriesDebug(config.scoreboardEntries.get().map { it.name to it.element }))
+                addAll(formatEntriesDebug(config.scoreboardEntries.get().map { it.name to it.element }, currentIslandEntries))
 
                 add("Custom Scoreboard Events:")
-                addAll(formatEntriesDebug(eventsConfig.eventEntries.get().map { it.name to it.event }))
+                addAll(formatEntriesDebug(eventsConfig.eventEntries.get().map { it.name to it.event }, currentIslandEvents))
 
                 allUnknownLines.takeIfNotEmpty()?.let { set ->
                     add("Recent Unknown Lines:")
@@ -228,13 +229,15 @@ object CustomScoreboard {
         }
     }
 
-    private fun formatEntriesDebug(entries: List<Pair<String, ScoreboardElement>>) = entries.map { (name, element) ->
-        val lines = element.getLines().takeIf { it.isNotEmpty() }?.joinToString(", ") { it.display } ?: "No lines to display"
-        "   ${name.firstLetterUppercase()} - " +
-            "island: ${element.showIsland()} - " +
-            "show: ${element.showWhen()} - " +
-            lines
-    }
+    private fun formatEntriesDebug(entries: List<Pair<String, ScoreboardElement>>, currentIslandList: List<ScoreboardElement>) =
+        entries.map { (name, element) ->
+            val lines = element.getLines().takeIf { it.isNotEmpty() }?.joinToString(", ") { it.display } ?: "No lines to display"
+            "   ${name.firstLetterUppercase()} - " +
+                "island: ${element.showIsland()} - " +
+                "in Island: ${element in currentIslandList} - " +
+                "show: ${element.showWhen()} - " +
+                lines
+        }
 
     @JvmStatic
     fun resetAppearance() {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -216,10 +216,10 @@ object CustomScoreboard {
                 add("Custom Scoreboard disabled.")
             } else {
                 add("Custom Scoreboard Lines:")
-                addAll(formatEntriesDebug(config.scoreboardEntries.get().map { it.name to it.element }))
+                addAll(formatEntriesDebug(config.scoreboardEntries.get().map { it.name to it.element }, currentIslandEntries))
 
                 add("Custom Scoreboard Events:")
-                addAll(formatEntriesDebug(eventsConfig.eventEntries.get().map { it.name to it.event }))
+                addAll(formatEntriesDebug(eventsConfig.eventEntries.get().map { it.name to it.event }, currentIslandEvents))
 
                 allUnknownLines.takeIfNotEmpty()?.let { set ->
                     add("Recent Unknown Lines:")
@@ -229,13 +229,14 @@ object CustomScoreboard {
         }
     }
 
-    private fun formatEntriesDebug(entries: List<Pair<String, ScoreboardElement>>) = entries.map { (name, element) ->
-        val lines = element.getLines().takeIf { it.isNotEmpty() }?.joinToString(", ") { it.display } ?: "No lines to display"
-        "   ${name.firstLetterUppercase()} - " +
-            "island: ${element.showIsland()} - " +
-            "in Island: ${element in currentIslandEntries} - " +
-            "show: ${element.showWhen()} - " +
-            lines
+    private fun formatEntriesDebug(entries: List<Pair<String, ScoreboardElement>>, currentIslandList: List<ScoreboardElement>) =
+        entries.map { (name, element) ->
+            val lines = element.getLines().takeIf { it.isNotEmpty() }?.joinToString(", ") { it.display } ?: "No lines to display"
+            "   ${name.firstLetterUppercase()} - " +
+                "island: ${element.showIsland()} - " +
+                "in Island: ${element in currentIslandList} - " +
+                "show: ${element.showWhen()} - " +
+                lines
         }
 
     @JvmStatic

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -216,10 +216,10 @@ object CustomScoreboard {
                 add("Custom Scoreboard disabled.")
             } else {
                 add("Custom Scoreboard Lines:")
-                addAll(formatEntriesDebug(config.scoreboardEntries.get().map { it.name to it.element }, currentIslandEntries))
+                addAll(formatEntriesDebug(config.scoreboardEntries.get().map { it.name to it.element }))
 
                 add("Custom Scoreboard Events:")
-                addAll(formatEntriesDebug(eventsConfig.eventEntries.get().map { it.name to it.event }, currentIslandEvents))
+                addAll(formatEntriesDebug(eventsConfig.eventEntries.get().map { it.name to it.event }))
 
                 allUnknownLines.takeIfNotEmpty()?.let { set ->
                     add("Recent Unknown Lines:")
@@ -229,14 +229,13 @@ object CustomScoreboard {
         }
     }
 
-    private fun formatEntriesDebug(entries: List<Pair<String, ScoreboardElement>>, currentIslandList: List<ScoreboardElement>) =
-        entries.map { (name, element) ->
-            val lines = element.getLines().takeIf { it.isNotEmpty() }?.joinToString(", ") { it.display } ?: "No lines to display"
-            "   ${name.firstLetterUppercase()} - " +
-                "island: ${element.showIsland()} - " +
-                "in Island: ${element in currentIslandList} - " +
-                "show: ${element.showWhen()} - " +
-                lines
+    private fun formatEntriesDebug(entries: List<Pair<String, ScoreboardElement>>) = entries.map { (name, element) ->
+        val lines = element.getLines().takeIf { it.isNotEmpty() }?.joinToString(", ") { it.display } ?: "No lines to display"
+        "   ${name.firstLetterUppercase()} - " +
+            "island: ${element.showIsland()} - " +
+            "in Island: ${element in currentIslandEntries} - " +
+            "show: ${element.showWhen()} - " +
+            lines
         }
 
     @JvmStatic


### PR DESCRIPTION
## What
This might be caused by the IslandChangeEvent firing a bit too fast from NONE to KUUDRA_ARENA? So I changed it to not update when the newIsland is NONE. Also adds a bit more debug just incase this doesnt fix it.


## Changelog Fixes
+ Potentially fixed Custom Scoreboard sometimes not showing Kuudra Lines. - j10a1n15
