### PR TITLE
Backend: Cache CheckRenderEntityEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderManager.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderManager.java
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
-import at.hannibal2.skyhanni.events.CheckRenderEntityEvent;
+import at.hannibal2.skyhanni.data.EntityData;
 import net.minecraft.client.renderer.culling.ICamera;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
@@ -14,7 +14,7 @@ public class MixinRenderManager {
 
     @Inject(method = "shouldRender", at = @At("HEAD"), cancellable = true)
     private void shouldRender(Entity entity, ICamera camera, double camX, double camY, double camZ, CallbackInfoReturnable<Boolean> cir) {
-        if (new CheckRenderEntityEvent<>(entity, camera, camX, camY, camZ).post()) {
+        if (EntityData.onRenderCheck(entity, camera, camX, camY, camZ)) {
             cir.setReturnValue(false);
         }
     }


### PR DESCRIPTION
## What
Add caching for CheckRenderEntityEvent.
Instead of fireing the event every frame for every mob, it only gets fired every 200ms per mob.
this reduces the invoke count from ~15k per second to ~3k per second inside dev env in hub1 for me.

this change will make the reaction on enabling/disabling render related features no longer instantly.
but the 200ms delay is not noticeable for me when swithcing buttons in the config as the ui visual animation for the button switch takes also around those 200ms.
for other features, the mob should not be visible for the first 200ms of spawning since we first check the event if there is no value cached yet.
only edge case i can see with this is were the first few frames still show the mob because some additional meta data is not yet fully loaded, but there it might also not load properly without this pr, and in workst case, seeing a mob for 1/5 of a second when it spawns even though it should be hidden is not that big of a deal imo.

## Changelog Technical Details
+ Added `CheckRenderEntityEvent` caching. - hannibal2