### PR TITLE
Fix: Misc Party Mode

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.events.render.EntityRenderLayersEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI.partyModeReplace
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
@@ -94,7 +95,7 @@ object HoppityEggDisplayManager {
                 val collectedFormat = formatEggsCollected(collectedEggs)
                 add("§7Locations: $collectedFormat$collectedEggs§7/§a$totalEggs")
             }
-        }
+        }.map { it.partyModeReplace() }
 
         if (displayList.size == 1) return emptyList()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
@@ -455,7 +455,7 @@ object HoppityEventSummary {
                 )
             } ?: if (isNextEventEnabled && !isAlreadyNextEvent) {
                 Renderable.optionalLink(
-                    "§d[ §7Next Hunt §r§f§l-> §r§d]",
+                    "§d[ §7Next Hunt §r§f§l-> §r§d]".partyModeReplace(),
                     onClick = { statYear = getCurrentSBYear() + 1 },
                 )
             } else null,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTracker.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.hoppity.EggFoundEvent
@@ -309,7 +310,15 @@ object ChocolateFactoryStrayTracker {
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
+        // Force a refresh for party mode
+        if (ChocolateFactoryAPI.inChocolateFactory && config.partyMode.get()) tracker.update()
         tracker.firstUpdate()
+    }
+
+    @SubscribeEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        if (!isEnabled()) return
+        tracker.update() // Make sure we don't stay in party mode
     }
 
     private fun <T> migrateJsonStringKeyToRarityKey(jElement: JsonElement, enumClass: Class<T>): JsonElement {


### PR DESCRIPTION
## What
Fixes a couple missing things from party mode, namely the unclaimed eggs display, the `Next Hunt ->` button, and makes the stray tracker force an update on CF open.

exclude_from_changelog

