### PR TITLE
Fix: Dungeon block texture reading

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -257,7 +257,8 @@ object ItemUtils {
 
     }
 
-    fun NBTTagCompound.getSkullTexture(): String = getCompoundTag("Properties").getCompoundList("textures")[0].getString("Value")
+    fun NBTTagCompound.getSkullTexture(): String? =
+        getCompoundTag("Properties").getCompoundList("textures").firstOrNull()?.getString("Value")
 
     fun ItemStack.getSkullOwner(): String? {
         if (item != Items.skull) return null


### PR DESCRIPTION
## What
reported: https://discord.com/channels/997079228510117908/1341889732346515607

fixed a IndexOutOfBoundsException when the list of texures are empty in dungeon.
idk why this happens, but this should properly return null

## Changelog Fixes
+ Fixed rare error when checking block textures in dungeons. - hannibal2