### PR TITLE
Backend: Contributor Rabbit Name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -92,6 +92,11 @@ public class ChocolateFactoryConfig {
     public boolean showStackSizes = true;
 
     @Expose
+    @ConfigOption(name = "Contributor Rabbit Name", desc = "Replaces the rabbit names in the rabbit collection menu with SkyHanni contributor names.")
+    @ConfigEditorBoolean
+    public boolean contributorRabbitName = false;
+
+    @Expose
     @ConfigOption(name = "Highlight Upgrades", desc = "Highlight any upgrades that you can afford.\n" +
         "The upgrade with a star is the most optimal and the lightest color of green is the most optimal you can afford.")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionData.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 
 @SkyHanniModule
 object HoppityCollectionData {
-    private val rabbitRarities = mutableMapOf<String, RabbitCollectionRarity>()
+    val rabbitRarities = mutableMapOf<String, RabbitCollectionRarity>()
     private val rarityBonuses = mutableMapOf<RabbitCollectionRarity, ChocolateBonuses>()
     private val specialBonuses = mutableMapOf<String, ChocolateBonuses>()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
@@ -21,7 +21,7 @@ object ReplaceHoppityWithContributor {
 
     private val config get() = ChocolateFactoryAPI.config
 
-    private var replaceMap = mutableMapOf<String, String>()
+    private val replaceMap = mutableMapOf<String, String>()
 
     @HandleEvent(priority = 5)
     fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
@@ -1,0 +1,82 @@
+package at.hannibal2.skyhanni.features.event.hoppity
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
+import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
+import at.hannibal2.skyhanni.features.misc.ContributorManager
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.CircularList
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.name
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.StringUtils.allLettersFirstUppercase
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import net.minecraftforge.fml.common.eventhandler.EventPriority
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object ReplaceHoppityWithContributor {
+
+    private val config get() = ChocolateFactoryAPI.config
+
+    private var replaceMap = mutableMapOf<String, String>()
+
+    @HandleEvent(priority = 5)
+    fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
+        update()
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    fun onRepoReload(event: RepositoryReloadEvent) {
+        update()
+    }
+
+    fun update() {
+        replaceMap.clear()
+
+        val contributors = ContributorManager.contributorNames
+        val rabbits = HoppityCollectionData.rabbitRarities
+
+        if (contributors.isEmpty()) return
+        if (rabbits.isEmpty()) return
+
+        val newNames = CircularList(contributors.toList())
+        for (internalName in rabbits.map { it.key }.shuffled()) {
+            val realName = internalName.replace("_", " ").allLettersFirstUppercase()
+            val newName = newNames.next()
+            replaceMap[realName] = newName
+        }
+    }
+
+    @HandleEvent(priority = HandleEvent.LOWEST)
+    fun onTooltip(event: ItemHoverEvent) {
+        if (!isEnabled()) return
+        if (!HoppityCollectionStats.inInventory) return
+
+        val itemStack = event.itemStack
+        val lore = itemStack.getLore()
+        val last = lore.lastOrNull() ?: return
+        if (!last.endsWith(" RABBIT")) return
+
+        val realName = itemStack.name
+        val cleanName = realName.removeColor()
+        val fakeName = replaceMap[cleanName] ?: return
+
+        val newName = event.toolTip[0].replace(cleanName, fakeName)
+        event.toolTip[0] = newName
+
+        // TODO find a way to handle non containing entries in a kotlin nullable way instead of checking for -1
+        val index = event.toolTip.indexOfFirst { it.contains(" a duplicate") }
+        if (index == -1) return
+        val oldLine = event.toolTip[index]
+        val newLine = oldLine.replace(cleanName, fakeName)
+        event.toolTip[index] = newLine
+
+        event.toolTip.add(" ")
+        event.toolTip.add("§8§oSome might say this rabbit is also known as $realName")
+    }
+
+    fun isEnabled() = LorenzUtils.inSkyBlock && config.contributorRabbitName
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
@@ -44,7 +44,7 @@ object ReplaceHoppityWithContributor {
 
         val newNames = CircularList(contributors.toList())
         for (internalName in rabbits.map { it.key }.shuffled()) {
-            val realName = internalName.replace("_", " ").allLettersFirstUppercase()
+            val realName = internalName.allLettersFirstUppercase()
             val newName = newNames.next()
             replaceMap[realName] = newName
         }
@@ -67,15 +67,15 @@ object ReplaceHoppityWithContributor {
         val newName = event.toolTip[0].replace(cleanName, fakeName)
         event.toolTip[0] = newName
 
+        event.toolTip.add(" ")
+        event.toolTip.add("§8§oSome might say this rabbit is also known as $realName")
+
         // TODO find a way to handle non containing entries in a kotlin nullable way instead of checking for -1
         val index = event.toolTip.indexOfFirst { it.contains(" a duplicate") }
         if (index == -1) return
         val oldLine = event.toolTip[index]
         val newLine = oldLine.replace(cleanName, fakeName)
         event.toolTip[index] = newLine
-
-        event.toolTip.add(" ")
-        event.toolTip.add("§8§oSome might say this rabbit is also known as $realName")
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.contributorRabbitName

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -16,11 +16,18 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 object ContributorManager {
     private val config get() = SkyHanniMod.feature.dev
 
+    // Key is the lowercase contributor name
     private var contributors: Map<String, ContributorJsonEntry> = emptyMap()
+
+    // Just the names of the contributors including their proper case
+    var contributorNames = emptyList<String>()
+        private set
 
     @SubscribeEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
-        contributors = event.getConstant<ContributorsJson>("Contributors").contributors.mapKeys { it.key.lowercase() }
+        val map = event.getConstant<ContributorsJson>("Contributors").contributors
+        contributors = map.mapKeys { it.key.lowercase() }
+        contributorNames = map.map { it.key }
     }
 
     @HandleEvent


### PR DESCRIPTION
added a funny little easteregg that users have to find in the config themselfes.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/b6daa5e8-3efb-4b7f-977a-dc3437812dff)

</details>


## Changelog Technical Details
+ Added contributor rabbit names. - hannibal2
    * Replaced rabbit names in the rabbit collection menu with SkyHanni contributor names.