### PR TITLE
Improvement: Cache render 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -395,4 +395,10 @@ public class MiscConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean warnAboutPcTimeOffset = true;
+
+    @Expose
+    @ConfigOption(name = "Cache Render", desc = "Caching render actions on a tick basis. will break smoooth animations in GUI's, but will also increase performance.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean cacheRender = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.features.misc.visualwords.VisualWordGui
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.ConfigUtils
+import at.hannibal2.skyhanni.utils.RenderCache
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiInventory
@@ -67,7 +68,7 @@ object RenderData {
 
     fun renderOverlay() {
         outsideInventory = true
-        GuiRenderEvent.GuiOverlayRenderEvent().post()
+        RenderCache.onFrame()
         outsideInventory = false
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderCache.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderCache.kt
@@ -177,6 +177,11 @@ object RenderCache {
     }
 
     fun onFrame() {
+        if (!useCache) {
+            heavyRenderCall()
+            return
+        }
+
         // Trigger debug logging for one second when the player is sneaking.
         val player = Minecraft.getMinecraft().thePlayer
         if (player != null && player.isSneaking && debugGLLoggingStartTime < 0L) {
@@ -191,10 +196,6 @@ object RenderCache {
         // Update the FBO if display size changed.
         updateFBOIfNeeded()
 
-        if (!useCache) {
-            heavyRenderCall()
-            return
-        }
 
         if (updateCache) {
             renderToFBO(frameBufferId, width, height)

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderCache.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderCache.kt
@@ -1,0 +1,225 @@
+package at.hannibal2.skyhanni.utils
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ReflectionUtils.makeAccessible
+import net.minecraft.client.Minecraft
+import net.minecraft.client.renderer.GlStateManager
+import org.lwjgl.BufferUtils
+import org.lwjgl.opengl.Display
+import org.lwjgl.opengl.GL11
+import org.lwjgl.opengl.GL30
+import java.nio.ByteBuffer
+import kotlin.math.abs
+
+@SkyHanniModule
+object RenderCache {
+
+    // -- FBO and caching variables --
+    private var frameBufferId: Int = 0
+    private var textureId: Int = 0
+    private var fboWidth: Int = Display.getWidth()
+    private var fboHeight: Int = Display.getHeight()
+    private val width get() = Display.getWidth()
+    private val height get() = Display.getHeight()
+    private val useCache get() = SkyHanniMod.feature.misc.cacheRender
+    private var updateCache = false
+
+    init {
+        // Initial FBO creation.
+        val (fbId, texId) = createFBO(fboWidth, fboHeight)
+        frameBufferId = fbId
+        textureId = texId
+    }
+
+    @HandleEvent
+    fun onTick(event: SkyHanniTickEvent) {
+        if (Minecraft.getMinecraft().renderManager.fontRenderer == null) return
+        if (useCache) {
+            updateCache = true
+        }
+    }
+
+    // -- FBO update --
+    private fun updateFBOIfNeeded() {
+        val newWidth = Display.getWidth()
+        val newHeight = Display.getHeight()
+        if (newWidth != fboWidth || newHeight != fboHeight) {
+            // Free old resources:
+            GL30.glDeleteFramebuffers(frameBufferId)
+            GL11.glDeleteTextures(textureId)
+
+            val (fbId, texId) = createFBO(newWidth, newHeight)
+            frameBufferId = fbId
+            textureId = texId
+            fboWidth = newWidth
+            fboHeight = newHeight
+        }
+    }
+
+    private fun createFBO(width: Int, height: Int): Pair<Int, Int> {
+        val fboID = GL30.glGenFramebuffers()
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fboID)
+
+        val texID = GL11.glGenTextures()
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, texID)
+        GL11.glTexImage2D(
+            GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, width, height, 0,
+            GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, null as ByteBuffer?,
+        )
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR)
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR)
+
+        GL30.glFramebufferTexture2D(
+            GL30.GL_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0,
+            GL11.GL_TEXTURE_2D, texID, 0,
+        )
+
+        if (GL30.glCheckFramebufferStatus(GL30.GL_FRAMEBUFFER) != GL30.GL_FRAMEBUFFER_COMPLETE)
+            throw RuntimeException("Framebuffer not complete")
+
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0)
+        return fboID to texID
+    }
+
+    private fun renderToFBO(fboID: Int, width: Int, height: Int) {
+        GlStateManager.pushMatrix()
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fboID)
+
+        // Save current viewport.
+        val viewportBuffer = BufferUtils.createIntBuffer(16)
+        GL11.glGetInteger(GL11.GL_VIEWPORT, viewportBuffer)
+        viewportBuffer.rewind()
+        val viewport = IntArray(4) { viewportBuffer.get() }
+
+        GL11.glViewport(0, 0, width, height)
+        GL11.glClear(GL11.GL_COLOR_BUFFER_BIT or GL11.GL_DEPTH_BUFFER_BIT)
+
+        // Set up orthographic projection.
+        GL11.glMatrixMode(GL11.GL_PROJECTION)
+        GL11.glPushMatrix()
+        GL11.glLoadIdentity()
+        GL11.glOrtho(0.0, width.toDouble(), height.toDouble(), 0.0, 0.0, 1.0)
+        GL11.glMatrixMode(GL11.GL_MODELVIEW)
+        GL11.glPushMatrix()
+        GL11.glLoadIdentity()
+
+        heavyRenderCall()
+
+        // Restore matrices.
+        GL11.glPopMatrix() // MODELVIEW
+        GL11.glMatrixMode(GL11.GL_PROJECTION)
+        GL11.glPopMatrix()
+        GL11.glMatrixMode(GL11.GL_MODELVIEW)
+
+        // Unbind the FBO.
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0)
+        // Restore the previous viewport.
+        GL11.glViewport(viewport[0], viewport[1], viewport[2], viewport[3])
+        GL11.glFlush() // Ensure rendering completes
+
+        GlStateManager.popMatrix()
+    }
+
+    private fun heavyRenderCall() {
+        GlStateManager.pushMatrix()
+        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS)
+        GuiRenderEvent.GuiOverlayRenderEvent().post()
+        GL11.glPopAttrib()
+        GlStateManager.popMatrix()
+    }
+
+    // -- Frame guard using renderPartialTicks --
+    private var lastPartialTicks = -1f
+    private val timerField by lazy {
+        Minecraft::class.java.getDeclaredField("timer").makeAccessible()
+    }
+    private val renderPartialTicksField by lazy {
+        val timer = timerField.get(Minecraft.getMinecraft())
+        timer.javaClass.getDeclaredField("renderPartialTicks").makeAccessible()
+    }
+
+    private fun getRenderPartialTicks(): Float {
+        val timer = timerField.get(Minecraft.getMinecraft())
+        return renderPartialTicksField.getFloat(timer)
+    }
+
+    // -- Debug GL state logging (active for 1 second after sneaking) --
+    private const val DEBUG_GL_LOG_DURATION = 1000L
+    private var debugGLLoggingStartTime: Long = -1L
+
+    private fun startGLLogging() {
+        debugGLLoggingStartTime = System.currentTimeMillis()
+    }
+
+    private fun logGLStateIfNeeded() {
+        if (debugGLLoggingStartTime < 0L) return
+        val currentTime = System.currentTimeMillis()
+        if (currentTime - debugGLLoggingStartTime <= DEBUG_GL_LOG_DURATION) {
+            logGLState()
+        } else {
+            debugGLLoggingStartTime = -1L
+        }
+    }
+
+    private fun logGLState() {
+        val viewportBuffer = BufferUtils.createIntBuffer(16)
+        GL11.glGetInteger(GL11.GL_VIEWPORT, viewportBuffer)
+        viewportBuffer.rewind()
+        val viewport = IntArray(4) { viewportBuffer.get() }
+        println("GL State - Viewport: ${viewport.joinToString(", ")}")
+        println("GL State - Depth Test Enabled: ${GL11.glIsEnabled(GL11.GL_DEPTH_TEST)}")
+        println("GL State - Blending Enabled: ${GL11.glIsEnabled(GL11.GL_BLEND)}")
+        println("GL State - Matrix Mode: ${GL11.glGetInteger(GL11.GL_MATRIX_MODE)}")
+    }
+
+    fun onFrame() {
+        // Trigger debug logging for one second when the player is sneaking.
+        val player = Minecraft.getMinecraft().thePlayer
+        if (player != null && player.isSneaking && debugGLLoggingStartTime < 0L) {
+            startGLLogging()
+        }
+
+        // Frame guard using renderPartialTicks.
+        val currentPartialTicks = getRenderPartialTicks()
+        if (abs(currentPartialTicks - lastPartialTicks) < 0.001f) return
+        lastPartialTicks = currentPartialTicks
+
+        // Update the FBO if display size changed.
+        updateFBOIfNeeded()
+
+        if (!useCache) {
+            heavyRenderCall()
+            return
+        }
+
+        if (updateCache) {
+            renderToFBO(frameBufferId, width, height)
+            updateCache = false
+        }
+        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS)
+        GL11.glDisable(GL11.GL_DEPTH_TEST)
+        drawCachedTexture(textureId, 0f, 0f, width.toFloat(), height.toFloat())
+        GL11.glPopAttrib()
+
+        // Log GL state if within the logging period.
+        logGLStateIfNeeded()
+    }
+
+    private fun drawCachedTexture(texID: Int, x: Float, y: Float, w: Float, h: Float) {
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, texID)
+        GL11.glBegin(GL11.GL_QUADS)
+        GL11.glTexCoord2f(0f, 0f)
+        GL11.glVertex2f(x, y)
+        GL11.glTexCoord2f(1f, 0f)
+        GL11.glVertex2f(x + w, y)
+        GL11.glTexCoord2f(1f, 1f)
+        GL11.glVertex2f(x + w, y + h)
+        GL11.glTexCoord2f(0f, 1f)
+        GL11.glVertex2f(x, y + h)
+        GL11.glEnd()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderCache.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderCache.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ReflectionUtils.makeAccessible
 import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import org.lwjgl.BufferUtils
