### PR TITLE
Fix: Decouple Pest Tracker and Message Fixing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -88,6 +88,7 @@ object PestProfitTracker {
 
     class BucketData : BucketedItemTrackerData<PestType>() {
         override fun resetItems() {
+            @Suppress("DEPRECATION")
             totalPestsKills = 0L
             pestKills.clear()
             spraysUsed.clear()
@@ -114,6 +115,7 @@ object PestProfitTracker {
 
         override fun PestType.isBucketSelectable() = this in PestType.filterableEntries
 
+        @Suppress("DEPRECATION")
         fun getTotalPestCount(): Long =
             if (selectedBucket != null) pestKills[selectedBucket] ?: 0L
             else (pestKills.entries.filter { it.key != PestType.UNKNOWN }.sumOf { it.value } + totalPestsKills)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -146,23 +146,6 @@ object PestProfitTracker {
     }
 
     private fun SkyHanniChatEvent.checkPestChats() {
-        pestRareDropPattern.matchMatcher(message) {
-            val itemGroup = group("item")
-            val internalName = NeuInternalName.fromItemNameOrNull(itemGroup) ?: return
-            val pest = PestType.getByInternalNameItemOrNull(internalName) ?: return@matchMatcher
-            val amount = 1.fixAmount(internalName, pest).also {
-                if (it == 1) return@also
-                // If the amount was fixed, edit the chat message to reflect the change
-                val fixedString = message.replace(itemGroup, "§a${it}x $itemGroup")
-                chatComponent = ChatComponentText(fixedString)
-            }
-
-            // Happens here so that the amount is fixed independently of tracker being enabled
-            if (!config.enabled) return
-
-            tracker.addItem(pest, internalName, amount)
-            // Pests always have guaranteed loot, therefore there's no need to add kill here
-        }
         PestApi.pestDeathChatPattern.matchMatcher(message) {
             val pest = PestType.getByNameOrNull(group("pest")) ?: ErrorManager.skyHanniError(
                 "Could not find PestType for killed pest, please report this in the Discord.",
@@ -180,6 +163,23 @@ object PestProfitTracker {
             // Field Mice drop 6 separate items, but we only want to count the kill once
             if (pest == PestType.FIELD_MOUSE && internalName == DUNG_ITEM) addKill(pest)
             else if (pest != PestType.FIELD_MOUSE) addKill(pest)
+        }
+        pestRareDropPattern.matchMatcher(message) {
+            val itemGroup = group("item")
+            val internalName = NeuInternalName.fromItemNameOrNull(itemGroup) ?: return
+            val pest = PestType.getByInternalNameItemOrNull(internalName) ?: return@matchMatcher
+            val amount = 1.fixAmount(internalName, pest).also {
+                if (it == 1) return@also
+                // If the amount was fixed, edit the chat message to reflect the change
+                val fixedString = message.replace(itemGroup, "§a${it}x $itemGroup")
+                chatComponent = ChatComponentText(fixedString)
+            }
+
+            // Happens here so that the amount is fixed independently of tracker being enabled
+            if (!config.enabled) return
+
+            tracker.addItem(pest, internalName, amount)
+            // Pests always have guaranteed loot, therefore there's no need to add kill here
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -139,29 +139,11 @@ object PestProfitTracker {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onChat(event: SkyHanniChatEvent) {
-        if (!config.enabled) return
         event.checkPestChats()
         event.checkSprayChats()
     }
 
     private fun SkyHanniChatEvent.checkPestChats() {
-        PestApi.pestDeathChatPattern.matchMatcher(message) {
-            val pest = PestType.getByNameOrNull(group("pest")) ?: ErrorManager.skyHanniError(
-                "Could not find PestType for killed pest, please report this in the Discord.",
-                "pest_name" to group("pest"),
-                "full_message" to message,
-            )
-            val internalName = NeuInternalName.fromItemNameOrNull(group("item")) ?: return
-            val amount = group("amount").toInt().fixAmount(internalName, pest)
-
-            tracker.addItem(pest, internalName, amount)
-
-            // Field Mice drop 6 separate items, but we only want to count the kill once
-            if (pest == PestType.FIELD_MOUSE && internalName == DUNG_ITEM) addKill(pest)
-            else if (pest != PestType.FIELD_MOUSE) addKill(pest)
-
-            if (config.hideChat) blockedReason = "pest_drop"
-        }
         pestRareDropPattern.matchMatcher(message) {
             val itemGroup = group("item")
             val internalName = NeuInternalName.fromItemNameOrNull(itemGroup) ?: return
@@ -173,12 +155,34 @@ object PestProfitTracker {
                 chatComponent = ChatComponentText(fixedString)
             }
 
+            // Happens here so that the amount is fixed independently of tracker being enabled
+            if (!config.enabled) return
+
             tracker.addItem(pest, internalName, amount)
             // Pests always have guaranteed loot, therefore there's no need to add kill here
+        }
+        PestApi.pestDeathChatPattern.matchMatcher(message) {
+            val pest = PestType.getByNameOrNull(group("pest")) ?: ErrorManager.skyHanniError(
+                "Could not find PestType for killed pest, please report this in the Discord.",
+                "pest_name" to group("pest"),
+                "full_message" to message,
+            )
+            val internalName = NeuInternalName.fromItemNameOrNull(group("item")) ?: return
+            val amount = group("amount").toInt().fixAmount(internalName, pest)
+
+            if (config.hideChat) blockedReason = "pest_drop"
+            if (!config.enabled) return
+
+            tracker.addItem(pest, internalName, amount)
+
+            // Field Mice drop 6 separate items, but we only want to count the kill once
+            if (pest == PestType.FIELD_MOUSE && internalName == DUNG_ITEM) addKill(pest)
+            else if (pest != PestType.FIELD_MOUSE) addKill(pest)
         }
     }
 
     private fun SkyHanniChatEvent.checkSprayChats() {
+        if (!config.enabled) return
         sprayonatorUsedPattern.matchGroup(message, "spray")?.let {
             SprayType.getByNameOrNull(it)?.addSprayUsed()
         }


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1341424702488449126
Not sure this is strictly necessary, as I figure anyone who cares about the messages being right will probably have the tracker enabled, but eh.

## Changelog Fixes
+ Fixed rare pest drop messages not including amounts when the pest tracker is disabled. - Daveed

