### PR TITLE
Fix: User Luck in rare drop messages when disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -141,10 +141,12 @@ object RareDropMessages {
 
         if (!anyRecentMessage) {
             var message = "§r§6§lRARE DROP! ${internalName.itemName}"
-            userLuck?.takeIf { it != 0f }?.let { luck ->
-                var luckString = luck.roundTo(2).addSeparators()
-                if (luck > 0) luckString = "+$luckString"
-                message += " §a($luckString ✴ SkyHanni User Luck)"
+            if (SkyHanniMod.feature.misc.userluckEnabled) {
+                userLuck?.takeIf { it != 0f }?.let { luck ->
+                    var luckString = luck.roundTo(2).addSeparators()
+                    if (luck > 0) luckString = "+$luckString"
+                    message += " §a($luckString ✴ SkyHanni User Luck)"
+                }
             }
             ChatUtils.chat(message, prefix = false)
             return


### PR DESCRIPTION
## What
fixes user luck still showing in the custom rare drop messages while disabled

## Changelog Fixes
+ Fixed user luck displaying in rare drop messages when disabled. - martimavocado
