### PR TITLE
Fix: Visitor Reward Highlight/Chat Warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -383,11 +383,13 @@ object GardenVisitorFeatures {
         val location = event.location
         event.parent.drawString(location.up(2.23), text)
         if (config.rewardWarning.showOverName) {
-            var counter = 1
+            val initialOffset = 2.73
+            val heightOffset = 0.25
+            var counter = 0
             visitor.getRewardWarningAwards().forEach { reward ->
                 val name = reward.displayName
-                val offset = counter * 2.73
-                event.parent.drawString(location.up(offset), "§c!$name§c!")
+                val offset = initialOffset + (counter * heightOffset)
+                event.parent.drawString(location.up(offset), "§c§l! $name §c§l!")
                 counter++
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -383,10 +383,12 @@ object GardenVisitorFeatures {
         val location = event.location
         event.parent.drawString(location.up(2.23), text)
         if (config.rewardWarning.showOverName) {
-            visitor.hasReward()?.let { reward ->
+            var counter = 1
+            visitor.getRewardWarningAwards().forEach { reward ->
                 val name = reward.displayName
-
-                event.parent.drawString(location.up(2.73), "§c!$name§c!")
+                val offset = counter * 2.73
+                event.parent.drawString(location.up(offset), "§c!$name§c!")
+                counter++
             }
         }
     }
@@ -436,11 +438,9 @@ object GardenVisitorFeatures {
         if (foundRewards.isNotEmpty()) {
             val wasEmpty = visitor.allRewards.isEmpty()
             visitor.allRewards = foundRewards
-            if (wasEmpty) {
-                visitor.hasReward()?.let { reward ->
-                    if (config.rewardWarning.notifyInChat) {
-                        ChatUtils.chat("Found Visitor Reward ${reward.displayName}§e!")
-                    }
+            if (wasEmpty && config.rewardWarning.notifyInChat) {
+                visitor.getRewardWarningAwards().forEach { reward ->
+                    ChatUtils.chat("Found Visitor Reward ${reward.displayName}§e!")
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
@@ -155,15 +155,13 @@ object VisitorAPI {
         fun getEntity() = EntityUtils.getEntityByID(entityId)
         fun getNameTagEntity() = EntityUtils.getEntityByID(nameTagEntityId)
 
-        fun hasReward(): VisitorReward? {
+        fun getRewardWarningAwards(): List<VisitorReward> = buildList {
             for (internalName in allRewards) {
                 val reward = VisitorReward.getByInternalName(internalName) ?: continue
                 if (reward in config.rewardWarning.drops) {
-                    return reward
+                    add(reward)
                 }
             }
-
-            return null
         }
     }
 
@@ -214,7 +212,7 @@ object VisitorAPI {
         val totalReward = totalReward ?: error("totalReward is null")
         val loss = totalPrice - totalReward
         return when {
-            preventRefusing && hasReward() != null -> VisitorBlockReason.RARE_REWARD
+            preventRefusing && getRewardWarningAwards().isNotEmpty() -> VisitorBlockReason.RARE_REWARD
             preventRefusingNew && offersAccepted == 0 -> VisitorBlockReason.NEVER_ACCEPTED
             preventRefusingCopper && pricePerCopper <= coinsPerCopperPrice -> VisitorBlockReason.CHEAP_COPPER
             preventAcceptingCopper && pricePerCopper > coinsPerCopperPrice -> VisitorBlockReason.EXPENSIVE_COPPER

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
@@ -134,8 +134,6 @@ object VisitorAPI {
         val offerItem: ItemStack,
     )
 
-    private val debug = true
-
     class Visitor(
         val visitorName: String,
         var entityId: Int = -1,
@@ -158,12 +156,6 @@ object VisitorAPI {
         fun getNameTagEntity() = EntityUtils.getEntityByID(nameTagEntityId)
 
         fun getRewardWarningAwards(): List<VisitorReward> = buildList {
-            if (debug) {
-                add(VisitorReward.SPACE_HELMET)
-                add(VisitorReward.COPPER_DYE)
-                add(VisitorReward.OVERGROWN_GRASS)
-                return@buildList
-            }
             for (internalName in allRewards) {
                 val reward = VisitorReward.getByInternalName(internalName) ?: continue
                 if (reward in config.rewardWarning.drops) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorAPI.kt
@@ -134,6 +134,8 @@ object VisitorAPI {
         val offerItem: ItemStack,
     )
 
+    private val debug = true
+
     class Visitor(
         val visitorName: String,
         var entityId: Int = -1,
@@ -156,6 +158,12 @@ object VisitorAPI {
         fun getNameTagEntity() = EntityUtils.getEntityByID(nameTagEntityId)
 
         fun getRewardWarningAwards(): List<VisitorReward> = buildList {
+            if (debug) {
+                add(VisitorReward.SPACE_HELMET)
+                add(VisitorReward.COPPER_DYE)
+                add(VisitorReward.OVERGROWN_GRASS)
+                return@buildList
+            }
             for (internalName in allRewards) {
                 val reward = VisitorReward.getByInternalName(internalName) ?: continue
                 if (reward in config.rewardWarning.drops) {


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1332224980553039882
Fixes an edge case where on getting more than one rare reward from a visitor, only one would be announced/displayed.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/dcb506a4-fd05-484e-86f5-d722264b9479)

</details>

## Changelog Fixes
+ Fixed visitor reward checks for multi-rare-reward visitors. - Daveed

