### PR TITLE
Backend: remove deprecated RenderUtils methods

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/anniversary/Year300RaffleEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/anniversary/Year300RaffleEvent.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUItems
-import at.hannibal2.skyhanni.utils.RenderUtils.renderSingleLineWithItems
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.SoundUtils
@@ -29,7 +29,7 @@ object Year300RaffleEvent {
     private var lastTimerReceived = SimpleTimeMark.farPast()
     private var lastTimeAlerted = SimpleTimeMark.farPast()
 
-    private var overlay: List<Any>? = null
+    private var overlay: List<Renderable>? = null
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
@@ -43,7 +43,7 @@ object Year300RaffleEvent {
 
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        config.activeTimerPosition.renderSingleLineWithItems(
+        config.activeTimerPosition.renderRenderables(
             overlay ?: return,
             posLabel = "300þ Anniversary Active Timer"
         )

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
@@ -11,9 +11,9 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.RenderUtils.addItemIcon
-import at.hannibal2.skyhanni.utils.RenderUtils.renderSingleLineWithItems
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.minutes
@@ -27,7 +27,7 @@ object JyrreTimer {
         "event.winter.drank.jyrre",
         "§aYou drank a §r§6Refined Bottle of Jyrre §r§aand gained §r§b\\+300✎ Intelligence §r§afor §r§b60 minutes§r§a!"
     )
-    private var display = emptyList<Any>()
+    private var display = emptyList<Renderable>()
     private var duration = 0.seconds
 
     @HandleEvent
@@ -50,7 +50,7 @@ object JyrreTimer {
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
-        config.pos.renderSingleLineWithItems(display, posLabel = "Refined Jyrre Timer")
+        config.pos.renderRenderables(display, posLabel = "Refined Jyrre Timer")
     }
 
     @SubscribeEvent
@@ -67,18 +67,18 @@ object JyrreTimer {
 
     private val displayIcon by lazy { "REFINED_BOTTLE_OF_JYRRE".toInternalName().getItemStack() }
 
-    fun drawDisplay(): MutableList<Any> {
+    fun drawDisplay(): MutableList<Renderable> {
         duration -= 1.seconds
 
-        return mutableListOf<Any>().apply {
-            addItemIcon(displayIcon)
-            add("§aJyrre Boost: ")
+        return mutableListOf<Renderable>().apply {
+            add(Renderable.itemStack(displayIcon))
+            add(Renderable.string("§aJyrre Boost: "))
 
             if (duration <= 0.seconds && config.showInactive) {
-                add("§cInactive!")
+                add(Renderable.string("§cInactive!"))
             } else {
                 val format = duration.format()
-                add("§b$format")
+                add(Renderable.string("§b$format"))
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -27,7 +28,7 @@ object JyrreTimer {
         "event.winter.drank.jyrre",
         "§aYou drank a §r§6Refined Bottle of Jyrre §r§aand gained §r§b\\+300✎ Intelligence §r§afor §r§b60 minutes§r§a!"
     )
-    private var display = emptyList<Renderable>()
+    private var display: Renderable? = null
     private var duration = 0.seconds
 
     @HandleEvent
@@ -36,8 +37,8 @@ object JyrreTimer {
     }
 
     private fun resetDisplay() {
-        if (display.isEmpty()) return
-        display = if (config.showInactive) drawDisplay() else emptyList()
+        if (display == null) return
+        display = if (config.showInactive) drawDisplay() else null
         duration = 0.seconds
     }
 
@@ -50,14 +51,14 @@ object JyrreTimer {
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
-        config.pos.renderRenderables(display, posLabel = "Refined Jyrre Timer")
+        config.pos.renderRenderable(display, posLabel = "Refined Jyrre Timer")
     }
 
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
 
-        if (display.isNotEmpty() && !config.showInactive && duration <= 0.seconds) {
+        if (display != null && !config.showInactive && duration <= 0.seconds) {
             resetDisplay()
             return
         }
@@ -67,10 +68,10 @@ object JyrreTimer {
 
     private val displayIcon by lazy { "REFINED_BOTTLE_OF_JYRRE".toInternalName().getItemStack() }
 
-    fun drawDisplay(): MutableList<Renderable> {
+    fun drawDisplay(): Renderable {
         duration -= 1.seconds
 
-        return mutableListOf<Renderable>().apply {
+        val list = mutableListOf<Renderable>().apply {
             add(Renderable.itemStack(displayIcon))
             add(Renderable.string("§aJyrre Boost: "))
 
@@ -81,6 +82,8 @@ object JyrreTimer {
                 add(Renderable.string("§b$format"))
             }
         }
+
+        return Renderable.horizontalContainer(list)
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenAPI.kt
@@ -41,7 +41,6 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUItems
-import at.hannibal2.skyhanni.utils.RenderUtils.addItemIcon
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getCultivatingCounter
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHoeCounter
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -171,14 +170,6 @@ object GardenAPI {
     }
 
     fun readCounter(itemStack: ItemStack): Long = itemStack.getHoeCounter() ?: itemStack.getCultivatingCounter() ?: -1L
-
-    @Deprecated("use renderable list instead", ReplaceWith(""))
-    fun MutableList<Any>.addCropIcon(
-        crop: CropType,
-        scale: Double = NEUItems.itemFontSize,
-        highlight: Boolean = false,
-    ) =
-        addItemIcon(crop.icon.copy(), highlight, scale = scale)
 
     // TODO rename to addCropIcon
     fun MutableList<Renderable>.addCropIconRenderable(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -489,7 +489,7 @@ object GardenNextJacobContest {
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
 
-        if (display != null) {
+        if (display == null) {
             config.pos.renderStrings(simpleDisplay, posLabel = "Next Jacob Contest")
         } else {
             config.pos.renderRenderable(display, posLabel = "Next Jacob Contest")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBestCropTime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBestCropTime.kt
@@ -8,22 +8,22 @@ import at.hannibal2.skyhanni.data.GardenCropMilestones.getCounter
 import at.hannibal2.skyhanni.data.GardenCropMilestones.isMaxed
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.GardenAPI
-import at.hannibal2.skyhanni.features.garden.GardenAPI.addCropIcon
+import at.hannibal2.skyhanni.features.garden.GardenAPI.addCropIconRenderable
 import at.hannibal2.skyhanni.features.garden.GardenNextJacobContest
 import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed.getSpeed
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.CollectionUtils.sorted
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
 object GardenBestCropTime {
 
-    var display = emptyList<List<Any>>()
+    var display: Renderable? = null
 
     private val config get() = GardenAPI.config.cropMilestones
     val timeTillNextCrop = mutableMapOf<CropType, Long>()
@@ -56,8 +56,9 @@ object GardenBestCropTime {
         }
     }
 
-    fun drawBestDisplay(currentCrop: CropType?): List<List<Any>> {
-        val newList = mutableListOf<List<Any>>()
+    fun drawBestDisplay(currentCrop: CropType?): Renderable {
+        val lines = mutableListOf<Renderable>()
+
         if (timeTillNextCrop.size < CropType.entries.size) {
             updateTimeTillNextCrop()
         }
@@ -82,56 +83,62 @@ object GardenBestCropTime {
 
         if (!config.next.bestHideTitle) {
             val title = if (gardenExp) "§2Garden Experience" else "§bSkyBlock Level"
-            if (config.next.bestCompact) {
-                newList.addAsSingletonList("§eBest Crop Time")
-            } else {
-                newList.addAsSingletonList("§eBest Crop Time §7($title§7)")
-            }
+            lines.add(
+                Renderable.string(
+                    if (config.next.bestCompact) "§eBest Crop Time" else "§eBest Crop Time §7($title§7)"
+                )
+            )
         }
 
         if (!config.progress) {
-            newList.addAsSingletonList("§cCrop Milestone Progress Display is disabled!")
-            return newList
+            lines.add(Renderable.string("§cCrop Milestone Progress Display is disabled!"))
+            return Renderable.verticalContainer(lines)
         }
 
         if (sorted.isEmpty()) {
-            newList.addAsSingletonList("§cFarm crops to add them to this list!")
-            return newList
+            lines.add(Renderable.string("§cFarm crops to add them to this list!"))
+            return Renderable.verticalContainer(lines)
         }
 
-        var number = 0
-        for (crop in sorted.keys) {
-            if (crop.isMaxed(useOverflow)) continue
-            val millis = timeTillNextCrop[crop]?.milliseconds ?: continue
-            // TODO, change functionality to use enum rather than ordinals
-            val biggestUnit = TimeUnit.entries[config.highestTimeFormat.get().ordinal]
-            val duration = millis.format(biggestUnit, maxUnits = 2)
-            val isCurrent = crop == currentCrop
-            number++
-            if (number > config.next.showOnlyBest && (!config.next.showCurrent || !isCurrent)) continue
-
-            val list = mutableListOf<Any>()
-            if (!config.next.bestCompact) {
-                list.add("§7$number# ")
-            }
-            list.addCropIcon(crop)
-
-            val color = if (isCurrent) "§e" else "§7"
-            val contestFormat = if (GardenNextJacobContest.isNextCrop(crop)) "§n" else ""
-            val currentTier = GardenCropMilestones.getTierForCropCount(crop.getCounter(), crop, allowOverflow = true)
-            val nextTier = if (config.bestShowMaxedNeeded.get()) 46 else currentTier + 1
-
-            val cropName = if (!config.next.bestCompact) crop.cropName + " " else ""
-            val tier = if (!config.next.bestCompact) "$currentTier➜$nextTier§r " else ""
-            list.add("$color$contestFormat$cropName$tier§b$duration")
-
-            if (gardenExp && !config.next.bestCompact) {
-                val gardenExpForTier = getGardenExpForTier(nextTier)
-                list.add(" §7(§2$gardenExpForTier §7Exp)")
-            }
-            newList.add(list)
+        lines += sorted.keys.withIndex().mapNotNull { (index, crop) ->
+            createCropLine(index, crop, currentCrop, useOverflow, gardenExp)
         }
-        return newList
+
+        return Renderable.verticalContainer(lines)
+    }
+
+    private fun createCropLine(
+        index: Int, crop: CropType, currentCrop: CropType?, useOverflow: Boolean, showGardenExp: Boolean
+    ): Renderable? {
+        if (crop.isMaxed(useOverflow)) return null
+        val millis = timeTillNextCrop[crop]?.milliseconds ?: return null
+        // TODO, change functionality to use enum rather than ordinals
+        val biggestUnit = TimeUnit.entries[config.highestTimeFormat.get().ordinal]
+        val duration = millis.format(biggestUnit, maxUnits = 2)
+        val isCurrent = crop == currentCrop
+        if (index + 1 > config.next.showOnlyBest && (!config.next.showCurrent || !isCurrent)) return null
+
+        val line = mutableListOf<Renderable>()
+        if (!config.next.bestCompact) {
+            line.add(Renderable.string("§7${index + 1}# "))
+        }
+        line.addCropIconRenderable(crop)
+
+        val color = if (isCurrent) "§e" else "§7"
+        val contestFormat = if (GardenNextJacobContest.isNextCrop(crop)) "§n" else ""
+        val currentTier = GardenCropMilestones.getTierForCropCount(crop.getCounter(), crop, allowOverflow = true)
+        val nextTier = if (config.bestShowMaxedNeeded.get()) 46 else currentTier + 1
+
+        val cropName = if (!config.next.bestCompact) crop.cropName + " " else ""
+        val tier = if (!config.next.bestCompact) "$currentTier➜$nextTier§r " else ""
+        line.add(Renderable.string("$color$contestFormat$cropName$tier§b$duration"))
+
+        if (showGardenExp && !config.next.bestCompact) {
+            val gardenExpForTier = getGardenExpForTier(nextTier)
+            line.add(Renderable.string(" §7(§2$gardenExpForTier §7Exp)"))
+        }
+
+        return Renderable.horizontalContainer(line)
     }
 
     private fun getGardenExpForTier(gardenLevel: Int) = if (gardenLevel > 30) 300 else gardenLevel * 10

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -29,8 +29,8 @@ import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
-import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUnit
@@ -86,7 +86,7 @@ object GardenCropMilestoneDisplay {
         }
 
         if (config.next.bestDisplay) {
-            config.next.displayPos.renderStringsAndItems(GardenBestCropTime.display, posLabel = "Best Crop Time")
+            config.next.displayPos.renderRenderable(GardenBestCropTime.display, posLabel = "Best Crop Time")
         }
     }
 
@@ -131,7 +131,7 @@ object GardenCropMilestoneDisplay {
     fun update() {
         progressDisplay = emptyList()
         mushroomCowPerkDisplay = emptyList()
-        GardenBestCropTime.display = emptyList()
+        GardenBestCropTime.display = null
         val currentCrop = GardenAPI.getCurrentlyFarmedCrop()
         currentCrop?.let {
             progressDisplay = drawProgressDisplay(it)

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -13,12 +13,10 @@ import at.hannibal2.skyhanni.features.misc.PatcherFixes
 import at.hannibal2.skyhanni.features.misc.RoundedRectangleOutlineShader
 import at.hannibal2.skyhanni.features.misc.RoundedRectangleShader
 import at.hannibal2.skyhanni.features.misc.RoundedTextureShader
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.zipWithNext3
 import at.hannibal2.skyhanni.utils.ColorUtils.getFirstColorCode
 import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils.getCorners
-import at.hannibal2.skyhanni.utils.compat.EnchantmentsCompat
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderXAligned
@@ -36,7 +34,6 @@ import net.minecraft.client.renderer.WorldRenderer
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats
 import net.minecraft.entity.Entity
 import net.minecraft.inventory.Slot
-import net.minecraft.item.ItemStack
 import net.minecraft.util.AxisAlignedBB
 import net.minecraft.util.MathHelper
 import net.minecraft.util.ResourceLocation
@@ -647,64 +644,6 @@ object RenderUtils {
         }
 
         this.renderRenderablesDouble(render, extraSpace, posLabel, true)
-    }
-
-    /**
-     * Accepts a single line to print.
-     * This line is a list of things to print. Can print String or ItemStack objects.
-     */
-    @Deprecated("use List<Renderable>", ReplaceWith(""))
-    fun Position.renderSingleLineWithItems(
-        list: List<Any?>,
-        posLabel: String,
-    ) {
-        if (list.isEmpty()) return
-        renderRenderable(
-            Renderable.horizontalContainer(
-                list.mapNotNull { Renderable.fromAny(it) },
-            ),
-            posLabel = posLabel,
-        )
-        // TODO Future write that better
-    }
-
-    private fun Position.renderLine(line: List<Any?>, offsetY: Int, itemScale: Double = NEUItems.itemFontSize): Int {
-        GlStateManager.pushMatrix()
-        val (x, y) = transform()
-        GlStateManager.translate(0f, offsetY.toFloat(), 0F)
-        var offsetX = 0
-        Renderable.withMousePosition(x, y) {
-            for (any in line) {
-                val renderable = Renderable.fromAny(any, itemScale = itemScale)
-                    ?: throw RuntimeException("Unknown render object: $any")
-                renderable.render(offsetX, offsetY)
-                offsetX += renderable.width
-                GlStateManager.translate(renderable.width.toFloat(), 0F, 0F)
-            }
-        }
-        GlStateManager.popMatrix()
-        return offsetX
-    }
-
-    @Deprecated("use renderable item list", ReplaceWith(""))
-    fun MutableList<Any>.addItemIcon(
-        item: ItemStack,
-        highlight: Boolean = false,
-        scale: Double = NEUItems.itemFontSize,
-    ) {
-        try {
-            if (highlight) {
-                // Hack to add enchant glint, like Hypixel does it
-                item.addEnchantment(EnchantmentsCompat.PROTECTION.enchantment, 0)
-            }
-            add(Renderable.itemStack(item, scale))
-        } catch (e: NullPointerException) {
-            ErrorManager.logErrorWithData(
-                e,
-                "Add item icon to renderable list",
-                "item" to item,
-            )
-        }
     }
 
     // totally not modified Autumn Client's TargetStrafe


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by a plus. For example, `Feature + Fix: Add new command and fix bug in command`.
Commonly used labels are Improvement, Backend, Feature and Fix.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

-->

## What
Removes deprecated RenderUtils methods `renderSingleLineWithItems` and `addItemIcon`, as well as an unused private method in that class. Also remove associated utility method in GardenAPI.

Assuming this goes well, I would like to remove the deprecated renderStringsAndItems in a second pass (that one has much broader usage currently, though). I think generally it might be a good idea to only render Renderables and deprecate all other methods rendering lists/strings/etc at Positions, but that can be saved for quite a bit later.

## Changelog Technical Details
+ Removed some deprecated render methods. - appable