### PR TITLE
Fix: GardenKeybinds not working with Inventory/Chat Keybind

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -44,7 +44,7 @@ object GardenCustomKeybinds {
     fun isKeyPressed(keyBinding: KeyBinding, cir: CallbackInfoReturnable<Boolean>) {
         if (!isActive()) return
         val override = map[keyBinding] ?: run {
-            if(map.containsValue(keyBinding.keyCode)){
+            if( map.containsValue(keyBinding.keyCode)) {
                 cir.returnValue = false
             }
             return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -43,7 +43,12 @@ object GardenCustomKeybinds {
     @JvmStatic
     fun isKeyPressed(keyBinding: KeyBinding, cir: CallbackInfoReturnable<Boolean>) {
         if (!isActive()) return
-        val override = map[keyBinding] ?: return
+        val override = map[keyBinding] ?: run {
+            if(map.containsValue(keyBinding.keyCode)){
+                cir.returnValue = false
+            }
+            return
+        }
         cir.returnValue = override.isKeyClicked()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -44,7 +44,7 @@ object GardenCustomKeybinds {
     fun isKeyPressed(keyBinding: KeyBinding, cir: CallbackInfoReturnable<Boolean>) {
         if (!isActive()) return
         val override = map[keyBinding] ?: run {
-            if( map.containsValue(keyBinding.keyCode)) {
+            if (map.containsValue(keyBinding.keyCode)) {
                 cir.returnValue = false
             }
             return


### PR DESCRIPTION
## Changelog Fixes
+ Fixed Custom Keybinds not working with inventory or chat keybind. - Thunderblade73


