### PR TITLE
Fix: Missing Label on DungeonFinder Item Stack

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -117,6 +117,14 @@ object DungeonFinderFeatures {
     /**
      * REGEX-TEST: Floor: Floor VII
      */
+    private val floorFloorPattern by patternGroup.pattern(
+        "floor.floor",
+        "Floor: .*",
+    )
+
+    /**
+     * REGEX-TEST: Floor VII
+     */
     private val floorPattern by patternGroup.pattern(
         "floor",
         "Floor .*",
@@ -211,7 +219,7 @@ object DungeonFinderFeatures {
             val name = stack.displayName.removeColor()
             if (!checkIfPartyPattern.matches(name)) continue
             val lore = stack.getLore()
-            val floor = lore.find { floorPattern.matches(it.removeColor()) } ?: continue
+            val floor = lore.find { floorFloorPattern.matches(it.removeColor()) } ?: continue
             val dungeon = lore.find { dungeonFloorPattern.matches(it.removeColor()) } ?: continue
             val floorNum = floorNumberPattern.matchMatcher(floor) {
                 group("floorNum").romanToDecimalIfNecessary()

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -115,19 +115,12 @@ object DungeonFinderFeatures {
     )
 
     /**
-     * REGEX-TEST: Floor: Floor VII
-     */
-    private val floorFloorPattern by patternGroup.pattern(
-        "floor.floor",
-        "Floor: .*",
-    )
-
-    /**
      * REGEX-TEST: Floor VII
+     * REGEX-TEST: Floor: Floor VII
      */
     private val floorPattern by patternGroup.pattern(
         "floor",
-        "Floor .*",
+        "Floor:? .*",
     )
     private val anyFloorPattern by patternGroup.pattern(
         "floor.any",
@@ -219,7 +212,7 @@ object DungeonFinderFeatures {
             val name = stack.displayName.removeColor()
             if (!checkIfPartyPattern.matches(name)) continue
             val lore = stack.getLore()
-            val floor = lore.find { floorFloorPattern.matches(it.removeColor()) } ?: continue
+            val floor = lore.find { floorPattern.matches(it.removeColor()) } ?: continue
             val dungeon = lore.find { dungeonFloorPattern.matches(it.removeColor()) } ?: continue
             val floorNum = floorNumberPattern.matchMatcher(floor) {
                 group("floorNum").romanToDecimalIfNecessary()


### PR DESCRIPTION
## What
idk how the original test case succeeded, it shouldn't have 🤷 


## Changelog Fixes
+ Fixed missing label on Partyfinder ItemStack. - j10a1n15
