### PR TITLE
Improvement: Add EliteBot profile link to rich presence 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/DiscordRPCConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/DiscordRPCConfig.java
@@ -97,6 +97,11 @@ public class DiscordRPCConfig {
     @ConfigEditorBoolean
     public Property<Boolean> showSkyCryptButton = Property.of(true);
 
+    @Expose
+    @ConfigOption(name = "Show Button for EliteBot", desc = "Add a button to the RPC that opens your EliteBot profile.")
+    @ConfigEditorBoolean
+    public Property<Boolean> showEliteBotButton = Property.of(true);
+
     public enum LineEntry implements HasLegacyId {
         NOTHING("Nothing", 0),
         LOCATION("Location", 1),

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -135,6 +135,15 @@ object DiscordRPCManager : IPCListener {
                 setStartTimestamp(startTimestamp)
                 setLargeImage(discordIconKey, location)
 
+                if (config.showEliteBotButton.get()) {
+                    addButton(
+                        RichPresenceButton(
+                            "https://elitebot.dev/@${LorenzUtils.getPlayerName()}/${HypixelData.profileName}",
+                            "Open EliteBot",
+                        ),
+                    )
+                }
+
                 if (config.showSkyCryptButton.get()) {
                     addButton(
                         RichPresenceButton(


### PR DESCRIPTION
## What
Add a button that links a player's EliteBot profile to discord rich presence, similar to the skycrypt button.  Elitebot is a skyblock stats website focused on farming stats and crop/skill leaderboards.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/339fe902-69cf-476f-9a1f-0a3ac1ce2502)

</details>

## Changelog Improvements
+ Added EliteBot profile button to Discord Rich Presence. - Chissl