### PR TITLE
Backend: Remove wrong spelling of "caducous" from dictionairy

### DIFF
--- a/.idea/dictionaries/default_user.xml
+++ b/.idea/dictionaries/default_user.xml
@@ -38,7 +38,6 @@
       <w>buffantics</w>
       <w>burningsoul</w>
       <w>caducous</w>
-      <w>cadycous</w>
       <w>carrolyn</w>
       <w>cata</w>
       <w>cavespider</w>


### PR DESCRIPTION

<details>
wrong spelling: "cadycous"

correct spelling: "caducous"
</details>

exclude_from_changelog
