### PR TITLE
Fix: CF shortcut vs century raffle

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/HoppityEggLocationsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/HoppityEggLocationsJson.kt
@@ -24,6 +24,7 @@ data class HoppityEggLocationsJson(
     @Expose val rabbitHitmanIndex: Int,
     @Expose val maxRabbits: Int,
     @Expose val maxPrestige: Int,
+    @Expose @SerializedName("cf_shortcut_index") val cfShortcutIndex: Int,
     @Expose val chocolateMilestones: TreeSet<Long>,
     @Expose @SerializedName("hitman_costs") val hitmanCosts: TreeSet<Long>,
     @Expose val chocolateShopMilestones: List<MilestoneJson>,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryApi.kt
@@ -108,6 +108,7 @@ object ChocolateFactoryApi {
     private var chocolateFactoryMilestones: MutableList<MilestoneJson> = mutableListOf()
     private var chocolateShopMilestones: MutableList<MilestoneJson> = mutableListOf()
     private var maxPrestige = 6
+    var cfShortcutIndex = 16
 
     var inChocolateFactory = false
     var chocolateFactoryPaused = false
@@ -166,6 +167,7 @@ object ChocolateFactoryApi {
         rabbitHitmanIndex = data.rabbitHitmanIndex
         maxRabbits = data.maxRabbits
         maxPrestige = data.maxPrestige
+        cfShortcutIndex = data.cfShortcutIndex
         chocolateMilestones = data.chocolateMilestones
         hitmanCosts = data.hitmanCosts
         chocolateFactoryMilestones = data.chocolateFactoryMilestones.toMutableList()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryShortcut.kt
@@ -22,6 +22,8 @@ object ChocolateFactoryShortcut {
     private var showItem = false
     private var lastClick = SimpleTimeMark.farPast()
 
+    private val slotId get() = ChocolateFactoryApi.cfShortcutIndex
+
     private val item by lazy {
         ItemUtils.createSkull(
             displayName = "§6Open Chocolate Factory",
@@ -53,14 +55,14 @@ object ChocolateFactoryShortcut {
 
     @HandleEvent
     fun replaceItem(event: ReplaceItemEvent) {
-        if (event.inventory is ContainerLocalMenu && showItem && event.slot == 15) {
+        if (event.inventory is ContainerLocalMenu && showItem && event.slot == slotId) {
             event.replace(item)
         }
     }
 
     @HandleEvent(priority = HandleEvent.HIGH)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!showItem || event.slotId != 15) return
+        if (!showItem || event.slotId != slotId) return
         event.cancel()
         if (lastClick.passedSince() > 2.seconds) {
             HypixelCommands.chocolateFactory()


### PR DESCRIPTION
## What
Hypixel added a new item to the skyblck menu.
this new item is at the same slot we currently show the "chcolate factory shortcut" icon.
this PR moves the button one to the right, and also adds support to change the slot via repo in the future if hypixel again overrides the current button id.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/b2c0c624-d900-42dc-bca3-49f9226601e0)

</details>

## Changelog Fixes
+ Fixed hiding new item in the SB menu.  - hannibal2
    * Moved the Chocolate Factory shortcut in the SB menu so it no longer hides the newly added "Raffle of the Century" item.