### PR TITLE
Fix: skill overflow event not posted

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.SkillExpGainEvent
+import at.hannibal2.skyhanni.events.SkillOverflowLevelUpEvent
 import at.hannibal2.skyhanni.features.skillprogress.SkillProgress
 import at.hannibal2.skyhanni.features.skillprogress.SkillType
 import at.hannibal2.skyhanni.features.skillprogress.SkillUtil.SPACE_SPLITTER
@@ -366,6 +367,10 @@ object SkillAPI {
         val levelXp = calculateLevelXp(level - 1).toLong() + currentXp
         val (currentLevel, currentOverflow, currentMaxOverflow, totalOverflow) =
             calculateSkillLevel(levelXp, defaultSkillCap[skillType.lowercaseName] ?: 60)
+
+        if (skillInfo.overflowLevel > 60 && currentLevel == skillInfo.overflowLevel + 1) {
+            SkillOverflowLevelUpEvent(skillType, skillInfo.overflowLevel, currentLevel).post()
+        }
 
         skillInfo.apply {
             this.overflowCurrentXp = currentOverflow

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -63,7 +63,7 @@ object SkillProgress {
 
     @SubscribeEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!isEnabled()) return
+        if (!isDisplayEnabled()) return
         if (display.isEmpty()) return
 
         if (showDisplay) {
@@ -81,7 +81,7 @@ object SkillProgress {
 
     @SubscribeEvent
     fun onGuiRender(event: GuiRenderEvent) {
-        if (!isEnabled()) return
+        if (!isDisplayEnabled()) return
         if (display.isEmpty()) return
 
         if (allSkillConfig.enabled.get()) {
@@ -145,7 +145,7 @@ object SkillProgress {
 
     @SubscribeEvent
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!isEnabled()) return
+        if (!isDisplayEnabled()) return
         if (lastUpdate.passedSince() > 3.seconds) showDisplay = config.alwaysShow.get()
 
         allDisplay = formatAllDisplay(drawAllDisplay())
@@ -159,7 +159,7 @@ object SkillProgress {
 
     @HandleEvent
     fun onLevelUp(event: SkillOverflowLevelUpEvent) {
-        if (!isEnabled()) return
+        if (!LorenzUtils.inSkyBlock) return
         if (!config.overflowConfig.enableInChat) return
         val skillName = event.skill.displayName
         val oldLevel = event.oldLevel
@@ -220,7 +220,7 @@ object SkillProgress {
 
     @HandleEvent(priority = HandleEvent.LOW)
     fun onActionBar(event: ActionBarUpdateEvent) {
-        if (!config.hideInActionBar || !isEnabled()) return
+        if (!config.hideInActionBar || !isDisplayEnabled()) return
         var msg = event.actionBar
         for (line in hideInActionBar) {
             msg = msg.replace(Regex("\\s*" + Regex.escape(line)), "")
@@ -532,5 +532,5 @@ object SkillProgress {
         xpInfo.isActive = true
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled.get()
+    private fun isDisplayEnabled() = LorenzUtils.inSkyBlock && config.enabled.get()
 }


### PR DESCRIPTION
## What
Fixes SkillOverflowLevelUpEvent never being posted (not sure if this was an intentional removal; it was removed in #3068 without any mention). Also removes unneeded dependency of overflow level up message on the skill progress display.

<details>
<summary>Images</summary>
<img width="335" alt="Screenshot 2025-01-01 at 11 45 26 PM" src="https://github.com/user-attachments/assets/4680a515-ac8a-46b8-b3d7-937b0b34efd2" />

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fixed overflow level-up message not showing and removed dependency on skill progress display. - appable
