### PR TITLE
Backend: LorenzVec generated methods

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
@@ -73,8 +73,6 @@ data class LorenzVec(
 
     fun add(x: Int = 0, y: Int = 0, z: Int = 0): LorenzVec = LorenzVec(this.x + x, this.y + y, this.z + z)
 
-    override fun toString() = "LorenzVec{x=$x, y=$y, z=$z}"
-
     fun dotProduct(other: LorenzVec): Double = (x * other.x) + (y * other.y) + (z * other.z)
 
     fun angleAsCos(other: LorenzVec) = normalize().dotProduct(other.normalize())
@@ -117,6 +115,8 @@ data class LorenzVec(
 
     fun toCleanString(separator: String = ", "): String = listOf(x, y, z).joinToString(separator)
 
+    fun asStoredString(): String = "$x:$y:$z"
+
     fun lengthSquared(): Double = x * x + y * y + z * z
     fun length(): Double = sqrt(lengthSquared())
 
@@ -130,21 +130,6 @@ data class LorenzVec(
     fun toFloatArray(): Array<Float> = arrayOf(x.toFloat(), y.toFloat(), z.toFloat())
 
     fun equalsIgnoreY(other: LorenzVec) = x == other.x && z == other.z
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-
-        return (other as? LorenzVec)?.let {
-            x == it.x && y == it.y && z == it.z
-        } ?: super.equals(other)
-    }
-
-    override fun hashCode(): Int {
-        var result = x.hashCode()
-        result = 31 * result + y.hashCode()
-        result = 31 * result + z.hashCode()
-        return result
-    }
 
     fun roundTo(precision: Int) = LorenzVec(x.roundTo(precision), y.roundTo(precision), z.roundTo(precision))
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SkyHanniTypeAdapters.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SkyHanniTypeAdapters.kt
@@ -39,8 +39,8 @@ object SkyHanniTypeAdapters {
     )
 
     val VEC_STRING: TypeAdapter<LorenzVec> = SimpleStringTypeAdapter(
-        { "$x:$y:$z" },
-        { LorenzVec.decodeFromString(this) },
+        LorenzVec::asStoredString,
+        LorenzVec::decodeFromString,
     )
 
     val TROPHY_RARITY: TypeAdapter<TrophyRarity> = SimpleStringTypeAdapter(


### PR DESCRIPTION
## What
Removes a couple of methods in LorenzVec that should already get generated by being a data class. The only exception to this is is the .toString() method, where the only difference is that instead of using curly brackets it uses parenthesis.

exclude_from_changelog