### PR TITLE
Fix: Enchanted Clock Warnings

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/EnchantedClockJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/EnchantedClockJson.kt
@@ -14,5 +14,5 @@ data class BoostJson(
     @Expose val color: String,
     @Expose @SerializedName("display_slot") val displaySlot: Int,
     @Expose @SerializedName("status_slot") val statusSlot: Int,
-    @Expose @SerializedName("usage_hours") val cooldownHours: Int = 48,
+    @Expose @SerializedName("usage_hours") val cooldownHours: Int,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/EnchantedClockHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/EnchantedClockHelper.kt
@@ -183,7 +183,7 @@ object EnchantedClockHelper {
         val boostType = BoostType.byUsageStringOrNull(usageString) ?: return
         val simpleType = boostType.toSimple() ?: return
         val storage = storage ?: return
-        storage[simpleType] = Status(State.CHARGING, boostType.getCooldownFromNow())
+        storage[simpleType] = Status(State.CHARGING, boostType.getCooldownFromNow(), exactTime = true)
     }
 
     private fun ItemStack.getTypePair(): Pair<BoostType?, SimpleBoostType?> {
@@ -209,7 +209,8 @@ object EnchantedClockHelper {
         for ((_, stack) in statusStacks) {
             val (boostType, simpleType) = stack.getTypePair()
             val currentBoostState = stack.getBoostState()
-            if (boostType == null || simpleType == null || currentBoostState == null) continue
+            val timeAlreadyExact = storage[simpleType]?.exactTime == true
+            if (boostType == null || simpleType == null || currentBoostState == null || timeAlreadyExact) continue
 
             val parsedCooldown: SimpleTimeMark? = when (currentBoostState) {
                 State.READY, State.PROBLEM -> {
@@ -235,9 +236,10 @@ object EnchantedClockHelper {
     }
 
     class Status(
-        @field:Expose var state: State,
-        @field:Expose var availableAt: SimpleTimeMark?,
-        @field:Expose var warned: Boolean = false,
+        @Expose var state: State,
+        @Expose var availableAt: SimpleTimeMark?,
+        @Expose var exactTime: Boolean = false,
+        @Expose var warned: Boolean = false,
     ) {
         override fun toString(): String = "Status(state=$state, availableAt=$availableAt, warned=$warned)"
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/EnchantedClockHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/EnchantedClockHelper.kt
@@ -118,7 +118,7 @@ object EnchantedClockHelper {
                         color = LorenzColor.valueOf(it.color),
                         displaySlot = it.displaySlot,
                         statusSlot = it.statusSlot,
-                        cooldown = it.cooldownHours.hours,
+                        cooldown = (it.cooldownHours.takeIf { cdh -> cdh > 0 } ?: 48).hours
                     )
                 }
             }
@@ -158,8 +158,8 @@ object EnchantedClockHelper {
         for ((type, status) in storage.filter { !it.value.warned }) {
             val inConfig = config.reminderBoosts.contains(type)
             val isProperState = status.state == State.CHARGING
-            val inFuture = status.availableAt?.isInFuture() == true
-            if (!inConfig || !isProperState || inFuture) continue
+            val inPast = status.availableAt?.isInPast() ?: false
+            if (!inConfig || !isProperState || !inPast) continue
 
             val complexType = BoostType.bySimpleBoostType(type) ?: continue
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/EnchantedClockHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/EnchantedClockHelper.kt
@@ -121,7 +121,7 @@ object EnchantedClockHelper {
                         color = LorenzColor.valueOf(it.color),
                         displaySlot = it.displaySlot,
                         statusSlot = it.statusSlot,
-                        cooldown = (it.cooldownHours.takeIf { cdh -> cdh > 0 } ?: 48).hours
+                        cooldown = (it.cooldownHours.takeIf { cdh -> cdh > 0 } ?: 48).hours,
                     )
                 }
             }


### PR DESCRIPTION
## What
Fixes an error in the cooldown calculations of the Enchanted Clock boost types, which was causing cooldown timers to go off immediately on use.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/b25a3c4e-4e3e-4e3a-8907-e09825b60155)

</details>

## Changelog Fixes
+ Fixed enchanted clock reminders triggering at incorrect times. - Daveed
