### PR TITLE
Fix: ATTRIBUTE_SHARD not found chat message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
@@ -171,6 +171,8 @@ object FishingProfitTracker {
     private fun checkMissingItems(data: Data) {
         val missingItems = mutableListOf<NEUInternalName>()
         for (internalName in data.items.keys) {
+            // TODO remove workaround to not warn about ATTRIBUTE_SHARD
+            if (internalName == "ATTRIBUTE_SHARD".toInternalName()) continue
             if (itemCategories.none { internalName in it.value }) {
                 missingItems.add(internalName)
             }


### PR DESCRIPTION
## What
Fixed chat message about ATTRIBUTE_SHARD missing in fishing profit tracker

```
SkyHanni 1.7.0: Loaded 1 item not in a fishing category
 
<no stack trace>

Extra data:
missingItems: 
 - 'internalName:ATTRIBUTE_SHARD'

```

related repo change: https://github.com/hannibal002/SkyHanni-REPO/commit/18ccca722a6cdf19a9804a2adb4b4a7eebfa8f0c

## Changelog Fixes
+ Fixed chat message about missing attribute shards in the Fishing Profit Tracker. - hannibal2