### PR TITLE
Fix: Dance room helper hide players

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
@@ -161,7 +161,7 @@ object DanceRoomHelper {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onCheckRender(event: CheckRenderEntityEvent<EntityOtherPlayerMP>) {
-        if (config.enabled && inRoom) {
+        if (config.hidePlayers && inRoom) {
             event.cancel()
         }
     }


### PR DESCRIPTION
## What
A previous commit changed `.hidePlayers` to `.enabled`, this changes it back to how it was

## Changelog Fixes
+ Fixed Rift Dance Room Helper always hiding players. - CalMWolfs

