### PR TITLE
Backend: Event Predicates

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
@@ -24,19 +24,6 @@ class EventHandler<T : SkyHanniEvent> private constructor(
         listeners.any { it.receiveCancelled },
     )
 
-    companion object {
-        private var eventHandlerDepth by object : ThreadLocal<Int>() {
-            override fun initialValue(): Int = 0
-        }
-
-        /**
-         * Returns true if the current thread is in an event handler. This is because the event handler catches exceptions which means
-         * that we are free to throw exceptions in the event handler without crashing the game.
-         * We also return true if we are in a dev environment to alert the developer of any errors effectively.
-         */
-        val isInEventHandler get() = eventHandlerDepth > 0 || PlatformUtils.isDevEnvironment
-    }
-
     fun post(event: T, onError: ((Throwable) -> Unit)? = null): Boolean {
         invokeCount++
         if (this.listeners.isEmpty()) return false
@@ -45,7 +32,6 @@ class EventHandler<T : SkyHanniEvent> private constructor(
 
         var errors = 0
 
-        eventHandlerDepth++
         for (listener in listeners) {
             if (!listener.shouldInvoke(event)) continue
             try {
@@ -62,7 +48,6 @@ class EventHandler<T : SkyHanniEvent> private constructor(
             }
             if (event.isCancelled && !canReceiveCancelled) break
         }
-        eventHandlerDepth--
 
         if (errors > 3) {
             val hiddenErrors = errors - 3

--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
@@ -1,13 +1,10 @@
 package at.hannibal2.skyhanni.api.event
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.mixins.hooks.getValue
 import at.hannibal2.skyhanni.mixins.hooks.setValue
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.inAnyIsland
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.chat.Text
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
@@ -23,15 +20,13 @@ class EventHandler<T : SkyHanniEvent> private constructor(
 
     constructor(event: Class<T>, listeners: List<EventListeners.Listener>) : this(
         (event.name.split(".").lastOrNull() ?: event.name).replace("$", "."),
-        listeners.sortedBy { it.options.priority }.toList(),
-        listeners.any { it.options.receiveCancelled },
+        listeners.sortedBy { it.priority }.toList(),
+        listeners.any { it.receiveCancelled },
     )
 
     companion object {
         private var eventHandlerDepth by object : ThreadLocal<Int>() {
-            override fun initialValue(): Int {
-                return 0
-            }
+            override fun initialValue(): Int = 0
         }
 
         /**
@@ -52,7 +47,7 @@ class EventHandler<T : SkyHanniEvent> private constructor(
 
         eventHandlerDepth++
         for (listener in listeners) {
-            if (!shouldInvoke(event, listener)) continue
+            if (!listener.shouldInvoke(event)) continue
             try {
                 listener.invoker.accept(event)
             } catch (throwable: Throwable) {
@@ -78,20 +73,5 @@ class EventHandler<T : SkyHanniEvent> private constructor(
             )
         }
         return event.isCancelled
-    }
-
-    private fun shouldInvoke(event: SkyHanniEvent, listener: EventListeners.Listener): Boolean {
-        if (SkyHanniEvents.isDisabledInvoker(listener.name)) return false
-        if (listener.options.onlyOnSkyblock && !LorenzUtils.inSkyBlock) return false
-        if (IslandType.ANY !in listener.onlyOnIslandTypes && !inAnyIsland(listener.onlyOnIslandTypes)) return false
-        if (event.isCancelled && !listener.options.receiveCancelled) return false
-        if (
-            event is GenericSkyHanniEvent<*> &&
-            listener.generic != null &&
-            !listener.generic.isAssignableFrom(event.type)
-        ) {
-            return false
-        }
-        return true
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
@@ -1,13 +1,10 @@
 package at.hannibal2.skyhanni.api.event
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.mixins.hooks.getValue
-import at.hannibal2.skyhanni.mixins.hooks.setValue
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.chat.Text
-import at.hannibal2.skyhanni.utils.system.PlatformUtils
 
 class EventHandler<T : SkyHanniEvent> private constructor(
     val name: String,

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -99,7 +99,7 @@ class ConfigManager {
         try {
             findPositionLinks(features, mutableSetOf())
         } catch (e: Exception) {
-            if (EventHandler.isInEventHandler) throw e
+            ErrorManager.crashInDevEnv("Couldn't load config links", e)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.config
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.api.event.EventHandler
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.core.config.PositionList
 import at.hannibal2.skyhanni.data.jsonobjects.local.FriendsJson

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -99,7 +99,7 @@ class ConfigManager {
         try {
             findPositionLinks(features, mutableSetOf())
         } catch (e: Exception) {
-            ErrorManager.crashInDevEnv("Couldn't load config links", e)
+            ErrorManager.crashInDevEnv("Couldn't load config links") { e }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -91,9 +91,9 @@ object ErrorManager {
         )
     }
 
-    inline fun crashInDevEnv(reason: String, t: () -> Throwable = { RuntimeException("SkyHanni crash") }) {
+    inline fun crashInDevEnv(reason: String, t: (String) -> Throwable = { RuntimeException(it) }) {
         if (!PlatformUtils.isDevEnvironment) return
-        Minecraft.getMinecraft().crashed(CrashReport("SkyHanni - $reason", t()))
+        Minecraft.getMinecraft().crashed(CrashReport("SkyHanni - $reason", t(reason)))
     }
 
     // just log for debug cases

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -12,7 +12,9 @@ import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeLimitedSet
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import net.minecraft.client.Minecraft
+import net.minecraft.crash.CrashReport
 import kotlin.time.Duration.Companion.minutes
 
 @SkyHanniModule
@@ -64,7 +66,7 @@ object ErrorManager {
         cache.clear()
     }
 
-    // throw a error, best to not use it if not absolutely necessary
+    // throw an error, best to not use it if not absolutely necessary
     fun skyHanniError(message: String, vararg extraData: Pair<String, Any?>): Nothing {
         val exception = IllegalStateException(message.removeColor())
         println("silent SkyHanni error:")
@@ -87,6 +89,11 @@ object ErrorManager {
                 "$name copied into the clipboard, please report it on the SkyHanni discord!"
             } ?: "Error id not found!",
         )
+    }
+
+    inline fun crashInDevEnv(reason: String, t: () -> Throwable = { RuntimeException("SkyHanni crash") }) {
+        if (!PlatformUtils.isDevEnvironment) return
+        Minecraft.getMinecraft().crashed(CrashReport("SkyHanni - $reason", t()))
     }
 
     // just log for debug cases

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
@@ -86,9 +86,7 @@ object ConfigUtils {
         if (tryJumpToEditor(ConfigGuiManager.getEditorInstance())) return
 
         // TODO create utils function "crashIfInDevEnv"
-        if (EventHandler.isInEventHandler) {
-            throw Error("can not jump to editor $name")
-        }
+        ErrorManager.crashInDevEnv("Can not open the config")
         ErrorManager.logErrorStateWithData(
             "Can not open the config",
             "error while trying to jump to an editor element",

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.api.event.EventHandler
 import at.hannibal2.skyhanni.config.ConfigGuiManager
 import at.hannibal2.skyhanni.config.HasLegacyId
 import at.hannibal2.skyhanni.test.command.ErrorManager

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
@@ -85,7 +85,6 @@ object ConfigUtils {
     fun KMutableProperty0<*>.jumpToEditor() {
         if (tryJumpToEditor(ConfigGuiManager.getEditorInstance())) return
 
-        // TODO create utils function "crashIfInDevEnv"
         ErrorManager.crashInDevEnv("Can not open the config")
         ErrorManager.logErrorStateWithData(
             "Can not open the config",

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
@@ -84,7 +84,7 @@ object ConfigUtils {
     fun KMutableProperty0<*>.jumpToEditor() {
         if (tryJumpToEditor(ConfigGuiManager.getEditorInstance())) return
 
-        ErrorManager.crashInDevEnv("Can not open the config")
+        ErrorManager.crashInDevEnv("Can not open config $name")
         ErrorManager.logErrorStateWithData(
             "Can not open the config",
             "error while trying to jump to an editor element",

--- a/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternManager.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.utils.repopatterns
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.api.event.EventHandler
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.features.dev.RepoPatternConfig

--- a/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternManager.kt
@@ -80,7 +80,9 @@ object RepoPatternManager {
     /**
      * Crash if in a development environment.
      */
-    private fun crash(reason: String) = ErrorManager.crashInDevEnv(reason) { RuntimeException(reason) }
+    private fun crash(reason: String) {
+        if (PlatformUtils.isDevEnvironment) throw RuntimeException(reason)
+    }
 
     /**
      * Check that the [owner] has exclusive right to the specified [key], and locks out other code parts from ever

--- a/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternManager.kt
@@ -79,13 +79,9 @@ object RepoPatternManager {
     private val logger = LogManager.getLogger("SkyHanni")
 
     /**
-     * Crash if in a development environment, or if inside a guarded event handler.
+     * Crash if in a development environment.
      */
-    fun crash(reason: String) {
-        if (EventHandler.isInEventHandler) {
-            throw RuntimeException(reason)
-        }
-    }
+    private fun crash(reason: String) = ErrorManager.crashInDevEnv(reason) { RuntimeException(reason) }
 
     /**
      * Check that the [owner] has exclusive right to the specified [key], and locks out other code parts from ever


### PR DESCRIPTION
## What
This PR changes the way in which conditions are checked when invoking events, only looking at which conditions will have to be checked when the listener is first initialized, and storing the conditions as lists of lambdas. it also makes it so that conditions such as onlyOnSkyblock and onlyOnIsland(s) are only calculated once every tick, which should help with performance a bit on events that get called a lot (such as render events getting called every frame).

This PR also indirectly fixes the issue found and fixed in #3411, because it only accesses the values of the HandleEvent object once.

Did some testing while in hub 1, this is the difference i found when profiling the previous and the new shouldInvoke function was of more or less ~66%

<details>
<summary>Profiling Images</summary>

before
![imagen](https://github.com/user-attachments/assets/d19687c0-c867-4958-ba06-5cba5415f160)
after
![imagen](https://github.com/user-attachments/assets/6c7095b8-6d3c-41cb-a62a-f0807d40e4b8)

</details>

## Changelog Improvements
+ Improved overall performance slightly. - Empa, Nessiesson

## Changelog Technical Details
+ Changed event preconditions to be cached per tick and checked only when necessary. - Empa, ThatGravyBoat