### PR TITLE
Improvement: opt in persistent search

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -125,6 +125,11 @@ public class MiscConfig {
     public LastServersConfig lastServers = new LastServersConfig();
 
     @Expose
+    @ConfigOption(name = "Reset Search on Close", desc = "Reset the search in GUIs after closing the inventory.")
+    @ConfigEditorBoolean
+    public boolean resetSearchGuiOnClose = true;
+
+    @Expose
     @ConfigOption(name = "Show Outside SkyBlock", desc = "Show these features outside of SkyBlock.")
     @ConfigEditorDraggableList
     public Property<List<OutsideSbFeature>> showOutsideSB = Property.of(new ArrayList<>());

--- a/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
@@ -13,7 +13,7 @@ import org.lwjgl.input.Keyboard
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 
-class TextInput {
+open class TextInput {
 
     var textBox: String = ""
     private var carriage: Int? = null
@@ -45,6 +45,10 @@ class TextInput {
     val isActive get() = Companion.activeInstance == this
 
     private val updateEvents = mutableMapOf<Int, (TextInput) -> Unit>()
+
+    protected fun update() {
+        updateEvents.forEach { (_, it) -> it(this) }
+    }
 
     fun registerToEvent(key: Int, event: (TextInput) -> Unit) {
         updateEvents[key] = event
@@ -102,7 +106,7 @@ class TextInput {
         private fun updated() {
             with(activeInstance) {
                 if (this == null) return
-                this.updateEvents.forEach { (_, it) -> it(this) }
+                update()
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.model.Graph
 import at.hannibal2.skyhanni.data.model.GraphNode
 import at.hannibal2.skyhanni.data.model.GraphNodeTag
-import at.hannibal2.skyhanni.data.model.TextInput
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzRenderWorldEvent
@@ -28,6 +27,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.SearchTextInput
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.buildSearchBox
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
@@ -45,7 +45,7 @@ object IslandAreas {
     var display: Renderable? = null
     private var targetNode: GraphNode? = null
     var currentAreaName = ""
-    private val textInput = TextInput()
+    private val textInput = SearchTextInput()
 
     @SubscribeEvent
     fun onWorldChange(event: LorenzWorldChangeEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
@@ -13,7 +13,7 @@ import org.lwjgl.input.Mouse
 
 class GuiOptionEditorUpdateCheck(option: ProcessedOption) : GuiOptionEditor(option) {
 
-    val button = GuiElementButton("", -1) { }
+    val button = GuiElementButton("", -1) {}
 
     override fun render(x: Int, y: Int, width: Int) {
         val fr = Minecraft.getMinecraft().fontRendererObj
@@ -55,7 +55,7 @@ class GuiOptionEditorUpdateCheck(option: ProcessedOption) : GuiOptionEditor(opti
             10F,
             true,
             widthRemaining / 2,
-            -1
+            -1,
         )
 
         GlStateManager.popMatrix()

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.test.graph
 
 import at.hannibal2.skyhanni.data.model.GraphNodeTag
-import at.hannibal2.skyhanni.data.model.TextInput
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.graph.GraphEditor.distanceSqToPlayer
@@ -14,6 +13,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.ScrollValue
+import at.hannibal2.skyhanni.utils.renderables.SearchTextInput
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.buildSearchableScrollable
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
@@ -27,7 +27,7 @@ object GraphNodeEditor {
 
     private val scrollValueNodes = ScrollValue()
     private val scrollValueTags = ScrollValue()
-    private val textInput = TextInput()
+    private val textInput = SearchTextInput()
     private var nodesDisplay = emptyList<Renderable>()
     private var lastUpdate = SimpleTimeMark.farPast()
     private val tagsToShow: MutableList<GraphNodeTag> = GraphNodeTag.entries.toMutableList()

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/SearchTextInput.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/SearchTextInput.kt
@@ -1,0 +1,38 @@
+package at.hannibal2.skyhanni.utils.renderables
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.model.TextInput
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class SearchTextInput : TextInput() {
+
+    init {
+        searchTextInputs.add(this)
+    }
+
+    @SkyHanniModule
+    companion object {
+
+        private val config get() = SkyHanniMod.feature.misc
+
+        val searchTextInputs = mutableListOf<SearchTextInput>()
+
+        @SubscribeEvent
+        fun onInventoryClose(event: InventoryCloseEvent) {
+            if (!isEnabled()) return
+
+            for (input in searchTextInputs) {
+                if (input.textBox != "") {
+                    input.textBox = ""
+                    input.update()
+                }
+            }
+        }
+
+        fun isEnabled() = LorenzUtils.inSkyBlock && config.resetSearchGuiOnClose
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Searchable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Searchable.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.utils.renderables
 
-import at.hannibal2.skyhanni.data.model.TextInput
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 
 class Searchable(val renderable: Renderable, val string: String?)
@@ -10,14 +9,15 @@ fun Searchable.toRenderable() = renderable
 fun List<Searchable>.toRenderable() = map { it.toRenderable() }
 fun List<Searchable>.toMap() = associate { it.renderable to it.string }
 const val SEARCH_PREFIX = "§eSearch: §7"
+
 fun List<Searchable>.buildSearchBox(
-    textInput: TextInput,
+    textInput: SearchTextInput,
 ): Renderable {
     val key = 0
     return Renderable.searchBox(
         Renderable.verticalSearchableContainer(toMap(), textInput = textInput, key = key + 1),
         SEARCH_PREFIX,
-        onUpdateSize = { println("onUpdateSize") },
+        onUpdateSize = {},
         textInput = textInput,
         key = key,
     )
@@ -25,7 +25,7 @@ fun List<Searchable>.buildSearchBox(
 
 fun List<Searchable>.buildSearchableScrollable(
     height: Int,
-    textInput: TextInput,
+    textInput: SearchTextInput,
     scrollValue: ScrollValue = ScrollValue(),
     velocity: Double = 2.0,
 ): Renderable {
@@ -46,13 +46,15 @@ fun List<Searchable>.buildSearchableScrollable(
     )
 }
 
+// TODO remove this function entirely, sack display should use a SearchTextInput object per sack name
+@Deprecated("remove this function, instead use a fix SearchTextInput object")
 fun Map<List<Renderable>, String?>.buildSearchableTable(): Renderable {
-    val textInput = TextInput()
+    val textInput = SearchTextInput()
     val key = 0
     return Renderable.searchBox(
         Renderable.searchableTable(toMap(), textInput = textInput, key = key + 1),
         SEARCH_PREFIX,
-        onUpdateSize = { println("onUpdateSize") },
+        onUpdateSize = {},
         textInput = textInput,
         key = key,
     )

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Searchable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Searchable.kt
@@ -40,7 +40,7 @@ fun List<Searchable>.buildSearchableScrollable(
             velocity = velocity,
         ),
         SEARCH_PREFIX,
-        onUpdateSize = { println("onUpdateSize") },
+        onUpdateSize = {},
         textInput = textInput,
         key = key,
     )

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.TrackerManager
-import at.hannibal2.skyhanni.data.model.TextInput
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -15,6 +14,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.SearchTextInput
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.buildSearchBox
 import at.hannibal2.skyhanni.utils.renderables.toRenderable
@@ -39,7 +39,7 @@ open class SkyHanniTracker<Data : TrackerData>(
     private var sessionResetTime = SimpleTimeMark.farPast()
     private var wasSearchEnabled = config.trackerSearchEnabled.get()
     private var dirty = false
-    private val textInput = TextInput()
+    private val textInput = SearchTextInput()
 
     companion object {
 


### PR DESCRIPTION
## What
added option to disable search in guis, opt in

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/fa7e2589-618f-4d63-bf39-3a49435fb6c6)

</details>

## Changelog Improvements
+ Added an option to reset search on close. - hannibal2
    * Reset search terms in GUIs after closing inventory (Profit Trackers, Area Navigation list, etc.).
    * Enabled by default to reduce confusion caused by the search feature.
