### PR TITLE
Backend: Dispatcher.Minecraft for Coroutines

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/MinecraftDispatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MinecraftDispatcher.kt
@@ -4,16 +4,76 @@ import kotlinx.coroutines.MainCoroutineDispatcher
 import net.minecraft.client.Minecraft
 import kotlin.coroutines.CoroutineContext
 
-object MinecraftDispatcher : MainCoroutineDispatcher() {
+import kotlinx.coroutines.*
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.internal.*
+import kotlin.time.Duration.Companion.milliseconds
 
-    override val immediate: MainCoroutineDispatcher
-        get() = this
+@Suppress("unused")
+public val Dispatchers.Minecraft : MinecraftDispatcher
+    get() = at.hannibal2.skyhanni.utils.Minecraft
 
-    override fun isDispatchNeeded(context: CoroutineContext): Boolean {
-        return !Minecraft.getMinecraft().isCallingFromMinecraftThread
-    }
-
+@OptIn(InternalCoroutinesApi::class)
+public sealed class MinecraftDispatcher : MainCoroutineDispatcher(), Delay {
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         Minecraft.getMinecraft().addScheduledTask(block)
     }
+
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        val cancellableRun = schedule(timeMillis) {
+            with(continuation) { resumeUndispatched(Unit) }
+        }
+        continuation.invokeOnCancellation { cancellableRun.cancel() }
+    }
+
+    override fun invokeOnTimeout(timeMillis: Long, block: Runnable, context: CoroutineContext): DisposableHandle {
+        val cancellableRun = schedule(timeMillis) {
+            block.run()
+        }
+        return DisposableHandle { cancellableRun.cancel() }
+    }
+
+    private fun schedule(timeMillis: Long, action: () -> Unit): CancellableRun {
+        val run = CancellableRun(action);
+        DelayedRun.runDelayed(timeMillis.milliseconds, run);
+        return run;
+    }
+
+    class CancellableRun(val run: () -> Unit, @Transient var isCancelled: Boolean = false): () -> Unit {
+        override fun invoke() {
+            if (isCancelled) return
+            this.run();
+        }
+
+        fun cancel() {
+            isCancelled = true
+        }
+    }
 }
+
+@OptIn(InternalCoroutinesApi::class)
+internal class MinecraftDispatcherFactory : MainDispatcherFactory {
+    override val loadPriority: Int
+        get() = 0
+
+    override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher = Minecraft
+}
+
+private object ImmediateMinecraftDispatcher : MinecraftDispatcher() {
+    override val immediate: MainCoroutineDispatcher
+        get() = this
+
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean = !Minecraft.getMinecraft().isCallingFromMinecraftThread
+
+    @OptIn(InternalCoroutinesApi::class)
+    override fun toString() = toStringInternalImpl() ?: "Minecraft.immediate"
+}
+
+internal object Minecraft : MinecraftDispatcher() {
+    override val immediate: MainCoroutineDispatcher
+        get() = ImmediateMinecraftDispatcher
+
+    @OptIn(InternalCoroutinesApi::class)
+    override fun toString() = toStringInternalImpl() ?: "Minecraft"
+}
+

--- a/src/main/java/at/hannibal2/skyhanni/utils/MinecraftDispatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MinecraftDispatcher.kt
@@ -1,16 +1,19 @@
 package at.hannibal2.skyhanni.utils
 
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Delay
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.MainCoroutineDispatcher
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.internal.MainDispatcherFactory
 import net.minecraft.client.Minecraft
 import kotlin.coroutines.CoroutineContext
-
-import kotlinx.coroutines.*
-import kotlinx.coroutines.Runnable
-import kotlinx.coroutines.internal.*
 import kotlin.time.Duration.Companion.milliseconds
 
 @Suppress("unused")
-public val Dispatchers.Minecraft : MinecraftDispatcher
+public val Dispatchers.Minecraft: MinecraftDispatcher
     get() = at.hannibal2.skyhanni.utils.Minecraft
 
 @OptIn(InternalCoroutinesApi::class)
@@ -34,15 +37,15 @@ public sealed class MinecraftDispatcher : MainCoroutineDispatcher(), Delay {
     }
 
     private fun schedule(timeMillis: Long, action: () -> Unit): CancellableRun {
-        val run = CancellableRun(action);
-        DelayedRun.runDelayed(timeMillis.milliseconds, run);
-        return run;
+        val run = CancellableRun(action)
+        DelayedRun.runDelayed(timeMillis.milliseconds, run)
+        return run
     }
 
-    class CancellableRun(val run: () -> Unit, @Transient var isCancelled: Boolean = false): () -> Unit {
+    class CancellableRun(val run: () -> Unit, @Transient var isCancelled: Boolean = false) : () -> Unit {
         override fun invoke() {
             if (isCancelled) return
-            this.run();
+            this.run()
         }
 
         fun cancel() {

--- a/src/main/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
+++ b/src/main/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
@@ -1,1 +1,0 @@
-at.hannibal2.skyhanni.utils.MinecraftDispatcherFactory

--- a/src/main/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
+++ b/src/main/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
@@ -1,0 +1,1 @@
+at.hannibal2.skyhanni.utils.MinecraftDispatcherFactory


### PR DESCRIPTION
## What
Properly Implement Dispatchers.Minecraft and Dispatchers.Minecraft.immediate (MainCoroutineDispatcher) with delay support.

This implementation is based on implementation for [kotlin-coroutines-swing](https://github.com/Kotlin/kotlinx.coroutines/blob/master/ui/kotlinx-coroutines-swing/src/SwingDispatcher.kt)

This enables things like
```kotlin
suspend fun doAthenwaitanddoB() {
  withContext(Dispatchers.Minecraft.immediate) {
    doStuffThatAbsolutelyNeedsToRunOnMinecraftThread()
    delay(1000)
    doOtherStuffThatAbsolutelyNeedsToRunOnMinecraftThread()
  }
}
```
without blocking main thread

## Changelog Technical Details
+ Added Dispatchers.Minecraft and Dispatchers.Minecraft.immediate for coroutines.  - syeyoung
