### PR TITLE
Fix: Remove bugs in burrow guessing logic

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -38,6 +38,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.drawLineToEye
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityPlayerSP
@@ -182,6 +183,10 @@ object GriffinBurrowHelper {
     fun onBurrowGuess(event: BurrowGuessEvent) {
         EntityMovementData.addToTrack(Minecraft.getMinecraft().thePlayer)
         val newLocation = event.guessLocation
+        val playerLocation = Minecraft.getMinecraft().thePlayer.getLorenzVec()
+
+        if (newLocation.distance(playerLocation) < 6) return
+
         latestGuess?.let {
             if (it.precise && config.multiGuesses) {
                 if (it.getLocation() == newLocation) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
@@ -17,8 +17,6 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.LorenzVec.Companion.toLorenzVec
 import at.hannibal2.skyhanni.utils.PolynomialFitter
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.toLorenzVec
-import net.minecraft.client.Minecraft
 import net.minecraft.util.EnumParticleTypes
 import kotlin.math.PI
 import kotlin.math.atan2
@@ -52,8 +50,6 @@ object PreciseGuessBurrow {
         if (lastDianaSpade.passedSince() > 3.seconds) return
         lastLavaParticle = SimpleTimeMark.now()
         if (particleLocations.isEmpty()) {
-            // First particle spawns exactly 1 block away from the player
-            if ((spadeUsePosition?.distance(currLoc) ?: 10.0) > 1.1555) return
             particleLocations.add(currLoc)
             return
         }
@@ -114,7 +110,6 @@ object PreciseGuessBurrow {
 
     private var lastDianaSpade = SimpleTimeMark.farPast()
     private var lastLavaParticle = SimpleTimeMark.farPast()
-    private var spadeUsePosition: LorenzVec? = null
 
     @HandleEvent(onlyOnIsland = IslandType.HUB)
     fun onUseAbility(event: ItemClickEvent) {
@@ -122,11 +117,12 @@ object PreciseGuessBurrow {
         if (event.clickType != ClickType.RIGHT_CLICK) return
         val item = event.itemInHand ?: return
         if (!item.isDianaSpade) return
-        if (lastLavaParticle.passedSince() < 0.5.seconds) return
-        if (lastDianaSpade.passedSince() < 0.1.seconds) return
+        if (lastLavaParticle.passedSince() < 0.5.seconds) {
+            event.cancel()
+            return
+        }
         particleLocations.clear()
         lastDianaSpade = SimpleTimeMark.now()
-        spadeUsePosition = Minecraft.getMinecraft().thePlayer.getPositionEyes(1.0F).toLorenzVec()
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
A usage of ancestral spade that occurred after 100ms but before the server sent any particle packets would move where the guesser thought the first click was and thus caused the guesser to fail under certain circumstances

Using the ancestral spade, then quickly collecting the burrow that that usage pointed to doesn't stop the particles from being sent to the client, and thus the guesser would continue guessing that the burrow, already looted, existed

## Changelog Fixes
+ Fixed various bugs in the burrow guessing logic. - bloxigus
    * Prevented the first burrow particle from being skipped with a well-timed spade use on high ping.
    * Prevented burrow guesses from being added when the player is within 6 blocks of the guess.

