### PR TITLE
Backend: Added /shtestactionbar and more debug

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ActionBarData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ActionBarData.kt
@@ -1,17 +1,61 @@
 package at.hannibal2.skyhanni.data
 
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.events.ActionBarUpdateEvent
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
+import kotlinx.coroutines.launch
 import net.minecraftforge.client.event.ClientChatReceivedEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
 object ActionBarData {
     private var actionBar = ""
+    private var debugActionBar: String? = null
 
     fun getActionBar() = actionBar
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.register("shtestactionbar") {
+            description = "Set your clipboard as a fake action bar."
+            category = CommandCategory.DEVELOPER_TEST
+            callback { debugCommand() }
+        }
+    }
+
+    private fun debugCommand() {
+        SkyHanniMod.coroutineScope.launch {
+            val clipboard = OSUtils.readFromClipboard()
+            if (debugActionBar == clipboard) {
+                debugActionBar = null
+                ChatUtils.chat("Disabled action bar test!")
+            } else {
+                debugActionBar = clipboard
+                ChatUtils.chat("Set action bar test to '$clipboard'")
+            }
+        }
+    }
+
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Action Bar")
+        debugActionBar?.let {
+            event.addData {
+                add("debug active!")
+                add("line: '$it'")
+            }
+        } ?: run {
+            event.addIrrelevant("not active.")
+        }
+    }
 
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {
@@ -27,7 +71,7 @@ object ActionBarData {
         //#endif
 
         val original = event.message
-        val message = original.formattedText.stripHypixelMessage()
+        val message = debugActionBar ?: original.formattedText.stripHypixelMessage()
         actionBar = message
         val actionBarEvent = ActionBarUpdateEvent(actionBar, event.message)
         actionBarEvent.post()

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyBlockIslandTest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyBlockIslandTest.kt
@@ -1,8 +1,12 @@
 package at.hannibal2.skyhanni.test
 
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 
+@SkyHanniModule
 object SkyBlockIslandTest {
 
     var testIsland: IslandType? = null
@@ -31,6 +35,19 @@ object SkyBlockIslandTest {
         testIsland = found
         ChatUtils.chat("Set test island to ${found.displayName}")
 
+    }
+
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Island Test")
+        testIsland?.let {
+            event.addData {
+                add("debug active!")
+                add("island: '$it'")
+            }
+        } ?: run {
+            event.addIrrelevant("not active.")
+        }
     }
 
     private fun find(search: String): IslandType? {

--- a/src/main/java/at/hannibal2/skyhanni/test/TestBingo.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestBingo.kt
@@ -1,7 +1,11 @@
 package at.hannibal2.skyhanni.test
 
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 
+@SkyHanniModule
 object TestBingo {
 
     var testBingo = false
@@ -9,5 +13,17 @@ object TestBingo {
     fun toggle() {
         testBingo = !testBingo
         ChatUtils.chat("Test Bingo " + (if (testBingo) "enabled" else "disabled"))
+    }
+
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Bingo Test")
+        if (testBingo) {
+            event.addData {
+                add("debug active!")
+            }
+        } else {
+            event.addIrrelevant("not active.")
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
@@ -1,8 +1,10 @@
 package at.hannibal2.skyhanni.utils
 
+//#if MC<1.12
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.model.TabWidget
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.TablistFooterUpdateEvent
@@ -20,12 +22,12 @@ import kotlinx.coroutines.launch
 import net.minecraft.client.Minecraft
 import net.minecraft.client.network.NetworkPlayerInfo
 import net.minecraft.network.play.server.S38PacketPlayerListItem
+import net.minecraft.world.WorldSettings
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.relauncher.Side
 import net.minecraftforge.fml.relauncher.SideOnly
 import kotlin.time.Duration.Companion.seconds
-//#if MC<1.12
-import net.minecraft.world.WorldSettings
+
 //#else
 //$$ import net.minecraft.world.GameType
 //#endif
@@ -46,6 +48,22 @@ object TabListData {
     fun getHeader() = header
     fun getFooter() = footer
 
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Tab List")
+        debugCache?.let {
+            event.addData {
+                add("debug active!")
+                add("lines: (${it.size})")
+                for (line in it) {
+                    add(" '$line'")
+                }
+            }
+        } ?: run {
+            event.addIrrelevant("not active.")
+        }
+    }
+
     fun toggleDebug() {
         if (debugCache != null) {
             ChatUtils.chat("Disabled tab list debug.")
@@ -64,7 +82,7 @@ object TabListData {
             ChatUtils.clickableChat(
                 "Tab list debug is enabled!",
                 onClick = { toggleDebug() },
-                "§eClick to disable!"
+                "§eClick to disable!",
             )
             return
         }
@@ -99,7 +117,7 @@ object TabListData {
             return ComparisonChain.start().compareTrueFirst(
                 //#if MC<1.12
                 o1.gameType != WorldSettings.GameType.SPECTATOR,
-                o2.gameType != WorldSettings.GameType.SPECTATOR
+                o2.gameType != WorldSettings.GameType.SPECTATOR,
                 //#else
                 //$$ o1.gameType != GameType.SPECTATOR,
                 //$$ o2.gameType != GameType.SPECTATOR


### PR DESCRIPTION
## What
Added /shtestactionbar command: Set your clipboard as a fake action bar, with /shdebug support.
Also added /shdebug enties for other tests: skyblock island, bingo and tab list data

## Changelog Technical Details
+ Added /shtestactionbar command: set your clipboard as a fake Action Bar. - hannibal2
+ Added /shdebug support for SkyBlock island, Bingo, and Tab List data tests. - hannibal2