### PR TITLE
Backend: Detekt Non-Mutable Types in Config

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -23,6 +23,10 @@ ImportRules:
     CustomImportOrdering:
         active: true
 
+StorageRules:
+    EnforceConfigMutableCollections:
+        active: true
+
 style:
     MagicNumber: # I, Linnea Gräf, of sound mind and body, disagree with disabling this rule
         active: false

--- a/detekt/src/main/kotlin/storage/EnforceConfigMutableCollections.kt
+++ b/detekt/src/main/kotlin/storage/EnforceConfigMutableCollections.kt
@@ -1,0 +1,99 @@
+package at.hannibal2.skyhanni.detektrules.storage
+
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+
+class EnforceConfigMutableCollections(config: Config): SkyHanniRule(config) {
+    override val issue = Issue(
+        "EnforceConfigMutableCollections",
+        Severity.Defect,
+        "Use specified mutable collections instead of immutable, or implied mutable ones.",
+        Debt.TEN_MINS,
+    )
+
+    companion object {
+        private const val CONFIG_PACKAGE = "at.hannibal2.skyhanni.config.features"
+
+        private val badListInitializers = setOf(
+            "listOf",
+            "ArrayList",
+            "arrayListOf"
+        )
+
+        private val badSetInitializers = setOf(
+            "setOf",
+            "HashSet",
+            "hashSetOf"
+        )
+
+        private val badMapInitializers = setOf(
+            "mapOf",
+            "HashMap",
+            "hashMapOf"
+        )
+
+        private val badInitializers by lazy {
+            badListInitializers + badSetInitializers + badMapInitializers
+        }
+    }
+
+    override fun visitKtFile(file: KtFile) {
+        val packageName = file.packageDirective?.fqName?.asString() ?: ""
+        if (!packageName.startsWith(CONFIG_PACKAGE)) return
+        super.visitKtFile(file)
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        // Only look at properties annotated with @Expose
+        if (!property.hasAnnotation("Expose")) return
+        // Only look at properties with @ConfigOption
+        if (!property.hasAnnotation("ConfigOption")) return
+
+        // If the property is a List<*>, Set<*>, or Map<*>, check how it's initialized
+        // We remove the "Property<" prefix from the type reference, e.g. "Property<List<String>>" -> "List<String>".
+        val typeRef = property.typeReference?.text?.replaceFirst("Property<", "") ?: ""
+        // println("typeRef = '${property.typeReference?.text}' initializer = '${property.initializer?.text}'")
+
+        if (typeRef.startsWith("List<") ||
+            typeRef.startsWith("Set<")  ||
+            typeRef.startsWith("Map<")
+        ) {
+            // Examine the initializer call, e.g. listOf(...), setOf(...), mapOf(...).
+            val callExpression = property.initializer as? KtCallExpression
+            val calleeName = callExpression?.getCallNameExpression()?.getReferencedName() ?: ""
+
+            val calleeIsBad = calleeName in badInitializers
+            if (calleeIsBad) {
+                val properCallee = getProperCallee(calleeName)
+                property.reportIssue("Use $properCallee instead of $calleeName.")
+            }
+        }
+
+        super.visitProperty(property)
+    }
+
+    private fun getProperCallee(calleeName: String) = when (calleeName) {
+        in badListInitializers -> "mutableListOf"
+        in badSetInitializers -> "mutableSetOf"
+        in badMapInitializers -> "mutableMapOf"
+        else -> ""
+    }
+
+    /**
+     * Helper function to check if a property has a specific annotation.
+     */
+    private fun KtModifierListOwner.hasAnnotation(annotationName: String): Boolean {
+        // shortName?.asString() should normally be 'Expose' even with @field:Expose
+        return annotationEntries.any {
+            it.shortName?.asString() == annotationName
+        }
+    }
+}

--- a/detekt/src/main/kotlin/storage/StorageRuleSetProvider.kt
+++ b/detekt/src/main/kotlin/storage/StorageRuleSetProvider.kt
@@ -1,0 +1,17 @@
+package at.hannibal2.skyhanni.detektrules.storage
+
+import com.google.auto.service.AutoService
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+@AutoService(RuleSetProvider::class)
+class StorageRuleSetProvider : RuleSetProvider {
+    override val ruleSetId: String = "StorageRules"
+
+    override fun instance(config: Config): RuleSet {
+        return RuleSet(ruleSetId, listOf(
+            EnforceConfigMutableCollections(config)
+        ))
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -31,7 +31,7 @@ class ChatConfig {
     @Expose
     @ConfigOption(name = "Dungeon Filters", desc = "Hide specific message types in Dungeons.")
     @ConfigEditorDraggableList
-    var dungeonFilteredMessageTypes: List<DungeonMessageTypes> = ArrayList()
+    var dungeonFilteredMessageTypes: List<DungeonMessageTypes> = mutableListOf()
 
 
     enum class DungeonMessageTypes(private val displayName: String) {

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/PlayerMessagesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/PlayerMessagesConfig.kt
@@ -19,7 +19,7 @@ class PlayerMessagesConfig {
     @Expose
     @ConfigOption(name = "Part Order", desc = "Drag text to change the chat message format order for chat messages.")
     @ConfigEditorDraggableList
-    var partsOrder: List<MessagePart> = listOf(
+    var partsOrder: List<MessagePart> = mutableListOf(
         MessagePart.SKYBLOCK_LEVEL,
         MessagePart.PRIVATE_ISLAND_RANK,
         MessagePart.PRIVATE_ISLAND_GUEST,

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningFilterConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningFilterConfig.kt
@@ -55,7 +55,7 @@ class PowderMiningFilterConfig {
     @Expose
     @ConfigOption(name = "Common Items", desc = "Hide reward messages for listed items.")
     @ConfigEditorDraggableList
-    var simplePowderMiningTypes: List<SimplePowderMiningRewardTypes> = listOf(
+    var simplePowderMiningTypes: List<SimplePowderMiningRewardTypes> = mutableListOf(
         SimplePowderMiningRewardTypes.ASCENSION_ROPE,
         SimplePowderMiningRewardTypes.WISHING_COMPASS,
         SimplePowderMiningRewardTypes.OIL_BARREL,


### PR DESCRIPTION
## What
Adds a new Detekt rule that enforces that all collections should use mutable types.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/89866caa-f287-464d-ba0a-67496ace81cf)

![image](https://github.com/user-attachments/assets/b7492022-78f1-4a38-a74e-da534417f16f)

</details>

exclude_from_changelog

