### PR TITLE
Fix: Kuudra Lines in CS

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -201,7 +201,13 @@ object CustomScoreboard {
 
     @HandleEvent
     fun onIslandChange(event: IslandChangeEvent) {
-        if (event.newIsland != IslandType.NONE) updateIslandEntries()
+        if (event.newIsland != IslandType.NONE) {
+            updateIslandEntries()
+
+            runDelayed(3.seconds) {
+                updateIslandEntries()
+            }
+        }
     }
 
     private fun updateIslandEntries() {


### PR DESCRIPTION
## What
I unironically dont know why this issue exists
Like the Kuudra element should be active in the island ("island") but is not in the island list ("in island").
![image](https://github.com/user-attachments/assets/111cff18-bc4c-4174-a954-9954c502c4ce)
So re-fetching the elements that should be active 3s after world switch might fix this?? idk



## Changelog Fixes
+ Fixed Kuudra Lines sometimes not displaying in Custom Scoreboard. - j10a1n15
