### PR TITLE
Backend: Detekt Enforce `@Expose` in Config and Storage

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -26,6 +26,8 @@ ImportRules:
 StorageRules:
     EnforceConfigMutableCollections:
         active: true
+    EnforceStorageExpose:
+        active: true
 
 style:
     MagicNumber: # I, Linnea Gräf, of sound mind and body, disagree with disabling this rule

--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -23,6 +23,10 @@ ImportRules:
     CustomImportOrdering:
         active: true
 
+StorageRules:
+    EnforceConfigMutableCollections:
+        active: true
+
 style:
     MagicNumber: # I, Linnea Gräf, of sound mind and body, disagree with disabling this rule
         active: false

--- a/detekt/src/main/kotlin/storage/EnforceConfigMutableCollections.kt
+++ b/detekt/src/main/kotlin/storage/EnforceConfigMutableCollections.kt
@@ -5,9 +5,9 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 
@@ -20,7 +20,7 @@ class EnforceConfigMutableCollections(config: Config): SkyHanniRule(config) {
     )
 
     companion object {
-        private const val CONFIG_PACKAGE = "at.hannibal2.skyhanni.config.features"
+        const val CONFIG_PACKAGE = "at.hannibal2.skyhanni.config.features"
 
         private val badListInitializers = setOf(
             "listOf",
@@ -85,15 +85,5 @@ class EnforceConfigMutableCollections(config: Config): SkyHanniRule(config) {
         in badSetInitializers -> "mutableSetOf"
         in badMapInitializers -> "mutableMapOf"
         else -> ""
-    }
-
-    /**
-     * Helper function to check if a property has a specific annotation.
-     */
-    private fun KtModifierListOwner.hasAnnotation(annotationName: String): Boolean {
-        // shortName?.asString() should normally be 'Expose' even with @field:Expose
-        return annotationEntries.any {
-            it.shortName?.asString() == annotationName
-        }
     }
 }

--- a/detekt/src/main/kotlin/storage/EnforceConfigMutableCollections.kt
+++ b/detekt/src/main/kotlin/storage/EnforceConfigMutableCollections.kt
@@ -1,0 +1,99 @@
+package at.hannibal2.skyhanni.detektrules.storage
+
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+
+class EnforceConfigMutableCollections(config: Config): SkyHanniRule(config) {
+    override val issue = Issue(
+        "EnforceConfigMutableCollections",
+        Severity.Defect,
+        "Use specified mutable collections instead of immutable, or implied mutable ones.",
+        Debt.TEN_MINS,
+    )
+
+    companion object {
+        private const val CONFIG_PACKAGE = "at.hannibal2.skyhanni.config.features"
+
+        private val badListInitializers = setOf(
+            "listOf",
+            "ArrayList",
+            "arrayListOf"
+        )
+
+        private val badSetInitializers = setOf(
+            "setOf",
+            "HashSet",
+            "hashSetOf"
+        )
+
+        private val badMapInitializers = setOf(
+            "mapOf",
+            "HashMap",
+            "hashMapOf"
+        )
+
+        private val badInitializers by lazy {
+            badListInitializers + badSetInitializers + badMapInitializers
+        }
+    }
+
+    override fun visitKtFile(file: KtFile) {
+        val packageName = file.packageDirective?.fqName?.asString() ?: ""
+        if (!packageName.startsWith(CONFIG_PACKAGE)) return
+        super.visitKtFile(file)
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        // Only look at properties annotated with @Expose
+        if (!property.hasAnnotation("Expose")) return
+        // Only look at properties with @ConfigOption
+        if (!property.hasAnnotation("ConfigOption")) return
+
+        // If the property is a List<*>, Set<*>, or Map<*>, check how it's initialized
+        // We remove the "Property<" prefix from the type reference, e.g. "Property<List<String>>" -> "List<String>".
+        val typeRef = property.typeReference?.text?.replaceFirst("Property<", "") ?: ""
+        // println("typeRef = '${property.typeReference?.text}' initializer = '${property.initializer?.text}'")
+
+        if (typeRef.startsWith("List<") ||
+            typeRef.startsWith("Set<")  ||
+            typeRef.startsWith("Map<")
+        ) {
+            // Examine the initializer call, e.g. listOf(...), setOf(...), mapOf(...).
+            val callExpression = property.initializer as? KtCallExpression
+            val calleeName = callExpression?.getCallNameExpression()?.getReferencedName() ?: ""
+
+            val calleeIsBad = calleeName in badInitializers
+            if (calleeIsBad) {
+                val properCallee = getProperCallee(calleeName)
+                property.reportIssue("Use $properCallee instead of $calleeName.")
+            }
+        }
+
+        super.visitProperty(property)
+    }
+
+    private fun getProperCallee(calleeName: String) = when (calleeName) {
+        in badListInitializers -> "mutableListOf"
+        in badSetInitializers -> "mutableSetOf"
+        in badMapInitializers -> "mutableMapOf"
+        else -> ""
+    }
+
+    /**
+     * Helper function to check if a property has a specific annotation.
+     */
+    private fun KtModifierListOwner.hasAnnotation(annotationName: String): Boolean {
+        // shortName?.asString() should normally be 'Expose' even with @field:Expose
+        return annotationEntries.any {
+            it.shortName?.asString() == annotationName
+        }
+    }
+}

--- a/detekt/src/main/kotlin/storage/EnforceStorageExpose.kt
+++ b/detekt/src/main/kotlin/storage/EnforceStorageExpose.kt
@@ -1,0 +1,51 @@
+package at.hannibal2.skyhanni.detektrules.storage
+
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
+import at.hannibal2.skyhanni.detektrules.storage.EnforceConfigMutableCollections.Companion.CONFIG_PACKAGE
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtProperty
+
+class EnforceStorageExpose(config: Config): SkyHanniRule(config) {
+    override val issue = Issue(
+        "EnforceStorageExpose",
+        Severity.Defect,
+        "Config/storage properties that are intended to store data should be annotated with @Expose.",
+        Debt.TEN_MINS,
+    )
+
+    companion object {
+        const val STORAGE_PACKAGE = "at.hannibal2.skyhanni.config.storage"
+    }
+
+    override fun visitKtFile(file: KtFile) {
+        val packageName = file.packageDirective?.fqName?.asString() ?: ""
+        if (!packageName.startsWith(CONFIG_PACKAGE) && !packageName.startsWith(STORAGE_PACKAGE)) return
+        super.visitKtFile(file)
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        // Skip local variables inside functions
+        if (property.isLocal) return
+
+        // If the property is not annotated with @Expose, report it
+        if (!property.hasAnnotation("Expose")) {
+
+            if (property.hasAnnotation("ConfigOption")) {
+                // Valid reasons to not have the @Expose annotation on a config option:
+                //  - Has the ConfigEditorInfoText annotation
+                //  - Has the ConfigEditorButton annotation
+                if(property.hasAnnotation("ConfigEditorInfoText")) return
+                if(property.hasAnnotation("ConfigEditorButton")) return
+            }
+
+            property.reportIssue("@Expose annotation is missing from property ${property.name}")
+        }
+
+        super.visitProperty(property)
+    }
+}

--- a/detekt/src/main/kotlin/storage/StorageRuleSetProvider.kt
+++ b/detekt/src/main/kotlin/storage/StorageRuleSetProvider.kt
@@ -1,0 +1,17 @@
+package at.hannibal2.skyhanni.detektrules.storage
+
+import com.google.auto.service.AutoService
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+@AutoService(RuleSetProvider::class)
+class StorageRuleSetProvider : RuleSetProvider {
+    override val ruleSetId: String = "StorageRules"
+
+    override fun instance(config: Config): RuleSet {
+        return RuleSet(ruleSetId, listOf(
+            EnforceConfigMutableCollections(config)
+        ))
+    }
+}

--- a/detekt/src/main/kotlin/storage/StorageRuleSetProvider.kt
+++ b/detekt/src/main/kotlin/storage/StorageRuleSetProvider.kt
@@ -11,7 +11,8 @@ class StorageRuleSetProvider : RuleSetProvider {
 
     override fun instance(config: Config): RuleSet {
         return RuleSet(ruleSetId, listOf(
-            EnforceConfigMutableCollections(config)
+            EnforceConfigMutableCollections(config),
+            EnforceStorageExpose(config)
         ))
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -31,7 +31,7 @@ class ChatConfig {
     @Expose
     @ConfigOption(name = "Dungeon Filters", desc = "Hide specific message types in Dungeons.")
     @ConfigEditorDraggableList
-    var dungeonFilteredMessageTypes: List<DungeonMessageTypes> = ArrayList()
+    var dungeonFilteredMessageTypes: List<DungeonMessageTypes> = mutableListOf()
 
 
     enum class DungeonMessageTypes(private val displayName: String) {

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/PlayerMessagesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/PlayerMessagesConfig.kt
@@ -19,7 +19,7 @@ class PlayerMessagesConfig {
     @Expose
     @ConfigOption(name = "Part Order", desc = "Drag text to change the chat message format order for chat messages.")
     @ConfigEditorDraggableList
-    var partsOrder: List<MessagePart> = listOf(
+    var partsOrder: List<MessagePart> = mutableListOf(
         MessagePart.SKYBLOCK_LEVEL,
         MessagePart.PRIVATE_ISLAND_RANK,
         MessagePart.PRIVATE_ISLAND_GUEST,

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningFilterConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/PowderMiningFilterConfig.kt
@@ -55,7 +55,7 @@ class PowderMiningFilterConfig {
     @Expose
     @ConfigOption(name = "Common Items", desc = "Hide reward messages for listed items.")
     @ConfigEditorDraggableList
-    var simplePowderMiningTypes: List<SimplePowderMiningRewardTypes> = listOf(
+    var simplePowderMiningTypes: List<SimplePowderMiningRewardTypes> = mutableListOf(
         SimplePowderMiningRewardTypes.ASCENSION_ROPE,
         SimplePowderMiningRewardTypes.WISHING_COMPASS,
         SimplePowderMiningRewardTypes.OIL_BARREL,


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni/pull/3202

## What
https://discord.com/channels/997079228510117908/1250434494473834597/1322271983429357709
Enforces that config/storage properties that are meant to store data have `@Expose` added to them.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/7120b056-6163-4e25-ae68-1848ae55286a)

![image](https://github.com/user-attachments/assets/7d18a197-6ede-446e-9b21-1daa732110fa)

</details>

exclude_from_changelog
