### PR TITLE
Improvement + Fix: Stonks Auction Not Showing The Right Price

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
@@ -39,10 +39,11 @@ object StockOfStonkFeature {
 
     /**
      * REGEX-TEST: §5§o§7§7▶ §c§lTOP 5,000§7 - §5Stock of Stonks §8x2
+     * REGEX-TEST: §5§o§7§a▶ §a§lTOP 100§7 - §5Stock of Stonks §8x25
      */
     private val topPattern by repoGroup.pattern(
         "top",
-        "§5§o§7§.▶ §c§lTOP (?<rank>[\\d,]+)§7 - §5Stock of Stonks §8x(?<amount>\\d+)",
+        "§5§o§7§.▶ §.§lTOP (?<rank>[\\d,]+)§7 - §5Stock of Stonks §8x(?<amount>\\d+)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
@@ -85,7 +85,7 @@ object StockOfStonkFeature {
                 continue@loop
             }
             bidPattern.matchMatcher(line) {
-                val cost = group("amount").replace(",", "").toLong()
+                val cost = group("amount").replace(",", "").toLong().coerceAtLeast(2000000) // minimum bid is 2,000,000
                 val ratio = cost / stonksReward.transformIf({ this == 0 }, { 1 })
                 event.toolTip[index - 1] = line + " §7(§6§6${ratio.addSeparators()} §7per)" // double §6 for the replacement at the end
                 if (ratio < bestRatio) {


### PR DESCRIPTION
## What
Fixes the regex pattern for the Stonks Auction not matching the current bracket the player is in and because of that not showing the right price per Stock of Stonks and adds the minimum bid in the price calculation.

## Changelog Improvements
+ Included the minimum bid in the Stonks Auction price calculation. - im-h

## Changelog Fixes
+ Fixed Stonks Auction not showing the correct price per Stock of Stonks. - im-h