### PR TITLE
Improvement: Neu overlays EIV support

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -71,6 +71,11 @@ object EstimatedItemValue {
         return inPv || inNeuTrade
     }
 
+    fun onNeuDrawEquipment(stack: ItemStack) {
+        renderedItems++
+        updateItem(stack)
+    }
+
     @HandleEvent(onlyOnSkyblock = true)
     fun onTooltip(event: ItemHoverEvent) {
         if (!config.enabled) return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -68,9 +68,9 @@ object EstimatedItemValue {
         val inPv = Minecraft.getMinecraft().currentScreen is GuiProfileViewer
         val inTrade = InventoryUtils.openInventoryName().startsWith("You  ")
         val inNeuTrade = inTrade && NotEnoughUpdates.INSTANCE.config.tradeMenu.enableCustomTrade
-        val inNeuOverlay = InventoryUtils.inStorage() && InventoryUtils.isNeuStorageEnabled
+        val inStorage = InventoryUtils.inStorage() && InventoryUtils.isNeuStorageEnabled
 
-        return inPv || inNeuTrade || inNeuOverlay
+        return inPv || inNeuTrade || inStorage
     }
 
     fun onNeuDrawEquipment(stack: ItemStack) {
@@ -87,18 +87,13 @@ object EstimatedItemValue {
         if (renderedItems == 0) {
             updateItem(event.itemStack)
         }
+        val inStorage = InventoryUtils.inStorage() && InventoryUtils.isNeuStorageEnabled
+        // we use renderInNeuStorageOverlay() for this
+        if (inStorage) return
 
-        // revert the offset of the neu storage overlay
-        neuStorageOffset?.let {
-            GlStateManager.translate(-it.first.toFloat(), -it.second.toFloat(), 0f)
-        }
-
-        // render the estimated item value above neu storage or pv
+        // render the estimated item value over NEU PV
         GlStateManager.translate(0f, 0f, 200f)
         tryRendering()
-        neuStorageOffset?.let {
-            GlStateManager.translate(it.first.toFloat(), it.second.toFloat(), 0f)
-        }
         GlStateManager.translate(0f, 0f, -200f)
 
         renderedItems++
@@ -145,9 +140,6 @@ object EstimatedItemValue {
             )
         }
     }
-
-    // guiLeft and guiTop values from the NEU storage overlay
-    var neuStorageOffset: Pair<Int, Int>? = null
 
     @HandleEvent
     fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
@@ -289,5 +281,15 @@ object EstimatedItemValue {
         event.move(3, "misc.itemPriceDataPos", "misc.estimatedItemValues.itemPriceDataPos")
 
         event.move(31, "misc.estimatedItemValues", "inventory.estimatedItemValues")
+    }
+
+    fun renderInNeuStorageOverlay() {
+        if (!config.enabled) return
+
+        // render the estimated item value over NEU Storage
+        GlStateManager.translate(0f, 0f, 200f)
+        tryRendering()
+        GlStateManager.translate(0f, 0f, -200f)
+        renderedItems++
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -30,6 +30,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
+import io.github.moulberry.notenoughupdates.NotEnoughUpdates
 import io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer
 import net.minecraft.client.Minecraft
 import net.minecraft.init.Items
@@ -62,11 +63,19 @@ object EstimatedItemValue {
         bookBundleAmount = data.bookBundleAmount
     }
 
+    private fun isInNeuOverlay(): Boolean {
+        val inPv = Minecraft.getMinecraft().currentScreen is GuiProfileViewer
+        val inTrade = InventoryUtils.openInventoryName().startsWith("You  ")
+        val inNeuTrade = inTrade && NotEnoughUpdates.INSTANCE.config.tradeMenu.enableCustomTrade
+
+        return inPv || inNeuTrade
+    }
+
     @HandleEvent(onlyOnSkyblock = true)
     fun onTooltip(event: ItemHoverEvent) {
         if (!config.enabled) return
         if (!PlatformUtils.isNeuLoaded()) return
-        if (Minecraft.getMinecraft().currentScreen !is GuiProfileViewer) return
+        if (!isInNeuOverlay()) return
 
         if (renderedItems == 0) {
             updateItem(event.itemStack)
@@ -112,7 +121,7 @@ object EstimatedItemValue {
             ErrorManager.logErrorWithData(
                 ex, "Error in Estimated Item Value renderer",
                 "display" to display,
-                "posLabel" to "Estimated Item Value"
+                "posLabel" to "Estimated Item Value",
             )
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/neu/MixinEquipmentOverlay.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/neu/MixinEquipmentOverlay.java
@@ -1,0 +1,21 @@
+package at.hannibal2.skyhanni.mixins.transformers.neu;
+
+import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue;
+import io.github.moulberry.notenoughupdates.overlays.EquipmentOverlay;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(value = EquipmentOverlay.class, remap = false)
+public class MixinEquipmentOverlay {
+
+    @Inject(method = "drawSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getTooltip(Lnet/minecraft/entity/player/EntityPlayer;Z)Ljava/util/List;"))
+    public void drawSlot(ItemStack stack, int x, int y, int mouseX, int mouseY, List<String> tooltip, CallbackInfo ci) {
+        EstimatedItemValue.INSTANCE.onNeuDrawEquipment(stack);
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/neu/MixinStorageOverlay.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/neu/MixinStorageOverlay.java
@@ -2,9 +2,7 @@ package at.hannibal2.skyhanni.mixins.transformers.neu;
 
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue;
 import io.github.moulberry.notenoughupdates.miscgui.StorageOverlay;
-import kotlin.Pair;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -12,20 +10,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = StorageOverlay.class, remap = false)
 public class MixinStorageOverlay {
 
-    @Shadow
-    private int guiTop;
-
-    @Shadow
-    private int guiLeft;
-
-    @Inject(method = "render", at = @At(value = "HEAD"))
-    public void renderHead(CallbackInfo ci) {
-        EstimatedItemValue.INSTANCE.setNeuStorageOffset(new Pair<>(guiLeft, guiTop));
-
-    }
     @Inject(method = "render", at = @At(value = "TAIL"))
     public void renderTail(CallbackInfo ci) {
-        EstimatedItemValue.INSTANCE.setNeuStorageOffset(null);
-
+        EstimatedItemValue.INSTANCE.renderInNeuStorageOverlay();
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/neu/MixinStorageOverlay.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/neu/MixinStorageOverlay.java
@@ -1,0 +1,31 @@
+package at.hannibal2.skyhanni.mixins.transformers.neu;
+
+import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue;
+import io.github.moulberry.notenoughupdates.miscgui.StorageOverlay;
+import kotlin.Pair;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = StorageOverlay.class, remap = false)
+public class MixinStorageOverlay {
+
+    @Shadow
+    private int guiTop;
+
+    @Shadow
+    private int guiLeft;
+
+    @Inject(method = "render", at = @At(value = "HEAD"))
+    public void renderHead(CallbackInfo ci) {
+        EstimatedItemValue.INSTANCE.setNeuStorageOffset(new Pair<>(guiLeft, guiTop));
+
+    }
+    @Inject(method = "render", at = @At(value = "TAIL"))
+    public void renderTail(CallbackInfo ci) {
+        EstimatedItemValue.INSTANCE.setNeuStorageOffset(null);
+
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -39,7 +39,7 @@ object InventoryUtils {
     }
 
     // TODO add cache that persists until the next gui/window open/close packet is sent/received
-    fun openInventoryName() = Minecraft.getMinecraft().currentScreen.let {
+    fun openInventoryName(): String = Minecraft.getMinecraft().currentScreen.let {
         if (it is GuiChest) {
             val chest = it.inventorySlots as ContainerChest
             chest.getInventoryName()


### PR DESCRIPTION
## What
added more neu support for estimated item value

## TODO

- [x] Trade
- [x] equipment
- [x] storage


## Known Bug
neu storage is only getting rendered inside the "neu storage box":
![grafik](https://github.com/user-attachments/assets/e60d8c64-9cae-424d-9bd0-305a04f1ec0e)



## Changelog Improvements
+ Added support for more NEU GUIs in Estimated Item Value. - hannibal2
    * Added Trade Overlay, Equipment Overlay, and Storage Overlay support.