### PR TITLE
Fix: Experiment Dry-Streak not Incrementing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.inventory.experimentationtable
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGH
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
@@ -70,7 +71,7 @@ object ExperimentsDryStreakDisplay {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(priority = HIGH)
     fun onInventoryClose(event: InventoryCloseEvent) {
         if (didJustFind || ExperimentationTableApi.currentExperiment == null) return
 


### PR DESCRIPTION
## What
Very simple fix for the dry-streak counter not incrementing.
I'll probably look at overhauling this API to use a loot event similar to other types here so that we don't have to worry about event priority, but for now this fixes it.

## Changelog Fixes
+ Fixed Experimentation Dry-Streak not incrementing. - Daveed
