### PR TITLE
Backend: Config backend format change

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -255,7 +255,7 @@ private fun getBackupFile(file: File): File {
 
     val directory = File(parent, "backup/$year/$month")
 
-    return File(directory, "$day-${SkyHanniMod.VERSION}-$fileName.json")
+    return File(directory, "$year-$month-$day-${SkyHanniMod.VERSION}-$fileName.json")
 }
 
 enum class ConfigFileType(val fileName: String, val clazz: Class<*>, val property: KMutableProperty0<*>) {


### PR DESCRIPTION
## What
Changed the name of backup files to make it clearer that the number is the current date

## Changelog Technical Details
+ Improved config backup name format. - hannibal2