### PR TITLE
Fix: Attribute Shard Check in ItemUtils.kt

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -534,7 +534,7 @@ object ItemUtils {
         }
 
     fun ItemStack.getAttributeFromShard(): Pair<String, Int>? {
-        if (!(getInternalName().asString().startsWith("ATTRIBUTE_SHARD") )) return null
+        if (!(getInternalName().asString().startsWith("ATTRIBUTE_SHARD"))) return null
         val attributes = getAttributes() ?: return null
         return attributes.firstOrNull()
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -534,7 +534,7 @@ object ItemUtils {
         }
 
     fun ItemStack.getAttributeFromShard(): Pair<String, Int>? {
-        if (getInternalName().asString() != "ATTRIBUTE_SHARD") return null
+        if (!(getInternalName().asString().startsWith("ATTRIBUTE_SHARD") )) return null
         val attributes = getAttributes() ?: return null
         return attributes.firstOrNull()
     }


### PR DESCRIPTION
## What
Fixes Item Utils Attribute Shard check after NEU started supporting a new Attribute Shard ID format of ATTRIBUTE_SHARD_{TYPE}_{LEVEL} breaking the old check for exactly "ATTRIBUTE_SHARD".
This does not fix Profit Trackers showing "Attribute Shard" though.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/7c1cbd19-4263-4db2-a1f0-a09ebaa174a7)

</details>

## Changelog Fixes
+ Fixed Attribute Shard Names in Chest Storage Value. - Fazfoxy


