### PR TITLE
Fix: Event Stats CF Leaderboard Edge Case

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
@@ -268,6 +268,7 @@ object HoppityEventSummary {
 
     @HandleEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
+        lastSnapshotServer = null
         checkEnded()
     }
 


### PR DESCRIPTION
## What
Fixes an issue where if you leave and join Hypixel without closing the game, and end up back in the same server you left, the Leaderboard status would not update in Event Stats.

exclude_from_changelog

