### PR TITLE
Fix: HypixelData Comparison

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/hypixelapi/HypixelLocationApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/hypixelapi/HypixelLocationApi.kt
@@ -149,45 +149,28 @@ object HypixelLocationApi {
         internalIsland = IslandType.NONE
     }
 
-    fun checkHypixel(hypixel: Boolean) {
+    fun checkEquals() {
         runNextSecond {
-            if (hypixel == inHypixel) return@runNextSecond
-            sendError("Hypixel")
+            val isHypixelEqual = (HypixelData.hypixelLive || HypixelData.hypixelAlpha) == inHypixel
+            val isSkyblockEqual = HypixelData.skyBlock == inSkyblock
+            val otherIsland = HypixelData.skyBlockIsland
+            val isIslandEqual = otherIsland == island || otherIsland == IslandType.NONE || island == IslandType.NONE
+            val isServerIdEqual = !inSkyblock || HypixelData.serverId == serverId || serverId == "limbo"
+            if (isHypixelEqual && isSkyblockEqual && isIslandEqual && isServerIdEqual) return@runNextSecond
+            sendError()
         }
     }
 
     private fun runNextSecond(run: () -> Unit) = DelayedRun.runDelayed(1.seconds, run)
 
-    fun checkSkyblock(skyblock: Boolean) {
-        runNextSecond {
-            if (skyblock == inSkyblock) return@runNextSecond
-            sendError("SkyBlock")
-        }
-    }
-
-    fun checkIsland(otherIsland: IslandType) {
-        if (otherIsland == IslandType.NONE) return
-        runNextSecond {
-            if (otherIsland == island) return@runNextSecond
-            sendError("Island")
-        }
-    }
-
-    fun checkServerId(otherId: String?) {
-        runNextSecond {
-            if (serverId == otherId) return@runNextSecond
-            sendError("ServerId")
-        }
-    }
-
-    private fun sendError(message: String) {
+    private fun sendError() {
         if (!config) return
         val data = debugData
         logger.log("ERROR: ${data.joinToString(transform = ::dataToString)}")
         @Suppress("SpreadOperator")
         ErrorManager.logErrorStateWithData(
-            "$message check comparison with HypixelModAPI failed. Please report in discord.",
-            "$message comparison failed",
+            "HypixelData check comparison with HypixelModAPI failed. Please report in discord.",
+            "HypixelData comparison failed",
             *data,
             betaOnly = true,
             noStackTrace = true,

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -202,7 +202,7 @@ object HypixelData {
 
         TabWidget.SERVER.matchMatcherFirstLine {
             serverId = group("serverid")
-            HypixelLocationApi.checkServerId(serverId)
+            HypixelLocationApi.checkEquals()
             lastSuccessfulServerIdFetchTime = SimpleTimeMark.now()
             lastSuccessfulServerIdFetchType = "tab list"
             failedServerIdFetchCounter = 0
@@ -212,7 +212,7 @@ object HypixelData {
         serverIdScoreboardPattern.firstMatcher(ScoreboardData.sidebarLinesFormatted) {
             val serverType = if (group("servertype") == "M") "mega" else "mini"
             serverId = "$serverType${group("serverid")}"
-            HypixelLocationApi.checkServerId(serverId)
+            HypixelLocationApi.checkEquals()
             lastSuccessfulServerIdFetchTime = SimpleTimeMark.now()
             lastSuccessfulServerIdFetchType = "scoreboard"
             failedServerIdFetchCounter = 0
@@ -447,7 +447,7 @@ object HypixelData {
 
         if (inSkyBlock == skyBlock) return
         skyBlock = inSkyBlock
-        HypixelLocationApi.checkSkyblock(skyBlock)
+        HypixelLocationApi.checkEquals()
     }
 
     private fun sendLocraw() {
@@ -516,7 +516,7 @@ object HypixelData {
         }
 
         hypixelLive = hypixel && !hypixelAlpha
-        HypixelLocationApi.checkHypixel(hypixelLive)
+        HypixelLocationApi.checkEquals()
     }
 
     private fun checkSidebar() {
@@ -564,7 +564,7 @@ object HypixelData {
             val oldIsland = skyBlockIsland
             skyBlockIsland = newIsland
             IslandChangeEvent(newIsland, oldIsland).post()
-            HypixelLocationApi.checkIsland(skyBlockIsland)
+            HypixelLocationApi.checkEquals()
 
             if (newIsland == IslandType.UNKNOWN) {
                 ChatUtils.debug("Unknown island detected: '$foundIsland'")


### PR DESCRIPTION
## What
This PR fixes the errors comparing the old hypixel data and the new system that uses hypixel mod api to now actually compare the values with the current ones, and not the ones from 1 second before. it also makes sure certain errors like server id do not happen when not in skyblock

## Changelog Fixes
+ Fixed HypixelData errors. - Empa