### PR TITLE
Fix: Precise griffin burrow detection with pet out

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
@@ -46,6 +46,8 @@ object PreciseGuessBurrow {
         if (!isEnabled()) return
         val type = event.type
         if (type != EnumParticleTypes.DRIP_LAVA) return
+        if (event.count != 2) return
+        if (event.speed != -0.5f) return
         val currLoc = event.location
         if (lastDianaSpade.passedSince() > 3.seconds) return
         lastLavaParticle = SimpleTimeMark.now()


### PR DESCRIPTION
prevents the griffin's particles from getting detected as part of the ancestral spade

exclude_from_changelog