### PR TITLE
Fix: Reset sprays used when resetting Pest Profit Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -90,6 +90,7 @@ object PestProfitTracker {
         override fun resetItems() {
             totalPestsKills = 0L
             pestKills.clear()
+            spraysUsed.clear()
         }
 
         override fun getDescription(bucket: PestType?, timesGained: Long): List<String> {


### PR DESCRIPTION
## What
Fixed sprays used not resetting when resetting Pest Profit Tracker.

## Changelog Fixes
+ Fixed sprays not resetting when Pest Profit Tracker is reset. - Luna
