### PR TITLE
Fix: Allow removing items with ReplaceItemEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/render/gui/ReplaceItemEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/render/gui/ReplaceItemEvent.kt
@@ -9,9 +9,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 class ReplaceItemEvent(val inventory: IInventory, val originalItem: ItemStack, val slot: Int) : SkyHanniEvent() {
     var replacement: ItemStack? = null
         private set
+    var shouldRemove = false
+        private set
 
-    fun replace(replacement: ItemStack?) {
+    fun replace(replacement: ItemStack) {
         this.replacement = replacement
+    }
+
+    fun remove() {
+        shouldRemove = true
     }
 
     companion object {
@@ -25,6 +31,10 @@ class ReplaceItemEvent(val inventory: IInventory, val originalItem: ItemStack, v
             val originalItem = inventoryContents.getOrNull(slot) ?: return
             val event = ReplaceItemEvent(inventory, originalItem, slot)
             event.post()
+            if (event.shouldRemove) {
+                cir.returnValue = null
+                return
+            }
             event.replacement?.let { cir.returnValue = it }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/plots/GardenPlotIcon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/plots/GardenPlotIcon.kt
@@ -81,7 +81,7 @@ object GardenPlotIcon {
                     lastClickedSlotId = -1
                     return
                 }
-                event.replace(cachedStack[event.slot] ?: return)
+                cachedStack[event.slot]?.let { event.replace(it) }
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/plots/GardenPlotIcon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/plots/GardenPlotIcon.kt
@@ -81,7 +81,7 @@ object GardenPlotIcon {
                     lastClickedSlotId = -1
                     return
                 }
-                event.replace(cachedStack[event.slot])
+                event.replace(cachedStack[event.slot] ?: return)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
@@ -100,12 +100,12 @@ object CarnivalShopHelper {
 
     private fun tryReplaceShopSpecificStack(event: ReplaceItemEvent) {
         if (currentProgress == null || event.isUnknownShop()) return
-        shopSpecificInfoItemStack.let { event.replace(it) }
+        event.replace(shopSpecificInfoItemStack ?: return)
     }
 
     private fun tryReplaceOverviewStack(event: ReplaceItemEvent) {
         if (!overviewInventoryNamesPattern.matches(event.inventory.name)) return
-        overviewInfoItemStack.let { event.replace(it) }
+        event.replace(overviewInfoItemStack ?: return)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
@@ -100,12 +100,12 @@ object CarnivalShopHelper {
 
     private fun tryReplaceShopSpecificStack(event: ReplaceItemEvent) {
         if (currentProgress == null || event.isUnknownShop()) return
-        event.replace(shopSpecificInfoItemStack ?: return)
+        shopSpecificInfoItemStack?.let { event.replace(it) }
     }
 
     private fun tryReplaceOverviewStack(event: ReplaceItemEvent) {
         if (!overviewInventoryNamesPattern.matches(event.inventory.name)) return
-        event.replace(overviewInfoItemStack ?: return)
+        overviewInfoItemStack?.let { event.replace(it) }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/EssenceShopHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/EssenceShopHelper.kt
@@ -113,7 +113,7 @@ object EssenceShopHelper {
     fun replaceItem(event: ReplaceItemEvent) {
         if (!isEnabled() || essenceShops.isEmpty() || currentProgress == null || event.slot != CUSTOM_STACK_LOCATION) return
         if (!essenceShopPattern.matches(event.inventory.name)) return
-        infoItemStack.let { event.replace(it) }
+        event.replace(infoItemStack ?: return)
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/EssenceShopHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/EssenceShopHelper.kt
@@ -113,7 +113,7 @@ object EssenceShopHelper {
     fun replaceItem(event: ReplaceItemEvent) {
         if (!isEnabled() || essenceShops.isEmpty() || currentProgress == null || event.slot != CUSTOM_STACK_LOCATION) return
         if (!essenceShopPattern.matches(event.inventory.name)) return
-        event.replace(infoItemStack ?: return)
+        infoItemStack?.let { event.replace(it) }
     }
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
@@ -104,7 +104,7 @@ object UserLuckBreakdown {
             10 -> event.replace(skillsItem)
             11 -> event.replace(limboItem)
 
-            in validItemSlots -> event.replace(null)
+            in validItemSlots -> event.remove()
 
             in invalidItemSlots -> {
                 if (event.originalItem.item == limboID.getItemStack().item) return


### PR DESCRIPTION
## What
Describe what this pull request does, including technical details, screenshots, links to discord, etc.

## Changelog Fixes
+ Fixed items from the previous menu leaking into the SkyHanni User Luck stat breakdown submenu. - martimavocado

## Changelog Technical Details
+ Added support for removing items with ReplaceItemEvent. - martimavocado

