### PR TITLE
Fix: Composter Overlay not Rendering

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -53,9 +53,8 @@ object ComposterDisplay {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onTabListUpdate(event: WidgetUpdateEvent) {
-        if (!GardenAPI.inGarden()) return
         if (!event.isWidget(TabWidget.COMPOSTER)) return
 
         readData(event.lines)
@@ -148,9 +147,10 @@ object ComposterDisplay {
         }
     }
 
-    @HandleEvent(onlyOnSkyblock = true)
+    @HandleEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!OutsideSbFeature.COMPOSTER_TIME.isSelected()) return
+        @Suppress("InSkyBlockEarlyReturn")
+        if (!LorenzUtils.inSkyBlock && !OutsideSbFeature.COMPOSTER_TIME.isSelected()) return
 
         if (GardenAPI.inGarden() && config.displayEnabled) {
             config.displayPos.renderStringsAndItems(display, posLabel = "Composter Display")


### PR DESCRIPTION
## What
Fixed the overlay not working.
Whoops.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/e7aca47b-065c-446b-876e-593fa83b70a7)

</details>

## Changelog Fixes
+ Fixed Composter Overlay display. - Daveed
