### PR TITLE
Fix: Dungeon Clean End

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCleanEnd.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCleanEnd.kt
@@ -59,7 +59,7 @@ object DungeonCleanEnd {
         return true
     }
 
-    @HandleEvent(onlyOnSkyblock = true)
+    @HandleEvent
     fun onWorldChange(event: WorldChangeEvent) {
         bossDone = false
         chestsSpawned = false


### PR DESCRIPTION
## What
Fixed the "Clean End" feature hiding mobs even after restarting a run.

## Changelog Fixes
+ Fixed the "Clean End" feature from hiding mobs even after restarting a run. - hannibal2