### PR TITLE
Fix: Force zero price for glitched Gemstone Collection item

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -25,6 +25,7 @@ object ItemPriceUtils {
         pastRecipes: List<PrimitiveRecipe> = emptyList(),
     ): Double? {
         when (this) {
+            NEUInternalName.GEMSTONE_COLLECTION -> return 0.0
             NEUInternalName.JASPER_CRYSTAL -> return 0.0
             NEUInternalName.RUBY_CRYSTAL -> return 0.0
             NEUInternalName.SKYBLOCK_COIN -> return 1.0

--- a/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NEUInternalName.kt
@@ -11,6 +11,7 @@ class NEUInternalName private constructor(private val internalName: String) {
         val NONE = "NONE".toInternalName()
         val MISSING_ITEM = "MISSING_ITEM".toInternalName()
 
+        val GEMSTONE_COLLECTION = "GEMSTONE_COLLECTION".toInternalName()
         val JASPER_CRYSTAL = "JASPER_CRYSTAL".toInternalName()
         val RUBY_CRYSTAL = "RUBY_CRYSTAL".toInternalName()
         val SKYBLOCK_COIN = "SKYBLOCK_COIN".toInternalName()


### PR DESCRIPTION
## What
Force price to 0 for glitched `GEMSTONE_COLLECTION` item, which is supposed to be a placeholder item for Gemstone collection, but it currently has a 350M lowest BIN price, because it used to be possible to glitch it out of menus, and it is causing insane prices to be shown for Gemstone Powder in Garden visitor rewards.

## Changelog Fixes
+ Fixed Gemstone Powder showing as being worth billions of coins in Garden visitor rewards. - Luna
