### PR TITLE
Fix: Burrow math is not mathing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -82,7 +82,7 @@ object GriffinBurrowParticleFinder {
 
                 if (burrow.hasEnchant && burrow.hasFootstep && burrow.type != -1) {
                     if (!burrow.found) {
-                        BurrowDetectEvent(burrow.location, burrow.getType()).post()
+                        BurrowDetectEvent(burrow.location.normalizeZero(), burrow.getType()).post()
                         burrow.found = true
                     }
                 }
@@ -175,7 +175,7 @@ object GriffinBurrowParticleFinder {
         recentlyDugParticleBurrows.add(location)
         lastDugParticleBurrow = null
 
-        BurrowDugEvent(burrow.location).post()
+        BurrowDugEvent(burrow.location.normalizeZero()).post()
         return true
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
@@ -59,7 +59,7 @@ object PreciseGuessBurrow {
 
         val guessPosition = guessBurrowLocation() ?: return
 
-        BurrowGuessEvent(guessPosition.down(0.5).roundLocationToBlock(), precise = true).post()
+        BurrowGuessEvent(guessPosition.down(0.5).roundLocationToBlock().normalizeZero(), precise = true).post()
     }
 
     private fun guessBurrowLocation(): LorenzVec? {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/SoopyGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/SoopyGuessBurrow.kt
@@ -234,7 +234,7 @@ object SoopyGuessBurrow {
                         } else {
                             LorenzVec(floor(p2.x), 255.0, floor(p2.z))
                         }
-                        BurrowGuessEvent(finalLocation, precise = false).post()
+                        BurrowGuessEvent(finalLocation.normalizeZero(), precise = false).post()
                     }
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
@@ -208,6 +208,10 @@ data class LorenzVec(
 
     private operator fun div(i: Number): LorenzVec = LorenzVec(x / i.toDouble(), y / i.toDouble(), z / i.toDouble())
 
+    private fun normalizeZero(value: Double) = if (value == 0.0) 0.0 else value
+
+    fun normalizeZero(): LorenzVec = LorenzVec(normalizeZero(x), normalizeZero(y), normalizeZero(z))
+
     companion object {
 
         val directions = setOf(


### PR DESCRIPTION
## What
`Double.compare(-0, 0)` is wrong.
`-0 == 0` is  correct.

## Changelog Fixes
+ Fixed rare case where the guess point shows over the known burrow location.