### PR TITLE
Fix: total collected regex

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/CollectionAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/CollectionAPI.kt
@@ -36,10 +36,11 @@ object CollectionAPI {
 
     /**
      * REGEX-TEST: §7Total collected: §e261,390
+     * REGEX-TEST: §7Total Collected: §e2,012,418
      */
     private val singleCounterPattern by patternGroup.pattern(
         "singlecounter",
-        "§7Total collected: §e(?<amount>.*)",
+        "§7Total [c|C]ollected: §e(?<amount>.*)",
     )
 
     /**


### PR DESCRIPTION
## What
Fix regex for collection menu

<details>
<summary>Images</summary>

string
![image](https://github.com/user-attachments/assets/a0caf889-87a2-435f-9f3b-9a630ab629b1)


</details>

## Changelog Fixes
+ Fixed collection tracker to recognize the current collection. - nopo

