### PR TITLE
Fix: Show Town Board for accepted Fetch quest

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -224,9 +224,9 @@ class DailyQuestHelper(val reputationHelper: CrimsonIsleReputationHelper) {
         event.drawDynamicText(location, "Town Board", 1.5)
     }
 
-    private fun Quest.needsTownBoardLocation(): Boolean = state.let { state ->
-        state == QuestState.READY_TO_COLLECT || (this is RescueMissionQuest && state == QuestState.ACCEPTED)
-    }
+    private fun Quest.needsTownBoardLocation() =
+        state == QuestState.READY_TO_COLLECT ||
+            (state == QuestState.ACCEPTED && (this is FetchQuest || this is RescueMissionQuest))
 
     fun MutableList<Renderable>.addQuests() {
         if (greatSpook) {


### PR DESCRIPTION
## What
Fixed Town Board waypoint not showing when the player has an uncompleted Fetch quest in the Crimson Isle.

## Changelog Fixes
+ Fixed Town Board waypoint not showing with an incomplete Fetch quest in the Crimson Isle. - Luna
