### PR TITLE
Backend: graph editor fix, title logic change

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
@@ -13,20 +13,24 @@ import net.minecraft.client.renderer.GlStateManager
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.lwjgl.opengl.GL11
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object TitleManager {
 
-    private var originalText = ""
+    private var currentText = ""
     private var display = ""
     private var endTime = SimpleTimeMark.farPast()
     private var heightModifier = 1.8
     private var fontSizeModifier = 4f
 
+    @Deprecated("Use LorenzUtils instead", ReplaceWith("LorenzUtils.sendTitle(text, duration, height, fontSize)"))
     fun sendTitle(text: String, duration: Duration, height: Double, fontSize: Float) {
-        originalText = text
+        setTitle(text, duration, height, fontSize)
+    }
+
+    fun setTitle(text: String, duration: Duration, height: Double, fontSize: Float) {
+        currentText = text
         display = "§f$text"
         endTime = SimpleTimeMark.now() + duration
         heightModifier = height
@@ -34,8 +38,8 @@ object TitleManager {
     }
 
     fun optionalResetTitle(condition: (String) -> Boolean) {
-        if (condition(originalText)) {
-            sendTitle("", 1.milliseconds, 1.8, 4f)
+        if (condition(currentText)) {
+            stop()
         }
     }
 
@@ -55,6 +59,10 @@ object TitleManager {
 
     @HandleEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
+        stop()
+    }
+
+    private fun stop() {
         endTime = SimpleTimeMark.farPast()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
@@ -44,8 +44,8 @@ object BurrowWarpHelper {
                 HypixelCommands.warp(it.name)
                 lastWarp = currentWarp
                 GriffinBurrowHelper.lastTitleSentTime = SimpleTimeMark.now() + 2.seconds
-                TitleManager.optionalResetTitle {
-                    it.startsWith("§bWarp to ")
+                TitleManager.optionalResetTitle { currentTitle ->
+                    currentTitle.startsWith("§bWarp to ")
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.fishing.trophy
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzChatEvent
@@ -256,7 +255,7 @@ object GoldenFishTimer {
     private fun rodWarning() {
         if (!config.throwRodWarning || hasWarnedRod) return
         hasWarnedRod = true
-        TitleManager.sendTitle("§cThrow your rod!", 5.seconds, 3.6, 7.0f)
+        LorenzUtils.sendTitle("§cThrow your rod!", 5.seconds, 3.6, 7.0f)
         SoundUtils.repeatSound(100, 10, SoundUtils.plingSound)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
@@ -42,6 +42,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 import java.awt.Color
 import kotlin.math.min
+import kotlin.time.Duration.Companion.seconds
 
 @Suppress("LargeClass")
 @SkyHanniModule
@@ -221,6 +222,8 @@ object GraphEditor {
         if (nodesToFind.isEmpty()) {
             currentNodeToFind = null
             ChatUtils.chat("Found all nodes on this island")
+            LorenzUtils.sendTitle("§eAll Found!", 3.seconds)
+            active = false
             return
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -286,7 +286,7 @@ object LorenzUtils {
     val JsonPrimitive.asIntOrNull get() = takeIf { it.isNumber }?.asInt
 
     fun sendTitle(text: String, duration: Duration, height: Double = 1.8, fontSize: Float = 4f) {
-        TitleManager.sendTitle(text, duration, height, fontSize)
+        TitleManager.setTitle(text, duration, height, fontSize)
     }
 
     inline fun <reified T : Enum<T>> enumValueOfOrNull(name: String): T? {


### PR DESCRIPTION
## What
fixed error and deprecated old function

<details>
<summary>Stack Trace</summary>

```
SkyHanni 1.3.0: Caught a NoSuchElementException in GraphEditor at LorenzTickEvent: Collection contains no element matching the predicate.
 
Caused by java.util.NoSuchElementException: Collection contains no element matching the predicate.
at SH.test.graph.GraphEditor.calculateNewAllNodeFind(GraphEditor.kt:920)
at SH.test.graph.GraphEditor.save(GraphEditor.kt:566)
at SH.test.graph.GraphEditor.input(GraphEditor.kt:418)
at SH.test.graph.GraphEditor.onTick(GraphEditor.kt:206)
at SH.data.MinecraftData.onTick(MinecraftData.kt:84)
at FML.common.eventhandler.EventBus.post(EventBus.java:140)
```

## Changelog Technical Details
+ Fixed bug in /shgraphfindall. - hannibal2