### PR TITLE
Improvement + Fix: Stash Compact

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/StashConfig.java
@@ -42,4 +42,9 @@ public class StashConfig {
     @ConfigOption(name = "Use /ViewStash", desc = "Use /viewstash [type] instead of /pickupstash.")
     @ConfigEditorBoolean
     public boolean useViewStash = false;
+
+    @Expose
+    @ConfigOption(name = "Disable Empty Warnings", desc = "Disable first-time warnings for empty messages left behind.")
+    @ConfigEditorBoolean
+    public boolean disableEmptyWarnings = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.chat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
+import at.hannibal2.skyhanni.features.chat.StashCompact.StashType.Companion.fromGroup
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
@@ -16,6 +17,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.util.regex.Matcher
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -85,7 +87,8 @@ object StashCompact {
         override fun toString() = name
 
         companion object {
-            fun fromStringOrNull(string: String) = entries.find { it.name.equals(string, ignoreCase = true) }
+            fun Matcher.fromGroup() = StashType.fromStringOrNull(group("type"))
+            private fun fromStringOrNull(string: String) = entries.find { it.name.equals(string, ignoreCase = true) }
         }
     }
 
@@ -120,14 +123,14 @@ object StashCompact {
                 emptyLineWarned = true
             }
 
-            val type = StashType.fromStringOrNull(group("type")) ?: return
+            val type = fromGroup() ?: return
             currentType = type
             currentMessages[type] = StashMessage(group("count").formatInt(), group("type"))
             event.blockedReason = "stash_compact"
         }
 
         differingMaterialsCountPattern.matchMatcher(event.message) {
-            val type = StashType.fromStringOrNull(group("type")) ?: return
+            val type = fromGroup() ?: return
             currentMessages[type]?.differingMaterialsCount = group("count").formatInt()
             event.blockedReason = "stash_compact"
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -79,12 +79,10 @@ object StashCompact {
     private var emptyLineWarned = false
     private var joinedProfileAt: SimpleTimeMark? = null
 
-    enum class StashType(val internalName: String, val colorCodePair: Pair<String, String>) {
+    enum class StashType(val displayName: String, val colorCodePair: Pair<String, String>) {
         ITEM("item", Pair("§e", "§6")),
         MATERIAL("material", Pair("§b", "§3")),
         ;
-
-        override fun toString() = internalName
 
         companion object {
             fun Matcher.fromGroup() = StashType.fromStringOrNull(group("type"))
@@ -156,7 +154,7 @@ object StashCompact {
     private fun StashMessage.sendCompactedStashMessage() {
         val currentType = currentType ?: return
 
-        val typeNameFormat = StringUtils.pluralize(materialCount, currentType.toString())
+        val typeNameFormat = StringUtils.pluralize(materialCount, currentType.displayName)
         val (mainColor, accentColor) = currentType.colorCodePair
 
         val typeStringExtra = differingMaterialsCount?.let {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -86,7 +86,7 @@ object StashCompact {
 
         companion object {
             fun Matcher.fromGroup() = StashType.fromStringOrNull(group("type"))
-            private fun fromStringOrNull(string: String) = entries.find { it.name.equals(string, ignoreCase = true) }
+            private fun fromStringOrNull(string: String) = entries.find { it.displayName == string }
         }
     }
 
@@ -138,9 +138,10 @@ object StashCompact {
             val currentType = currentType ?: return@matchMatcher
 
             val currentMessage = currentMessages[currentType] ?: return@matchMatcher
-            val lastMessage = lastMessages[currentType] ?: return@matchMatcher
             if (currentMessage.materialCount <= config.hideLowWarningsThreshold) return@matchMatcher
-            if (config.hideDuplicateCounts && currentMessage == lastMessage) return@matchMatcher
+            lastMessages[currentType]?.let { lastMessage ->
+                if (config.hideDuplicateCounts && lastMessage == currentMessage) return@matchMatcher
+            }
 
             currentMessage.sendCompactedStashMessage()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -53,6 +53,7 @@ object StashCompact {
     /**
      * REGEX-TEST: §f                §3§l>>> §3§lCLICK HERE§b to pick them up! §3§l<<<
      * REGEX-TEST: §f                §6§l>>> §6§lCLICK HERE§e to pick them up! §6§l<<<
+     * REGEX-TEST: §f                §3§l>>> §3§lCLICK HERE§b to pick them up! §3§l<<<
      */
     private val pickupStashPattern by patternGroup.pattern(
         "pickup.stash",
@@ -123,15 +124,15 @@ object StashCompact {
                 emptyLineWarned = true
             }
 
-            val type = fromGroup() ?: return
-            currentType = type
-            currentMessages[type] = StashMessage(group("count").formatInt(), group("type"))
+            currentType = fromGroup() ?: return
+            val currentType = currentType ?: return
+            currentMessages[currentType] = StashMessage(group("count").formatInt(), group("type"))
             event.blockedReason = "stash_compact"
         }
 
         differingMaterialsCountPattern.matchMatcher(event.message) {
-            val type = fromGroup() ?: return
-            currentMessages[type]?.differingMaterialsCount = group("count").formatInt()
+            currentType = fromGroup() ?: return
+            currentMessages[currentType]?.differingMaterialsCount = group("count").formatInt()
             event.blockedReason = "stash_compact"
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -113,7 +113,7 @@ object StashCompact {
             val emptyEnabled = filterConfig.empty
             val hideWarnings = config.disableEmptyWarnings
             val tenSecPassed = (joinedProfileAt?.passedSince() ?: 0.seconds) > 10.seconds
-            if (emptyEnabled && !hideWarnings && !emptyLineWarned && tenSecPassed) {
+            if (!emptyEnabled && !hideWarnings && !emptyLineWarned && tenSecPassed) {
                 ChatUtils.clickToActionOrDisable(
                     "Above empty lines were left behind by §6/sh stash compact§e." +
                         "This can be prevented with §6/sh empty messages§e.",
@@ -124,28 +124,28 @@ object StashCompact {
                 emptyLineWarned = true
             }
 
-            currentType = fromGroup() ?: return
-            val currentType = currentType ?: return
+            currentType = fromGroup() ?: return@matchMatcher
+            val currentType = currentType ?: return@matchMatcher
             currentMessages[currentType] = StashMessage(group("count").formatInt(), group("type"))
             event.blockedReason = "stash_compact"
         }
 
         differingMaterialsCountPattern.matchMatcher(event.message) {
-            currentType = fromGroup() ?: return
+            currentType = fromGroup() ?: return@matchMatcher
             currentMessages[currentType]?.differingMaterialsCount = group("count").formatInt()
             event.blockedReason = "stash_compact"
         }
 
-        if (pickupStashPattern.matches(event.message)) {
-            val currentType = currentType ?: return
+        pickupStashPattern.matchMatcher(event.message) {
+            event.blockedReason = "stash_compact"
+            val currentType = currentType ?: return@matchMatcher
 
-            val currentMessage = currentMessages[currentType] ?: return
-            val lastMessage = lastMessages[currentType]
-            if (currentMessage.materialCount <= config.hideLowWarningsThreshold) return
-            if (config.hideDuplicateCounts && currentMessage == lastMessage) return
+            val currentMessage = currentMessages[currentType] ?: return@matchMatcher
+            val lastMessage = lastMessages[currentType] ?: return@matchMatcher
+            if (currentMessage.materialCount <= config.hideLowWarningsThreshold) return@matchMatcher
+            if (config.hideDuplicateCounts && currentMessage == lastMessage) return@matchMatcher
 
             currentMessage.sendCompactedStashMessage()
-            event.blockedReason = "stash_compact"
         }
 
         if (!config.hideAddedMessages) return

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -84,7 +84,7 @@ object StashCompact {
         MATERIAL("material", Pair("§b", "§3")),
         ;
 
-        override fun toString() = name
+        override fun toString() = internalName
 
         companion object {
             fun Matcher.fromGroup() = StashType.fromStringOrNull(group("type"))


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1312680137501704283
Fixes an issue where if you had both items and materials in stash, the warnings would stop being negated, and would show in duplicate. Also added a disablable warning text that informs users about the Empty Messages issue on first-boot if they have the filter off.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/86328bd4-5727-4fda-9ce3-d0ff59825c30)

</details>

## Changelog Improvements
+ Added a warning for empty messages left behind by Stash Compact. - Daveed

## Changelog Fixes
+ Fixed an issue where item and material stashes together would break Stash Compact. - Daveed

