### PR TITLE
Feature: Fishy Treat Profit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.java
@@ -59,6 +59,11 @@ public class EventConfig {
     @Expose
     public AnniversaryCelebration400Config anniversaryCelebration400 = new AnniversaryCelebration400Config();
 
+    @ConfigOption(name = "Year of the Seal", desc = "Features for the 400þ year of SkyBlock")
+    @Accordion
+    @Expose
+    public YearOfTheSealConfig yearOfTheSeal = new YearOfTheSealConfig();
+
     @Category(name = "Lobby Waypoints", desc = "Lobby Event Waypoint settings")
     @Expose
     public LobbyWaypointsConfig lobbyWaypoints = new LobbyWaypointsConfig();

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.java
@@ -54,12 +54,12 @@ public class EventConfig {
     @Expose
     public CenturyConfig century = new CenturyConfig();
 
-    @ConfigOption(name = "400þ Anniversary Celebration", desc = "Features for the 400þ year of SkyBlock")
+    @ConfigOption(name = "400þ Anniversary Celebration", desc = "Features for the 400þ year of SkyBlock.")
     @Accordion
     @Expose
     public AnniversaryCelebration400Config anniversaryCelebration400 = new AnniversaryCelebration400Config();
 
-    @ConfigOption(name = "Year of the Seal", desc = "Features for the 400þ year of SkyBlock")
+    @ConfigOption(name = "Year of the Seal", desc = "Features for Year of the Seals.")
     @Accordion
     @Expose
     public YearOfTheSealConfig yearOfTheSeal = new YearOfTheSealConfig();

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/YearOfTheSealConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/YearOfTheSealConfig.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.config.features.event
 
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
-import at.hannibal2.skyhanni.config.features.garden.AnitaShopConfig
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
@@ -19,6 +18,6 @@ class YearOfTheSealConfig {
     var fishyTreatProfit: Boolean = false
 
     @Expose
-    @ConfigLink(owner = AnitaShopConfig::class, field = "fishyTreatProfit")
+    @ConfigLink(owner = YearOfTheSealConfig::class, field = "fishyTreatProfit")
     var fishyTreatProfitPosition: Position = Position(206, 158)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/YearOfTheSealConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/YearOfTheSealConfig.kt
@@ -1,0 +1,24 @@
+package at.hannibal2.skyhanni.config.features.event
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.garden.AnitaShopConfig
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class YearOfTheSealConfig {
+    @Expose
+    @ConfigOption(
+        name = "Fishy Treat Profit",
+        desc = "Shows what items to buy with your hard earned Fishy Treat.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var fishyTreatProfit: Boolean = false
+
+    @Expose
+    @ConfigLink(owner = AnitaShopConfig::class, field = "fishyTreatProfit")
+    var fishyTreatProfitPosition: Position = Position(206, 158)
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
@@ -36,6 +36,7 @@ object FishyTreatProfit {
     private val config get() = SkyHanniMod.feature.event.yearOfTheSeal
     private var display = emptyList<Renderable>()
     private val inventory = InventoryDetector { name -> name == "Lukas the Aquarist" }
+    private val FISHY_TREAT = "FISHY_TREAT".toInternalName()
 
     private val patternGroup = RepoPattern.group("event.year-of-the-seal.fishy-treat")
 
@@ -75,12 +76,9 @@ object FishyTreatProfit {
 
     private fun readItem(slot: Int, item: ItemStack, table: MutableList<DisplayTableEntry>) {
         val itemName = getItemName(item)
-        if (isInvalidItemName(itemName)) return
-
         val allMaterials = getAdditionalMaterials(getRequiredItems(item))
-        val fishyTreat = "FISHY_TREAT".toInternalName()
-        val additionalMaterials = allMaterials.filter { it.key != fishyTreat }
-        val amountOfFishyTreat = allMaterials[fishyTreat] ?: run {
+        val additionalMaterials = allMaterials.filter { it.key != FISHY_TREAT }
+        val amountOfFishyTreat = allMaterials[FISHY_TREAT] ?: run {
             ErrorManager.logErrorStateWithData(
                 "failed reading fishy treat amount",
                 "fishy treat amount not found in additionalMaterials",
@@ -142,16 +140,6 @@ object FishyTreatProfit {
         for ((internalName, amount) in additionalMaterials) {
             add(internalName.getPriceName(amount))
         }
-    }
-
-    private fun isInvalidItemName(itemName: String): Boolean = when (itemName) {
-        " ",
-        "§cClose",
-        "§eUnique Gold Medals",
-        "§aMedal Trades",
-        -> true
-
-        else -> false
     }
 
     private fun getItemName(item: ItemStack): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
@@ -1,15 +1,13 @@
-package at.hannibal2.skyhanni.features.garden
+package at.hannibal2.skyhanni.features.event.yearoftheseal
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
-import at.hannibal2.skyhanni.features.garden.visitor.VisitorApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.add
 import at.hannibal2.skyhanni.utils.DisplayTableEntry
+import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
@@ -22,47 +20,45 @@ import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.item.ItemStack
 
 @SkyHanniModule
-object AnitaMedalProfit {
+object FishyTreatProfit {
 
-    private val config get() = GardenApi.config.anitaShop
+    private val config get() = SkyHanniMod.feature.event.yearOfTheSeal
     private var display = emptyList<Renderable>()
+    private val inventory = InventoryDetector { name -> name == "Lukas the Aquarist" }
 
-    var inInventory = false
+    private val patternGroup = RepoPattern.group("event.year-of-the-seal.fishy-treat")
 
-    enum class MedalType(val displayName: String, val factorBronze: Int) {
-        GOLD("§6Gold medal", 8),
-        SILVER("§fSilver medal", 2),
-        BRONZE("§cBronze medal", 1),
-    }
+    /**
+     * REGEX-TEST: §62,000,000 Coins
+     */
+    private val coinsPattern by patternGroup.pattern(
+        "coins",
+        "§6(?<coins>.*) Coins",
+    )
 
-    private fun getMedal(name: String) = MedalType.entries.firstOrNull { it.displayName == name }
-
-    @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
-        inInventory = false
-    }
-
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!config.medalProfitEnabled) return
-        if (event.inventoryName != "Anita") return
-        if (VisitorApi.inInventory) return
-
-        inInventory = true
-
+        if (!config.fishyTreatProfit || !inventory.isInside()) return
         val table = mutableListOf<DisplayTableEntry>()
         for ((slot, item) in event.inventoryItems) {
+            // ignore the last line of menu items
+            if (slot > 44) continue
             try {
                 readItem(slot, item, table)
             } catch (e: Throwable) {
                 ErrorManager.logErrorWithData(
-                    e, "Error in AnitaMedalProfit while reading item '${item.itemName}'",
+                    e, "Error in FishyTreatProfit while reading item '${item.itemName}'",
                     "item" to item,
                     "name" to item.itemName,
                     "inventory name" to InventoryUtils.openInventoryName(),
@@ -71,21 +67,31 @@ object AnitaMedalProfit {
         }
 
         val newList = mutableListOf<Renderable>()
-        newList.add(Renderable.string("§eProfit per Bronze Medal"))
+        newList.add(Renderable.string("§eProfit per Fishy Treat"))
         newList.add(LorenzUtils.fillTable(table, padding = 5, itemScale = 0.7))
         display = newList
+        return
     }
 
     private fun readItem(slot: Int, item: ItemStack, table: MutableList<DisplayTableEntry>) {
         val itemName = getItemName(item)
         if (isInvalidItemName(itemName)) return
 
-        val requiredItems = getRequiredItems(item)
-        val additionalMaterials = getAdditionalMaterials(requiredItems)
-        val additionalCost = getAdditionalCost(additionalMaterials)
+        val allMaterials = getAdditionalMaterials(getRequiredItems(item))
+        val fishyTreat = "FISHY_TREAT".toInternalName()
+        val additionalMaterials = allMaterials.filter { it.key != fishyTreat }
+        val amountOfFishyTreat = allMaterials[fishyTreat] ?: run {
+            ErrorManager.logErrorStateWithData(
+                "failed reading fishy treat amount",
+                "fishy treat amount not found in additionalMaterials",
+                "itemName" to itemName,
+                "additionalMaterials" to allMaterials,
+                "inventory" to "",
+            )
+            return
+        }
 
-        // Ignore items without medal cost, e.g. InfiniDirt Wand
-        val bronzeCost = getBronzeCost(requiredItems) ?: return
+        val additionalCost = getAdditionalCost(additionalMaterials)
 
         val (name, amount) = ItemUtils.readItemAmount(itemName) ?: return
 
@@ -100,11 +106,11 @@ object AnitaMedalProfit {
         val profitPerSell = itemPrice - additionalCost
 
         // profit per bronze
-        val profitPerBronze = profitPerSell / bronzeCost
+        val profitPerFishy = profitPerSell / amountOfFishyTreat
 
-        val profitPerSellFormat = profitPerSell.shortFormat()
-        val profitPerBronzeFormat = profitPerBronze.shortFormat()
-        val color = if (profitPerBronze > 0) "§6" else "§c"
+//         val profitPerSellFormat = profitPerSell.shortFormat()
+        val profitPerFishyFormat = profitPerFishy.shortFormat()
+        val color = if (profitPerFishy > 0) "§6" else "§c"
 
         val hover = buildList {
             add(itemName)
@@ -115,16 +121,16 @@ object AnitaMedalProfit {
             add("§7Additional cost: §6${additionalCost.shortFormat()}")
             addAdditionalMaterials(additionalMaterials)
 
-            add("§7Profit per sell: §6$profitPerSellFormat")
+//             add("§7Profit per sell: §6$profitPerSellFormat")
             add("")
-            add("§7Bronze medals required: §c$bronzeCost")
-            add("§7Profit per bronze medal: §6$profitPerBronzeFormat")
+            add("§7Fishy Treat required: §c$amountOfFishyTreat")
+            add("§7Profit per Fishy Treat: §6$profitPerFishyFormat")
         }
         table.add(
             DisplayTableEntry(
                 itemName,
-                "$color$profitPerBronzeFormat",
-                profitPerBronze,
+                "$color$profitPerFishyFormat",
+                profitPerFishy,
                 internalName,
                 hover,
                 highlightsOnHoverSlots = listOf(slot),
@@ -159,8 +165,9 @@ object AnitaMedalProfit {
     private fun getAdditionalMaterials(requiredItems: Map<String, Int>): Map<NeuInternalName, Int> {
         val additionalMaterials = mutableMapOf<NeuInternalName, Int>()
         for ((name, amount) in requiredItems) {
-            val medal = getMedal(name)
-            if (medal == null) {
+            coinsPattern.matchMatcher(name) {
+                additionalMaterials[NeuInternalName.SKYBLOCK_COIN] = group("coins").formatInt()
+            } ?: run {
                 additionalMaterials[NeuInternalName.fromItemName(name)] = amount
             }
         }
@@ -173,15 +180,6 @@ object AnitaMedalProfit {
             otherItemsPrice += name.getPrice() * amount
         }
         return otherItemsPrice
-    }
-
-    private fun getBronzeCost(requiredItems: Map<String, Int>): Int? {
-        for ((name, amount) in requiredItems) {
-            getMedal(name)?.let {
-                return it.factorBronze * amount
-            }
-        }
-        return null
     }
 
     private fun getRequiredItems(item: ItemStack): MutableMap<String, Int> {
@@ -204,7 +202,7 @@ object AnitaMedalProfit {
                 val pair = ItemUtils.readItemAmount(rawItemName)
                 if (pair == null) {
                     ErrorManager.logErrorStateWithData(
-                        "Error in Anita Medal Contest", "Could not read item amount",
+                        "Error in FishyTreat Profit", "Could not read item amount",
                         "rawItemName" to rawItemName,
                         "name" to item.name,
                         "lore" to lore,
@@ -217,19 +215,12 @@ object AnitaMedalProfit {
         return items
     }
 
-    @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
-        if (!inInventory || VisitorApi.inInventory) return
-        config.medalProfitPos.renderRenderables(
-            display,
-            extraSpace = 5,
-            posLabel = "Anita Medal Profit",
-        )
-    }
-
-    @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
-        event.move(3, "garden.anitaMedalProfitEnabled", "garden.anitaShop.medalProfitEnabled")
-        event.move(3, "garden.anitaMedalProfitPos", "garden.anitaShop.medalProfitPos")
+    init {
+        RenderDisplayHelper(
+            condition = { config.fishyTreatProfit },
+            inventory = inventory,
+        ) {
+            config.fishyTreatProfitPosition.renderRenderables(display, posLabel = "Fishy Treat Profit")
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PesthunterProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PesthunterProfit.kt
@@ -35,7 +35,6 @@ object PesthunterProfit {
         " ",
     )
     private var display = emptyList<Renderable>()
-    private val tradeProfits = mutableListOf<Double>()
     private var inInventory = false
 
     /**
@@ -52,7 +51,6 @@ object PesthunterProfit {
     @HandleEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
         inInventory = false
-        tradeProfits.clear()
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -16,13 +16,17 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.EssenceUtils
 import at.hannibal2.skyhanni.utils.EssenceUtils.getEssencePrices
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.formatCoin
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.formatCoinWithBrackets
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getRawCraftCostOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getAttributeFromShard
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.getNumberedName
 import at.hannibal2.skyhanni.utils.ItemUtils.getReadableNBTDump
 import at.hannibal2.skyhanni.utils.ItemUtils.isRune
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
@@ -35,9 +39,7 @@ import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.SKYBLOCK_COIN
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NeuItems.removePrefix
-import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.intPow
-import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PrimitiveIngredient
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAbilityScrolls
@@ -176,7 +178,7 @@ object EstimatedItemValueCalculator {
         if (comboPrice != null) {
             val useless = isUselessAttribute(combo)
             val gray = comboPrice <= basePrice || useless
-            list.add("§7Attribute Combo: ${comboPrice.formatWithBrackets(gray)}")
+            list.add("§7Attribute Combo: ${comboPrice.formatCoinWithBrackets(gray)}")
             if (!useless) {
                 subTotal += addAttributePrice(comboPrice, basePrice)
             }
@@ -200,7 +202,7 @@ object EstimatedItemValueCalculator {
             list.add(
                 "  $nameColor${
                     displayName.allLettersFirstUppercase()
-                } ${attr.second}§7: ${price?.format(gray) ?: "Unknown"}",
+                } ${attr.second}§7: ${price?.formatCoin(gray) ?: "Unknown"}",
             )
         }
         // Adding 0.1 so that we always show the estimated item value overlay
@@ -247,8 +249,8 @@ object EstimatedItemValueCalculator {
         val applyCost = reforge.costs?.let { getReforgeStoneApplyCost(stack, it, internalName) } ?: return 0.0
 
         list.add("§7Reforge: §9${reforge.name}")
-        list.add(" §7Stone: $reforgeStoneName ${reforgeStonePrice.formatWithBrackets()}")
-        list.add(" §7Apply cost: ${applyCost.formatWithBrackets()}")
+        list.add(" §7Stone: $reforgeStoneName ${reforgeStonePrice.formatCoinWithBrackets()}")
+        list.add(" §7Apply cost: ${applyCost.formatCoinWithBrackets()}")
         return reforgeStonePrice + applyCost
     }
 
@@ -352,14 +354,14 @@ object EstimatedItemValueCalculator {
 
     private fun MutableList<String>.formatHaving(label: String, internalName: NeuInternalName): Double {
         val price = internalName.getPrice()
-        add("§7$label: §a§l✔ ${price.formatWithBrackets()}")
+        add("§7$label: §a§l✔ ${price.formatCoinWithBrackets()}")
         return price
     }
 
     private fun addEtherwarp(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.hasEtherwarp()) return 0.0
         val price = ETHERWARP_CONDUIT.getPrice() + ETHERWARP_MERGER.getPrice()
-        list.add("§7Etherwarp: §a§l✔ ${price.formatWithBrackets()}")
+        list.add("§7Etherwarp: §a§l✔ ${price.formatCoinWithBrackets()}")
         return price
     }
 
@@ -480,7 +482,7 @@ object EstimatedItemValueCalculator {
     }
 
     private fun formatProgress(label: String, have: Int, max: Int, price: Number): String {
-        return "§7$label: §e$have§7/§e$max ${price.formatWithBrackets()}"
+        return "§7$label: §e$have§7/§e$max ${price.formatCoinWithBrackets()}"
     }
 
     private fun addStars(stack: ItemStack, list: MutableList<String>): Double {
@@ -591,7 +593,7 @@ object EstimatedItemValueCalculator {
 
         val (totalPrice, names) = getTotalAndNames(drillUpgrades)
         if (names.isNotEmpty()) {
-            list.add("§7Drill upgrades: " + totalPrice.format())
+            list.add("§7Drill upgrades: " + totalPrice.formatCoin())
             list += names
         }
         return totalPrice
@@ -602,7 +604,7 @@ object EstimatedItemValueCalculator {
 
         val (totalPrice, names) = getTotalAndNames(abilityScrolls)
         if (names.isNotEmpty()) {
-            list.add("§7Ability Scrolls: " + totalPrice.format())
+            list.add("§7Ability Scrolls: " + totalPrice.formatCoin())
             list += names
         }
         return totalPrice
@@ -613,7 +615,7 @@ object EstimatedItemValueCalculator {
 
         val enchantmentsCap: Int = config.enchantmentsCap.get()
         if (names.isEmpty()) return 0.0
-        list.add("§7Enchantments: " + totalPrice.format())
+        list.add("§7Enchantments: " + totalPrice.formatCoin())
         var i = 0
         for (name in names) {
             if (i == enchantmentsCap) {
@@ -703,7 +705,7 @@ object EstimatedItemValueCalculator {
 
         val (totalPrice, names) = getTotalAndNames(items)
         if (names.isNotEmpty()) {
-            list.add("§7Gemstones Applied: " + totalPrice.format())
+            list.add("§7Gemstones Applied: " + totalPrice.formatCoin())
             list += names
         }
         return totalPrice
@@ -738,7 +740,7 @@ object EstimatedItemValueCalculator {
         if (slotNames.isEmpty()) return 0.0
 
         val (totalPrice, names) = getTotalAndNames(items)
-        list.add("§7Gemstone Slot Unlock Cost: " + totalPrice.format())
+        list.add("§7Gemstone Slot Unlock Cost: " + totalPrice.formatCoin())
 
         list += names
 
@@ -763,34 +765,13 @@ object EstimatedItemValueCalculator {
             val price = internalName.getPriceOrNull()
             if (price != null) {
                 totalPrice += price * amount.toDouble()
-                map[internalName.getPriceName(amount)] = price
+                map[internalName.getPriceName(amount, internalName.getPrice())] = price
             } else {
                 val name = internalName.getNumberedName(amount)
                 map[" $name §cUnknown price!"] = Double.MAX_VALUE
             }
         }
         return totalPrice to map.sortedDesc().keys.toList()
-    }
-
-    private fun NeuInternalName.getPriceName(amount: Number): String {
-        val price = getPrice() * amount.toDouble()
-        if (this == SKYBLOCK_COIN) return " ${price.format()} coins"
-
-        return " ${getNumberedName(amount)} ${price.formatWithBrackets()}"
-    }
-
-    private fun NeuInternalName.getNumberedName(amount: Number): String {
-        val prefix = if (amount == 1.0) "" else "§8${amount.addSeparators()}x "
-        return "$prefix§r$itemName"
-    }
-
-    private fun Number.formatWithBrackets(gray: Boolean = false): String {
-        return "§7(" + format(gray) + "§7)"
-    }
-
-    private fun Number.format(gray: Boolean = false): String {
-        val color = if (gray) "§7" else "§6"
-        return color + shortFormat()
     }
 
     private fun addHelmetSkin(stack: ItemStack, list: MutableList<String>): Double {
@@ -821,7 +802,7 @@ object EstimatedItemValueCalculator {
         val displayName = name ?: "§c${internalName.asString()}"
         val gray = shouldIgnorePrice.get()
 
-        list.add("§7$label: $displayName " + price.formatWithBrackets(gray))
+        list.add("§7$label: $displayName " + price.formatCoinWithBrackets(gray))
         if (name == null) {
             list.add("   §8(Not yet in NEU Repo)")
         }
@@ -835,7 +816,7 @@ object EstimatedItemValueCalculator {
 
         val price = internalName.getPrice()
         val name = internalName.itemName
-        list.add("§7Enrichment: $name ${price.formatWithBrackets()}")
+        list.add("§7Enrichment: $name ${price.formatCoinWithBrackets()}")
         return price
     }
 
@@ -846,7 +827,7 @@ object EstimatedItemValueCalculator {
             val price = it.getAttributePrice()
             if (price != null) {
                 val name = it.getAttributeName()
-                list.add("§7Base item: $name ${price.formatWithBrackets()}")
+                list.add("§7Base item: $name ${price.formatCoinWithBrackets()}")
                 return price
             }
         }
@@ -873,7 +854,7 @@ object EstimatedItemValueCalculator {
             return 0.0
         }
 
-        list.add("§7Base item: $name ${price.formatWithBrackets()}")
+        list.add("§7Base item: $name ${price.formatCoinWithBrackets()}")
         return price
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -7,12 +7,15 @@ import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.getBazaarData
 import at.hannibal2.skyhanni.features.inventory.bazaar.HypixelItemApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.ItemUtils.getNumberedName
 import at.hannibal2.skyhanni.utils.ItemUtils.getRecipePrice
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.SKYBLOCK_COIN
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NeuItems.getRecipes
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import com.google.gson.JsonObject
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates
@@ -174,5 +177,21 @@ object ItemPriceUtils {
 
     private fun refreshLowestBins() {
         lowestBins = ApiUtils.getJSONResponse("https://moulberry.codes/lowestbin.json.gz", gunzip = true)
+    }
+
+    fun NeuInternalName.getPriceName(amount: Number, pricePer: Double = getPrice()): String {
+        val price = pricePer * amount.toDouble()
+        if (this == SKYBLOCK_COIN) return " ${price.formatCoin()} coins"
+
+        return " ${getNumberedName(amount)} ${price.formatCoinWithBrackets()}"
+    }
+
+    fun Number.formatCoinWithBrackets(gray: Boolean = false): String {
+        return "§7(" + formatCoin(gray) + "§7)"
+    }
+
+    fun Number.formatCoin(gray: Boolean = false): String {
+        val color = if (gray) "§7" else "§6"
+        return color + shortFormat()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -774,4 +774,9 @@ object ItemUtils {
         getTagList(key, Constants.NBT.TAG_COMPOUND).let { loreList ->
             List(loreList.tagCount()) { loreList.getCompoundTagAt(it) }
         }
+
+    fun NeuInternalName.getNumberedName(amount: Number): String {
+        val prefix = if (amount == 1.0) "" else "§8${amount.addSeparators()}x "
+        return "$prefix§r$itemName"
+    }
 }


### PR DESCRIPTION
## What
Added Fishy Treat Profit Display.
Copied code from Anita Medal Profit (we need to abstract this finally!!)
Also moved some coin formatting functions from estimated item value into public domain.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/5faa66f4-52a2-47dc-a70c-22ea6e3323f1)

</details>

## Changelog New Features
+ Added Fishy Treat Profit Display. - hannibal2
    * Shows what item to purchase with your hard-earned Fishy Treat.