### PR TITLE
Improvement: Replace old hoppity ready reminder messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -252,7 +252,7 @@ object HoppityEggsManager {
                 actionName = actionName,
                 action = action,
             )
-        } else ChatUtils.chat(message)
+        } else ChatUtils.chat(message, replaceSameMessage = true)
         LorenzUtils.sendTitle("§e$amount Hoppity Eggs!", 5.seconds)
         SoundUtils.repeatSound(100, 10, SoundUtils.plingSound)
     }


### PR DESCRIPTION
## What
Replaces old Hoppity ready reminder messages when clickable is disabled.
Suggestion: https://discord.com/channels/997079228510117908/1327896826984136756

## Changelog Improvements
+ Replaced old hoppity ready reminder messages when clickable is disabled. - hannibal2