### PR TITLE
Feature: Shorten Coin Amounts in Chat

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -149,4 +149,14 @@ class ChatConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var petRarityDropMessage: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Shorten Coin Amounts",
+        desc = "Replace coin amounts in chat messages with their shortened version.\n" +
+            "e.g. §65,100,000 Coins §7-> §65.1M Coins"
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var shortenCoinAmounts: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -1,0 +1,39 @@
+package at.hannibal2.skyhanni.features.chat
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.events.LorenzChatEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
+import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.util.ChatComponentText
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+@SkyHanniModule
+object ShortenCoins {
+    private val config get() = SkyHanniMod.feature.chat
+    private val patternGroup = RepoPattern.group("chat.coins")
+
+    /**
+     * REGEX-TEST: §6[Auction] §aEuropaPlus §ebought §fAtmospheric Filter §efor §62,650,000 coins §lCLICK
+     * REGEX-TEST: §aYou sold §r§aCicada Symphony Vinyl§r§8 x1 §r§afor §r§650,000 Coins§r§a!
+     */
+    private val coinsPattern by patternGroup.pattern(
+        "format",
+        ".*§6(?<amount>[\\d,]+).*"
+    )
+
+    @SubscribeEvent
+    fun onChat(event: LorenzChatEvent) {
+        if (!config.shortenCoinAmounts) return
+        val message = event.message
+        val modifiedMessage = coinsPattern.toRegex().replace(message) { match ->
+            val amount = match.groups["amount"]?.value ?: return@replace match.value
+            val amountAsDouble = amount.formatDouble()
+            val displayAmount = amountAsDouble.shortFormat(preciseBillions = true)
+            "§6$displayAmount"
+        }.takeIf { it != message } ?: return
+
+        event.chatComponent = ChatComponentText(modifiedMessage)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -20,7 +20,7 @@ object ShortenCoins {
      */
     private val coinsPattern by patternGroup.pattern(
         "format",
-        ".*§6(?<amount>[\\d,]+).*"
+        "§6(?<amount>[\\d,]+)"
     )
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.chat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.replace
@@ -24,11 +25,12 @@ object ShortenCoins {
      */
     private val coinsPattern by patternGroup.pattern(
         "format",
-        "§6(?<amount>[\\d,.]+)(?![\\d.,kMB])"
+        "§6(?<amount>[\\d,.]+)(?![\\d.,kMB])",
     )
 
     @SubscribeEvent
     fun onChat(event: LorenzChatEvent) {
+        if (!LorenzUtils.inSkyBlock) return
         if (!config.shortenCoinAmounts) return
         val message = event.message
         val modifiedMessage = coinsPattern.replace(message) {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -16,20 +16,11 @@ object ShortenCoins {
     private val patternGroup = RepoPattern.group("chat.coins")
 
     /**
-     * Because this regex isn't matching the whole message but parts of it, the real regex
-     * tests can't be included here. The regex tests are just the coins section of the message.
-     *
-     * §6[Auction] §aEuropaPlus §ebought §fAtmospheric Filter §efor §62,650,000 coins §lCLICK
-     * §aYou sold §r§aCicada Symphony Vinyl§r§8 x1 §r§afor §r§650,000 Coins§r§a!
-     * §6§lALLOWANCE! §r§eYou earned §r§650,000 coins§r§e!
-     * §6[Bazaar] §r§7§r§eSell Offer Setup! §r§a5§r§7x §r§9Enchanted Melon Block §r§7for §r§6250,303 coins§r§7.
-     *
-     * Should not match:
-     * §aYou have withdrawn §r§610.5k coins§r§a! You now have §r§6991.1M coins §r§ain your account!
-     *
-     * REGEX-TEST: §62,650,000
-     * REGEX-TEST: §650,000
-     * REGEX-TEST: §6250,303
+     * REGEX-TEST: §6[Auction] §aEuropaPlus §ebought §fAtmospheric Filter §efor §62,650,000 coins §lCLICK
+     * REGEX-TEST: §aYou sold §r§aCicada Symphony Vinyl§r§8 x1 §r§afor §r§650,000 Coins§r§a!
+     * REGEX-TEST: §6§lALLOWANCE! §r§eYou earned §r§650,000 coins§r§e!
+     * REGEX-TEST: §6[Bazaar] §r§7§r§eSell Offer Setup! §r§a5§r§7x §r§9Enchanted Melon Block §r§7for §r§6250,303 coins§r§7.
+     * REGEX-FAIL: §aYou have withdrawn §r§610.5k coins§r§a! You now have §r§6991.1M coins §r§ain your account!
      */
     private val coinsPattern by patternGroup.pattern(
         "format",

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -38,10 +38,7 @@ object ShortenCoins {
         if (!config.shortenCoinAmounts) return
         val message = event.message
         val modifiedMessage = coinsPattern.replace(message) {
-            val amount = group("amount")
-            val amountAsDouble = amount.formatDouble()
-            val displayAmount = amountAsDouble.shortFormat(preciseBillions = true)
-            "§6$displayAmount"
+            "§6${group("amount").formatDouble().shortFormat(preciseBillions = true)}"
         }.takeIf { it != message } ?: return
 
         event.chatComponent = ChatComponentText(modifiedMessage)

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -24,12 +24,12 @@ object ShortenCoins {
      * §6[Bazaar] §r§7§r§eSell Offer Setup! §r§a5§r§7x §r§9Enchanted Melon Block §r§7for §r§6250,303 coins§r§7.
      *
      * REGEX-TEST: §62,650,000
-     * REGEX-TEST: §r§650,000
-     * REGEX-TEST: §r§6250,303
+     * REGEX-TEST: §650,000
+     * REGEX-TEST: §6250,303
      */
     private val coinsPattern by patternGroup.pattern(
         "format",
-        "(?:§.)*§6(?<amount>[\\d,]+)"
+        "§6(?<amount>[\\d,.]+)"
     )
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -24,13 +24,16 @@ object ShortenCoins {
      * §6§lALLOWANCE! §r§eYou earned §r§650,000 coins§r§e!
      * §6[Bazaar] §r§7§r§eSell Offer Setup! §r§a5§r§7x §r§9Enchanted Melon Block §r§7for §r§6250,303 coins§r§7.
      *
+     * Should not match:
+     * §aYou have withdrawn §r§610.5k coins§r§a! You now have §r§6991.1M coins §r§ain your account!
+     *
      * REGEX-TEST: §62,650,000
      * REGEX-TEST: §650,000
      * REGEX-TEST: §6250,303
      */
     private val coinsPattern by patternGroup.pattern(
         "format",
-        "§6(?<amount>[\\d,.]+)"
+        "§6(?<amount>[\\d,.]+)(?![\\d.,kMB])"
     )
 
     @SubscribeEvent
@@ -38,7 +41,7 @@ object ShortenCoins {
         if (!config.shortenCoinAmounts) return
         val message = event.message
         val modifiedMessage = coinsPattern.replace(message) {
-            "§6${group("amount").formatDouble().shortFormat(preciseBillions = true)}"
+            "§6${group("amount").formatDouble().shortFormat()}"
         }.takeIf { it != message } ?: return
 
         event.chatComponent = ChatComponentText(modifiedMessage)

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.RegexUtils.replace
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.util.ChatComponentText
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -36,8 +37,8 @@ object ShortenCoins {
     fun onChat(event: LorenzChatEvent) {
         if (!config.shortenCoinAmounts) return
         val message = event.message
-        val modifiedMessage = coinsPattern.toRegex().replace(message) { match ->
-            val amount = match.groups["amount"]?.value ?: return@replace match.value
+        val modifiedMessage = coinsPattern.replace(message) {
+            val amount = group("amount")
             val amountAsDouble = amount.formatDouble()
             val displayAmount = amountAsDouble.shortFormat(preciseBillions = true)
             "§6$displayAmount"

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -15,12 +15,21 @@ object ShortenCoins {
     private val patternGroup = RepoPattern.group("chat.coins")
 
     /**
-     * REGEX-TEST: §6[Auction] §aEuropaPlus §ebought §fAtmospheric Filter §efor §62,650,000 coins §lCLICK
-     * REGEX-TEST: §aYou sold §r§aCicada Symphony Vinyl§r§8 x1 §r§afor §r§650,000 Coins§r§a!
+     * Because this regex isn't matching the whole message but parts of it, the real regex
+     * tests can't be included here. The regex tests are just the coins section of the message.
+     *
+     * §6[Auction] §aEuropaPlus §ebought §fAtmospheric Filter §efor §62,650,000 coins §lCLICK
+     * §aYou sold §r§aCicada Symphony Vinyl§r§8 x1 §r§afor §r§650,000 Coins§r§a!
+     * §6§lALLOWANCE! §r§eYou earned §r§650,000 coins§r§e!
+     * §6[Bazaar] §r§7§r§eSell Offer Setup! §r§a5§r§7x §r§9Enchanted Melon Block §r§7for §r§6250,303 coins§r§7.
+     *
+     * REGEX-TEST: §62,650,000
+     * REGEX-TEST: §r§650,000
+     * REGEX-TEST: §r§6250,303
      */
     private val coinsPattern by patternGroup.pattern(
         "format",
-        "§6(?<amount>[\\d,]+)"
+        "(?:§.)*§6(?<amount>[\\d,]+)"
     )
 
     @SubscribeEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -99,4 +99,19 @@ object RegexUtils {
             }
         }
     }
+
+    /** Replaces all occurrences of the pattern in the input string with the result of the [transform] function. */
+    fun Pattern.replace(input: String, transform: Matcher.() -> String): String {
+        val matcher = matcher(input)
+        var lastEnd = 0
+        return buildString {
+            while (matcher.find()) {
+                append(input, lastEnd, matcher.start())
+                append(transform(matcher))
+                lastEnd = matcher.end()
+            }
+
+            if (lastEnd < input.length) append(input, lastEnd, input.length)
+        }
+    }
 }


### PR DESCRIPTION
## What
Adds an option to chat to shorten coin amounts in chat messages, i.e. 500,000 -> 500k.
I don't know if we have a native way or util to do replacing all instances of a pattern in a message, so if my implementation is sketchy please lmk.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/1eb5cd14-0e7b-4ac8-bf7d-266c65143c6a)

![image](https://github.com/user-attachments/assets/553a9f23-9d7d-42f1-a2a8-884a7f48c8fe)

</details>

## Changelog New Features
+ Added option to shorten coin amounts in chat messages. - Daveed
