### PR TITLE
Backend: Bump NEU depend to 2.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,8 +192,8 @@ dependencies {
         isTransitive = false
     }
     // October 3, 2024, 11:43 PM AEST
-    // https://github.com/NotEnoughUpdates/NotEnoughUpdates/tree/2.4.0
-    devenvMod("com.github.NotEnoughUpdates:NotEnoughUpdates:2.4.0:all") {
+    // https://github.com/NotEnoughUpdates/NotEnoughUpdates/tree/2.5.0
+    devenvMod("com.github.NotEnoughUpdates:NotEnoughUpdates:2.5.0:all") {
         exclude(module = "unspecified")
         isTransitive = false
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -191,7 +191,7 @@ dependencies {
         exclude(module = "unspecified")
         isTransitive = false
     }
-    // October 3, 2024, 11:43 PM AEST
+    // December 29, 2024, 07:30 PM EST
     // https://github.com/NotEnoughUpdates/NotEnoughUpdates/tree/2.5.0
     devenvMod("com.github.NotEnoughUpdates:NotEnoughUpdates:2.5.0:all") {
         exclude(module = "unspecified")


### PR DESCRIPTION
## What
Bumps the NEU dependency to 2.5.0

exclude_from_changelog

