### PR TITLE
Backend: IsInIslandCheck #DeathToEarlyReturns

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -28,6 +28,8 @@ ImportRules:
 SkyHanniStyle:
     InSkyBlockEarlyReturn:
         active: true
+    IsInIslandEarlyReturn:
+        active: true
 
 style:
     MagicNumber: # I, Linnea Gräf, of sound mind and body, disagree with disabling this rule

--- a/detekt/src/main/kotlin/style/IsInIslandEarlyReturn.kt
+++ b/detekt/src/main/kotlin/style/IsInIslandEarlyReturn.kt
@@ -1,0 +1,43 @@
+package at.hannibal2.skyhanni.detektrules.style
+
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+class IsInIslandEarlyReturn(config: Config) : SkyHanniRule(config) {
+    override val issue = Issue(
+        "IsInIslandEarlyReturn",
+        Severity.Style,
+        "!isInIsland checks should be removed and replaced with onlyOnIsland = IslandType in @HandleEvent annotation",
+        Debt.FIVE_MINS
+    )
+
+    private fun KtExpression.containsIsInIslandCheck(): Boolean = isInIslandRegex.matches(text)
+    private fun KtExpression.isEarlyReturn(): Boolean = this is KtIfExpression && then is KtReturnExpression
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        if (function.hasAnnotation("HandleEvent")) {
+            val bodyExpressions = function.bodyExpression?.collectDescendantsOfType<KtIfExpression>() ?: return
+
+            for (ifExpression in bodyExpressions) {
+                if (ifExpression.containsIsInIslandCheck() && ifExpression.isEarlyReturn()) {
+                    ifExpression.reportIssue("This early return should be replaced with onlyOnIsland = IslandType in @HandleEvent annotation")
+                }
+            }
+        }
+
+        super.visitNamedFunction(function)
+    }
+
+    companion object {
+        private val isInIslandRegex = Regex(".*!IslandType\\..*\\.isInIsland\\(\\).*")
+    }
+}

--- a/detekt/src/main/kotlin/style/SkyHanniStyleProvider.kt
+++ b/detekt/src/main/kotlin/style/SkyHanniStyleProvider.kt
@@ -11,7 +11,8 @@ class SkyHanniStyleProvider : RuleSetProvider {
 
     override fun instance(config: Config): RuleSet {
         return RuleSet(ruleSetId, listOf(
-            InSkyBlockEarlyReturn(config)
+            InSkyBlockEarlyReturn(config),
+            IsInIslandEarlyReturn(config)
         ))
     }
 }

