### PR TITLE
Fix: Experimentation Table profit tracker gray

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.PetApi
 import at.hannibal2.skyhanni.data.ProfileStorageData
-import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -248,7 +248,10 @@ object ExperimentsProfitTracker {
     }
 
     init {
-        tracker.initRenderer({ config.position }) { isEnabled() }
+        tracker.initRenderer(
+            { config.position },
+            ExperimentationTableApi.superpairInventory,
+        ) { isEnabled() }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
@@ -10,11 +10,11 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
  * The InventoryDetector tracks whether an inventory is open and provides
  * an inventory open consumer and a isInside function to handle inventory check logic.
  *
- * @property onInventoryOpen A callback triggered when the given inventory is detected to be open. Optional.
+ * @property openInventory A callback triggered when the given inventory is detected to be open. Contains the name of the inventory. Optional.
  * @property checkInventoryName Define what inventory name or names we are looking for.
  */
 class InventoryDetector(
-    val onInventoryOpen: () -> Unit = {},
+    val openInventory: (String) -> Unit = {},
     val checkInventoryName: (String) -> Boolean,
 ) {
 
@@ -54,7 +54,7 @@ class InventoryDetector(
 
         if (inInventory) {
             try {
-                onInventoryOpen()
+                openInventory(inventoryName)
             } catch (e: Exception) {
                 ErrorManager.logErrorWithData(e, "Failed to run inventory open in InventoryDetector")
             }


### PR DESCRIPTION
## What
Fixed Experimentation Table profit tracker being gray while in superpair inventory. the same fix as of in https://github.com/hannibal002/SkyHanni/pull/3327

## Changelog Fixes
+ Fixed Experimentation Table profit tracker being gray while in superpair inventory. - hannibal2