### PR TITLE
Improvement: Mining event sending check

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningEventConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningEventConfig.java
@@ -66,4 +66,9 @@ public class MiningEventConfig {
     @Expose
     @ConfigLink(owner = MiningEventConfig.class, field = "enabled")
     public Position position = new Position(200, 60, false, true);
+
+    @Expose
+    @ConfigOption(name = "Sharing Event Data", desc = "Sending Mining Event data to a server. This allows everyone to see more precise mining event timings. Thanks for your help!")
+    @ConfigEditorBoolean
+    public boolean allowDataSharing = true;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -124,13 +124,15 @@ object MiningEventTracker {
     }
 
     private fun sendData(eventName: String, time: String?) {
+        // do not send data if the feature is disabled.
+        if (!config.enabled) return
+
         // we now ignore mineshaft events.
         if (IslandType.MINESHAFT.isInIsland()) return
         // TODO fix this via regex
         if (eventName == "SLAYER QUEST") return
 
         val eventType = MiningEventType.fromEventName(eventName) ?: run {
-            if (!config.enabled) return
             ErrorManager.logErrorWithData(
                 Exception("UnknownMiningEvent"), "Unknown mining event detected from string $eventName",
                 "eventName" to eventName,

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -124,15 +124,13 @@ object MiningEventTracker {
     }
 
     private fun sendData(eventName: String, time: String?) {
-        // do not send data if the feature is disabled.
-        if (!config.enabled) return
-
         // we now ignore mineshaft events.
         if (IslandType.MINESHAFT.isInIsland()) return
         // TODO fix this via regex
         if (eventName == "SLAYER QUEST") return
 
         val eventType = MiningEventType.fromEventName(eventName) ?: run {
+            if (!config.enabled) return
             ErrorManager.logErrorWithData(
                 Exception("UnknownMiningEvent"), "Unknown mining event detected from string $eventName",
                 "eventName" to eventName,
@@ -227,6 +225,7 @@ object MiningEventTracker {
 
             if (!miningEventData.success) {
                 if (data.toString() == "{}") {
+                    if (!config.enabled) return@launch
                     ChatUtils.chat(
                         "§cFailed loading Mining Event data!\n" +
                             "§cPlease wait until the server-problem fixes itself! There is nothing else to do at the moment.",

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -228,11 +228,10 @@ object MiningEventTracker {
 
             if (!miningEventData.success) {
                 if (data.toString() == "{}") {
-                    if (!config.enabled) return@launch
                     ChatUtils.chat(
                         "§cFailed loading Mining Event data!\n" +
                             "§cPlease wait until the server-problem fixes itself! There is nothing else to do at the moment.",
-                        replaceSameMessage = true,
+                        onlySendOnce = true
                     )
                 } else {
                     ErrorManager.logErrorWithData(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -124,6 +124,9 @@ object MiningEventTracker {
     }
 
     private fun sendData(eventName: String, time: String?) {
+        // Option to opt out of data sending
+        if (!config.allowDataSharing) return
+
         // we now ignore mineshaft events.
         if (IslandType.MINESHAFT.isInIsland()) return
         // TODO fix this via regex

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -92,7 +92,7 @@ object ChatUtils {
         }
     }
 
-    private var messagesThatAreOnlySentOnce = mutableListOf<String>()
+    private val messagesThatAreOnlySentOnce = mutableListOf<String>()
 
     private fun internalChat(
         message: String,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -82,20 +82,30 @@ object ChatUtils {
         prefix: Boolean = true,
         prefixColor: String = "§e",
         replaceSameMessage: Boolean = false,
+        onlySendOnce: Boolean = false,
     ) {
 
         if (prefix) {
-            internalChat(prefixColor + CHAT_PREFIX + message, replaceSameMessage)
+            internalChat(prefixColor + CHAT_PREFIX + message, replaceSameMessage, onlySendOnce)
         } else {
-            internalChat(message, replaceSameMessage)
+            internalChat(message, replaceSameMessage, onlySendOnce)
         }
     }
+
+    private var messagesThatAreOnlySentOnce = mutableListOf<String>()
 
     private fun internalChat(
         message: String,
         replaceSameMessage: Boolean,
+        onlySendOnce: Boolean = false,
     ): Boolean {
         val text = ChatComponentText(message)
+        if (onlySendOnce) {
+            if (message in messagesThatAreOnlySentOnce) {
+                return false
+            }
+            messagesThatAreOnlySentOnce.add(message)
+        }
 
         return if (replaceSameMessage) {
             text.send(getUniqueMessageIdForString(message))


### PR DESCRIPTION
## What
Somehow we send the data from every player all the time to Soopy server? This is definitely not intended.
Reported: https://discord.com/channels/997079228510117908/1316207755719348324

## Changelog Improvements
+ Added option to disable sharing mining event data. - hannibal2
    * Improved accuracy when multiple users share mining event data.
    * Shared data includes event type, start, and end times.
+ Limited the "Mining Event Data can't be loaded from the server" error message to once in chat. - hannibal2

## Changelog Technical Details
+ Added option to send a chat message only once. - hannibal2