### PR TITLE
Fix: Neu Souls Dwarven Mines/Glacite Tunnels

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FairySoulPathFind.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FairySoulPathFind.kt
@@ -31,11 +31,20 @@ object FairySoulPathFind {
 
         val souls = mutableMapOf<LorenzVec, GraphNode>()
 
+        var skipped = 0
         for (pos in list) {
             val vec = pos.toLorenzVec()
             val node = graph.minBy { it.position.distance(vec) }
-            souls[vec] = node
+            val distance = node.position.distance(vec)
+            if (distance > 15) {
+                // we skip some souls that are too far away from the closest node, especially for dwarven mines/glacite tunnels
+                skipped++
+            } else {
+                souls[vec] = node
+            }
         }
+        // stopped bc we are done already
+        if (souls.isEmpty()) return
 
         val playerNode = graph.minBy { it.position.distanceSqToPlayer() }
 
@@ -46,8 +55,10 @@ object FairySoulPathFind {
             distances[location] = distance + lastDistance
         }
 
-        val percentage = (found.toDouble() / total) * 100
-        val label = "§b$found/$total (${percentage.roundTo(1)}%)"
+        val displayTotal = total - skipped
+
+        val percentage = (found.toDouble() / displayTotal) * 100
+        val label = "§b$found/$displayTotal (${percentage.roundTo(1)}%)"
 
         val closest = distances.minBy { it.value }.key
         IslandGraphs.pathFind(


### PR DESCRIPTION
## What
Added a disatance check to ignore fairy souls in dwarven mines/glacite tunnels.
This is just a workaround, the proper solution is that NEU should not highlight the wrong fairy souls to begin with.
Maybe blocking the highlight for those souls in the future via this sh workaround?

reported: https://discord.com/channels/997079228510117908/1339795740159119460

## Changelog Fixes
+ Fixed NEU Souls in Dwarven Mines and Glacite Tunnels. - hannibal2