### PR TITLE
Fix: Playtime Copy not working without Limbo Playtime

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CopyPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CopyPlaytime.kt
@@ -3,11 +3,11 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.LorenzToolTipEvent
-import at.hannibal2.skyhanni.features.misc.limbo.LimboPlaytime
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ClipboardUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -32,7 +32,7 @@ object CopyPlaytime {
         if (event.clickedButton != 0) return
 
         event.cancel()
-        val text = LimboPlaytime.tooltipPlaytime.dropLast(2).toMutableList()
+        val text = event.item?.getLore()?.toMutableList() ?: return
 
         val profile = HypixelData.profileName.firstLetterUppercase()
         text.add(0, "${LorenzUtils.getPlayerName()}'s - $profile Playtime Stats")


### PR DESCRIPTION
## What
Fixed the copy option in `/playtimedetailed` not working unless Limbo Playtime Detailed is enabled.

## Changelog Fixes
+ Fixed copy option in `/playtimedetailed` not working unless Limbo Playtime Detailed is enabled. - Luna