### PR TITLE
Improvement: Enchanted Book Message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/RareDropMessagesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/RareDropMessagesConfig.kt
@@ -19,9 +19,18 @@ class RareDropMessagesConfig {
     @Expose
     @ConfigOption(
         name = "Enchanted Book Name",
-        desc = "Shows what enchantment the dropped enchanted book is, and sends a message if you get one without a chat message."
+        desc = "Shows what enchantment the dropped enchanted book is."
     )
     @ConfigEditorBoolean
     @FeatureToggle
     var enchantedBook: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Missing Enchanted Book Message",
+        desc = "Sends a custom Rare Drop message if you get an enchanted book without a message in chat."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enchantedBookMissingMessage: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -78,10 +78,11 @@ object RareDropMessages {
 
     /**
      * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book §r§b(+§r§b208% §r§b✯ Magic Find§r§b)
+     * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book
      */
     private val enchantedBookPattern by repoGroup.pattern(
         "enchantedbook",
-        "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book (?<end>§r§b\\([+](?:§.)*(?<mf>\\d*)% §r§b✯ Magic Find§r§b\\)).*",
+        "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book(?<end> §r§b\\([+](?:§.)*(?<mf>\\d*)% §r§b✯ Magic Find§r§b\\))?.*",
     )
 
     private val petPatterns = listOf(
@@ -121,7 +122,7 @@ object RareDropMessages {
     @HandleEvent(onlyOnSkyblock = true)
     fun onItemAdd(event: ItemAddEvent) {
         if (event.amount != 1 || event.source != ItemAddManager.Source.ITEM_ADD) return
-        if (!config.enchantedBook) return
+        if (!config.enchantedBook || !config.enchantedBookMissingMessage) return
         val internalName = event.internalName
         val category = internalName.getItemStackOrNull()?.getItemCategoryOrNull() ?: return
         if (category != ItemCategory.ENCHANTED_BOOK) return
@@ -139,7 +140,15 @@ object RareDropMessages {
             }
         }
 
-        if (!anyRecentMessage) {
+        if (anyRecentMessage && config.enchantedBook) {
+            ChatUtils.editFirstMessage(
+                component = { it.formattedText.replace("Enchanted Book", internalName.itemName).asComponent() },
+                "enchanted book",
+                predicate = { it.passedSinceSent() < 1.seconds && enchantedBookPattern.matches(it.message) },
+            )
+        }
+
+        if (!anyRecentMessage && config.enchantedBookMissingMessage) {
             var message = "§r§6§lRARE DROP! ${internalName.itemName}"
             userLuck?.takeIf { it != 0f }?.let { luck ->
                 var luckString = luck.roundTo(2).addSeparators()
@@ -147,14 +156,7 @@ object RareDropMessages {
                 message += " §a($luckString ✴ SkyHanni User Luck)"
             }
             ChatUtils.chat(message, prefix = false)
-            return
         }
-        ChatUtils.editFirstMessage(
-            component = { it.formattedText.replace("Enchanted Book", internalName.itemName).asComponent() },
-            "enchanted book",
-            predicate = { it.passedSinceSent() < 1.seconds && enchantedBookPattern.matches(it.message) },
-        )
-
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
This PR splits the current enchanted book message functionality into 2 toggles, one that controls editing messages that dont say what enchantment the dropped book is (default enabled), and one that controls sending new messages if there isnt one in chat (default disabled). The sending new message part is currently still a bit buggy, so its better so split it like this so that less people experience the issues with it. Also makes it so that it detects messages without magic find (eg: `RARE DROP! Enchanted Book`).

## Changelog Improvements
+ Separated Enchanted Book Name feature into two. - Empa
    * Added separate toggles for editing and sending chat messages.