### PR TITLE
Fix: Motes Session negative

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
@@ -64,7 +64,7 @@ object MotesSession {
         val initial = initialMotes ?: return
         val current = currentMotes ?: return
         val gained = current - initial
-        if (gained == 0L) return
+        if (gained < 1) return
         val timeInRift = enterRiftTime.passedSince()
         val motesPerHour = (gained / timeInRift.inPartialHours).toLong()
         val hover = buildList {


### PR DESCRIPTION
## What
Fixed Motes Session showing negative changes as gained motes.
Reported: https://discord.com/channels/997079228510117908/1325604969365377095

## Changelog Fixes
+ Fixed Motes Session incorrectly showing negative changes as gained motes. - hannibal2