### PR TITLE
Fix: Visitor Supercraft incorrectly showing/not showing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
@@ -70,6 +70,8 @@ object GardenVisitorSupercraft {
     }
 
     private fun getSupercraftForSacks(internalName: NeuInternalName, amount: Int) {
+        val amountInSacks = internalName.getAmountInSacks()
+
         val ingredients = NeuItems.getRecipes(internalName)
             // TODO describe what this line does
             .firstOrNull { !it.ingredients.first().internalName.contains("PEST") }
@@ -82,7 +84,7 @@ object GardenVisitorSupercraft {
         for ((key, value) in requiredIngredients) {
             val sackItem = key.getAmountInSacks()
             lastSuperCraftMaterial = internalName.asString()
-            if (sackItem < value * amount) {
+            if (sackItem < value * (amount - amountInSacks)) {
                 hasIngredients = false
                 break
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
@@ -71,6 +71,7 @@ object GardenVisitorSupercraft {
 
     private fun getSupercraftForSacks(internalName: NeuInternalName, amount: Int) {
         val amountInSacks = internalName.getAmountInSacks()
+        if (amountInSacks >= amount) return
 
         val ingredients = NeuItems.getRecipes(internalName)
             // TODO describe what this line does


### PR DESCRIPTION
## What
Fixed Garden Visitor Supercraft button incorrectly showing or not showing in some cases.

## Changelog Fixes
+ Fixed Garden Visitor Supercraft button not appearing when you can't craft all crops but already have the remainder in sacks. - Luna
    * E.g., if a visitor wants 8 Enchanted Melon Blocks and you have 2 Enchanted Melon Blocks and 960 Enchanted Melons.
+ Fixed Garden Visitor Supercraft button displaying even when all required items are already crafted. - Luna