### PR TITLE
Fix: auction price comparison inventory close

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/AuctionHousePriceComparison.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/AuctionHousePriceComparison.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
 import at.hannibal2.skyhanni.features.inventory.AuctionsHighlighter
@@ -34,9 +35,8 @@ object AuctionHousePriceComparison {
 
     @SubscribeEvent
     fun onInventoryOpen(event: InventoryOpenEvent) {
-        inInventory = false
-        if (!event.inventoryName.startsWith("Auctions")) return
-        inInventory = true
+        inInventory = event.inventoryName.startsWith("Auctions")
+        if (!inInventory) return
 
         bestPrice = 0L
         worstPrice = 0L
@@ -54,6 +54,11 @@ object AuctionHousePriceComparison {
             }
         }
         this.slotPriceMap = map
+    }
+
+    @SubscribeEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        inInventory = false
     }
 
     private fun MutableMap<Int, Long>.add(stack: ItemStack, binPrice: Long, slot: Int) {


### PR DESCRIPTION
## What
Fixed auction price comparison not properly detecting inventory close.
Reported: https://discord.com/channels/997079228510117908/1325806517353582735

Inventory close event is not used here, and therefore opening a screen that is not an inventory can break this logic.
One reason to use https://github.com/hannibal002/SkyHanni/pull/3154 in the future instead.

## Changelog Fixes
+ Fixed auction price comparison not detecting when the inventory is closed. - hannibal2