### PR TITLE
Fix: Vacuum Bag Item Stack after 1k Pests

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -79,10 +79,11 @@ object ItemDisplayOverlayFeatures {
     /**
      * REGEX-TEST: §7Vacuum Bag: §21 Pest
      * REGEX-TEST: §7Vacuum Bag: §2444 Pests
+     * REGEX-TEST: §7Vacuum Bag: §21,652 Pests
      */
     private val gardenVacuumPattern by patternGroup.pattern(
         "vacuum",
-        "§7Vacuum Bag: §2(?<amount>\\d*) Pests?",
+        "§7Vacuum Bag: §2(?<amount>[\\d.,]*) Pests?",
     )
     private val harvestPattern by patternGroup.pattern(
         "harvest",


### PR DESCRIPTION
## Changelog Fixes
+ Fixed Vacuum Item Stack Size not showing with over 1k Pests. - j10a1n15
