### PR TITLE
Backend: Change Error Cache

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -124,7 +124,6 @@ object UnknownLinesHandler {
                 if (firstFoundSince > 10.seconds && lastWarnedSince > 30.minutes) {
                     unknownLine.lastWarned = SimpleTimeMark.now()
                     warn(line, "same line active for 10 seconds")
-                    continue
                 }
             }
         }
@@ -143,7 +142,7 @@ object UnknownLinesHandler {
             // line included in chat message to not cache a previous message
             Exception(line),
             "CustomScoreboard detected a unknown line: '$line'",
-            "Unknown Line" to line,
+            "Unknown Line(s)" to line,
             "reason" to reason,
             "Island" to LorenzUtils.skyBlockIsland,
             "Area" to HypixelData.skyBlockArea,

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -142,7 +142,7 @@ object UnknownLinesHandler {
             // line included in chat message to not cache a previous message
             Exception(line),
             "CustomScoreboard detected a unknown line: '$line'",
-            "Unknown Line(s)" to line,
+            "Unknown Line" to line,
             "reason" to reason,
             "Island" to LorenzUtils.skyBlockIsland,
             "Area" to HypixelData.skyBlockArea,

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -21,7 +21,7 @@ object ErrorManager {
     // random id -> error message
     private val errorMessages = mutableMapOf<String, String>()
     private val fullErrorMessages = mutableMapOf<String, String>()
-    private val cache = TimeLimitedSet<Pair<String, Int>>(10.minutes)
+    private val cache = TimeLimitedSet<Pair<String, String>>(10.minutes)
     private var repoErrors: List<RepoErrorData> = emptyList()
 
     private val breakAfter = listOf(
@@ -132,8 +132,8 @@ object ErrorManager {
         if (betaOnly && !SkyHanniMod.isBetaVersion) return
         if (!ignoreErrorCache) {
             val pair = if (throwable.stackTrace.isNotEmpty()) {
-                throwable.stackTrace[0].let { (it.fileName ?: "<unknown>") to it.lineNumber }
-            } else message to 0
+                (throwable.stackTrace[0].fileName ?: "<unknown>") to message
+            } else "<unknown>" to message
             if (pair in cache) return
             cache.add(pair)
         }


### PR DESCRIPTION
## What
Change the error cache from "filename - linenumber" to "filename - error message" to allow multiple errors in the same line at the same time. 
[Discussed here](https://discord.com/channels/997079228510117908/1332009394476421182)


exclude_from_changelog