### PR TITLE
Improvement: Item Tracker Buttons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.java
@@ -93,11 +93,6 @@ public class TrackerConfig {
     }
 
     @Expose
-    @ConfigOption(name = "Hide outside Inventory", desc = "Hide Profit Trackers while not inside an inventory.")
-    @ConfigEditorBoolean
-    public boolean hideItemTrackersOutsideInventory = false;
-
-    @Expose
     @ConfigOption(name = "Tracker Search", desc = "Add a search bar to tracker GUIs.")
     @ConfigEditorBoolean
     public Property<Boolean> trackerSearchEnabled = Property.of(true);

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage
 import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.RenderData
 import at.hannibal2.skyhanni.data.TrackerManager
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -76,9 +77,9 @@ open class SkyHanniTracker<Data : TrackerData>(
     fun renderDisplay(position: Position) {
         if (config.hideInEstimatedItemValue && EstimatedItemValue.isCurrentlyShowing()) return
 
-        val currentlyOpen = Minecraft.getMinecraft().currentScreen?.let { it is GuiInventory || it is GuiChest } ?: false
-        if (!currentlyOpen && config.hideItemTrackersOutsideInventory && this is SkyHanniItemTracker) {
-            return
+        var currentlyOpen = Minecraft.getMinecraft().currentScreen?.let { it is GuiInventory || it is GuiChest } ?: false
+        if (RenderData.outsideInventory) {
+            currentlyOpen = false
         }
         if (inventoryOpen != currentlyOpen) {
             inventoryOpen = currentlyOpen


### PR DESCRIPTION
## What
Made Item Tracker buttons not show up while grayed out, and removed the option to hide trackers while inside menus, since we want to render every tracker always, and if not necessary grayed out

## Changelog Improvements
+ Hide Item Tracker buttons when the display is grayed out. - hannibal2