### PR TITLE
Fix: `/shskills` printing help when resetting goal

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillAPI.kt
@@ -437,6 +437,7 @@ object SkillAPI {
                     val skill = storage?.get(skillType) ?: return
                     skill.customGoalLevel = 0
                     ChatUtils.chat("Custom goal level for §b${skillType.displayName} §ereset")
+                    return
                 }
             }
         }


### PR DESCRIPTION
## What
Fixed the `/shskills goal <skill>` command, when used without further arguments, showing command usage (despite also resetting the custom goal).

Before:
```
> /shskills goal fishing
[SkyHanni] Custom goal level for Fishing reset
/shskills levelwithxp <xp> - Get a level with the given current XP.
/shskills xpforlevel <desiredLevel> - Get how much XP you need for a desired level.
/shskills goal - View your current goal
/shskills goal <skill> <level> - Define your goal for <skill>
```

After:
```
> /shskills goal fishing
[SkyHanni] Custom goal level for Fishing reset
```

## Changelog Fixes
+ Fixed `/shskills` command showing usage when resetting a custom skill goal. - Luna
