### PR TITLE
Fix: Motes per Session when leaving Hypixel

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -12,10 +12,12 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.hypixel.HypixelLeaveEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
+import at.hannibal2.skyhanni.events.skyblock.SkyBlockLeaveEvent
 import at.hannibal2.skyhanni.features.bingo.BingoApi
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.rift.RiftApi
@@ -416,13 +418,23 @@ object HypixelData {
             checkProfileName()
         }
 
-        if (!LorenzUtils.onHypixel) {
-            checkHypixel()
-            if (LorenzUtils.onHypixel) {
+        val wasOnHypixel = LorenzUtils.onHypixel
+        checkHypixel()
+        val nowOnHypixel = LorenzUtils.onHypixel
+        when {
+            !wasOnHypixel && nowOnHypixel -> {
                 HypixelJoinEvent.post()
                 RepoManager.displayRepoStatus(true)
             }
+            wasOnHypixel && !nowOnHypixel -> {
+                if (skyBlock) {
+                    skyBlock = false
+                    SkyBlockLeaveEvent.post()
+                }
+                HypixelLeaveEvent.post()
+            }
         }
+
         if (!LorenzUtils.onHypixel) return
 
         if (!event.isMod(5)) return
@@ -431,6 +443,10 @@ object HypixelData {
         if (inSkyBlock) {
             checkSidebar()
             checkCurrentServerId()
+        } else {
+            if (!skyBlock) {
+                SkyBlockLeaveEvent.post()
+            }
         }
 
         if (inSkyBlock == skyBlock) return
@@ -442,6 +458,13 @@ object HypixelData {
         if (LorenzUtils.onHypixel && locrawData == null && lastLocRaw.passedSince() > 15.seconds) {
             lastLocRaw = SimpleTimeMark.now()
             HypixelCommands.locraw()
+        }
+    }
+
+    @HandleEvent
+    fun onSkyBlockLeave(event: SkyBlockLeaveEvent) {
+        if (skyBlockIsland != IslandType.NONE) {
+            IslandChangeEvent(IslandType.NONE, skyBlockIsland)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/events/hypixel/HypixelLeaveEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/hypixel/HypixelLeaveEvent.kt
@@ -1,0 +1,5 @@
+package at.hannibal2.skyhanni.events.hypixel
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+object HypixelLeaveEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/skyblock/SkyBlockLeaveEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/skyblock/SkyBlockLeaveEvent.kt
@@ -1,0 +1,5 @@
+package at.hannibal2.skyhanni.events.skyblock
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+object SkyBlockLeaveEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/utils/DelayedRun.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DelayedRun.kt
@@ -14,13 +14,13 @@ object DelayedRun {
 
     fun runDelayed(duration: Duration, run: () -> Unit): SimpleTimeMark {
         val time = SimpleTimeMark.now() + duration
-        futureTasks.add(Pair(run, time))
+        futureTasks.add(run to time)
         return time
     }
 
     /** Runs in the next full Tick so the delay is between 50ms to 100ms**/
     fun runNextTick(run: () -> Unit) {
-        futureTasks.add(Pair(run, SimpleTimeMark.farPast()))
+        futureTasks.add(run to SimpleTimeMark.farPast())
     }
 
     fun checkRuns() {


### PR DESCRIPTION
## What
sending island change events when leaving hypixel/skyblock.
Related bug report: https://discord.com/channels/997079228510117908/1336742301162147840

## Changelog Fixes
+ Fixed Motes per Session when leaving Hypixel. - hannibal2

## Changelog Technical Details
+ Added `HypixelLeaveEvent` and `SkyBlockLeaveEvent`. - hannibal2