### PR TITLE
Fix: Golden Fish Timer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
@@ -72,7 +72,8 @@ object GoldenFishTimer {
     private val timeOut = 10.seconds
     private val despawnTime = 1.minutes
     private val maxRodTime = 3.minutes
-    private val minimumSpawnTime = 15.minutes
+    private val minimumSpawnTime = 8.minutes
+    private val maximumSpawnTime = 12.minutes
     private const val MAX_INTERACTIONS = 3
 
     private var lastFishEntity = SimpleTimeMark.farPast()
@@ -199,7 +200,8 @@ object GoldenFishTimer {
                 )
                 else {
                     add("§7Can spawn since: §b${timePossibleSpawn.passedSince().formatTime()}")
-                    val chance = timePossibleSpawn.passedSince().inWholeSeconds.toDouble() / 5.minutes.inWholeSeconds
+                    val diff = maximumSpawnTime - minimumSpawnTime
+                    val chance = timePossibleSpawn.passedSince().inWholeSeconds.toDouble() / diff.inWholeSeconds
                     add("§7Chance: §b${LorenzUtils.formatPercentage(chance.coerceAtMost(1.0))}")
                 }
             } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
@@ -187,7 +187,7 @@ object GoldenFishTimer {
             if (!isGoldenFishActive()) {
                 if (lastGoldenFishTime.isFarPast()) add("§7Last Golden Fish: §cNone this session")
                 else add("§7Last Golden Fish: §b${lastGoldenFishTime.passedSince().formatTime()}")
-                if (lastRodThrowTime.isFarPast()) add("§7Last Row Throw: §cNone yet")
+                if (lastRodThrowTime.isFarPast()) add("§7Last Rod Throw: §cNone yet")
                 else add(
                     "§7Last Rod Throw: §b${lastRodThrowTime.passedSince().formatTime()} " +
                         "§3(${(lastRodThrowTime + maxRodTime + 1.seconds).timeUntil().formatTime()})",


### PR DESCRIPTION
## What
Updated Golden Fish Timer from 15-20 minutes to 8-12 minutes, per Hypixel update.

## Changelog Fixes
+ Updated Golden Fish Timer from 15-20 minutes to 8-12 minutes, per the Hypixel update. - Luna
+ Fixed a typo in the Golden Fish Timer. - Luna