### PR TITLE
Fix: Farming Skill XP

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -62,7 +62,7 @@ ktlint_standard_no-wildcard-imports = enabled
 ktlint_standard_function-expression-body = disabled
 
 # Additional Kotlin-specific formatting for conditions and continuation
-ij_kotlin_continuation_indent_size = 8
+ij_kotlin_continuation_indent_size = 4
 ij_kotlin_binary_expression_wrap = if_long
 ij_kotlin_keep_line_breaks = true
 ij_kotlin_annotations_new_line_after_suppress = true

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
@@ -414,7 +414,7 @@ object SkillAPI {
                     val (overflowLevel, current, needed, _) = calculateSkillLevel(xp, 60)
                     ChatUtils.chat(
                         "With §b${xp.addSeparators()} §eXP you would be level §b$overflowLevel " +
-                                "§ewith progress (§b${current.addSeparators()}§e/§b${needed.addSeparators()}§e) XP",
+                            "§ewith progress (§b${current.addSeparators()}§e/§b${needed.addSeparators()}§e) XP",
                     )
                     return
                 }

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.features.skillprogress.SkillUtil.getSkillInfo
 import at.hannibal2.skyhanni.features.skillprogress.SkillUtil.xpRequiredForLevel
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -154,7 +155,11 @@ object SkillAPI {
         levelArray = data.levelingXp
         levelingMap = levelArray.withIndex().associate { (index, xp) -> (index + 1) to xp }
         exactLevelingMap = levelArray.withIndex().associate { (index, xp) -> xp to (index + 1) }
-        defaultSkillCap = data.levelingCaps
+        defaultSkillCap = data.levelingCaps.editCopy {
+            if (this["farming"] == 50) {
+                this["farming"] = 60
+            }
+        }
     }
 
     @SubscribeEvent
@@ -409,7 +414,7 @@ object SkillAPI {
                     val (overflowLevel, current, needed, _) = calculateSkillLevel(xp, 60)
                     ChatUtils.chat(
                         "With §b${xp.addSeparators()} §eXP you would be level §b$overflowLevel " +
-                            "§ewith progress (§b${current.addSeparators()}§e/§b${needed.addSeparators()}§e) XP",
+                                "§ewith progress (§b${current.addSeparators()}§e/§b${needed.addSeparators()}§e) XP",
                     )
                     return
                 }


### PR DESCRIPTION
## What
workaround for most farming skill xp bugs

## Changelog Fixes
+ Fixed most incorrect farming skill XP cases. - hannibal2
    * Calculation errors when reaching a skill cap below 60 are not fixed yet.