### PR TITLE
Fix: King's Scent not detected

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
@@ -136,7 +136,7 @@ object NonGodPotEffectDisplay {
             effectDuration[NonGodPotEffect.PEST_REPELLENT_MAX] = Timer(1.hours)
         }
 
-        if (event.message == "§e[NPC] §6King Yolkar§f: §rThese eggs will help me stomach my pain.") {
+        if (event.message == "§e[NPC] §6King Yolkar§f: §rThis egg will help me stomach my pain.") {
             effectDuration[NonGodPotEffect.GOBLIN] = Timer(20.minutes)
             update()
         }


### PR DESCRIPTION
## What
Fixed King's Scent not getting detected when applying to Non God Pot display. 

## Changelog Fixes
+ Fixed King's Scent detection for Non-God Pot display. - hannibal2