### PR TITLE
Fix: Improve text for when fewer than 10 levels remain on HOTM perk when holding shift

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/PowderPerHotmPerk.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/PowderPerHotmPerk.kt
@@ -42,7 +42,10 @@ object PowderPerHotmPerk {
         val powderFor10Levels =
             perk.calculateTotalCost((perk.rawLevel + 10).coerceAtMost(perk.maxLevel)) - perk.calculateTotalCost(perk.rawLevel)
 
-        event.toolTip.add(indexOfCost + 2, "§7Powder for 10 levels: §e${powderFor10Levels.addSeparators()}")
+        val numberOfLevels = (perk.maxLevel - perk.rawLevel).coerceAtMost(10)
+        val s = if (numberOfLevels != 1) "s" else ""
+
+        event.toolTip.add(indexOfCost + 2, "§7Powder for $numberOfLevels level$s §e${powderFor10Levels.addSeparators()}")
     }
 
     private fun handlePowderSpend(perk: HotmData): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/PowderPerHotmPerk.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/PowderPerHotmPerk.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.fractionOf
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.lwjgl.input.Keyboard
@@ -43,9 +44,9 @@ object PowderPerHotmPerk {
             perk.calculateTotalCost((perk.rawLevel + 10).coerceAtMost(perk.maxLevel)) - perk.calculateTotalCost(perk.rawLevel)
 
         val numberOfLevels = (perk.maxLevel - perk.rawLevel).coerceAtMost(10)
-        val s = if (numberOfLevels != 1) "s" else ""
+        val levelsFormat = StringUtils.pluralize(numberOfLevels, "level")
 
-        event.toolTip.add(indexOfCost + 2, "§7Powder for $numberOfLevels level$s §e${powderFor10Levels.addSeparators()}")
+        event.toolTip.add(indexOfCost + 2, "§7Powder for $numberOfLevels $levelsFormat §e${powderFor10Levels.addSeparators()}")
     }
 
     private fun handlePowderSpend(perk: HotmData): String {


### PR DESCRIPTION
## What
If there are fewer than 10 levels left on a HOTM perk it now shows the correct number and is aware of when to use the plural s thingy. The powder amount calculation already accounts for this.

<details>
<summary>Images</summary>

<!-- drop images here -->
Before:
![amazingpicture](https://github.com/user-attachments/assets/deed5227-99c3-4201-936f-179ddcbded01)

After:
![Screenshot_20250117_163206](https://github.com/user-attachments/assets/ee8da6b0-1f81-401e-aada-68b24e65b49f)


</details>

## Changelog Fixes
+ Fixed 'Buy 10 levels' text for fewer levels remaining in HOTM menu. - Nessiesson

