### PR TITLE
Fix: Use TimeLimitedCache instead of a 'hand-rolled' solution.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.entity.EntityDisplayNameEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthDisplayEvent
 import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
@@ -27,6 +26,7 @@ object EntityData {
     private val maxHealthMap = mutableMapOf<Int, Int>()
     private val nametagCache = TimeLimitedCache<Entity, ChatComponentText>(50.milliseconds)
     private val healthDisplayCache = TimeLimitedCache<String, String>(50.milliseconds)
+    private val lastVisibilityCheck = TimeLimitedCache<Entity, Pair<SimpleTimeMark, Boolean>>(500.milliseconds)
 
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {
@@ -72,16 +72,6 @@ object EntityData {
         val event = EntityHealthDisplayEvent(text)
         event.post()
         event.text
-    }
-
-    private val lastVisibilityCheck = mutableMapOf<Entity, Pair<SimpleTimeMark, Boolean>>()
-
-    @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
-        val now = SimpleTimeMark.now()
-        lastVisibilityCheck.entries.removeIf { entry ->
-            now - entry.value.first > 500.milliseconds
-        }
     }
 
     @JvmStatic


### PR DESCRIPTION
I think(?) it fixes the EntityPlayerSP leak. Idk. Kinda. _Maybe_. Mods seem to leak that and WorldClient all over the place. Turns out that storing those is bad since they change on world change/login/logout/etc.

## What
For some reason the `now - entry.value.first > 500.milliseconds` check isn't properly getting rid of EntityPlayerSP. Something else is probably keeping it alive. It's weird and black magic. The TimeLimitedCache internally uses weak references to the map keys and values so it does not keep them around. idk i'm just typing words now ._.

## Changelog Fixes
+ Fixed memory leak in entity rendering code. - Nessiesson


