### PR TITLE
Backend: InventoryDetector and RenderDisplayHelper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
@@ -44,9 +44,7 @@ object SackAPI {
     private val chatConfig get() = SkyHanniMod.feature.chat
     private var lastOpenedInventory = ""
 
-    val inventory = InventoryDetector { name ->
-        sackPattern.matches(name)
-    }
+    val inventory = InventoryDetector { name -> sackPattern.matches(name) }
 
     private val patternGroup = RepoPattern.group("data.sacks")
 

--- a/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackAPI.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.features.inventory.SackDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
+import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -43,7 +44,9 @@ object SackAPI {
     private val chatConfig get() = SkyHanniMod.feature.chat
     private var lastOpenedInventory = ""
 
-    var inSackInventory = false
+    val inventory = InventoryDetector { name ->
+        sackPattern.matches(name)
+    }
 
     private val patternGroup = RepoPattern.group("data.sacks")
 
@@ -104,7 +107,6 @@ object SackAPI {
 
     @SubscribeEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
-        inSackInventory = false
         isRuneSack = false
         isGemstoneSack = false
         isTrophySack = false
@@ -119,14 +121,12 @@ object SackAPI {
         val inventoryName = event.inventoryName
         val isNewInventory = inventoryName != lastOpenedInventory
         lastOpenedInventory = inventoryName
-        val match = sackPattern.matches(inventoryName)
-        if (!match) return
+        if (!inventory.isInside()) return
         val stacks = event.inventoryItems
         isRuneSack = inventoryName == "Runes Sack"
         isGemstoneSack = inventoryName == "Gemstones Sack"
         isTrophySack = inventoryName.contains("Trophy Fishing Sack")
         sackRarity = inventoryName.getTrophyRarity()
-        inSackInventory = true
         stackList.putAll(stacks)
         SackDisplay.update(isNewInventory)
     }

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiRenderEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiRenderEvent.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.events
 
 open class GuiRenderEvent : LorenzEvent() {
+    // Renders only while inside a inventory
     class ChestGuiOverlayRenderEvent : GuiRenderEvent()
+    // Renders always, and while in a inventory it renders a bit darker, gray
     class GuiOverlayRenderEvent : GuiRenderEvent()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -233,7 +233,6 @@ object MineshaftPityDisplay {
     init {
         RenderDisplayHelper(
             condition = { isDisplayEnabled() },
-//             inOwnInventory = true,
             outsideInventory = true,
         ) {
             display.ifEmpty { update() }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.data.HotmReward
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.MiningAPI
 import at.hannibal2.skyhanni.data.ProfileStorageData
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -20,6 +19,7 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -196,7 +196,6 @@ object MineshaftPityDisplay {
             }
         }
 
-
         val neededToPityRenderable = Renderable.verticalContainer(
             listOf(
                 Renderable.string("§3Needed to pity:"),
@@ -231,15 +230,20 @@ object MineshaftPityDisplay {
         display = config.mineshaftPityLines.filter { it.shouldDisplay() }.mapNotNull { map[it] }
     }
 
-    @SubscribeEvent
-    fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!isDisplayEnabled()) return
-        display.ifEmpty { update() }
-        if (display.isEmpty()) return
-        config.position.renderRenderables(
-            listOf(Renderable.verticalContainer(display, 2)),
-            posLabel = "Mineshaft Pity Display",
-        )
+    init {
+        RenderDisplayHelper(
+            condition = { isDisplayEnabled() },
+//             inOwnInventory = true,
+            outsideInventory = true,
+        ) {
+            display.ifEmpty { update() }
+            if (display.isNotEmpty()) {
+                config.position.renderRenderables(
+                    listOf(Renderable.verticalContainer(display, 2)),
+                    posLabel = "Mineshaft Pity Display",
+                )
+            }
+        }
     }
 
     private fun resetCounter() {

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
@@ -13,8 +13,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
  *
  * @property onInventoryOpen A callback triggered when the given inventory is detected to be open. Optional.
  * @property checkInventoryName Define what inventory name or names we are looking for.
- *
- * @constructor Initializes the detector and registers it to a global list of active detectors.
  */
 class InventoryDetector(
     val onInventoryOpen: () -> Unit = {},

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
@@ -7,6 +7,15 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
+/**
+ * The InventoryDetector tracks whether an inventory is open and provides
+ * a inventory open consumer and a isInside function to handle inventory check logic.
+ *
+ * @property onInventoryOpen A callback triggered when the given inventory is detected to be open. Optional.
+ * @property checkInventoryName Define what inventory name or names we are looking for.
+ *
+ * @constructor Initializes the detector and registers it to a global list of active detectors.
+ */
 class InventoryDetector(
     val onInventoryOpen: () -> Unit = {},
     val checkInventoryName: (String) -> Boolean,
@@ -18,12 +27,15 @@ class InventoryDetector(
 
     private var inInventory = false
 
+    /**
+     * Check if the player is currently inside this inventory.
+     */
     fun isInside() = inInventory
 
     @SkyHanniModule
     companion object {
 
-        val detectors = mutableListOf<InventoryDetector>()
+        private val detectors = mutableListOf<InventoryDetector>()
 
         @SubscribeEvent(priority = EventPriority.HIGHEST)
         fun onInventoryClose(event: InventoryCloseEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
@@ -1,0 +1,55 @@
+package at.hannibal2.skyhanni.utils
+
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
+import net.minecraftforge.fml.common.eventhandler.EventPriority
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class InventoryDetector(
+    val onInventoryOpen: () -> Unit = {},
+    val checkInventoryName: (String) -> Boolean,
+) {
+
+    init {
+        detectors.add(this)
+    }
+
+    private var inInventory = false
+
+    fun isInside() = inInventory
+
+    @SkyHanniModule
+    companion object {
+
+        val detectors = mutableListOf<InventoryDetector>()
+
+        @SubscribeEvent(priority = EventPriority.HIGHEST)
+        fun onInventoryClose(event: InventoryCloseEvent) {
+            detectors.forEach { it.inInventory = false }
+        }
+
+        @SubscribeEvent(priority = EventPriority.HIGHEST)
+        fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
+            detectors.forEach { it.updateInventoryState(event.inventoryName) }
+        }
+    }
+
+    private fun updateInventoryState(inventoryName: String) {
+        inInventory = try {
+            checkInventoryName(inventoryName)
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Failed checking inventory state")
+            false
+        }
+
+        if (inInventory) {
+            try {
+                onInventoryOpen()
+            } catch (e: Exception) {
+                ErrorManager.logErrorWithData(e, "Failed to run inventory open in InventoryDetector")
+            }
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
@@ -1,0 +1,68 @@
+package at.hannibal2.skyhanni.utils
+
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.LorenzTickEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.inventory.GuiInventory
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+class RenderDisplayHelper(
+    private val inventory: InventoryDetector = noInventory,
+    private val outsideInventory: Boolean = false,
+    private val inOwnInventory: Boolean = false,
+    private val condition: () -> Boolean,
+    private val onRender: () -> Unit,
+) {
+
+    init {
+        renderDisplays.add(this)
+    }
+
+    @SkyHanniModule
+    companion object {
+        private val noInventory = InventoryDetector { false }
+
+        private val renderDisplays = mutableListOf<RenderDisplayHelper>()
+
+        private var visibleDisplays = emptyList<RenderDisplayHelper>()
+
+        @SubscribeEvent
+        fun onTick(event: LorenzTickEvent) {
+            visibleDisplays = renderDisplays.filter { it.checkCondition() }
+        }
+
+        @SubscribeEvent
+        fun onRenderDisplay(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+            val isInOwnInventory = Minecraft.getMinecraft().currentScreen is GuiInventory
+            for (display in visibleDisplays) {
+                if ((display.inOwnInventory && isInOwnInventory) || display.inventory.isInside()) {
+                    display.render()
+                }
+            }
+        }
+
+        @SubscribeEvent
+        fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+            for (display in visibleDisplays) {
+                if (display.outsideInventory) {
+                    display.render()
+                }
+            }
+        }
+    }
+
+    private fun checkCondition(): Boolean = try {
+        condition()
+    } catch (e: Exception) {
+        ErrorManager.logErrorWithData(e, "Failed to check render display condition")
+        false
+    }
+
+    private fun render() = try {
+        onRender()
+    } catch (e: Exception) {
+        ErrorManager.logErrorWithData(e, "Failed to render a display")
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
@@ -1,3 +1,4 @@
+
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -8,6 +9,17 @@ import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiInventory
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
+/**
+ * RenderDisplayHelper determines when to render displays based on
+ * conditions and context, such as whether the player is in their inventory or
+ * outside of an inventory GUI, or in a inventory defined by InventoryDetector.
+ *
+ * @property inventory set a InventoryDetector the display should be rendered in.
+ * @property outsideInventory Specifies if the display should render when not inside any inventory.
+ * @property inOwnInventory Specifies if the display should render when the player is in their own inventory.
+ * @property condition Should the display be rendered at all? Insert the isEnabled() function here.
+ * @property onRender This is getting called when the render should happen.
+ */
 class RenderDisplayHelper(
     private val inventory: InventoryDetector = noInventory,
     private val outsideInventory: Boolean = false,
@@ -17,13 +29,13 @@ class RenderDisplayHelper(
 ) {
 
     init {
+        // Registers the instance to the list of all display helpers.
         allDisplays.add(this)
     }
 
     @SkyHanniModule
     companion object {
         private val noInventory = InventoryDetector { false }
-
         private val allDisplays = mutableListOf<RenderDisplayHelper>()
         private var currentlyVisibleDisplays = emptyList<RenderDisplayHelper>()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
@@ -17,26 +17,25 @@ class RenderDisplayHelper(
 ) {
 
     init {
-        renderDisplays.add(this)
+        allDisplays.add(this)
     }
 
     @SkyHanniModule
     companion object {
         private val noInventory = InventoryDetector { false }
 
-        private val renderDisplays = mutableListOf<RenderDisplayHelper>()
-
-        private var visibleDisplays = emptyList<RenderDisplayHelper>()
+        private val allDisplays = mutableListOf<RenderDisplayHelper>()
+        private var currentlyVisibleDisplays = emptyList<RenderDisplayHelper>()
 
         @SubscribeEvent
         fun onTick(event: LorenzTickEvent) {
-            visibleDisplays = renderDisplays.filter { it.checkCondition() }
+            currentlyVisibleDisplays = allDisplays.filter { it.checkCondition() }
         }
 
         @SubscribeEvent
         fun onRenderDisplay(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
             val isInOwnInventory = Minecraft.getMinecraft().currentScreen is GuiInventory
-            for (display in visibleDisplays) {
+            for (display in currentlyVisibleDisplays) {
                 if ((display.inOwnInventory && isInOwnInventory) || display.inventory.isInside()) {
                     display.render()
                 }
@@ -45,7 +44,7 @@ class RenderDisplayHelper(
 
         @SubscribeEvent
         fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-            for (display in visibleDisplays) {
+            for (display in currentlyVisibleDisplays) {
                 if (display.outsideInventory) {
                     display.render()
                 }


### PR DESCRIPTION
## What
This PR adds two utils classes that work together perfectly:

**inventory detector**: checks if the player is currently in a defined inventory
The main point is to reduce code duplication caused by every feature having a isInventory boolean that then gets reset on inventory close event (or maybe forgotten to do so).

**render display helper**: provides a consumer in where the render part guis could be put, a condition check, and checks for "show outside inventory", ""show in own inventory", or a inventory detector object from above. No more "what render event do i need to use when?"

Those two utils classes should greatly reduce complexity with deciding when what display should render.

To see the new approach in action look at https://github.com/hannibal002/SkyHanni/blob/5b4a305eb94a8efcb34608a961ab1f335ad1ff32/src/main/java/at/hannibal2/skyhanni/features/inventory/SackDisplay.kt#L41

Im happy with any suggestions, especially with better names

## Changelog Technical Details
+ Added `InventoryDetector` and `RenderDisplayHelper` utility classes. - hannibal2