### PR TITLE
Improvement: "Not Accepted" Crimson Isle quest state

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -73,14 +73,6 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
     )
 
     /**
-     * REGEX-TEST: §eClick to start!
-     */
-    val clickToStartPattern by patternGroup.pattern(
-        "clicktostart",
-        "(?:§.)*Click to start!",
-    )
-
-    /**
      * REGEX-TEST: §a§lCOMPLETE
      */
     val completedPattern by patternGroup.pattern(
@@ -232,9 +224,7 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
     }
 
     private fun Quest.needsTownBoardLocation(): Boolean = state.let { state ->
-        state == QuestState.READY_TO_COLLECT ||
-            state == QuestState.NOT_ACCEPTED ||
-            (this is RescueMissionQuest && state == QuestState.ACCEPTED)
+        state == QuestState.READY_TO_COLLECT || (this is RescueMissionQuest && state == QuestState.ACCEPTED)
     }
 
     fun render(display: MutableList<List<Any>>) {
@@ -279,7 +269,7 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
             ""
         }
 
-        val stateText = if (quest !is UnknownQuest) {
+        val stateText = if (quest !is UnknownQuest && quest.state != QuestState.ACCEPTED) {
             "$stateColor[$state] §f"
         } else {
             ""

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
@@ -79,7 +79,7 @@ class QuestLoader(private val dailyQuestHelper: DailyQuestHelper) {
             return
         }
 
-        val state = if (green) QuestState.READY_TO_COLLECT else QuestState.NOT_ACCEPTED
+        val state = if (green) QuestState.READY_TO_COLLECT else QuestState.ACCEPTED
         dailyQuestHelper.update()
         addQuest(addQuest(name, state, needAmount))
     }
@@ -152,11 +152,6 @@ class QuestLoader(private val dailyQuestHelper: DailyQuestHelper) {
                 dailyQuestHelper.update()
             }
 
-            val accepted = !stack.getLore().any { dailyQuestHelper.clickToStartPattern.matches(it) }
-            if (accepted && quest.state == QuestState.NOT_ACCEPTED) {
-                quest.state = QuestState.ACCEPTED
-                dailyQuestHelper.update()
-            }
             if (name == "Miniboss") {
                 fixMinibossAmount(quest, stack)
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
@@ -190,7 +190,11 @@ class QuestLoader(private val dailyQuestHelper: DailyQuestHelper) {
         for (text in storage.quests.toList()) {
             val split = text.split(":")
             val name = split[0]
-            val state = QuestState.valueOf(split[1])
+            val state = if (split[1] == "NOT_ACCEPTED") {
+                QuestState.ACCEPTED
+            } else {
+                QuestState.valueOf(split[1])
+            }
             val needAmount = split[2].toInt()
             val quest = addQuest(name, state, needAmount)
             if (quest is UnknownQuest) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/quest/QuestState.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/quest/QuestState.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.quest
 
 enum class QuestState(val displayName: String, val color: String) {
-    NOT_ACCEPTED("Not Accepted", "§c"),
     ACCEPTED("Accepted", "§b"),
     READY_TO_COLLECT("Ready to collect", "§a"),
     COLLECTED("Collected", "§7"),

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/quest/UnknownQuest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/quest/UnknownQuest.kt
@@ -3,4 +3,4 @@ package at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.quest
 import at.hannibal2.skyhanni.utils.NEUInternalName
 
 class UnknownQuest(unknownName: String) :
-    Quest(NEUInternalName.MISSING_ITEM, null, QuestCategory.UNKNOWN, unknownName, QuestState.NOT_ACCEPTED)
+    Quest(NEUInternalName.MISSING_ITEM, null, QuestCategory.UNKNOWN, unknownName, QuestState.ACCEPTED)


### PR DESCRIPTION
## What
This PR removes the "Not Accepted" state for Daily Quests in the Crimson Isle.
After the 0.20.9 update, quests are accepted automatically.

<details>
<summary>Images</summary>
![image](https://github.com/user-attachments/assets/3ddd649f-9672-4ee5-a984-7ce31f3841ff)
</details>

## Changelog Improvements
+ Added auto-accept for Crimson Isle quests. - Donaldino7712
    * Removed unused "Not Accepted" quest state after 0.20.9 SB update.