### PR TITLE
Improvement: re-add coins to cancelled buy order text

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.replace
@@ -36,5 +37,13 @@ object ShortenCoins {
         }.takeIf { it != message } ?: return
 
         event.chatComponent = ChatComponentText(modifiedMessage)
+    }
+
+    fun Number.formatChatCoins(): String {
+        return "§6" + if (config.shortenCoinAmounts) {
+            shortFormat()
+        } else {
+            addSeparators()
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -95,7 +95,6 @@ object BazaarCancelledBuyOrderClipboard {
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent) {
         if (!isEnabled()) return
-        @Suppress("UnusedPrivateProperty")
         val coins = cancelledMessagePattern.matchMatcher(event.message) {
             group("coins").formatInt().addSeparators()
         } ?: return
@@ -104,8 +103,8 @@ object BazaarCancelledBuyOrderClipboard {
         event.blockedReason = "bazaar cancelled buy order clipboard"
         val lastClicked = lastClickedItem ?: error("last clicked bz item is null")
 
-        val message = "Bazaar buy order cancelled. Click to re-order. " +
-            "(§8${latestAmount.addSeparators()}x §r${lastClicked.itemName}§e)"
+        val message = "Bazaar buy order cancelled. Click to re-order.\n" +
+            "(§8${latestAmount.addSeparators()}x §r${lastClicked.itemName}§e for §6$coins coins§e)"
         ChatUtils.clickableChat(
             message,
             onClick = {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -104,7 +104,7 @@ object BazaarCancelledBuyOrderClipboard {
         val lastClicked = lastClickedItem ?: error("last clicked bz item is null")
 
         val message = "Bazaar buy order cancelled. Click to re-order.\n" +
-            "(§8${latestAmount.addSeparators()}x §r${lastClicked.itemName}§e for §6$coins coins§e)"
+            "§e(§8${latestAmount.addSeparators()}x §r${lastClicked.itemName}§e for §6$coins coins§e)"
         ChatUtils.clickableChat(
             message,
             onClick = {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.features.chat.ShortenCoins.formatChatCoins
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -96,7 +97,7 @@ object BazaarCancelledBuyOrderClipboard {
     fun onChat(event: SkyHanniChatEvent) {
         if (!isEnabled()) return
         val coins = cancelledMessagePattern.matchMatcher(event.message) {
-            group("coins").formatInt().addSeparators()
+            group("coins").formatInt()
         } ?: return
 
         val latestAmount = latestAmount ?: return
@@ -104,7 +105,7 @@ object BazaarCancelledBuyOrderClipboard {
         val lastClicked = lastClickedItem ?: error("last clicked bz item is null")
 
         val message = "Bazaar buy order cancelled. Click to re-order.\n" +
-            "§e(§8${latestAmount.addSeparators()}x §r${lastClicked.itemName}§e for §6$coins coins§e)"
+            "§e(§8${latestAmount.addSeparators()}x §r${lastClicked.itemName}§e for ${coins.formatChatCoins()} coins§e)"
         ChatUtils.clickableChat(
             message,
             onClick = {


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1290906058641903627
Re-adds a small bit of text for refunded coins to the Bazaar "Cancelled Buy Order Clipboard" feature, which shouldn't have been removed in https://github.com/hannibal002/SkyHanni/pull/1946

## Changelog Improvements
+ Re-added text for refunded coins in the Bazaar "Cancelled Buy Order Clipboard" feature. - MTOnline
