### PR TITLE
Feature: Highlight Century Daily Tasks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/AnniversaryCelebration400Config.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/AnniversaryCelebration400Config.kt
@@ -1,0 +1,18 @@
+package at.hannibal2.skyhanni.config.features.event
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class AnniversaryCelebration400Config {
+
+    @ConfigOption(
+        name = "Daily Highlight",
+        desc = "Highlights incomplete daily tasks.",
+    )
+    @Expose
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var highlightDailyTasks: Boolean = true
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.java
@@ -54,6 +54,11 @@ public class EventConfig {
     @Expose
     public CenturyConfig century = new CenturyConfig();
 
+    @ConfigOption(name = "400þ Anniversary Celebration", desc = "Features for the 400þ year of SkyBlock")
+    @Accordion
+    @Expose
+    public AnniversaryCelebration400Config anniversaryCelebration400 = new AnniversaryCelebration400Config();
+
     @Category(name = "Lobby Waypoints", desc = "Lobby Event Waypoint settings")
     @Expose
     public LobbyWaypointsConfig lobbyWaypoints = new LobbyWaypointsConfig();

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
@@ -260,6 +260,12 @@ class SkyblockGuideHighlightFeature private constructor(
                 "\\w+ Collections|Collections",
                 "§7Progress to .*|§7Find this item to add it to your|§7Kill this boss once to view collection|§7(?:Boss )?Collections (?:Unlocked|Maxed Out): §e.*",
             )
+            SkyblockGuideHighlightFeature(
+                { SkyHanniMod.feature.event.anniversaryCelebration400.highlightDailyTasks },
+                "century",
+                "Daily Tasks",
+                "§c§lINCOMPLETE",
+            )
         }
     }
 }


### PR DESCRIPTION
## What
Highlights the incomplete tasks in red. Simply reused the SkyblockGuideHighlightFeature. Since it was designed to handle any generic highlight (in red only xD). Maybe the class should be renamed to something better later on, but for now this works.
(Also I copied #3354 century config)

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/51d0cea8-a058-4edc-b9f2-bcdd339c8639)

</details>

## Changelog New Features
+ Added Century Daily Task Highlight. - Thunderbalde73
