### PR TITLE
Improvement: Add /shlockmouse as an alias for /shmouselock

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -114,6 +114,7 @@ object Commands {
         event.register("shmouselock") {
             description = "Lock/Unlock the mouse so it will no longer rotate the player (for farming)"
             category = CommandCategory.USERS_ACTIVE
+            aliases = listOf("shlockmouse")
             callback { LockMouseLook.toggleLock() }
         }
         event.register("shsensreduce") {


### PR DESCRIPTION
## What
Add /shlockmouse as an alias for /shmouselock, as people (mainly me) sometimes mix them up.

## Changelog Improvements
+ Added /shlockmouse as an alias for /shmouselock. - Chissl

