### PR TITLE
Improvement: SackDisplay Searchables

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SackDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SackDisplay.kt
@@ -29,9 +29,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.SearchTextInput
-import at.hannibal2.skyhanni.utils.renderables.buildSearchBox
 import at.hannibal2.skyhanni.utils.renderables.buildSearchableTable
-import at.hannibal2.skyhanni.utils.renderables.toSearchable
 
 @SkyHanniModule
 object SackDisplay {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SackDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SackDisplay.kt
@@ -28,13 +28,20 @@ import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.renderables.Renderable
-import at.hannibal2.skyhanni.utils.renderables.buildSearchableTable
+import at.hannibal2.skyhanni.utils.renderables.SearchTextInput
+import at.hannibal2.skyhanni.utils.renderables.buildSearchBox
+import at.hannibal2.skyhanni.utils.renderables.toSearchable
 
 @SkyHanniModule
 object SackDisplay {
 
     private var display = emptyList<Renderable>()
     private val config get() = SkyHanniMod.feature.inventory.sackDisplay
+
+    private val MAGMA_FISH = "MAGMA_FISH".toInternalName()
+    private val normalSacksTextInput = SearchTextInput()
+    private val runeSacksTextInput = SearchTextInput()
+    private val gemstoneSacksTextInput = SearchTextInput()
 
     init {
         RenderDisplayHelper(
@@ -63,17 +70,15 @@ object SackDisplay {
         display = drawDisplay(savingSacks)
     }
 
-    private fun drawDisplay(savingSacks: Boolean): List<Renderable> {
-        val list = mutableListOf<Renderable>()
+    private fun drawDisplay(savingSacks: Boolean) = buildList {
         var totalPrice = 0L
-        totalPrice += drawNormalList(savingSacks, list)
-        totalPrice += drawGemstoneDisplay(list)
-        drawRunesDisplay(list)
-        drawOptions(list, totalPrice)
-        return list
+        totalPrice += drawNormalList(savingSacks)
+        totalPrice += drawGemstoneDisplay()
+        drawRunesDisplay()
+        drawOptions(totalPrice)
     }
 
-    private fun drawNormalList(savingSacks: Boolean, list: MutableList<Renderable>): Long {
+    private fun MutableList<Renderable>.drawNormalList(savingSacks: Boolean): Long {
         SackApi.getSacksData(savingSacks)
         val sackItems = SackApi.sackItem.toList()
         if (sackItems.isEmpty()) return 0L
@@ -83,19 +88,19 @@ object SackDisplay {
         var totalMagmaFish = 0L
         val sortedPairs = sort(sackItems)
         val amountShowing = if (config.itemToShow > sortedPairs.size) sortedPairs.size else config.itemToShow
-        list.addString("§7Items in Sacks: §o(Rendering $amountShowing of ${sortedPairs.size} items)")
-        val table = mutableMapOf<List<Renderable>, String?>()
-        for ((itemName, item) in sortedPairs) {
-            val (internalName, colorCode, total, magmaFish) = item
-            val stored = item.stored
-            val price = item.price
-            val slot = item.slot
+        addString("§7Items in Sacks: §o(Rendering $amountShowing of ${sortedPairs.size} items)")
+        val searchables = buildList {
+            for ((itemName, item) in sortedPairs) {
+                val (internalName, colorCode, total, magmaFish) = item
+                val stored = item.stored
+                val price = item.price
+                val slot = item.slot
 
-            totalPrice += price
-            if (rendered >= config.itemToShow) continue
-            if (stored == 0 && !config.showEmpty) continue
-            table[
-                buildList {
+                totalPrice += price
+                if (rendered >= config.itemToShow) continue
+                if (stored == 0 && !config.showEmpty) continue
+
+                val searchable = buildList {
                     addString(" §7- ")
                     addItemStack(internalName)
                     // TODO move replace into itemName
@@ -155,17 +160,18 @@ object SackDisplay {
                                 ),
                             ),
                         )
-                        // TODO add cache
-                        addItemStack("MAGMA_FISH".toInternalName())
+                        addItemStack(MAGMA_FISH)
                     }
                     if (config.showPrice && price != 0L) addAlignedNumber("§6${format(price)}")
-                },
-            ] = itemName
-            rendered++
+                }.toSearchable(itemName)
+                add(searchable)
+                rendered++
+            }
         }
-        list.add(table.buildSearchableTable())
 
-        if (SackApi.isTrophySack) list.addString("§cTotal Magmafish: §6${totalMagmaFish.addSeparators()}")
+        add(searchables.buildSearchBox(normalSacksTextInput))
+
+        if (SackApi.isTrophySack) addString("§cTotal Magmafish: §6${totalMagmaFish.addSeparators()}")
         return totalPrice
     }
 
@@ -186,11 +192,11 @@ object SackDisplay {
         return sortedPairs
     }
 
-    private fun drawOptions(list: MutableList<Renderable>, totalPrice: Long) {
+    private fun MutableList<Renderable>.drawOptions(totalPrice: Long) {
         val name = SortType.entries[config.sortingType.ordinal].longName // todo avoid ordinal
-        list.addString("§7Sorted By: §c$name")
+        addString("§7Sorted By: §c$name")
 
-        list.addSelector<SortType>(
+        addSelector<SortType>(
             " ",
             getName = { type -> type.shortName },
             isCurrent = { it.ordinal == config.sortingType.ordinal }, // todo avoid ordinal
@@ -200,7 +206,7 @@ object SackDisplay {
             },
         )
 
-        list.addButton(
+        addButton(
             prefix = "§7Number format: ",
             getName = NumberFormat.entries[config.numberFormat.ordinal].displayName, // todo avoid ordinal
             onChange = {
@@ -212,7 +218,7 @@ object SackDisplay {
         )
 
         if (config.showPrice) {
-            list.addSelector<ItemPriceSource>(
+            addSelector<ItemPriceSource>(
                 " ",
                 getName = { type -> type.sellName },
                 isCurrent = { it.ordinal == config.priceSource.ordinal }, // todo avoid ordinal
@@ -221,7 +227,7 @@ object SackDisplay {
                     update(false)
                 },
             )
-            list.addButton(
+            addButton(
                 prefix = "§7Price Format: ",
                 getName = PriceFormat.entries[config.priceFormat.ordinal].displayName, // todo avoid ordinal
                 onChange = {
@@ -231,18 +237,17 @@ object SackDisplay {
                     update(false)
                 },
             )
-            list.addString("§eTotal price: §6${format(totalPrice)}")
+            addString("§eTotal price: §6${format(totalPrice)}")
         }
     }
 
-    private fun drawRunesDisplay(list: MutableList<Renderable>) {
+    private fun MutableList<Renderable>.drawRunesDisplay() {
         if (SackApi.runeItem.isEmpty()) return
-        list.addString("§7Runes:")
-        val table = mutableMapOf<List<Renderable>, String?>()
-        for ((name, rune) in sort(SackApi.runeItem.toList())) {
-            val (stack, lv1, lv2, lv3) = rune
-            table[
-                buildList {
+        addString("§7Runes:")
+        val searchables = buildList {
+            for ((name, rune) in sort(SackApi.runeItem.toList())) {
+                val (stack, lv1, lv2, lv3) = rune
+                val searchable = buildList {
                     addString(" §7- ")
                     stack?.let { addItemStack(it) }
                     add(
@@ -255,20 +260,20 @@ object SackDisplay {
                     addAlignedNumber("§e$lv1")
                     addAlignedNumber("§e$lv2")
                     addAlignedNumber("§e$lv3")
-                },
-            ] = name
+                }.toSearchable(name)
+                add(searchable)
+            }
         }
-        list.add(table.buildSearchableTable())
+        add(searchables.buildSearchBox(runeSacksTextInput))
     }
 
-    private fun drawGemstoneDisplay(list: MutableList<Renderable>): Long {
+    private fun MutableList<Renderable>.drawGemstoneDisplay(): Long {
         if (SackApi.gemstoneItem.isEmpty()) return 0L
-        list.addString("§7Gemstones:")
+        addString("§7Gemstones:")
         var totalPrice = 0L
-        val table = mutableMapOf<List<Renderable>, String?>()
-        for ((name, gem) in sort(SackApi.gemstoneItem.toList())) {
-            table[
-                buildList {
+        val searchables = buildList {
+            for ((name, gem) in sort(SackApi.gemstoneItem.toList())) {
+                val searchable = buildList {
                     addString(" §7- ")
                     addItemStack(gem.internalName)
                     add(
@@ -286,11 +291,12 @@ object SackDisplay {
                     val price = gem.priceSum
                     totalPrice += price
                     if (config.showPrice && price != 0L) addAlignedNumber("§7(§6${format(price)}§7)")
-                },
-            ] = name
+                }.toSearchable(name)
+                add(searchable)
+            }
         }
 
-        list.add(table.buildSearchableTable())
+        add(searchables.buildSearchBox(gemstoneSacksTextInput))
         return totalPrice
     }
 
@@ -306,6 +312,7 @@ object SackDisplay {
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
 
+    // TODO: one mod wide enum for sorttype, priceformat, etc instead of one per feature (e.g. ChestValue)
     enum class SortType(val shortName: String, val longName: String) {
         STORED_DESC("Stored D", "Stored Descending"),
         STORED_ASC("Stored A", "Stored Ascending"),

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -14,7 +15,6 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
-import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -249,9 +249,8 @@ object NonGodPotEffectDisplay {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
-        if (!GardenApi.inGarden()) return
         if (!event.isWidget(TabWidget.PESTS)) return
 
         event.lines.firstNotNullOfOrNull {

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Searchable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Searchable.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 class Searchable(val renderable: Renderable, val string: String?)
 
 fun Renderable.toSearchable(searchText: String? = null) = Searchable(this, searchText?.removeColor())
+fun List<Renderable>.toSearchable(searchText: String? = null) = Searchable(Renderable.verticalContainer(this), searchText?.removeColor())
 fun Searchable.toRenderable() = renderable
 fun List<Searchable>.toRenderable() = map { it.toRenderable() }
 fun List<Searchable>.toMap() = associate { it.renderable to it.string }
@@ -39,20 +40,6 @@ fun List<Searchable>.buildSearchableScrollable(
             scrollValue = scrollValue,
             velocity = velocity,
         ),
-        SEARCH_PREFIX,
-        onUpdateSize = {},
-        textInput = textInput,
-        key = key,
-    )
-}
-
-// TODO remove this function entirely, sack display should use a SearchTextInput object per sack name
-@Deprecated("remove this function, instead use a fix SearchTextInput object")
-fun Map<List<Renderable>, String?>.buildSearchableTable(): Renderable {
-    val textInput = SearchTextInput()
-    val key = 0
-    return Renderable.searchBox(
-        Renderable.searchableTable(toMap(), textInput = textInput, key = key + 1),
         SEARCH_PREFIX,
         onUpdateSize = {},
         textInput = textInput,

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Searchable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Searchable.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 class Searchable(val renderable: Renderable, val string: String?)
 
 fun Renderable.toSearchable(searchText: String? = null) = Searchable(this, searchText?.removeColor())
-fun List<Renderable>.toSearchable(searchText: String? = null) = Searchable(Renderable.verticalContainer(this), searchText?.removeColor())
 fun Searchable.toRenderable() = renderable
 fun List<Searchable>.toRenderable() = map { it.toRenderable() }
 fun List<Searchable>.toMap() = associate { it.renderable to it.string }
@@ -40,6 +39,17 @@ fun List<Searchable>.buildSearchableScrollable(
             scrollValue = scrollValue,
             velocity = velocity,
         ),
+        SEARCH_PREFIX,
+        onUpdateSize = {},
+        textInput = textInput,
+        key = key,
+    )
+}
+
+fun Map<List<Renderable>, String?>.buildSearchableTable(textInput: SearchTextInput): Renderable {
+    val key = 0
+    return Renderable.searchBox(
+        Renderable.searchableTable(toMap(), textInput = textInput, key = key + 1),
         SEARCH_PREFIX,
         onUpdateSize = {},
         textInput = textInput,

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -67,7 +67,6 @@
     <ID>NoNameShadowing:ContributorManager.kt$ContributorManager${ it.isAllowed() }</ID>
     <ID>NoNameShadowing:Graph.kt$Graph.Companion${ out.name("Name").value(it) }</ID>
     <ID>NoNameShadowing:Graph.kt$Graph.Companion${ out.name("Tags") out.beginArray() for (tagName in it) { out.value(tagName) } out.endArray() }</ID>
-    <ID>NoNameShadowing:GraphEditorBugFinder.kt$GraphEditorBugFinder${ it.position.distanceSqToPlayer() }</ID>
     <ID>NoNameShadowing:HoppityCollectionStats.kt$HoppityCollectionStats${ val displayAmount = it.amount.shortFormat() val operationFormat = when (milestoneType) { HoppityEggType.CHOCOLATE_SHOP_MILESTONE -&gt; "spending" HoppityEggType.CHOCOLATE_FACTORY_MILESTONE -&gt; "reaching" else -&gt; "" // Never happens } // List indexing is weird existingLore[replaceIndex - 1] = "§7Obtained by $operationFormat §6$displayAmount" existingLore[replaceIndex] = "§7all-time §6Chocolate." return existingLore }</ID>
     <ID>NoNameShadowing:HotmData.kt$HotmData.Companion${ it.setCurrent(it.getTotal()) }</ID>
     <ID>NoNameShadowing:LorenzVec.kt$LorenzVec.Companion$pitch</ID>
@@ -163,7 +162,6 @@
     <ID>RepoPatternRegexTestMissing:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$by patternGroup.pattern( "bingogoalrank", "(?:§.)*You were the (?:§.)*(?&lt;rank&gt;\\w+)(?&lt;ordinal&gt;st|nd|rd|th) (?:§.)*to", )</ID>
     <ID>RepoPatternRegexTestMissing:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$by patternGroup.pattern( "harvest", "§7§7You may harvest §6(?&lt;amount&gt;.).*", )</ID>
     <ID>RepoPatternRegexTestMissing:JacobFarmingContestsInventory.kt$JacobFarmingContestsInventory$by RepoPattern.pattern( "garden.jacob.contests.inventory.medal", "§7§7You placed in the (?&lt;medal&gt;.*) §7bracket!" )</ID>
-    <ID>RepoPatternRegexTestMissing:KloonHacking.kt$KloonHacking$by RepoPattern.pattern( "rift.area.westvillage.kloon.color", "You've set the color of this terminal to (?&lt;color&gt;.*)!" )</ID>
     <ID>RepoPatternRegexTestMissing:KuudraApi.kt$KuudraApi$by patternGroup.pattern( "chat.complete", "§.\\s*(?:§.)*KUUDRA DOWN!", )</ID>
     <ID>RepoPatternRegexTestMissing:MaxPurseItems.kt$MaxPurseItems$by patternGroup.pattern( "instant", ".*Price per unit: §6(?&lt;coins&gt;[\\d.,]+) coins.*", )</ID>
     <ID>RepoPatternRegexTestMissing:MaxPurseItems.kt$MaxPurseItems$by patternGroup.pattern( "order", ".*§6(?&lt;coins&gt;[\\d.,]+) coins §7each.*", )</ID>
@@ -187,7 +185,6 @@
     <ID>RepoPatternRegexTestMissing:MythologicalCreatureTracker.kt$MythologicalCreatureTracker$by patternGroup.pattern( "siameselynxes", ".* §r§eYou dug out §r§2Siamese Lynxes§r§e!", )</ID>
     <ID>RepoPatternRegexTestMissing:NewYearCakeReminder.kt$NewYearCakeReminder$by RepoPattern.pattern( "event.winter.newyearcake.reminder.sidebar", "§dNew Year Event!§f (?&lt;time&gt;.*)", )</ID>
     <ID>RepoPatternRegexTestMissing:NonGodPotEffectDisplay.kt$NonGodPotEffectDisplay$by RepoPattern.pattern( "misc.nongodpot.effects", "§7You have §e(?&lt;name&gt;\\d+) §7non-god effects\\.", )</ID>
-    <ID>RepoPatternRegexTestMissing:NpcVisitorFix.kt$NpcVisitorFix$by RepoPattern.pattern( "garden.barn.skin.change", "§aChanging Barn skin to §r.*" )</ID>
     <ID>RepoPatternRegexTestMissing:PartyApi.kt$PartyApi$by patternGroup.pattern( "kuudrafinder.join", "§dParty Finder §f&gt; (?&lt;name&gt;.*?) §ejoined the group! \\(§[a-fA-F0-9]+Combat Level \\d+§e\\)", )</ID>
     <ID>RepoPatternRegexTestMissing:PestApi.kt$PestApi$by patternGroup.pattern( "inventory", "§4§lൠ §cThis plot has §6(?&lt;amount&gt;\\d) Pests?§c!", )</ID>
     <ID>RepoPatternRegexTestMissing:PestApi.kt$PestApi$by patternGroup.pattern( "scoreboard.pests", " §7⏣ §[ac]The Garden §4§lൠ§7 x(?&lt;pests&gt;.*)", )</ID>
@@ -278,7 +275,6 @@
     <ID>SpreadOperator:LimboPlaytime.kt$LimboPlaytime$( itemID.getItemStack().item, ITEM_NAME, *createItemLore() )</ID>
     <ID>SpreadOperator:Text.kt$Text$(*component.toTypedArray(), separator = separator)</ID>
     <ID>TooManyFunctions:CollectionUtils.kt$CollectionUtils</ID>
-    <ID>TooManyFunctions:DailyQuestHelper.kt$DailyQuestHelper</ID>
     <ID>TooManyFunctions:EstimatedItemValueCalculator.kt$EstimatedItemValueCalculator</ID>
     <ID>TooManyFunctions:HypixelCommands.kt$HypixelCommands</ID>
     <ID>TooManyFunctions:InventoryUtils.kt$InventoryUtils</ID>
@@ -349,7 +345,6 @@
     <ID>UnsafeCallOnNullableType:MobFinder.kt$MobFinder$floor6GiantsSeparateDelay[uuid]!!</ID>
     <ID>UnsafeCallOnNullableType:NavigationHelper.kt$NavigationHelper$distances[node]!!</ID>
     <ID>UnsafeCallOnNullableType:NumberUtil.kt$NumberUtil$romanSymbols[this]!!</ID>
-    <ID>UnsafeCallOnNullableType:PositionList.kt$PositionList$configLink!!</ID>
     <ID>UnsafeCallOnNullableType:ReminderManager.kt$ReminderManager$storage[args.drop(1).first()]!!</ID>
     <ID>UnsafeCallOnNullableType:ReminderManager.kt$ReminderManager$storage[args.first()]!!</ID>
     <ID>UnsafeCallOnNullableType:RenderEntityOutlineEvent.kt$RenderEntityOutlineEvent$entitiesToChooseFrom!!</ID>


### PR DESCRIPTION
## What
Remove deprecation from buildSearchTable (we really need it or else it wont be a table), it cant use the Searchable class unless we use List<Renderables> instead of just Renderable.
We do now have sack specific searchables though!

## Changelog Improvements
+ Made searches in Sack display GUIs sack-specific. - j10a1n15
