### PR TITLE
Fix: shwords causing blank messages in chat

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -19,8 +19,6 @@ object ModifyVisualWords {
 
     var modifiedWords = mutableListOf<VisualWord>()
 
-    val reverseRegex = "(§.|^|[\\s:()+-])([^§\\s:()+-]*)".toRegex()
-
     fun modifyText(originalText: String?): String? {
         var modifiedText = originalText ?: return null
         if (!LorenzUtils.onHypixel) return originalText
@@ -47,14 +45,6 @@ object ModifyVisualWords {
                 }
             }
 
-            // Disabled, as it's only a novelty for 30 seconds and will annoy after that everyone.
-            /*
-            if (LorenzUtils.isAprilFoolsDay && !FontRendererHook.cameFromChat && Random.nextDouble() < 0.02) {
-                modifiedText = modifiedText.replace(reverseRegex) {
-                    it.groupValues[1] + it.groupValues[2].reversed()
-                }
-            }
-             */
             modifiedText
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -22,6 +22,32 @@ object ModifyVisualWords {
     // Replacements the user added manually via /shwords
     var userModifiedWords = mutableListOf<VisualWord>()
 
+    // Replacements the mod added automatically for some features, april jokes, etc
+    var modModifiedWords = mutableListOf<VisualWord>()
+    private var finalWordsList = listOf<VisualWord>()
+    private var debug = false
+
+    fun update() {
+        finalWordsList = modModifiedWords + userModifiedWords
+        textCache.clear()
+    }
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.register("shdebugvisualwords") {
+            description = "Prints in the console all replaced words by /shwords"
+            callback { toggleDebug() }
+        }
+    }
+
+    private fun toggleDebug() {
+        debug = !debug
+        ChatUtils.chat("Visual Words debug ${if (debug) "enabled" else "disabled"}")
+        if (debug) {
+            update()
+        }
+    }
+
     fun modifyText(originalText: String?): String? {
         var modifiedText = originalText ?: return null
         if (!LorenzUtils.onHypixel) return originalText

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiUtilRenderComponents.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiUtilRenderComponents.java
@@ -1,0 +1,17 @@
+package at.hannibal2.skyhanni.mixins.transformers.gui;
+
+import at.hannibal2.skyhanni.features.misc.visualwords.ModifyVisualWords;
+import net.minecraft.client.gui.GuiUtilRenderComponents;
+import net.minecraft.util.IChatComponent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(GuiUtilRenderComponents.class)
+public class MixinGuiUtilRenderComponents {
+
+    @Redirect(method = "splitText", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/IChatComponent;getUnformattedTextForChat()Ljava/lang/String;"))
+    private static String onSplitText(IChatComponent instance) {
+        return ModifyVisualWords.INSTANCE.modifyText(instance.getUnformattedTextForChat());
+    }
+}


### PR DESCRIPTION
## What
Fixes chat messages becoming blank if they are too long after being effected by /shwords.
This has a small downside:
Messages sent before turning on the shwords will look like this:
![image](https://github.com/user-attachments/assets/c8f4e388-b29c-44a5-b245-924d916e4d8f)
Messages sent while shwords is on look normal: (However they stay like this even after turning off the rule)
![image](https://github.com/user-attachments/assets/6c6466c7-475f-4ee5-9cb9-92f61135d1dd)

This does not effect the messages text anywhere else as far as I could tell.
The Minecraft log, /shchathistory and chat events all have the correct text


<details>
<summary>Images</summary>

unlucky they arent in the dropdown

</details>

## Changelog Fixes
+ Fixed /shwords causing blank messages in chat. - nopo