### PR TITLE
Fix: Miniboss Amount

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -65,10 +65,11 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
      * REGEX-TEST: §7Kill the §cAshfang §7miniboss §a2 §7times!
      * REGEX-TEST: §7Kill the §cMage Outlaw §7miniboss §a1 §7time!
      * REGEX-TEST: §7miniboss §a1 §7time!
+     * REGEX-TEST: §7Kill the §cBarbarian Duke X §7miniboss §a2
      */
     val minibossAmountPattern by patternGroup.pattern(
         "minibossamount",
-        "(?:§7Kill the §c.+ §7|.*)miniboss §a(?<amount>\\d) §7times?!",
+        "(?:§7Kill the §c.+ §7)?miniboss §a(?<amount>\\d)(?: §7times?!)?",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -69,7 +69,7 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
      */
     val minibossAmountPattern by patternGroup.pattern(
         "minibossamount",
-        "(?:§7Kill the §c.+ §7)?miniboss §a(?<amount>\\d)(?: §7times?!)?",
+        "(?:§7Kill the §c.+ §7|.*)miniboss §a(?<amount>\\d)(?: §7times?!)?",
     )
 
     /**


### PR DESCRIPTION
## What
Fixed an edge case where the Crimson Isle Reputation Helper was failing to parse the miniboss amount.

## Changelog Fixes
+ Fixed Crimson Isle Reputation Helper showing incorrect miniboss count in some cases. - Luna

