### PR TITLE
Backend: Exposed Runnable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/BackgroundConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/BackgroundConfig.java
@@ -72,7 +72,6 @@ public class BackgroundConfig {
     @ConfigEditorSlider(minValue = 0, maxValue = 100, minStep = 1)
     public int customBackgroundImageOpacity = 100;
 
-    @Expose
     @ConfigOption(
         name = "Pack Creator",
         desc = "Click here to open the background creator. You can use this website to add your own image into as your Scoreboard Background."


### PR DESCRIPTION
## What
-1, just getting rid of an `@Expose` on a Runnable that was causing some errors in logs while I was doing #3323

exclude_from_changelog
