### PR TITLE
Backend: StoargeNeedsExpose Ignore `private` Properties

### DIFF
--- a/detekt/src/main/kotlin/potentialbugs/StorageNeedsExpose.kt
+++ b/detekt/src/main/kotlin/potentialbugs/StorageNeedsExpose.kt
@@ -6,8 +6,10 @@ import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import org.jetbrains.kotlin.lexer.KtTokens.PRIVATE_KEYWORD
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 
 class StorageNeedsExpose(config: Config): SkyHanniRule(config) {
     override val issue = Issue(
@@ -31,6 +33,8 @@ class StorageNeedsExpose(config: Config): SkyHanniRule(config) {
     override fun visitProperty(property: KtProperty) {
         // Skip local variables inside functions
         if (property.isLocal) return
+        // Skip private properties
+        if (property.visibilityModifierTypeOrDefault() == PRIVATE_KEYWORD) return
 
         // If the property is not annotated with @Expose, report it
         if (!property.hasAnnotation("Expose")) {


### PR DESCRIPTION
## What
There are valid use cases to have a private not exposed property in a config class, so this is necessary now.

exclude_from_changelog
