### PR TITLE
Fix: Anvil Combine Helper bug

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/anvil/AnvilCombineHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/anvil/AnvilCombineHelper.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils.getInventoryName
 import at.hannibal2.skyhanni.utils.InventoryUtils.getLowerItems
-import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -30,12 +29,16 @@ object AnvilCombineHelper {
 
         val matchLore = mutableListOf<String>()
 
-        for ((slot, stack) in chest.getUpperItems()) {
-            if (slot.slotNumber == 29) {
-                val lore = stack.getLore()
-                matchLore.addAll(lore)
-                break
-            }
+        val leftStack = chest.getSlot(29)?.stack
+        val rightStack = chest.getSlot(33)?.stack
+
+        // don't highlight if both slots have items
+        if (leftStack != null && rightStack != null) return
+
+        if (leftStack != null) {
+            matchLore.addAll(leftStack.getLore())
+        } else if (rightStack != null) {
+            matchLore.addAll(rightStack.getLore())
         }
 
         if (matchLore.isEmpty()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/anvil/AnvilCombineHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/anvil/AnvilCombineHelper.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils.getInventoryName
 import at.hannibal2.skyhanni.utils.InventoryUtils.getLowerItems
+import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -26,6 +27,7 @@ object AnvilCombineHelper {
         val chestName = chest.getInventoryName()
 
         if (chestName != "Anvil") return
+        if (chest.getUpperItems().size < 52) return
 
         val matchLore = mutableListOf<String>()
 


### PR DESCRIPTION
## What
Fix the Anvil Combine Helper not highlighting matching items when the book is in the second anvil slot

<details>
<summary>Images</summary>

<!-- drop images here -->
## OLD
![old](https://github.com/user-attachments/assets/5e28f161-7f2a-40a1-8460-691cfa5ad8c9)


## NEW
![new](https://github.com/user-attachments/assets/92965910-5e02-4981-bbb4-ff20ed581159)


</details>

## Changelog Fixes
+ Fixed Anvil Combine Helper not highlighting when a book is in the second slot. - Ownwn