### PR TITLE
Fix: Custom Scoreboard Missing Patterns

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/card/nextstephelper/BingoNextStepHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/card/nextstephelper/BingoNextStepHelper.kt
@@ -43,24 +43,26 @@ object BingoNextStepHelper {
     )
 
     /**
-     * REGEX-TEST: §7§7Reach §a1,000 §7Ink Sac Collection.
+     * REGEX-TEST: Reach 1,000 Ink Sac Collection.
      */
     private val collectionPattern by patternGroup.pattern(
         "collection",
         "Reach (?<amount>[0-9]+(?:,\\d+)*) (?<name>.*) Collection\\.",
     )
+
     private val crystalPattern by patternGroup.pattern(
         "crystal.obtain",
         "Obtain a (?<name>\\w+) Crystal in the Crystal Hollows\\.",
     )
 
     /**
-     * REGEX-TEST: §7§7Obtain level §e10§7 in the §6Foraging §7Skill.
+     * REGEX-TEST: Obtain level 10 in the Foraging Skill.
      */
     private val skillPattern by patternGroup.pattern(
         "skill",
         "Obtain level (?<level>.*) in the (?<skill>.*) Skill.",
     )
+
     private val crystalFoundPattern by patternGroup.pattern(
         "crystal.found",
         " *§r§5§l✦ CRYSTAL FOUND §r§7\\(.§r§7/5§r§7\\)",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -68,8 +68,8 @@ object GardenNextJacobContest {
     private val patternGroup = RepoPattern.group("garden.nextcontest")
 
     /**
-     * REGEX-TEST: Day 1
-     * REGEX-TEST: Day 31
+     * REGEX-TEST: §aDay 1
+     * REGEX-TEST: §aDay 31
      */
     val dayPattern by patternGroup.pattern(
         "day",

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -321,15 +321,6 @@ object ScoreboardPattern {
         "(?:§.)*᠅ §.(?<type>Gemstone|Mithril|Glacite)(?: Powder)?(?:§.)*:? (?:§.)*(?<amount>[\\d,.]*)",
     )
 
-    /**
-     * REGEX-TEST: §2᠅ §fMithril§f:§695
-     * REGEX-TEST: §d᠅ §fGemstone§f
-     * REGEX-TEST: §d᠅ §fGemstone§f§e(+1)
-     */
-    val powderGreedyPattern by miningSb.pattern(
-        "powdergreedy",
-        "(?:§.)*᠅ §.(?<type>Gemstone|Mithril|Glacite)(?: Powder)?.*",
-    )
     val windCompassPattern by miningSb.pattern(
         "windcompass",
         "§9Wind Compass",
@@ -917,12 +908,16 @@ object ScoreboardPattern {
      * REGEX-TEST:  §e§l⚡ §cRedston
      * REGEX-TEST:       §ce: §e§b0%
      * REGEX-TEST: Starting in: §a0 §c1:55
+     * REGEX-TEST: §2᠅ §fMithril§f:§695
+     * REGEX-TEST: §d᠅ §fGemstone§f
+     * REGEX-TEST: §d᠅ §fGemstone§f§e(+1)
      */
     val brokenPatterns by group.list(
         "broken",
         "\\s*§.§l⚡ §cRedston",
         "\\s*§ce: §e§b0%",
         "\\s*Starting in: §a0 §c[\\d:]+",
+        "(?:§.)*᠅ §.(?<type>Gemstone|Mithril|Glacite)(?: Powder)?.*",
     )
 
     // Lines from the tablist

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLocation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLocation.kt
@@ -15,5 +15,5 @@ object ScoreboardElementLocation : ScoreboardElement() {
 
     override val configLine = "§7⏣ §bVillage"
 
-    override val elementPatterns = listOf(ScoreboardPattern.locationPattern)
+    override val elementPatterns = listOf(ScoreboardPattern.locationPattern, ScoreboardPattern.plotPattern)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementObjective.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementObjective.kt
@@ -25,7 +25,11 @@ object ScoreboardElementObjective : ScoreboardElement() {
 
     override val configLine = "Objective:\n§eStar SkyHanni on Github"
 
-    override val elementPatterns = listOf(ScoreboardPattern.objectivePattern, ScoreboardPattern.wtfAreThoseLinesPattern)
+    override val elementPatterns = listOf(
+        ScoreboardPattern.objectivePattern,
+        ScoreboardPattern.thirdObjectiveLinePattern,
+        ScoreboardPattern.wtfAreThoseLinesPattern,
+    )
 }
 
 // click: open the objective page (i think a command should exist)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventGarden.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventGarden.kt
@@ -13,7 +13,11 @@ object ScoreboardEventGarden : ScoreboardEvent() {
 
     override val configLine = "§7(All Garden Lines)"
 
-    override val elementPatterns = listOf(ScoreboardPattern.pastingPattern, ScoreboardPattern.cleanUpPattern)
+    override val elementPatterns = listOf(
+        ScoreboardPattern.lockedPattern,
+        ScoreboardPattern.pastingPattern,
+        ScoreboardPattern.cleanUpPattern,
+    )
 
     override fun showIsland() = GardenAPI.inGarden()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventJacobMedals.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventJacobMedals.kt
@@ -13,5 +13,5 @@ object ScoreboardEventJacobMedals : ScoreboardEvent() {
 
     override val elementPatterns = listOf(ScoreboardPattern.medalsPattern)
 
-    // Can appear in any island when calling Anita through the AbiPhone
+    // Can appear on any island when calling Anita through the AbiPhone
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventJacobMedals.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventJacobMedals.kt
@@ -1,9 +1,7 @@
 package at.hannibal2.skyhanni.features.gui.customscoreboard.events
 
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils.getSbLines
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
-import at.hannibal2.skyhanni.utils.LorenzUtils.inAnyIsland
 import at.hannibal2.skyhanni.utils.RegexUtils.allMatches
 
 // scoreboard
@@ -15,5 +13,5 @@ object ScoreboardEventJacobMedals : ScoreboardEvent() {
 
     override val elementPatterns = listOf(ScoreboardPattern.medalsPattern)
 
-    override fun showIsland() = inAnyIsland(IslandType.GARDEN, IslandType.HUB)
+    // Can appear in any island when calling Anita through the AbiPhone
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventMining.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventMining.kt
@@ -84,7 +84,6 @@ object ScoreboardEventMining : ScoreboardEvent() {
         ScoreboardPattern.remainingGoblinPattern,
         ScoreboardPattern.fortunateFreezingBonusPattern,
         ScoreboardPattern.fossilDustPattern,
-        ScoreboardPattern.powderGreedyPattern,
         ScoreboardPattern.raffleUselessPattern,
         ScoreboardPattern.mithrilUselessPattern,
         ScoreboardPattern.goblinUselessPattern,

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventRift.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventRift.kt
@@ -10,11 +10,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.allMatches
 // scoreboard update event
 object ScoreboardEventRift : ScoreboardEvent() {
 
-    override fun getDisplay() = elementPatterns.allMatches(getSbLines())
-
-    override val configLine = "§7(All Rift Lines)"
-
-    override val elementPatterns = listOf(
+    private val importantPatterns = listOf(
         RiftBloodEffigies.heartsPattern,
         ScoreboardPattern.riftHotdogTitlePattern,
         ScoreboardPattern.timeLeftPattern,
@@ -24,10 +20,15 @@ object ScoreboardEventRift : ScoreboardEvent() {
         ScoreboardPattern.cluesPattern,
         ScoreboardPattern.barryProtestorsQuestlinePattern,
         ScoreboardPattern.barryProtestorsHandledPattern,
-        ScoreboardPattern.riftDimensionPattern,
         ScoreboardPattern.timeSlicedPattern,
         ScoreboardPattern.bigDamagePattern,
     )
+
+    override fun getDisplay() = importantPatterns.allMatches(getSbLines())
+
+    override val configLine = "§7(All Rift Lines)"
+
+    override val elementPatterns = importantPatterns + listOf(ScoreboardPattern.riftDimensionPattern)
 
     override fun showIsland() = RiftAPI.inRift()
 }

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -77,9 +77,7 @@
     <ID>NoNameShadowing:RepoPatternManager.kt$RepoPatternManager${ it == '.' }</ID>
     <ID>NoNameShadowing:Shimmy.kt$Shimmy.Companion$source</ID>
     <ID>NoNameShadowing:SkyHanniBucketedItemTracker.kt$SkyHanniBucketedItemTracker${ ItemPriceSource.entries[it.ordinal] }</ID>
-    <ID>RepoPatternRegexTestFailed:BingoNextStepHelper.kt$BingoNextStepHelper$by patternGroup.pattern( "collection", "Reach (?&lt;amount&gt;[0-9]+(?:,\\d+)*) (?&lt;name&gt;.*) Collection\\.", )</ID>
-    <ID>RepoPatternRegexTestFailed:BingoNextStepHelper.kt$BingoNextStepHelper$by patternGroup.pattern( "skill", "Obtain level (?&lt;level&gt;.*) in the (?&lt;skill&gt;.*) Skill.", )</ID>
-    <ID>RepoPatternRegexTestFailed:GardenNextJacobContest.kt$GardenNextJacobContest$by patternGroup.pattern( "day", "§aDay (?&lt;day&gt;.*)", )</ID><ID>RepoPatternRegexTestMissing:AshfangFreezeCooldown.kt$AshfangFreezeCooldown$by RepoPattern.pattern( "ashfang.freeze.cryogenic", "§cAshfang Follower's Cryogenic Blast hit you for .* damage!", )</ID>
+    <ID>RepoPatternRegexTestMissing:AshfangFreezeCooldown.kt$AshfangFreezeCooldown$by RepoPattern.pattern( "ashfang.freeze.cryogenic", "§cAshfang Follower's Cryogenic Blast hit you for .* damage!", )</ID>
     <ID>RepoPatternRegexTestMissing:AuctionsHighlighter.kt$AuctionsHighlighter$by patternGroup.pattern( "auction", "§7(?:Starting bid|Top bid): §6(?&lt;coins&gt;.*) coins" )</ID>
     <ID>RepoPatternRegexTestMissing:AuctionsHighlighter.kt$AuctionsHighlighter$by patternGroup.pattern( "buyitnow", "§7Buy it now: §6(?&lt;coins&gt;.*) coins" )</ID>
     <ID>RepoPatternRegexTestMissing:BasketWaypoints.kt$BasketWaypoints$by patternGroup.pattern( "basket", "^(?:(?:§.)+You found a Candy Basket! (?:(?:§.)+\\((?:§.)+(?&lt;current&gt;\\d+)(?:§.)+/(?:§.)+(?&lt;max&gt;\\d+)(?:§.)+\\))?|(?:§.)+You already found this Candy Basket!)\$" )</ID>


### PR DESCRIPTION
## What
Added some patterns that were missing in some pattern lists.
Also fixed some failed regex tests



## Changelog Fixes
+ Fixed Custom Scoreboard in the Garden. - j10a1n15
+ Fixed "Rift Dimension" appearing on Custom Scoreboard in the Rift. - j10a1n15

