### PR TITLE
Fix: Rift Transfer Logic

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -261,16 +261,8 @@ object HideNotClickableItems {
         if (chestName != "Rift Transfer Chest") return false
 
         showGreenLine = true
-        val riftTransferable = stack.isRiftTransferable() ?: return true
-        if (riftTransferable) {
-            return false
-        }
-        if (RiftAPI.inRift()) {
-            val riftExportable = stack.isRiftExportable() ?: return true
-            if (riftExportable) {
-                return false
-            }
-        }
+
+        if (stack.isRiftTransferable() || stack.isRiftExportable()) return false
 
         hideReason = "Not Rift-Transferable!"
         return true

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/RiftAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/RiftAPI.kt
@@ -31,6 +31,7 @@ object RiftAPI {
         get() = this?.getInternalName() == blowgun
 
     fun ItemStack.motesNpcPrice(): Double? {
+        if (getAttributeBoolean("rift_transferred")) return null
         val baseMotes = motesPrice[getInternalName()] ?: return null
         val burgerStacks = config.motes.burgerStacks
         val pricePer = baseMotes + (burgerStacks * 5) * baseMotes / 100

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/RiftAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/RiftAPI.kt
@@ -11,6 +11,8 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRiftExportable
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.wasRiftTransferred
 import net.minecraft.item.ItemStack
 
 @SkyHanniModule
@@ -31,7 +33,7 @@ object RiftAPI {
         get() = this?.getInternalName() == blowgun
 
     fun ItemStack.motesNpcPrice(): Double? {
-        if (getAttributeBoolean("rift_transferred")) return null
+        if (isRiftExportable() && wasRiftTransferred()) return null
         val baseMotes = motesPrice[getInternalName()] ?: return null
         val burgerStacks = config.motes.burgerStacks
         val pricePer = baseMotes + (burgerStacks * 5) * baseMotes / 100

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import com.google.gson.JsonObject
 import net.minecraft.item.Item
@@ -75,21 +76,21 @@ object SkyBlockItemModifierUtils {
         return data.heldItem
     }
 
-    fun ItemStack.isRiftTransferable(): Boolean? {
+    fun ItemStack.isRiftTransferable(): Boolean {
         val data = cachedData
-        if (data.riftTransferable == null) {
-            data.riftTransferable = getLore().any { it == "§5§kX§5 Rift-Transferable §kX" }
-        }
         return data.riftTransferable
+            ?: UtilsPatterns.riftTransferablePattern.anyMatches(getLore())
+                .also { data.riftTransferable = it }
     }
 
-    fun ItemStack.isRiftExportable(): Boolean? {
+    fun ItemStack.isRiftExportable(): Boolean {
         val data = cachedData
-        if (data.riftExportable == null) {
-            data.riftExportable = getLore().any { it == "§5§kX§5 Rift-Exportable §kX" }
-        }
         return data.riftExportable
+            ?: UtilsPatterns.riftExportablePattern.anyMatches(getLore())
+                .also { data.riftExportable = it }
     }
+
+    fun ItemStack.wasRiftTransferred(): Boolean = getAttributeBoolean("rift_transferred")
 
     private fun ItemStack.getPetInfo() =
         ConfigManager.gson.fromJson(getExtraAttributes()?.getString("petInfo"), JsonObject::class.java)

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -109,6 +109,22 @@ object UtilsPatterns {
     )
 
     /**
+     * REGEX-TEST: §5§kX§5 Rift-Transferable §kX
+     */
+    val riftTransferablePattern by patternGroup.pattern(
+        "item.rift.transferable",
+        "§5§kX§5 Rift-Transferable §kX",
+    )
+    /**
+     * REGEX-TEST: §5§kX§5 Rift-Exportable §kX
+     * REGEX-TEST: §5§kX§5 Rift-Exported §kX
+     */
+    val riftExportablePattern by patternGroup.pattern(
+        "item.rift.exportable",
+        "§5§kX§5 Rift-Export(?:able|ed) §kX",
+    )
+
+    /**
      * REGEX-TEST: Late Winter
      * REGEX-TEST: Early Spring
      * REGEX-TEST: Summer


### PR DESCRIPTION
## What
Fixed some Rift transfer related stuff.

## Changelog Fixes
+ Fixed Rift-Exportable items incorrectly marked as non-transferable with Hide Not Clickable Items. - Luna
    * Items can still be transferred inside the Rift but cannot be sold for motes.
+ Fixed "Rift-Exported" items incorrectly marked as "salable" for motes in the features "Show Motes Price" and "Hide Not Clickable Items". - Luna
