### PR TITLE
Feature: Add Trinity helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.java
@@ -106,6 +106,10 @@ public class DungeonConfig {
     @Accordion
     public LividFinderConfig lividFinder = new LividFinderConfig();
 
+    @Expose
+    @ConfigOption(name = "Trinity", desc = "")
+    @Accordion
+    public DungeonTrinityHelperConfig trinityHelper = new DungeonTrinityHelperConfig();
 
     @Expose
     @ConfigOption(name = "Terracotta Phase", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonTrinityHelperConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonTrinityHelperConfig.java
@@ -1,0 +1,22 @@
+package at.hannibal2.skyhanni.config.features.dungeon;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+public class DungeonTrinityHelperConfig {
+
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Notifies user when Trinity is highly likely to appear on dungeon. (Puzzle count == 5)")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean enabled = true;
+
+    @Expose
+    @ConfigOption(name = "Notify party", desc = "Automatically send message to party to watch out for Trinity")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean sendPartyChat = true;
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
@@ -2,38 +2,28 @@ package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.dungeon.DungeonEnterEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.SoundUtils.createSound
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
-import at.hannibal2.skyhanni.utils.TabListData
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object DungeonTrinityHelper {
     private val config get() = SkyHanniMod.feature.dungeon.trinityHelper
-
-    // TODO how to handle duped regex in TabWidget.kt ?
-    private val dungeonPuzzleCountPattern by RepoPattern.pattern(
-        "dungeon.puzzle.count",
-        "(?:§.)*Puzzles: (?:§.)*\\((?<amount>\\d+)\\)",
-    )
-
     private val dragonSound by lazy { createSound("mob.enderdragon.growl", 1f) }
 
     @HandleEvent
     fun onDungeonEnter(event: DungeonEnterEvent) {
         if (!config.enabled) return
-        val puzzleCount = dungeonPuzzleCountPattern.firstMatcher(TabListData.getTabList()) {
-            group("amount")?.toIntOrNull()
-        } ?: 0
+
+        val puzzleCount = TabWidget.DUNGEON_PUZZLE.matchMatcherFirstLine { group("amount") }?.toIntOrNull() ?: 0
 
         // https://hypixel.net/threads/best-way-to-get-trinitys-number-instead-of-acquiring-actual-friends.5489159/
-        if (puzzleCount == 5) {
+        if (puzzleCount <= 6) {
             dragonSound.playSound()
             LorenzUtils.sendTitle("§dTrinity ?!?!", 5.seconds)
             if (config.sendPartyChat) HypixelCommands.partyChat("5 Puzzle dungeon, watch out for Trinity room")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
@@ -7,8 +7,6 @@ import at.hannibal2.skyhanni.events.dungeon.DungeonStartEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.SoundUtils.createSound
-import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.dungeon
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.model.TabWidget
-import at.hannibal2.skyhanni.events.dungeon.DungeonEnterEvent
+import at.hannibal2.skyhanni.events.dungeon.DungeonStartEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -14,19 +14,20 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object DungeonTrinityHelper {
     private val config get() = SkyHanniMod.feature.dungeon.trinityHelper
-    private val dragonSound by lazy { createSound("mob.enderdragon.growl", 1f) }
 
     @HandleEvent
-    fun onDungeonEnter(event: DungeonEnterEvent) {
+    fun onDungeonStart(event: DungeonStartEvent) {
         if (!config.enabled) return
 
-        val puzzleCount = TabWidget.DUNGEON_PUZZLE.matchMatcherFirstLine { group("amount") }?.toIntOrNull() ?: 0
+        TabWidget.DUNGEON_PUZZLE.matchMatcherFirstLine {
+            val puzzleCount = group("amount")?.toIntOrNull() ?: 0
 
-        // https://hypixel.net/threads/best-way-to-get-trinitys-number-instead-of-acquiring-actual-friends.5489159/
-        if (puzzleCount == 5) {
-            dragonSound.playSound()
-            LorenzUtils.sendTitle("§dTrinity ?!?!", 5.seconds)
-            if (config.sendPartyChat) HypixelCommands.partyChat("5 Puzzle dungeon, watch out for Trinity room")
+            // https://hypixel.net/threads/best-way-to-get-trinitys-number-instead-of-acquiring-actual-friends.5489159/
+            if (puzzleCount == 5) {
+                LorenzUtils.sendTitle("§dTrinity ?!?!", 5.seconds)
+                if (config.sendPartyChat) HypixelCommands.partyChat("5 Puzzle dungeon, watch out for Trinity room")
+            }
         }
     }
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
@@ -1,0 +1,42 @@
+package at.hannibal2.skyhanni.features.dungeon
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.dungeon.DungeonEnterEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
+import at.hannibal2.skyhanni.utils.SoundUtils.createSound
+import at.hannibal2.skyhanni.utils.SoundUtils.playSound
+import at.hannibal2.skyhanni.utils.TabListData
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import kotlin.time.Duration.Companion.seconds
+
+@SkyHanniModule
+object DungeonTrinityHelper {
+    private val config get() = SkyHanniMod.feature.dungeon.trinityHelper
+
+    // TODO how to handle duped regex in TabWidget.kt ?
+    private val dungeonPuzzleCountPattern by RepoPattern.pattern(
+        "dungeon.puzzle.count",
+        "(?:§.)*Puzzles: (?:§.)*\\((?<amount>\\d+)\\)",
+    )
+
+    private val dragonSound by lazy { createSound("mob.enderdragon.growl", 1f) }
+
+    @HandleEvent
+    fun onDungeonEnter(event: DungeonEnterEvent) {
+        if (!config.enabled) return
+        val puzzleCount = dungeonPuzzleCountPattern.firstMatcher(TabListData.getTabList()) {
+            group("amount")?.toIntOrNull()
+        } ?: 0
+
+        // https://hypixel.net/threads/best-way-to-get-trinitys-number-instead-of-acquiring-actual-friends.5489159/
+        if (puzzleCount == 5) {
+            dragonSound.playSound()
+            LorenzUtils.sendTitle("§dTrinity ?!?!", 5.seconds)
+            if (config.sendPartyChat) HypixelCommands.partyChat("5 Puzzle dungeon, watch out for Trinity room")
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonTrinityHelper.kt
@@ -23,7 +23,7 @@ object DungeonTrinityHelper {
         val puzzleCount = TabWidget.DUNGEON_PUZZLE.matchMatcherFirstLine { group("amount") }?.toIntOrNull() ?: 0
 
         // https://hypixel.net/threads/best-way-to-get-trinitys-number-instead-of-acquiring-actual-friends.5489159/
-        if (puzzleCount <= 6) {
+        if (puzzleCount == 5) {
             dragonSound.playSound()
             LorenzUtils.sendTitle("§dTrinity ?!?!", 5.seconds)
             if (config.sendPartyChat) HypixelCommands.partyChat("5 Puzzle dungeon, watch out for Trinity room")


### PR DESCRIPTION
## What
Add a notification when user joins a dungeons with 5 puzzles, as this dungeons have a high chance of containing rare 1x1 rooms, like the one Trinity spawns on. There is no official info on [Trinity spawn chances](https://wiki.hypixel.net/Trinity), but [flex posts](https://hypixel.net/threads/best-way-to-get-trinitys-number-instead-of-acquiring-actual-friends.5489159/) and videos I watched, all reinforce the idea of 5 puzzles == Trinity.

## Changelog New Features
+ Add Trinity helper. - Bugzilla