### PR TITLE
Fix: config load/save with StringFileHandler

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -9,36 +9,24 @@ import at.hannibal2.skyhanni.data.jsonobjects.local.JacobContestsJson
 import at.hannibal2.skyhanni.data.jsonobjects.local.KnownFeaturesJson
 import at.hannibal2.skyhanni.data.jsonobjects.local.VisualWordsJson
 import at.hannibal2.skyhanni.features.misc.update.UpdateManager
-import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.enumMapOf
-import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.IdentityCharacteristics
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.ReflectionUtils.makeAccessible
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.StringFileHandler
 import at.hannibal2.skyhanni.utils.json.BaseGsonBuilder
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.google.gson.JsonObject
 import com.google.gson.TypeAdapterFactory
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.processor.BuiltinMoulConfigGuis
 import io.github.notenoughupdates.moulconfig.processor.ConfigProcessorDriver
 import io.github.notenoughupdates.moulconfig.processor.MoulConfigProcessor
-import java.io.BufferedReader
-import java.io.BufferedWriter
 import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
 import java.io.IOException
-import java.io.InputStreamReader
-import java.io.OutputStreamWriter
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import kotlin.concurrent.fixedRateTimer
 import kotlin.reflect.KMutableProperty0
 
@@ -155,7 +143,7 @@ class ConfigManager {
             println("")
             println(
                 "This crash is here to remind you to fix the missing " +
-                    "@ConfigLink annotation over your new config position config element."
+                    "@ConfigLink annotation over your new config position config element.",
             )
             println("")
             println("Steps to fix:")
@@ -174,14 +162,12 @@ class ConfigManager {
 
         if (file!!.exists()) {
             try {
-                val inputStreamReader = InputStreamReader(FileInputStream(file), StandardCharsets.UTF_8)
-                val bufferedReader = BufferedReader(inputStreamReader)
+                val text = StringFileHandler(file).load()
                 val lenientGson = BaseGsonBuilder.lenientGson().create()
-
                 logger.log("load-$fileName-now")
 
                 output = if (fileType == ConfigFileType.FEATURES) {
-                    val jsonObject = lenientGson.fromJson(bufferedReader.readText(), JsonObject::class.java)
+                    val jsonObject = lenientGson.fromJson(text, com.google.gson.JsonObject::class.java)
                     val newJsonObject = ConfigUpdaterMigrator.fixConfig(jsonObject)
                     val run = { lenientGson.fromJson(newJsonObject, defaultValue.javaClass) }
                     if (PlatformUtils.isDevEnvironment) {
@@ -195,7 +181,7 @@ class ConfigManager {
                         run()
                     }
                 } else {
-                    lenientGson.fromJson(bufferedReader.readText(), defaultValue.javaClass)
+                    lenientGson.fromJson(text, defaultValue.javaClass)
                 }
 
                 logger.log("Loaded $fileName from file")
@@ -236,40 +222,11 @@ class ConfigManager {
         try {
             logger.log("Saving $fileName file")
             file.parentFile.mkdirs()
-            val unit = file.parentFile.resolve("$fileName.json.write")
-            unit.createNewFile()
-            BufferedWriter(OutputStreamWriter(FileOutputStream(unit), StandardCharsets.UTF_8)).use { writer ->
-                writer.write(gson.toJson(data))
-            }
-            // Perform move — which is atomic, unlike writing — after writing is done.
-            move(unit, file, reason)
+            StringFileHandler(file).save(gson.toJson(data))
+            logger.log("Saved $fileName file successfully")
         } catch (e: IOException) {
             logger.log("Could not save $fileName file to $file")
             logger.log(e.stackTraceToString())
-        }
-    }
-
-    private fun move(unit: File, file: File, reason: String, loop: Int = 0) {
-        try {
-            Files.move(
-                unit.toPath(),
-                file.toPath(),
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.ATOMIC_MOVE,
-            )
-        } catch (e: AccessDeniedException) {
-            if (loop == 5) {
-                ErrorManager.logErrorWithData(
-                    e,
-                    "could not save config.",
-                    "config save reason" to reason,
-                )
-                return
-            }
-            ChatUtils.debug("config save AccessDeniedException! (loop $loop)")
-            DelayedRun.runNextTick {
-                move(unit, file, reason, loop + 1)
-            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringFileHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringFileHandler.kt
@@ -1,0 +1,43 @@
+package at.hannibal2.skyhanni.utils
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.AccessDeniedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+class StringFileHandler(private val file: File) {
+    private val backupFile = File(file.parentFile, "${file.name}.bak")
+    private val tempFile = File(file.parentFile, "${file.name}.tmp")
+
+    @Throws(IOException::class)
+    fun load(): String = try {
+        file.readText()
+    } catch (e: Exception) {
+        if (backupFile.exists()) backupFile.readText()
+        else throw e
+    }
+
+    @Throws(IOException::class)
+    fun save(content: String, attempt: Int = 0) {
+        try {
+            tempFile.writeText(content)
+            if (file.exists()) file.copyTo(backupFile, overwrite = true)
+            Files.move(
+                tempFile.toPath(),
+                file.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+            backupFile.delete()
+        } catch (e: AccessDeniedException) {
+            if (attempt >= 5) throw e
+            Thread.sleep(50L)
+            save(content, attempt + 1)
+        } catch (e: Exception) {
+            tempFile.delete()
+            if (backupFile.exists()) backupFile.copyTo(file, overwrite = true)
+            throw e
+        }
+    }
+}


### PR DESCRIPTION
## What
Users sometimes complain their config got reset, because we fill it accidentally with invalid data.
This PR tries to reduce such cases by changing the file read/write logic.

Moved config load save into another class `StringFileHandler`.
added a backup file that always holds the config state of the config prior to file movement.
This backup file gets used if the normal file is corrupt.

Additionally, a check that blocks other threads from accessing the same file at the same time might be useful to add here.

## Changelog Fixes
+ Possibly fixed some config reset errors. - hannibal2