### PR TITLE
Backend: Improve speed of event posting.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
@@ -83,7 +83,7 @@ class EventHandler<T : SkyHanniEvent> private constructor(
     private fun shouldInvoke(event: SkyHanniEvent, listener: EventListeners.Listener): Boolean {
         if (SkyHanniEvents.isDisabledInvoker(listener.name)) return false
         if (listener.options.onlyOnSkyblock && !LorenzUtils.inSkyBlock) return false
-        if (IslandType.ANY !in listener.onlyOnIslandTypes && !inAnyIsland(listener.onlyOnIslandTypes)) return false
+        if (IslandType.ANY !in listener.options.onlyOnIslandTypes && !inAnyIsland(listener.options.onlyOnIslandTypes)) return false
         if (event.isCancelled && !listener.options.receiveCancelled) return false
         if (
             event is GenericSkyHanniEvent<*> &&

--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventListeners.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventListeners.kt
@@ -69,30 +69,28 @@ class EventListeners private constructor(val name: String, private val isGeneric
         val name: String,
         val invoker: Consumer<Any>,
         val options: HandleEventCached,
-        val generic: Class<*>?,
-    ) {
-        val onlyOnIslandTypes: Set<IslandType> = getIslands(options)
-
-        companion object {
-            private fun getIslands(options: HandleEventCached): Set<IslandType> =
-                if (options.onlyOnIslands.isEmpty()) setOf(options.onlyOnIsland)
-                else options.onlyOnIslands.toSet()
-        }
-    }
+        val generic: Class<*>?
+    )
 
     class HandleEventCached(
         val onlyOnSkyblock: Boolean,
         val onlyOnIsland: IslandType,
-        val onlyOnIslands: Array<out IslandType>,
+        val onlyOnIslandTypes: Set<IslandType>,
         val priority: Int,
         val receiveCancelled: Boolean
     ) {
         constructor(event: HandleEvent) : this(
             event.onlyOnSkyblock,
             event.onlyOnIsland,
-            event.onlyOnIslands,
+            getIslands(event.onlyOnIsland, event.onlyOnIslands),
             event.priority,
             event.receiveCancelled
         )
+
+        companion object {
+            private fun getIslands(onlyOnIsland: IslandType, onlyOnIslands: Array<out IslandType>): Set<IslandType> =
+                if (onlyOnIslands.isEmpty()) setOf(onlyOnIsland)
+                else onlyOnIslands.toSet()
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventListeners.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventListeners.kt
@@ -17,7 +17,7 @@ class EventListeners private constructor(val name: String, private val isGeneric
         GenericSkyHanniEvent::class.java.isAssignableFrom(event),
     )
 
-    fun addListener(method: Method, instance: Any, options: HandleEvent) {
+    fun addListener(method: Method, instance: Any, options: HandleEventCached) {
         require(method.parameterCount == 1)
         val generic: Class<*>? = if (isGeneric) {
             ReflectionUtils.resolveUpperBoundSuperClassGenericParameter(
@@ -68,15 +68,31 @@ class EventListeners private constructor(val name: String, private val isGeneric
     class Listener(
         val name: String,
         val invoker: Consumer<Any>,
-        val options: HandleEvent,
+        val options: HandleEventCached,
         val generic: Class<*>?,
     ) {
         val onlyOnIslandTypes: Set<IslandType> = getIslands(options)
 
         companion object {
-            private fun getIslands(options: HandleEvent): Set<IslandType> =
+            private fun getIslands(options: HandleEventCached): Set<IslandType> =
                 if (options.onlyOnIslands.isEmpty()) setOf(options.onlyOnIsland)
                 else options.onlyOnIslands.toSet()
         }
+    }
+
+    data class HandleEventCached(
+        val onlyOnSkyblock: Boolean,
+        val onlyOnIsland: IslandType,
+        val onlyOnIslands: Array<out IslandType>,
+        val priority: Int,
+        val receiveCancelled: Boolean
+    ) {
+        constructor(event: HandleEvent) : this(
+            event.onlyOnSkyblock,
+            event.onlyOnIsland,
+            event.onlyOnIslands,
+            event.priority,
+            event.receiveCancelled
+        )
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventListeners.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventListeners.kt
@@ -80,7 +80,7 @@ class EventListeners private constructor(val name: String, private val isGeneric
         }
     }
 
-    data class HandleEventCached(
+    class HandleEventCached(
         val onlyOnSkyblock: Boolean,
         val onlyOnIsland: IslandType,
         val onlyOnIslands: Array<out IslandType>,

--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.api.event
 
+import at.hannibal2.skyhanni.api.event.EventListeners.HandleEventCached
 import at.hannibal2.skyhanni.data.MinecraftData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.DisabledEventsJson
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
@@ -38,7 +39,8 @@ object SkyHanniEvents {
     @Suppress("UNCHECKED_CAST")
     private fun registerMethod(method: Method, instance: Any) {
         if (method.parameterCount != 1) return
-        val options = method.getAnnotation(HandleEvent::class.java) ?: return
+        val annotation = method.getAnnotation(HandleEvent::class.java) ?: return
+        val options = HandleEventCached(annotation)
         val event = method.parameterTypes[0]
         if (!SkyHanniEvent::class.java.isAssignableFrom(event)) return
         listeners.getOrPut(event as Class<SkyHanniEvent>) { EventListeners(event) }


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by a plus. For example, `Feature + Fix: Add new command and fix bug in command`.
Commonly used labels are Improvement, Backend, Feature and Fix.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

-->

## What
When posting an event, the code does a check for stuff like whether it should only run when in skyblock or on certain islands etc. This information is currently queried through the annotation data of the event handler method, and this is apparently somewhat expensive. It goes through some proxy object and spends time doing linked hashmap idk things.

Instead of that expensive operation being performed every single time the event is posted, this PR queries that annotation data once when registered and then uses those values from then on. All of this assumes that the annotation values never change which I don't think they can anyways (not without gross hax).

Below are pictures of profiling data showing the before and after. These were taken from a 2 minute run where I stood still and stared on my island. Ideally more data should gathered as I do not have a ton of render stuff on my screen/etc. Also I have PolyPatcher's hud caching enabled+FPS limit of 180FPS. And things. idk. However event posting went from ~5400ms to ~3900ms which is about 30% faster.

<details>
<summary>Images</summary>

Before:
![event-post-before](https://github.com/user-attachments/assets/22083d9a-4298-4f4e-b809-4f4c00d2a052)

After:
![event-post-after](https://github.com/user-attachments/assets/af068e0c-087e-4ea2-b8c6-cb114c0231e6)


<!-- drop images here -->

</details>

## Changelog Improvements
+ Improved performance overall slightly. - Nessiesson

## Changelog Technical Details
+ Code now queries `HandleEventCached` instead of `HandleEvent` directly. - Nessiesson
