### PR TITLE
Backend: ReputationHelper "Rewrite"

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
@@ -224,7 +224,7 @@ enum class TabWidget(
     ),
     REPUTATION(
         // language=RegExp
-        "(?:§.)*(Barbarian|Mage) Reputation:",
+        "(?:§.)*(?<faction>Barbarian|Mage) Reputation:",
     ),
     FACTION_QUESTS(
         // language=RegExp

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -77,13 +77,11 @@ abstract class GuiContainerEvent(open val gui: GuiContainer, open val container:
         val slot: Slot?,
         val slotId: Int,
         val clickedButton: Int,
-        @Deprecated("old", ReplaceWith("clickTypeEnum"))
-        val clickType: Int,
-        val clickTypeEnum: ClickType? = ClickType.getTypeById(clickType),
+        val clickType: ClickType?,
     ) : GuiContainerEvent(gui, container) {
 
         fun makePickblock() {
-            if (this.clickedButton == 2 && this.clickTypeEnum == ClickType.MIDDLE) return
+            if (this.clickedButton == 2 && this.clickType == ClickType.MIDDLE) return
             slot?.slotNumber?.let { slotNumber ->
                 InventoryUtils.clickSlot(slotNumber, container.windowId, 2, 3)
                 isCanceled = true

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
@@ -71,7 +71,7 @@ object VisitorRewardWarning {
         }
 
         // all but shift click types work for accepting visitor
-        if (event.clickTypeEnum == GuiContainerEvent.ClickType.SHIFT) return
+        if (event.clickType == GuiContainerEvent.ClickType.SHIFT) return
         if (isRefuseSlot) {
             VisitorAPI.changeStatus(visitor, VisitorAPI.VisitorStatus.REFUSED, "refused")
             // fallback if tab list is disabled

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -158,7 +158,7 @@ object HarpFeatures {
         if (isHarpGui(InventoryUtils.openInventoryName())) {
             if (config.keybinds) {
                 // needed to not send duplicate clicks via keybind feature
-                if (event.clickTypeEnum == GuiContainerEvent.ClickType.HOTBAR) {
+                if (event.clickType == GuiContainerEvent.ClickType.HOTBAR) {
                     event.cancel()
                     return
                 }
@@ -172,8 +172,9 @@ object HarpFeatures {
         event.container.inventory.filterNotNull().indexOfFirst {
             songSelectedPattern.anyMatches(it.getLore())
         }.takeIf { it != -1 }?.let {
+            val clickType = event.clickType?.id ?: return
             event.cancel()
-            InventoryUtils.clickSlot(it, event.container.windowId, event.clickedButton, event.clickType)
+            InventoryUtils.clickSlot(it, event.container.windowId, event.clickedButton, clickType)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryInventory.kt
@@ -101,7 +101,7 @@ object ChocolateFactoryInventory {
         ) return
 
         // this would break ChocolateFactoryKeybinds otherwise
-        if (event.clickTypeEnum == GuiContainerEvent.ClickType.HOTBAR) return
+        if (event.clickType == GuiContainerEvent.ClickType.HOTBAR) return
 
         // if the user is holding shift, we don't want to pickblock, handled by hypixel as +10 levels for rabbits
         if (KeyboardManager.isShiftKeyDown() && slotNumber in ChocolateFactoryAPI.rabbitSlots.keys) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryKeybinds.kt
@@ -45,7 +45,7 @@ object ChocolateFactoryKeybinds {
         if (!ChocolateFactoryAPI.inChocolateFactory) return
 
         // needed to not send duplicate clicks via keybind feature
-        if (event.clickTypeEnum == GuiContainerEvent.ClickType.HOTBAR) {
+        if (event.clickType == GuiContainerEvent.ClickType.HOTBAR) {
             event.cancel()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -26,7 +26,6 @@ import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NEUItems
-import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -102,7 +101,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.REPUTATION)) return
 
-        TabWidget.REPUTATION.matchMatcherFirstLine(){
+        TabWidget.REPUTATION.matchMatcherFirstLine() {
             factionType = FactionType.fromName(group("faction"))
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -101,7 +101,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.REPUTATION)) return
 
-        TabWidget.REPUTATION.matchMatcherFirstLine() {
+        TabWidget.REPUTATION.matchMatcherFirstLine {
             factionType = FactionType.fromName(group("faction"))
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -7,11 +7,13 @@ import at.hannibal2.skyhanni.config.features.crimsonisle.ReputationHelperConfig.
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.CrimsonIsleReputationJson
+import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.LorenzTickEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.SackChangeEvent
+import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.DailyQuestHelper
 import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.QuestLoader
 import at.hannibal2.skyhanni.features.nether.reputationhelper.kuudra.DailyKuudraBossHelper
@@ -24,6 +26,7 @@ import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NEUItems
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
 import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -95,6 +98,15 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
         dirty = true
     }
 
+    @HandleEvent
+    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+        if (!event.isWidget(TabWidget.REPUTATION)) return
+
+        event.widget.pattern.firstMatcher(event.lines) {
+            factionType = FactionType.fromName(group("faction"))
+        }
+    }
+
     @SubscribeEvent
     fun onTick(event: LorenzTickEvent) {
         if (!IslandType.CRIMSON_ISLE.isInIsland()) return
@@ -105,19 +117,6 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
         if (dirty) {
             dirty = false
             updateRender()
-        }
-
-        if (event.repeatSeconds(3)) {
-            val list = TabListData.getTabList().filter { it.contains("Reputation:") }
-            for (line in list) {
-                factionType = if (line.contains("Mage")) {
-                    FactionType.MAGE
-                } else if (line.contains("Barbarian")) {
-                    FactionType.BARBARIAN
-                } else {
-                    FactionType.NONE
-                }
-            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -31,7 +31,6 @@ import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiInventory
-import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -41,7 +41,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
     val miniBossHelper = DailyMiniBossHelper(this)
     val kuudraBossHelper = DailyKuudraBossHelper(this)
 
-    var factionType = FactionType.NONE
+    var factionType: FactionType? = null
 
     private var display = emptyList<Renderable>()
     private var dirty = true
@@ -121,7 +121,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
     private fun updateRender() {
         display = buildList {
             addString("§e§lReputation Helper")
-            if (factionType == FactionType.NONE) {
+            if (factionType == null) {
                 addString("§cFaction not found!")
                 return
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -102,7 +102,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.REPUTATION)) return
 
-        event.widget.pattern.firstMatcher(event.lines) {
+        TabWidget.REPUTATION.matchMatcherFirstLine(){
             factionType = FactionType.fromName(group("faction"))
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.QuestLo
 import at.hannibal2.skyhanni.features.nether.reputationhelper.kuudra.DailyKuudraBossHelper
 import at.hannibal2.skyhanni.features.nether.reputationhelper.miniboss.DailyMiniBossHelper
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.CollectionUtils.addString
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
@@ -27,8 +27,8 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
-import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
-import at.hannibal2.skyhanni.utils.TabListData
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
+import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiInventory
@@ -45,7 +45,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
 
     var factionType = FactionType.NONE
 
-    private var display = emptyList<List<Any>>()
+    private var display = emptyList<Renderable>()
     private var dirty = true
     var tabListQuestsMissing = false
 
@@ -121,23 +121,28 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
     }
 
     private fun updateRender() {
-        val newList = mutableListOf<List<Any>>()
+        display = buildList {
+            addString("§e§lReputation Helper")
+            if (factionType == FactionType.NONE) {
+                addString("§cFaction not found!")
+                return
+            }
 
-        // TODO test
-        if (factionType == FactionType.NONE) return
-
-        newList.addAsSingletonList("§e§lReputation Helper")
-        if (tabListQuestsMissing) {
-            newList.addAsSingletonList("§cFaction Quests Widget not found!")
-            newList.addAsSingletonList("§7Open §e/tab §7and enable it!")
-        } else {
-            questHelper.render(newList)
-            miniBossHelper.render(newList)
-            kuudraBossHelper.render(newList)
+            if (tabListQuestsMissing) {
+                addString("§cFaction Quests Widget not found!")
+                addString("§7Open §e/tab §7and enable it!")
+            } else {
+                questHelper.run {
+                    addQuests()
+                }
+                miniBossHelper.run {
+                    addDailyMiniBoss()
+                }
+                kuudraBossHelper.run {
+                    addKuudraBoss()
+                }
+            }
         }
-
-
-        display = newList
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -149,7 +154,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
             return
         }
 
-        config.position.renderStringsAndItems(
+        config.position.renderRenderables(
             display,
             posLabel = "Crimson Isle Reputation Helper",
         )

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -144,7 +144,7 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
         }
     }
 
-    @SubscribeEvent(priority = EventPriority.LOWEST)
+    @HandleEvent(priority = HandleEvent.LOWEST)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.enabled.get()) return
         if (!IslandType.CRIMSON_ISLE.isInIsland()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/FactionType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/FactionType.kt
@@ -1,8 +1,12 @@
 package at.hannibal2.skyhanni.features.nether.reputationhelper
 
-enum class FactionType {
-    BARBARIAN,
-    MAGE,
+enum class FactionType(val factionName: String) {
+    BARBARIAN("Barbarian"),
+    MAGE("Mage"),
+    NONE("None"),
+    ;
 
-    NONE
+    companion object {
+        fun fromName(name: String) = entries.firstOrNull { it.factionName.equals(name, ignoreCase = true) } ?: NONE
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/FactionType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/FactionType.kt
@@ -3,10 +3,9 @@ package at.hannibal2.skyhanni.features.nether.reputationhelper
 enum class FactionType(val factionName: String) {
     BARBARIAN("Barbarian"),
     MAGE("Mage"),
-    NONE("None"),
     ;
 
     companion object {
-        fun fromName(name: String) = entries.firstOrNull { it.factionName.equals(name, ignoreCase = true) } ?: NONE
+        fun fromName(name: String) = entries.firstOrNull { it.factionName.equals(name, ignoreCase = true) }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -29,7 +29,8 @@ import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.quest.T
 import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.quest.UnknownQuest
 import at.hannibal2.skyhanni.features.nether.reputationhelper.miniboss.CrimsonMiniBoss
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.CollectionUtils.addItemStack
+import at.hannibal2.skyhanni.utils.CollectionUtils.addString
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getInventoryName
@@ -45,6 +46,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.StringUtils.removeWordsAtEnd
+import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.inventory.ContainerChest
@@ -227,23 +229,23 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
         state == QuestState.READY_TO_COLLECT || (this is RescueMissionQuest && state == QuestState.ACCEPTED)
     }
 
-    fun render(display: MutableList<List<Any>>) {
+    fun MutableList<Renderable>.addQuests() {
         if (greatSpook) {
-            display.addAsSingletonList("")
-            display.addAsSingletonList("§7Daily Quests (§cdisabled§7)")
-            display.addAsSingletonList(" §5§lThe Great Spook §7happened :O")
+            addString("")
+            addString("§7Daily Quests (§cdisabled§7)")
+            addString(" §5§lThe Great Spook §7happened :O")
             return
         }
         val done = quests.count { it.state == QuestState.COLLECTED }
-        display.addAsSingletonList("")
-        display.addAsSingletonList("§7Daily Quests (§e$done§8/§e5 collected§7)")
+        addString("")
+        addString("§7Daily Quests (§e$done§8/§e5 collected§7)")
         if (done != 5) {
             val filteredQuests = quests.filter { !config.hideComplete.get() || it.state != QuestState.COLLECTED }
-            filteredQuests.mapTo(display) { renderQuest(it) }
+            addAll(filteredQuests.map { renderQuest(it) })
         }
     }
 
-    private fun renderQuest(quest: Quest): List<Any> {
+    private fun renderQuest(quest: Quest): Renderable {
         val category = quest.category
         val state = quest.state.displayName
         val stateColor = quest.state.color
@@ -275,7 +277,6 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
             ""
         }
 
-        val result = mutableListOf<Any>()
         val item = quest.displayItem.getItemStack()
 
         val displayName = if (category == QuestCategory.FETCH || category == QuestCategory.FISHING) {
@@ -287,10 +288,13 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
 
         val categoryName = category.displayName
 
-        result.add("  $stateText$categoryName: ")
-        result.add(item)
-        result.add("§f$displayName$progressText$sacksText")
-        return result
+        return Renderable.horizontalContainer(
+            buildList {
+                addString("  $stateText$categoryName: ")
+                addItemStack(item)
+                addString("§f$displayName$progressText$sacksText")
+            },
+        )
     }
 
     fun finishMiniBoss(miniBoss: CrimsonMiniBoss) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -215,11 +215,9 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
 
     private fun renderTownBoard(event: LorenzRenderWorldEvent) {
         if (!quests.any { it.needsTownBoardLocation() }) return
-        val location = when (reputationHelper.factionType) {
+        val location = when (reputationHelper.factionType ?: return) {
             FactionType.BARBARIAN -> townBoardBarbarian
             FactionType.MAGE -> townBoardMage
-
-            FactionType.NONE -> return
         }
         event.drawWaypointFilled(location, LorenzColor.WHITE.toColor())
         event.drawDynamicText(location, "Town Board", 1.5)

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/kuudra/DailyKuudraBossHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/kuudra/DailyKuudraBossHelper.kt
@@ -10,13 +10,15 @@ import at.hannibal2.skyhanni.events.kuudra.KuudraCompleteEvent
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraTier
 import at.hannibal2.skyhanni.features.nether.reputationhelper.CrimsonIsleReputationHelper
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.CollectionUtils.addItemStack
+import at.hannibal2.skyhanni.utils.CollectionUtils.addString
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
+import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class DailyKuudraBossHelper(private val reputationHelper: CrimsonIsleReputationHelper) {
@@ -52,21 +54,25 @@ class DailyKuudraBossHelper(private val reputationHelper: CrimsonIsleReputationH
         reputationHelper.update()
     }
 
-    fun render(display: MutableList<List<Any>>) {
+    fun MutableList<Renderable>.addKuudraBoss() {
         val done = kuudraTiers.count { it.doneToday }
-        display.addAsSingletonList("")
-        display.addAsSingletonList("§7Daily Kuudra (§e$done§8/§e5 killed§7)")
+        addString("")
+        addString("§7Daily Kuudra (§e$done§8/§e5 killed§7)")
         if (done < 5) {
             for (tier in kuudraTiers) {
                 if (config.hideComplete.get() && tier.doneToday) continue
                 val result = if (tier.doneToday) "§aDone" else "§bTodo"
                 val displayName = tier.getDisplayName()
                 val displayItem = tier.displayItem
-                val lineList = mutableListOf<Any>()
-                lineList.add(" ")
-                lineList.add(displayItem.getItemStack())
-                lineList.add("$displayName: $result")
-                display.add(lineList)
+
+                val row = Renderable.horizontalContainer(
+                    buildList {
+                        addString(" ")
+                        addItemStack(displayItem.getItemStack())
+                        addString("$displayName: $result")
+                    },
+                )
+                add(row)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/miniboss/DailyMiniBossHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/miniboss/DailyMiniBossHelper.kt
@@ -10,7 +10,8 @@ import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorMana
 import at.hannibal2.skyhanni.features.nether.reputationhelper.CrimsonIsleReputationHelper
 import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.quest.MiniBossQuest
 import at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.quest.QuestState
-import at.hannibal2.skyhanni.utils.CollectionUtils.addAsSingletonList
+import at.hannibal2.skyhanni.utils.CollectionUtils.addItemStack
+import at.hannibal2.skyhanni.utils.CollectionUtils.addString
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
@@ -18,6 +19,7 @@ import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
+import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 class DailyMiniBossHelper(private val reputationHelper: CrimsonIsleReputationHelper) {
@@ -64,10 +66,12 @@ class DailyMiniBossHelper(private val reputationHelper: CrimsonIsleReputationHel
         reputationHelper.update()
     }
 
-    fun render(display: MutableList<List<Any>>) {
+    fun MutableList<Renderable>.addDailyMiniBoss() {
         val done = miniBosses.count { it.doneToday }
-        display.addAsSingletonList("")
-        display.addAsSingletonList("§7Daily Bosses (§e$done§8/§e5 killed§7)")
+
+        addString("")
+        addString("§7Daily Bosses (§e$done§8/§e5 killed§7)")
+
         if (done != 5) {
             for (miniBoss in miniBosses) {
                 if (config.hideComplete.get() && miniBoss.doneToday) continue
@@ -75,11 +79,14 @@ class DailyMiniBossHelper(private val reputationHelper: CrimsonIsleReputationHel
                 val displayName = miniBoss.displayName
                 val displayItem = miniBoss.displayItem
 
-                val lineList = mutableListOf<Any>()
-                lineList.add(" ")
-                lineList.add(displayItem.getItemStack())
-                lineList.add("§5$displayName§7: $result")
-                display.add(lineList)
+                val row = Renderable.horizontalContainer(
+                    buildList {
+                        addString(" ")
+                        addItemStack(displayItem.getItemStack())
+                        addString("§5$displayName§7: $result")
+                    },
+                )
+                add(row)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.mixins.hooks
 import at.hannibal2.skyhanni.data.GuiData
 import at.hannibal2.skyhanni.events.DrawScreenAfterEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.GuiContainerEvent.ClickType
 import at.hannibal2.skyhanni.events.GuiContainerEvent.CloseWindowEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent.SlotClickEvent
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
@@ -68,7 +69,7 @@ class GuiContainerHook(guiAny: Any) {
 
     fun onMouseClick(slot: Slot?, slotId: Int, clickedButton: Int, clickType: Int, ci: CallbackInfo) {
         val item = gui.inventorySlots?.inventory?.takeIf { it.size > slotId && slotId >= 0 }?.get(slotId)
-        if (SlotClickEvent(gui, gui.inventorySlots, item, slot, slotId, clickedButton, clickType).postAndCatch()
+        if (SlotClickEvent(gui, gui.inventorySlots, item, slot, slotId, clickedButton, ClickType.getTypeById(clickType)).postAndCatch()
         ) ci.cancel()
     }
 

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -24,7 +24,6 @@
     <ID>CyclomaticComplexMethod:PacketTest.kt$PacketTest$private fun Packet&lt;*&gt;.print()</ID>
     <ID>CyclomaticComplexMethod:ParkourHelper.kt$ParkourHelper$fun render(event: LorenzRenderWorldEvent)</ID>
     <ID>CyclomaticComplexMethod:Renderable.kt$Renderable.Companion$internal fun shouldAllowLink(debug: Boolean = false, bypassChecks: Boolean): Boolean</ID>
-    <ID>CyclomaticComplexMethod:SkillProgress.kt$SkillProgress$private fun drawDisplay()</ID>
     <ID>CyclomaticComplexMethod:VampireSlayerFeatures.kt$VampireSlayerFeatures$private fun EntityOtherPlayerMP.process()</ID>
     <ID>CyclomaticComplexMethod:VisualWordGui.kt$VisualWordGui$override fun drawScreen(unusedX: Int, unusedY: Int, partialTicks: Float)</ID>
     <ID>InjectDispatcher:ClipboardUtils.kt$ClipboardUtils$IO</ID>
@@ -61,7 +60,6 @@
     <ID>MemberNameEqualsClassName:TestBingo.kt$TestBingo$var testBingo = false</ID>
     <ID>MemberNameEqualsClassName:Text.kt$Text$fun text(text: String, init: IChatComponent.() -&gt; Unit = {})</ID>
     <ID>NoNameShadowing:BucketedItemTrackerData.kt$BucketedItemTrackerData${ it.hidden = !it.hidden }</ID>
-    <ID>NoNameShadowing:BurrowWarpHelper.kt$BurrowWarpHelper${ it.startsWith("§bWarp to ") }</ID>
     <ID>NoNameShadowing:ContributorManager.kt$ContributorManager${ it.isAllowed() }</ID>
     <ID>NoNameShadowing:Graph.kt$Graph.Companion${ out.name("Name").value(it) }</ID>
     <ID>NoNameShadowing:Graph.kt$Graph.Companion${ out.name("Tags") out.beginArray() for (tagName in it) { out.value(tagName) } out.endArray() }</ID>
@@ -202,8 +200,6 @@
     <ID>RepoPatternRegexTest:QuiverAPI.kt$QuiverAPI$by chatGroup.pattern( "cleared", "§aCleared your quiver!|§c§lYour quiver is now completely empty!", )</ID>
     <ID>RepoPatternRegexTest:QuiverAPI.kt$QuiverAPI$by chatGroup.pattern( "ranout", "§c§lQUIVER! §cYou have run out of §f(?&lt;type&gt;.*)s§c!", )</ID>
     <ID>RepoPatternRegexTest:RestorePieceOfWizardPortalLore.kt$RestorePieceOfWizardPortalLore$by RepoPattern.pattern( "misc.restore.wizard.portal.earned", "§7Earned by:.*" )</ID>
-    <ID>RepoPatternRegexTest:RiftBloodEffigies.kt$RiftBloodEffigies$by patternGroup.pattern( "heart", "Effigies: (?&lt;hearts&gt;(?:(?:§[7c])?⧯)*)" )</ID>
-    <ID>RepoPatternRegexTest:RiftBloodEffigies.kt$RiftBloodEffigies$by patternGroup.pattern( "respawn", "§eRespawn §c(?&lt;time&gt;.*) §7\\(or click!\\)" )</ID>
     <ID>RepoPatternRegexTest:ScoreboardPattern.kt$ScoreboardPattern$by dungeonSb.pattern( "cleared", "(?:§.)*Cleared: (?:§.)*(?&lt;percent&gt;[\\w,.]+)% (?:§.)*\\((?:§.)*(?&lt;score&gt;[\\w,.]+)(?:§.)*\\)", )</ID>
     <ID>RepoPatternRegexTest:ScoreboardPattern.kt$ScoreboardPattern$by dungeonSb.pattern( "keys", "Keys: §.■ §.[✗✓] §.■ §a.x", )</ID>
     <ID>RepoPatternRegexTest:ScoreboardPattern.kt$ScoreboardPattern$by dungeonSb.pattern( "teammates", "(?:§.)*(?&lt;classAbbv&gt;\\[\\w]) (?:§.)*(?&lt;username&gt;\\w{2,16}) (?:(?:§.)*(?&lt;classLevel&gt;\\[Lvl?(?&lt;level&gt;[\\w,.]+)?]?)|(?:§.)*(?&lt;health&gt;[\\w,.]+)(?:§.)*.?)", )</ID>


### PR DESCRIPTION
## What
Rewrote ReputationHelper to use renderables, changed the factionType getter to use TabwidgetUpdateEvent.
Removed clickType in favor of clickTypeEnum, renamed the clickTypeEnum variable to just clickType


## Changelog Technical Details
+ Rewrote ReputationHelper to use Renderables & TabWidgetUpdateEvent. - j10a1n15
+ Removed deprecated clickType field. - j10a1n15
