### PR TITLE
Fix: `inChocolateFactory` Check for Hoppity Collection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
@@ -81,12 +81,13 @@ object HoppityEventSummary {
 
     /**
      * REGEX-TEST: Hoppity's Collection
+     * REGEX-TEST: (1/2) Hoppity's Collection
      * REGEX-TEST: Chocolate Factory Milestones
      * REGEX-TEST: Chocolate Shop Milestones
      */
     private val miscCfInventoryPatterns by ChocolateFactoryApi.patternGroup.pattern(
         "cf.inventory",
-        "Hoppity's Collection|Chocolate (?:Factory|Shop) Milestones|Rabbit Hitman",
+        "(?:\\(\\d*\\/\\d*\\) )?Hoppity's Collection|Chocolate (?:Factory|Shop) Milestones|Rabbit Hitman",
     )
 
     private const val LINE_HEADER = "    "


### PR DESCRIPTION
## What
Fixes `inChocolateFactory` check for multi-page hoppity UI name.

## Changelog Fixes
+ Fixed chocolate factory features disappearing when Hoppity's Collection contains multiple pages. - Daveed

