### PR TITLE
Improvement + Fix: Roman Allow List

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -305,7 +305,7 @@ public class MiscConfig {
     @ConfigOption(name = "Replace Roman Numerals", desc = "Replace Roman Numerals with Arabic Numerals on any item.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean replaceRomanNumerals = false;
+    public Property<Boolean> replaceRomanNumerals = Property.of(false);
 
     @Expose
     @ConfigOption(name = "Thunder Bottle", desc = "Show a notification when your Thunder Bottle is fully charged.")

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/RomanNumeralReplaceListJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/RomanNumeralReplaceListJson.kt
@@ -1,7 +1,0 @@
-package at.hannibal2.skyhanni.data.jsonobjects.repo
-
-import com.google.gson.annotations.Expose
-
-class RomanNumeralReplaceListJson(
-    @Expose val list: List<String>,
-)

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/RomanNumeralReplaceListJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/RomanNumeralReplaceListJson.kt
@@ -1,0 +1,7 @@
+package at.hannibal2.skyhanni.data.jsonobjects.repo
+
+import com.google.gson.annotations.Expose
+
+class RomanNumeralReplaceListJson(
+    @Expose val list: List<String>,
+)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementSlayer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementSlayer.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.gui.customscoreboard.elements
 
 import at.hannibal2.skyhanni.data.SlayerAPI
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard.informationFilteringConfig
+import at.hannibal2.skyhanni.features.misc.ReplaceRomanNumerals
 
 // internal
 // scoreboard update event
@@ -9,7 +10,7 @@ object ScoreboardElementSlayer : ScoreboardElement() {
     override fun getDisplay() = buildList {
         if (!SlayerAPI.hasActiveSlayerQuest()) return@buildList
         add("Slayer Quest")
-        add(SlayerAPI.latestSlayerCategory)
+        add(ReplaceRomanNumerals.replaceLine(SlayerAPI.latestSlayerCategory))
         add(SlayerAPI.latestSlayerProgress)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
@@ -34,7 +34,7 @@ object ReplaceRomanNumerals {
 
     @Suppress("MaxLineLength")
     private val allowedPatterns by patternGroup.list(
-        "allowed-patterns",
+        "allowed.patterns",
         "§o§a(?:Combat|Farming|Fishing|Mining|Foraging|Enchanting|Alchemy|Carpentry|Runecrafting|Taming|Social|)( Level)? (?<roman>[IVXLCDM]+)§r",
         "(?:§5§o)?§7Progress to (?:Collection|Level|Tier|Floor|Milestone|Chocolate Factory) (?<roman>[IVXLCDM]+): §.(?:.*)%",
         "§5§o  §e(?:\\w+) (?<roman>[IVXLCDM]+)",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
@@ -3,55 +3,50 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
+import at.hannibal2.skyhanni.data.jsonobjects.repo.RomanNumeralReplaceListJson
 import at.hannibal2.skyhanni.events.ChatHoverEvent
-import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.LorenzToolTipEvent
+import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.features.inventory.patternGroup
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
-import at.hannibal2.skyhanni.utils.RegexUtils.findMatcher
+import at.hannibal2.skyhanni.utils.RecalculatingValue
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.applyIfPossible
 import at.hannibal2.skyhanni.utils.StringUtils.isRoman
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.TimeLimitedCache
 import net.minecraft.event.HoverEvent
 import net.minecraft.util.ChatComponentText
+import net.minecraftforge.fml.common.eventhandler.EventPriority
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.util.regex.Pattern
+import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object ReplaceRomanNumerals {
-    private val patternGroup = RepoPattern.group("replace.roman")
+    // Using toRegex here since toPattern doesn't seem to provide the necessary functionality
+    private val splitRegex = "((§\\w)|(\\s+)|(\\W))+|(\\w*)".toRegex()
+    private val cachedStrings = TimeLimitedCache<String, String>(5.seconds)
+    private var allowedPatterns = emptyList<Pattern>()
 
     /**
-     * REGEX-TEST: §9Dedication IV
-     * REGEX-FAIL: §cD§6y§ee§as
+     * REGEX-TEST: §eSelect an option: §r§a[§aOk, then what?§a]
      */
-    private val findRomanNumeralPattern by patternGroup.pattern(
-        "findroman",
-        "[ ➜](?=[MDCLXVI])(?<roman>M*(?:C[MD]|D?C{0,3})(?:X[CL]|L?X{0,3})(?:I[XV]|V?I{0,3}))(?<extra>.?)"
+    private val isSelectOptionPattern by patternGroup.pattern(
+        "string.isselectoption",
+        "§eSelect an option: .*",
     )
 
-    /**
-     * REGEX-TEST: K
-     */
-    private val isWordPattern by patternGroup.pattern(
-        "findword",
-        "^[\\w-']"
-    )
-
-    /**
-     * REGEX-TEST: ➜
-     */
-    private val allowedCharactersAfter by patternGroup.pattern(
-        "allowedcharactersafter",
-        "[➜):]?"
-    )
-
-    @HandleEvent(priority = HandleEvent.LOWEST)
-    fun onTooltip(event: ItemHoverEvent) {
+    // TODO: Remove after pr 1717 is ready and switch to ItemHoverEvent
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    fun onTooltip(event: LorenzToolTipEvent) {
         if (!isEnabled()) return
 
-        event.toolTip.replaceAll { it.transformLine() }
+        event.toolTip.replaceAll { it.tryReplace() }
     }
 
     @HandleEvent(priority = HandleEvent.LOWEST)
@@ -60,7 +55,7 @@ object ReplaceRomanNumerals {
         if (!isEnabled()) return
 
         val lore = event.getHoverEvent().value.formattedText.split("\n").toMutableList()
-        lore.replaceAll { it.transformLine() }
+        lore.replaceAll { it.tryReplace() }
 
         val chatComponentText = ChatComponentText(lore.joinToString("\n"))
         val hoverEvent = HoverEvent(event.component.chatStyle.chatHoverEvent?.action, chatComponentText)
@@ -70,38 +65,60 @@ object ReplaceRomanNumerals {
 
     @HandleEvent
     fun onSystemMessage(event: SystemMessageEvent) {
-        if (!isEnabled()) return
-        event.applyIfPossible { it.transformLine() }
+        if (!isEnabled() || event.message.isSelectOption()) return
+        event.applyIfPossible { it.tryReplace() }
     }
 
-    /**
-     * Transforms a line with a roman numeral to a line with a decimal numeral.
-     * Override block one is to be used for tablist or other places where there is no need to check for normal text containing
-     * the word "I".
-     *
-     * Currently not replaced:
-     * - "§7Bonzo I Reward:" in the collection rewards when hovering on the collection
-     */
-    private fun String.transformLine(overrideBlockOne: Boolean = false): String {
-        val (romanNumeral, rest) = findRomanNumeralPattern.findMatcher(this.removeFormatting()) {
-            group("roman") to group("extra")
-        } ?: return this
+    @SubscribeEvent(priority = EventPriority.LOW)
+    fun onRepoReload(event: RepositoryReloadEvent) {
+        allowedPatterns = event.getConstant<RomanNumeralReplaceListJson>("RomanNumeralReplacePatterns").list
+            .map { it.toPattern() }
+        cachedStrings.clear()
+    }
 
-        if (romanNumeral.isNullOrEmpty() || !romanNumeral.isRoman() || isWordPattern.matches(rest)) {
-            return recursiveSplit(romanNumeral)
+    private fun String.isSelectOption(): Boolean = isSelectOptionPattern.matches(this)
+
+    private fun String.tryReplace(): String = cachedStrings.getOrPut(this) {
+        if (allowedPatterns.matches(this)) replace() else this
+    }
+
+    fun replaceLine(line: String): String {
+        if (!isEnabled()) return line
+
+        return cachedStrings.getOrPut(line) {
+            line.replace()
         }
-
-        val parsedRomanNumeral = romanNumeral.romanToDecimal()
-
-        return takeIf { parsedRomanNumeral != 1 || overrideBlockOne || rest.isEmpty() || allowedCharactersAfter.matches(rest) }
-            ?.replaceFirst(romanNumeral, parsedRomanNumeral.toString())?.transformLine()
-            ?: recursiveSplit(romanNumeral)
     }
 
-    private fun String.recursiveSplit(romanNumeral: String) =
-        this.split(romanNumeral, limit = 2).let { it[0] + romanNumeral + it[1].transformLine() }
+    private fun String.replace() = splitRegex.findAll(this).map { it.value }.joinToString("") {
+        it.takeIf { it.isValidRomanNumeral() && it.removeFormatting().romanToDecimal() != 2000 }?.coloredRomanToDecimal() ?: it
+    }
 
     private fun String.removeFormatting() = removeColor().replace(",", "")
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && SkyHanniMod.feature.misc.replaceRomanNumerals
+    private fun String.isValidRomanNumeral() = removeFormatting().let { it.isRoman() && it.isNotEmpty() }
+
+    private fun String.coloredRomanToDecimal() = removeFormatting().let { replace(it, it.romanToDecimal().toString()) }
+
+    private fun isEnabled() = LorenzUtils.inSkyBlock && SkyHanniMod.feature.misc.replaceRomanNumerals.get()
+
+    init {
+        RecalculatingValue
+    }
+
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Replace Roman Numerals")
+        event.addIrrelevant {
+            val map = cachedStrings.toMap()
+            add("cachedStrings: (${map.size})")
+            for ((original, changed) in map) {
+                if (original == changed) {
+                    add("unchanged: '$original'")
+                } else {
+                    add("'$original' -> '$changed'")
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
@@ -30,7 +30,7 @@ object ReplaceRomanNumerals {
     private val splitRegex = "((§\\w)|(\\s+)|(\\W))+|(\\w*)".toRegex()
     private val cachedStrings = TimeLimitedCache<String, String>(5.seconds)
 
-    private val patternGroup = RepoPattern.group("replace-roman-numerals")
+    private val patternGroup = RepoPattern.group("replace.roman.numerals")
 
     @Suppress("MaxLineLength")
     private val allowedPatterns by patternGroup.list(

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -19,7 +19,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getAttributeFromShard
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getReadableNBTDump
 import at.hannibal2.skyhanni.utils.ItemUtils.isRune
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
@@ -777,10 +776,9 @@ object EstimatedItemValueCalculator {
             if (rawName in tieredEnchants) level = 1
 
             val enchantmentName = "$rawName;$level".uppercase().toInternalName()
-            val itemStack = enchantmentName.getItemStackOrNull() ?: continue
             val singlePrice = enchantmentName.getPriceOrNull(config.priceSource.get()) ?: continue
 
-            var name = itemStack.getLore()[0]
+            var name = enchantmentName.itemName
             // TODO find a way to use this here "".toInternalName().getPriceName(multiplier)
             if (multiplier > 1) {
                 name = "§8${multiplier}x $name"

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
@@ -222,8 +222,6 @@ object SlayerRngMeterDisplay {
         ) {
             return ""
         }
-        val latestSlayerCategory = SlayerAPI.latestSlayerCategory
-        latestSlayerCategory.endsWith(" I")
 
         with(storage) {
             if (itemGoal == "?") return "§cOpen RNG Meter Inventory!"

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -1,10 +1,13 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.NotificationManager
 import at.hannibal2.skyhanni.data.PetAPI
 import at.hannibal2.skyhanni.data.SkyHanniNotification
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.features.misc.ReplaceRomanNumerals
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator.getAttributeName
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -45,6 +48,13 @@ object ItemUtils {
 
     private val missingRepoItems = mutableSetOf<String>()
     private var lastRepoWarning = SimpleTimeMark.farPast()
+
+    @HandleEvent
+    fun onConfigLoad(event: ConfigLoadEvent) {
+        ConditionalUtils.onToggle(SkyHanniMod.feature.misc.replaceRomanNumerals) {
+            itemNameCache.clear()
+        }
+    }
 
     private val SKYBLOCK_MENU by lazy { "SKYBLOCK_MENU".toInternalName() }
 
@@ -500,15 +510,20 @@ object ItemUtils {
 
         // show enchanted book name
         if (itemStack.getItemCategoryOrNull() == ItemCategory.ENCHANTED_BOOK) {
-            return itemStack.getLore()[0]
+            return ReplaceRomanNumerals.replaceLine(itemStack.getLore()[0])
         }
         if (name.endsWith("Enchanted Book Bundle")) {
-            return name.replace("Enchanted Book", itemStack.getLore()[0].removeColor())
+            return name.replace("Enchanted Book", ReplaceRomanNumerals.replaceLine(itemStack.getLore()[0]).removeColor())
         }
 
         // obfuscated trophy fish
         if (name.contains("§kObfuscated")) {
             return name.replace("§kObfuscated", "Obfuscated")
+        }
+
+        // remove roman runic tier
+        if (isRune()) {
+            return ReplaceRomanNumerals.replaceLine(name)
         }
 
         // hide pet level


### PR DESCRIPTION
## Dependencies
- #https://github.com/hannibal002/SkyHanni-REPO/pull/313

## What
This is a big one. Instead of trying to find roman numbers in every line, we now just replace lines we deem "allowed" via a regex list from repo.
This will fix all possible cases of "accidentally replacing parts of valid words to numbers".

I have started replacing parts of the code that relies on the old logic to use the new one, but I assume this is not fully done yet. If we get more reports, we can easily migrate those features over.

Additionally, I'm sure the list of patterns doesn't match every scenario from items. Moreover, I have not yet done one single chat message.
Once we start getting reports over not replaced numbers, we can add them easily to the list.

## Changelog Improvements
+ Added Roman numeral support to slayer names in trackers, Profit Tracker Items, and Scoreboard. - hannibal2

## Changelog Fixes
+ Fixed distortion of regular words due to incorrect Roman numeral replacement. - hannibal2

## Changelog Technical Details
+ Added allowlist for Roman numeral replacement. - hannibal2