### PR TITLE
Fix: ElectionAPI not checking every minute if no mayor is known

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ElectionApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ElectionApi.kt
@@ -210,8 +210,13 @@ object ElectionApi {
 
     private fun checkHypixelApi(forceReload: Boolean = false) {
         if (!forceReload) {
-            if (currentMayor == ElectionCandidate.UNKNOWN && lastUpdate.passedSince() < 1.minutes) return
-            if (lastUpdate.passedSince() < 20.minutes) return
+            if (!forceReload) {
+                if (currentMayor == ElectionCandidate.UNKNOWN) {
+                    if (lastUpdate.passedSince() < 1.minutes) return
+                } else {
+                    if (lastUpdate.passedSince() < 20.minutes) return
+                }
+            }
         }
         lastUpdate = SimpleTimeMark.now()
 

--- a/src/main/java/at/hannibal2/skyhanni/data/ElectionApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ElectionApi.kt
@@ -210,8 +210,8 @@ object ElectionApi {
 
     private fun checkHypixelApi(forceReload: Boolean = false) {
         if (!forceReload) {
-            if (lastUpdate.passedSince() < 20.minutes) return
             if (currentMayor == ElectionCandidate.UNKNOWN && lastUpdate.passedSince() < 1.minutes) return
+            if (lastUpdate.passedSince() < 20.minutes) return
         }
         lastUpdate = SimpleTimeMark.now()
 


### PR DESCRIPTION
## What
I think this should fix it, I guess we dont even need to recheck every 20mins if we have an active mayor (hi nopo I kinda agree), but I guess its a good failsafe just incase


## Changelog Fixes
+ Fixed Mayor updating too slow if no mayor is known. - j10a1n15

