### PR TITLE
Fix: BZ insant buy detection v2

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -162,6 +162,13 @@ object BazaarApi {
             return true
         }
 
+        // check for Buy Instantly
+        event.inventoryItems[16]?.let {
+            if (it.name == "§aCustom Amount" && it.getLore().firstOrNull() == "§8Buy Order Quantity") {
+                return true
+            }
+        }
+
         if (event.inventoryName.startsWith("Bazaar ➜ ")) return true
         return when (event.inventoryName) {
             "How many do you want?" -> true


### PR DESCRIPTION
## What
Fixed bazaar detection not working while inside instant buy menu
Reported: https://discord.com/channels/997079228510117908/1330643748887199846

replaces 
- #3260

## Changelog Fixes
+ Fixed bazaar detection in instant buy menu, breaking visibility of features like Visitor Shopping List and Hide Non Clickable Items. - hannibal2