### PR TITLE
Fix: Reforge Helper NPE

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
@@ -417,8 +417,8 @@ object ReforgeHelper {
         if (slot != null) {
             slot highlight color
         } else {
-            inventory[HEX_REFORGE_NEXT_DOWN_BUTTON]?.takeIf { it.stack.item == Items.skull }?.highlight(color)
-            inventory[HEX_REFORGE_NEXT_UP_BUTTON]?.takeIf { it.stack.item == Items.skull }?.highlight(color)
+            inventory[HEX_REFORGE_NEXT_DOWN_BUTTON]?.takeIf { it.stack?.item == Items.skull }?.highlight(color)
+            inventory[HEX_REFORGE_NEXT_UP_BUTTON]?.takeIf { it.stack?.item == Items.skull }?.highlight(color)
         }
     }
 


### PR DESCRIPTION
## What
Fixes a NPE in the reforge helper logic because the item stack of a slot might be null.
stack trace and report are at https://discord.com/channels/997079228510117908/1319355646960734270

## Changelog Fixes
+ Fixed a rare error with Reforge Helper. - hannibal2