### PR TITLE
Feature: Option to disable Skyhanni chat prefix

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -174,6 +174,5 @@ class ChatConfig {
             "§cWarning: It's not recommended to enable this unless you know what you're doing!"
     )
     @ConfigEditorBoolean
-    @FeatureToggle
     var removeChatPrefix: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -170,7 +170,7 @@ class ChatConfig {
     @Expose
     @ConfigOption(
         name = "Remove [Skyhanni] Chat Prefix",
-        desc = "Removes the [Skyhanni] prefix before messages sent from the mod."
+        desc = "Remove the [Skyhanni] prefix before messages sent from the mod."
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -170,7 +170,8 @@ class ChatConfig {
     @Expose
     @ConfigOption(
         name = "Remove [Skyhanni] Chat Prefix",
-        desc = "Remove the [Skyhanni] prefix before messages sent by the mod."
+        desc = "Remove the [Skyhanni] prefix before messages sent by the mod.\n" +
+            "§cWarning: It's not recommended to enable this unless you know what you're doing!"
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -166,4 +166,13 @@ class ChatConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var shortenCoinAmounts: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Remove [Skyhanni] Chat Prefix",
+        desc = "Removes the [Skyhanni] prefix before messages sent from the mod."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var removeChatPrefix: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -170,7 +170,7 @@ class ChatConfig {
     @Expose
     @ConfigOption(
         name = "Remove [Skyhanni] Chat Prefix",
-        desc = "Remove the [Skyhanni] prefix before messages sent from the mod."
+        desc = "Remove the [Skyhanni] prefix before messages sent by the mod."
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -36,7 +36,7 @@ object ChatUtils {
 
     private const val DEBUG_PREFIX = "[SkyHanni Debug] §7"
     private const val USER_ERROR_PREFIX = "§c[SkyHanni] "
-    private const val CHAT_PREFIX = "[SkyHanni] "
+    private val CHAT_PREFIX = if (config.removeChatPrefix) "" else "[SkyHanni] "
 
     /**
      * Sends a debug message to the chat and the console.
@@ -87,7 +87,7 @@ object ChatUtils {
         onlySendOnce: Boolean = false,
     ) {
 
-        if (prefix && !config.removeChatPrefix) {
+        if (prefix) {
             internalChat(prefixColor + CHAT_PREFIX + message, replaceSameMessage, onlySendOnce)
         } else {
             internalChat(message, replaceSameMessage, onlySendOnce)
@@ -159,7 +159,7 @@ object ChatUtils {
         oneTimeClick: Boolean = false,
         replaceSameMessage: Boolean = false,
     ) {
-        val msgPrefix = if (prefix && !config.removeChatPrefix) prefixColor + CHAT_PREFIX else ""
+        val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
 
         val rawText = msgPrefix + message
         val text = Text.text(rawText) {
@@ -201,7 +201,7 @@ object ChatUtils {
         prefix: Boolean = true,
         prefixColor: String = "§e",
     ) {
-        val msgPrefix = if (prefix && !config.removeChatPrefix) prefixColor + CHAT_PREFIX else ""
+        val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
 
         chat(
             Text.text(msgPrefix + message) {
@@ -232,7 +232,7 @@ object ChatUtils {
         prefix: Boolean = true,
         prefixColor: String = "§e",
     ) {
-        val msgPrefix = if (prefix && !config.removeChatPrefix) prefixColor + CHAT_PREFIX else ""
+        val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
         chat(
             Text.text(msgPrefix + message) {
                 this.url = url
@@ -255,7 +255,7 @@ object ChatUtils {
         prefix: Boolean = true,
         prefixColor: String = "§e",
     ) {
-        val msgPrefix = if (prefix && !config.removeChatPrefix) prefixColor + CHAT_PREFIX else ""
+        val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
         chat(Text.join(components).prefix(msgPrefix))
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
@@ -27,6 +28,7 @@ import kotlin.time.times
 
 @SkyHanniModule
 object ChatUtils {
+    private val config get() = SkyHanniMod.feature.chat
 
     // TODO log based on chat category (error, warning, debug, user error, normal)
     private val log = LorenzLogger("chat/mod_sent")
@@ -85,7 +87,7 @@ object ChatUtils {
         onlySendOnce: Boolean = false,
     ) {
 
-        if (prefix) {
+        if (prefix && !config.removeChatPrefix) {
             internalChat(prefixColor + CHAT_PREFIX + message, replaceSameMessage, onlySendOnce)
         } else {
             internalChat(message, replaceSameMessage, onlySendOnce)

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -159,7 +159,7 @@ object ChatUtils {
         oneTimeClick: Boolean = false,
         replaceSameMessage: Boolean = false,
     ) {
-        val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
+        val msgPrefix = if (prefix && !config.removeChatPrefix) prefixColor + CHAT_PREFIX else ""
 
         val rawText = msgPrefix + message
         val text = Text.text(rawText) {
@@ -201,7 +201,7 @@ object ChatUtils {
         prefix: Boolean = true,
         prefixColor: String = "§e",
     ) {
-        val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
+        val msgPrefix = if (prefix && !config.removeChatPrefix) prefixColor + CHAT_PREFIX else ""
 
         chat(
             Text.text(msgPrefix + message) {
@@ -232,7 +232,7 @@ object ChatUtils {
         prefix: Boolean = true,
         prefixColor: String = "§e",
     ) {
-        val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
+        val msgPrefix = if (prefix && !config.removeChatPrefix) prefixColor + CHAT_PREFIX else ""
         chat(
             Text.text(msgPrefix + message) {
                 this.url = url
@@ -255,7 +255,7 @@ object ChatUtils {
         prefix: Boolean = true,
         prefixColor: String = "§e",
     ) {
-        val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
+        val msgPrefix = if (prefix && !config.removeChatPrefix) prefixColor + CHAT_PREFIX else ""
         chat(Text.join(components).prefix(msgPrefix))
     }
 


### PR DESCRIPTION
## What
Add an option to config to remove the [Skyhanni] chat prefix, as I find it annoying on some messages. Option defaulted to off, has a large red warning, and is buried at the bottom of a config menu, so people probably won't unintentionally enable it. 

## Changelog New Features
+ Added option to disable the [Skyhanni] chat prefix. - Chissl


