### PR TITLE
Backend: cachedExtraData

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -63,13 +63,18 @@ object ErrorManager {
     fun resetCache() {
         cache.clear()
     }
+    // Extra data from last thrown error
+    private var cachedExtraData: String? = null
 
     // throw a error, best to not use it if not absolutely necessary
     fun skyHanniError(message: String, vararg extraData: Pair<String, Any?>): Nothing {
         val exception = IllegalStateException(message.removeColor())
         println("silent SkyHanni error:")
         println("message: '$message'")
-        println("extraData: \n${buildExtraDataString(extraData)}")
+        buildExtraDataString(extraData)?.let {
+            println("extraData: \n$it")
+            cachedExtraData = it
+        }
         throw exception
     }
 
@@ -99,6 +104,7 @@ object ErrorManager {
         betaOnly: Boolean = false,
         condition: () -> Boolean = { true },
     ) {
+        cachedExtraData = null
         logError(
             IllegalStateException(internalMessage),
             userMessage,
@@ -158,7 +164,7 @@ object ErrorManager {
         }
         val randomId = StringUtils.generateRandomId()
 
-        val extraDataString = buildExtraDataString(extraData)
+        val extraDataString = getExtraDataOrCached(extraData)
         val rawMessage = message.removeColor()
         errorMessages[randomId] = "```\nSkyHanni ${SkyHanniMod.VERSION}: $rawMessage\n \n$stackTrace\n$extraDataString```"
         fullErrorMessages[randomId] =
@@ -171,6 +177,16 @@ object ErrorManager {
             "§eClick to copy!",
             prefix = false,
         )
+    }
+
+    private fun getExtraDataOrCached(extraData: Array<out Pair<String, Any?>>): String {
+        cachedExtraData?.let {
+            cachedExtraData = null
+            if (extraData.isEmpty()) {
+                return it
+            }
+        }
+        return buildExtraDataString(extraData) ?: ""
     }
 
     private fun buildFinalMessage(message: String): String? {
@@ -216,7 +232,7 @@ object ErrorManager {
         repoErrors = data.changedErrorMessages.filter { it.fixedIn == null || version < it.fixedIn }
     }
 
-    private fun buildExtraDataString(extraData: Array<out Pair<String, Any?>>): String {
+    private fun buildExtraDataString(extraData: Array<out Pair<String, Any?>>): String? {
         val extraDataString = if (extraData.isNotEmpty()) {
             val builder = StringBuilder()
             for ((key, value) in extraData) {
@@ -234,7 +250,7 @@ object ErrorManager {
                 builder.append("\n")
             }
             "\nExtra data:\n$builder"
-        } else ""
+        } else null
         return extraDataString
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -196,7 +196,7 @@ object ErrorManager {
                 return it
             }
         }
-        return buildExtraDataString(extraData) ?: ""
+        return buildExtraDataString(extraData).orEmpty()
     }
 
     private fun buildFinalMessage(message: String): String? {

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -63,6 +63,7 @@ object ErrorManager {
     fun resetCache() {
         cache.clear()
     }
+
     // Extra data from last thrown error
     private var cachedExtraData: String? = null
 
@@ -104,7 +105,9 @@ object ErrorManager {
         betaOnly: Boolean = false,
         condition: () -> Boolean = { true },
     ) {
-        cachedExtraData = null
+        if (extraData.isNotEmpty()) {
+            cachedExtraData = null
+        }
         logError(
             IllegalStateException(internalMessage),
             userMessage,


### PR DESCRIPTION
## What

Currently, when running `Errormanager.skyHanniError()` with extra data, this data is not shown in the final strack trace since the error is getting catched by another sh error manager that then does the logic.

This PR tries to fix this by caching the extra data over to the final error.

Does not yet work

## Changelog Technical Details
+ Added cachedExtraData to ErrorManager. - hannibal2