### PR TITLE
Backend: NPC -> Npc

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.java
@@ -56,6 +56,7 @@ public class DebugMobConfig {
         @Expose
         @ConfigOption(name = "DisplayNPC", desc = "Shows the internal mobs that are 'DisplayNPC' as highlight (in red) or the name.")
         @ConfigEditorDropdown
+        // TODO rename to displayNpc
         public HowToShow displayNPC = HowToShow.OFF;
 
         @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.java
@@ -280,6 +280,7 @@ public class InventoryConfig {
     @ConfigOption(name = "Shift Click NPC sell", desc = "Change normal clicks to shift clicks in npc inventory for selling.")
     @ConfigEditorBoolean
     @FeatureToggle
+    // TODO rename to shiftClickNpcSell
     public boolean shiftClickNPCSell = false;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.data.mob
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.mob.MobFilter.makeMobResult
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
-import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
+import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LocationUtils
@@ -70,16 +70,16 @@ object IslandExceptions {
         baseEntity is EntityCaveSpider -> MobUtils.getClosestArmorStand(baseEntity, 2.0).takeNonDefault()
             .makeMobResult { MobFactories.dungeon(baseEntity, it) }
 
-        baseEntity is EntityOtherPlayerMP && baseEntity.isNPC() && baseEntity.name == "Shadow Assassin" ->
+        baseEntity is EntityOtherPlayerMP && baseEntity.isNpc() && baseEntity.name == "Shadow Assassin" ->
             MobUtils.getClosestArmorStandWithName(baseEntity, 3.0, "Shadow Assassin")
                 .makeMobResult { MobFactories.dungeon(baseEntity, it) }
 
-        baseEntity is EntityOtherPlayerMP && baseEntity.isNPC() && baseEntity.name == "The Professor" ->
+        baseEntity is EntityOtherPlayerMP && baseEntity.isNpc() && baseEntity.name == "The Professor" ->
             MobUtils.getArmorStand(baseEntity, 9)
                 .makeMobResult { MobFactories.boss(baseEntity, it) }
 
         baseEntity is EntityOtherPlayerMP &&
-            baseEntity.isNPC() &&
+            baseEntity.isNpc() &&
             (nextEntity is EntityGiantZombie || nextEntity == null) &&
             baseEntity.name.contains("Livid") -> MobUtils.getClosestArmorStandWithName(baseEntity, 6.0, "﴾ Livid")
             .makeMobResult { MobFactories.boss(baseEntity, it, overriddenName = "Real Livid") }
@@ -114,7 +114,7 @@ object IslandExceptions {
         baseEntity is EntitySlime && armorStand != null && armorStand.cleanName().startsWith("﴾ [Lv10] B") ->
             MobData.MobResult.found(Mob(baseEntity, Mob.Type.BOSS, armorStand, name = "Bacte"))
 
-        baseEntity is EntityOtherPlayerMP && baseEntity.isNPC() && baseEntity.name == "Branchstrutter " ->
+        baseEntity is EntityOtherPlayerMP && baseEntity.isNpc() && baseEntity.name == "Branchstrutter " ->
             MobData.MobResult.found(Mob(baseEntity, Mob.Type.DISPLAY_NPC, name = "Branchstrutter"))
 
         else -> null
@@ -129,13 +129,13 @@ object IslandExceptions {
             MobData.MobResult.found(MobFactories.special(baseEntity, "Heavy Pearl"))
 
         baseEntity is EntityPig && nextEntity is EntityPig -> MobData.MobResult.illegal // Matriarch Tongue
-        baseEntity is EntityOtherPlayerMP && baseEntity.isNPC() && baseEntity.name == "BarbarianGuard " ->
+        baseEntity is EntityOtherPlayerMP && baseEntity.isNpc() && baseEntity.name == "BarbarianGuard " ->
             MobData.MobResult.found(Mob(baseEntity, Mob.Type.DISPLAY_NPC, name = "Barbarian Guard"))
 
-        baseEntity is EntityOtherPlayerMP && baseEntity.isNPC() && baseEntity.name == "MageGuard " ->
+        baseEntity is EntityOtherPlayerMP && baseEntity.isNpc() && baseEntity.name == "MageGuard " ->
             MobData.MobResult.found(Mob(baseEntity, Mob.Type.DISPLAY_NPC, name = "Mage Guard"))
 
-        baseEntity is EntityOtherPlayerMP && baseEntity.isNPC() && baseEntity.name == "Mage Outlaw" ->
+        baseEntity is EntityOtherPlayerMP && baseEntity.isNpc() && baseEntity.name == "Mage Outlaw" ->
             // fix for wierd name
             MobData.MobResult.found(Mob(baseEntity, Mob.Type.BOSS, armorStand, name = "Mage Outlaw"))
 
@@ -143,7 +143,7 @@ object IslandExceptions {
             baseEntity.getEntityHelmet()?.getSkullTexture() == MobFilter.NPC_TURD_SKULL ->
             MobData.MobResult.found(Mob(baseEntity, Mob.Type.DISPLAY_NPC, name = "Turd"))
 
-        baseEntity is EntityOcelot -> if (MobFilter.createDisplayNPC(baseEntity)) {
+        baseEntity is EntityOcelot -> if (MobFilter.createDisplayNpc(baseEntity)) {
             MobData.MobResult.illegal
         } else {
             MobData.MobResult.notYetFound // Maybe a problem in the future
@@ -215,7 +215,7 @@ object IslandExceptions {
     }
 
     private fun garden(baseEntity: EntityLivingBase) = when {
-        baseEntity is EntityOtherPlayerMP && baseEntity.isNPC() ->
+        baseEntity is EntityOtherPlayerMP && baseEntity.isNpc() ->
             MobData.MobResult.found(Mob(baseEntity, Mob.Type.DISPLAY_NPC, name = baseEntity.cleanName()))
 
         else -> null

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobData.kt
@@ -20,7 +20,7 @@ object MobData {
     }
 
     val players = MobSet()
-    val displayNPCs = MobSet()
+    val displayNpcs = MobSet()
     val skyblockMobs = MobSet()
     val summoningMobs = MobSet()
     val special = MobSet()
@@ -134,13 +134,13 @@ object MobData {
     }
 
     @HandleEvent
-    fun onDisplayNPCSpawnEvent(event: MobEvent.Spawn.DisplayNPC) {
-        displayNPCs.add(event.mob)
+    fun onDisplayNpcSpawnEvent(event: MobEvent.Spawn.DisplayNpc) {
+        displayNpcs.add(event.mob)
     }
 
     @HandleEvent
-    fun onDisplayNPCDeSpawnEvent(event: MobEvent.DeSpawn.DisplayNPC) {
-        displayNPCs.remove(event.mob)
+    fun onDisplayNpcDeSpawnEvent(event: MobEvent.DeSpawn.DisplayNpc) {
+        displayNpcs.remove(event.mob)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
@@ -57,7 +57,7 @@ object MobDebug {
             MobData.skyblockMobs.highlight(event) { if (it.mobType == Mob.Type.BOSS) LorenzColor.DARK_GREEN else LorenzColor.GREEN }
         }
         if (config.displayNPC.isHighlight()) {
-            MobData.displayNPCs.highlight(event) { LorenzColor.RED }
+            MobData.displayNpcs.highlight(event) { LorenzColor.RED }
         }
         if (config.realPlayerHighlight) {
             MobData.players.highlight(event) { if (it.baseEntity is EntityPlayerSP) LorenzColor.CHROMA else LorenzColor.BLUE }
@@ -72,7 +72,7 @@ object MobDebug {
             MobData.skyblockMobs.showName(event)
         }
         if (config.displayNPC.isName()) {
-            MobData.displayNPCs.showName(event)
+            MobData.displayNpcs.showName(event)
         }
         if (config.summon.isName()) {
             MobData.summoningMobs.showName(event)

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.data.mob
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.mob.MobFilter.isDisplayNPC
+import at.hannibal2.skyhanni.data.mob.MobFilter.isDisplayNpc
 import at.hannibal2.skyhanni.data.mob.MobFilter.isRealPlayer
 import at.hannibal2.skyhanni.data.mob.MobFilter.isSkyBlockMob
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
@@ -80,7 +80,7 @@ object MobDetection {
         if (MobData.players.any { it.watchdogCheck(world) }) {
             ChatUtils.chat("Watchdog: Players")
         }
-        if (MobData.displayNPCs.any { it.watchdogCheck(world) }) {
+        if (MobData.displayNpcs.any { it.watchdogCheck(world) }) {
             ChatUtils.chat("Watchdog: Display NPCs")
         }
         if (MobData.skyblockMobs.any { it.watchdogCheck(world) }) {
@@ -141,7 +141,7 @@ object MobDetection {
     /** Splits the entity into player, displayNPC and other */
     private fun EntityLivingBase.getRoughType() = when {
         this is EntityPlayer && this.isRealPlayer() -> Mob.Type.PLAYER
-        this.isDisplayNPC() -> Mob.Type.DISPLAY_NPC
+        this.isDisplayNpc() -> Mob.Type.DISPLAY_NPC
         this.isSkyBlockMob() && !islandException() -> Mob.Type.BASIC
         else -> null
     }
@@ -166,7 +166,7 @@ object MobDetection {
                 Mob.Type.SUMMON -> MobEvent.FirstSeen.Summon(mob)
                 Mob.Type.SPECIAL -> MobEvent.FirstSeen.Special(mob)
                 Mob.Type.PROJECTILE -> MobEvent.FirstSeen.Projectile(mob)
-                Mob.Type.DISPLAY_NPC -> MobEvent.FirstSeen.DisplayNPC(mob)
+                Mob.Type.DISPLAY_NPC -> MobEvent.FirstSeen.DisplayNpc(mob)
                 Mob.Type.BASIC, Mob.Type.DUNGEON, Mob.Type.BOSS, Mob.Type.SLAYER -> MobEvent.FirstSeen.SkyblockMob(mob)
             }.post()
         }
@@ -178,7 +178,7 @@ object MobDetection {
         when (roughType) {
             Mob.Type.PLAYER -> MobEvent.Spawn.Player(MobFactories.player(entity)).post()
 
-            Mob.Type.DISPLAY_NPC -> return MobFilter.createDisplayNPC(entity)
+            Mob.Type.DISPLAY_NPC -> return MobFilter.createDisplayNpc(entity)
             Mob.Type.BASIC -> {
                 val (result, mob) = MobFilter.createSkyblockEntity(entity)
                 when (result) {
@@ -192,7 +192,7 @@ object MobDetection {
                             Mob.Type.BASIC, Mob.Type.DUNGEON, Mob.Type.BOSS, Mob.Type.SLAYER -> MobEvent.Spawn.SkyblockMob(mob)
                             Mob.Type.SPECIAL -> MobEvent.Spawn.Special(mob)
                             Mob.Type.PROJECTILE -> MobEvent.Spawn.Projectile(mob)
-                            Mob.Type.DISPLAY_NPC -> MobEvent.Spawn.DisplayNPC(mob) // Needed for some special cases
+                            Mob.Type.DISPLAY_NPC -> MobEvent.Spawn.DisplayNpc(mob) // Needed for some special cases
                             Mob.Type.PLAYER -> return mobDetectionError("An Player Ended Here. How?")
                         }.post()
                     }
@@ -227,7 +227,7 @@ object MobDetection {
                 val entity = EntityUtils.getEntityByID(id) as? EntityVillager ?: return@drainForEach
                 val mob = MobData.entityToMob[entity]
                 if (mob != null && mob.mobType == Mob.Type.DISPLAY_NPC) {
-                    MobEvent.DeSpawn.DisplayNPC(mob)
+                    MobEvent.DeSpawn.DisplayNpc(mob)
                     addRetry(entity)
                     return@drainForEach
                 }
@@ -282,7 +282,7 @@ object MobDetection {
         Mob.Type.SUMMON -> MobEvent.DeSpawn.Summon(this)
         Mob.Type.SPECIAL -> MobEvent.DeSpawn.Special(this)
         Mob.Type.PROJECTILE -> MobEvent.DeSpawn.Projectile(this)
-        Mob.Type.DISPLAY_NPC -> MobEvent.DeSpawn.DisplayNPC(this)
+        Mob.Type.DISPLAY_NPC -> MobEvent.DeSpawn.DisplayNpc(this)
         Mob.Type.BASIC, Mob.Type.DUNGEON, Mob.Type.BOSS, Mob.Type.SLAYER -> MobEvent.DeSpawn.SkyblockMob(this)
     }
 
@@ -291,7 +291,7 @@ object MobDetection {
         Mob.Type.SUMMON -> MobEvent.Hurt.Summon(mob, source, amount)
         Mob.Type.SPECIAL -> MobEvent.Hurt.Special(mob, source, amount)
         Mob.Type.PROJECTILE -> MobEvent.Hurt.Projectile(mob, source, amount)
-        Mob.Type.DISPLAY_NPC -> MobEvent.Hurt.DisplayNPC(mob, source, amount)
+        Mob.Type.DISPLAY_NPC -> MobEvent.Hurt.DisplayNpc(mob, source, amount)
         Mob.Type.BASIC, Mob.Type.DUNGEON, Mob.Type.BOSS, Mob.Type.SLAYER -> MobEvent.Hurt.SkyblockMob(mob, source, amount)
     }.post()
 

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFactories.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFactories.kt
@@ -100,7 +100,7 @@ object MobFactories {
             )
         }
 
-    fun displayNPC(baseEntity: EntityLivingBase, armorStand: EntityArmorStand, clickArmorStand: EntityArmorStand): Mob =
+    fun displayNpc(baseEntity: EntityLivingBase, armorStand: EntityArmorStand, clickArmorStand: EntityArmorStand): Mob =
         Mob(
             baseEntity = baseEntity,
             mobType = Mob.Type.DISPLAY_NPC,

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.takeWhileInclusive
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
-import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
+import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -150,17 +150,17 @@ object MobFilter {
         }
     }
 
-    private val extraDisplayNPCByName = setOf(
+    private val extraDisplayNpcByName = setOf(
         "Guy ", // Guy NPC (but only as visitor)
         "vswiblxdxg", // Mayor Cole
         "anrrtqytsl", // Weaponsmith
     )
 
-    private val displayNPCCompressedNamePattern by patternGroup.pattern("displaynpc.name", "[a-z0-9]{10}")
+    private val displayNpcCompressedNamePattern by patternGroup.pattern("displaynpc.name", "[a-z0-9]{10}")
 
-    private fun displayNPCNameCheck(name: String) = name.startsWith('§') ||
-        displayNPCCompressedNamePattern.matches(name) ||
-        extraDisplayNPCByName.contains(name)
+    private fun displayNpcNameCheck(name: String) = name.startsWith('§') ||
+        displayNpcCompressedNamePattern.matches(name) ||
+        extraDisplayNpcByName.contains(name)
 
     private val listOfClickArmorStand = setOf(
         "§e§lCLICK",
@@ -175,26 +175,26 @@ object MobFilter {
         this !is EntityLivingBase -> false
         this is EntityArmorStand -> false
         this is EntityPlayer && this.isRealPlayer() -> false
-        this.isDisplayNPC() -> false
+        this.isDisplayNpc() -> false
         this is EntityWither && this.entityId < 0 -> false
         else -> true
     }
 
     fun EntityPlayer.isRealPlayer() = uniqueID?.let { it.version() == 4 } ?: false
 
-    fun EntityLivingBase.isDisplayNPC() =
-        (this is EntityPlayer && isNPC() && displayNPCNameCheck(this.name)) ||
+    fun EntityLivingBase.isDisplayNpc() =
+        (this is EntityPlayer && isNpc() && displayNpcNameCheck(this.name)) ||
             (this is EntityVillager && this.maxHealth == 20.0f) || // Villager NPCs in the Village
             (this is EntityWitch && this.entityId <= 500) || // Alchemist NPC
             (this is EntityCow && this.entityId <= 500) || // Shania NPC (in Rift and Outside)
             (this is EntitySnowman && this.entityId <= 500) // Sherry NPC (in Jerry Island)
 
-    fun createDisplayNPC(entity: EntityLivingBase): Boolean {
+    fun createDisplayNpc(entity: EntityLivingBase): Boolean {
         val clickArmorStand = MobUtils.getArmorStandByRangeAll(entity, 1.5).firstOrNull { armorStand ->
             listOfClickArmorStand.contains(armorStand.name)
         } ?: return false
         val armorStand = MobUtils.getArmorStand(clickArmorStand, -1) ?: return false
-        MobEvent.Spawn.DisplayNPC(MobFactories.displayNPC(entity, armorStand, clickArmorStand)).post()
+        MobEvent.Spawn.DisplayNpc(MobFactories.displayNpc(entity, armorStand, clickArmorStand)).post()
         return true
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/events/MobEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/MobEvent.kt
@@ -9,7 +9,7 @@ open class MobEvent(val mob: Mob) : SkyHanniEvent() {
         class SkyblockMob(mob: Mob) : Spawn(mob)
         class Summon(mob: Mob) : Spawn(mob)
         class Player(mob: Mob) : Spawn(mob)
-        class DisplayNPC(mob: Mob) : Spawn(mob)
+        class DisplayNpc(mob: Mob) : Spawn(mob)
         class Special(mob: Mob) : Spawn(mob)
         class Projectile(mob: Mob) : Spawn(mob)
     }
@@ -18,7 +18,7 @@ open class MobEvent(val mob: Mob) : SkyHanniEvent() {
         class SkyblockMob(mob: Mob) : DeSpawn(mob)
         class Summon(mob: Mob) : DeSpawn(mob)
         class Player(mob: Mob) : DeSpawn(mob)
-        class DisplayNPC(mob: Mob) : DeSpawn(mob)
+        class DisplayNpc(mob: Mob) : DeSpawn(mob)
         class Special(mob: Mob) : DeSpawn(mob)
         class Projectile(mob: Mob) : DeSpawn(mob)
     }
@@ -27,7 +27,7 @@ open class MobEvent(val mob: Mob) : SkyHanniEvent() {
         class SkyblockMob(mob: Mob) : FirstSeen(mob)
         class Summon(mob: Mob) : FirstSeen(mob)
         class Player(mob: Mob) : FirstSeen(mob)
-        class DisplayNPC(mob: Mob) : FirstSeen(mob)
+        class DisplayNpc(mob: Mob) : FirstSeen(mob)
         class Special(mob: Mob) : FirstSeen(mob)
         class Projectile(mob: Mob) : FirstSeen(mob)
     }
@@ -36,7 +36,7 @@ open class MobEvent(val mob: Mob) : SkyHanniEvent() {
         class SkyblockMob(mob: Mob, source: DamageSource, amount: Float) : Hurt(mob, source, amount)
         class Summon(mob: Mob, source: DamageSource, amount: Float) : Hurt(mob, source, amount)
         class Player(mob: Mob, source: DamageSource, amount: Float) : Hurt(mob, source, amount)
-        class DisplayNPC(mob: Mob, source: DamageSource, amount: Float) : Hurt(mob, source, amount)
+        class DisplayNpc(mob: Mob, source: DamageSource, amount: Float) : Hurt(mob, source, amount)
         class Special(mob: Mob, source: DamageSource, amount: Float) : Hurt(mob, source, amount)
         class Projectile(mob: Mob, source: DamageSource, amount: Float) : Hurt(mob, source, amount)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CrystalNucleusChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CrystalNucleusChatFilter.kt
@@ -161,7 +161,7 @@ object CrystalNucleusChatFilter {
             ?: blockRunCompleted(message)
             ?: blockNonToolScavenge(message)
             ?: blockGoblinGuards(message)
-            ?: blockNPC(message)
+            ?: blockNpc(message)
     }
 
     private fun blockCrystalCollected(message: String): NucleusChatFilterRes? {
@@ -234,7 +234,7 @@ object CrystalNucleusChatFilter {
         return NucleusChatFilterRes("npc_goblin_guard")
     }
 
-    private fun blockNPC(message: String): NucleusChatFilterRes? {
+    private fun blockNpc(message: String): NucleusChatFilterRes? {
         if (!message.startsWith("§e[NPC]")) return null
 
         return blockProfessorRobot(message)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/UniqueGiftingOpportunitiesFeatures.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
-import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
+import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -76,7 +76,7 @@ object UniqueGiftingOpportunitiesFeatures {
         if (entity.name != HAS_GIFTED_NAMETAG) return
 
         val matchedPlayer = EntityUtils.getEntitiesNearby<EntityPlayer>(entity.getLorenzVec(), 2.0)
-            .singleOrNull { !it.isNPC() } ?: return
+            .singleOrNull { !it.isNpc() } ?: return
         addGiftedPlayer(matchedPlayer.name)
     }
 
@@ -95,7 +95,7 @@ object UniqueGiftingOpportunitiesFeatures {
     private fun playerColor(event: EntityEnterWorldEvent<Entity>) {
         if (event.entity is EntityOtherPlayerMP) {
             val entity = event.entity
-            if (entity.isNPC() || isIronman(entity) || isBingo(entity)) return
+            if (entity.isNpc() || isIronman(entity) || isBingo(entity)) return
 
             RenderLivingEntityHelper.setEntityColor(
                 entity,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -591,7 +591,7 @@ object GardenVisitorFeatures {
             val visitorName = visitor.visitorName
             val entity = visitor.getEntity()
             if (entity == null) {
-                NPCVisitorFix.findNametag(visitorName.removeColor())?.let {
+                NpcVisitorFix.findNametag(visitorName.removeColor())?.let {
                     findEntity(it, visitor)
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/NpcVisitorFix.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/NpcVisitorFix.kt
@@ -24,7 +24,7 @@ import kotlin.time.Duration.Companion.seconds
  * Fixing the visitor detection problem with Anita and Jacob, as those two are on the garden twice when visiting.
  */
 @SkyHanniModule
-object NPCVisitorFix {
+object NpcVisitorFix {
     private val staticVisitors = listOf("Jacob", "Anita")
 
     private val barnSkinChangePattern by RepoPattern.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -267,7 +267,7 @@ object HideNotClickableItems {
 
     private fun hideRiftMotesGrubber(chestName: String, stack: ItemStack): Boolean {
         if (!RiftApi.inRift()) return false
-        if (chestName != "Motes Grubber" && !ShiftClickNPCSell.inInventory) return false
+        if (chestName != "Motes Grubber" && !ShiftClickNpcSell.inInventory) return false
 
         showGreenLine = true
 
@@ -475,7 +475,7 @@ object HideNotClickableItems {
 
     private fun hideNpcSell(stack: ItemStack): Boolean {
         if (RiftApi.inRift()) return false
-        if (!ShiftClickNPCSell.inInventory) return false
+        if (!ShiftClickNpcSell.inInventory) return false
         if (VisitorApi.inInventory) return false
         showGreenLine = true
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNpcSell.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNpcSell.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
-object ShiftClickNPCSell {
+object ShiftClickNpcSell {
 
     private val config get() = SkyHanniMod.feature.inventory.shiftClickNPCSell
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.getArmorInventory
-import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
+import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.FakePlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat
@@ -29,7 +29,7 @@ object HideArmor {
         if (entity !is EntityPlayer) return false
         if (entity is FakePlayer) return false
         if (entity.hasPotionEffect(EffectsCompat.INVISIBILITY)) return false
-        if (entity.isNPC()) return false
+        if (entity.isNpc()) return false
 
         return when (config.mode) {
             ModeEntry.ALL -> true

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/RiftGunthersRace.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/RiftGunthersRace.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
-import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
+import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.ParkourHelper
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
@@ -116,7 +116,7 @@ object RiftGunthersRace {
         if (!RiftApi.inRiftRace) return
 
         val entity = event.entity
-        if (entity is EntityOtherPlayerMP && !entity.isNPC()) {
+        if (entity is EntityOtherPlayerMP && !entity.isNpc()) {
             event.cancel()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
-import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
+import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
@@ -173,7 +173,7 @@ object PunchcardHighlight {
     fun onPunch(event: EntityClickEvent) {
         val entity = event.clickedEntity
         if (entity !is AbstractClientPlayer) return
-        if (entity.isNPC()) return
+        if (entity.isNpc()) return
         val name = entity.name
         if (name in playerList || name in playerQueue) return
         playerQueue.add(name)

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -21,7 +21,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.getAllNameTagsInRadiusWith
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
-import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
+import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -157,9 +157,9 @@ object VampireSlayerFeatures {
                 taggedEntityList.remove(entityId)
             }
             val canUseSteak = health <= neededHealth
-            val ownBoss = configOwnBoss.highlight && containUser && isNPC()
-            val otherBoss = configOtherBoss.highlight && taggedEntityList.contains(entityId) && isNPC()
-            val coopBoss = configCoopBoss.highlight && containCoop && isNPC()
+            val ownBoss = configOwnBoss.highlight && containUser && isNpc()
+            val otherBoss = configOtherBoss.highlight && taggedEntityList.contains(entityId) && isNpc()
+            val coopBoss = configCoopBoss.highlight && containCoop && isNpc()
             val shouldRender = if (ownBoss) true else if (otherBoss) true else coopBoss
 
             val color = when {
@@ -200,7 +200,7 @@ object VampireSlayerFeatures {
         if (!isEnabled()) return
         if (event.clickType != ClickType.LEFT_CLICK) return
         if (event.clickedEntity !is EntityOtherPlayerMP) return
-        if (!event.clickedEntity.isNPC()) return
+        if (!event.clickedEntity.isNpc()) return
         val coopList = configCoopBoss.coopMembers.split(",").toList()
         val regexA = ".*§(?:\\d|\\w)+Spawned by: §(?:\\d|\\w)(\\w*).*".toRegex()
         val regexB = ".*§(?:\\d|\\w)+Spawned by: §(?:\\d|\\w)(\\w*)".toRegex()

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.test.command
 
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.data.mob.MobData
-import at.hannibal2.skyhanni.data.mob.MobFilter.isDisplayNPC
+import at.hannibal2.skyhanni.data.mob.MobFilter.isDisplayNpc
 import at.hannibal2.skyhanni.data.mob.MobFilter.isRealPlayer
 import at.hannibal2.skyhanni.data.mob.MobFilter.isSkyBlockMob
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.EntityUtils.getSkinTexture
-import at.hannibal2.skyhanni.utils.EntityUtils.isNPC
+import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.ItemUtils.isEnchanted
@@ -222,8 +222,8 @@ object CopyNearbyEntitiesCommand {
     }
 
     private fun getType(entity: Entity, mob: Mob?) = buildString {
-        if (entity is EntityLivingBase && entity.isDisplayNPC()) append("DisplayNPC, ")
-        if (entity is EntityPlayer && entity.isNPC()) append("NPC, ")
+        if (entity is EntityLivingBase && entity.isDisplayNpc()) append("DisplayNPC, ")
+        if (entity is EntityPlayer && entity.isNpc()) append("NPC, ")
         if (entity is EntityPlayer && entity.isRealPlayer()) append("RealPlayer, ")
         if (mob?.mobType == Mob.Type.SUMMON) append("Summon, ")
         if (entity.isSkyBlockMob()) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -49,7 +49,7 @@ object EntityUtils {
     fun getPlayerEntities(): MutableList<EntityOtherPlayerMP> {
         val list = mutableListOf<EntityOtherPlayerMP>()
         for (entity in Minecraft.getMinecraft().theWorld?.getLoadedPlayers().orEmpty()) {
-            if (!entity.isNPC() && entity is EntityOtherPlayerMP) {
+            if (!entity.isNpc() && entity is EntityOtherPlayerMP) {
                 list.add(entity)
             }
         }
@@ -154,7 +154,7 @@ object EntityUtils {
     fun EntityArmorStand.wearingSkullTexture(skin: String) = getStandHelmet()?.getSkullTexture() == skin
     fun EntityArmorStand.holdingSkullTexture(skin: String) = getHandItem()?.getSkullTexture() == skin
 
-    fun EntityPlayer.isNPC() = !isRealPlayer()
+    fun EntityPlayer.isNpc() = !isRealPlayer()
 
     fun EntityLivingBase.getArmorInventory(): Array<ItemStack?>? =
         if (this is EntityPlayer) inventory.armorInventory.normalizeAsArray() else null

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -188,9 +188,9 @@
     <ID>RepoPatternRegexTestMissing:MythologicalCreatureTracker.kt$MythologicalCreatureTracker$by patternGroup.pattern( "minosinquisitor", ".* §r§eYou dug out a §r§2Minos Inquisitor§r§e!", )</ID>
     <ID>RepoPatternRegexTestMissing:MythologicalCreatureTracker.kt$MythologicalCreatureTracker$by patternGroup.pattern( "minotaur", ".* §r§eYou dug out a §r§2Minotaur§r§e!", )</ID>
     <ID>RepoPatternRegexTestMissing:MythologicalCreatureTracker.kt$MythologicalCreatureTracker$by patternGroup.pattern( "siameselynxes", ".* §r§eYou dug out §r§2Siamese Lynxes§r§e!", )</ID>
-    <ID>RepoPatternRegexTestMissing:NPCVisitorFix.kt$NPCVisitorFix$by RepoPattern.pattern( "garden.barn.skin.change", "§aChanging Barn skin to §r.*" )</ID>
     <ID>RepoPatternRegexTestMissing:NewYearCakeReminder.kt$NewYearCakeReminder$by RepoPattern.pattern( "event.winter.newyearcake.reminder.sidebar", "§dNew Year Event!§f (?&lt;time&gt;.*)", )</ID>
     <ID>RepoPatternRegexTestMissing:NonGodPotEffectDisplay.kt$NonGodPotEffectDisplay$by RepoPattern.pattern( "misc.nongodpot.effects", "§7You have §e(?&lt;name&gt;\\d+) §7non-god effects\\.", )</ID>
+    <ID>RepoPatternRegexTestMissing:NpcVisitorFix.kt$NpcVisitorFix$by RepoPattern.pattern( "garden.barn.skin.change", "§aChanging Barn skin to §r.*" )</ID>
     <ID>RepoPatternRegexTestMissing:PartyApi.kt$PartyApi$by patternGroup.pattern( "kuudrafinder.join", "§dParty Finder §f&gt; (?&lt;name&gt;.*?) §ejoined the group! \\(§[a-fA-F0-9]+Combat Level \\d+§e\\)", )</ID>
     <ID>RepoPatternRegexTestMissing:PestApi.kt$PestApi$by patternGroup.pattern( "inventory", "§4§lൠ §cThis plot has §6(?&lt;amount&gt;\\d) Pests?§c!", )</ID>
     <ID>RepoPatternRegexTestMissing:PestApi.kt$PestApi$by patternGroup.pattern( "scoreboard.pests", " §7⏣ §[ac]The Garden §4§lൠ§7 x(?&lt;pests&gt;.*)", )</ID>


### PR DESCRIPTION
## What
Following
- #3296

This pr renames `NPC` to `Npc`.

## Changelog Technical Details
+ Followed Kotlin conventions: `NPC` → `Npc`. - hannibal2