### PR TITLE
Fix: NPE in chat line

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -92,7 +92,7 @@ object ChatManager {
         val hoverInfo = listOf(
             "§7Message created by §a${originatingModCall?.toString() ?: "§cprobably minecraft"}",
             "§7Mod id: §a${originatingModContainer?.id}",
-            "§7Mod name: §a${originatingModContainer?.name}"
+            "§7Mod name: §a${originatingModContainer?.name}",
         )
         val stackTrace =
             Thread.currentThread().stackTrace.map {
@@ -102,7 +102,7 @@ object ChatManager {
         val result = MessageFilteringResult(
             component, ActionKind.OUTGOING, null, null,
             hoverInfo = hoverInfo,
-            hoverExtraInfo = hoverInfo + listOf("") + stackTrace
+            hoverExtraInfo = hoverInfo + listOf("") + stackTrace,
         )
 
         messageHistory[IdentityCharacteristics(component)] = result
@@ -110,7 +110,7 @@ object ChatManager {
         if (MessageSendToServerEvent(
                 trimmedMessage,
                 trimmedMessage.split(" "),
-                originatingModContainer
+                originatingModContainer,
             ).post()
         ) {
             event.cancel()
@@ -190,7 +190,7 @@ object ChatManager {
     fun MutableList<ChatLine>.editChatLine(
         component: (IChatComponent) -> IChatComponent,
         predicate: (ChatLine) -> Boolean,
-        reason: String? = null
+        reason: String? = null,
     ) {
         indexOfFirst {
             predicate(it)
@@ -224,6 +224,11 @@ object ChatManager {
         var removed = 0
         while (iterator.hasNext() && removed < amount) {
             val chatLine = iterator.next()
+
+            // chatLine can be null. maybe bc of other mods?
+            @Suppress("SENSELESS_COMPARISON")
+            if (chatLine == null) continue
+
             if (predicate(chatLine)) {
                 iterator.remove()
                 removed++


### PR DESCRIPTION
## What
Fixed a bug when the chat line entry is null.

<details>
<summary>Stack trace</summary>

```
SkyHanni 1.18.0: Caught a NullPointerException in at.hannibal2.skyhanni.features.chat.StashCompact.onChat(at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent) at SkyHanniChatEvent: Parameter specified as non-null is null: method at.hannibal2.skyhanni.features.chat.StashCompact.onChat$lambda$1$lambda$0, parameter it
 
Caused by java.lang.NullPointerException: Parameter specified as non-null is null: method at.hannibal2.skyhanni.features.chat.StashCompact.onChat$lambda$1$lambda$0, parameter it
    at SH.features.chat.StashCompact.onChat$lambda$1$lambda$0(StashCompact.kt)
    at SH.features.chat.StashCompact$$Lambda$4228/2073742831.invoke(Unknown Source)
    at SH.data.ChatManager.deleteChatLine(ChatManager.kt:227)
    at SH.utils.ChatUtils.deleteMessage(ChatUtils.kt:299)
    at SH.features.chat.StashCompact.onChat(StashCompact.kt:112)
    at SH.api.event.EventListeners$$Lambda$1332/720659889.accept(Unknown Source)
    at SH.data.ChatManager.onChatReceive(ChatManager.kt:141)
    at FML.common.eventhandler.EventBus.post(EventBus.java:140)
```

</details>

## Changelog Fixes
+ Fixed rare bug in chat features. - hannibal2