### PR TITLE
Backend: Suppress LargeClass in LoadedModules

### DIFF
--- a/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
+++ b/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
@@ -104,6 +104,7 @@ class ModuleProcessor(private val codeGenerator: CodeGenerator, private val logg
 
         OutputStreamWriter(file).use {
             it.write("package at.hannibal2.skyhanni.skyhannimodule\n\n")
+            it.write("@Suppress(\"LargeClass\")\n")
             it.write("object LoadedModules {\n")
             it.write("    val isDev: Boolean = at.hannibal2.skyhanni.utils.system.PlatformUtils.isDevEnvironment\n")
             it.write("    val hasNeu: Boolean get() = at.hannibal2.skyhanni.utils.system.PlatformUtils.isNeuLoaded()\n")


### PR DESCRIPTION
## What
Has come up a couple times in open PRs getting screamed at for LoadedModules being too big.

exclude_from_changelog

