### PR TITLE
Fix: Damage Indicator Ender Dragon

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/DragonFightAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/DragonFightAPI.kt
@@ -36,7 +36,7 @@ object DragonFightAPI {
     )
 
     /**
-     * REGEX-TEST: Dragon HP: §a4,824,217 §c❤
+     * REGEX-TEST: Dragon HP: 4,824,217 ❤
      */
     private val scoreboardHPPattern by group.pattern(
         "scoreboard.hp",
@@ -44,7 +44,7 @@ object DragonFightAPI {
     )
 
     /**
-     * REGEX-TEST: Your Damage: §c0
+     * REGEX-TEST: Your Damage: 0
      */
     private val scoreboardYourDamagePattern by group.pattern(
         "scoreboard.your-damage",

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/DragonFightAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/DragonFightAPI.kt
@@ -1,0 +1,86 @@
+package at.hannibal2.skyhanni.features.combat
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
+import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
+import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object DragonFightAPI {
+
+    var currentType: String? = null
+    var currentHp: Int? = null
+    var yourDamage: Int? = null
+
+    private val group = RepoPattern.group("combat.end-dragon-fight")
+
+    /**
+     * REGEX-TEST: ☬ The Wise Dragon has spawned!
+     */
+    private val chatSpawnPattern by group.pattern(
+        "chat.spawn",
+        "☬ The (?<type>.*) Dragon has spawned!",
+    )
+
+    /**
+     * REGEX-TEST:                           YOUNG DRAGON DOWN!
+     */
+    private val chatDeath by group.pattern(
+        "chat.death",
+        ".*DRAGON DOWN!",
+    )
+
+    /**
+     * REGEX-TEST: Dragon HP: §a4,824,217 §c❤
+     */
+    private val scoreboardHPPattern by group.pattern(
+        "scoreboard.hp",
+        "Dragon HP: (?<hp>.*) ❤",
+    )
+
+    /**
+     * REGEX-TEST: Your Damage: §c0
+     */
+    private val scoreboardYourDamagePattern by group.pattern(
+        "scoreboard.your-damage",
+        "Your Damage: (?<damage>.*)",
+    )
+
+    @HandleEvent
+    fun onChat(event: SystemMessageEvent) {
+        chatSpawnPattern.matchMatcher(event.message.removeColor()) {
+            currentType = group("type")
+        }
+        chatDeath.matchMatcher(event.message.removeColor()) {
+            reset()
+        }
+    }
+
+    fun reset() {
+        currentType = null
+        currentHp = null
+        yourDamage = null
+    }
+
+    @HandleEvent
+    fun onWorldChange(event: WorldChangeEvent) {
+        reset()
+    }
+
+    @HandleEvent
+    fun onScoreboardChange(event: ScoreboardUpdateEvent) {
+        for (line in event.full.map { it.removeColor() }) {
+            scoreboardHPPattern.matchMatcher(line) {
+                currentHp = group("hp").formatInt()
+            }
+            scoreboardYourDamagePattern.matchMatcher(line) {
+                yourDamage = group("damage").formatInt()
+            }
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/BossType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/BossType.kt
@@ -21,7 +21,7 @@ enum class BossType(
     NETHER_VANQUISHER("§5Vanquisher", Type.VANQUISHER),
 
     END_ENDSTONE_PROTECTOR("§cEndstone Protector", Type.ENDERSTONE_PROTECTOR),
-    END_ENDER_DRAGON("Ender Dragon", Type.ENDER_DRAGON), // TODO fix totally
+    END_ENDER_DRAGON("Dragon", Type.ENDER_DRAGON),
 
     SLAYER_ZOMBIE_1("§aRevenant Horror 1", Type.REVENANT_HORROR, "§aRev 1", showDeathTime = true),
     SLAYER_ZOMBIE_2("§eRevenant Horror 2", Type.REVENANT_HORROR, "§eRev 2", showDeathTime = true),

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -494,7 +494,7 @@ object DamageIndicatorManager {
         }
         return DragonFightAPI.currentHp?.let {
             "§c" + it.shortFormat()
-        } ?: ""
+        }.orEmpty()
     }
 
     private fun checkBacte(entityData: EntityData): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import at.hannibal2.skyhanni.features.combat.DragonFightAPI
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.rift.area.colosseum.BacteApi
 import at.hannibal2.skyhanni.features.rift.area.colosseum.BacteApi.currentPhase
@@ -477,9 +478,23 @@ object DamageIndicatorManager {
                 return checkBacte(entityData)
             }
 
+            BossType.END_ENDER_DRAGON,
+            -> {
+                return checkEnderDragon(entityData)
+            }
+
             else -> return ""
         }
         return ""
+    }
+
+    private fun checkEnderDragon(entityData: EntityData): String {
+        DragonFightAPI.currentType?.let {
+            entityData.namePrefix = "§c§l$it "
+        }
+        return DragonFightAPI.currentHp?.let {
+            "§c" + it.shortFormat()
+        } ?: ""
     }
 
     private fun checkBacte(entityData: EntityData): String {


### PR DESCRIPTION
## What
Added DragonFightAPI for detecting current ender dragon type and hp

<details>
<summary>Images</summary>

![grafik](https://github.com/user-attachments/assets/1fb8f517-3891-4b62-a5b2-ffedad38462a)

</details>

## Changelog Fixes
+ Fixed Damage Indicator not showing HP and type during Ender Dragon fights. - hannibal2