### PR TITLE
Fix: ExperimentationTable wrong npc price & new bits regex

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
@@ -142,11 +142,11 @@ object ExperimentationTableApi {
     )
 
     /**
-     * REGEX-TEST: ☕ You renewed the experiment table! (1/3)
+     * REGEX-TEST: §d☕ §r§eYou bought a bonus charge for the Experimentation Table! §r§b(2/3)
      */
     val experimentRenewPattern by patternGroup.pattern(
         "renew",
-        "^☕ You renewed the experiment table! \\((?<current>\\d)/3\\)$",
+        "^(?:§d)?☕ (?:§r)?§eYou (?:renewed|bought a bonus charge for) the (?:E|e)xperiment(?:ation)? (?:T|t)able! (?:§r)?§b\\((?<current>\\d)/3\\)\$",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
@@ -146,8 +146,7 @@ object ExperimentationTableApi {
      */
     val experimentRenewPattern by patternGroup.pattern(
         "renew",
-        "^(?:§d)?☕ (?:§r)?§eYou (?:renewed|bought a bonus charge for) the " +
-            "[Ee]xperiment(?:ation)? [Tt]able! (?:§r)?§b\\((?<current>\\d)/3\\)\$",
+        "^§d☕ §r§eYou bought a bonus charge for the Experimentation Table! §r§b\\((?<current>\\d)/3\\)\$",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
@@ -146,7 +146,7 @@ object ExperimentationTableApi {
      */
     val experimentRenewPattern by patternGroup.pattern(
         "renew",
-        "^§d☕ §r§eYou bought a bonus charge for the Experimentation Table! §r§b\\((?<current>\\d)/3\\)\$",
+        "§d☕ §r§eYou bought a bonus charge for the Experimentation Table! §r§b\\((?<current>\\d)/3\\)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
@@ -146,7 +146,8 @@ object ExperimentationTableApi {
      */
     val experimentRenewPattern by patternGroup.pattern(
         "renew",
-        "^(?:§d)?☕ (?:§r)?§eYou (?:renewed|bought a bonus charge for) the (?:E|e)xperiment(?:ation)? (?:T|t)able! (?:§r)?§b\\((?<current>\\d)/3\\)\$",
+        "^(?:§d)?☕ (?:§r)?§eYou (?:renewed|bought a bonus charge for) the " +
+            "[Ee]xperiment(?:ation)? [Tt]able! (?:§r)?§b\\((?<current>\\d)/3\\)\$",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -60,11 +60,8 @@ object ItemPriceUtils {
             return 7.0 // NPC price
         }
 
-        return if (priceSource == ItemPriceSource.NPC_SELL) {
-            getNpcPriceOrNull()
-        } else {
-            getNpcPriceOrNull() ?: getRawCraftCostOrNull(priceSource, pastRecipes)
-        }
+        return getNpcPriceOrNull()
+            ?: getRawCraftCostOrNull(priceSource, pastRecipes).takeUnless { priceSource == ItemPriceSource.NPC_SELL }
     }
 
     fun NeuInternalName.isAuctionHouseItem(): Boolean = getLowestBinOrNull() != null

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -60,7 +60,11 @@ object ItemPriceUtils {
             return 7.0 // NPC price
         }
 
-        return getNpcPriceOrNull() ?: getRawCraftCostOrNull(priceSource, pastRecipes)
+        return if (priceSource == ItemPriceSource.NPC_SELL) {
+            getNpcPriceOrNull()
+        } else {
+            getNpcPriceOrNull() ?: getRawCraftCostOrNull(priceSource, pastRecipes)
+        }
     }
 
     fun NeuInternalName.isAuctionHouseItem(): Boolean = getLowestBinOrNull() != null


### PR DESCRIPTION
## What

+ Experiment profit tracker shows scavenger enchant buy npc price (15m), since Raw Craft Cost is 15m, but it should show sell npc sell price, which is 0
+ Hypixel updated the chat message on buying additional charges for Experimentation table, updated regex to the new message

## Changelog Fixes
+ Fixed Scavenger V NPC price from 15m to 0. - YoGoUrT_20
+ Fixed bits spent calculation in Experimentation Table. - YoGoUrT_20