### PR TITLE
Remove: Daedalus Axe as Farming Tool

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/KeyBindConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/KeyBindConfig.java
@@ -13,7 +13,7 @@ import org.lwjgl.input.Keyboard;
 
 public class KeyBindConfig {
     @Expose
-    @ConfigOption(name = "Enabled", desc = "Use custom keybinds while holding a farming tool or Daedalus Axe in the hand.")
+    @ConfigOption(name = "Enabled", desc = "Use custom keybinds while holding a farming tool in your hand.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = false;

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -78,8 +78,6 @@ object GardenApi {
 
     // TODO USE SH-REPO
     private val otherToolsList = listOf(
-        "DAEDALUS_AXE",
-        "STARRED_DAEDALUS_AXE",
         "BASIC_GARDENING_HOE",
         "ADVANCED_GARDENING_AXE",
         "BASIC_GARDENING_AXE",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
@@ -145,7 +145,6 @@ object CaptureFarmingGear {
 
         if (currentCrop == null) {
             // todo better fall back items
-            // todo Daedalus axe
         } else {
             currentCrop.farmingItem.setItem(itemStack)
         }


### PR DESCRIPTION
## What
Removed support for Daedalus Axe as a farming tool on the Garden.

## Changelog Removed Features
+ Removed support for Daedalus Axe as a farming tool in the Garden. - Luna
    * Hypixel removed the ability to break crops with weapons.

