### PR TITLE
Fix: Decrease Next Visitor Timer on Pest Kill

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestKillEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestKillEvent.kt
@@ -1,0 +1,5 @@
+package at.hannibal2.skyhanni.events.garden.pests
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+class PestKillEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestKillEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestKillEvent.kt
@@ -2,4 +2,4 @@ package at.hannibal2.skyhanni.events.garden.pests
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-class PestKillEvent : SkyHanniEvent()
+object PestKillEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -255,7 +255,7 @@ object PestAPI {
         if (pestDeathChatPattern.matches(event.message)) {
             lastPestKillTime = SimpleTimeMark.now()
             removeNearestPest()
-            PestKillEvent().post()
+            PestKillEvent.post()
         }
         if (noPestsChatPattern.matches(event.message)) {
             resetAllPests()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestAPI.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
+import at.hannibal2.skyhanni.events.garden.pests.PestKillEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestSpawnEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestUpdateEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
@@ -254,6 +255,7 @@ object PestAPI {
         if (pestDeathChatPattern.matches(event.message)) {
             lastPestKillTime = SimpleTimeMark.now()
             removeNearestPest()
+            PestKillEvent().post()
         }
         if (noPestsChatPattern.matches(event.message)) {
             resetAllPests()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.garden.pests.PestKillEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorArrivalEvent
 import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed
@@ -212,6 +213,16 @@ object GardenVisitorTimer {
         // We only need manually retracting the time when hypixel shows 6 minutes or above
         if (lastMillis > 5.minutes) {
             lastTimerUpdate -= 100.milliseconds
+        }
+    }
+
+    @HandleEvent
+    fun onPestKill(event: PestKillEvent) {
+        if (!isEnabled()) return
+        sixthVisitorArrivalTime -= 30.seconds
+
+        if (lastMillis > 5.minutes) {
+            lastTimerUpdate -= 30.seconds
         }
     }
 


### PR DESCRIPTION
## What
Fixes visitor timer not decreasing on pest kill; pests were buffed to decrease visitor spawn cooldown by 30 seconds in update [0.20.5](https://hypixel.net/threads/hypixel-skyblock-0-20-5-artist%E2%80%99s-abode.5738722/). 

## Changelog Fixes
+ Fixed the next visitor timer not decreasing on pest kills. - Chissl

