### PR TITLE
Fix: Item Value Estimation Coloring

### DIFF
--- a/.idea/dictionaries/default_user.xml
+++ b/.idea/dictionaries/default_user.xml
@@ -211,6 +211,7 @@
       <w>rclick</w>
       <w>recomb</w>
       <w>recombobulated</w>
+      <w>recombobulation</w>
       <w>recombobulator</w>
       <w>redstone</w>
       <w>reindrake</w>

--- a/.idea/dictionaries/default_user.xml
+++ b/.idea/dictionaries/default_user.xml
@@ -209,6 +209,7 @@
       <w>quazii</w>
       <w>ragnarock</w>
       <w>rclick</w>
+      <w>recomb</w>
       <w>recombobulated</w>
       <w>recombobulator</w>
       <w>redstone</w>

--- a/.idea/dictionaries/default_user.xml
+++ b/.idea/dictionaries/default_user.xml
@@ -209,7 +209,6 @@
       <w>quazii</w>
       <w>ragnarock</w>
       <w>rclick</w>
-      <w>recomb</w>
       <w>recombobulated</w>
       <w>recombobulation</w>
       <w>recombobulator</w>

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
@@ -17,7 +17,6 @@ data class ItemsJson(
 
 data class ItemValueCalculationDataJson(
     @Expose @SerializedName("always_active_enchants") val alwaysActiveEnchants: Map<String, AlwaysActiveEnchantJson>,
-    @Expose @SerializedName("tiered_enchants") val tieredEnchants: List<String>,
     @Expose @SerializedName("only_tier_one_prices") val onlyTierOnePrices: List<String>,
     @Expose @SerializedName("only_tier_five_prices") val onlyTierFivePrices: List<String>,
 )

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.data.jsonobjects.repo
 
 import at.hannibal2.skyhanni.utils.NEUInternalName
+import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 
@@ -11,4 +12,19 @@ data class ItemsJson(
     @Expose @SerializedName("lava_fishing_rods") val lavaFishingRods: List<NEUInternalName>,
     @Expose @SerializedName("water_fishing_rods") val waterFishingRods: List<NEUInternalName>,
     @Expose @SerializedName("book_bundle_amount") val bookBundleAmount: Map<String, Int>,
+    @Expose @SerializedName("value_calculation_data") val valueCalculationData: ItemValueCalculationDataJson,
 )
+
+data class ItemValueCalculationDataJson(
+    @Expose @SerializedName("always_active_enchants") val alwaysActiveEnchants: Map<String, AlwaysActiveEnchantJson>,
+    @Expose @SerializedName("tiered_enchants") val tieredEnchants: List<String>,
+    @Expose @SerializedName("only_tier_one_prices") val onlyTierOnePrices: List<String>,
+    @Expose @SerializedName("only_tier_five_prices") val onlyTierFivePrices: List<String>,
+)
+
+data class AlwaysActiveEnchantJson(
+    @Expose val level: Int,
+    @Expose val items: List<String>,
+) {
+    val internalNames = items.map { it.toInternalName() }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FarmingReforge.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FarmingReforge.kt
@@ -10,7 +10,7 @@ enum class FarmingReforge(
     val epic: Int,
     val legendary: Int,
     val mythic: Int,
-) { // if reforge item is an empty string it means it will never be called, just for upgrading and recomb stats
+) { // if reforge item is an empty string it means it will never be called, just for upgrading and recombobulating stats
     BLESSED("Blessed", "BLESSED_FRUIT", 5, 7, 9, 13, 16, 20),
     BOUNTIFUL("Bountiful", "GOLDEN_BALL", 1, 2, 3, 5, 7, 10),
     BLOOMING("Blooming", "FLOWERING_BOUQUET", 1, 2, 3, 4, 5, 6),

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.itemNameRarityAware
+import at.hannibal2.skyhanni.utils.ItemUtils.itemNameFullyRarityAware
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.addButton
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
@@ -121,12 +121,12 @@ object ChestValue {
             if (total < config.hideBelow) continue
             val textAmount = " §7x${amount.addSeparators()}:"
             val width = Minecraft.getMinecraft().fontRendererObj.getStringWidth(textAmount)
-            val name = "${stack.itemNameRarityAware.reduceStringLength((config.nameLength - width), ' ')} $textAmount"
+            val name = "${stack.itemNameFullyRarityAware.reduceStringLength((config.nameLength - width), ' ')} $textAmount"
             val price = "§6${(total).formatPrice()}"
             val text = if (config.alignedDisplay)
                 "$name $price"
             else
-                "${stack.itemNameRarityAware} §7x$amount: §6${total.formatPrice()}"
+                "${stack.itemNameFullyRarityAware} §7x$amount: §6${total.formatPrice()}"
             newDisplay.add(
                 buildList {
                     val renderable = Renderable.hoverTips(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.itemName
+import at.hannibal2.skyhanni.utils.ItemUtils.itemNameRecombobulatorAware
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.addButton
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
@@ -121,12 +121,12 @@ object ChestValue {
             if (total < config.hideBelow) continue
             val textAmount = " §7x${amount.addSeparators()}:"
             val width = Minecraft.getMinecraft().fontRendererObj.getStringWidth(textAmount)
-            val name = "${stack.displayName.reduceStringLength((config.nameLength - width), ' ')} $textAmount"
+            val name = "${stack.itemNameRecombobulatorAware.reduceStringLength((config.nameLength - width), ' ')} $textAmount"
             val price = "§6${(total).formatPrice()}"
             val text = if (config.alignedDisplay)
                 "$name $price"
             else
-                "${stack.displayName} §7x$amount: §6${total.formatPrice()}"
+                "${stack.itemNameRecombobulatorAware} §7x$amount: §6${total.formatPrice()}"
             newDisplay.add(
                 buildList {
                     val renderable = Renderable.hoverTips(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.itemNameRecombobulatorAware
+import at.hannibal2.skyhanni.utils.ItemUtils.itemNameRarityAware
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.addButton
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
@@ -121,12 +121,12 @@ object ChestValue {
             if (total < config.hideBelow) continue
             val textAmount = " §7x${amount.addSeparators()}:"
             val width = Minecraft.getMinecraft().fontRendererObj.getStringWidth(textAmount)
-            val name = "${stack.itemNameRecombobulatorAware.reduceStringLength((config.nameLength - width), ' ')} $textAmount"
+            val name = "${stack.itemNameRarityAware.reduceStringLength((config.nameLength - width), ' ')} $textAmount"
             val price = "§6${(total).formatPrice()}"
             val text = if (config.alignedDisplay)
                 "$name $price"
             else
-                "${stack.itemNameRecombobulatorAware} §7x$amount: §6${total.formatPrice()}"
+                "${stack.itemNameRarityAware} §7x$amount: §6${total.formatPrice()}"
             newDisplay.add(
                 buildList {
                     val renderable = Renderable.hoverTips(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -121,12 +121,12 @@ object ChestValue {
             if (total < config.hideBelow) continue
             val textAmount = " §7x${amount.addSeparators()}:"
             val width = Minecraft.getMinecraft().fontRendererObj.getStringWidth(textAmount)
-            val name = "${stack.itemName.reduceStringLength((config.nameLength - width), ' ')} $textAmount"
+            val name = "${stack.displayName.reduceStringLength((config.nameLength - width), ' ')} $textAmount"
             val price = "§6${(total).formatPrice()}"
             val text = if (config.alignedDisplay)
                 "$name $price"
             else
-                "${stack.itemName} §7x$amount: §6${total.formatPrice()}"
+                "${stack.displayName} §7x$amount: §6${total.formatPrice()}"
             newDisplay.add(
                 buildList {
                     val renderable = Renderable.hoverTips(

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -49,6 +49,7 @@ object DiscordRPCManager : IPCListener {
     private var started = false
     private var nextUpdate: SimpleTimeMark = SimpleTimeMark.farPast()
 
+    // TODO move into item utils/api class
     var stackingEnchants: Map<String, StackingEnchantData> = emptyMap()
 
     fun start(fromCommand: Boolean = false) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.misc.EstimatedItemValueConfig
+import at.hannibal2.skyhanni.data.jsonobjects.repo.ItemValueCalculationDataJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ItemsJson
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -49,6 +50,9 @@ object EstimatedItemValue {
     var bookBundleAmount = mapOf<String, Int>()
     private var currentlyShowing = false
 
+    lateinit var itemValueCalculationData: ItemValueCalculationDataJson
+        private set
+
     fun isCurrentlyShowing() = currentlyShowing && Minecraft.getMinecraft().currentScreen != null
 
     @HandleEvent
@@ -61,6 +65,7 @@ object EstimatedItemValue {
     fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<ItemsJson>("Items")
         bookBundleAmount = data.bookBundleAmount
+        itemValueCalculationData = data.valueCalculationData
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -23,6 +23,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getReadableNBTDump
 import at.hannibal2.skyhanni.utils.ItemUtils.isRune
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
+import at.hannibal2.skyhanni.utils.ItemUtils.itemNameRecombobulatorAware
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzRarity
@@ -700,13 +701,7 @@ object EstimatedItemValueCalculator {
             }
         }
 
-        val name = if (stack.isRecombobulated()) {
-            val rarity = stack.getItemRarityOrNull()
-            if (rarity == null) stack.itemName
-            else if (stack.itemName.startsWith("§")) {
-                stack.itemName.replaceFirst(Regex("§[0-9a-f]"), rarity.chatColorCode)
-            } else stack.itemName
-        } else stack.itemName
+        val name = stack.itemNameRecombobulatorAware
         if (internalName.startsWith("ENCHANTED_BOOK_BUNDLE_")) {
             list.add("§7Base item: $name")
             return 0.0

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.misc.items
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.ReforgeAPI
+import at.hannibal2.skyhanni.features.misc.discordrpc.DiscordRPCManager
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraAPI
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraAPI.getKuudraTier
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraAPI.isKuudraArmor
@@ -752,7 +753,7 @@ object EstimatedItemValueCalculator {
             if (internalName.startsWith("ENCHANTED_BOOK_BUNDLE_")) {
                 multiplier = EstimatedItemValue.bookBundleAmount.getOrDefault(rawName, 5)
             }
-            if (rawName in EstimatedItemValue.itemValueCalculationData.tieredEnchants) level = 1
+            if (rawName in DiscordRPCManager.stackingEnchants.keys) level = 1
 
             val enchantmentName = "$rawName;$level".uppercase().toInternalName()
             val itemStack = enchantmentName.getItemStackOrNull() ?: continue

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -24,7 +24,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getReadableNBTDump
 import at.hannibal2.skyhanni.utils.ItemUtils.isRune
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
-import at.hannibal2.skyhanni.utils.ItemUtils.itemNameRarityAware
+import at.hannibal2.skyhanni.utils.ItemUtils.itemNameBaseRarityAware
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzRarity
@@ -700,7 +700,7 @@ object EstimatedItemValueCalculator {
             }
         }
 
-        val name = stack.itemNameRarityAware
+        val name = stack.itemNameBaseRarityAware
         if (internalName.startsWith("ENCHANTED_BOOK_BUNDLE_")) {
             list.add("§7Base item: $name")
             return 0.0

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -700,7 +700,13 @@ object EstimatedItemValueCalculator {
             }
         }
 
-        val name = internalName.itemName
+        val name = if (stack.isRecombobulated()) {
+            val rarity = stack.getItemRarityOrNull()
+            if (rarity == null) stack.itemName
+            else if (stack.itemName.startsWith("§")) {
+                stack.itemName.replaceFirst(Regex("§[0-9a-f]"), rarity.chatColorCode)
+            } else stack.itemName
+        } else stack.itemName
         if (internalName.startsWith("ENCHANTED_BOOK_BUNDLE_")) {
             list.add("§7Base item: $name")
             return 0.0

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -23,7 +23,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getReadableNBTDump
 import at.hannibal2.skyhanni.utils.ItemUtils.isRune
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
-import at.hannibal2.skyhanni.utils.ItemUtils.itemNameRecombobulatorAware
+import at.hannibal2.skyhanni.utils.ItemUtils.itemNameRarityAware
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzRarity
@@ -701,7 +701,7 @@ object EstimatedItemValueCalculator {
             }
         }
 
-        val name = stack.itemNameRecombobulatorAware
+        val name = stack.itemNameRarityAware
         if (internalName.startsWith("ENCHANTED_BOOK_BUNDLE_")) {
             list.add("§7Base item: $name")
             return 0.0

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -10,8 +10,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
-import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
@@ -460,6 +458,17 @@ object ItemUtils {
                 return it.getAttributeName()
             }
             return getInternalNameOrNull()?.itemName ?: "<null>"
+        }
+
+    val ItemStack.itemNameRecombobulatorAware: String
+        get() {
+            return if (isRecombobulated()) {
+                val rarity = getItemRarityOrNull()
+                if (rarity == null) itemName
+                else if (itemName.startsWith("§")) {
+                    itemName.replaceFirst(Regex("§[0-9a-f]"), rarity.chatColorCode)
+                } else itemName
+            } else itemName
         }
 
     fun ItemStack.getAttributeFromShard(): Pair<String, Int>? {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -460,14 +460,12 @@ object ItemUtils {
             return getInternalNameOrNull()?.itemName ?: "<null>"
         }
 
-    val ItemStack.itemNameRecombobulatorAware: String
+    val ItemStack.itemNameRarityAware: String
         get() {
-            return if (isRecombobulated()) {
-                val rarity = getItemRarityOrNull()
-                if (rarity == null) itemName
-                else if (itemName.startsWith("§")) {
-                    itemName.replaceFirst(Regex("§[0-9a-f]"), rarity.chatColorCode)
-                } else itemName
+            val rarity = getItemRarityOrNull()
+            return if (rarity == null) return itemName
+            else if (itemName.startsWith("§")) {
+                itemName.replaceFirst(Regex("§[0-9a-f]"), rarity.chatColorCode)
             } else itemName
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -10,6 +10,8 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -463,7 +463,7 @@ object ItemUtils {
     val ItemStack.itemNameRarityAware: String
         get() {
             val rarity = getItemRarityOrNull()
-            return if (rarity == null) return itemName
+            return if (rarity == null) itemName
             else if (itemName.startsWith("§")) {
                 itemName.replaceFirst(Regex("§[0-9a-f]"), rarity.chatColorCode)
             } else itemName


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/310

## What
Fixes an issue with items not showing their correct colors, both due to varying name, and recombobulation not being accounted for. If this was intentional let me know and I'll make it a config option.

<details>
<summary>Images</summary>

Before
![image](https://github.com/user-attachments/assets/b5c1e09a-68de-4364-8f2c-9f667d5c12fe)

After
![image](https://github.com/user-attachments/assets/d42fcf34-b51f-4317-8197-200db16a6505)

</details>

## Changelog Fixes
+ Fixed incorrect display colors in Item Value Estimation. - Daveed

