### PR TITLE
Fix: Experimentation Tracker Issues

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
@@ -34,7 +34,7 @@ object ExperimentationTableApi {
                 Experiment.entries.find { it.nameString == group("experiment") }
             }
         },
-    ) { name -> superpairsPattern.matches(name) }
+    ) { name -> inventoriesPattern.matches(name) }
 
     // <editor-fold desc="Patterns">
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
@@ -4,13 +4,13 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.PetApi
 import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils.openInventoryName
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -23,22 +23,20 @@ import net.minecraft.entity.item.EntityArmorStand
 object ExperimentationTableApi {
 
     private val storage get() = ProfileStorageData.profileSpecific?.experimentation
+    private val patternGroup = RepoPattern.group("enchanting.experiments")
 
-    val inTable get() = inventoriesPattern.matches(openInventoryName())
-
-    var openExperiment: Experiment? = null
-
+    private val EXPERIMENTATION_TABLE_SKULL by lazy { SkullTextureHolder.getTexture("EXPERIMENTATION_TABLE") }
+    private val inTable get() = inventoriesPattern.matches(openInventoryName())
+    var currentExperiment: Experiment? = null
     val superpairInventory = InventoryDetector(
         openInventory = { name ->
-            openExperiment = superpairsPattern.matchMatcher(name) {
+            currentExperiment = superpairsPattern.matchMatcher(name) {
                 Experiment.entries.find { it.nameString == group("experiment") }
             }
         },
     ) { name -> superpairsPattern.matches(name) }
 
-    private val EXPERIMENTATION_TABLE_SKULL by lazy { SkullTextureHolder.getTexture("EXPERIMENTATION_TABLE") }
-    private val patternGroup = RepoPattern.group("enchanting.experiments")
-
+    // <editor-fold desc="Patterns">
     /**
      * REGEX-TEST: Superpairs (Metaphysical)
      */
@@ -163,24 +161,28 @@ object ExperimentationTableApi {
         "guardianpet",
         "§[956d]Guardian.*",
     )
-
-    @Deprecated("outdated", ReplaceWith("this.openExperiment"))
-    fun getCurrentExperiment(): Experiment? = openExperiment
-
-    @HandleEvent
-    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
-        if (LorenzUtils.skyBlockIsland != IslandType.PRIVATE_ISLAND || !inTable) return
-
-        val entity = EntityUtils.getEntities<EntityArmorStand>().find {
-            it.wearingSkullTexture(EXPERIMENTATION_TABLE_SKULL)
-        } ?: return
-        val vec = entity.getLorenzVec()
-        if (storage?.tablePos != vec) storage?.tablePos = vec
-    }
+    // </editor-fold>
 
     fun inDistanceToTable(max: Double): Boolean {
         val vec = LorenzVec.getBlockBelowPlayer()
         return storage?.tablePos?.let { it.distance(vec) <= max } ?: false
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
+    fun onInventoryClosed(event: InventoryCloseEvent) {
+        currentExperiment = null
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
+    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+        if (!inTable) {
+            currentExperiment = null
+            return
+        }
+
+        storage?.tablePos = EntityUtils.getEntities<EntityArmorStand>().find {
+            it.wearingSkullTexture(EXPERIMENTATION_TABLE_SKULL)
+        }?.getLorenzVec().takeIf { it != storage?.tablePos } ?: return
     }
 
     fun hasGuardianPet(): Boolean = petNamePattern.matches(PetApi.currentPet)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
@@ -50,7 +50,7 @@ object ExperimentsDryStreakDisplay {
 
     @HandleEvent
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
-        if (!isEnabled() || didJustFind || ExperimentationTableApi.getCurrentExperiment() == null) return
+        if (!isEnabled() || didJustFind || ExperimentationTableApi.currentExperiment == null) return
 
         for (lore in event.inventoryItems.map { it.value.getLore() }) {
             val firstLine = lore.firstOrNull() ?: continue
@@ -72,7 +72,7 @@ object ExperimentsDryStreakDisplay {
 
     @HandleEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
-        if (didJustFind || ExperimentationTableApi.getCurrentExperiment() == null) return
+        if (didJustFind || ExperimentationTableApi.currentExperiment == null) return
 
         val storage = storage ?: return
         storage.attemptsSince += 1

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -216,7 +216,7 @@ object ExperimentsProfitTracker {
     fun onInventoryClose(event: InventoryCloseEvent) {
         if (!isEnabled()) return
 
-        if (ExperimentationTableApi.getCurrentExperiment() != null) {
+        if (ExperimentationTableApi.currentExperiment != null) {
             tracker.modify {
                 it.experimentsDone++
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/SuperpairDataDisplay.kt
@@ -61,7 +61,7 @@ object SuperpairDataDisplay {
             // Render here so they can move it around.
             config.superpairDisplayPosition.renderString("§6Superpair Experimentation Data", posLabel = "Superpair Experimentation Data")
         }
-        if (ExperimentationTableApi.getCurrentExperiment() == null) return
+        if (ExperimentationTableApi.currentExperiment == null) return
 
         if (display.isEmpty()) display = drawDisplay()
 
@@ -71,9 +71,9 @@ object SuperpairDataDisplay {
     @HandleEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled()) return
-        if (ExperimentationTableApi.getCurrentExperiment() == null) return
+        if (ExperimentationTableApi.currentExperiment == null) return
 
-        val currentExperiment = ExperimentationTableApi.getCurrentExperiment() ?: return
+        val currentExperiment = ExperimentationTableApi.currentExperiment ?: return
 
         val item = event.item ?: return
         if (isOutOfBounds(event.slotId, currentExperiment) || item.displayName.removeColor() == "?") return
@@ -219,7 +219,7 @@ object SuperpairDataDisplay {
     }
 
     private fun drawDisplay() = buildList {
-        val currentExperiment = ExperimentationTableApi.getCurrentExperiment() ?: return emptyList<String>()
+        val currentExperiment = ExperimentationTableApi.currentExperiment ?: return emptyList<String>()
 
         add("§6Superpair Experimentation Data")
         add("")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/UltraRareBookAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/UltraRareBookAlert.kt
@@ -90,5 +90,5 @@ object UltraRareBookAlert {
     }
 
     private fun isEnabled() =
-        LorenzUtils.inSkyBlock && config.ultraRareBookAlert && ExperimentationTableApi.getCurrentExperiment() != null
+        LorenzUtils.inSkyBlock && config.ultraRareBookAlert && ExperimentationTableApi.currentExperiment != null
 }


### PR DESCRIPTION
## What
#3329 caused some rather major bugs with the Experimentation Tracker, this fixes:
- Profit tracker incrementing every time you close an inventory on your private island
- If you go near your table, you will get a display in every gui on your private island until you leave
- Issues with the tracker _still_ not being highlighted correctly

https://discord.com/channels/997079228510117908/1334125281497055304
https://discord.com/channels/997079228510117908/1334225962958848081

## Changelog Fixes
+ Fixed various issues with Experimentation Tracker. - Daveed
