### PR TITLE
Fix: Hide Other Players in Dance Room Helper not updating if disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.DanceRoomInstructionsJson
+import at.hannibal2.skyhanni.data.mob.MobFilter.isRealPlayer
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
@@ -86,7 +87,7 @@ object DanceRoomHelper {
         } + this@addColor
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (!inRoom) return
@@ -102,9 +103,10 @@ object DanceRoomHelper {
         inRoom = false
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onTick(event: SkyHanniTickEvent) {
-        if (!isEnabled()) return
+        // We want this to run even if not enabled, so that the Hide Other Players feature
+        // properly updates without the helper being enabled
         if (event.isMod(10)) {
             inRoom = danceRoom.isPlayerInside()
         }
@@ -113,7 +115,7 @@ object DanceRoomHelper {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onPlaySound(event: PlaySoundEvent) {
         if (!isEnabled() || !inRoom) return
         if ((event.soundName == "random.burp" && event.volume == 0.8f) ||
@@ -131,7 +133,7 @@ object DanceRoomHelper {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onTitleReceived(event: TitleReceivedEvent) {
         if (!isEnabled()) return
         if (config.hideOriginalTitle && inRoom) event.cancel()
@@ -160,7 +162,7 @@ object DanceRoomHelper {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onCheckRender(event: CheckRenderEntityEvent<EntityOtherPlayerMP>) {
-        if (config.hidePlayers && inRoom) {
+        if (config.hidePlayers && inRoom && event.entity.isRealPlayer()) {
             event.cancel()
         }
     }
@@ -180,7 +182,7 @@ object DanceRoomHelper {
         }
     }
 
-    fun isEnabled() = RiftApi.inRift() && config.enabled
+    fun isEnabled() = config.enabled
 
     @HandleEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
@@ -89,7 +89,7 @@ object DanceRoomHelper {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!isEnabled()) return
+        if (!config.enabled) return
         if (!inRoom) return
         config.position.renderStrings(
             display,
@@ -108,7 +108,7 @@ object DanceRoomHelper {
         // We want this to run even if not enabled, so that the Hide Other Players feature
         // properly updates without the helper being enabled
         if (event.isMod(10)) {
-            inRoom = danceRoom.isPlayerInside()
+            inRoom = RiftApi.inMirrorVerse && danceRoom.isPlayerInside()
         }
         if (inRoom) {
             update()
@@ -117,7 +117,7 @@ object DanceRoomHelper {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onPlaySound(event: PlaySoundEvent) {
-        if (!isEnabled() || !inRoom) return
+        if (!config.enabled || !inRoom) return
         if ((event.soundName == "random.burp" && event.volume == 0.8f) ||
             (event.soundName == "random.levelup" && event.pitch == 1.8412699f && event.volume == 1.0f)
         ) {
@@ -135,7 +135,7 @@ object DanceRoomHelper {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onTitleReceived(event: TitleReceivedEvent) {
-        if (!isEnabled()) return
+        if (!config.enabled) return
         if (config.hideOriginalTitle && inRoom) event.cancel()
     }
 
@@ -181,8 +181,6 @@ object DanceRoomHelper {
             }
         }
     }
-
-    fun isEnabled() = config.enabled
 
     @HandleEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {


### PR DESCRIPTION
## What
Fixed the "Hide Other Players" option in Dance Room Helper not being properly respected if the main "Enabled" switch is off. (`inRoom` was not being updated, so it could also result in players being hidden outside the Mirrorverse.)

Also some small code refactors, using `onlyInIsland` as well as adding a `RealPlayer` check just in case, though it is not strictly necessary with the main bugfix, as we don't need to show any entities in the Dance Room. (I've confirmed that the mirrored players are also detected as `RealPlayer`.)

## Changelog Fixes
+ Fixed "Hide Other Players" in Dance Room Helper not working when the helper is disabled. - Luna
+ Fixed players and some mobs being hidden outside the Mirrorverse when "Hide Other Players" is enabled in Dance Room Helper. - Luna