### PR TITLE
Backend: ModVersion changes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.launch
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiScreen
 import net.minecraftforge.common.MinecraftForge
-import net.minecraftforge.fml.common.Loader
 import net.minecraftforge.fml.common.Mod
 import net.minecraftforge.fml.common.event.FMLInitializationEvent
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent
@@ -43,7 +42,7 @@ import org.apache.logging.log4j.Logger
     clientSideOnly = true,
     useMetadata = true,
     guiFactory = "at.hannibal2.skyhanni.config.ConfigGuiForgeInterop",
-    version = "@MOD_VERSION@",
+    version = SkyHanniMod.VERSION,
 )
 class SkyHanniMod {
 
@@ -107,15 +106,10 @@ class SkyHanniMod {
 
     companion object {
 
-        const val MODID = "skyhanni"
+        const val MODID: String = "skyhanni"
+        const val VERSION: String = "@MOD_VERSION@"
 
-        val modVersion: ModVersion by lazy {
-            ModVersion.fromString(Loader.instance().indexedModList[MODID]!!.version)
-        }
-
-        @JvmStatic
-        val version: String
-            get() = modVersion.asString
+        val modVersion: ModVersion = ModVersion.fromString(VERSION)
 
         val isBetaVersion: Boolean
             get() = modVersion.isBeta

--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
@@ -73,7 +73,7 @@ class EventHandler<T : SkyHanniEvent> private constructor(
             val hiddenErrors = errors - 3
             ChatUtils.chat(
                 Text.text(
-                    "§c[SkyHanni/${SkyHanniMod.version}] $hiddenErrors more errors in $name are hidden!",
+                    "§c[SkyHanni/${SkyHanniMod.VERSION}] $hiddenErrors more errors in $name are hidden!",
                 ),
             )
         }

--- a/src/main/java/at/hannibal2/skyhanni/config/Features.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/Features.java
@@ -68,7 +68,7 @@ public class Features extends Config {
         if (LorenzUtils.INSTANCE.isAprilFoolsDay())
             modName = new StringBuilder().append("اسکای هانی").reverse().toString(); // Minecraft does not render RTL strings very nicely, so we reverse the string here. Not authentic, but close enough.
 
-        return modName + " " + SkyHanniMod.getVersion() + " by §channibal2§r, config by §5Moulberry §rand §5nea89";
+        return modName + " " + SkyHanniMod.VERSION + " by §channibal2§r, config by §5Moulberry §rand §5nea89";
     }
 
     /*

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -240,7 +240,7 @@ class RepoManager(private val configLocation: File) {
                 val text = mutableListOf<IChatComponent>()
                 text.add(
                     (
-                        "§c[SkyHanni-${SkyHanniMod.version}] §7Repo Issue! Some features may not work. " +
+                        "§c[SkyHanni-${SkyHanniMod.VERSION}] §7Repo Issue! Some features may not work. " +
                             "Please report this error on the Discord!"
                         ).asComponent(),
                 )

--- a/src/main/java/at/hannibal2/skyhanni/events/LorenzEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/LorenzEvent.kt
@@ -71,7 +71,7 @@ abstract class LorenzEvent : Event() {
             val hiddenErrors = errors - visibleErrors
             ChatUtils.chat(
                 Text.text(
-                    "§c[SkyHanni-${SkyHanniMod.version}] $hiddenErrors more errors in $eventName are hidden!",
+                    "§c[SkyHanni-${SkyHanniMod.VERSION}] $hiddenErrors more errors in $eventName are hidden!",
                 ),
             )
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigFeatures.kt
@@ -28,10 +28,10 @@ object DefaultConfigFeatures {
         }
 
         val knownToggles = SkyHanniMod.knownFeaturesData.knownFeatures
-        val updated = SkyHanniMod.version !in knownToggles
+        val updated = SkyHanniMod.VERSION !in knownToggles
         val processor = FeatureToggleProcessor()
         ConfigProcessorDriver(processor).processConfig(SkyHanniMod.feature)
-        knownToggles[SkyHanniMod.version] = processor.allOptions.map { it.path }
+        knownToggles[SkyHanniMod.VERSION] = processor.allOptions.map { it.path }
         SkyHanniMod.configManager.saveConfig(ConfigFileType.KNOWN_FEATURES, "Updated known feature flags")
         if (!SkyHanniMod.feature.storage.hasPlayedBefore) {
             SkyHanniMod.feature.storage.hasPlayedBefore = true
@@ -42,12 +42,12 @@ object DefaultConfigFeatures {
                 "§eClick to run /shdefaultoptions!"
             )
         } else if (updated) {
-            val lastVersion = knownToggles.keys.last { it != SkyHanniMod.version }
-            val command = "/shdefaultoptions $lastVersion ${SkyHanniMod.version}"
+            val lastVersion = knownToggles.keys.last { it != SkyHanniMod.VERSION }
+            val command = "/shdefaultoptions $lastVersion ${SkyHanniMod.VERSION}"
             ChatUtils.clickableChat(
                 "Looks like you updated SkyHanni. " +
                     "Click here to configure the newly introduced options, or run $command.",
-                onClick = { onCommand(lastVersion, SkyHanniMod.version) },
+                onClick = { onCommand(lastVersion, SkyHanniMod.VERSION) },
                 "§eClick to run /shdefaultoptions!"
             )
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
@@ -45,7 +45,7 @@ class GuiOptionEditorUpdateCheck(option: ProcessedOption) : GuiOptionEditor(opti
         val widthRemaining = adjustedWidth - button.width - 10
 
         GlStateManager.scale(2F, 2F, 1F)
-        val currentVersion = SkyHanniMod.version
+        val currentVersion = SkyHanniMod.VERSION
         val sameVersion = currentVersion.equals(nextVersion, ignoreCase = true)
         TextRenderUtils.drawStringCenteredScaledMaxWidth(
             "${if (UpdateManager.updateState == UpdateManager.UpdateState.NONE) GREEN else RED}$currentVersion" +

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzLogger
+import at.hannibal2.skyhanni.utils.system.ModVersion
 import com.google.gson.JsonElement
 import io.github.notenoughupdates.moulconfig.observer.Property
 import io.github.notenoughupdates.moulconfig.processor.MoulConfigProcessor
@@ -133,19 +134,14 @@ object UpdateManager {
         CustomGithubReleaseUpdateSource("hannibal002", "SkyHanni"),
         UpdateTarget.deleteAndSaveInTheSameFolder(UpdateManager::class.java),
         object : CurrentVersion {
-            val normalDelegate = CurrentVersion.ofTag(SkyHanniMod.VERSION)
-            override fun display(): String =
-                if (SkyHanniMod.feature.dev.debug.alwaysOutdated) "Force Outdated"
-                else SkyHanniMod.VERSION
+            private val debug get() = SkyHanniMod.feature.dev.debug.alwaysOutdated
+            override fun display(): String = if (debug) "Force Outdated" else SkyHanniMod.VERSION
 
-            override fun isOlderThan(element: JsonElement): Boolean {
-                if (SkyHanniMod.feature.dev.debug.alwaysOutdated)
-                    return true
-                return normalDelegate.isOlderThan(element)
-            }
-
-            override fun toString(): String {
-                return "ForceOutdateDelegate($normalDelegate)"
+            override fun isOlderThan(element: JsonElement?): Boolean {
+                if (debug) return true
+                val asString = element?.asString ?: return true
+                val otherVersion = ModVersion.fromString(asString)
+                return SkyHanniMod.modVersion < otherVersion
             }
         },
         SkyHanniMod.MODID,

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -133,12 +133,10 @@ object UpdateManager {
         CustomGithubReleaseUpdateSource("hannibal002", "SkyHanni"),
         UpdateTarget.deleteAndSaveInTheSameFolder(UpdateManager::class.java),
         object : CurrentVersion {
-            val normalDelegate = CurrentVersion.ofTag(SkyHanniMod.version)
-            override fun display(): String {
-                if (SkyHanniMod.feature.dev.debug.alwaysOutdated)
-                    return "Force Outdated"
-                return normalDelegate.display()
-            }
+            val normalDelegate = CurrentVersion.ofTag(SkyHanniMod.VERSION)
+            override fun display(): String =
+                if (SkyHanniMod.feature.dev.debug.alwaysOutdated) "Force Outdated"
+                else SkyHanniMod.VERSION
 
             override fun isOlderThan(element: JsonElement): Boolean {
                 if (SkyHanniMod.feature.dev.debug.alwaysOutdated)

--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -23,7 +23,7 @@ object DebugCommand {
         }
         val list = mutableListOf<String>()
         list.add("```")
-        list.add("= Debug Information for SkyHanni ${SkyHanniMod.version} =")
+        list.add("= Debug Information for SkyHanni ${SkyHanniMod.VERSION} =")
         list.add("")
 
         val search = args.joinToString(" ")

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniConfigSearchResetCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniConfigSearchResetCommand.kt
@@ -169,7 +169,7 @@ object SkyHanniConfigSearchResetCommand {
         val elements = findConfigElements(configFilter, classFilter)
         val builder = StringBuilder()
         builder.append("```\n")
-        builder.append("Search config for SkyHanni ${SkyHanniMod.version}\n")
+        builder.append("Search config for SkyHanni ${SkyHanniMod.VERSION}\n")
         builder.append("configSearchTerm: $configSearchTerm\n")
         builder.append("classSearchTerm: $classSearchTerm\n")
         builder.append("\n")

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -340,7 +340,7 @@ object SkyHanniDebugsAndTests {
     }
 
     fun debugVersion() {
-        val name = "SkyHanni ${SkyHanniMod.version}"
+        val name = "SkyHanni ${SkyHanniMod.VERSION}"
         ChatUtils.chat("§eYou are using $name")
         OSUtils.copyToClipboard(name)
     }

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -155,13 +155,13 @@ object ErrorManager {
 
         val extraDataString = buildExtraDataString(extraData)
         val rawMessage = message.removeColor()
-        errorMessages[randomId] = "```\nSkyHanni ${SkyHanniMod.version}: $rawMessage\n \n$stackTrace\n$extraDataString```"
+        errorMessages[randomId] = "```\nSkyHanni ${SkyHanniMod.VERSION}: $rawMessage\n \n$stackTrace\n$extraDataString```"
         fullErrorMessages[randomId] =
-            "```\nSkyHanni ${SkyHanniMod.version}: $rawMessage\n(full stack trace)\n \n$fullStackTrace\n$extraDataString```"
+            "```\nSkyHanni ${SkyHanniMod.VERSION}: $rawMessage\n(full stack trace)\n \n$fullStackTrace\n$extraDataString```"
 
         val finalMessage = buildFinalMessage(message) ?: return
         ChatUtils.clickableChat(
-            "§c[SkyHanni-${SkyHanniMod.version}]: $finalMessage Click here to copy the error into the clipboard.",
+            "§c[SkyHanni-${SkyHanniMod.VERSION}]: $finalMessage Click here to copy the error into the clipboard.",
             onClick = { copyError(randomId) },
             "§eClick to copy!",
             prefix = false,

--- a/src/main/java/at/hannibal2/skyhanni/utils/APIUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/APIUtils.kt
@@ -54,7 +54,7 @@ object APIUtils {
     data class ApiResponse(val success: Boolean, val message: String?, val data: JsonObject)
 
     private val builder: HttpClientBuilder =
-        HttpClients.custom().setUserAgent("SkyHanni/${SkyHanniMod.version}")
+        HttpClients.custom().setUserAgent("SkyHanni/${SkyHanniMod.VERSION}")
             .setDefaultHeaders(
                 mutableListOf(
                     BasicHeader("Pragma", "no-cache"),

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SkyHanniTypeAdapters.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SkyHanniTypeAdapters.kt
@@ -83,10 +83,7 @@ object SkyHanniTypeAdapters {
         { SkyblockStat.getValue(this.uppercase()) },
     )
 
-    val MOD_VERSION: TypeAdapter<ModVersion> = SimpleStringTypeAdapter(
-        { asString },
-        { ModVersion.fromString(this) },
-    )
+    val MOD_VERSION: TypeAdapter<ModVersion> = SimpleStringTypeAdapter(ModVersion::asString, ModVersion::fromString)
 
     val TRACKER_DISPLAY_MODE = SimpleStringTypeAdapter.forEnum<SkyHanniTracker.DefaultDisplayMode>()
     val ISLAND_TYPE = SimpleStringTypeAdapter.forEnum<IslandType>()

--- a/src/main/java/at/hannibal2/skyhanni/utils/system/ModVersion.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/system/ModVersion.kt
@@ -1,33 +1,29 @@
 package at.hannibal2.skyhanni.utils.system
 
-data class ModVersion(val major: Int, val minor: Int, val beta: Int) {
+data class ModVersion(val major: Int, val minor: Int, val beta: Int) : Comparable<ModVersion> {
+
+    val isBeta get() = beta != 0
+
+    inline val asString get() = toString()
+
+    override fun toString(): String = "$major.$minor.$beta"
+
+    override fun compareTo(other: ModVersion): Int {
+        return when {
+            major != other.major -> major.compareTo(other.major)
+            minor != other.minor -> minor.compareTo(other.minor)
+            else -> beta.compareTo(other.beta)
+        }
+    }
 
     companion object {
         fun fromString(version: String): ModVersion {
-
             val parts = version.split('.')
             return ModVersion(
                 parts.getOrNull(0)?.toIntOrNull() ?: 0,
                 parts.getOrNull(1)?.toIntOrNull() ?: 0,
                 parts.getOrNull(2)?.toIntOrNull() ?: 0,
             )
-        }
-    }
-
-    val isBeta = beta != 0
-
-    val asString: String
-        get() = toString()
-
-    override fun toString(): String {
-        return "$major.$minor.$beta"
-    }
-
-    operator fun compareTo(other: ModVersion): Int {
-        return when {
-            major != other.major -> major.compareTo(other.major)
-            minor != other.minor -> minor.compareTo(other.minor)
-            else -> beta.compareTo(other.beta)
         }
     }
 }


### PR DESCRIPTION
## What
This PR changes some things related to the new ModVersion class and how we store the current version. It makes the ModVersion class implement the Comparable interface instead of just having the compareTo operator, and it changes the string replaced with the actual version string by blossom to be the one accessed, instead of blossom replacing the one in the @.Mod annotation and the version val being lazily accessed by getting it in the indexed mods list. Also changed the CurrentVersion implementation in UpdateManager to use ModVersion class for comparing versions.

## Changelog Technical Details
+ Improved ModVersion class and integrated it into UpdateManager. - Empa

