### PR TITLE
Fix: Copy Rng Meter Debug Feature

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
@@ -19,10 +19,18 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 object TestCopyRngMeterValues {
 
     private val patternGroup = RepoPattern.group("test.dev.copyrng")
+
+    /**
+     * REGEX-TEST: §7§7Slayer XP: §d20,625§5/§d7,917
+     */
     private val slayerPattern by patternGroup.pattern(
         "slayer",
         "§7§7Slayer XP: §d.*§5/§d(?<xp>.*)"
     )
+
+    /**
+     * REGEX-TEST: §7§7Dungeon Score: §d1,237§5/§d40,620
+     */
     private val dungeonPattern by patternGroup.pattern(
         "dungeon",
         "§7§7Dungeon Score: §d.*§5/§d(?<xp>.*)"

--- a/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
@@ -21,11 +21,11 @@ object TestCopyRngMeterValues {
     private val patternGroup = RepoPattern.group("test.dev.copyrng")
     private val slayerPattern by patternGroup.pattern(
         "slayer",
-        "§7Slayer XP: §d.*§5/§d(?<xp>.*)"
+        "§7§7Slayer XP: §d.*§5/§d(?<xp>.*)"
     )
     private val dungeonPattern by patternGroup.pattern(
         "dungeon",
-        "§7Dungeon Score: §d.*§5/§d(?<xp>.*)"
+        "§7§7Dungeon Score: §d.*§5/§d(?<xp>.*)"
     )
 
     @HandleEvent


### PR DESCRIPTION


## What
Fixes copy rng meter feature


## Changelog Fixes
+ Fixed Copy RNG Meter Debug feature slayer and dungeon pattern not including a very comedy gold §7 from the hypixel minecraft server. - jani


exclude_from_changelog
