### PR TITLE
Backend: onlyTierOnePrices and onlyTierFivePrices

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -726,11 +726,12 @@ object EstimatedItemValueCalculator {
         val map = mutableMapOf<String, Double>()
 
         val internalName = stack.getInternalName()
+        val data = EstimatedItemValue.itemValueCalculationData ?: return 0.0
         for ((rawName, rawLevel) in enchantments) {
             // efficiency 1-5 is cheap, 6-10 is handled by silex
             if (rawName == "efficiency") continue
 
-            val isAlwaysActive = EstimatedItemValue.itemValueCalculationData?.alwaysActiveEnchants.orEmpty().entries.any {
+            val isAlwaysActive = data.alwaysActiveEnchants.entries.any {
                 it.key == rawName && it.value.level == rawLevel && it.value.internalNames.contains(internalName)
             }
             if (isAlwaysActive) continue
@@ -738,12 +739,12 @@ object EstimatedItemValueCalculator {
             var multiplier = 1
 
             when {
-                rawName in EstimatedItemValue.itemValueCalculationData?.onlyTierOnePrices.orEmpty() && rawLevel in 2..5 -> {
+                rawName in data.onlyTierOnePrices && rawLevel in 2..5 -> {
                     multiplier = 2.intPow(rawLevel - 1)
                     level = 1
                 }
 
-                rawName in EstimatedItemValue.itemValueCalculationData?.onlyTierFivePrices.orEmpty() && rawLevel in 6..10 -> {
+                rawName in data.onlyTierFivePrices && rawLevel in 6..10 -> {
                     multiplier = 2.intPow(rawLevel - 5)
                     if (multiplier > 1) level = 5
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -32,6 +32,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.removePrefix
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.intPow
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PrimitiveIngredient
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils
@@ -759,29 +760,18 @@ object EstimatedItemValueCalculator {
             if (rawName == "replenish" && rawLevel == 1 && internalName in hasAlwaysReplenish) {
                 continue
             }
-
             var level = rawLevel
             var multiplier = 1
-            if (rawName in onlyTierOnePrices) {
 
-                when (rawLevel) {
-                    2 -> multiplier = 2
-                    3 -> multiplier = 4
-                    4 -> multiplier = 8
-                    5 -> multiplier = 16
+            when {
+                rawName in onlyTierOnePrices && rawLevel in 2..5 -> {
+                    multiplier = 2.intPow(rawLevel - 1)
+                    level = 1
                 }
-                level = 1
-            }
-            if (rawName in onlyTierFivePrices) {
-                when (rawLevel) {
-                    6 -> multiplier = 2
-                    7 -> multiplier = 4
-                    8 -> multiplier = 8
-                    9 -> multiplier = 16
-                    10 -> multiplier = 32
-                }
-                if (multiplier > 1) {
-                    level = 5
+
+                rawName in onlyTierFivePrices && rawLevel in 6..10 -> {
+                    multiplier = 2.intPow(rawLevel - 5)
+                    if (multiplier > 1) level = 5
                 }
             }
             if (internalName.startsWith("ENCHANTED_BOOK_BUNDLE_")) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -274,4 +274,6 @@ object NumberUtil {
         return interp
     }
 
+    fun Int.intPow(n: Int): Int = toDouble().pow(n).toInt()
+
 }


### PR DESCRIPTION
## What
Using a more compact algorythm to check the new amount for items that match onlyTierOnePrices and onlyTierFivePrices

## Changelog Technical Details
+ Cleaned EstimatedItemValueCalculator code: improved onlyTierOnePrices and onlyTierFivePrices calculations. - hannibal2