### PR TITLE
Improvement: Hide Trophy Fish if higher tier caught

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfishing/TrophyFishDisplayConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfishing/TrophyFishDisplayConfig.java
@@ -172,9 +172,17 @@ public class TrophyFishDisplayConfig {
     public Property<Boolean> showCheckmark = Property.of(false);
 
     @Expose
-    @ConfigOption(name = "Only Show Missing", desc = "Only show Trophy Fishes that are still missing at this rarity.")
+    @ConfigOption(name = "Only Show Missing", desc = "Only show Trophy Fish that are still missing at this tier.")
     @ConfigEditorDropdown
     public Property<HideCaught> onlyShowMissing = Property.of(HideCaught.NONE);
+
+    @Expose
+    @ConfigOption(
+        name = "Show If Caught Higher Tier",
+        desc = "Show Trophy Fish missing at the chosen tier even if a higher tier has already been caught."
+    )
+    @ConfigEditorBoolean
+    public Property<Boolean> showCaughtHigher = Property.of(false);
 
     public enum HideCaught {
         NONE("Show All"),

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
@@ -86,6 +86,7 @@ object TrophyFishDisplay {
                 showCross,
                 showCheckmark,
                 onlyShowMissing,
+                showCaughtHigher,
             ) {
                 update()
             }
@@ -132,8 +133,8 @@ object TrophyFishDisplay {
         table: MutableList<List<Renderable>>,
     ) {
         get(config.onlyShowMissing.get())?.let { atLeast ->
-            val list = TrophyRarity.entries.filter { it == atLeast }
-            if (list.all { (data[it] ?: 0) > 0 }) {
+            val list = TrophyRarity.entries.filter { it == atLeast || (!config.showCaughtHigher.get() && it > atLeast) }
+            if (list.any { (data[it] ?: 0) > 0 }) {
                 return
             }
         }


### PR DESCRIPTION
## What
Hides Trophy Fish from the display that you have already caught a higher than desired tier of, since it now counts for Odger and SkyBlock XP as well.

I added an option to show them anyway, the only reason to do that would be for people going for the Gold/Diamond Hunter emblem or SkyBlock Guide completion, which are still bugged to require the specific tier.

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Improvements
+ Added option to hide Trophy Fish caught at a higher tier in Trophy Fish Display by default. - Luna
    * This option can be disabled when aiming for the emblem or SkyBlock Guide completion.

