### PR TITLE
Fix: sulphur skitter box visual slightly too small

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/SulphurSkitterBox.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/SulphurSkitterBox.kt
@@ -65,7 +65,7 @@ object SulphurSkitterBox {
         closestBlock?.let {
             if (it.toLorenzVec().distanceToPlayer() >= 50) return
             val pos1 = it.add(-RADIUS, -RADIUS, -RADIUS)
-            val pos2 = it.add(RADIUS, RADIUS, RADIUS)
+            val pos2 = it.add(RADIUS + 1, RADIUS + 1, RADIUS + 1)
             val axis = AxisAlignedBB(pos1, pos2).expandBlock()
 
             drawBox(axis, event.partialTicks)


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by a plus. For example, `Feature + Fix: Add new command and fix bug in command`.
Commonly used labels are Improvement, Backend, Feature and Fix.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

-->

## What
Fixes the Sulphur Skitter box rendering visually off by one block in the +x, +y, +z directions.

## Changelog Fixes
+ Fixed the visual position of the sulphur skitter box. - appable