### PR TITLE
Backend: `HoppityDataSet` + `ResettableStorageSet`

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ResettableStorageSet.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ResettableStorageSet.kt
@@ -1,0 +1,24 @@
+package at.hannibal2.skyhanni.config.storage
+import at.hannibal2.skyhanni.test.command.ErrorManager
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.memberProperties
+
+open class ResettableStorageSet {
+    open fun reset() {
+        val default = this::class.createInstance()
+        // For every *mutable* property (var), set its value on `this` to the value from `default`.
+        this::class.memberProperties
+            .filterIsInstance<KMutableProperty1<Any, Any?>>()
+            .forEach { prop ->
+                // Prop is declared as KMutableProperty1<Any, Any?>, but we know `this` is the same type at runtime.
+                @Suppress("UNCHECKED_CAST")
+                try {
+                    (prop as KMutableProperty1<Any?, Any?>).set(this, prop.get(default))
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    ErrorManager.skyHanniError("Failed to reset property ${prop.name} in ${this::class.simpleName}")
+                }
+            }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
@@ -49,8 +49,6 @@ import net.minecraft.init.Items
 import net.minecraft.inventory.Slot
 import net.minecraft.item.Item
 import net.minecraft.item.ItemStack
-import kotlin.reflect.KMutableProperty1
-import kotlin.reflect.full.memberProperties
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.event.hoppity
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
+import at.hannibal2.skyhanni.config.storage.ResettableStorageSet
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -135,16 +136,7 @@ object HoppityApi {
         var lastProfit: String = "",
         var lastMeal: HoppityEggType? = null,
         var lastDuplicateAmount: Long? = null
-    ) {
-        fun reset() {
-            val default = HoppityStateDataSet()
-            this::class.memberProperties
-                .filterIsInstance<KMutableProperty1<HoppityStateDataSet, Any?>>()
-                .forEach { prop ->
-                    prop.set(this, prop.get(default))
-                }
-        }
-    }
+    ) : ResettableStorageSet()
 
     val hoppityRarities = LorenzRarity.entries.filter { it <= DIVINE }
     private val hoppityDataSet = HoppityStateDataSet()


### PR DESCRIPTION
## What
Guess this hasn't made it to `/beta` yet, as it's part of #3235, but `ResettableStorageSet` defines an open class that performs the same work that the `HoppityDataSet` currently does on its reset - this PR changes it to use the open class, and adds some error logging re: https://discord.com/channels/997079228510117908/1340881250046447716

## Changelog Technical Details
+ Added `ResettableStorageSet`; calling `reset()` resets all mutable properties to default values. - Daveed

