### PR TITLE
Fix: Mineshaft Room Id again

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -191,11 +191,11 @@ object MiningApi {
 
     @HandleEvent
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {
-        if (!inColdIsland()) return
-
         dungeonRoomPattern.firstMatcher(event.added) {
             mineshaftRoomId = group("roomId")
         }
+
+        if (!inColdIsland()) return
 
         val newCold = coldPattern.firstMatcher(event.added) {
             group("cold").toInt().absoluteValue

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -27,6 +27,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -191,8 +192,8 @@ object MiningApi {
 
     @HandleEvent
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {
-        dungeonRoomPattern.firstMatcher(event.added) {
-            mineshaftRoomId = group("roomId")
+        dungeonRoomPattern.firstMatcher(event.full) {
+            groupOrNull("roomId")?.let { mineshaftRoomId = it }
         }
 
         if (!inColdIsland()) return

--- a/src/main/java/at/hannibal2/skyhanni/events/ScoreboardUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/ScoreboardUpdateEvent.kt
@@ -3,9 +3,11 @@ package at.hannibal2.skyhanni.events
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
 class ScoreboardUpdateEvent(
+    @Deprecated("Use new instead", ReplaceWith("new"))
     val full: List<String>,
     val old: List<String>,
 ) : SkyHanniEvent() {
+    val new = full
 
     val added: List<String> = full - old.toSet()
     val removed: List<String> = old - full.toSet()

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
@@ -15,6 +15,7 @@ object ScoreboardElementLobbyCode : ScoreboardElement() {
         listOfNotNull(
             HypixelData.serverId,
             DungeonApi.roomId,
+            "test string",
             MiningApi.mineshaftRoomId,
         ).forEach { append(" §8$it") }
     }.trim()

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
@@ -15,7 +15,6 @@ object ScoreboardElementLobbyCode : ScoreboardElement() {
         listOfNotNull(
             HypixelData.serverId,
             DungeonApi.roomId,
-            "test string",
             MiningApi.mineshaftRoomId,
         ).forEach { append(" §8$it") }
     }.trim()


### PR DESCRIPTION
## What
this time surely
the lines probably get set before the island type is known, causing the room to not be in added lines after its known


## Changelog Fixes
+ Fixed Custom Scoreboard not displaying Mineshaft Room ID. - j10a1n15