### PR TITLE
Improvement + Fix: Time Tower new profiles

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.java
@@ -146,7 +146,7 @@ public class ProfileSpecificStorage {
         public int timeTowerCooldown = 8;
 
         @Expose
-        public int maxTimeTowerUses = 3;
+        public int maxTimeTowerUses = 0;
 
         @Expose
         public boolean hasMuRabbit = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -42,6 +42,7 @@ object ChocolateFactoryBlockOpen {
         if (!LorenzUtils.inSkyBlock) return
         if (!commandPattern.matches(event.message)) return
         if (commandSentTimer.passedSince() < 5.seconds) return
+        if (LorenzUtils.isBingoProfile) return
 
         if (config.mythicRabbitRequirement && !MythicRabbitPetWarning.correctPet()) {
             event.cancelOpen()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -127,6 +127,14 @@ object ChocolateFactoryDataLoader {
     )
 
     /**
+     * REGEX-TEST: §7What does it do? Nobody knows...
+     */
+    private val timeTowerAmountEmptyPattern by ChocolateFactoryAPI.patternGroup.pattern(
+        "timetower.amount.empty",
+        "§7What does it do\\? Nobody knows\\.\\.\\.",
+    )
+
+    /**
      * REGEX-TEST: §7Status: §a§lACTIVE §f59m58s
      * REGEX-TEST:
      */
@@ -392,6 +400,10 @@ object ChocolateFactoryDataLoader {
                 profileStorage.currentTimeTowerUses = group("uses").formatInt()
                 profileStorage.maxTimeTowerUses = group("max").formatInt()
                 ChocolateFactoryTimeTowerManager.checkTimeTowerWarning(true)
+            }
+            if (timeTowerAmountEmptyPattern.matches(line)) {
+                profileStorage.currentTimeTowerUses = 0
+                profileStorage.maxTimeTowerUses = 0
             }
             timeTowerStatusPattern.matchMatcher(line) {
                 val activeTime = group("acitveTime")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryDataLoader.kt
@@ -404,6 +404,7 @@ object ChocolateFactoryDataLoader {
             if (timeTowerAmountEmptyPattern.matches(line)) {
                 profileStorage.currentTimeTowerUses = 0
                 profileStorage.maxTimeTowerUses = 0
+                profileStorage.currentTimeTowerUses = 0
             }
             timeTowerStatusPattern.matchMatcher(line) {
                 val activeTime = group("acitveTime")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -94,6 +94,7 @@ object ChocolateFactoryTimeTowerManager {
         if (!config.timeTowerWarning) return
         if (!timeTowerFull()) return
         if (ReminderUtils.isBusy()) return
+        if (maxCharges() == 0) return
 
         val warningSeparation = if (inInventory) 30.seconds else 5.minutes
         if (lastTimeTowerWarning.passedSince() < warningSeparation) return


### PR DESCRIPTION
## What
Fixed showing Time Tower is full warnings on new profiles.
Report: https://discord.com/channels/997079228510117908/1301925158923145226

## Changelog Fixes
+ Fixed Time Tower warnings showing up on new profiles (e.g. Bingo). - hannibal2
    * You can open `/cf` once to make the message disappear without changing settings if a new profile was created before applying the fix for the first time.

## Changelog Improvements
+ Disabled the Chocolate Factory's open feature without the Mythic Rabbit on Bingo profiles. - hannibal2