### PR TITLE
Fix: Skyblock XP Bar in Catacombs & Rift

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -170,7 +170,7 @@ public class MiscConfig {
     public boolean crashOnDeath = false;
 
     @Expose
-    @ConfigOption(name = "SkyBlock XP Bar", desc = "Replaces the vanilla XP bar with a SkyBlock XP bar.")
+    @ConfigOption(name = "SkyBlock XP Bar", desc = "Replaces the vanilla XP bar with a SkyBlock XP bar.\nExcept in Catacombs & Rift.")
     @SearchTag("skyblockxp")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyBlockXPBar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyBlockXPBar.kt
@@ -2,8 +2,10 @@ package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.SkyBlockXPAPI
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.inAnyIsland
 import net.minecraft.client.Minecraft
 import net.minecraftforge.client.event.RenderGameOverlayEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
@@ -20,5 +22,5 @@ object SkyBlockXPBar {
         Minecraft.getMinecraft().thePlayer.setXPStats(xp / 100f, 100, level)
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.skyblockXpBar
+    private fun isEnabled() = LorenzUtils.inSkyBlock && !inAnyIsland(IslandType.THE_RIFT, IslandType.CATACOMBS) && config.skyblockXpBar
 }


### PR DESCRIPTION
## What
The xp bar serves a different purpose in those islands (catacombs = ultimate progress; rift = rift time), so it shouldnt actually override it in there.
This was an oversight by me.


## Changelog Fixes
+ Fixed SkyBlock XP Bar overriding in Rift & Catacombs. - j10a1n15

