### PR TITLE
Backend: Replace `LorenzUtils.inSkyBlock` early returns

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -25,6 +25,10 @@ ImportRules:
     CustomImportOrdering:
         active: true
 
+SkyHanniStyle:
+    InSkyBlockEarlyReturn:
+        active: true
+
 style:
     MagicNumber: # I, Linnea Gräf, of sound mind and body, disagree with disabling this rule
         active: false

--- a/detekt/src/main/kotlin/style/InSkyBlockEarlyReturn.kt
+++ b/detekt/src/main/kotlin/style/InSkyBlockEarlyReturn.kt
@@ -1,0 +1,39 @@
+package at.hannibal2.skyhanni.detektrules.style
+
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+class InSkyBlockEarlyReturn(config: Config) : SkyHanniRule(config) {
+    override val issue = Issue(
+        "InSkyBlockEarlyReturn",
+        Severity.Style,
+        ".inSkyBlock checks should be removed and replaced with onlyOnSkyblock = true in @HandleEvent annotation",
+        Debt.FIVE_MINS
+    )
+
+    private fun KtExpression.containsInSkyBlockCheck(): Boolean = text.contains("LorenzUtils.inSkyBlock")
+    private fun KtExpression.isEarlyReturn(): Boolean = this is KtIfExpression && then is KtReturnExpression
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        if (function.hasAnnotation("HandleEvent")) {
+            val bodyExpressions = function.bodyExpression?.collectDescendantsOfType<KtIfExpression>() ?: return
+
+            for (ifExpression in bodyExpressions) {
+                if (ifExpression.containsInSkyBlockCheck() && ifExpression.isEarlyReturn()) {
+                    ifExpression.reportIssue("This early return should be replaced with onlyOnSkyblock = true in @HandleEvent annotation")
+                }
+            }
+        }
+
+        super.visitNamedFunction(function)
+    }
+}

