### PR TITLE
Backend: Add the regex 101 link when a pattern fails

### DIFF
--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyDelegate
 import org.jetbrains.kotlin.psi.KtStringTemplateEntryWithExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import java.net.URLEncoder
 
 class RepoPatternElement private constructor(
     val variableName: String,
@@ -17,6 +18,13 @@ class RepoPatternElement private constructor(
 ) {
 
     val pattern by lazy { rawPattern.toPattern() }
+
+    val regex101Url: String by lazy {
+        URLEncoder.encode(
+            "https://regex101.com/?regex=${pattern.pattern()}&test=${regexTests.joinToString("\n")}",
+            "UTF-8",
+        )
+    }
 
     companion object {
         fun KtPropertyDelegate.asRepoPatternElement(): RepoPatternElement? {

--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -20,10 +20,9 @@ class RepoPatternElement private constructor(
     val pattern by lazy { rawPattern.toPattern() }
 
     val regex101Url: String by lazy {
-        URLEncoder.encode(
-            "https://regex101.com/?regex=${pattern.pattern()}&test=${regexTests.joinToString("\n")}",
-            "UTF-8",
-        )
+        val encodedPattern = URLEncoder.encode(rawPattern, "UTF-8")
+        val encodedTests = regexTests.joinToString("\n") { URLEncoder.encode(it, "UTF-8") }
+        "https://regex101.com/?regex=$encodedPattern&testString=$encodedTests"
     }
 
     companion object {

--- a/detekt/src/main/kotlin/repo/RepoPatternRegexTest.kt
+++ b/detekt/src/main/kotlin/repo/RepoPatternRegexTest.kt
@@ -32,13 +32,15 @@ class RepoPatternRegexTest(config: Config) : SkyHanniRule(config) {
 
         repoPatternElement.regexTests.forEach { test ->
             if (!repoPatternElement.pattern.matcher(test).find()) {
-                delegate.reportIssue("Repo pattern `$variableName` failed regex test: `$test` pattern: `$rawPattern`.")
+                delegate.reportIssue("Repo pattern `$variableName` failed regex test: `$test` pattern: `$rawPattern`. " +
+                    "[View on Regex101](${repoPatternElement.regex101Url})")
             }
         }
 
         repoPatternElement.failingRegexTests.forEach { test ->
             if (repoPatternElement.pattern.matcher(test).find()) {
-                delegate.reportIssue("Repo pattern `$variableName` passed regex test: `$test` pattern: `$rawPattern` even though it was set to fail.")
+                delegate.reportIssue("Repo pattern `$variableName` passed regex test: `$test` pattern: `$rawPattern` " +
+                    "even though it was set to fail. [View on Regex101](${repoPatternElement.regex101Url})")
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/FriendAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/FriendAPI.kt
@@ -54,7 +54,7 @@ object FriendAPI {
     )
 
     /**
-     * REGEX-TEST: §eClick here to viaaaaaaew §bThrowpo§e's profile
+     * REGEX-TEST: §eClick here to view §bThrowpo§e's profile
      */
     private val rawNamePattern by patternGroup.pattern(
         "rawname",

--- a/src/main/java/at/hannibal2/skyhanni/data/FriendAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/FriendAPI.kt
@@ -54,7 +54,7 @@ object FriendAPI {
     )
 
     /**
-     * REGEX-TEST: §eClick here to view §bThrowpo§e's profile
+     * REGEX-TEST: §eClick here to viaaaaaaew §bThrowpo§e's profile
      */
     private val rawNamePattern by patternGroup.pattern(
         "rawname",


### PR DESCRIPTION
## What
Show regex101 link when there is a failing detekt rule on a regex test

## Changelog Technical Details
+ Show a regex101 link when a detekt rule fails on a regex test. - CalMWolfs
