### PR TITLE
Improvement: Readded Hide outside Inventory tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.java
@@ -93,6 +93,11 @@ public class TrackerConfig {
     }
 
     @Expose
+    @ConfigOption(name = "Hide outside Inventory", desc = "Hide Profit Trackers while not inside an inventory.")
+    @ConfigEditorBoolean
+    public boolean hideItemTrackersOutsideInventory = false;
+
+    @Expose
     @ConfigOption(name = "Tracker Search", desc = "Add a search bar to tracker GUIs.")
     @ConfigEditorBoolean
     public Property<Boolean> trackerSearchEnabled = Property.of(true);

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -98,6 +98,9 @@ open class SkyHanniTracker<Data : TrackerData>(
         if (config.hideInEstimatedItemValue && EstimatedItemValue.isCurrentlyShowing()) return
 
         var currentlyOpen = Minecraft.getMinecraft().currentScreen?.let { it is GuiInventory || it is GuiChest } ?: false
+        if (!currentlyOpen && config.hideItemTrackersOutsideInventory && this is SkyHanniItemTracker) {
+            return
+        }
         if (RenderData.outsideInventory) {
             currentlyOpen = false
         }


### PR DESCRIPTION
## What
Added back the previously removed Item Tracker option "Hide outside Inventory"

## Changelog Improvements
+ Added back the Item Tracker option "Hide outside Inventory". - hannibal2
    * Added option to hide Profit Trackers when not in an inventory.