### PR TITLE
Backend: fixed /shchathistory

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilterGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilterGui.kt
@@ -27,7 +27,7 @@ class ChatFilterGui(private val history: List<ChatManager.MessageFilteringResult
         history.maxOf { reasonLength(it) }
 
     private fun reasonLength(result: ChatManager.MessageFilteringResult): Int =
-        result.actionReason?.let { Minecraft.getMinecraft().fontRendererObj.getStringWidth(it) } ?: 0
+        result.actionReason?.let { fontRenderer().getStringWidth(it) } ?: 0
 
     private val historySize =
         history.sumOf { splitLine(it.message).size * 10 + if (it.modified != null) splitLine(it.modified).size * 10 else 0 }
@@ -49,15 +49,15 @@ class ChatFilterGui(private val history: List<ChatManager.MessageFilteringResult
         GlScissorStack.push(l + 5, t + 5, w + l - 5, h + t - 5, sr)
 
         for (msg in history) {
-            drawString(mc.fontRendererObj, msg.actionKind.renderedString, 0, 0, -1)
-            drawString(mc.fontRendererObj, msg.actionReason, ChatManager.ActionKind.maxLength + 5, 0, -1)
+            drawString(fontRenderer(), msg.actionKind.renderedString, 0, 0, -1)
+            drawString(fontRenderer(), msg.actionReason, ChatManager.ActionKind.maxLength + 5, 0, -1)
             var size = drawMultiLineText(
                 msg.message,
                 ChatManager.ActionKind.maxLength + reasonMaxLength + 10,
             )
             if (msg.modified != null) {
                 drawString(
-                    mc.fontRendererObj,
+                    fontRenderer(),
                     "§e§lNEW TEXT",
                     0, 0, -1,
                 )
@@ -96,7 +96,7 @@ class ChatFilterGui(private val history: List<ChatManager.MessageFilteringResult
         return GuiUtilRenderComponents.splitText(
             comp,
             w - (ChatManager.ActionKind.maxLength + reasonMaxLength + 10 + 10),
-            mc.fontRendererObj,
+            fontRenderer(),
             false,
             true,
         )
@@ -117,7 +117,7 @@ class ChatFilterGui(private val history: List<ChatManager.MessageFilteringResult
         val modifiedSplitText = splitLine(comp)
         for (line in modifiedSplitText) {
             drawString(
-                mc.fontRendererObj,
+                fontRenderer(),
                 line.formattedText,
                 xPos,
                 0,
@@ -127,6 +127,8 @@ class ChatFilterGui(private val history: List<ChatManager.MessageFilteringResult
         }
         return modifiedSplitText.size
     }
+
+    private fun fontRenderer() = Minecraft.getMinecraft().fontRendererObj
 
     override fun handleMouseInput() {
         super.handleMouseInput()


### PR DESCRIPTION
## What
Fixed /shchathistory

```
SkyHanni 1.7.0: Error while running command /shchathistory
 
Caused by java.lang.NullPointerException: null
	at SH.features.chat.ChatFilterGui.splitLine(ChatFilterGui.kt:99)
	at SH.features.chat.ChatFilterGui.<init>(ChatFilterGui.kt:33)
	at SH.data.ChatManager.openChatFilterGUI(ChatManager.kt:177)
	at SH.config.commands.Commands.devTest$lambda$193$lambda$192(Commands.kt:612)
	at net.minecraftforge.client.ClientCommandHandler.executeCommand(ClientCommandHandler.java:72)
	at MC.client.gui.GuiScreen.sendChatMessage(GuiScreen.java:446)
	at MC.client.gui.GuiScreen.sendChatMessage(GuiScreen.java:437)
	at MC.client.gui.GuiChat.keyTyped(GuiChat.java:111)
	at MC.client.gui.GuiScreen.handleKeyboardInput(GuiScreen.java:578)
	at MC.client.gui.GuiScreen.handleInput(GuiScreen.java:534)
	at MC.client.Minecraft.runTick(Minecraft.java:1674)
	at MC.client.Minecraft.runGameLoop(Minecraft.java:1024)
	at MC.client.Minecraft.run(Minecraft.java:349)
	at MC.client.main.Main.main(Main.java:124)
```


## Changelog Technical Details
+ Fixed /shchathistory not working. - hannibal2