### PR TITLE
Fix: Wrong skill level being displayed in some places and some instances of it freezing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -329,8 +329,7 @@ object SkillApi {
                     60 -> XP_NEEDED_FOR_60
                     else -> 0
                 }
-            }
-            else {
+            } else {
                 0
             }
         } ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -321,7 +321,7 @@ object SkillApi {
     }
 
     private fun updateSkillInfo(existingLevel: SkillInfo, level: Int, currentXP: Long, maxXP: Long, totalXP: Long, gained: String) {
-        val cap = activeSkill?.maxLevel
+        val cap = activeSkill?.maxLevel ?: 0 // null value will never be used
         val add = if (level >= cap) {
             when (cap) {
                 50 -> XP_NEEDED_FOR_50

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -321,8 +321,8 @@ object SkillApi {
     }
 
     private fun updateSkillInfo(existingLevel: SkillInfo, level: Int, currentXP: Long, maxXP: Long, totalXP: Long, gained: String) {
-        val cap = activeSkill?.maxLevel ?: 60
-        val add = if (level >= cap) {
+        val cap = activeSkill?.maxLevel
+        val add = if (level >= cap ?: 0) {
             when (cap) {
                 50 -> XP_NEEDED_FOR_50
                 60 -> XP_NEEDED_FOR_60

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -327,7 +327,6 @@ object SkillApi {
                 when (it) {
                     50 -> XP_NEEDED_FOR_50
                     60 -> XP_NEEDED_FOR_60
-                    else -> 0
                 }
             }
         } ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -332,7 +332,7 @@ object SkillApi {
         } ?: 0
 
         val (levelOverflow, currentOverflow, currentMaxOverflow, totalOverflow) =
-            calculateSkillLevel(totalXP + add, cap)
+            calculateSkillLevel(totalXP + add, cap ?: 60)
 
         existingLevel.apply {
             this.totalXp = totalXP

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -279,8 +279,10 @@ object SkillApi {
             }
 
             maxSkillTabPattern.matchMatcher(line) {
-                tablistLevel = group("level").toInt()
-                if (group("type").lowercase() != activeSkill?.lowercaseName) tablistLevel = null
+                if (group("type") == skillType.displayName) {
+                    tablistLevel = group("level").toInt()
+                    if (group("type").lowercase() != activeSkill?.lowercaseName) tablistLevel = null
+                }
             }
 
             skillTabNoPercentPattern.matchMatcher(line) {

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -322,7 +322,7 @@ object SkillApi {
 
     private fun updateSkillInfo(existingLevel: SkillInfo, level: Int, currentXP: Long, maxXP: Long, totalXP: Long, gained: String) {
         val cap = activeSkill?.maxLevel
-        val add = if (level >= 50) {
+        val add = if (level >= cap) {
             when (cap) {
                 50 -> XP_NEEDED_FOR_50
                 60 -> XP_NEEDED_FOR_60

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -322,15 +322,11 @@ object SkillApi {
 
     private fun updateSkillInfo(existingLevel: SkillInfo, level: Int, currentXP: Long, maxXP: Long, totalXP: Long, gained: String) {
         val cap = activeSkill?.maxLevel
-        val add = cap?.let {
-            if (level >= it) {
-                when (it) {
-                    50 -> XP_NEEDED_FOR_50
-                    60 -> XP_NEEDED_FOR_60
-                    else -> 0
-                }
-            } else {
-                0
+        val add = cap?.takeIf { level >= it }?.let {
+            when (it) {
+                50 -> XP_NEEDED_FOR_50
+                60 -> XP_NEEDED_FOR_60
+                else -> 0
             }
         } ?: 0
 

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -321,7 +321,7 @@ object SkillApi {
     }
 
     private fun updateSkillInfo(existingLevel: SkillInfo, level: Int, currentXP: Long, maxXP: Long, totalXP: Long, gained: String) {
-        val cap = activeSkill?.maxLevel ?: 0 // null value will never be used
+        val cap = activeSkill?.maxLevel ?: 60
         val add = if (level >= cap) {
             when (cap) {
                 50 -> XP_NEEDED_FOR_50
@@ -333,7 +333,7 @@ object SkillApi {
         }
 
         val (levelOverflow, currentOverflow, currentMaxOverflow, totalOverflow) =
-            calculateSkillLevel(totalXP + add, cap ?: 60)
+            calculateSkillLevel(totalXP + add, cap)
 
         existingLevel.apply {
             this.totalXp = totalXP

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -329,6 +329,9 @@ object SkillApi {
                     60 -> XP_NEEDED_FOR_60
                 }
             }
+            else {
+                0
+            }
         } ?: 0
 
         val (levelOverflow, currentOverflow, currentMaxOverflow, totalOverflow) =

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -322,15 +322,15 @@ object SkillApi {
 
     private fun updateSkillInfo(existingLevel: SkillInfo, level: Int, currentXP: Long, maxXP: Long, totalXP: Long, gained: String) {
         val cap = activeSkill?.maxLevel
-        val add = if (level >= cap ?: 0) {
-            when (cap) {
-                50 -> XP_NEEDED_FOR_50
-                60 -> XP_NEEDED_FOR_60
-                else -> 0
+        val add = cap?.let {
+            if (level >= it) {
+                when (it) {
+                    50 -> XP_NEEDED_FOR_50
+                    60 -> XP_NEEDED_FOR_60
+                    else -> 0
+                }
             }
-        } else {
-            0
-        }
+        } ?: 0
 
         val (levelOverflow, currentOverflow, currentMaxOverflow, totalOverflow) =
             calculateSkillLevel(totalXP + add, cap)

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -327,6 +327,7 @@ object SkillApi {
                 when (it) {
                     50 -> XP_NEEDED_FOR_50
                     60 -> XP_NEEDED_FOR_60
+                    else -> 0
                 }
             }
             else {


### PR DESCRIPTION
## What
Fixes skill exp progress bar and overflow level in the skills menu displaying the wrong level and freezing when a maxed skill is in the tablist that isn't the one being tracked. (First one was reported https://discord.com/channels/997079228510117908/1000669238035497022/1296910244168994858 second one I encountered).

Note: The skill exp will still freeze if the skill being tracked isn't in the tablist. I don't think much can be done to fix this.

## Changelog Fixes
+ Fixed incorrect skill level display and occasional freezing. - SuperClash