### PR TITLE
Fix: Jerry statspocalypse not correctly effecting the Skyhanni User Luck stat

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
@@ -22,6 +23,9 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.inventory.ContainerLocalMenu
+import net.minecraft.init.Blocks
+import net.minecraft.init.Items
+import net.minecraft.item.Item
 import net.minecraft.item.ItemStack
 import kotlin.time.Duration.Companion.seconds
 
@@ -36,20 +40,24 @@ object UserLuckBreakdown {
     private val config get() = SkyHanniMod.feature.misc
 
     private lateinit var mainLuckItem: ItemStack
-    private val mainLuckID = "ENDER_PEARL".toInternalName()
+    private val mainLuckID = Items.ender_pearl
     private const val MAIN_LUCK_NAME = "§a✴ SkyHanni User Luck"
 
     private lateinit var fillerItem: ItemStack
-    private val fillerID = "STAINED_GLASS_PANE".toInternalName()
+    private val fillerID = Item.getItemFromBlock(Blocks.stained_glass_pane)
     private const val FILLER_NAME = " "
 
     private lateinit var limboItem: ItemStack
-    private val limboID = "ENDER_PEARL".toInternalName()
+    private val limboID = Items.ender_pearl
     private const val LIMBO_NAME = "§a✴ Limbo Personal Best"
 
     private lateinit var skillsItem: ItemStack
-    private val skillsID = "DIAMOND_SWORD".toInternalName()
+    private val skillsID = Items.diamond_sword
     private const val SKILLS_NAME = "§a✴ Category: Skills"
+
+    private lateinit var jerryItem: ItemStack
+    private val jerryID = Items.paper
+    private const val JERRY_NAME = "§a✴ Statspocalypse"
 
     private var showAllStats = true
 
@@ -101,11 +109,12 @@ object UserLuckBreakdown {
 
             10 -> event.replace(skillsItem)
             11 -> event.replace(limboItem)
+            12 -> event.replace(jerryItem)
 
             in validItemSlots -> event.remove()
 
             in invalidItemSlots -> {
-                if (event.originalItem.item == limboID.getItemStack().item) return
+                if (event.originalItem.item == limboID || event.originalItem.item == jerryID) return
                 event.replace(fillerItem)
                 return
             }
@@ -171,10 +180,13 @@ object UserLuckBreakdown {
         if (limboLuck == 0.0f && !showAllStats) return
 
         val skillLuck = skillOverflowLuck.values.sum()
-        val totalLuck = skillLuck + limboLuck
+        var totalLuck = skillLuck + limboLuck
         val lastIndex = event.toolTip.indexOfLast { it == "§5§o" }
         if (lastIndex == -1) return
 
+        if (Perk.STATSPOCALYPSE.isActive) {
+            totalLuck *= 1.1f
+        }
         val luckString = tryTruncateFloat(totalLuck)
         event.toolTip.add(lastIndex, "$LUCK_TOOLTIP$luckString")
     }
@@ -188,7 +200,10 @@ object UserLuckBreakdown {
         if (limboLuck == 0.0f && !showAllStats) return
 
         val skillLuck = skillOverflowLuck.values.sum()
-        val totalLuck = skillLuck + limboLuck
+        var totalLuck = skillLuck + limboLuck
+        if (Perk.STATSPOCALYPSE.isActive) {
+            totalLuck *= 1.1f
+        }
         val luckString = tryTruncateFloat(totalLuck)
         event.toolTip.add("§5§o §a✴ SkyHanni User Luck §f$luckString")
     }
@@ -199,8 +214,11 @@ object UserLuckBreakdown {
         if (lastIndex == -1) return
 
         val skillLuck = skillOverflowLuck.values.sum()
-        val totalLuck = skillLuck + limboLuck
+        var totalLuck = skillLuck + limboLuck
         if (totalLuck == 0f) return
+        if (Perk.STATSPOCALYPSE.isActive) {
+            totalLuck *= 1.1f
+        }
 
         val luckString = tryTruncateFloat(totalLuck)
         event.toolTip.add(lastIndex, "$LUCK_TOOLTIP$luckString")
@@ -238,7 +256,7 @@ object UserLuckBreakdown {
 
     private fun createItems() {
         fillerItem = ItemUtils.createItemStack(
-            fillerID.getItemStack().item,
+            fillerID,
             FILLER_NAME,
             listOf(),
             1,
@@ -247,23 +265,35 @@ object UserLuckBreakdown {
 
         val limboLuck = storage?.limbo?.userLuck ?: 0.0f
         val skillLuck = skillOverflowLuck.values.sum()
-        val totalLuck = skillLuck + limboLuck
+        var totalLuck = skillLuck + limboLuck
+        var jerryLuck = 0f
+        if (Perk.STATSPOCALYPSE.isActive) {
+            jerryLuck = totalLuck * .1f
+        }
+        totalLuck += jerryLuck
 
         mainLuckItem = ItemUtils.createItemStack(
-            mainLuckID.getItemStack().item,
+            mainLuckID,
             "$MAIN_LUCK_NAME §f${tryTruncateFloat(totalLuck)}",
             createItemLore("mainMenu", totalLuck),
         )
         limboItem = ItemUtils.createItemStack(
-            limboID.getItemStack().item,
+            limboID,
             LIMBO_NAME,
             createItemLore("limbo", limboLuck),
         )
         skillsItem = ItemUtils.createItemStack(
-            skillsID.getItemStack().item,
+            skillsID,
             SKILLS_NAME,
             createItemLore("skills"),
         )
+        if (jerryLuck > 0) {
+            jerryItem = ItemUtils.createItemStack(
+                jerryID,
+                JERRY_NAME,
+                createItemLore("jerry", jerryLuck),
+            )
+        }
     }
 
     private fun createItemLore(type: String, luckInput: Float = 0.0f): Array<String> {
@@ -329,6 +359,18 @@ object UserLuckBreakdown {
                 }
                 finalList.addAll(secondHalf)
                 finalList.toTypedArray()
+            }
+
+            "jerry" -> {
+                val luckString = tryTruncateFloat(luckInput.roundTo(2))
+                arrayOf(
+                    "§8Elected Mayor",
+                    "",
+                    "§7Value: §a+$luckString✴",
+                    "",
+                    "§8Stats from the currently elected",
+                    "§8mayor. Proof that voting does matter.",
+                )
             }
 
             else -> arrayOf("")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
@@ -15,8 +15,6 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.name
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
-import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by a plus. For example, `Feature + Fix: Add new command and fix bug in command`.
Commonly used labels are Improvement, Backend, Feature and Fix.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

-->

## What
Adds Statspocalypse support to sh user luck

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/42b87adc-68d9-4cb0-b444-46e12ea12e97)

</details>

## Changelog Fixes
+ Fixed Statspocalypse not affecting SkyHanni User Luck. - nopo
