### PR TITLE
Backend: more detekt rules

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -101,6 +101,18 @@ formatting:
         maxLineLength: 140
     Wrapping:
         maxLineLength: 140
+    allowExplicitReturnType:
+        active: true
+        includePublic: true
+        includePrivate: false
+        includeProtected: false
+        includeInternal: false
+    VarCouldBeVal: #
+        active: true
+        ignoreInConstructors: false # Set to true if you want to skip constructor parameters.
+        ignoreInLambdaParameters: false # Set to true if you want to skip lambda parameters.
+        ignoreInAnonymousObjects: false # Set to true if you want to skip anonymous object members.
+
 
 complexity:
     CyclomaticComplexMethod: # default threshold of 15, caught almost every complex method


### PR DESCRIPTION
## What
public function needs explicit return type, vars that could be vals

## Changelog Technical Details
+ Added detekt rules for public function needs explicit return type and for vars that could be vals. - hannibal2