### PR TITLE
Backend + Fix: Use correct type for item attributes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -262,6 +262,8 @@ object NumberUtil {
         this.toDouble() / max
     }?.coerceIn(0.0, 1.0) ?: 1.0
 
+    fun Int?.isPositive(): Boolean = (this ?: 0) > 0
+
     fun interpolate(now: Float, last: Float, lastUpdate: Long): Float {
         var interp = now
         if (last >= 0 && last != now) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -168,20 +168,19 @@ object SkyBlockItemModifierUtils {
         }
     }
 
-    fun ItemStack.isRecombobulated() = getAttributeBoolean("rarity_upgrades")
+    fun ItemStack.isRecombobulated() = (getAttributeInt("rarity_upgrades") ?: 0) > 0
 
-    fun ItemStack.hasJalapenoBook() = getAttributeBoolean("jalapeno_count")
+    fun ItemStack.hasJalapenoBook() = (getAttributeInt("jalapeno_count") ?: 0) > 0
 
     fun ItemStack.hasEtherwarp() = getAttributeBoolean("ethermerge")
 
-    fun ItemStack.hasWoodSingularity() = getAttributeBoolean("wood_singularity_count")
+    fun ItemStack.hasWoodSingularity() = (getAttributeInt("wood_singularity_count") ?: 0) > 0
 
     fun ItemStack.hasDivanPowderCoating() = getAttributeBoolean("divan_powder_coating")
 
-    fun ItemStack.hasArtOfWar() = getAttributeBoolean("art_of_war_count")
+    fun ItemStack.hasArtOfWar() = (getAttributeInt("art_of_war_count") ?: 0) > 0
 
-    // TODO untested
-    fun ItemStack.hasBookOfStats() = getAttributeBoolean("stats_book")
+    fun ItemStack.hasBookOfStats() = getAttributeInt("stats_book") != null
 
     fun ItemStack.hasArtOfPeace() = getAttributeBoolean("artOfPeaceApplied")
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NumberUtil.isPositive
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import com.google.gson.JsonObject
@@ -168,17 +169,17 @@ object SkyBlockItemModifierUtils {
         }
     }
 
-    fun ItemStack.isRecombobulated() = (getAttributeInt("rarity_upgrades") ?: 0) > 0
+    fun ItemStack.isRecombobulated() = getAttributeInt("rarity_upgrades").isPositive()
 
-    fun ItemStack.hasJalapenoBook() = (getAttributeInt("jalapeno_count") ?: 0) > 0
+    fun ItemStack.hasJalapenoBook() = getAttributeInt("jalapeno_count").isPositive()
 
     fun ItemStack.hasEtherwarp() = getAttributeBoolean("ethermerge")
 
-    fun ItemStack.hasWoodSingularity() = (getAttributeInt("wood_singularity_count") ?: 0) > 0
+    fun ItemStack.hasWoodSingularity() = getAttributeInt("wood_singularity_count").isPositive()
 
     fun ItemStack.hasDivanPowderCoating() = getAttributeBoolean("divan_powder_coating")
 
-    fun ItemStack.hasArtOfWar() = (getAttributeInt("art_of_war_count") ?: 0) > 0
+    fun ItemStack.hasArtOfWar() = getAttributeInt("art_of_war_count").isPositive()
 
     fun ItemStack.hasBookOfStats() = getAttributeInt("stats_book") != null
 


### PR DESCRIPTION
## What
Fixed SkyBlockItemModifierUtils incorrectly treating multiple attributes as booleans, when they're actually integers. While the current way of doing it caused no issues so far except for the Book of Stats case, relying on implicit type conversion here is bad practice.

## Changelog Fixes
+ Fixed Book of Stats not counting in Estimated Item Value for items with 0 kills. - Luna

## Changelog Technical Details
+ Fixed some item attributes treated as Boolean instead of Int. - Luna