### PR TITLE
Fix: GardenKeybinds not working with Inventory/Chat Keybind 2

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -37,7 +37,13 @@ object GardenCustomKeybinds {
     @JvmStatic
     fun isKeyDown(keyBinding: KeyBinding, cir: CallbackInfoReturnable<Boolean>) {
         if (!isActive()) return
-        val override = map[keyBinding] ?: return
+        val override = map[keyBinding] ?: run {
+            if (map.containsValue(keyBinding.keyCode)) {
+                cir.returnValue = false
+            }
+            return
+        }
+
         cir.returnValue = override.isKeyHeld()
     }
 


### PR DESCRIPTION
## What
#3186 but finished as it was only for isKeyPressed and not also for isKeyDown

## Changelog Fixes
+ ixed Custom Keybinds not working with inventory or chat keys. - rueblimaster