### PR TITLE
Improvement: Colorfus /shcommand aliases

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
@@ -27,7 +27,7 @@ object HelpCommand {
         return Text.text("§7 - $color${command.name}") {
             this.hover = Text.multiline(
                 "§e/${command.name}",
-                if (aliases.isNotEmpty()) "§7Aliases: ${aliases.joinToString(", ")}" else null,
+                if (aliases.isNotEmpty()) "§7Aliases: §e/${aliases.joinToString("§7, §e/")}" else null,
                 if (description.isNotEmpty()) description.prependIndent("  ") else null,
                 "",
                 "$color§l${category.categoryName}",


### PR DESCRIPTION
## What
Added colores to aliases in the `/shcommand` list. - hannibal2

<details>
<summary>Images</summary>

before
![image](https://github.com/user-attachments/assets/2017a1c8-518e-4716-8d4a-b7bd52629d20)
after
![image](https://github.com/user-attachments/assets/9abecae7-ebb3-403f-a0e1-f30ef662580e)


</details>

## Changelog Improvements
+ Added colors to aliases in the `/shcommand` list. - hannibal2