### PR TITLE
Backend: EstimatedItemValueCalculator cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -609,7 +609,7 @@ object EstimatedItemValueCalculator {
 
         val (totalPrice, names) = getTotalAndNames(drillUpgrades)
         if (names.isNotEmpty()) {
-            list.add("§7Drill upgrades: §6" + totalPrice.shortFormat())
+            list.add("§7Drill upgrades: " + totalPrice.format())
             list += names
         }
         return totalPrice
@@ -623,7 +623,7 @@ object EstimatedItemValueCalculator {
     }
 
     private fun Number.formatWithBrackets(gray: Boolean = false): String {
-        return "§7(§6" + format(gray) + "§7)"
+        return "§7(" + format(gray) + "§7)"
     }
 
     fun Number.format(gray: Boolean = false): String {
@@ -685,7 +685,7 @@ object EstimatedItemValueCalculator {
 
         val (totalPrice, names) = getTotalAndNames(abilityScrolls)
         if (names.isNotEmpty()) {
-            list.add("§7Ability Scrolls: §6" + totalPrice.shortFormat())
+            list.add("§7Ability Scrolls: " + totalPrice.format())
             list += names
         }
         return totalPrice
@@ -737,7 +737,7 @@ object EstimatedItemValueCalculator {
         val (totalPrice, names) = getTotalAndNames(items)
         val enchantmentsCap: Int = config.enchantmentsCap.get()
         if (names.isEmpty()) return 0.0
-        list.add("§7Enchantments: §6" + totalPrice.shortFormat())
+        list.add("§7Enchantments: " + totalPrice.format())
         var i = 0
         for (name in names) {
             if (i == enchantmentsCap) {
@@ -815,7 +815,7 @@ object EstimatedItemValueCalculator {
 
         val (totalPrice, names) = getTotalAndNames(items)
         if (names.isNotEmpty()) {
-            list.add("§7Gemstones Applied: §6" + totalPrice.shortFormat())
+            list.add("§7Gemstones Applied: " + totalPrice.format())
             list += names
         }
         return totalPrice
@@ -878,7 +878,7 @@ object EstimatedItemValueCalculator {
         if (slotNames.isEmpty()) return 0.0
 
         val (totalPrice, names) = getTotalAndNames(items)
-        list.add("§7Gemstone Slot Unlock Cost: §6" + totalPrice.shortFormat())
+        list.add("§7Gemstone Slot Unlock Cost: " + totalPrice.format())
 
         list += names
 
@@ -890,7 +890,7 @@ object EstimatedItemValueCalculator {
 
     private fun NEUInternalName.getPriceName(amount: Number): String {
         val price = getPrice() * amount.toDouble()
-        if (this == SKYBLOCK_COIN) return " §6${price.shortFormat()} coins"
+        if (this == SKYBLOCK_COIN) return " ${price.format()} coins"
 
         return " ${getNumberedName(amount)} ${price.formatWithBrackets()}"
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -243,8 +243,8 @@ object EstimatedItemValueCalculator {
         val applyCost = reforge.costs?.let { getReforgeStoneApplyCost(stack, it, internalName) } ?: return 0.0
 
         list.add("§7Reforge: §9${reforge.name}")
-        list.add(" §7Stone: $reforgeStoneName §7(§6" + reforgeStonePrice.shortFormat() + "§7)")
-        list.add(" §7Apply cost: (§6" + applyCost.shortFormat() + "§7)")
+        list.add(" §7Stone: $reforgeStoneName ${reforgeStonePrice.formatWithBrackets()}")
+        list.add(" §7Apply cost: ${applyCost.formatWithBrackets()}")
         return reforgeStonePrice + applyCost
     }
 
@@ -295,7 +295,7 @@ object EstimatedItemValueCalculator {
         if (!stack.isRecombobulated()) return 0.0
 
         val price = RECOMBOBULATOR_3000.getPrice()
-        list.add("§7Recombobulated: §a§l✔ §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Recombobulated: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
@@ -303,7 +303,7 @@ object EstimatedItemValueCalculator {
         if (!stack.hasJalapenoBook()) return 0.0
 
         val price = JALAPENO_BOOK.getPrice()
-        list.add("§7Jalapeno Book: §a§l✔ §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Jalapeno Book: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
@@ -311,7 +311,7 @@ object EstimatedItemValueCalculator {
         if (!stack.hasEtherwarp()) return 0.0
 
         val price = ETHERWARP_CONDUIT.getPrice() + ETHERWARP_MERGER.getPrice()
-        list.add("§7Etherwarp: §a§l✔ §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Etherwarp: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
@@ -319,7 +319,7 @@ object EstimatedItemValueCalculator {
         if (!stack.hasWoodSingularity()) return 0.0
 
         val price = WOOD_SINGULARITY.getPrice()
-        list.add("§7Wood Singularity: §a§l✔ §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Wood Singularity: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
@@ -327,14 +327,14 @@ object EstimatedItemValueCalculator {
         if (!stack.hasDivanPowderCoating()) return 0.0
 
         val price = DIVAN_POWDER_COATING.getPrice()
-        list.add("§7Divan Powder Coating: §a§l✔ §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Divan Powder Coating: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
     private fun addMithrilInfusion(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.getMithrilInfusion()) return 0.0
         val price = MITHRIL_INFUSION.getPrice()
-        list.add("§7Mithril Infusion: §a§l✔ §7(§6${price.shortFormat()}§7)")
+        list.add("§7Mithril Infusion: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
@@ -342,7 +342,7 @@ object EstimatedItemValueCalculator {
         if (!stack.hasArtOfWar()) return 0.0
 
         val price = ART_OF_WAR.getPrice()
-        list.add("§7The Art of War: §a§l✔ §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7The Art of War: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
@@ -350,7 +350,7 @@ object EstimatedItemValueCalculator {
         if (!stack.hasBookOfStats()) return 0.0
 
         val price = BOOK_OF_STATS.getPrice()
-        list.add("§7Book of Stats: §a§l✔ §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Book of Stats: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
@@ -359,7 +359,7 @@ object EstimatedItemValueCalculator {
         if (!stack.hasArtOfPeace()) return 0.0
 
         val price = ART_OF_PEACE.getPrice()
-        list.add("§7The Art Of Peace: §a§l✔ §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7The Art Of Peace: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
@@ -379,12 +379,12 @@ object EstimatedItemValueCalculator {
         var totalPrice = 0.0
 
         val hpbPrice = HOT_POTATO_BOOK.getPrice() * hpb
-        list.add("§7HPB's: §e$hpb§7/§e10 §7(§6" + hpbPrice.shortFormat() + "§7)")
+        list.add("§7HPB's: §e$hpb§7/§e10 ${hpbPrice.formatWithBrackets()}")
         totalPrice += hpbPrice
 
         if (fuming > 0) {
             val fumingPrice = FUMING_POTATO_BOOK.getPrice() * fuming
-            list.add("§7Fuming: §e$fuming§7/§e5 §7(§6" + fumingPrice.shortFormat() + "§7)")
+            list.add("§7Fuming: §e$fuming§7/§e5 ${fumingPrice.formatWithBrackets()}")
             totalPrice += fumingPrice
         }
 
@@ -395,7 +395,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getFarmingForDummiesCount() ?: return 0.0
 
         val price = FARMING_FOR_DUMMIES.getPrice() * count
-        list.add("§7Farming for Dummies: §e$count§7/§e5 §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Farming for Dummies: §e$count§7/§e5 ${price.formatWithBrackets()}")
         return price
     }
 
@@ -403,7 +403,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getPolarvoidBookCount() ?: return 0.0
 
         val price = POLARVOID_BOOK.getPrice() * count
-        list.add("§7Polarvoid: §e$count§7/§e5 §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Polarvoid: §e$count§7/§e5 ${price.formatWithBrackets()}")
         return price
     }
 
@@ -411,7 +411,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getAppliedPocketSackInASack() ?: return 0.0
 
         val price = POCKET_SACK_IN_A_SACK.getPrice() * count
-        list.add("§7Pocket Sack-in-a-Sack: §e$count§7/§e3 §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Pocket Sack-in-a-Sack: §e$count§7/§e3 ${price.formatWithBrackets()}")
         return price
     }
 
@@ -419,7 +419,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getBookwormBookCount() ?: return 0.0
 
         val price = BOOKWORM_BOOK.getPrice() * count
-        list.add("§7Bookworm's Favorite Book: §e$count§7/§e5 §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Bookworm's Favorite Book: §e$count§7/§e5 ${price.formatWithBrackets()}")
         return price
     }
 
@@ -430,7 +430,7 @@ object EstimatedItemValueCalculator {
         val maxTier = if (internalName == STONK_PICKAXE) 4 else 5
 
         val price = SILEX.getPrice() * tier
-        list.add("§7Silex: §e$tier§7/§e$maxTier §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Silex: §e$tier§7/§e$maxTier ${price.formatWithBrackets()}")
         return price
     }
 
@@ -438,7 +438,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getTransmissionTunerCount() ?: return 0.0
 
         val price = TRANSMISSION_TUNER.getPrice() * count
-        list.add("§7Transmission Tuners: §e$count§7/§e4 §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Transmission Tuners: §e$count§7/§e4 ${price.formatWithBrackets()}")
         return price
     }
 
@@ -446,7 +446,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getManaDisintegrators() ?: return 0.0
 
         val price = MANA_DISINTEGRATOR.getPrice() * count
-        list.add("§7Mana Disintegrators: §e$count§7/§e10 §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Mana Disintegrators: §e$count§7/§e10 ${price.formatWithBrackets()}")
         return price
     }
 
@@ -478,7 +478,7 @@ object EstimatedItemValueCalculator {
         }
         val (totalPrice, names) = getTotalAndNames(items)
 
-        list.add("§7Stars: §e$havingStars§7/§e$maxStars §7(§6" + totalPrice.shortFormat() + "§7)")
+        list.add("§7Stars: §e$havingStars§7/§e$maxStars ${totalPrice.formatWithBrackets()}")
         val starMaterialCap: Int = config.starMaterialCap.get()
         list.addAll(names.take(starMaterialCap))
         return totalPrice
@@ -578,7 +578,7 @@ object EstimatedItemValueCalculator {
             }
         }
 
-        list.add("§7Master Stars: §e$masterStars§7/§e5 §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Master Stars: §e$masterStars§7/§e5 ${price.formatWithBrackets()}")
         return price
     }
 
@@ -622,8 +622,12 @@ object EstimatedItemValueCalculator {
 
         val price = internalName.getPrice()
         val name = internalName.itemNameWithoutColor
-        list.add("§7$name: §a§l✔ §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7$name: §a§l✔ ${price.formatWithBrackets()}")
         return price
+    }
+
+    private fun Number.formatWithBrackets(): String {
+        return "§7(§6" + this.shortFormat() + "§7)"
     }
 
     private fun addHelmetSkin(stack: ItemStack, list: MutableList<String>): Double {
@@ -661,7 +665,7 @@ object EstimatedItemValueCalculator {
 
         val price = internalName.getPrice()
         val name = internalName.itemName
-        list.add("§7Enrichment: $name §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Enrichment: $name ${price.formatWithBrackets()}")
         return price
     }
 
@@ -692,7 +696,7 @@ object EstimatedItemValueCalculator {
             val price = it.getAttributePrice()
             if (price != null) {
                 val name = it.getAttributeName()
-                list.add("§7Base item: $name §7(§6" + price.shortFormat() + "§7)")
+                list.add("§7Base item: $name ${price.formatWithBrackets()}")
                 return price
             }
         }
@@ -719,7 +723,7 @@ object EstimatedItemValueCalculator {
             return 0.0
         }
 
-        list.add("§7Base item: $name §7(§6" + price.shortFormat() + "§7)")
+        list.add("§7Base item: $name ${price.formatWithBrackets()}")
         return price
     }
 
@@ -884,7 +888,7 @@ object EstimatedItemValueCalculator {
         val price = getPrice() * amount.toDouble()
         if (this == SKYBLOCK_COIN) return " §6${price.shortFormat()} coins"
 
-        return " ${getNumberedName(amount)} §7(§6${price.shortFormat()}§7)"
+        return " ${getNumberedName(amount)} ${price.formatWithBrackets()}"
     }
 
     private fun NEUInternalName.getNumberedName(amount: Number): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -306,10 +306,13 @@ object EstimatedItemValueCalculator {
 
     private fun addEtherwarp(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasEtherwarp()) return 0.0
-        // TODO use list function
-        val price = ETHERWARP_CONDUIT.getPrice() + ETHERWARP_MERGER.getPrice()
-        list.add("§7Etherwarp: §a§l✔ ${price.formatWithBrackets()}")
-        return price
+
+        val (totalPrice, names) = getTotalAndNames(listOf(ETHERWARP_CONDUIT, ETHERWARP_MERGER))
+        if (names.isNotEmpty()) {
+            list.add("§7Etherwarp §e" + totalPrice.shortFormat())
+            list += names
+        }
+        return totalPrice
     }
 
     private fun addWoodSingularity(stack: ItemStack, list: MutableList<String>): Double {
@@ -604,10 +607,10 @@ object EstimatedItemValueCalculator {
     private fun addDrillUpgrades(stack: ItemStack, list: MutableList<String>): Double {
         val drillUpgrades = stack.getDrillUpgrades() ?: return 0.0
 
-        val (totalPrice, items) = getTotalAndNames(drillUpgrades)
-        if (items.isNotEmpty()) {
+        val (totalPrice, b) = getTotalAndNames(drillUpgrades)
+        if (b.isNotEmpty()) {
             list.add("§7Drill upgrades: §6" + totalPrice.shortFormat())
-            list += items
+            list += b
         }
         return totalPrice
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -34,6 +34,7 @@ import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NEUItems.removePrefix
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.intPow
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PrimitiveIngredient
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils
@@ -754,39 +755,30 @@ object EstimatedItemValueCalculator {
     private fun fetchEnchantmentItems(
         enchantments: Map<String, Int>,
         internalName: NEUInternalName,
-    ): MutableMap<NEUInternalName, Int> {
+    ): Map<NEUInternalName, Int> {
+        val data = EstimatedItemValue.itemValueCalculationData ?: return emptyMap()
+
         val items = mutableMapOf<NEUInternalName, Int>()
         for ((rawName, rawLevel) in enchantments) {
             // efficiency 1-5 is cheap, 6-10 is handled by silex
             if (rawName == "efficiency") continue
 
-            val isAlwaysActive = EstimatedItemValue.itemValueCalculationData?.alwaysActiveEnchants.orEmpty().entries.any {
+            val isAlwaysActive = data.alwaysActiveEnchants.entries.any {
                 it.key == rawName && it.value.level == rawLevel && it.value.internalNames.contains(internalName)
             }
             if (isAlwaysActive) continue
-
             var level = rawLevel
             var multiplier = 1
-            if (rawName in EstimatedItemValue.itemValueCalculationData?.onlyTierOnePrices.orEmpty()) {
 
-                when (rawLevel) {
-                    2 -> multiplier = 2
-                    3 -> multiplier = 4
-                    4 -> multiplier = 8
-                    5 -> multiplier = 16
+            when {
+                rawName in data.onlyTierOnePrices && rawLevel in 2..5 -> {
+                    multiplier = 2.intPow(rawLevel - 1)
+                    level = 1
                 }
-                level = 1
-            }
-            if (rawName in EstimatedItemValue.itemValueCalculationData?.onlyTierFivePrices.orEmpty()) {
-                when (rawLevel) {
-                    6 -> multiplier = 2
-                    7 -> multiplier = 4
-                    8 -> multiplier = 8
-                    9 -> multiplier = 16
-                    10 -> multiplier = 32
-                }
-                if (multiplier > 1) {
-                    level = 5
+
+                rawName in data.onlyTierFivePrices && rawLevel in 6..10 -> {
+                    multiplier = 2.intPow(rawLevel - 5)
+                    if (multiplier > 1) level = 5
                 }
             }
             if (internalName.startsWith("ENCHANTED_BOOK_BUNDLE_")) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -727,6 +727,28 @@ object EstimatedItemValueCalculator {
         val enchantments = stack.getEnchantments() ?: return 0.0
 
         val internalName = stack.getInternalName()
+        val items = fetchEnchantmentItems(enchantments, internalName)
+        val (totalPrice, names) = getTotalAndNames(items)
+        val enchantmentsCap: Int = config.enchantmentsCap.get()
+        if (names.isEmpty()) return 0.0
+        list.add("§7Enchantments: §6" + totalPrice.shortFormat())
+        var i = 0
+        for (name in names) {
+            if (i == enchantmentsCap) {
+                val missing = names.size - enchantmentsCap
+                list.add(" §7§o$missing more enchantments..")
+                break
+            }
+            list.add(name)
+            i++
+        }
+        return totalPrice
+    }
+
+    private fun fetchEnchantmentItems(
+        enchantments: Map<String, Int>,
+        internalName: NEUInternalName,
+    ): MutableMap<NEUInternalName, Int> {
         val items = mutableMapOf<NEUInternalName, Int>()
         for ((rawName, rawLevel) in enchantments) {
             // efficiency 1-5 is cheap, 6-10 is handled by silex
@@ -770,21 +792,7 @@ object EstimatedItemValueCalculator {
 
             items[enchantmentName] = multiplier
         }
-        val (totalPrice, names) = getTotalAndNames(items)
-        val enchantmentsCap: Int = config.enchantmentsCap.get()
-        if (names.isEmpty()) return 0.0
-        list.add("§7Enchantments: §6" + totalPrice.shortFormat())
-        var i = 0
-        for (name in names) {
-            if (i == enchantmentsCap) {
-                val missing = names.size - enchantmentsCap
-                list.add(" §7§o$missing more enchantments..")
-                break
-            }
-            list.add(name)
-            i++
-        }
-        return totalPrice
+        return items
     }
 
     private fun addGemstones(stack: ItemStack, list: MutableList<String>): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.misc.items
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.ReforgeAPI
+import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.isBazaarItem
 import at.hannibal2.skyhanni.features.misc.discordrpc.DiscordRPCManager
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraAPI
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraAPI.getKuudraTier
@@ -600,7 +601,7 @@ object EstimatedItemValueCalculator {
                 map[internalName.getPriceName(amount)] = price
             } else {
                 val name = internalName.getNumberedName(amount)
-                map[" $name §cUnknwon price!"] = Double.MAX_VALUE
+                map[" $name §cUnknown price!"] = Double.MAX_VALUE
             }
         }
         return totalPrice to map.sortedDesc().keys.toList()
@@ -794,7 +795,9 @@ object EstimatedItemValueCalculator {
 
             val enchantmentName = "$rawName;$level".toInternalName()
 
-            items[enchantmentName] = multiplier
+            if (enchantmentName.isBazaarItem()) {
+                items[enchantmentName] = multiplier
+            }
         }
         return items
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -172,8 +172,8 @@ object EstimatedItemValueCalculator {
 
         if (comboPrice != null) {
             val useless = isUselessAttribute(combo)
-            val color = if (comboPrice > basePrice && !useless) "§6" else "§7"
-            list.add("§7Attribute Combo: ($color${comboPrice.shortFormat()}§7)")
+            val gray = comboPrice <= basePrice || useless
+            list.add("§7Attribute Combo: ${comboPrice.formatWithBrackets(gray)}")
             if (!useless) {
                 subTotal += addAttributePrice(comboPrice, basePrice)
             }
@@ -183,13 +183,13 @@ object EstimatedItemValueCalculator {
         for (attr in attributes) {
             val attributeName = "$genericName+ATTRIBUTE_${attr.first}"
             val price = getPriceOrCompositePriceForAttribute(attributeName, attr.second)
-            var priceColor = "§7"
+            var gray = true
             val useless = isUselessAttribute(attributeName)
             val nameColor = if (!useless) "§9" else "§7"
             if (price != null) {
                 if (price > basePrice && !useless) {
                     subTotal += addAttributePrice(price, basePrice)
-                    priceColor = "§6"
+                    gray = false
                 }
 
             }
@@ -197,7 +197,7 @@ object EstimatedItemValueCalculator {
             list.add(
                 "  $nameColor${
                     displayName.allLettersFirstUppercase()
-                } ${attr.second}§7: $priceColor${price?.shortFormat() ?: "Unknown"}",
+                } ${attr.second}§7: ${price?.format(gray) ?: "Unknown"}",
             )
         }
         // Adding 0.1 so that we always show the estimated item value overlay
@@ -622,8 +622,13 @@ object EstimatedItemValueCalculator {
         return list.formatHaving(name, internalName)
     }
 
-    private fun Number.formatWithBrackets(): String {
-        return "§7(§6" + this.shortFormat() + "§7)"
+    private fun Number.formatWithBrackets(gray: Boolean = false): String {
+        return "§7(§6" + format(gray) + "§7)"
+    }
+
+    fun Number.format(gray: Boolean = false): String {
+        val color = if (gray) "§7" else "§6"
+        return color + shortFormat()
     }
 
     private fun addHelmetSkin(stack: ItemStack, list: MutableList<String>): Double {
@@ -645,8 +650,9 @@ object EstimatedItemValueCalculator {
         val price = internalName.getPrice()
         val name = internalName.getNameOrRepoError()
         val displayName = name ?: "§c${internalName.asString()}"
-        val color = if (shouldIgnorePrice.get()) "§7" else "§6"
-        list.add("§7$label: $displayName §7($color" + price.shortFormat() + "§7)")
+        val gray = shouldIgnorePrice.get()
+
+        list.add("§7$label: $displayName " + price.formatWithBrackets(gray))
         if (name == null) {
             list.add("   §8(Not yet in NEU Repo)")
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -380,12 +380,12 @@ object EstimatedItemValueCalculator {
         var totalPrice = 0.0
 
         val hpbPrice = HOT_POTATO_BOOK.getPrice() * hpb
-        list.add("§7HPB's: §e$hpb§7/§e10 ${hpbPrice.formatWithBrackets()}")
+        list.add(formatProgress("HPB's", hpb, max = 10, hpbPrice))
         totalPrice += hpbPrice
 
         if (fuming > 0) {
             val fumingPrice = FUMING_POTATO_BOOK.getPrice() * fuming
-            list.add("§7Fuming: §e$fuming§7/§e5 ${fumingPrice.formatWithBrackets()}")
+            list.add(formatProgress("Fuming", fuming, max = 5, fumingPrice))
             totalPrice += fumingPrice
         }
 
@@ -396,7 +396,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getFarmingForDummiesCount() ?: return 0.0
 
         val price = FARMING_FOR_DUMMIES.getPrice() * count
-        list.add("§7Farming for Dummies: §e$count§7/§e5 ${price.formatWithBrackets()}")
+        list.add(formatProgress("Farming for Dummies", count, max = 5, price))
         return price
     }
 
@@ -404,15 +404,19 @@ object EstimatedItemValueCalculator {
         val count = stack.getPolarvoidBookCount() ?: return 0.0
 
         val price = POLARVOID_BOOK.getPrice() * count
-        list.add("§7Polarvoid: §e$count§7/§e5 ${price.formatWithBrackets()}")
+        list.add(formatProgress("Polarvoid", count, max = 5, price))
         return price
+    }
+
+    private fun formatProgress(label: String, have: Int, max: Int, price: Number): String {
+        return "§7$label: §e$have§7/§e$max ${price.formatWithBrackets()}"
     }
 
     private fun addPocketSackInASack(stack: ItemStack, list: MutableList<String>): Double {
         val count = stack.getAppliedPocketSackInASack() ?: return 0.0
 
         val price = POCKET_SACK_IN_A_SACK.getPrice() * count
-        list.add("§7Pocket Sack-in-a-Sack: §e$count§7/§e3 ${price.formatWithBrackets()}")
+        list.add(formatProgress("Pocket Sack-in-a-Sack", count, max = 3, price))
         return price
     }
 
@@ -420,7 +424,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getBookwormBookCount() ?: return 0.0
 
         val price = BOOKWORM_BOOK.getPrice() * count
-        list.add("§7Bookworm's Favorite Book: §e$count§7/§e5 ${price.formatWithBrackets()}")
+        list.add(formatProgress("Bookworm's Favorite Book", count, max = 5, price))
         return price
     }
 
@@ -431,7 +435,7 @@ object EstimatedItemValueCalculator {
         val maxTier = if (internalName == STONK_PICKAXE) 4 else 5
 
         val price = SILEX.getPrice() * tier
-        list.add("§7Silex: §e$tier§7/§e$maxTier ${price.formatWithBrackets()}")
+        list.add(formatProgress("Silex", tier, maxTier, price))
         return price
     }
 
@@ -439,7 +443,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getTransmissionTunerCount() ?: return 0.0
 
         val price = TRANSMISSION_TUNER.getPrice() * count
-        list.add("§7Transmission Tuners: §e$count§7/§e4 ${price.formatWithBrackets()}")
+        list.add(formatProgress("Transmission Tuners", count, max = 4, price))
         return price
     }
 
@@ -447,7 +451,7 @@ object EstimatedItemValueCalculator {
         val count = stack.getManaDisintegrators() ?: return 0.0
 
         val price = MANA_DISINTEGRATOR.getPrice() * count
-        list.add("§7Mana Disintegrators: §e$count§7/§e10 ${price.formatWithBrackets()}")
+        list.add(formatProgress("Mana Disintegrators", count, max = 10, price))
         return price
     }
 
@@ -479,7 +483,7 @@ object EstimatedItemValueCalculator {
         }
         val (totalPrice, names) = getTotalAndNames(items)
 
-        list.add("§7Stars: §e$havingStars§7/§e$maxStars ${totalPrice.formatWithBrackets()}")
+        list.add(formatProgress("Stars", havingStars, maxStars, totalPrice))
         val starMaterialCap: Int = config.starMaterialCap.get()
         list.addAll(names.take(starMaterialCap))
         return totalPrice
@@ -579,7 +583,7 @@ object EstimatedItemValueCalculator {
             }
         }
 
-        list.add("§7Master Stars: §e$masterStars§7/§e5 ${price.formatWithBrackets()}")
+        list.add(formatProgress("Master Stars", masterStars, max = 5, price))
         return price
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -607,10 +607,10 @@ object EstimatedItemValueCalculator {
     private fun addDrillUpgrades(stack: ItemStack, list: MutableList<String>): Double {
         val drillUpgrades = stack.getDrillUpgrades() ?: return 0.0
 
-        val (totalPrice, b) = getTotalAndNames(drillUpgrades)
-        if (b.isNotEmpty()) {
+        val (totalPrice, names) = getTotalAndNames(drillUpgrades)
+        if (names.isNotEmpty()) {
             list.add("§7Drill upgrades: §6" + totalPrice.shortFormat())
-            list += b
+            list += names
         }
         return totalPrice
     }
@@ -677,10 +677,10 @@ object EstimatedItemValueCalculator {
     private fun addAbilityScrolls(stack: ItemStack, list: MutableList<String>): Double {
         val abilityScrolls = stack.getAbilityScrolls() ?: return 0.0
 
-        val (totalPrice, items) = getTotalAndNames(abilityScrolls)
-        if (items.isNotEmpty()) {
+        val (totalPrice, names) = getTotalAndNames(abilityScrolls)
+        if (names.isNotEmpty()) {
             list.add("§7Ability Scrolls: §6" + totalPrice.shortFormat())
-            list += items
+            list += names
         }
         return totalPrice
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -295,22 +295,18 @@ object EstimatedItemValueCalculator {
     private fun addRecombobulator(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.isRecombobulated()) return 0.0
 
-        val price = RECOMBOBULATOR_3000.getPrice()
-        list.add("§7Recombobulated: §a§l✔ ${price.formatWithBrackets()}")
-        return price
+        return list.formatHaving("Recombobulated", RECOMBOBULATOR_3000)
     }
 
     private fun addJalapenoBook(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasJalapenoBook()) return 0.0
 
-        val price = JALAPENO_BOOK.getPrice()
-        list.add("§7Jalapeno Book: §a§l✔ ${price.formatWithBrackets()}")
-        return price
+        return list.formatHaving("Jalapeno Book", JALAPENO_BOOK)
     }
 
     private fun addEtherwarp(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasEtherwarp()) return 0.0
-
+        // TODO use list function
         val price = ETHERWARP_CONDUIT.getPrice() + ETHERWARP_MERGER.getPrice()
         list.add("§7Etherwarp: §a§l✔ ${price.formatWithBrackets()}")
         return price
@@ -319,48 +315,42 @@ object EstimatedItemValueCalculator {
     private fun addWoodSingularity(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasWoodSingularity()) return 0.0
 
-        val price = WOOD_SINGULARITY.getPrice()
-        list.add("§7Wood Singularity: §a§l✔ ${price.formatWithBrackets()}")
-        return price
+        return list.formatHaving("Wood Singularity", WOOD_SINGULARITY)
     }
 
     private fun addDivanPowderCoating(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasDivanPowderCoating()) return 0.0
 
-        val price = DIVAN_POWDER_COATING.getPrice()
-        list.add("§7Divan Powder Coating: §a§l✔ ${price.formatWithBrackets()}")
-        return price
+        return list.formatHaving("Divan Powder Coating", DIVAN_POWDER_COATING)
     }
 
     private fun addMithrilInfusion(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.getMithrilInfusion()) return 0.0
-        val price = MITHRIL_INFUSION.getPrice()
-        list.add("§7Mithril Infusion: §a§l✔ ${price.formatWithBrackets()}")
-        return price
+        return list.formatHaving("Mithril Infusion", MITHRIL_INFUSION)
     }
 
     private fun addArtOfWar(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasArtOfWar()) return 0.0
 
-        val price = ART_OF_WAR.getPrice()
-        list.add("§7The Art of War: §a§l✔ ${price.formatWithBrackets()}")
-        return price
+        return list.formatHaving("The Art of War", ART_OF_WAR)
     }
 
     private fun addStatsBook(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasBookOfStats()) return 0.0
 
-        val price = BOOK_OF_STATS.getPrice()
-        list.add("§7Book of Stats: §a§l✔ ${price.formatWithBrackets()}")
-        return price
+        return list.formatHaving("Book of Stats", BOOK_OF_STATS)
     }
 
     // TODO untested
     private fun addArtOfPeace(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasArtOfPeace()) return 0.0
 
-        val price = ART_OF_PEACE.getPrice()
-        list.add("§7The Art Of Peace: §a§l✔ ${price.formatWithBrackets()}")
+        return list.formatHaving("The Art Of Peace", ART_OF_PEACE)
+    }
+
+    private fun MutableList<String>.formatHaving(label: String, internalName: NEUInternalName): Double {
+        val price = internalName.getPrice()
+        add("§7$label: §a§l✔ ${price.formatWithBrackets()}")
         return price
     }
 
@@ -625,10 +615,8 @@ object EstimatedItemValueCalculator {
     private fun addPowerScrolls(stack: ItemStack, list: MutableList<String>): Double {
         val internalName = stack.getPowerScroll() ?: return 0.0
 
-        val price = internalName.getPrice()
         val name = internalName.itemNameWithoutColor
-        list.add("§7$name: §a§l✔ ${price.formatWithBrackets()}")
-        return price
+        return list.formatHaving(name, internalName)
     }
 
     private fun Number.formatWithBrackets(): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -462,11 +462,11 @@ object EstimatedItemValueCalculator {
         val (price, stars) = calculateStarPrice(internalName, totalStars) ?: return 0.0
         val (havingStars, maxStars) = stars
 
-        val items = mutableMapOf<NEUInternalName, Long>()
+        val items = mutableMapOf<NEUInternalName, Number>()
         price.essencePrice.let {
             val essenceName = "ESSENCE_${it.essenceType}".toInternalName()
             val amount = it.essenceAmount
-            items[essenceName] = amount.toLong()
+            items[essenceName] = amount
         }
 
         price.coinPrice.takeIf { it != 0L }?.let {
@@ -474,7 +474,7 @@ object EstimatedItemValueCalculator {
         }
 
         for ((materialInternalName, amount) in price.itemPrice) {
-            items[materialInternalName] = amount.toLong()
+            items[materialInternalName] = amount
         }
         val (totalPrice, names) = getTotalAndNames(items)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -802,7 +802,7 @@ object EstimatedItemValueCalculator {
         shouldIgnorePrice: Property<Boolean>,
     ): Double {
         val price = internalName.getPrice()
-        val name = internalName.getNameOrRepoError()
+        val name = internalName.getItemStackOrNull()?.itemName
         val displayName = name ?: "§c${internalName.asString()}"
         val gray = shouldIgnorePrice.get()
 
@@ -815,7 +815,6 @@ object EstimatedItemValueCalculator {
     }
 
     private fun addEnrichment(stack: ItemStack, list: MutableList<String>): Double {
-
         val enrichmentName = stack.getEnrichment() ?: return 0.0
         val internalName = "TALISMAN_ENRICHMENT_$enrichmentName".toInternalName()
 
@@ -824,8 +823,6 @@ object EstimatedItemValueCalculator {
         list.add("§7Enrichment: $name ${price.formatWithBrackets()}")
         return price
     }
-
-    private fun NEUInternalName.getNameOrRepoError(): String? = getItemStackOrNull()?.itemName
 
     private fun addBaseItem(stack: ItemStack, list: MutableList<String>): Double {
         val internalName = stack.getInternalName().removeKuudraTier()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -594,10 +594,14 @@ object EstimatedItemValueCalculator {
         var totalPrice = 0.0
         val map = mutableMapOf<String, Double>()
         for ((internalName, amount) in items) {
-            val price = internalName.getPriceOrNull() ?: continue
-
-            totalPrice += price * amount.toDouble()
-            map[internalName.getPriceName(amount)] = price
+            val price = internalName.getPriceOrNull()
+            if (price != null) {
+                totalPrice += price * amount.toDouble()
+                map[internalName.getPriceName(amount)] = price
+            } else {
+                val name = internalName.getNumberedName(amount)
+                map[" $name §cUnknwon price!"] = Double.MAX_VALUE
+            }
         }
         return totalPrice to map.sortedDesc().keys.toList()
     }
@@ -872,8 +876,12 @@ object EstimatedItemValueCalculator {
         val price = getPrice() * amount.toDouble()
         if (this == SKYBLOCK_COIN) return " §6${price.shortFormat()} coins"
 
+        return " ${getNumberedName(amount)} §7(§6${price.shortFormat()}§7)"
+    }
+
+    private fun NEUInternalName.getNumberedName(amount: Number): String {
         val prefix = if (amount == 1.0) "" else "§8${amount.addSeparators()}x "
-        return " $prefix§r$itemName §7(§6${price.shortFormat()}§7)"
+        return "$prefix§r$itemName"
     }
 
     private fun NEUInternalName.getPrice(): Double = getPriceOrNull() ?: 0.0

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -306,13 +306,6 @@ object EstimatedItemValueCalculator {
         return list.formatHaving("Jalapeno Book", JALAPENO_BOOK)
     }
 
-    private fun addEtherwarp(stack: ItemStack, list: MutableList<String>): Double {
-        if (!stack.hasEtherwarp()) return 0.0
-        val price = ETHERWARP_CONDUIT.getPrice() + ETHERWARP_MERGER.getPrice()
-        list.add("§7Etherwarp: §a§l✔ ${price.formatWithBrackets()}")
-        return price
-    }
-
     private fun addWoodSingularity(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasWoodSingularity()) return 0.0
 
@@ -349,9 +342,52 @@ object EstimatedItemValueCalculator {
         return list.formatHaving("The Art Of Peace", ART_OF_PEACE)
     }
 
+    private fun addPowerScrolls(stack: ItemStack, list: MutableList<String>): Double {
+        val internalName = stack.getPowerScroll() ?: return 0.0
+
+        val name = internalName.itemNameWithoutColor
+        return list.formatHaving(name, internalName)
+    }
+
     private fun MutableList<String>.formatHaving(label: String, internalName: NEUInternalName): Double {
         val price = internalName.getPrice()
         add("§7$label: §a§l✔ ${price.formatWithBrackets()}")
+        return price
+    }
+
+    private fun addEtherwarp(stack: ItemStack, list: MutableList<String>): Double {
+        if (!stack.hasEtherwarp()) return 0.0
+        val price = ETHERWARP_CONDUIT.getPrice() + ETHERWARP_MERGER.getPrice()
+        list.add("§7Etherwarp: §a§l✔ ${price.formatWithBrackets()}")
+        return price
+    }
+
+    private fun addMasterStars(stack: ItemStack, list: MutableList<String>): Double {
+        var totalStars = stack.getDungeonStarCount() ?: return 0.0
+        starChange.takeIf { it != 0 }?.let {
+            totalStars += it
+        }
+
+        val masterStars = (totalStars - 5).coerceAtMost(5)
+        if (masterStars < 1) return 0.0
+
+        var price = 0.0
+
+        val stars = mapOf(
+            "FIRST" to 1,
+            "SECOND" to 2,
+            "THIRD" to 3,
+            "FOURTH" to 4,
+            "FIFTH" to 5,
+        )
+
+        for ((prefix, number) in stars) {
+            if (masterStars >= number) {
+                price += "${prefix}_MASTER_STAR".toInternalName().getPrice()
+            }
+        }
+
+        list.add(formatProgress("Master Stars", masterStars, max = 5, price))
         return price
     }
 
@@ -399,10 +435,6 @@ object EstimatedItemValueCalculator {
         return price
     }
 
-    private fun formatProgress(label: String, have: Int, max: Int, price: Number): String {
-        return "§7$label: §e$have§7/§e$max ${price.formatWithBrackets()}"
-    }
-
     private fun addPocketSackInASack(stack: ItemStack, list: MutableList<String>): Double {
         val count = stack.getAppliedPocketSackInASack() ?: return 0.0
 
@@ -444,6 +476,10 @@ object EstimatedItemValueCalculator {
         val price = MANA_DISINTEGRATOR.getPrice() * count
         list.add(formatProgress("Mana Disintegrators", count, max = 10, price))
         return price
+    }
+
+    private fun formatProgress(label: String, have: Int, max: Int, price: Number): String {
+        return "§7$label: §e$have§7/§e$max ${price.formatWithBrackets()}"
     }
 
     private fun addStars(stack: ItemStack, list: MutableList<String>): Double {
@@ -549,35 +585,6 @@ object EstimatedItemValueCalculator {
         return EssenceUtils.EssenceUpgradePrice(totalEssencePrice, totalCoinPrice, totalItemPrice)
     }
 
-    private fun addMasterStars(stack: ItemStack, list: MutableList<String>): Double {
-        var totalStars = stack.getDungeonStarCount() ?: return 0.0
-        starChange.takeIf { it != 0 }?.let {
-            totalStars += it
-        }
-
-        val masterStars = (totalStars - 5).coerceAtMost(5)
-        if (masterStars < 1) return 0.0
-
-        var price = 0.0
-
-        val stars = mapOf(
-            "FIRST" to 1,
-            "SECOND" to 2,
-            "THIRD" to 3,
-            "FOURTH" to 4,
-            "FIFTH" to 5,
-        )
-
-        for ((prefix, number) in stars) {
-            if (masterStars >= number) {
-                price += "${prefix}_MASTER_STAR".toInternalName().getPrice()
-            }
-        }
-
-        list.add(formatProgress("Master Stars", masterStars, max = 5, price))
-        return price
-    }
-
     private fun getTotalAndNames(
         singleItems: List<NEUInternalName>,
     ): Pair<Double, List<String>> {
@@ -611,13 +618,6 @@ object EstimatedItemValueCalculator {
             list += names
         }
         return totalPrice
-    }
-
-    private fun addPowerScrolls(stack: ItemStack, list: MutableList<String>): Double {
-        val internalName = stack.getPowerScroll() ?: return 0.0
-
-        val name = internalName.itemNameWithoutColor
-        return list.formatHaving(name, internalName)
     }
 
     private fun Number.formatWithBrackets(gray: Boolean = false): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -308,13 +308,9 @@ object EstimatedItemValueCalculator {
 
     private fun addEtherwarp(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasEtherwarp()) return 0.0
-
-        val (totalPrice, names) = getTotalAndNames(listOf(ETHERWARP_CONDUIT, ETHERWARP_MERGER))
-        if (names.isNotEmpty()) {
-            list.add("§7Etherwarp §e" + totalPrice.shortFormat())
-            list += names
-        }
-        return totalPrice
+        val price = ETHERWARP_CONDUIT.getPrice() + ETHERWARP_MERGER.getPrice()
+        list.add("§7Etherwarp: §a§l✔ ${price.formatWithBrackets()}")
+        return price
     }
 
     private fun addWoodSingularity(stack: ItemStack, list: MutableList<String>): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -626,7 +626,7 @@ object EstimatedItemValueCalculator {
         return "§7(" + format(gray) + "§7)"
     }
 
-    fun Number.format(gray: Boolean = false): String {
+    private fun Number.format(gray: Boolean = false): String {
         val color = if (gray) "§7" else "§6"
         return color + shortFormat()
     }
@@ -903,6 +903,7 @@ object EstimatedItemValueCalculator {
     private fun NEUInternalName.getPrice(): Double = getPriceOrNull() ?: 0.0
     private fun NEUInternalName.getPriceOrNull(): Double? = getPriceOrNull(config.priceSource.get())
 
+    // TODO create attribute class and use this instead of pair, sync with getAttributeFromShard()
     fun Pair<String, Int>.getAttributeName(): String {
         val name = first.fixMending().allLettersFirstUppercase()
         return "§b$name $second Shard"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -468,12 +468,12 @@ object EstimatedItemValueCalculator {
             val essenceName = "ESSENCE_${it.essenceType}".toInternalName()
             val amount = it.essenceAmount
             val essencePrice = essenceName.getPrice() * amount
-            map["  §8${amount.addSeparators()}x ${essenceName.itemName} §7(§6${essencePrice.shortFormat()}§7)"] = essencePrice
+            map[essenceName.getPriceName(amount)] = essencePrice
             totalPrice += essencePrice
         }
 
         price.coinPrice.takeIf { it != 0L }?.let {
-            map["  §6${it.shortFormat()} coins"] = it.toDouble()
+            map[SKYBLOCK_COIN.getPriceName(it)] = it.toDouble()
             totalPrice += it
         }
 
@@ -766,15 +766,8 @@ object EstimatedItemValueCalculator {
             val enchantmentName = "$rawName;$level".toInternalName()
             val singlePrice = enchantmentName.getPriceOrNull() ?: continue
 
-            var name = enchantmentName.itemName
-            // TODO find a way to use this here "".toInternalName().getPriceName(multiplier)
-            if (multiplier > 1) {
-                name = "§8${multiplier}x $name"
-            }
             val price = singlePrice * multiplier
-            val format = price.shortFormat()
-
-            map[" $name §7(§6$format§7)"] = price
+            map[enchantmentName.getPriceName(multiplier)] = price
         }
         val enchantmentsCap: Int = config.enchantmentsCap.get()
         if (map.isEmpty()) return 0.0
@@ -888,11 +881,11 @@ object EstimatedItemValueCalculator {
         return totalPrice
     }
 
-    private fun NEUInternalName.getPriceName(amount: Int): String {
-        val price = getPrice() * amount
+    private fun NEUInternalName.getPriceName(amount: Number): String {
+        val price = getPrice() * amount.toDouble()
         if (this == SKYBLOCK_COIN) return " §6${price.shortFormat()} coins"
 
-        val prefix = if (amount == 1) "" else "§8${amount.addSeparators()}x "
+        val prefix = if (amount == 1.0) "" else "§8${amount.addSeparators()}x "
         return " $prefix§r$itemName §7(§6${price.shortFormat()}§7)"
     }
 


### PR DESCRIPTION
## What
Using `getTotalAndNames()` to cleanup all lists in estimated item value logic
Using `formatWithBrackets` to avoid duplicate bracket formattings
using `formatProgress()` to avoid duplicate `x/y (price)` lines
Using `formatHaving()` to avoid duplicate `name: check (price)` lines

## Changelog Technical Details
+ Cleaned up estimated item value logic. - hannibal2