### PR TITLE
Fix: Burrow location wildly inaccurate under specific circumstances

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
@@ -31,11 +31,9 @@ object PreciseGuessBurrow {
     private val config get() = SkyHanniMod.feature.event.diana
 
     private val particleLocations = mutableListOf<LorenzVec>()
-    private var guessPoint: LorenzVec? = null
 
     @HandleEvent(onlyOnIsland = IslandType.HUB)
     fun onWorldChange(event: IslandChangeEvent) {
-        guessPoint = null
         particleLocations.clear()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
@@ -46,9 +46,9 @@ object PreciseGuessBurrow {
         if (type != EnumParticleTypes.DRIP_LAVA) return
         if (event.count != 2) return
         if (event.speed != -0.5f) return
+        lastLavaParticle = SimpleTimeMark.now()
         val currLoc = event.location
         if (lastDianaSpade.passedSince() > 3.seconds) return
-        lastLavaParticle = SimpleTimeMark.now()
         if (particleLocations.isEmpty()) {
             particleLocations.add(currLoc)
             return
@@ -117,7 +117,7 @@ object PreciseGuessBurrow {
         if (event.clickType != ClickType.RIGHT_CLICK) return
         val item = event.itemInHand ?: return
         if (!item.isDianaSpade) return
-        if (lastLavaParticle.passedSince() < 0.5.seconds) {
+        if (lastLavaParticle.passedSince() < 0.2.seconds) {
             event.cancel()
             return
         }


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1341582719582474333/1342165087170986035
Here a particle from an old burrow is received after the player uses the ability leading to a wildly inaccurate guess.
One possible solution is to prevent the player from using the ability when hypixel is still sending lava particles.

## Changelog Fixes
+ Fixed incorrect burrow guesses under certain circumstances. - bloxigus