### PR TITLE
Backend: Fixed /shconfig reset

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniConfigSearchResetCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniConfigSearchResetCommand.kt
@@ -255,7 +255,7 @@ object SkyHanniConfigSearchResetCommand {
         val line = term.split(".").drop(1)
         var field: Field? = null
         for (entry in line) {
-            field = obj.javaClass.getField(entry).makeAccessible()
+            field = obj.javaClass.getDeclaredField(entry).makeAccessible()
             parentObject = obj
             obj = field.get(obj)
         }


### PR DESCRIPTION
## What
Fixed `/shconfig reset <path>` not working after the config from java to kotlin change. now all /shconfig features should work again

## Changelog Technical Details
+ Fixed `/shconfig reset` not working. - hannibal2