### PR TITLE
Improvement: Backup config

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -98,11 +98,7 @@ class ConfigManager {
     }
 
     private fun deleteOldBackups() {
-        val directoryFiles = File("skyhanni/config/backup").listFiles() ?: run {
-            println("backup directory has no files")
-            return
-        }
-        OSUtils.deleteRecursively(directoryFiles, SkyHanniMod.feature.dev.configBackupExpiryTime.days)
+        OSUtils.deleteExpiredFiles(File("skyhanni/config/backup"), SkyHanniMod.feature.dev.configBackupExpiryTime.days)
     }
 
     // Some position elements don't need config links as they don't have a config option.

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.enumMapOf
 import at.hannibal2.skyhanni.utils.IdentityCharacteristics
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.ReflectionUtils.makeAccessible
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringFileHandler
@@ -27,8 +28,11 @@ import io.github.notenoughupdates.moulconfig.processor.ConfigProcessorDriver
 import io.github.notenoughupdates.moulconfig.processor.MoulConfigProcessor
 import java.io.File
 import java.io.IOException
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import kotlin.concurrent.fixedRateTimer
 import kotlin.reflect.KMutableProperty0
+import kotlin.time.Duration.Companion.days
 
 private fun GsonBuilder.registerIfBeta(create: TypeAdapterFactory): GsonBuilder {
     return if (SkyHanniMod.isBetaVersion) {
@@ -89,6 +93,16 @@ class ConfigManager {
         } catch (e: Exception) {
             ErrorManager.crashInDevEnv("Couldn't load config links") { e }
         }
+
+        deleteOldBackups()
+    }
+
+    private fun deleteOldBackups() {
+        val directoryFiles = File("skyhanni/config/backup").listFiles() ?: run {
+            println("backup directory has no files")
+            return
+        }
+        OSUtils.deleteRecursively(directoryFiles, SkyHanniMod.feature.dev.configBackupExpiryTime.days)
     }
 
     // Some position elements don't need config links as they don't have a config option.
@@ -213,12 +227,12 @@ class ConfigManager {
     fun saveConfig(fileType: ConfigFileType, reason: String) {
         val json = jsonHolder[fileType] ?: error("Could not find json object for $fileType")
         saveFile(fileType.file, fileType.fileName, json, reason)
+        saveFile(fileType.backupFile, fileType.fileName, json, reason)
     }
 
-    private fun saveFile(file: File?, fileName: String, data: Any, reason: String) {
+    private fun saveFile(file: File, fileName: String, data: Any, reason: String) {
         if (disableSaving) return
         logger.log("saveConfig: $reason")
-        if (file == null) throw Error("Can not save $fileName, ${fileName}File is null!")
         try {
             logger.log("Saving $fileName file")
             file.parentFile.mkdirs()
@@ -235,6 +249,19 @@ class ConfigManager {
     }
 }
 
+private fun getBackupFile(file: File): File {
+    val parent = file.parentFile
+    val fileName = file.nameWithoutExtension
+    val now = LocalDate.now()
+    val year = now.format(DateTimeFormatter.ofPattern("yyyy"))
+    val month = now.format(DateTimeFormatter.ofPattern("MM"))
+    val day = now.format(DateTimeFormatter.ofPattern("dd"))
+
+    val directory = File(parent, "backup/$year/$month")
+
+    return File(directory, "$day-${SkyHanniMod.VERSION}-$fileName.json")
+}
+
 enum class ConfigFileType(val fileName: String, val clazz: Class<*>, val property: KMutableProperty0<*>) {
     FEATURES("config", Features::class.java, SkyHanniMod::feature),
     SACKS("sacks", SackData::class.java, SkyHanniMod::sackData),
@@ -245,4 +272,5 @@ enum class ConfigFileType(val fileName: String, val clazz: Class<*>, val propert
     ;
 
     val file by lazy { File(ConfigManager.configDirectory, "$fileName.json") }
+    val backupFile get() = getBackupFile(file)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.java
@@ -37,6 +37,11 @@ public class DevConfig {
     public int logExpiryTime = 14;
 
     @Expose
+    @ConfigOption(name = "Backup Expiry Time", desc = "Deletes your backups of SkyHanni configs after this time period in days.")
+    @ConfigEditorSlider(minValue = 1, maxValue = 30, minStep = 1)
+    public int configBackupExpiryTime = 7;
+
+    @Expose
     @ConfigOption(
         name = "Chat History Length",
         desc = "The number of messages to keep in memory for §e/shchathistory§7.\n" +

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzLogger.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzLogger.kt
@@ -63,11 +63,7 @@ class LorenzLogger(filePath: String) {
 
         if (!hasDone && LorenzUtils.onHypixel) {
             hasDone = true
-            val directoryFiles = LOG_DIRECTORY.listFiles() ?: run {
-                println("log directory has no files")
-                return logger
-            }
-            OSUtils.deleteRecursively(directoryFiles, SkyHanniMod.feature.dev.logExpiryTime.days)
+            OSUtils.deleteExpiredFiles(LOG_DIRECTORY, SkyHanniMod.feature.dev.logExpiryTime.days)
         }
 
         return logger

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzLogger.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzLogger.kt
@@ -2,11 +2,8 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.utils.LorenzUtils.formatCurrentTime
-import kotlinx.coroutines.launch
 import java.io.File
 import java.io.IOException
-import java.nio.file.Files
-import java.nio.file.attribute.BasicFileAttributes
 import java.text.SimpleDateFormat
 import java.util.logging.FileHandler
 import java.util.logging.Formatter
@@ -70,28 +67,7 @@ class LorenzLogger(filePath: String) {
                 println("log directory has no files")
                 return logger
             }
-            SkyHanniMod.coroutineScope.launch {
-                val timeToDelete = SkyHanniMod.feature.dev.logExpiryTime.days
-
-                for (file in directoryFiles) {
-                    val path = file.toPath()
-                    try {
-                        val attributes = Files.readAttributes(path, BasicFileAttributes::class.java)
-                        val creationTime = attributes.creationTime().toMillis()
-                        val timeSinceCreation = SimpleTimeMark(creationTime).passedSince()
-                        if (timeSinceCreation > timeToDelete) {
-                            if (!file.deleteRecursively()) {
-                                println("failed to delete directory: ${file.name}")
-                            }
-                        }
-                    } catch (e: SecurityException) {
-                        e.printStackTrace()
-                    } catch (e: IOException) {
-                        e.printStackTrace()
-                        println("Error: Unable to get creation date.")
-                    }
-                }
-            }
+            OSUtils.deleteRecursively(directoryFiles, SkyHanniMod.feature.dev.logExpiryTime.days)
         }
 
         return logger

--- a/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
@@ -77,14 +77,21 @@ object OSUtils {
 
     suspend fun readFromClipboard() = ClipboardUtils.readFromClipboard()
 
-    private fun File.isExpired(expiryDuration: Duration): Boolean = lastModifiedTime()?.let {
-        it.passedSince() > expiryDuration
-    } ?: false
+    private fun File.isExpired(
+        expiryDuration: Duration,
+        lastModifiedTime: SimpleTimeMark = lastModifiedTime(),
+    ): Boolean = lastModifiedTime.passedSince() > expiryDuration
 
-    private fun File.lastModifiedTime(): SimpleTimeMark? = try {
+    private fun File.lastModifiedTime(): SimpleTimeMark = try {
         val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
         SimpleTimeMark(attributes.lastModifiedTime().toMillis())
     } catch (e: IOException) {
+        ErrorManager.logErrorWithData(
+            e,
+            "Error reading last modified attributes",
+            "file" to this,
+            "path" to toPath(),
+        )
         SimpleTimeMark.now()
     }
 
@@ -105,10 +112,12 @@ object OSUtils {
     fun deleteExpiredFiles(root: File, expiryDuration: Duration) {
         SkyHanniMod.coroutineScope.launch {
             val allFiles = root.walk().filter { it.isFile }.toList()
-            @Suppress("ConvertCallChainIntoSequence")
-            val recentDays = allFiles.mapNotNull { file ->
-                file.lastModifiedTime()?.toLocalDate()
+            val lastModified = allFiles.associateWith { file ->
+                file.lastModifiedTime()
             }
+
+            @Suppress("ConvertCallChainIntoSequence")
+            val recentDays = lastModified.mapNotNull { it.value.toLocalDate() }
                 .distinct()
                 .sortedDescending()
                 .take(3)
@@ -117,24 +126,30 @@ object OSUtils {
             root.walkBottomUp().forEach { file ->
                 when {
                     file.isFile -> {
-                        val fileDate = file.lastModifiedTime()?.toLocalDate()
-                        // Always retain files modified on the three most recent distinct dates.
-                        if (fileDate != null && fileDate in recentDays) return@forEach
+                        val lastModifiedTime = lastModified[file] ?: file.lastModifiedTime()
+                        if (lastModifiedTime.toLocalDate() in recentDays) return@forEach
 
-                        if (file.isEmptyFile() || file.isExpired(expiryDuration)) {
-                            if (!file.delete()) {
-                                println("Failed to delete file: ${file.absolutePath}")
-                            }
+                        if (file.isEmptyFile() || file.isExpired(expiryDuration, lastModifiedTime)) {
+                            file.deleteWithError()
                         }
                     }
 
                     file.isDirectory && file.isEmptyDirectory() -> {
-                        if (!file.delete()) {
-                            println("Failed to delete empty directory: ${file.absolutePath}")
-                        }
+                        file.deleteWithError()
                     }
                 }
             }
+        }
+    }
+
+    fun File.deleteWithError() {
+        if (!this.delete()) {
+            ErrorManager.logErrorStateWithData(
+                "Failed to delete file",
+                "Failed to delete file",
+                "file" to this,
+                "file" to this.absolutePath,
+            )
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
@@ -77,24 +77,45 @@ object OSUtils {
 
     suspend fun readFromClipboard() = ClipboardUtils.readFromClipboard()
 
-    fun deleteRecursively(directoryFiles: Array<File>, timeToDelete: Duration) {
+    private fun File.isExpired(expiryDuration: Duration): Boolean = lastModifiedTime()?.let {
+        it.passedSince() > expiryDuration
+    } ?: false
+
+    private fun File.lastModifiedTime(): SimpleTimeMark? = try {
+        val attributes = Files.readAttributes(toPath(), BasicFileAttributes::class.java)
+        SimpleTimeMark(attributes.lastModifiedTime().toMillis())
+    } catch (e: IOException) {
+        SimpleTimeMark.now()
+    }
+
+    private fun File.isEmptyFile() = length() == 0L
+    private fun File.isEmptyDirectory() = listFiles()?.isEmpty() == true
+
+    /**
+     * Recursively deletes files and directories inside the root directory.
+     *
+     * Empty or expired files are deleted.
+     * They are deemed expired if their last modified time is longer than the given expiry duration
+     * Directories are deleted if they are empty after deleting all files inside
+     *
+     * @param root the starting directory for recursive deletion.
+     * @param expiryDuration the duration threshold to check if a file is expired.
+     */
+    fun deleteExpiredFiles(root: File, expiryDuration: Duration) {
         SkyHanniMod.coroutineScope.launch {
-            for (file in directoryFiles) {
-                val path = file.toPath()
-                try {
-                    val attributes = Files.readAttributes(path, BasicFileAttributes::class.java)
-                    val creationTime = attributes.creationTime().toMillis()
-                    val timeSinceCreation = SimpleTimeMark(creationTime).passedSince()
-                    if (timeSinceCreation > timeToDelete) {
-                        if (!file.deleteRecursively()) {
-                            println("failed to delete directory: ${file.name}")
+            root.walkBottomUp().forEach { file ->
+                when {
+                    file.isFile && (file.isEmptyFile() || file.isExpired(expiryDuration)) -> {
+                        if (!file.delete()) {
+                            println("Failed to delete file: ${file.absolutePath}")
                         }
                     }
-                } catch (e: SecurityException) {
-                    e.printStackTrace()
-                } catch (e: IOException) {
-                    e.printStackTrace()
-                    println("Error: Unable to get creation date.")
+
+                    file.isDirectory && file.isEmptyDirectory() -> {
+                        if (!file.delete()) {
+                            println("Failed to delete empty directory: ${file.absolutePath}")
+                        }
+                    }
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
@@ -94,20 +94,37 @@ object OSUtils {
     /**
      * Recursively deletes files and directories inside the root directory.
      *
-     * Empty or expired files are deleted.
-     * They are deemed expired if their last modified time is longer than the given expiry duration
-     * Directories are deleted if they are empty after deleting all files inside
+     * Empty or expired files are deleted. Files are considered expired if their last modified time
+     * exceeds the specified expiry duration.
+     * Directories are removed if they are empty after file deletion.
+     * Files modified on the three most recent distinct dates are always retained.
      *
      * @param root the starting directory for recursive deletion.
-     * @param expiryDuration the duration threshold to check if a file is expired.
+     * @param expiryDuration the duration threshold used to determine if a file is expired.
      */
     fun deleteExpiredFiles(root: File, expiryDuration: Duration) {
         SkyHanniMod.coroutineScope.launch {
+            val allFiles = root.walk().filter { it.isFile }.toList()
+            @Suppress("ConvertCallChainIntoSequence")
+            val recentDays = allFiles.mapNotNull { file ->
+                file.lastModifiedTime()?.toLocalDate()
+            }
+                .distinct()
+                .sortedDescending()
+                .take(3)
+                .toSet()
+
             root.walkBottomUp().forEach { file ->
                 when {
-                    file.isFile && (file.isEmptyFile() || file.isExpired(expiryDuration)) -> {
-                        if (!file.delete()) {
-                            println("Failed to delete file: ${file.absolutePath}")
+                    file.isFile -> {
+                        val fileDate = file.lastModifiedTime()?.toLocalDate()
+                        // Always retain files modified on the three most recent distinct dates.
+                        if (fileDate != null && fileDate in recentDays) return@forEach
+
+                        if (file.isEmptyFile() || file.isExpired(expiryDuration)) {
+                            if (!file.delete()) {
+                                println("Failed to delete file: ${file.absolutePath}")
+                            }
                         }
                     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
@@ -1,9 +1,15 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import kotlinx.coroutines.launch
 import java.awt.Desktop
+import java.io.File
 import java.io.IOException
 import java.net.URI
+import java.nio.file.Files
+import java.nio.file.attribute.BasicFileAttributes
+import kotlin.time.Duration
 
 object OSUtils {
 
@@ -70,4 +76,27 @@ object OSUtils {
     }
 
     suspend fun readFromClipboard() = ClipboardUtils.readFromClipboard()
+
+    fun deleteRecursively(directoryFiles: Array<File>, timeToDelete: Duration) {
+        SkyHanniMod.coroutineScope.launch {
+            for (file in directoryFiles) {
+                val path = file.toPath()
+                try {
+                    val attributes = Files.readAttributes(path, BasicFileAttributes::class.java)
+                    val creationTime = attributes.creationTime().toMillis()
+                    val timeSinceCreation = SimpleTimeMark(creationTime).passedSince()
+                    if (timeSinceCreation > timeToDelete) {
+                        if (!file.deleteRecursively()) {
+                            println("failed to delete directory: ${file.name}")
+                        }
+                    }
+                } catch (e: SecurityException) {
+                    e.printStackTrace()
+                } catch (e: IOException) {
+                    e.printStackTrace()
+                    println("Error: Unable to get creation date.")
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
@@ -90,7 +90,7 @@ object OSUtils {
             e,
             "Error reading last modified attributes",
             "file" to this,
-            "path" to toPath(),
+            "path" to this.absolutePath,
         )
         SimpleTimeMark.now()
     }
@@ -148,7 +148,7 @@ object OSUtils {
                 "Failed to delete file",
                 "Failed to delete file",
                 "file" to this,
-                "file" to this.absolutePath,
+                "path" to this.absolutePath,
             )
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -61,7 +62,9 @@ value class SimpleTimeMark(private val millis: Long) : Comparable<SimpleTimeMark
 
     fun toMillis() = millis
 
-    fun toSkyBlockTime() = SkyBlockTime.fromInstant(Instant.ofEpochMilli(millis))
+    fun toSkyBlockTime(): SkyBlockTime = SkyBlockTime.fromInstant(Instant.ofEpochMilli(millis))
+
+    fun toLocalDate(): LocalDate = toLocalDateTime().toLocalDate()
 
     companion object {
 


### PR DESCRIPTION
## What
Adds backup logic for the config save. 
Writes the current version of the config also into the backup file on every save. 
Separates per version number and per date.
Per default, backups older than 7 days will get deleted. Configurable in the dev category.
The last three distinct days are always kept, when you come back from a 8 day break you still have backups

## Changelog Improvements
+ Added automatic backups for the config files. - hannibal2
    * Allows a 7-day manual rollback option for config issues.