### PR TITLE
Feature: Block Clicking Not Spawnable Slayer

### DIFF
--- a/.idea/dictionaries/default_user.xml
+++ b/.idea/dictionaries/default_user.xml
@@ -250,6 +250,7 @@
       <w>soulflow</w>
       <w>soulsand</w>
       <w>soulweaver</w>
+      <w>spawnable</w>
       <w>sprayonator</w>
       <w>statspocalypse</w>
       <w>stillgore</w>

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
@@ -48,6 +48,15 @@ class SlayerConfig {
     var slayerBossWarning: SlayerBossWarningConfig = SlayerBossWarningConfig()
 
     @Expose
+    @ConfigOption(
+        name = "Block Not Spawnable",
+        desc = "Prevent clicking slayer bosses that cannot be started in the current dimension in Maddox's menu.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var blockNotSpawnable: Boolean = true
+
+    @Expose
     @ConfigOption(name = "Miniboss Highlight", desc = "Highlight Slayer Mini-Boss in blue color.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
@@ -50,7 +50,7 @@ class SlayerConfig {
     @Expose
     @ConfigOption(
         name = "Block Not Spawnable",
-        desc = "Prevent clicking slayer bosses that cannot be started in the current dimension in Maddox's menu.",
+        desc = "Prevent clicking slayer bosses that cannot be spawned in the current dimension in Maddox's menu.",
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
@@ -1,0 +1,37 @@
+package at.hannibal2.skyhanni.features.slayer
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object BlockNotSpawnable {
+    private val config get() = SkyHanniMod.feature.slayer
+
+    /**
+     * REGEX-TEST: §cOnly inside The Rift!
+     * REGEX-TEST: §cDoesn't exist here!
+     */
+    private val notSpawnablePattern by RepoPattern.pattern(
+        "slayer.notspawnable",
+        "§c(?:Only inside The Rift!|Doesn't exist here!)",
+    )
+
+    @SubscribeEvent
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!isEnabled()) return
+
+        val slot = event.slot ?: return
+        if (slot.inventory.name != "Slayer") return
+
+        if (notSpawnablePattern.anyMatches(slot.stack.getLore())) {
+            event.cancel()
+        }
+    }
+
+    private fun isEnabled() = config.blockNotSpawnable
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
@@ -1,12 +1,13 @@
 package at.hannibal2.skyhanni.features.slayer
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
 object BlockNotSpawnable {
@@ -21,7 +22,7 @@ object BlockNotSpawnable {
         "§c(?:Only inside The Rift!|Doesn't exist here!)",
     )
 
-    @SubscribeEvent
+    @HandleEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled()) return
 
@@ -33,5 +34,5 @@ object BlockNotSpawnable {
         }
     }
 
-    private fun isEnabled() = config.blockNotSpawnable
+    private fun isEnabled() = LorenzUtils.inSkyBlock && config.blockNotSpawnable
 }


### PR DESCRIPTION
## What
Added an option to block clicking slayers that are not spawnable in the current dimension to Maddox's menu (Riftstalker Bloodfiend in the Overworld and everything else in the Rift), because they take you out of the menu if you try to click them.

## Changelog New Features
+ Added blocking for slayers that cannot spawn in the current dimension to prevent Maddox's menu from closing. - Luna
