### PR TITLE
Fix: CF Party Mode Chroma Check

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -229,7 +229,7 @@ public class ChocolateFactoryConfig {
     @Expose
     @ConfigOption(
         name = "§6CF §zParty Mode",
-        desc = "Don't turn this on.\n§cRequires Chroma to be enabled to fully function."
+        desc = "Don't turn this on.\n§cRequires SkyHanni Chroma to be enabled to fully function."
     )
     @ConfigEditorBoolean
     public Property<Boolean> partyMode = Property.of(false);

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/ChocolateFactoryConfig.java
@@ -229,9 +229,8 @@ public class ChocolateFactoryConfig {
     @Expose
     @ConfigOption(
         name = "§6CF §zParty Mode",
-        desc = "Don't turn this on."
+        desc = "Don't turn this on.\n§cRequires Chroma to be enabled to fully function."
     )
     @ConfigEditorBoolean
-    @FeatureToggle
     public Property<Boolean> partyMode = Property.of(false);
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.HoppityEggLocationsJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.MilestoneJson
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.features.chroma.ChromaManager
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityCollectionStats
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.nextAfter
@@ -36,6 +37,7 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object ChocolateFactoryAPI {
 
+    private val chromaEnabled get() = ChromaManager.config.enabled.get()
     val config: ChocolateFactoryConfig get() = SkyHanniMod.feature.inventory.chocolateFactory
     val profileStorage: ChocolateFactoryStorage? get() = ProfileStorageData.profileSpecific?.chocolateFactory
     val patternGroup = RepoPattern.group("misc.chocolatefactory")
@@ -267,6 +269,6 @@ object ChocolateFactoryAPI {
     } ?: false
 
     fun String.partyModeReplace(): String =
-        if (config.partyMode.get() && inChocolateFactory) replace(Regex("§[a-fA-F0-9]"), "§z")
+        if (config.partyMode.get() && inChocolateFactory && chromaEnabled) replace(Regex("§[a-fA-F0-9]"), "§z")
         else this
 }


### PR DESCRIPTION
## What
Removes `@FeatureToggle` from Party Mode so people stop asking "how did this get enabled?!?!" when they blindly enable all features. Also adds a chroma check to the text replacement so the rendered text isn't just white.

## Changelog Fixes
+ Fixed Chocolate Factory's "Party Mode" not checking if chroma is enabled. - Daveed

