### PR TITLE
Fix: sending mining event data when the event tracker is disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -128,9 +128,9 @@ object MiningEventTracker {
         if (IslandType.MINESHAFT.isInIsland()) return
         // TODO fix this via regex
         if (eventName == "SLAYER QUEST") return
-
+        // don't send events if the setting is disabled
+        if (!config.enabled) return
         val eventType = MiningEventType.fromEventName(eventName) ?: run {
-            if (!config.enabled) return
             ErrorManager.logErrorWithData(
                 Exception("UnknownMiningEvent"), "Unknown mining event detected from string $eventName",
                 "eventName" to eventName,


### PR DESCRIPTION
## What
Fix sending mining event data to the soopy api when the mining event tracker is disabled
https://discord.com/channels/997079228510117908/1316207755719348324

## Changelog Fixes
+ Fixed sending mining events when the tracker is disabled. - DerGruenkohl
