### PR TITLE
Fix: Experimentation Table (2x)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableAPI.kt
@@ -25,8 +25,10 @@ object ExperimentationTableAPI {
 
     val inTable get() = inventoriesPattern.matches(openInventoryName())
 
-    fun inDistanceToTable(vec: LorenzVec, max: Double): Boolean =
-        storage?.tablePos?.let { it.distance(vec) <= max } ?: false
+    fun inDistanceToTable(max: Double): Boolean {
+        val vec = LorenzVec.getBlockBelowPlayer()
+        return storage?.tablePos?.let { it.distance(vec) <= max } ?: false
+    }
 
     fun getCurrentExperiment(): Experiment? =
         superpairsPattern.matchMatcher(openInventoryName()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -30,7 +30,7 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
@@ -167,14 +167,15 @@ object ExperimentsProfitTracker {
 
     @HandleEvent
     fun onItemClick(event: ItemClickEvent) {
-        if (!isEnabled() || event.clickType != ClickType.RIGHT_CLICK) return
+        if (!isEnabled(checkDistanceToExperimentationTable = false)) return
+        if (event.clickType != ClickType.RIGHT_CLICK) return
         val item = event.itemInHand ?: return
         val internalName = item.getInternalName()
         if (!internalName.isExpBottle()) return
 
         lastSplashTime = SimpleTimeMark.now()
 
-        if (ExperimentationTableAPI.inDistanceToTable(LorenzVec.getBlockBelowPlayer(), 15.0)) {
+        if (ExperimentationTableAPI.inDistanceToTable(15.0)) {
             tracker.modify {
                 it.startCost -= calculateBottlePrice(internalName)
             }
@@ -292,6 +293,8 @@ object ExperimentsProfitTracker {
 
     private fun ExperimentMessages.isSelected() = config.hideMessages.contains(this)
 
-    private fun isEnabled() =
-        LorenzUtils.inSkyBlock && config.enabled && ExperimentationTableAPI.inDistanceToTable(LorenzVec.getBlockBelowPlayer(), 5.0)
+    private fun isEnabled(checkDistanceToExperimentationTable: Boolean = true) =
+        LorenzUtils.inSkyBlock && config.enabled && IslandType.PRIVATE_ISLAND.isInIsland() &&
+            (!checkDistanceToExperimentationTable || ExperimentationTableAPI.inDistanceToTable(5.0))
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -294,7 +294,7 @@ object ExperimentsProfitTracker {
     private fun ExperimentMessages.isSelected() = config.hideMessages.contains(this)
 
     private fun isEnabled(checkDistanceToExperimentationTable: Boolean = true) =
-        LorenzUtils.inSkyBlock && config.enabled && IslandType.PRIVATE_ISLAND.isInIsland() &&
+        IslandType.PRIVATE_ISLAND.isInIsland() && config.enabled &&
             (!checkDistanceToExperimentationTable || ExperimentationTableAPI.inDistanceToTable(5.0))
 
 }


### PR DESCRIPTION
## What
Fixed two similar bugs in exp table tracker

## Changelog Fixes
+ Fixed Experimentation Table Tracker appearing on other islands at correct coordinates. - hannibal2
+ Fixed Experimentation Table Tracker not detecting Exp Bottles thrown over 5 blocks away. - hannibal2
    *  Limited Experimentation Table Tracker checks to within 15 blocks around the table.