### PR TITLE
Improvement: Damage Indicator forever

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
@@ -126,6 +126,11 @@ public class DevConfig {
     public boolean numberFormatOverride = false;
 
     @Expose
+    @ConfigOption(name = "Damage Indicator", desc = "Enable the backend of the Damage Indicator. §cOnly disable when you know what you are doing!")
+    @ConfigEditorBoolean
+    public boolean damageIndicatorBackend = true;
+
+    @Expose
     @ConfigOption(
         name = "NTP Server",
         desc = "Change the NTP-Server Address. Default is \"time.google.com\".\n§cONLY CHANGE THIS IF YOU KNOW WHAT YOU'RE DOING!"

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -79,8 +79,6 @@ object DamageIndicatorManager {
     private var data = mapOf<UUID, EntityData>()
     private val damagePattern = "[✧✯]?(\\d+[⚔+✧❤♞☄✷ﬗ✯]*)".toPattern()
 
-    fun isBoss(entity: EntityLivingBase) = data.values.any { it.entity == entity }
-
     fun isDamageSplash(entity: EntityLivingBase): Boolean {
         if (entity.ticksExisted > 300 || entity !is EntityArmorStand) return false
         if (!entity.hasCustomName()) return false
@@ -129,6 +127,9 @@ object DamageIndicatorManager {
     @SubscribeEvent
     fun onWorldRender(event: LorenzRenderWorldEvent) {
         if (!isEnabled()) return
+
+        // only render when actually enabled
+        if (!config.enabled) return
 
         GlStateManager.disableDepth()
         GlStateManager.disableCull()
@@ -277,22 +278,20 @@ object DamageIndicatorManager {
 
     private fun EntityData.isConfigEnabled() = bossType.bossTypeToggle in config.bossesToShow
 
-    private fun noDeathDisplay(bossType: BossType): Boolean {
-        return when (bossType) {
-            BossType.SLAYER_BLAZE_TYPHOEUS_1,
-            BossType.SLAYER_BLAZE_TYPHOEUS_2,
-            BossType.SLAYER_BLAZE_TYPHOEUS_3,
-            BossType.SLAYER_BLAZE_TYPHOEUS_4,
-            BossType.SLAYER_BLAZE_QUAZII_1,
-            BossType.SLAYER_BLAZE_QUAZII_2,
-            BossType.SLAYER_BLAZE_QUAZII_3,
-            BossType.SLAYER_BLAZE_QUAZII_4,
+    private fun noDeathDisplay(bossType: BossType): Boolean = when (bossType) {
+        BossType.SLAYER_BLAZE_TYPHOEUS_1,
+        BossType.SLAYER_BLAZE_TYPHOEUS_2,
+        BossType.SLAYER_BLAZE_TYPHOEUS_3,
+        BossType.SLAYER_BLAZE_TYPHOEUS_4,
+        BossType.SLAYER_BLAZE_QUAZII_1,
+        BossType.SLAYER_BLAZE_QUAZII_2,
+        BossType.SLAYER_BLAZE_QUAZII_3,
+        BossType.SLAYER_BLAZE_QUAZII_4,
 
             // TODO f3/m3 4 guardians, f2/m2 4 boss room fighters
-            -> true
+        -> true
 
-            else -> false
-        }
+        else -> false
     }
 
     private fun tickDamage(damageCounter: DamageCounter) {
@@ -392,6 +391,7 @@ object DamageIndicatorManager {
         }
     }
 
+    @Suppress("ReturnCount")
     private fun getCustomHealth(
         entityData: EntityData,
         health: Long,
@@ -738,6 +738,7 @@ object DamageIndicatorManager {
         return ""
     }
 
+    @Suppress("CyclomaticComplexMethod", "ReturnCount")
     private fun checkThorn(realHealth: Long, realMaxHealth: Long): String? {
         val maxHealth: Int
         val health = if (DungeonAPI.isOneOf("F4")) {
@@ -864,6 +865,7 @@ object DamageIndicatorManager {
 
     @SubscribeEvent(priority = EventPriority.HIGH)
     fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityLivingBase>) {
+        if (!isEnabled()) return
         val entity = event.entity
 
         val entityData = data.values.find {
@@ -887,7 +889,7 @@ object DamageIndicatorManager {
                 }
             }
         } else {
-            if (entityData != null && isEnabled() && config.hideVanillaNametag && entityData.isConfigEnabled()) {
+            if (entityData != null && config.hideVanillaNametag && entityData.isConfigEnabled()) {
                 val name = entity.name
                 if (name.contains("Plasmaflux")) return
                 if (name.contains("Overflux")) return
@@ -932,5 +934,5 @@ object DamageIndicatorManager {
         }
     }
 
-    fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
+    fun isEnabled() = LorenzUtils.inSkyBlock && SkyHanniMod.feature.dev.damageIndicatorBackend
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -278,6 +278,7 @@ object DamageIndicatorManager {
 
     private fun EntityData.isConfigEnabled() = bossType.bossTypeToggle in config.bossesToShow
 
+    @Suppress("Indentation")
     private fun noDeathDisplay(bossType: BossType): Boolean = when (bossType) {
         BossType.SLAYER_BLAZE_TYPHOEUS_1,
         BossType.SLAYER_BLAZE_TYPHOEUS_2,

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -50,7 +50,7 @@ object SeaCreatureFeatures {
         rareSeaCreatures.add(mob)
 
         var shouldHighlight = config.highlight
-        if (damageIndicatorConfig.enabled && DamageIndicatorConfig.BossCategory.SEA_CREATURES in damageIndicatorConfig.bossesToShow) {
+        if (DamageIndicatorConfig.BossCategory.SEA_CREATURES in damageIndicatorConfig.bossesToShow) {
             val seaCreaturesBosses =
                 BossType.entries.filter { it.bossTypeToggle == DamageIndicatorConfig.BossCategory.SEA_CREATURES }
             if (seaCreaturesBosses.any { it.fullName.removeColor() == mob.name }) {


### PR DESCRIPTION
## What
Some features that are outside the damage indicator setting require damage indicator backend enabled.
so this PR does the only logical thing, and made damage indicator logic always enabled, and only hide the visuals while the feature is disabled.
this behaviour is still toggleable via a dev option, similar to mob detection logic.

## Changelog Improvements
+ Fixed Blaze Slayer features requiring Damage Indicator to be enabled. - hannibal2