### PR TITLE
Backend: Add mid-tier Umber

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -95,6 +95,7 @@ enum class OreBlock(
 
     // GLACIAL
     LOW_TIER_UMBER(::isLowTierUmber, { inGlacite }),
+    MID_TIER_UMBER(::isMidTierUmber, { inGlacite }),
     HIGH_TIER_UMBER(::isHighTierUmber, { inGlacite }),
 
     LOW_TIER_TUNGSTEN_TUNNELS(::isLowTierTungstenTunnels, { inTunnels }),
@@ -166,8 +167,10 @@ private fun isRedSand(state: IBlockState): Boolean =
     (state.block == Blocks.sand && state.getValue(BlockSand.VARIANT) == BlockSand.EnumType.RED_SAND)
 
 private fun isLowTierUmber(state: IBlockState): Boolean =
-    state.block == Blocks.hardened_clay ||
-        (state.block == Blocks.stained_hardened_clay && state.getValue(BlockColored.COLOR) == EnumDyeColor.BROWN)
+    state.block == Blocks.hardened_clay
+
+private fun isMidTierUmber(state: IBlockState): Boolean =
+    (state.block == Blocks.stained_hardened_clay && state.getValue(BlockColored.COLOR) == EnumDyeColor.BROWN)
 
 private fun isHighTierUmber(state: IBlockState): Boolean =
     (state.block == Blocks.double_stone_slab2 && state.getValue(BlockStoneSlabNew.VARIANT) == BlockStoneSlabNew.EnumType.RED_SANDSTONE)

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreType.kt
@@ -173,7 +173,7 @@ enum class OreType(
     UMBER(
         "Umber",
         "UMBER",
-        OreBlock.LOW_TIER_UMBER, OreBlock.HIGH_TIER_UMBER,
+        OreBlock.LOW_TIER_UMBER, OreBlock.MID_TIER_UMBER, OreBlock.HIGH_TIER_UMBER,
     ),
     TUNGSTEN(
         "Tungsten",


### PR DESCRIPTION
## What
Separated one of the low-tier Umber blocks into a new mid-tier, per [wiki update](https://wiki.hypixel.net/index.php?title=Umber&diff=271756&oldid=232022), confirmed in-game.

## Changelog Technical Details
+ Added mid-tier Umber and changed brown stained clay from low-tier to mid-tier. - Luna
