### PR TITLE
Fix: ChestValue with non en_Us Languages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -36,6 +36,7 @@ import at.hannibal2.skyhanni.utils.renderables.addLine
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiInventory
+import net.minecraft.client.resources.I18n
 import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
 
@@ -248,9 +249,9 @@ object ChestValue {
         }
 
         val inMinion = name.contains("Minion") && !name.contains("Recipe") && IslandType.PRIVATE_ISLAND.isInIsland()
+        val inNormalChest = I18n.format("container.chest") == name || I18n.format("container.chestDouble") == name
         // TODO: Use repo for this
-        return name == "Chest" || name == "Large Chest" || inMinion ||
-            name == "Personal Vault" || name == "Chest Storage" || name == "Wood Chest+"
+        return inNormalChest || inMinion || name == "Personal Vault" || name == "Chest Storage" || name == "Wood Chest+"
     }
 
     private fun String.reduceStringLength(targetLength: Int, char: Char): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -36,7 +36,6 @@ import at.hannibal2.skyhanni.utils.renderables.addLine
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiInventory
-import net.minecraft.client.resources.I18n
 import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
 
@@ -249,9 +248,8 @@ object ChestValue {
         }
 
         val inMinion = name.contains("Minion") && !name.contains("Recipe") && IslandType.PRIVATE_ISLAND.isInIsland()
-        val inNormalChest = I18n.format("container.chest") == name || I18n.format("container.chestDouble") == name
         // TODO: Use repo for this
-        return inNormalChest || inMinion || name == "Personal Vault" || name == "Chest Storage" || name == "Wood Chest+"
+        return InventoryUtils.isInNormalChest() || inMinion || name == "Personal Vault" || name == "Chest Storage" || name == "Wood Chest+"
     }
 
     private fun String.reduceStringLength(targetLength: Int, char: Char): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.inventory
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.HideNotClickableItemsJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.SalvageFilter
 import at.hannibal2.skyhanni.events.GuiContainerEvent
@@ -34,6 +35,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.isVanilla
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.MultiFilter
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -199,7 +201,7 @@ object HideNotClickableItems {
             hideSackOfSacks(chestName, stack) -> true
             hideFishingBag(chestName, stack) -> true
             hidePotionBag(chestName, stack) -> true
-            hidePrivateIslandChest(chestName, stack) -> true
+            hidePrivateIslandChest(stack) -> true
             hideAttributeFusion(chestName, stack) -> true
             hideYourEquipment(chestName, stack) -> true
             hideComposter(chestName, stack) -> true
@@ -338,11 +340,9 @@ object HideNotClickableItems {
         return true
     }
 
-    private fun hidePrivateIslandChest(chestName: String, stack: ItemStack): Boolean {
-        if (chestName != "Chest" && chestName != "Large Chest") return false
-
-        // TODO make check if player is on private island
-
+    private fun hidePrivateIslandChest(stack: ItemStack): Boolean {
+        if (!InventoryUtils.isInNormalChest()) return false
+        if (!IslandType.PRIVATE_ISLAND.isInIsland()) return false
         if (!stack.isSoulBound()) return false
 
         hideReason = "This item cannot be stored into a chest!"

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -10,6 +10,7 @@ import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.gui.inventory.GuiInventory
 import net.minecraft.client.player.inventory.ContainerLocalMenu
+import net.minecraft.client.resources.I18n
 import net.minecraft.entity.player.InventoryPlayer
 import net.minecraft.inventory.ContainerChest
 import net.minecraft.inventory.IInventory
@@ -161,4 +162,7 @@ object InventoryUtils {
     fun closeInventory() {
         Minecraft.getMinecraft().currentScreen = null
     }
+
+    fun isInNormalChest() = openInventoryName() in listOf(I18n.format("container.chest"), I18n.format("container.chestDouble"))
+
 }


### PR DESCRIPTION
## What
Replaced String comparisons by comparing against the I18N value of container.chest & container.chestDouble to support both different languages & texturepacks changing the chest name.
I suppose this will break/trigger badly if some texturepack names container.chest to like "SkyBlock Menu" but who does that!

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/246ccc58-a7d3-497e-a43d-3fd0e47c4480)
![image](https://github.com/user-attachments/assets/655a7815-ffeb-41e6-a966-6a614d3343d3)

</details>


## Changelog Fixes
+ Fixed ChestValue not showing when using different Minecraft languages. - j10a1n15


