### PR TITLE
Improvement: Better guess name for hoppity

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -103,7 +103,10 @@ object HoppityEggLocator {
 
     private fun SkyHanniRenderWorldEvent.drawGuessLocations() {
         for ((index, eggLocation) in possibleEggLocations.withIndex()) {
-            drawEggWaypoint(eggLocation, "§aGuess #${index + 1}")
+            val name = if (possibleEggLocations.size == 1) {
+                "§aGuess"
+            } else "§aGuess #${index + 1}"
+            drawEggWaypoint(eggLocation, name)
             if (config.showLine) {
                 drawLineToEye(eggLocation.blockCenter(), LorenzColor.GREEN.toColor(), 2, false)
             }


### PR DESCRIPTION
## What
Removed the #1 from the guess point if there is only one.

## Changelog Improvements
+ Made Hoppity Guess Waypoint name more compact. - hannibal2