### PR TITLE
Fix: wisp potion

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 73
+    const val CONFIG_VERSION = 74
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -251,7 +251,6 @@ object EstimatedItemValue {
                     internalName.startsWith("MASTER_CATACOMBS_PASS_") ||
                     internalName.startsWith("MAP-") ||
                     internalName.contains("UNIQUE_RUNE") ||
-//                     internalName.contains("WISP_POTION") ||
                     (
                         !InventoryUtils.isSlotInPlayerInventory(this) &&
                             InventoryUtils.openInventoryName() == "Choose a wardrobe slot"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -251,7 +251,7 @@ object EstimatedItemValue {
                     internalName.startsWith("MASTER_CATACOMBS_PASS_") ||
                     internalName.startsWith("MAP-") ||
                     internalName.contains("UNIQUE_RUNE") ||
-                    internalName.contains("WISP_POTION") ||
+//                     internalName.contains("WISP_POTION") ||
                     (
                         !InventoryUtils.isSlotInPlayerInventory(this) &&
                             InventoryUtils.openInventoryName() == "Choose a wardrobe slot"

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -265,7 +265,7 @@ object SlayerProfitTracker {
         event.transform(74, "#profile.slayerProfitData") { old ->
             for (data in old.asJsonObject.entrySet().map { it.value.asJsonObject }) {
                 val items = data.get("items").asJsonObject
-                for ((key, value) in items.entrySet()) {
+                for ((key, value) in items.entrySet().toList()) {
                     if (key == "WISP_POTION") {
                         items.remove(key)
                         items.add("POTION_WISP_ICE;1", value)
@@ -274,7 +274,6 @@ object SlayerProfitTracker {
             }
             old
         }
-
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -261,6 +261,20 @@ object SlayerProfitTracker {
 
             old
         }
+
+        event.transform(74, "#profile.slayerProfitData") { old ->
+            for (data in old.asJsonObject.entrySet().map { it.value.asJsonObject }) {
+                val items = data.get("items").asJsonObject
+                for ((key, value) in items.entrySet()) {
+                    if (key == "WISP_POTION") {
+                        items.remove(key)
+                        items.add("POTION_WISP_ICE;1", value)
+                    }
+                }
+            }
+            old
+        }
+
     }
 
     fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -39,7 +39,6 @@ object ItemPriceUtils {
             NeuInternalName.JASPER_CRYSTAL -> return 0.0
             NeuInternalName.RUBY_CRYSTAL -> return 0.0
             NeuInternalName.SKYBLOCK_COIN -> return 1.0
-//             NeuInternalName.WISP_POTION -> return 20_000.0
             NeuInternalName.ENCHANTED_HAY_BLOCK -> return 7_776.0
             NeuInternalName.TIGHTLY_TIED_HAY_BALE -> return 1_119_744.0
         }
@@ -94,9 +93,6 @@ object ItemPriceUtils {
     fun NeuInternalName.getNpcPrice(): Double = getNpcPriceOrNull() ?: 0.0
 
     fun NeuInternalName.getNpcPriceOrNull(): Double? {
-//         if (this == NeuInternalName.WISP_POTION) {
-//             return 20_000.0
-//         }
         return HypixelItemApi.getNpcPrice(this)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -39,7 +39,7 @@ object ItemPriceUtils {
             NeuInternalName.JASPER_CRYSTAL -> return 0.0
             NeuInternalName.RUBY_CRYSTAL -> return 0.0
             NeuInternalName.SKYBLOCK_COIN -> return 1.0
-            NeuInternalName.WISP_POTION -> return 20_000.0
+//             NeuInternalName.WISP_POTION -> return 20_000.0
             NeuInternalName.ENCHANTED_HAY_BLOCK -> return 7_776.0
             NeuInternalName.TIGHTLY_TIED_HAY_BALE -> return 1_119_744.0
         }
@@ -94,9 +94,9 @@ object ItemPriceUtils {
     fun NeuInternalName.getNpcPrice(): Double = getNpcPriceOrNull() ?: 0.0
 
     fun NeuInternalName.getNpcPriceOrNull(): Double? {
-        if (this == NeuInternalName.WISP_POTION) {
-            return 20_000.0
-        }
+//         if (this == NeuInternalName.WISP_POTION) {
+//             return 20_000.0
+//         }
         return HypixelItemApi.getNpcPrice(this)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -226,9 +226,9 @@ object ItemUtils {
     }
 
     private fun ItemStack.grabInternalNameOrNull(): NeuInternalName? {
-        if (name == "§fWisp's Ice-Flavored Water I Splash Potion") {
-            return NeuInternalName.WISP_POTION
-        }
+//         if (name == "§fWisp's Ice-Flavored Water I Splash Potion") {
+//             return NeuInternalName.WISP_POTION
+//         }
         val internalName = NeuItems.getInternalName(this)?.replace("ULTIMATE_ULTIMATE_", "ULTIMATE_")
         return internalName?.let { ItemNameResolver.fixEnchantmentName(it) }
     }
@@ -549,9 +549,9 @@ object ItemUtils {
         get() = asString().replace("_", " ").lowercase()
 
     private fun NeuInternalName.grabItemName(): String {
-        if (this == NeuInternalName.WISP_POTION) {
-            return "§fWisp's Ice-Flavored Water"
-        }
+//         if (this == NeuInternalName.WISP_POTION) {
+//             return "§fWisp's Ice-Flavored Water"
+//         }
         if (this == NeuInternalName.SKYBLOCK_COIN) {
             return "§6Coins"
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -226,9 +226,6 @@ object ItemUtils {
     }
 
     private fun ItemStack.grabInternalNameOrNull(): NeuInternalName? {
-//         if (name == "§fWisp's Ice-Flavored Water I Splash Potion") {
-//             return NeuInternalName.WISP_POTION
-//         }
         val internalName = NeuItems.getInternalName(this)?.replace("ULTIMATE_ULTIMATE_", "ULTIMATE_")
         return internalName?.let { ItemNameResolver.fixEnchantmentName(it) }
     }
@@ -549,9 +546,6 @@ object ItemUtils {
         get() = asString().replace("_", " ").lowercase()
 
     private fun NeuInternalName.grabItemName(): String {
-//         if (this == NeuInternalName.WISP_POTION) {
-//             return "§fWisp's Ice-Flavored Water"
-//         }
         if (this == NeuInternalName.SKYBLOCK_COIN) {
             return "§6Coins"
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -15,7 +15,7 @@ class NeuInternalName private constructor(private val internalName: String) {
         val JASPER_CRYSTAL = "JASPER_CRYSTAL".toInternalName()
         val RUBY_CRYSTAL = "RUBY_CRYSTAL".toInternalName()
         val SKYBLOCK_COIN = "SKYBLOCK_COIN".toInternalName()
-        val WISP_POTION = "WISP_POTION".toInternalName()
+//         val WISP_POTION = "WISP_POTION".toInternalName()
         val ENCHANTED_HAY_BLOCK = "ENCHANTED_HAY_BLOCK".toInternalName()
         val TIGHTLY_TIED_HAY_BALE = "TIGHTLY_TIED_HAY_BALE".toInternalName()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -15,7 +15,6 @@ class NeuInternalName private constructor(private val internalName: String) {
         val JASPER_CRYSTAL = "JASPER_CRYSTAL".toInternalName()
         val RUBY_CRYSTAL = "RUBY_CRYSTAL".toInternalName()
         val SKYBLOCK_COIN = "SKYBLOCK_COIN".toInternalName()
-//         val WISP_POTION = "WISP_POTION".toInternalName()
         val ENCHANTED_HAY_BLOCK = "ENCHANTED_HAY_BLOCK".toInternalName()
         val TIGHTLY_TIED_HAY_BALE = "TIGHTLY_TIED_HAY_BALE".toInternalName()
 


### PR DESCRIPTION
## What

NEU REPO used to not have potion support.
To support all blaze slayer drops, we invented the id `WISP_POTION` for Wisp Ice Potion.

NEU had added potion ids since then, and we want to use this ID#s for our slayer rng meter feature, we need to remove our workaround and use the new NEU-ID `POTION_WISP_ICE;1`. 

Related NEU-REPO pr: https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/pull/1659

## TODO
The migration does not work yet

https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/pull/1659

## Changelog Fixes
+ Fixed Wisp Ice Potion not working in RNG Meter display. - hannibal2