### PR TITLE
Backend: Fix IDE error in newer IntelliJ versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,8 @@
-import at.skyhanni.sharedvariables.*
+import at.skyhanni.sharedvariables.MinecraftVersion
+import at.skyhanni.sharedvariables.MultiVersionStage
+import at.skyhanni.sharedvariables.ProjectTarget
+import at.skyhanni.sharedvariables.SHVersionInfo
+import at.skyhanni.sharedvariables.versionString
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import moe.nea.shot.ShotParser
@@ -162,7 +166,7 @@ dependencies {
 
     headlessLwjgl(libs.headlessLwjgl)
 
-    compileOnly(ksp(project(":annotation-processors"))!!)
+    ksp(project(":annotation-processors"))?.let { compileOnly(it) }
 
     val mixinVersion = if (target.minecraftVersion >= MinecraftVersion.MC11200) "0.8.2" else "0.7.11-SNAPSHOT"
 
@@ -219,7 +223,6 @@ dependencies {
         compileOnly(libs.hypixelmodapi)
         shadowImpl(libs.hypixelmodapitweaker)
     }
-
 
     // getting clock offset
     shadowImpl("commons-net:commons-net:3.11.1")


### PR DESCRIPTION
## What
Fixed the ide error that happens in newer Intellji versions. For some reason it can't parse the one line with !! anymore in newer versions. I added a ?.let wrap to fix that. But idk if it has any side effects @CalMWolfs 

<details>
<summary>Error Message</summary>

```
java.lang.AssertionError: Failed to create expression from text: '"annotation-processors"))"', resulting expression's text was: '"annotation-processors"'
	at org.jetbrains.kotlin.psi.KtPsiFactory.createExpression(KtPsiFactory.kt:102)
	at com.android.tools.idea.gradle.dsl.kotlin.KotlinDslUtilKt.createLiteral(KotlinDslUtil.kt:432)
	at com.android.tools.idea.gradle.dsl.kotlin.KotlinDslParser.convertToPsiElement(KotlinDslParser.kt:110)
	at com.android.tools.idea.gradle.dsl.parser.elements.FakeElement.lambda$createPsiElement$0(FakeElement.java:70)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction$lambda$4(AnyThreadWriteThreadingSupport.kt:260)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction(AnyThreadWriteThreadingSupport.kt:272)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction(AnyThreadWriteThreadingSupport.kt:260)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:859)
	at com.android.tools.idea.gradle.dsl.parser.elements.FakeElement.createPsiElement(FakeElement.java:70)
	at com.android.tools.idea.gradle.dsl.parser.elements.FakeElement.produceValue(FakeElement.java:130)
	at com.android.tools.idea.gradle.dsl.model.CachedValue.updateValue(CachedValue.java:68)
	at com.android.tools.idea.gradle.dsl.model.CachedValue.getValue(CachedValue.java:53)
	at com.android.tools.idea.gradle.dsl.parser.elements.GradleDslSimpleExpression.getValue(GradleDslSimpleExpression.java:78)
	at com.android.tools.idea.gradle.dsl.model.ext.GradlePropertyModelImpl.extractAndGetValueType(GradlePropertyModelImpl.java:673)
	at com.android.tools.idea.gradle.dsl.model.ext.GradlePropertyModelImpl.getValueType(GradlePropertyModelImpl.java:112)
	at com.android.tools.idea.gradle.dsl.model.ext.PropertyUtil.resolveModel(PropertyUtil.java:149)
	at com.android.tools.idea.gradle.dsl.model.ext.ResolvedPropertyModelImpl.resolveModel(ResolvedPropertyModelImpl.java:274)
	at com.android.tools.idea.gradle.dsl.model.ext.ResolvedPropertyModelImpl.getValueType(ResolvedPropertyModelImpl.java:50)
	at com.android.tools.idea.gradle.dsl.model.dependencies.ArtifactDependencyModelImpl$CompactNotationStrategy.isValidDSL(ArtifactDependencyModelImpl.java:492)
	at com.android.tools.idea.gradle.dsl.model.dependencies.ArtifactDependencyModelImpl$DynamicNotation.isValidDSL(ArtifactDependencyModelImpl.java:349)
	at com.android.tools.idea.gradle.dsl.model.dependencies.ArtifactDependencyModelImpl$DynamicNotation.create(ArtifactDependencyModelImpl.java:366)
	at com.android.tools.idea.gradle.dsl.model.dependencies.ScriptDependenciesModelImpl.lambda$getArtifactFetcher$0(ScriptDependenciesModelImpl.java:83)
	at com.android.tools.idea.gradle.dsl.model.dependencies.ScriptDependenciesModelImpl.collectFrom(ScriptDependenciesModelImpl.java:465)
	at com.android.tools.idea.gradle.dsl.model.dependencies.AbstractDependenciesModel.all(AbstractDependenciesModel.java:304)
	at com.android.tools.idea.gradle.dsl.model.dependencies.AbstractDependenciesModel.artifacts(AbstractDependenciesModel.java:121)
	at org.jetbrains.plugins.gradle.dsl.GradleDependencyModificator.declaredDependencies(GradleDependencyModificator.kt:154)
	at com.intellij.externalSystem.DependencyModifierService.declaredDependencies$lambda$2(DependencyModifierService.kt:28)
	at com.intellij.externalSystem.DependencyModifierService.read(DependencyModifierService.kt:62)
	at com.intellij.externalSystem.DependencyModifierService.declaredDependencies(DependencyModifierService.kt:27)
	at com.intellij.packageChecker.java.BuildSystemDependenciesModelBase.declaredDependenciesInModule(BuildSystemDependenciesModelBase.kt:70)
	at com.intellij.packageChecker.java.BuildSystemDependenciesModelBase.declaredDependencies(BuildSystemDependenciesModelBase.kt:62)
	at com.intellij.packageChecker.service.PackageService.declaredDependencies(PackageService.kt:40)
	at com.intellij.packageChecker.service.VulnerableApiService$createLibrariesFqnVulnerabilitiesFlow$1.invokeSuspend$lambda$0(VulnerableApiService.kt:125)
	at com.intellij.openapi.application.rw.PlatformReadWriteActionSupport.computeCancellable$lambda$1(PlatformReadWriteActionSupport.kt:43)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal$lambda$3$lambda$2$lambda$1(cancellableReadAction.kt:32)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.tryRunReadAction(AnyThreadWriteThreadingSupport.kt:351)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:972)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal$lambda$3$lambda$2(cancellableReadAction.kt:30)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtilService.runActionAndCancelBeforeWrite(ProgressIndicatorUtilService.java:66)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:157)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal(cancellableReadAction.kt:28)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadAction$lambda$0(cancellableReadAction.kt:17)
	at com.intellij.openapi.progress.ContextKt.prepareThreadContext(context.kt:85)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadAction(cancellableReadAction.kt:16)
	at com.intellij.openapi.application.rw.PlatformReadWriteActionSupport.computeCancellable(PlatformReadWriteActionSupport.kt:42)
	at com.intellij.openapi.application.ReadAction.computeCancellable(ReadAction.java:115)
	at com.intellij.packageChecker.service.VulnerableApiService$createLibrariesFqnVulnerabilitiesFlow$1.invokeSuspend(VulnerableApiService.kt:124)
	at com.intellij.packageChecker.service.VulnerableApiService$createLibrariesFqnVulnerabilitiesFlow$1.invoke(VulnerableApiService.kt)
	at com.intellij.packageChecker.service.VulnerableApiService$createLibrariesFqnVulnerabilitiesFlow$1.invoke(VulnerableApiService.kt)
	at kotlinx.coroutines.flow.FlowKt__ZipKt$combine$1$1.invokeSuspend(Zip.kt:29)
	at kotlinx.coroutines.flow.FlowKt__ZipKt$combine$1$1.invoke(Zip.kt)
	at kotlinx.coroutines.flow.FlowKt__ZipKt$combine$1$1.invoke(Zip.kt)
	at kotlinx.coroutines.flow.internal.CombineKt$combineInternal$2.invokeSuspend(Combine.kt:73)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:608)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:873)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:763)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:750)
```

</details>

## Changelog Technical Details
+ Fixed IDE error for 2024.3. - Thunderblade73