@@ -13,214 +12,209 @@ import org.lwjgl.opengl.Display
 import org.lwjgl.opengl.GL11
 import org.lwjgl.opengl.GL30
 import java.nio.ByteBuffer
-import kotlin.math.abs
 
 @SkyHanniModule
 object RenderCache {
 
-    // -- FBO and caching variables --
-    private var frameBufferId: Int = 0
-    private var textureId: Int = 0
-    private var fboWidth: Int = Display.getWidth()
-    private var fboHeight: Int = Display.getHeight()
-    private val width get() = Display.getWidth()
-    private val height get() = Display.getHeight()
+    // ---------- FBO and Cache Variables ----------
+    private var frameBufferId: Int = 0       // The offscreen framebuffer ID.
+    private var textureId: Int = 0           // The texture attached to the FBO.
+    private var fboWidth: Int = Display.getWidth()    // Initial FBO width.
+    private var fboHeight: Int = Display.getHeight()  // Initial FBO height.
+    private val width get() = Display.getWidth()       // Current display width.
+    private val height get() = Display.getHeight()     // Current display height.
+
+    // If caching is enabled, we use the cached overlay.
     private val useCache get() = SkyHanniMod.feature.misc.cacheRender
-    private var updateCache = false
 
+    // ---------- Tick Synchronization ----------
+    // currentTick is incremented once per tick.
+    private var currentTick: Long = 0
+    // lastUpdateTick records the tick number when we last updated the FBO.
+    private var lastUpdateTick: Long = -1
+
+    // ---------- Initialization ----------
     init {
-        // Initial FBO creation.
-        val (fbId, texId) = createFBO(fboWidth, fboHeight)
-        frameBufferId = fbId
-        textureId = texId
-    }
-
-    @HandleEvent
-    fun onTick(event: SkyHanniTickEvent) {
-        if (Minecraft.getMinecraft().renderManager.fontRenderer == null) return
-        if (useCache) {
-            updateCache = true
-        }
-    }
-
-    // -- FBO update --
-    private fun updateFBOIfNeeded() {
-        val newWidth = Display.getWidth()
-        val newHeight = Display.getHeight()
-        if (newWidth != fboWidth || newHeight != fboHeight) {
-            // Free old resources:
-            GL30.glDeleteFramebuffers(frameBufferId)
-            GL11.glDeleteTextures(textureId)
-
-            val (fbId, texId) = createFBO(newWidth, newHeight)
+        // Create the initial FBO with current dimensions.
+        createFBO(fboWidth, fboHeight).let { (fbId, texId) ->
             frameBufferId = fbId
             textureId = texId
-            fboWidth = newWidth
-            fboHeight = newHeight
+            println("Init: Created FBO id=$frameBufferId, texture id=$textureId, dimensions=($fboWidth x $fboHeight)")
         }
     }
 
-    private fun createFBO(width: Int, height: Int): Pair<Int, Int> {
-        val fboID = GL30.glGenFramebuffers()
-        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fboID)
-
-        val texID = GL11.glGenTextures()
-        GL11.glBindTexture(GL11.GL_TEXTURE_2D, texID)
-        GL11.glTexImage2D(
-            GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, width, height, 0,
-            GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, null as ByteBuffer?,
-        )
-        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR)
-        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR)
-
-        GL30.glFramebufferTexture2D(
-            GL30.GL_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0,
-            GL11.GL_TEXTURE_2D, texID, 0,
-        )
-
-        if (GL30.glCheckFramebufferStatus(GL30.GL_FRAMEBUFFER) != GL30.GL_FRAMEBUFFER_COMPLETE)
-            throw RuntimeException("Framebuffer not complete")
-
-        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0)
-        return fboID to texID
-    }
-
-    private fun renderToFBO(fboID: Int, width: Int, height: Int) {
-        GlStateManager.pushMatrix()
-        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fboID)
-
-        // Save current viewport.
-        val viewportBuffer = BufferUtils.createIntBuffer(16)
-        GL11.glGetInteger(GL11.GL_VIEWPORT, viewportBuffer)
-        viewportBuffer.rewind()
-        val viewport = IntArray(4) { viewportBuffer.get() }
-
-        GL11.glViewport(0, 0, width, height)
-        GL11.glClear(GL11.GL_COLOR_BUFFER_BIT or GL11.GL_DEPTH_BUFFER_BIT)
-
-        // Set up orthographic projection.
-        GL11.glMatrixMode(GL11.GL_PROJECTION)
-        GL11.glPushMatrix()
-        GL11.glLoadIdentity()
-        GL11.glOrtho(0.0, width.toDouble(), height.toDouble(), 0.0, 0.0, 1.0)
-        GL11.glMatrixMode(GL11.GL_MODELVIEW)
-        GL11.glPushMatrix()
-        GL11.glLoadIdentity()
-
-        heavyRenderCall()
-
-        // Restore matrices.
-        GL11.glPopMatrix() // MODELVIEW
-        GL11.glMatrixMode(GL11.GL_PROJECTION)
-        GL11.glPopMatrix()
-        GL11.glMatrixMode(GL11.GL_MODELVIEW)
-
-        // Unbind the FBO.
-        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0)
-        // Restore the previous viewport.
-        GL11.glViewport(viewport[0], viewport[1], viewport[2], viewport[3])
-        GL11.glFlush() // Ensure rendering completes
-
-        GlStateManager.popMatrix()
-    }
-
-    private fun heavyRenderCall() {
-        GlStateManager.pushMatrix()
-        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS)
-        GuiRenderEvent.GuiOverlayRenderEvent().post()
-        GL11.glPopAttrib()
-        GlStateManager.popMatrix()
-    }
-
-    // -- Frame guard using renderPartialTicks --
-    private var lastPartialTicks = -1f
-    private val timerField by lazy {
-        Minecraft::class.java.getDeclaredField("timer").makeAccessible()
-    }
-    private val renderPartialTicksField by lazy {
-        val timer = timerField.get(Minecraft.getMinecraft())
-        timer.javaClass.getDeclaredField("renderPartialTicks").makeAccessible()
-    }
-
-    private fun getRenderPartialTicks(): Float {
-        val timer = timerField.get(Minecraft.getMinecraft())
-        return renderPartialTicksField.getFloat(timer)
-    }
-
-    // -- Debug GL state logging (active for 1 second after sneaking) --
-    private const val DEBUG_GL_LOG_DURATION = 1000L
-    private var debugGLLoggingStartTime: Long = -1L
-
-    private fun startGLLogging() {
-        debugGLLoggingStartTime = System.currentTimeMillis()
-    }
-
-    private fun logGLStateIfNeeded() {
-        if (debugGLLoggingStartTime < 0L) return
-        val currentTime = System.currentTimeMillis()
-        if (currentTime - debugGLLoggingStartTime <= DEBUG_GL_LOG_DURATION) {
-            logGLState()
-        } else {
-            debugGLLoggingStartTime = -1L
+    // ---------- Tick Event Handler ----------
+    @HandleEvent
+    fun onTick(event: SkyHanniTickEvent) {
+        // This event is fired once per game tick.
+        currentTick++  // Increment our tick counter.
+        // Only update if the fontRenderer is available.
+        if (Minecraft.getMinecraft().renderManager.fontRenderer == null) return
+        if (useCache) {
+            println("onTick: currentTick set to $currentTick")
         }
     }
 
-    private fun logGLState() {
-        val viewportBuffer = BufferUtils.createIntBuffer(16)
-        GL11.glGetInteger(GL11.GL_VIEWPORT, viewportBuffer)
-        viewportBuffer.rewind()
-        val viewport = IntArray(4) { viewportBuffer.get() }
-        println("GL State - Viewport: ${viewport.joinToString(", ")}")
-        println("GL State - Depth Test Enabled: ${GL11.glIsEnabled(GL11.GL_DEPTH_TEST)}")
-        println("GL State - Blending Enabled: ${GL11.glIsEnabled(GL11.GL_BLEND)}")
-        println("GL State - Matrix Mode: ${GL11.glGetInteger(GL11.GL_MATRIX_MODE)}")
-    }
-
+    // ---------- Frame Rendering ----------
     fun onFrame() {
+        // If caching is disabled, perform the heavy render every frame.
         if (!useCache) {
             heavyRenderCall()
             return
         }
 
-        // Trigger debug logging for one second when the player is sneaking.
-        val player = Minecraft.getMinecraft().thePlayer
-        if (player != null && player.isSneaking && debugGLLoggingStartTime < 0L) {
-            startGLLogging()
-        }
-
-        // Frame guard using renderPartialTicks.
-        val currentPartialTicks = getRenderPartialTicks()
-        if (abs(currentPartialTicks - lastPartialTicks) < 0.001f) return
-        lastPartialTicks = currentPartialTicks
-
-        // Update the FBO if display size changed.
+        // Check if the display size has changed.
         updateFBOIfNeeded()
 
-
-        if (updateCache) {
+        // If a new tick is detected (currentTick != lastUpdateTick),
+        // update the FBO (i.e. re-render the overlay) once per tick.
+        if (currentTick != lastUpdateTick) {
+            println("onFrame: New tick detected (currentTick=$currentTick, lastUpdateTick=$lastUpdateTick). Rendering overlay to FBO.")
             renderToFBO(frameBufferId, width, height)
-            updateCache = false
+            lastUpdateTick = currentTick
         }
-        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS)
-        GL11.glDisable(GL11.GL_DEPTH_TEST)
-        drawCachedTexture(textureId, 0f, 0f, width.toFloat(), height.toFloat())
-        GL11.glPopAttrib()
 
-        // Log GL state if within the logging period.
-        logGLStateIfNeeded()
+        // Always draw the cached overlay texture.
+        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS) // Save current GL state.
+        GL11.glDisable(GL11.GL_DEPTH_TEST)          // Disable depth testing for overlay.
+        drawCachedTexture(textureId, 0f, 0f, width.toFloat(), height.toFloat())
+        GL11.glPopAttrib()                          // Restore GL state.
     }
 
-    private fun drawCachedTexture(texID: Int, x: Float, y: Float, w: Float, h: Float) {
+    // ---------- FBO Update on Display Resize ----------
+    private fun updateFBOIfNeeded() {
+        val newWidth = Display.getWidth()
+        val newHeight = Display.getHeight()
+        if (newWidth != fboWidth || newHeight != fboHeight) {
+            // Delete the old FBO and texture.
+            GL30.glDeleteFramebuffers(frameBufferId)
+            GL11.glDeleteTextures(textureId)
+            println("updateFBOIfNeeded: Display size changed from ($fboWidth x $fboHeight) to ($newWidth x $newHeight)")
+
+            // Create a new FBO with updated dimensions.
+            createFBO(newWidth, newHeight).let { (fbId, texId) ->
+                frameBufferId = fbId
+                textureId = texId
+                fboWidth = newWidth
+                fboHeight = newHeight
+                println("updateFBOIfNeeded: New FBO id=$frameBufferId, texture id=$textureId")
+            }
+        }
+    }
+
+    // ---------- FBO Creation ----------
+    private fun createFBO(width: Int, height: Int): Pair<Int, Int> {
+        // Generate a new framebuffer.
+        val fboID = GL30.glGenFramebuffers()
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fboID)
+
+        // Generate a texture to attach to the FBO.
+        val texID = GL11.glGenTextures()
         GL11.glBindTexture(GL11.GL_TEXTURE_2D, texID)
+        // Allocate texture storage with RGBA8 format.
+        GL11.glTexImage2D(
+            GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, width, height, 0,
+            GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, null as ByteBuffer?
+        )
+        // Set texture filtering for scaling.
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR)
+        GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR)
+
+        // Attach the texture to the FBO as its color buffer.
+        GL30.glFramebufferTexture2D(
+            GL30.GL_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0,
+            GL11.GL_TEXTURE_2D, texID, 0
+        )
+
+        // Check that the FBO is complete.
+        if (GL30.glCheckFramebufferStatus(GL30.GL_FRAMEBUFFER) != GL30.GL_FRAMEBUFFER_COMPLETE)
+            throw RuntimeException("createFBO: Framebuffer not complete")
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0) // Unbind the FBO.
+        println("createFBO: FBO id=$fboID with texture id=$texID created for dimensions ($width x $height)")
+        return fboID to texID
+    }
+
+    // ---------- Render to FBO ----------
+    private fun renderToFBO(fboID: Int, width: Int, height: Int) {
+        // Save the current transformation matrix.
+        GlStateManager.pushMatrix()
+        // Bind the FBO so that rendering commands draw into it.
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fboID)
+        println("renderToFBO: Bound FBO id=$fboID")
+
+        // Save the current viewport.
+        val viewportBuffer = BufferUtils.createIntBuffer(16)
+        GL11.glGetInteger(GL11.GL_VIEWPORT, viewportBuffer)
+        viewportBuffer.rewind()
+        val viewport = IntArray(4) { viewportBuffer.get() }
+        println("renderToFBO: Original viewport = ${viewport.joinToString(", ")}")
+
+        // Set the viewport to cover the entire FBO.
+        GL11.glViewport(0, 0, width, height)
+        // Clear the FBO’s color and depth buffers.
+        GL11.glClear(GL11.GL_COLOR_BUFFER_BIT or GL11.GL_DEPTH_BUFFER_BIT)
+
+        // Set up a 2D orthographic projection.
+        GL11.glMatrixMode(GL11.GL_PROJECTION)
+        GL11.glPushMatrix()   // Save the current projection matrix.
+        GL11.glLoadIdentity() // Reset projection.
+        GL11.glOrtho(0.0, width.toDouble(), height.toDouble(), 0.0, 0.0, 1.0)
+        GL11.glMatrixMode(GL11.GL_MODELVIEW)
+        GL11.glPushMatrix()   // Save the current modelview matrix.
+        GL11.glLoadIdentity() // Reset modelview.
+        println("renderToFBO: Set orthographic projection for dimensions ($width x $height)")
+
+        // Perform the heavy overlay rendering.
+        heavyRenderCall()
+
+        // Restore the matrices.
+        GL11.glPopMatrix() // Restore modelview.
+        GL11.glMatrixMode(GL11.GL_PROJECTION)
+        GL11.glPopMatrix() // Restore projection.
+        GL11.glMatrixMode(GL11.GL_MODELVIEW)
+
+        // Unbind the FBO to resume normal screen rendering.
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0)
+        // Restore the original viewport.
+        GL11.glViewport(viewport[0], viewport[1], viewport[2], viewport[3])
+        println("renderToFBO: Restored viewport to ${viewport.joinToString(", ")} and unbound FBO")
+        GL11.glFinish() // Ensure all FBO rendering commands are completed.
+        GlStateManager.popMatrix()
+    }
+
+    // ---------- Heavy Render Call ----------
+    private fun heavyRenderCall() {
+        // Save the current matrix and attribute states.
+        GlStateManager.pushMatrix()
+        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS)
+        println("heavyRenderCall: Starting heavy render call.")
+        // Post the overlay render event.
+        GuiRenderEvent.GuiOverlayRenderEvent().post()
+        println("heavyRenderCall: Finished heavy render call.")
+        // Restore states.
+        GL11.glPopAttrib()
+        GlStateManager.popMatrix()
+    }
+
+    // ---------- Draw Cached Texture ----------
+    private fun drawCachedTexture(texID: Int, x: Float, y: Float, w: Float, h: Float) {
+        // Bind the cached texture.
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, texID)
+        // Begin drawing a textured quad.
         GL11.glBegin(GL11.GL_QUADS)
+        // Bottom-left
         GL11.glTexCoord2f(0f, 0f)
         GL11.glVertex2f(x, y)
+        // Bottom-right
         GL11.glTexCoord2f(1f, 0f)
         GL11.glVertex2f(x + w, y)
+        // Top-right
         GL11.glTexCoord2f(1f, 1f)
         GL11.glVertex2f(x + w, y + h)
+        // Top-left
         GL11.glTexCoord2f(0f, 1f)
         GL11.glVertex2f(x, y + h)
         GL11.glEnd()
+        println("drawCachedTexture: Rendered quad with texture id=$texID at ($x, $y, $w, $h)")
     }
 }


### PR DESCRIPTION
## What
caching the render action to only happen once per tick, then fire the cached result every frame until next tick

## does not yet work, causes flickers and doesnt show the actual display info.
idk why. this is just my current state of where i left off.
i heavily used AI to help me with the GL state calls as i have no experience with gl at all, so this might be the reason why it doesnt work.
anyway, here it is. i appreciate if others might look at it and find the obvious error im too blind to see rn.


## Changelog Fixes
+ Increased performance while rendering GUI's

## Changelog Technical Details
+ Caching render calls