### PR TITLE
Fix: Waypoints behind blocks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -140,8 +140,9 @@ object RenderUtils {
         color: LorenzColor,
         beacon: Boolean = false,
         alpha: Float = -1f,
+        seeThroughBlocks: Boolean = true,
     ) {
-        drawColor(location, color.toColor(), beacon, alpha)
+        drawColor(location, color.toColor(), beacon, alpha, seeThroughBlocks)
     }
 
     fun SkyHanniRenderWorldEvent.drawColor(
@@ -149,7 +150,7 @@ object RenderUtils {
         color: Color,
         beacon: Boolean = false,
         alpha: Float = -1f,
-        seeThroughBlocks: Boolean = false,
+        seeThroughBlocks: Boolean = true,
     ) {
         val (viewerX, viewerY, viewerZ) = getViewerPos(partialTicks)
         val x = location.x - viewerX


### PR DESCRIPTION
## What
Fixed waypoint render not behind blocks.

## Changelog Fixes
+ Fixed waypoints not visible behind blocks. - hannibal2
    * E.g. In Diana, Slayer, Hoppity Eggs.