### PR TITLE
Backend: Improved /shtestitem

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -440,11 +440,6 @@ object Commands {
             category = CommandCategory.DEVELOPER_TEST
             callback { RepoPatternGui.open() }
         }
-        event.register("shtestitem") {
-            description = "test item internal name resolving"
-            category = CommandCategory.DEVELOPER_TEST
-            callback { SkyHanniDebugsAndTests.testItemCommand(it) }
-        }
         event.register("shfindnullconfig") {
             description = "Find config elements that are null and prints them into the console"
             category = CommandCategory.DEVELOPER_TEST

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -151,7 +151,7 @@ object IslandGraphs {
     fun onWorldChange(event: WorldChangeEvent) {
         currentIslandGraph = null
         if (currentTarget != null) {
-            "§e[SkyHanni] Navigation stopped because of world switch!".asComponent().send(PATHFIND_ID)
+            "§e[SkyHanni] Navigation stopped because of world switch!".asComponent().send(pathFindMessageId)
         }
         reset()
     }
@@ -239,7 +239,7 @@ object IslandGraphs {
         currentTarget?.let {
             if (it.distanceToPlayer() < 3) {
                 onFound()
-                "§e[SkyHanni] Navigation reached §r$label§e!".asComponent().send(PATHFIND_ID)
+                "§e[SkyHanni] Navigation reached §r$label§e!".asComponent().send(pathFindMessageId)
                 reset()
             }
             if (!condition()) {
@@ -432,7 +432,7 @@ object IslandGraphs {
         updateChat()
     }
 
-    private const val PATHFIND_ID = -6457563
+    private val pathFindMessageId = ChatUtils.getUniqueMessageId()
 
     private fun updateChat() {
         if (label == "") return
@@ -462,11 +462,11 @@ object IslandGraphs {
         componentText.onClick(
             onClick = {
                 stop()
-                "§e[SkyHanni] Navigation stopped!".asComponent().send(PATHFIND_ID)
+                "§e[SkyHanni] Navigation stopped!".asComponent().send(pathFindMessageId)
             },
         )
         componentText.hover = "§eClick to stop navigating!".asComponent()
-        componentText.send(PATHFIND_ID)
+        componentText.send(pathFindMessageId)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandBuilder
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.StringUtils.splitLines
 import at.hannibal2.skyhanni.utils.chat.Text
 import at.hannibal2.skyhanni.utils.chat.Text.hover
@@ -14,7 +15,7 @@ import net.minecraft.util.IChatComponent
 object HelpCommand {
 
     private const val COMMANDS_PER_PAGE = 15
-    private const val HELP_ID = -6457563
+    private val messageId = ChatUtils.getUniqueMessageId()
 
     private fun createCommandEntry(command: CommandBuilder): IChatComponent {
         val category = command.category
@@ -48,7 +49,7 @@ object HelpCommand {
         Text.displayPaginatedList(
             title,
             filtered,
-            chatLineId = HELP_ID,
+            chatLineId = messageId,
             emptyMessage = "No commands found.",
             currentPage = page,
             maxPerPage = COMMANDS_PER_PAGE,

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.model.GraphNode
 import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.features.misc.IslandAreas
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.sorted
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
@@ -17,7 +18,7 @@ import at.hannibal2.skyhanni.utils.chat.Text.send
 import kotlinx.coroutines.launch
 
 object NavigationHelper {
-    private const val NAVIGATION_CHAT_ID = -6457562
+    private val messageId = ChatUtils.getUniqueMessageId()
 
     val allowedTags = listOf(
         GraphNodeTag.NPC,
@@ -52,7 +53,7 @@ object NavigationHelper {
         Text.displayPaginatedList(
             title,
             locations,
-            chatLineId = NAVIGATION_CHAT_ID,
+            chatLineId = messageId,
             emptyMessage = "No locations found.",
         ) { (name, node) ->
             val distance = distances[node]!!.roundTo(1)
@@ -72,7 +73,7 @@ object NavigationHelper {
         val componentText = "§7Navigating to §r$name".asComponent()
         componentText.onClick(onClick = goBack)
         componentText.hover = "§eClick to stop navigating and return to previous search".asComponent()
-        componentText.send(NAVIGATION_CHAT_ID)
+        componentText.send(messageId)
     }
 
     private fun calculateNames(distances: Map<GraphNode, Double>): List<Pair<String, GraphNode>> {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
@@ -28,9 +28,9 @@ object ReminderManager {
     private const val REMINDERS_PER_PAGE = 10
 
     // Random numbers chosen, this will be used to delete the old list and action messages
-    private const val REMINDERS_LIST_ID = -546745
-    private const val REMINDERS_ACTION_ID = -546746
-    private const val REMINDERS_MESSAGE_ID = -546747
+    private val REMINDERS_LIST_ID = ChatUtils.getUniqueMessageId()
+    private val REMINDERS_ACTION_ID = ChatUtils.getUniqueMessageId()
+    private val REMINDERS_MESSAGE_ID = ChatUtils.getUniqueMessageId()
 
     private val storage get() = SkyHanniMod.feature.storage.reminders
     private val config get() = SkyHanniMod.feature.misc.reminders

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -29,7 +29,6 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
-import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getRawCraftCostOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
@@ -45,9 +44,7 @@ import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
-import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.OSUtils
@@ -364,41 +361,6 @@ object SkyHanniDebugsAndTests {
         } else {
             ChatUtils.chat("§cDisabled global renderer! Run this command again to show SkyHanni rendering again.")
         }
-    }
-
-    fun testItemCommand(args: Array<String>) {
-        if (args.isEmpty()) {
-            ChatUtils.userError("Usage: /shtestitem <item name or internal name>")
-            return
-        }
-
-        val input = args.joinToString(" ")
-        val result = buildList {
-            add("")
-            add("§bSkyHanni Test Item")
-            add("§einput: '§f$input§e'")
-
-            NeuInternalName.fromItemNameOrNull(input)?.let { internalName ->
-                add("§eitem name -> internalName: '§7${internalName.asString()}§e'")
-                add("  §eitemName: '${internalName.itemName}§e'")
-                val price = internalName.getPriceOrNull()?.let { "§6" + it.addSeparators() } ?: "§7null"
-                add("  §eprice: '§6$price§e'")
-                return@buildList
-            }
-
-            input.toInternalName().getItemStackOrNull()?.let { item ->
-                val itemName = item.itemName
-                val internalName = item.getInternalName()
-                add("§einternal name: §7${internalName.asString()}")
-                add("§einternal name -> item name: '$itemName§e'")
-                val price = internalName.getPriceOrNull()?.let { "§6" + it.addSeparators() } ?: "§7null"
-                add("  §eprice: '§6$price§e'")
-                return@buildList
-            }
-
-            add("§cNothing found!")
-        }
-        ChatUtils.chat(result.joinToString("\n"), prefix = false)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -180,7 +180,7 @@ object ChatUtils {
 
     private var lastUniqueMessageId = 123242
 
-    private fun getUniqueMessageId() = lastUniqueMessageId++
+    fun getUniqueMessageId() = lastUniqueMessageId++
 
     /**
      * Sends a message to the user that they can click and run a command

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -116,8 +116,8 @@ object ItemNameResolver {
             return it
         }
 
-        if (NeuItems.allItemsCache.isEmpty()) {
-            NeuItems.allItemsCache = NeuItems.readAllNeuItems()
+        if (NeuItems.allInternalNames.isEmpty()) {
+            NeuItems.readAllNeuItems()
         }
 
         // supports colored names, rarities

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -2,6 +2,8 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.NotificationManager
 import at.hannibal2.skyhanni.data.PetApi
 import at.hannibal2.skyhanni.data.SkyHanniNotification
@@ -14,10 +16,13 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.CollectionUtils.removeIfKey
+import at.hannibal2.skyhanni.utils.CollectionUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
+import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PrimitiveIngredient.Companion.toPrimitiveItemStacks
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -27,8 +32,14 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRecombobulated
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
+import at.hannibal2.skyhanni.utils.chat.Text
+import at.hannibal2.skyhanni.utils.chat.Text.asComponent
+import at.hannibal2.skyhanni.utils.chat.Text.onClick
+import at.hannibal2.skyhanni.utils.chat.Text.onHover
+import at.hannibal2.skyhanni.utils.chat.Text.send
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
+import kotlinx.coroutines.launch
 import net.minecraft.client.Minecraft
 import net.minecraft.init.Items
 import net.minecraft.item.Item
@@ -36,6 +47,7 @@ import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.nbt.NBTTagList
 import net.minecraft.nbt.NBTTagString
+import net.minecraft.util.ChatComponentText
 import net.minecraftforge.common.util.Constants
 import java.util.LinkedList
 import java.util.regex.Matcher
@@ -46,7 +58,7 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object ItemUtils {
 
-    private val itemNameCache = mutableMapOf<NeuInternalName, String>() // internal name -> item name
+    val itemNameCache = mutableMapOf<NeuInternalName, String>() // internal name -> item name
 
     // This map might not contain all stats the item has, compare with itemBaseStatsRaw if unclear
     private var itemBaseStats = mapOf<NeuInternalName, Map<SkyblockStat, Int>>()
@@ -550,6 +562,7 @@ object ItemUtils {
             return "§cBugged Item"
         }
 
+        // We do not use NeuItems.allItemsCache here since we need itemStack below
         val itemStack = getItemStackOrNull()
         val name = itemStack?.name ?: run {
             val name = toString()
@@ -615,6 +628,99 @@ object ItemUtils {
     ): Double = neededItems(this).map {
         it.key.getPrice(priceSource, pastRecipes) * it.value
     }.sum()
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.register("shtestitem") {
+            description = "test item internal name resolving"
+            category = CommandCategory.DEVELOPER_TEST
+            callback { testItemCommand(it) }
+        }
+    }
+
+    private fun testItemCommand(args: Array<String>) {
+        if (args.isEmpty()) {
+            ChatUtils.userError("Usage: /shtestitem <item name or internal name>")
+            return
+        }
+
+        val input = args.joinToString(" ")
+        Text.text("§eProcessing..").send(testItemMessageId)
+
+        SkyHanniMod.coroutineScope.launch {
+            buildTestItemMessage(input).send(testItemMessageId)
+        }
+    }
+
+    private fun buildTestItemMessage(input: String) = buildList {
+        add("".asComponent())
+        add("§bSkyHanni Test Item".asComponent())
+        add("§eInput: '§f$input§e'".asComponent())
+
+        NeuInternalName.fromItemNameOrNull(input)?.let<NeuInternalName, Nothing> { internalName ->
+            formatTestItem(internalName, internalName.getPrice())
+            return@buildList
+        }
+
+        input.toInternalName().getItemStackOrNull()?.let<ItemStack, Nothing> { item ->
+            val internalName = item.getInternalName()
+            formatTestItem(internalName, internalName.getPrice())
+            return@buildList
+        }
+
+        val matches = mutableSetOf<NeuInternalName>()
+        for ((name, internalName) in NeuItems.allItemsCache) {
+            if (name.contains(input, ignoreCase = true)) {
+                matches.add(internalName)
+            } else if (internalName.asString().contains(input.replace(" ", "_"), ignoreCase = true)) {
+                matches.add(internalName)
+            }
+        }
+        // somehow enchantments arent part of NeuItems.allItemsCache
+        for ((internalName, name) in itemNameCache) {
+            if (name.contains(input, ignoreCase = true)) {
+                matches.add(internalName)
+            } else if (internalName.asString().contains(input.replace(" ", "_"), ignoreCase = true)) {
+                matches.add(internalName)
+            }
+        }
+
+        if (matches.isEmpty()) {
+            add("§cNothing found!".asComponent())
+        } else {
+            add("§eNo exact match! Show partial matches:".asComponent())
+            val max = 10
+            if (matches.size > max) {
+                add("§7(Showing only the first $max results of ${matches.size.addSeparators()} total)".asComponent())
+            }
+            for ((internalName, price) in matches.associateWith { it.getPrice() }.sortedDesc().entries.take(max)) {
+                formatTestItem(internalName, price)
+            }
+        }
+    }
+
+    private val testItemMessageId = ChatUtils.getUniqueMessageId()
+
+    private fun MutableList<ChatComponentText>.formatTestItem(internalName: NeuInternalName, price: Double) {
+        val priceColor = if (price > 0) "§6" else "§7"
+        val name = internalName.itemName
+        val priceFormat = "$priceColor${price.shortFormat()}"
+        val componentText = " §8- §r$name $priceFormat".asComponent()
+        componentText.onClick {
+            ClipboardUtils.copyToClipboard(internalName.asString())
+        }
+        componentText.onHover(
+            listOf(
+                name,
+                "",
+                "§ePrice: $priceFormat",
+                "§eInternal name: §8${internalName.asString()}",
+                "",
+                "§eClick to copy internal name to clipboard!",
+            ),
+        )
+        add(componentText)
+    }
 
     @HandleEvent
     fun onDebug(event: DebugDataCollectEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -647,10 +647,13 @@ object ItemUtils {
         val input = args.joinToString(" ")
         Text.text("§eProcessing..").send(testItemMessageId)
 
+        // running .getPrice() on thousands of items may take ~500ms
         SkyHanniMod.coroutineScope.launch {
             buildTestItemMessage(input).send(testItemMessageId)
         }
     }
+
+    private val testItemMessageId = ChatUtils.getUniqueMessageId()
 
     private fun buildTestItemMessage(input: String) = buildList {
         add("".asComponent())
@@ -676,7 +679,10 @@ object ItemUtils {
                 matches.add(internalName)
             }
         }
-        // somehow enchantments arent part of NeuItems.allItemsCache
+        // TODO add all enchantments to NeuItems.allItemsCache
+        // somehow, enchantments arent part of NeuItems.allItemsCache atm
+        // itemNameCache contains bazaar enchantments
+        // the non bz enchantments are only in the cache after found in game
         for ((internalName, name) in itemNameCache) {
             if (name.contains(input, ignoreCase = true)) {
                 matches.add(internalName)
@@ -699,8 +705,6 @@ object ItemUtils {
         }
     }
 
-    private val testItemMessageId = ChatUtils.getUniqueMessageId()
-
     private fun MutableList<ChatComponentText>.formatTestItem(internalName: NeuInternalName, price: Double) {
         val priceColor = if (price > 0) "§6" else "§7"
         val name = internalName.itemName
@@ -713,8 +717,8 @@ object ItemUtils {
             listOf(
                 name,
                 "",
-                "§ePrice: $priceFormat",
-                "§eInternal name: §8${internalName.asString()}",
+                "§7Price: $priceFormat",
+                "§7Internal name: §8${internalName.asString()}",
                 "",
                 "§eClick to copy internal name to clipboard!",
             ),

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/Text.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/Text.kt
@@ -71,6 +71,16 @@ object Text {
     fun IChatComponent.send(id: Int = 0) =
         Minecraft.getMinecraft().ingameGUI.chatGUI.printChatMessageWithOptionalDeletion(this, id)
 
+    fun List<IChatComponent>.send(id: Int = 0) {
+        val parent = "".asComponent()
+        forEach {
+            parent.siblings.add(it)
+            parent.siblings.add("\n".asComponent())
+        }
+
+        Minecraft.getMinecraft().ingameGUI.chatGUI.printChatMessageWithOptionalDeletion(parent, id)
+    }
+
     var IChatComponent.hover: IChatComponent?
         get() = this.chatStyle.chatHoverEvent?.value
         set(value) {
@@ -98,6 +108,14 @@ object Text {
     fun IChatComponent.onClick(expiresAt: SimpleTimeMark = SimpleTimeMark.farFuture(), oneTime: Boolean = true, onClick: () -> Any) {
         val token = ChatClickActionManager.createAction(onClick, expiresAt, oneTime)
         this.command = "/shaction $token"
+    }
+
+    fun IChatComponent.onHover(tip: String) {
+        this.hover = tip.asComponent()
+    }
+
+    fun IChatComponent.onHover(tips: List<String>) {
+        this.hover = tips.joinToString("\n").asComponent()
     }
 
     fun createDivider(dividerColor: EnumChatFormatting = EnumChatFormatting.BLUE) = HYPHEN.fitToChat().style {


### PR DESCRIPTION
## What
Added partial match logic to /shtestitem debug command.
Also added hover text, and clickable to copy internal name to clipboard..
Moved the /shtestitem into ItemUtils

Also used getUniqueMessageId() everywhere, renamed a bunch of variables in the process
Changed stuff around internal name loading cache loading, should be a tiny bit faster now, and better maintainable.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/ef4cb39a-ab8c-4ad7-84ea-440ec86eb0e7)
![image](https://github.com/user-attachments/assets/8ec29af8-80e7-42c8-9c0e-8f93c746fc4a)
![image](https://github.com/user-attachments/assets/cfe8cdda-94f3-4875-8af5-bf8de203496b)

</details>

## Changelog Technical Details
+ Added partial match logic to debug command `/shtestitem`. - hannibal2