### PR TITLE
Improvement: Remove indent for totals on Mythological Creature Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
@@ -122,8 +122,8 @@ object MythologicalCreatureTracker {
                 searchText = creatureType.displayName,
             )
         }
-        addSearchString(" §7- §e${total.addSeparators()} §7Total Mythological Creatures")
-        addSearchString(" §7- §e${data.creaturesSinceLastInquisitor.addSeparators()} §7Creatures since last Minos Inquisitor")
+        addSearchString("§7Total Mythological Creatures: §e${total.addSeparators()}")
+        addSearchString("§7Creatures since last Minos Inquisitor: §e${data.creaturesSinceLastInquisitor.addSeparators()} ")
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
Format totals like other trackers (Diana Profit Tracker namely) by removing indent.

![image](https://github.com/user-attachments/assets/69b492b2-2bfa-4619-917c-ca16bb05a69d)

## Changelog Improvements
+ Separated totals from mob list on Mythological Creature Tracker. - indigo_polecat

