### PR TITLE
Backend: Remove Unused Config Option

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -212,15 +212,6 @@ public class ChocolateFactoryConfig {
     public Position strayRabbitTrackerPosition = new Position(300, 300, false, true);
 
     @Expose
-    @ConfigOption(
-        name = "Hitman Slot Rabbit",
-        desc = "Show the last rabbit found in hitman slots that are on cooldown."
-    )
-    @ConfigEditorBoolean
-    @FeatureToggle
-    public boolean hitmanSlotInfo = false;
-
-    @Expose
     @ConfigOption(name = "Hitman Costs", desc = "Show the sum cost of remaining hitman slots.")
     @ConfigEditorBoolean
     @FeatureToggle


### PR DESCRIPTION
## What
Re: #3078, the config option didn't get removed in that one, I wish we could point detekt at the config files :(

exclude_from_changelog