--- a/detekt/src/main/kotlin/style/SkyHanniStyleProvider.kt
+++ b/detekt/src/main/kotlin/style/SkyHanniStyleProvider.kt
@@ -12,7 +12,7 @@ class SkyHanniStyleProvider : RuleSetProvider {
     override fun instance(config: Config): RuleSet {
         return RuleSet(ruleSetId, listOf(
             InSkyBlockEarlyReturn(config),
-            IsInIslandEarlyReturn(config)
+            IsInIslandEarlyReturn(config),
         ))
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GeyserFishing.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GeyserFishing.kt
@@ -54,13 +54,12 @@ object GeyserFishing {
         geyserBox = null
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
     fun onRenderWorld(event: RenderWorldEvent) {
         if (!config.drawBox) return
         val geyserBox = geyserBox ?: return
         val geyser = geyser ?: return
         if (geyser.distanceToPlayerIgnoreY() > 96) return
-        if (!IslandType.CRIMSON_ISLE.isInIsland()) return
         if (config.onlyWithRod && !FishingAPI.holdingLavaRod) return
 
         val color = config.boxColor.toSpecialColor()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorAPI.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.events.mining.FossilExcavationEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NEUInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -52,9 +51,8 @@ object FossilExcavatorAPI {
 
     val scrapItem = "SUSPICIOUS_SCRAP".toInternalName()
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!IslandType.DWARVEN_MINES.isInIsland()) return
         if (event.inventoryName != "Fossil Excavator") return
         inInventory = true
     }
@@ -79,9 +77,8 @@ object FossilExcavatorAPI {
         inExcavatorMenu = false
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES)
     fun onChat(event: SkyHanniChatEvent) {
-        if (!IslandType.DWARVEN_MINES.isInIsland()) return
 
         val message = event.message
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseAPI.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.mining.CorpseLootedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -43,10 +42,8 @@ object CorpseAPI {
 
     private var corpseType: CorpseType? = null
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.MINESHAFT)
     fun onChat(event: SkyHanniChatEvent) {
-        if (!IslandType.MINESHAFT.isInIsland()) return
-
         val message = event.message
 
         startPattern.matchMatcher(message) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/JoinCrystalHollows.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/JoinCrystalHollows.kt
@@ -57,9 +57,8 @@ object JoinCrystalHollows {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES)
     fun onRenderWorld(event: RenderWorldEvent) {
-        if (!IslandType.DWARVEN_MINES.isInIsland()) return
         if (!isEnabled()) return
 
         if (inTime()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadCompactName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadCompactName.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.entity.EntityLivingBase
@@ -31,9 +30,8 @@ object TeleportPadCompactName {
         "§.✦ §cNo Destination"
     )
 
-    @HandleEvent(priority = HandleEvent.HIGH)
+    @HandleEvent(priority = HandleEvent.HIGH, onlyOnIsland = IslandType.PRIVATE_ISLAND)
     fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityLivingBase>) {
-        if (!IslandType.PRIVATE_ISLAND.isInIsland()) return
         if (!SkyHanniMod.feature.misc.teleportPad.compactName) return
         val entity = event.entity
         if (entity !is EntityArmorStand) return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadInventoryNumber.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadInventoryNumber.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.name
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
@@ -75,9 +74,8 @@ object TeleportPadInventoryNumber {
             event.inventoryName == "Set Destination" && SkyHanniMod.feature.misc.teleportPad.inventoryNumbers
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
     fun onRenderItemTip(event: RenderInventoryItemTipEvent) {
-        if (!IslandType.PRIVATE_ISLAND.isInIsland()) return
         if (!inTeleportPad) return
 
         padNumberPattern.matchMatcher(event.stack.name.lowercase()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangManager.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.isAtFullHealth
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.MobUtils.mob
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraft.entity.item.EntityArmorStand
@@ -32,9 +31,8 @@ object AshfangManager {
 
     val active get() = ashfang != null
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
     fun onMobSpawn(event: MobEvent.Spawn.SkyblockMob) {
-        if (!IslandType.CRIMSON_ISLE.isInIsland()) return
         val mob = event.mob
         val color = when (mob.name) {
             "Ashfang Follower" -> LorenzColor.DARK_GRAY
@@ -51,9 +49,8 @@ object AshfangManager {
         if (config.highlightBlazes) mob.highlight(color.toColor().addAlpha(40))
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
     fun onMobFirstSeen(event: MobEvent.FirstSeen.SkyblockMob) {
-        if (!IslandType.CRIMSON_ISLE.isInIsland()) return
         if (!event.mob.name.contains("Ashfang ")) return
         if (lastSpawnTime.passedSince() < 10.seconds) return
         lastSpawnTime = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -143,10 +143,9 @@ class CrimsonIsleReputationHelper(skyHanniMod: SkyHanniMod) {
         }
     }
 
-    @HandleEvent(priority = HandleEvent.LOWEST)
+    @HandleEvent(priority = HandleEvent.LOWEST, onlyOnIsland = IslandType.CRIMSON_ISLE)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.enabled.get()) return
-        if (!IslandType.CRIMSON_ISLE.isInIsland()) return
 
         if (config.useHotkey && !isHotkeyHeld()) {
             return

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/kuudra/DailyKuudraBossHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/kuudra/DailyKuudraBossHelper.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.CollectionUtils.addString
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NEUItems.getItemStack
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
@@ -30,9 +29,8 @@ class DailyKuudraBossHelper(private val reputationHelper: CrimsonIsleReputationH
 
     private val config get() = SkyHanniMod.feature.crimsonIsle.reputationHelper
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
     fun onRenderWorld(event: RenderWorldEvent) {
-        if (!IslandType.CRIMSON_ISLE.isInIsland()) return
         if (!config.enabled.get()) return
         if (!reputationHelper.showLocations()) return
         if (allKuudraDone) return

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
@@ -78,10 +78,9 @@ object PunchcardHighlight {
     private val displayIcon by lazy { PUNCHCARD_ARTIFACT.getItemStack() }
     private var display: Renderable = Renderable.string("hello")
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onPlayerSpawn(event: MobEvent.Spawn.Player) {
         if (!config.highlight.get()) return
-        if (!IslandType.THE_RIFT.isInIsland()) return
         if (config.reverse.get()) return
         val size = playerList.size
         if (size >= 20) return
@@ -185,9 +184,8 @@ object PunchcardHighlight {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onChat(event: SkyHanniChatEvent) {
-        if (!IslandType.THE_RIFT.isInIsland()) return
         if (!listening) return
         if (playerQueue.isEmpty()) return
         val message = event.message

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -22,7 +22,6 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
@@ -99,10 +98,8 @@ object EndermanSlayerFeatures {
 
     private fun showBeacon() = beaconConfig.highlightBeacon || beaconConfig.showWarning || beaconConfig.showLine
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.THE_END)
     fun onRenderWorld(event: RenderWorldEvent) {
-        if (!IslandType.THE_END.isInIsland()) return
-
         if (beaconConfig.highlightBeacon) {
             endermenWithBeacons.removeIf { it.isDead || !hasBeaconInHand(it) }
 
@@ -184,10 +181,8 @@ object EndermanSlayerFeatures {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.THE_END)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!IslandType.THE_END.isInIsland()) return
-
         nukekubiSkulls.removeAll {
             if (it.isDead) {
                 RenderLivingEntityHelper.removeEntityColor(it)
@@ -211,9 +206,8 @@ object EndermanSlayerFeatures {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.THE_END)
     fun onBlockChange(event: ServerBlockChangeEvent) {
-        if (!IslandType.THE_END.isInIsland()) return
         if (!showBeacon()) return
 
         val location = event.location


### PR DESCRIPTION
## What
Adds another detekt rule pushing people to use the HandleEvent annotations where possible instead of early returns.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/ef0a901e-1b06-4104-b966-48ce34b0837f)

</details>

## Changelog Technical Details
+ Added detekt rule for early returns instead of island type annotations. - Daveed