--- a/detekt/src/main/kotlin/style/SkyHanniStyleProvider.kt
+++ b/detekt/src/main/kotlin/style/SkyHanniStyleProvider.kt
@@ -1,0 +1,17 @@
+package at.hannibal2.skyhanni.detektrules.style
+
+import com.google.auto.service.AutoService
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+@AutoService(RuleSetProvider::class)
+class SkyHanniStyleProvider : RuleSetProvider {
+    override val ruleSetId: String = "SkyHanniStyle"
+
+    override fun instance(config: Config): RuleSet {
+        return RuleSet(ruleSetId, listOf(
+            InSkyBlockEarlyReturn(config)
+        ))
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackAPI.kt
@@ -105,9 +105,8 @@ object GetFromSackAPI {
         inventoryMap.clear()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (event.clickedButton != 1) return // filter none right clicks
         addToQueue(inventoryMap[event.slotId] ?: return)
         inventoryMap.remove(event.slotId)
@@ -125,9 +124,8 @@ object GetFromSackAPI {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onMessageToServer(event: MessageSendToServerEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.queuedGFS && !config.bazaarGFS) return
         if (!event.isCommand(commandsWithSlash)) return
         val replacedEvent = GetFromSacksTabComplete.handleUnderlineReplace(event)

--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackAPI.kt
@@ -113,9 +113,8 @@ object GetFromSackAPI {
         event.cancel()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         val list = inventoryMap[event.slot.slotIndex] ?: return
         event.toolTip.let { tip ->
             tip.add("")

--- a/src/main/java/at/hannibal2/skyhanni/data/ActionBarStatsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ActionBarStatsData.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.ActionBarUpdateEvent
 import at.hannibal2.skyhanni.events.ActionBarValueUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import org.intellij.lang.annotations.Language
@@ -45,9 +44,8 @@ enum class ActionBarStatsData(@Language("RegExp") rawPattern: String) {
             entries.forEach { it.pattern }
         }
 
-        @HandleEvent
+        @HandleEvent(onlyOnSkyblock = true)
         fun onActionBarUpdate(event: ActionBarUpdateEvent) {
-            if (!LorenzUtils.inSkyBlock) return
 
             entries.mapNotNull { data ->
                 data.pattern.matchMatcher(event.actionBar) {

--- a/src/main/java/at/hannibal2/skyhanni/data/CropAccessoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/CropAccessoryData.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.features.garden.GardenAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.item.ItemStack
@@ -45,9 +44,8 @@ object CropAccessoryData {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!event.repeatSeconds(5)) return
 
         accessoryInInventory = bestCropAccessory(InventoryUtils.getItemsInOwnInventory())

--- a/src/main/java/at/hannibal2/skyhanni/data/ElectionAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ElectionAPI.kt
@@ -129,6 +129,7 @@ object ElectionAPI {
             getTimeTillNextMayor()
         }
 
+        @Suppress("InSkyBlockEarlyReturn")
         if (!LorenzUtils.inSkyBlock) return
         if (!ElectionCandidate.JERRY.isActive()) return
         if (jerryExtraMayor.first != null && jerryExtraMayor.second.isInPast()) {
@@ -162,9 +163,8 @@ object ElectionAPI {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         if (!calendarGuiPattern.matches(event.inventoryName)) return
 

--- a/src/main/java/at/hannibal2/skyhanni/data/HighlightOnHoverSlot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HighlightOnHoverSlot.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 
 @SkyHanniModule
@@ -24,9 +23,8 @@ object HighlightOnHoverSlot {
         currentSlots.clear()
     }
 
-    @HandleEvent(priority = HandleEvent.LOW)
+    @HandleEvent(priority = HandleEvent.LOW, onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         val list = currentSlots.flatMapTo(mutableSetOf()) { it.value }
         for (slot in InventoryUtils.getItemsInOpenChest()) {
             if (slot.slotNumber in list) {

--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -691,9 +691,8 @@ enum class HotmData(
             }
         }
 
-        @HandleEvent
+        @HandleEvent(onlyOnSkyblock = true)
         fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
-            if (!LorenzUtils.inSkyBlock) return
 
             ScoreboardPattern.powderPattern.firstMatcher(event.added) {
                 val type = HotmAPI.PowderType.entries.firstOrNull { it.displayName == group("type") } ?: return
@@ -714,9 +713,8 @@ enum class HotmData(
             heartItem = null
         }
 
-        @HandleEvent
+        @HandleEvent(onlyOnSkyblock = true)
         fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-            if (!LorenzUtils.inSkyBlock) return
             inInventory = inventoryPattern.matches(event.inventoryName)
             if (!inInventory) return
             DelayedRun.runNextTick {

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -135,9 +135,8 @@ object IslandGraphs {
         "Glacite Tunnels|Dwarven Base Camp|Great Glacite Lake|Fossil Research Center",
     )
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRepoReload(event: RepositoryReloadEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         loadIsland(LorenzUtils.skyBlockIsland)
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemAddManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemAddManager.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.SackChangeEvent
 import at.hannibal2.skyhanni.events.entity.ItemAddInInventoryEvent
 import at.hannibal2.skyhanni.features.inventory.SuperCraftFeatures.craftedPattern
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -55,9 +54,8 @@ object ItemAddManager {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSackChange(event: SackChangeEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         if (inSackInventory || lastSackInventoryLeave.passedSince() < 10.seconds) return
 
@@ -71,9 +69,8 @@ object ItemAddManager {
         superCraftedItems.clear()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onItemAdd(event: ItemAddInInventoryEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         val internalName = event.internalName
         if (internalName == ARCHFIEND_DICE || internalName == HIGH_CLASS_ARCHFIEND_DICE) {

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.mixins.transformers.gui.AccessorGuiContainer
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.InventoryUtils.getInventoryName
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSlotText
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
@@ -19,10 +18,9 @@ import net.minecraft.inventory.ContainerChest
 @SkyHanniModule
 object ItemTipHelper {
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemOverlayPost(event: GuiRenderItemEvent.RenderOverlayEvent.GuiRenderItemPost) {
-        val stack = event.stack ?: return
-        if (!LorenzUtils.inSkyBlock || stack.stackSize != 1) return
+        val stack = event.stack?.takeIf { it.stackSize == 1 } ?: return
 
         val itemTipEvent = RenderItemTipEvent(stack, mutableListOf())
         itemTipEvent.post()
@@ -38,9 +36,8 @@ object ItemTipHelper {
         }
     }
 
-    @HandleEvent(priority = HandleEvent.HIGHEST)
+    @HandleEvent(priority = HandleEvent.HIGHEST, onlyOnSkyblock = true)
     fun onRenderInventoryItemOverlayPost(event: DrawScreenAfterEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniDebugsAndTests.globalRender) return
 
         val gui = Minecraft.getMinecraft().currentScreen

--- a/src/main/java/at/hannibal2/skyhanni/data/SkillExperience.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SkillExperience.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -31,9 +30,8 @@ object SkillExperience {
         skillExp.clear()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onActionBarUpdate(event: ActionBarUpdateEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         actionBarPattern.matchMatcher(event.actionBar) {
             val skill = group("skill").lowercase()

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/LineToMobHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/LineToMobHandler.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.minecraft.RenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils
 import java.awt.Color
 
@@ -30,9 +29,8 @@ object LineToMobHandler {
         lines.remove(event.mob)
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderWorld(event: RenderWorldEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (lines.isEmpty()) return
         RenderUtils.LineDrawer.draw3D(event.partialTicks) {
             for ((mob, settings) in lines) {

--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.allLettersFirstUppercase
@@ -172,9 +171,8 @@ enum class SkyblockStat(
             }
         }
 
-        @HandleEvent
+        @HandleEvent(onlyOnSkyblock = true)
         fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-            if (!LorenzUtils.inSkyBlock) return
             onSkyblockMenu(event)
             onStatsMenu(event)
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
@@ -392,9 +392,9 @@ enum class TabWidget(
 
         private val FORCE_UPDATE_DELAY = 2.seconds
 
-        @HandleEvent
+        @HandleEvent(onlyOnSkyblock = true)
         fun onSecondPassed(event: SecondPassedEvent) {
-            if (sentSinceWorldChange || !LorenzUtils.inSkyBlock) return
+            if (sentSinceWorldChange) return
             if (LorenzUtils.lastWorldSwitch.passedSince() < FORCE_UPDATE_DELAY) return
             sentSinceWorldChange = true
             @Suppress("DEPRECATION")

--- a/src/main/java/at/hannibal2/skyhanni/features/anvil/AnvilCombineHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/anvil/AnvilCombineHelper.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils.getLowerItems
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.inventory.ContainerChest
@@ -18,9 +17,8 @@ import net.minecraft.inventory.ContainerChest
 object AnvilCombineHelper {
 
     // TODO use InventoryUpdatedEvent and item id instead of no cache and lore comparison
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.inventory.anvilCombineHelper) return
 
         if (event.gui !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PlayerDeathMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PlayerDeathMessages.kt
@@ -26,9 +26,8 @@ object PlayerDeathMessages {
         checkOtherPlayers()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onPlayerDeath(event: PlayerDeathEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         val name = event.name
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/HideDamageSplash.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/HideDamageSplash.kt
@@ -6,15 +6,13 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.EntityLivingBase
 
 @SkyHanniModule
 object HideDamageSplash {
 
-    @HandleEvent(priority = HandleEvent.HIGH)
+    @HandleEvent(priority = HandleEvent.HIGH, onlyOnSkyblock = true)
     fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityLivingBase>) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.combat.hideDamageSplash) return
 
         if (DamageIndicatorManager.isDamageSplash(event.entity)) {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AshfangMinisNametagHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AshfangMinisNametagHider.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
 
@@ -13,9 +12,8 @@ object AshfangMinisNametagHider {
 
     private val config get() = SkyHanniMod.feature.combat.mobs
 
-    @HandleEvent(priority = HandleEvent.HIGH)
+    @HandleEvent(priority = HandleEvent.HIGH, onlyOnSkyblock = true)
     fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityLivingBase>) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.hideNameTagArachneMinis) return
 
         val entity = event.entity

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.EntityUtils.hasNameTagWith
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.RenderUtils.drawLineToEye
 import at.hannibal2.skyhanni.utils.getLorenzVec
@@ -31,9 +30,8 @@ object MobHighlight {
     private val config get() = SkyHanniMod.feature.combat.mobs
     private var arachne: EntityLivingBase? = null
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onEntityHealthUpdate(event: EntityHealthUpdateEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         val entity = event.entity
         val baseMaxHealth = entity.baseMaxHealth
@@ -45,9 +43,8 @@ object MobHighlight {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onEntityHealthUpdate(event: EntityMaxHealthUpdateEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         val entity = event.entity
         val maxHealth = event.maxHealth
@@ -99,9 +96,9 @@ object MobHighlight {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderWorld(event: RenderWorldEvent) {
-        if (!LorenzUtils.inSkyBlock || !config.lineToArachne) return
+        if (!config.lineToArachne) return
 
         val arachne = arachne ?: return
         if (arachne.isDead || arachne.health <= 0) {

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/TransferCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/TransferCooldown.kt
@@ -32,9 +32,9 @@ object TransferCooldown {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onCommand(event: MessageSendToServerEvent) {
-        if (!LorenzUtils.inSkyBlock || !config.transferCooldown || lastRunCompleted.isInPast()) return
+        if (!config.transferCooldown || lastRunCompleted.isInPast()) return
         when (event.splitMessage[0]) {
             "/is" -> {
                 event.cancel()

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/WarpIsCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/WarpIsCommand.kt
@@ -5,14 +5,12 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzUtils
 
 @SkyHanniModule
 object WarpIsCommand {
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onMessageSendToServer(event: MessageSendToServerEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.misc.commands.replaceWarpIs) return
 
         if (event.message.lowercase() == "/warp is") {

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
@@ -30,9 +30,8 @@ object WikiManager {
         event.move(6, "commands.useFandomWiki", "commands.fandomWiki.enabled")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onMessageSendToServer(event: MessageSendToServerEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!isEnabled()) return
         val message = event.message.lowercase()
         if (!(message.startsWith("/wiki"))) return
@@ -57,9 +56,8 @@ object WikiManager {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onKeybind(event: GuiKeyPressEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (NEUItems.neuHasFocus()) return
         val stack = event.guiContainer.slotUnderMouse?.stack ?: return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils.getAmountInInventory
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
@@ -71,9 +70,8 @@ object CroesusChestTracker {
 
     private val croesusChests get() = ProfileStorageData.profileSpecific?.dungeons?.runs
 
-    @HandleEvent(priority = HandleEvent.LOW)
+    @HandleEvent(priority = HandleEvent.LOW, onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.dungeon.croesusUnopenedChestTracker) return
 
         if (inCroesusInventory && !croesusEmpty) {
@@ -92,9 +90,8 @@ object CroesusChestTracker {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if ((SkyHanniMod.feature.dungeon.croesusUnopenedChestTracker || config.showUsedKismets) &&
             croesusPattern.matches(event.inventoryName)
         ) {
@@ -177,9 +174,8 @@ object CroesusChestTracker {
         chestInventory = null
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.showUsedKismets) return
         if (chestInventory != null && event.slotId == KISMET_SLOT) {
             setKismetUsed()
@@ -203,9 +199,8 @@ object CroesusChestTracker {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemTip(event: RenderItemTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.kismetStackSize) return
         if (chestInventory == null) return
         if (!kismetPattern.matches(event.stack.name)) return
@@ -213,9 +208,8 @@ object CroesusChestTracker {
         event.stackTip = "§a$kismetAmountCache"
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemTipIsKismetable(event: RenderInventoryItemTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.showUsedKismets) return
         if (!inCroesusInventory) return
         if (event.slot.slotIndex != event.slot.slotNumber) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
@@ -155,9 +155,8 @@ object DianaProfitTracker {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.enabled) return
         val spadeInHand = InventoryUtils.getItemInHand()?.isDianaSpade ?: false
         if (!DianaAPI.isDoingDiana() && !spadeInHand) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/MythologicalCreatureTracker.kt
@@ -133,9 +133,8 @@ object MythologicalCreatureTracker {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.enabled) return
         val spadeInHand = InventoryUtils.getItemInHand()?.isDianaSpade ?: false
         if (!DianaAPI.isDoingDiana() && !spadeInHand) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityAPI.kt
@@ -232,9 +232,8 @@ object HoppityAPI {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onCommandSend(event: MessageSendToServerEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!pickupOutgoingCommandPattern.matches(event.message)) return
         checkNextInvOpen = true
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCallWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCallWarning.kt
@@ -137,9 +137,8 @@ object HoppityCallWarning {
         GlStateManager.color(1F, 1F, 1F, 1F)
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onCommandSend(event: MessageSendToServerEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!HoppityAPI.pickupOutgoingCommandPattern.matches(event.message)) return
         if (!config.ensureCoins || commandSentTimer.passedSince() < 5.seconds) return
         if (PurseAPI.getPurse() >= config.coinThreshold) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -303,9 +303,8 @@ object HoppityCollectionStats {
         reCalcHotspotCount()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!(LorenzUtils.inSkyBlock)) return
         if (!pagePattern.matches(event.inventoryName)) {
             // Clear highlight cache in case options are toggled
             highlightMap.clear()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -129,9 +129,9 @@ object HoppityEggLocations {
         ChatUtils.chat("$enabledDisabled hoppity egg location debug viewer.")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderWorld(event: RenderWorldEvent) {
-        if (!LorenzUtils.inSkyBlock || !showEggLocationsDebug) return
+        if (!showEggLocationsDebug) return
         val legacyLocations = legacyEggLocations[LorenzUtils.skyBlockIsland] ?: return
         val apiLocations = apiEggLocations[LorenzUtils.skyBlockIsland] ?: return
         val collectedLocations = islandCollectedLocations

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
@@ -194,15 +194,13 @@ object HoppityEventSummary {
         if (event.chocGained > 0) stats.dupeChocolateGained += event.chocGained
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         reCheckInventoryState()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryClose(event: InventoryCloseEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         reCheckInventoryState()
     }
 
@@ -263,9 +261,8 @@ object HoppityEventSummary {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         checkLbUpdateWarning()
         reCheckInventoryState()
         checkEnded()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/WarpMenuUniques.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/WarpMenuUniques.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.ChocolateFactoryAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -29,9 +28,8 @@ object WarpMenuUniques {
 
     private val config get() = SkyHanniMod.feature.event.hoppityEggs.warpMenu
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.enabled) return
         if (!HoppityAPI.isHoppityEvent()) return
         if (event.slot.inventory.name != "Fast Travel") return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.entity.passive.EntityVillager
 
 @SkyHanniModule
@@ -27,9 +26,8 @@ object HighlightJerries {
         LorenzColor.LIGHT_PURPLE,
     )
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onEntityHealthUpdate(event: EntityMaxHealthUpdateEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.highlightJerries) return
 
         val entity = event.entity

--- a/src/main/java/at/hannibal2/skyhanni/features/event/spook/TheGreatSpook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/spook/TheGreatSpook.kt
@@ -78,9 +78,8 @@ object TheGreatSpook {
         "§5§lFEAR\\. §r§eA §r§dPrimal Fear §r§ehas been summoned!",
     )
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!isGreatSpookActive) return
 
         val fear = SkyblockStat.FEAR.lastKnownValue ?: 0.0
@@ -147,9 +146,8 @@ object TheGreatSpook {
         isGreatSpookActive = currentTime in timeRange
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!isGreatSpookActive) return
 
         if (config.primalFearTimer) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/NewYearCakeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/NewYearCakeReminder.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
@@ -54,9 +53,8 @@ object NewYearCakeReminder {
         return playerSpecific.winter.cakeCollectedYear == SkyBlockTime.now().year
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.newYearCakeReminder) return
         if (!isCakeTime()) return
         if (ReminderUtils.isBusy()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -101,9 +101,8 @@ object CityProjectFeatures {
         inInventory = false
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         inInventory = false
         if (!inCityProject(event)) return
@@ -208,18 +207,16 @@ object CityProjectFeatures {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.showMaterials) return
         if (!inInventory) return
 
         config.pos.renderStringsAndItems(display, posLabel = "City Project Materials")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.showReady) return
         if (!inInventory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
@@ -95,9 +95,8 @@ object UpgradeReminder {
         lastReminderSend = SimpleTimeMark.now()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         inInventory = event.inventoryName == "Community Shop"
         if (!inInventory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -74,9 +74,8 @@ object SeaCreatureFeatures {
         rareSeaCreatures.remove(event.mob)
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSeaCreatureFish(event: SeaCreatureFishEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.alertOwnCatches) return
 
         if (event.seaCreature.rare) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureMessageShortener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureMessageShortener.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.fishing.SeaCreatureFishEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import net.minecraft.util.ChatComponentText
 
 @SkyHanniModule
@@ -12,9 +11,8 @@ object SeaCreatureMessageShortener {
 
     private val config get() = SkyHanniMod.feature.fishing
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSeaCreatureFish(event: SeaCreatureFishEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         val original = event.chatEvent.chatComponent.formattedText
         var edited = original

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SharkFishCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SharkFishCounter.kt
@@ -78,9 +78,8 @@ object SharkFishCounter {
 
     private fun isWaterFishingRod() = FishingAPI.isFishing() && !FishingAPI.holdingLavaRod
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.fishing.sharkFishCounter) return
         if (!hasWaterRodInHand) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.find
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getFarmingForDummiesCount
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeName
@@ -42,10 +41,8 @@ object ToolTooltipTweaks {
 
     private val statFormatter = DecimalFormat("0.##")
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-
         val itemStack = event.itemStack
         val itemLore = itemStack.getLore()
         val internalName = itemStack.getInternalName()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -148,9 +148,9 @@ object ComposterDisplay {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock && !OutsideSbFeature.COMPOSTER_TIME.isSelected()) return
+        if (!OutsideSbFeature.COMPOSTER_TIME.isSelected()) return
 
         if (GardenAPI.inGarden() && config.displayEnabled) {
             config.displayPos.renderStringsAndItems(display, posLabel = "Composter Display")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/GardenComposterInventoryFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/GardenComposterInventoryFeatures.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
@@ -74,9 +73,8 @@ object GardenComposterInventoryFeatures {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.highlightUpgrade) return
 
         if (InventoryUtils.openInventoryName() == "Composter Upgrades") {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestAPI.kt
@@ -59,9 +59,8 @@ object FarmingContestAPI {
         ContestBracket.entries.forEach { it.bracketPattern }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         if (internalContest && startTime.passedSince() > 20.minutes) {
             FarmingContestEvent(contestCrop!!, FarmingContestPhase.STOP).post()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -177,9 +177,8 @@ object JacobFarmingContestsInventory {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!InventoryUtils.openInventoryName().contains("Your Contests")) return
 
         val slot = event.slot.slotNumber

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -55,9 +55,8 @@ object JacobFarmingContestsInventory {
         hideEverything = true
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (event.inventoryName != "Your Contests") return
 
         realTime.clear()
@@ -83,11 +82,10 @@ object JacobFarmingContestsInventory {
         realTime[slot] = "$dayFormat $startTimeFormat-$endTimeFormat"
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         // TODO add tooltip line "click + press <keybind> to open on elite website
         if (!config.openOnElite.isKeyHeld()) return
-        if (!LorenzUtils.inSkyBlock) return
 
         val slot = event.slot ?: return
         val itemName = slot.stack.name
@@ -161,9 +159,8 @@ object JacobFarmingContestsInventory {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!InventoryUtils.openInventoryName().contains("Your Contests")) return
         if (!config.highlightRewards) return
 
@@ -197,9 +194,8 @@ object JacobFarmingContestsInventory {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemOverlayPost(event: GuiRenderItemEvent.RenderOverlayEvent.GuiRenderItemPost) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.medalIcon) return
         if (!InventoryUtils.openInventoryName().contains("Your Contests")) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
@@ -181,9 +181,8 @@ object CaptureFarmingGear {
         captureFarmingGear()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         val storage = GardenAPI.storage?.fortune ?: return
         val outdatedItems = outdatedItems ?: return
         val items = event.inventoryItems

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenCropMilestoneInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenCropMilestoneInventory.kt
@@ -55,9 +55,8 @@ object GardenCropMilestoneInventory {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.tooltipTweak.cropMilestoneTotalProgress) return
 
         val crop = GardenCropMilestones.getCropTypeByLore(event.itemStack) ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayDisplay.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.name
 import at.hannibal2.skyhanni.features.garden.GardenPlotAPI.plots
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -46,9 +45,8 @@ object SprayDisplay {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onIslandChange(event: IslandChangeEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.expiryNotification || event.newIsland != IslandType.GARDEN) return
         sendExpiredPlotsToChat(true)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
@@ -61,9 +61,8 @@ object BeaconPower {
     private const val BEACON_POWER_SLOT = 22
     private const val STATS_SLOT = 23
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (event.inventoryName != "Beacon") return
         val items = event.inventoryItems
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils.getInventoryName
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
@@ -33,9 +32,8 @@ object AuctionsHighlighter {
         "§7(?:Starting bid|Top bid): §6(?<coins>.*) coins"
     )
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.highlightAuctions) return
         if (event.gui !is GuiChest) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -62,9 +62,8 @@ object HarpFeatures {
     private fun isHarpGui(chestName: String) = inventoryTitlePattern.matches(chestName)
     private fun isMenuGui(chestName: String) = menuTitlePattern.matches(chestName)
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onGui(event: GuiKeyPressEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.keybinds) return
         if (!isHarpGui(InventoryUtils.openInventoryName())) return
         val chest = event.guiContainer as? GuiChest ?: return
@@ -96,9 +95,8 @@ object HarpFeatures {
 
     private var openTime: SimpleTimeMark = SimpleTimeMark.farPast()
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (config.quickRestart && isMenuGui(event.inventoryName)) {
             openTime = SimpleTimeMark.now()
         }
@@ -121,9 +119,8 @@ object HarpFeatures {
         minecraft.currentScreen?.setWorldAndResolution(minecraft, width, height)
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryClose(event: InventoryCloseEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.guiScale) return
         unSetGUIScale()
     }
@@ -151,9 +148,8 @@ object HarpFeatures {
         isGUIScaled = false
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         if (isHarpGui(InventoryUtils.openInventoryName())) {
             if (config.keybinds) {
@@ -178,9 +174,8 @@ object HarpFeatures {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemTip(event: RenderItemTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.showNumbers) return
         if (!isHarpGui(InventoryUtils.openInventoryName())) return
         if (Item.getIdFromItem(event.stack.item) != 159) return // Stained hardened clay item id = 159

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -193,9 +192,8 @@ object HarpFeatures {
         event.move(2, "misc.harpNumbers", "inventory.helper.harp.showNumbers")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.hideMelodyTooltip) return
         if (!isHarpGui(InventoryUtils.openInventoryName())) return
         if (event.slot.inventory !is ContainerLocalMenu) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HeldTimeInLore.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.addOrInsert
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getSecondsHeld
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import kotlin.time.Duration.Companion.seconds
@@ -14,9 +13,8 @@ import kotlin.time.Duration.Companion.seconds
 object HeldTimeInLore {
     private val config get() = SkyHanniMod.feature.inventory
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.timeHeldInLore) return
 
         val seconds = event.itemStack.getSecondsHeld() ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -109,9 +109,8 @@ object HideNotClickableItems {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onForegroundDrawn(event: GuiContainerEvent.ForegroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!isEnabled()) return
         if (bypassActive()) return
         if (event.gui !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemStars.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemStars.kt
@@ -48,9 +48,8 @@ object ItemStars {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemTip(event: RenderItemTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!CRIMSON_ARMOR.isSelected()) return
         val stack = event.stack
         if (stack.getInternalNameOrNull()?.isKuudraArmor() != true) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/PersonalCompactorOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/PersonalCompactorOverlay.kt
@@ -106,9 +106,8 @@ object PersonalCompactorOverlay {
         compactorEnabledMap.clear()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemTip(event: RenderItemTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.showToggle) return
         val itemStack = event.stack
         val internalName = itemStack.getInternalNameOrNull() ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
@@ -178,9 +178,8 @@ object ReforgeHelper {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         when {
             isHexReforgeMenu(event.inventoryName) -> {
                 isInHexReforgeMenu = true

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/RngMeterInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/RngMeterInventory.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -43,9 +42,8 @@ object RngMeterInventory {
         }
     }
 
-    @HandleEvent(priority = HandleEvent.LOW)
+    @HandleEvent(priority = HandleEvent.LOW, onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         val chestName = InventoryUtils.openInventoryName()
         if (config.noDrop && chestName == "Catacombs RNG Meter") {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.makeShiftClick
 import net.minecraft.client.gui.inventory.GuiChest
 
@@ -13,9 +12,8 @@ import net.minecraft.client.gui.inventory.GuiChest
 object ShiftClickBrewing {
     private const val closeButtonIndex = 49
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.inventory.shiftClickBrewing) return
 
         if (event.gui !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickEquipment.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickEquipment.kt
@@ -5,16 +5,14 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.makeShiftClick
 import net.minecraft.client.gui.inventory.GuiChest
 
 @SkyHanniModule
 object ShiftClickEquipment {
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.inventory.shiftClickForEquipment) return
 
         if (event.gui !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNPCSell.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNPCSell.kt
@@ -32,9 +32,8 @@ object ShiftClickNPCSell {
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (event.inventoryItems.isEmpty()) return
         val item = event.inventoryItems[event.inventoryItems.keys.last() + sellSlot] ?: return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
@@ -98,10 +97,8 @@ object StatsTuning {
         }
     }
 
-    @HandleEvent(priority = HandleEvent.LOW)
+    @HandleEvent(priority = HandleEvent.LOW, onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-
         val chestName = InventoryUtils.openInventoryName()
         if (!config.selectedTemplate || chestName != "Stats Tuning") return
         for (slot in InventoryUtils.getItemsInOpenChest()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseCopyUnderbidPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseCopyUnderbidPrice.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
@@ -48,9 +47,8 @@ object AuctionHouseCopyUnderbidPrice {
         "Auctions Browser|Manage Auctions|Auctions: \".*\"?",
     )
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.autoCopyUnderbidPrice) return
         if (!event.fullyOpenedOnce) return
         if (event.inventoryName != "Create BIN Auction") return
@@ -69,10 +67,9 @@ object AuctionHouseCopyUnderbidPrice {
         ChatUtils.chat("Copied ${newPrice.addSeparators()} to clipboard. (Copy Underbid Price)")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onKeybind(event: GuiKeyPressEvent) {
         if (!config.copyUnderbidKeybind.isKeyHeld()) return
-        if (!LorenzUtils.inSkyBlock) return
         if (!allowedInventoriesPattern.matches(InventoryUtils.openInventoryName())) return
         val stack = event.guiContainer.slotUnderMouse?.stack ?: return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -125,9 +125,8 @@ object BazaarApi {
     }
 
     // TODO cache
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!inBazaarInventory) return
         if (!SkyHanniMod.feature.inventory.bazaar.purchaseHelper) return
         if (currentSearchedItem == "") return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderHelper.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -48,9 +47,8 @@ object BazaarOrderHelper {
         "§7Price per unit: §6(?<number>.*) coins",
     )
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.inventory.bazaar.orderHelper) return
         if (event.gui !is GuiChest) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryAPI.kt
@@ -125,9 +125,8 @@ object ChocolateFactoryAPI {
     var specialRabbitTextures = listOf<String>()
     var warningSound = SoundUtils.createSound("note.pling", 1f)
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         if (chocolateFactoryInventoryNamePattern.matches(event.inventoryName)) {
             if (config.enabled) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryBlockOpen.kt
@@ -49,9 +49,8 @@ object ChocolateFactoryBlockOpen {
 
     private var commandSentTimer = SimpleTimeMark.farPast()
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         val slotDisplayName = event.slot?.stack?.displayName ?: return
         if (!openCfItemPattern.matches(slotDisplayName)) return
         if (EnchantedClockHelper.enchantedClockPattern.matches(InventoryUtils.openInventoryName())) return
@@ -59,9 +58,8 @@ object ChocolateFactoryBlockOpen {
         if (checkIsBlocked()) event.cancel()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onCommandSend(event: MessageSendToServerEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!commandPattern.matches(event.message)) return
         if (commandSentTimer.passedSince() < 5.seconds) return
         if (LorenzUtils.isBingoProfile) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryKeybinds.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraft.client.gui.inventory.GuiChest
 import kotlin.time.Duration.Companion.milliseconds
@@ -16,9 +15,8 @@ object ChocolateFactoryKeybinds {
     private val config get() = ChocolateFactoryAPI.config.keybinds
     private var lastClick = SimpleTimeMark.farPast()
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onKeyPress(event: GuiKeyPressEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.enabled) return
         if (!ChocolateFactoryAPI.inChocolateFactory) return
 
@@ -37,9 +35,8 @@ object ChocolateFactoryKeybinds {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.enabled) return
         if (!ChocolateFactoryAPI.inChocolateFactory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -34,9 +34,8 @@ object ChocolateFactoryShortcut {
         )
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (LorenzUtils.inAnyIsland(
                 IslandType.THE_RIFT,
                 IslandType.KUUDRA_ARENA,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStats.kt
@@ -32,9 +32,8 @@ object ChocolateFactoryStats {
 
     private var display: Renderable? = null
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!ChocolateFactoryAPI.chocolateFactoryPaused) return
         updateDisplay()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryTimeTowerManager.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils
@@ -32,9 +31,8 @@ object ChocolateFactoryTimeTowerManager {
 
     private const val HOVER_TEXT = "§eClick to run /cf!"
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         val profileStorage = profileStorage ?: return
 
         if (profileStorage.currentTimeTowerEnds.isInPast()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryUpgradeWarning.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.minutes
@@ -22,9 +21,8 @@ object ChocolateFactoryUpgradeWarning {
     private var lastUpgradeSlot = -1
     private var lastUpgradeLevel = 0
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         val profileStorage = profileStorage ?: return
 
         val upgradeAvailableAt = profileStorage.bestUpgradeAvailableAt

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/tiarelay/TiaRelayHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/tiarelay/TiaRelayHelper.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.sorted
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import kotlin.time.Duration.Companion.minutes
 
@@ -29,9 +28,8 @@ object TiaRelayHelper {
 
     private val resultDisplay = mutableMapOf<Int, Int>()
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onPlaySound(event: PlaySoundEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         val soundName = event.soundName
 
         if (config.tiaRelayMute && soundName == "mob.wolf.whine") {
@@ -55,9 +53,8 @@ object TiaRelayHelper {
         tryResult()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.soundHelper) return
 
         if (InventoryUtils.openInventoryName().contains("Network Relay")) {
@@ -98,9 +95,8 @@ object TiaRelayHelper {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemTip(event: RenderInventoryItemTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.soundHelper) return
         if (!inInventory) return
 
@@ -127,9 +123,8 @@ object TiaRelayHelper {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.soundHelper) return
         if (!inInventory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/tiarelay/TiaRelayWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/tiarelay/TiaRelayWaypoints.kt
@@ -44,9 +44,8 @@ object TiaRelayWaypoints {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderWorld(event: RenderWorldEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         if (config.allWaypoints) {
             for (relay in Relay.entries) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeAPI.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.name
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -114,10 +113,8 @@ object WardrobeAPI {
         }
     }
 
-    @HandleEvent(priority = HandleEvent.HIGH)
+    @HandleEvent(priority = HandleEvent.HIGH, onlyOnSkyblock = true)
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-
         inventoryPattern.matchMatcher(event.inventoryName) {
             inWardrobe = true
             currentPage = group("currentPage").formatInt()

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireVeilWandParticles.kt
@@ -52,9 +52,8 @@ object FireVeilWandParticles {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderWorld(event: RenderWorldEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (config.display != DisplayEntry.LINE) return
         if (lastClick.passedSince() > 5.5.seconds) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -114,10 +114,10 @@ object MiningEventTracker {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!config.enabled) return
-        if (!LorenzUtils.inSkyBlock || (!config.outsideMining && !isMiningIsland())) return
+        if (!config.outsideMining && !isMiningIsland()) return
         if (!canRequestAt.isInPast()) return
 
         fetchData()

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/InfernoMinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/InfernoMinionFeatures.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.KeyboardManager
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -48,9 +47,8 @@ object InfernoMinionFeatures {
         inInventory = false
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.infernoFuelBlocker) return
         if (!inInventory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -418,9 +418,8 @@ object MinionFeatures {
 
     private fun enableWithHub() = isEnabled() || IslandType.HUB.isInIsland()
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!minionInventoryOpen) return
 
         if (config.hopperProfitDisplay) {

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionXp.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionXp.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.enumMapOf
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
@@ -145,9 +144,8 @@ object MinionXp {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.xpDisplay) return
         when {
             MinionFeatures.minionInventoryOpen -> {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/BetterWikiFromMenus.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/BetterWikiFromMenus.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.features.commands.WikiManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 
 @SkyHanniModule
@@ -21,9 +20,8 @@ object BetterWikiFromMenus {
         event.move(6, "fandomWiki", "commands.fandomWiki")
     }
 
-    @HandleEvent(priority = HandleEvent.HIGH)
+    @HandleEvent(priority = HandleEvent.HIGH, onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!isEnabled()) return
 
         val chestName = InventoryUtils.openInventoryName()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/BrewingStandOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/BrewingStandOverlay.kt
@@ -5,14 +5,12 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.name
-import at.hannibal2.skyhanni.utils.LorenzUtils
 
 @SkyHanniModule
 object BrewingStandOverlay {
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemTip(event: RenderInventoryItemTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.misc.brewingStandOverlay) return
 
         if (event.inventoryName != "Brewing Stand") return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
@@ -113,9 +113,8 @@ object CarryTracker {
         slayerNames = data.slayerNames.mapKeys { SlayerType.valueOf(it.key) }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         config.carryPosition.renderRenderables(display, posLabel = "Carry Tracker")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CollectionTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CollectionTracker.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.name
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
@@ -234,10 +233,8 @@ object CollectionTracker {
         updateDisplay()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-
         SkyHanniMod.feature.misc.collectionCounterPos.renderStringsAndItems(display, posLabel = "Collection Tracker")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
@@ -207,9 +207,8 @@ object NonGodPotEffectDisplay {
         checkFooter = true
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!event.inventoryName.endsWith("Active Effects")) return
 
         for (stack in event.inventoryItems.values) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PocketSackInASackDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PocketSackInASackDisplay.kt
@@ -18,10 +18,9 @@ object PocketSackInASackDisplay {
     private val config get() = SkyHanniMod.feature.inventory.pocketSackInASack
     private const val MAX_STITCHES = 3
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemOverlayPost(event: GuiRenderItemEvent.RenderOverlayEvent.GuiRenderItemPost) {
-        val stack = event.stack ?: return
-        if (!LorenzUtils.inSkyBlock || stack.stackSize != 1) return
+        val stack = event.stack?.takeIf { it.stackSize == 1 } ?: return
         if (!config.showOverlay) return
         val pocketSackInASackApplied = stack.getAppliedPocketSackInASack() ?: return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PocketSackInASackDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PocketSackInASackDisplay.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.GuiRenderItemEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSlotText
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAppliedPocketSackInASack
 
@@ -30,9 +29,8 @@ object PocketSackInASackDisplay {
         event.drawSlotText(x, y, stackTip, .9f)
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.replaceLore) return
         val itemStack = event.itemStack
         val applied = itemStack.getAppliedPocketSackInASack() ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ServerRestartTitle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ServerRestartTitle.kt
@@ -34,9 +34,8 @@ object ServerRestartTitle {
         "§cServer closing.*",
     )
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.serverRestartTitle) return
 
         restartingPattern.firstMatcher(ScoreboardData.sidebarLinesFormatted) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TimeFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TimeFeatures.kt
@@ -31,6 +31,7 @@ object TimeFeatures {
 
     @HandleEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        @Suppress("InSkyBlockEarlyReturn")
         if (!LorenzUtils.inSkyBlock && !OutsideSbFeature.REAL_TIME.isSelected()) return
         if (config.realTime) {
             val timeFormat = if (config.realTimeFormatToggle) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -152,10 +151,9 @@ object UserLuckBreakdown {
         return null
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onTooltip(event: ToolTipEvent) {
         if (!config.userluckEnabled) return
-        if (!LorenzUtils.inSkyBlock) return
         if (skillCalcCoolDown.passedSince() > 3.seconds) {
             skillCalcCoolDown = SimpleTimeMark.now()
             calcSkillLuck()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -46,9 +46,8 @@ object TabListRenderer {
     private var isPressed = false
     private var isTabToggled = false
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.enabled.get()) return
         if (!config.toggleTab) return
         if (Minecraft.getMinecraft().currentScreen != null) return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -184,9 +184,8 @@ object EstimatedItemValue {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemTooltip(event: RenderItemTooltipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.enabled) return
 
         updateItem(event.stack)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.events.render.gui.ReplaceItemEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -86,9 +85,8 @@ object LimboPlaytime {
         else -> arrayOf("§7Playtime: §a$wholeMinutes minutes")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!enabled) return
         if (!event.slot.inventory.name.startsWith("Detailed /playtime")) return
         if (event.slot.slotIndex != 4) return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pets/CurrentPetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pets/CurrentPetDisplay.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.events.LorenzChatEvent
 import at.hannibal2.skyhanni.features.rift.RiftAPI
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -94,11 +93,9 @@ object CurrentPetDisplay {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (RiftAPI.inRift()) return
-
         if (!config.display) return
 
         config.displayPos.renderString(PetAPI.currentPet, posLabel = "Current Pet")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pets/PetCandyUsedDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pets/PetCandyUsedDisplay.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.GuiRenderItemEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSlotText
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getMaxPetLevel
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetCandyUsed
@@ -16,12 +15,11 @@ object PetCandyUsedDisplay {
 
     private val config get() = SkyHanniMod.feature.misc.petCandy
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemOverlayPost(event: GuiRenderItemEvent.RenderOverlayEvent.GuiRenderItemPost) {
-        val stack = event.stack ?: return
-        if (!LorenzUtils.inSkyBlock || stack.stackSize != 1) return
         if (!config.showCandy) return
 
+        val stack = event.stack?.takeIf { it.stackSize == 1 } ?: return
         if (config.hideOnMaxed) {
             if (stack.getPetLevel() == stack.getMaxPetLevel()) return
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pets/PetExpTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pets/PetExpTooltip.kt
@@ -29,9 +29,8 @@ object PetExpTooltip {
     private const val LEVEL_100_LEGENDARY = 25_353_230
     private const val LEVEL_200_LEGENDARY = 210_255_385
 
-    @HandleEvent(priority = HandleEvent.LOWEST)
+    @HandleEvent(priority = HandleEvent.LOWEST, onlyOnSkyblock = true)
     fun onTooltip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.petDisplay) return
         if (!KeyboardManager.isShiftKeyDown() && !config.showAlways) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pets/PetItemDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pets/PetItemDisplay.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiRenderItemEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSlotText
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetItem
 import net.minecraft.client.Minecraft
@@ -14,10 +13,9 @@ object PetItemDisplay {
 
     private val config get() = SkyHanniMod.feature.misc.pets
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderItemOverlayPost(event: GuiRenderItemEvent.RenderOverlayEvent.GuiRenderItemPost) {
-        val stack = event.stack ?: return
-        if (!LorenzUtils.inSkyBlock || stack.stackSize != 1) return
+        val stack = event.stack?.takeIf { it.stackSize == 1 } ?: return
         if (config.petItemDisplay.isEmpty()) return
 
         val petItem = stack.getPetItem() ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraAPI.kt
@@ -66,9 +66,8 @@ object KuudraAPI {
 
     fun inKuudra() = kuudraTier != null
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (kuudraTier != null) return
         tierPattern.firstMatcher(event.added) {
             val tier = group("tier").toInt()

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -155,9 +155,8 @@ object SkillProgress {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onLevelUp(event: SkillOverflowLevelUpEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!config.overflowConfig.enableInChat) return
         val skillName = event.skill.displayName
         val oldLevel = event.oldLevel

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillTooltip.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.NumberUtil.toRoman
@@ -21,9 +20,8 @@ object SkillTooltip {
     private val overflowConfig get() = SkillProgress.config.overflowConfig
     private val customGoalConfig get() = SkillProgress.config.customGoalConfig
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         val inventoryName = InventoryUtils.openInventoryName()
         val stack = event.itemStack
         if (inventoryName == "Your Skills" && stack.getLore().any { it.contains("Click to view!") }) {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/HideMobNames.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/HideMobNames.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.LorenzWorldChangeEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.TimeLimitedCache
 import net.minecraft.entity.EntityLivingBase
@@ -50,9 +49,8 @@ object HideMobNames {
         patterns.add("§8\\[§7Lv\\d+§8] §c$bossName§r §[ae](?<min>.+)§f/§a(?<max>.+)§c❤".toPattern())
     }
 
-    @HandleEvent(priority = HandleEvent.HIGH)
+    @HandleEvent(priority = HandleEvent.HIGH, onlyOnSkyblock = true)
     fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityLivingBase>) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.slayer.hideMobNames) return
 
         val entity = event.entity

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
@@ -112,9 +112,8 @@ object SlayerQuestWarning {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onEntityHealthUpdate(event: EntityHealthUpdateEvent) {
-        if (!LorenzUtils.inSkyBlock) return
 
         val entity = event.entity
         if (entity.getLorenzVec().distanceToPlayer() < 6 && isSlayerMob(entity)) {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerClearView.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerClearView.kt
@@ -18,9 +18,8 @@ object BlazeSlayerClearView {
 
     private var nearBlaze = false
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!event.repeatSeconds(3)) return
         nearBlaze = DamageIndicatorManager.getDistanceTo(
             BossType.SLAYER_BLAZE_1,

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -94,6 +94,7 @@ object SummoningMobManager {
         mobs -= mob
 
         // since MobEvent.DeSpawn can be fired while outside sb
+        @Suppress("InSkyBlockEarlyReturn")
         if (!LorenzUtils.inSkyBlock) return
         if (!config.summonMessages) return
 
@@ -105,16 +106,16 @@ object SummoningMobManager {
         }
     }
 
-    @HandleEvent(priority = HandleEvent.HIGH)
+    @HandleEvent(priority = HandleEvent.HIGH, onlyOnSkyblock = true)
     fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityArmorStand>) {
-        if (!LorenzUtils.inSkyBlock || !config.summoningMobHideNametag) return
+        if (!config.summoningMobHideNametag) return
         if (event.entity.mob !in mobs) return
         event.cancel()
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock || !config.summoningMobDisplay) return
+        if (!config.summoningMobDisplay) return
         if (mobs.isEmpty()) return
 
         val list = buildList {

--- a/src/main/java/at/hannibal2/skyhanni/test/HighlightMissingRepoItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/HighlightMissingRepoItems.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NEUItems
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import net.minecraft.client.Minecraft
@@ -18,9 +17,8 @@ import net.minecraft.inventory.Slot
 @SkyHanniModule
 object HighlightMissingRepoItems {
 
-    @HandleEvent(priority = HandleEvent.LOWEST)
+    @HandleEvent(priority = HandleEvent.LOWEST, onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!SkyHanniMod.feature.dev.debug.highlightMissingRepo) return
 
         val gui = event.gui

--- a/src/main/java/at/hannibal2/skyhanni/test/ParkourWaypointSaver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/ParkourWaypointSaver.kt
@@ -27,6 +27,7 @@ object ParkourWaypointSaver {
 
     @HandleEvent
     fun onKeyPress(event: KeyPressEvent) {
+        @Suppress("InSkyBlockEarlyReturn")
         if (!LorenzUtils.inSkyBlock && !config.parkourOutsideSB) return
         if (Minecraft.getMinecraft().currentScreen != null) return
         if (NEUItems.neuHasFocus()) return
@@ -70,6 +71,7 @@ object ParkourWaypointSaver {
 
     @HandleEvent
     fun onRenderWorld(event: RenderWorldEvent) {
+        @Suppress("InSkyBlockEarlyReturn")
         if (!LorenzUtils.inSkyBlock && !config.parkourOutsideSB) return
 
         if (locations.size > 1) {

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -511,11 +511,9 @@ object SkyHanniDebugsAndTests {
     fun onChat(event: LorenzChatEvent) {
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     @Suppress("ConstantConditionIf")
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!LorenzUtils.inSkyBlock) return
-
         if (false) {
             itemRenderDebug()
         }

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -413,9 +413,8 @@ object SkyHanniDebugsAndTests {
         ChatUtils.chat("§eCopied internal name §7$rawInternalName §eto the clipboard!")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onShowInternalName(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!debugConfig.showInternalName) return
         val itemStack = event.itemStack
         val internalName = itemStack.getInternalName()
@@ -423,9 +422,8 @@ object SkyHanniDebugsAndTests {
         event.toolTip.add("Internal Name: '${internalName.asString()}'")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun showItemRarity(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!debugConfig.showItemRarity) return
         val itemStack = event.itemStack
 
@@ -433,9 +431,8 @@ object SkyHanniDebugsAndTests {
         event.toolTip.add("Item rarity: $rarity")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun showItemCategory(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!debugConfig.showItemCategory) return
         val itemStack = event.itemStack
 
@@ -443,9 +440,8 @@ object SkyHanniDebugsAndTests {
         event.toolTip.add("Item category: $category")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onShowNpcPrice(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!debugConfig.showNpcPrice) return
         val internalName = event.itemStack.getInternalNameOrNull() ?: return
 
@@ -453,9 +449,8 @@ object SkyHanniDebugsAndTests {
         event.toolTip.add("§7NPC price: ${npcPrice.addSeparators()}")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onShowBaseStats(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!debugConfig.showBaseValues) return
         val internalName = event.itemStack.getInternalNameOrNull() ?: return
 
@@ -469,18 +464,16 @@ object SkyHanniDebugsAndTests {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onShowCraftPrice(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!debugConfig.showCraftPrice) return
         val price = event.itemStack.getInternalNameOrNull()?.getRawCraftCostOrNull() ?: return
 
         event.toolTip.add("§7Craft price: ${price.addSeparators()}")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onShowBzPrice(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!debugConfig.showBZPrice) return
         val internalName = event.itemStack.getInternalNameOrNull() ?: return
 
@@ -492,9 +485,8 @@ object SkyHanniDebugsAndTests {
         event.toolTip.add("§7BZ sellOfferPrice: ${sellOfferPrice.addSeparators()}")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onShowItemName(event: ToolTipEvent) {
-        if (!LorenzUtils.inSkyBlock) return
         if (!debugConfig.showItemName) return
         val itemStack = event.itemStack
         val internalName = itemStack.getInternalName()


### PR DESCRIPTION
## What
Replaces all reasonable instances of inSkyBlock early return checks with `onlyOnSkyblock = true` in the HandleEvent annotation. Also introduced a new detekt rule to enforce it.

exclude_from_changelog

