### PR TITLE
Fix: Stray Timer w/Hitman Eggs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTimer.kt
@@ -50,8 +50,7 @@ object ChocolateFactoryStrayTimer {
 
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
-        if (!HoppityAPI.isHoppityEvent() || !ChocolateFactoryAPI.inChocolateFactory) return
-        if (timer <= Duration.ZERO) return
+        if (!ChocolateFactoryAPI.inChocolateFactory || timer <= Duration.ZERO) return
         lastTimerSubtraction = lastTimerSubtraction?.takeIfInitialized()?.let {
             timer -= it.passedSince()
             if (timer < Duration.ZERO) timer = Duration.ZERO


### PR DESCRIPTION
## What
Fixes the fact that Hitman eggs can start the Stray Timer outside of the event being active, which was not possible with the code as it was.

## Changelog Fixes
+ Fixed stray timer not activating from Hitman Eggs outside of Hoppity's Hunt. - Daveed
