### PR TITLE
Backend: Refactor `/config/features/mining`

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/MiningConfig.java
@@ -1,6 +1,17 @@
 package at.hannibal2.skyhanni.config.features.mining;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
+import at.hannibal2.skyhanni.config.features.mining.caverns.DeepCavernsGuideConfig;
+import at.hannibal2.skyhanni.config.features.mining.dwarves.KingTalismanConfig;
+import at.hannibal2.skyhanni.config.features.mining.glacite.ColdOverlayConfig;
+import at.hannibal2.skyhanni.config.features.mining.glacite.FossilExcavatorConfig;
+import at.hannibal2.skyhanni.config.features.mining.glacite.GlaciteMineshaftConfig;
+import at.hannibal2.skyhanni.config.features.mining.glacite.MineshaftConfig;
+import at.hannibal2.skyhanni.config.features.mining.glacite.MineshaftPityDisplayConfig;
+import at.hannibal2.skyhanni.config.features.mining.glacite.TunnelMapsConfig;
+import at.hannibal2.skyhanni.config.features.mining.nucleus.AreaWallsConfig;
+import at.hannibal2.skyhanni.config.features.mining.nucleus.CrystalHighlighterConfig;
+import at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig;
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.Accordion;
 import io.github.notenoughupdates.moulconfig.annotations.Category;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/caverns/DeepCavernsGuideConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/caverns/DeepCavernsGuideConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.caverns;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/dwarves/KingTalismanConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/dwarves/KingTalismanConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.dwarves;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ColdOverlayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ColdOverlayConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/CorpseLocatorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/CorpseLocatorConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/CorpseTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/CorpseTrackerConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorTooltipHiderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorTooltipHiderConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorSolverConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorSolverConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/GlaciteMineshaftConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/GlaciteMineshaftConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.Accordion;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/MineshaftConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/MineshaftConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/MineshaftPityDisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/MineshaftPityDisplayConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/MineshaftWaypointsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/MineshaftWaypointsConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/TunnelMapsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/TunnelMapsConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.glacite;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.core.config.Position;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/AreaWallsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/AreaWallsConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.nucleus;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalHighlighterColorConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalHighlighterColorConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.nucleus;
 
 import com.google.gson.annotations.Expose;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalHighlighterConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalHighlighterConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.nucleus;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import com.google.gson.annotations.Expose;

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/PowderTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/PowderTrackerConfig.java
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.mining;
+package at.hannibal2.skyhanni.config.features.mining.nucleus;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.HasLegacyId;
@@ -14,24 +14,24 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.AMBER;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.AMETHYST;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.DIAMOND_ESSENCE;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.DOUBLE_POWDER;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.ELECTRON;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.FTX;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.GEMSTONE_POWDER;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.GOLD_ESSENCE;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.HARD_STONE;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.JADE;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.ROBOTRON;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.RUBY;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.SAPPHIRE;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.SPACER_1;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.SPACER_2;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.SPACER_3;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.TOPAZ;
-import static at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry.TOTAL_CHESTS;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.AMBER;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.AMETHYST;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.DIAMOND_ESSENCE;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.DOUBLE_POWDER;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.ELECTRON;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.FTX;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.GEMSTONE_POWDER;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.GOLD_ESSENCE;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.HARD_STONE;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.JADE;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.ROBOTRON;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.RUBY;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.SAPPHIRE;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.SPACER_1;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.SPACER_2;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.SPACER_3;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.TOPAZ;
+import static at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry.TOTAL_CHESTS;
 
 public class PowderTrackerConfig {
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderTracker.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.HotmAPI
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.config.features.mining.PowderTrackerConfig.PowderDisplayEntry
+import at.hannibal2.skyhanni.config.features.mining.nucleus.PowderTrackerConfig.PowderDisplayEntry
 import at.hannibal2.skyhanni.data.BossbarData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.TabWidget


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1326209626307428352
In preparation for moving config to Kotlin, and needing to split up some of the packages due to size, this PR organizes the previously flat structure of the mining package into subpackages.

exclude_from_changelog

