### PR TITLE
Backend: Storage Needs @Expose

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -147,3 +147,5 @@ potential-bugs:
         active: false
     HasPlatformType: # false positives on config get() methods
         active: false
+    StorageNeedsExpose:
+        active: true

--- a/detekt/src/main/kotlin/potentialbugs/PotentialBugsProvider.kt
+++ b/detekt/src/main/kotlin/potentialbugs/PotentialBugsProvider.kt
@@ -13,9 +13,7 @@ class PotentialBugsProvider : RuleSetProvider {
     override fun instance(config: Config): RuleSet {
         return RuleSet(
             ruleSetId,
-            listOf(
-                StorageNeedsExpose(config),
-            ),
+            listOf(StorageNeedsExpose(config)),
         )
     }
 }

--- a/detekt/src/main/kotlin/potentialbugs/PotentialBugsProvider.kt
+++ b/detekt/src/main/kotlin/potentialbugs/PotentialBugsProvider.kt
@@ -1,0 +1,21 @@
+package at.hannibal2.skyhanni.detektrules.potentialbugs
+
+import com.google.auto.service.AutoService
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+@AutoService(RuleSetProvider::class)
+class PotentialBugsProvider : RuleSetProvider {
+    override val ruleSetId: String
+        get() = "potential-bugs"
+
+    override fun instance(config: Config): RuleSet {
+        return RuleSet(
+            ruleSetId,
+            listOf(
+                StorageNeedsExpose(config),
+            ),
+        )
+    }
+}

--- a/detekt/src/main/kotlin/potentialbugs/StorageNeedsExpose.kt
+++ b/detekt/src/main/kotlin/potentialbugs/StorageNeedsExpose.kt
@@ -1,0 +1,51 @@
+package at.hannibal2.skyhanni.detektrules.potentialbugs
+
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtProperty
+
+class StorageNeedsExpose(config: Config): SkyHanniRule(config) {
+    override val issue = Issue(
+        "StorageNeedsExpose",
+        Severity.Defect,
+        "Config/storage properties that are intended to store data should be annotated with @Expose.",
+        Debt.TEN_MINS,
+    )
+
+    companion object {
+        const val STORAGE_PACKAGE = "at.hannibal2.skyhanni.config.storage"
+        const val CONFIG_PACKAGE = "at.hannibal2.skyhanni.config.features"
+    }
+
+    override fun visitKtFile(file: KtFile) {
+        val packageName = file.packageDirective?.fqName?.asString() ?: ""
+        if (!packageName.startsWith(CONFIG_PACKAGE) && !packageName.startsWith(STORAGE_PACKAGE)) return
+        super.visitKtFile(file)
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        // Skip local variables inside functions
+        if (property.isLocal) return
+
+        // If the property is not annotated with @Expose, report it
+        if (!property.hasAnnotation("Expose")) {
+
+            if (property.hasAnnotation("ConfigOption")) {
+                // Valid reasons to not have the @Expose annotation on a config option:
+                //  - Has the ConfigEditorInfoText annotation
+                //  - Has the ConfigEditorButton annotation
+                if(property.hasAnnotation("ConfigEditorInfoText")) return
+                if(property.hasAnnotation("ConfigEditorButton")) return
+            }
+
+            property.reportIssue("@Expose annotation is missing from property ${property.name}")
+        }
+
+        super.visitProperty(property)
+    }
+}


### PR DESCRIPTION
## What
Follow-up on #3203, a functional version that'll play well with nea's PR #3285 (but not dependent on it).

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/604b41af-e3f1-47bf-b4b3-68c58644bb88)

</details>

## Changelog Technical Details
+ Added detekt rule to prevent `@Expose` from being removed during merges. - Daveed

