### PR TITLE
Fix: BZ insant buy detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -164,6 +164,7 @@ object BazaarApi {
         }
 
         if (event.inventoryName.startsWith("Bazaar ➜ ")) return true
+        if (event.inventoryName.endsWith(" ➜ Instant Buy")) return true
         return when (event.inventoryName) {
             "How many do you want?" -> true
             "How much do you want to pay?" -> true


### PR DESCRIPTION
## What
Fixed bazaar detection not working while inside instant buy menu
Reported: https://discord.com/channels/997079228510117908/1330643748887199846

## Changelog Fixes
+ Fixed bazaar detection not working while inside instant buy menu. - hannibal2
    * This affects the visibility of the Visitor Shopping List or Hide Non Clickable Items feature.