### PR TITLE
Fix: Bazaar cancel detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -51,7 +51,7 @@ object BazaarApi {
 
     var currentlyOpenedProduct: NeuInternalName? = null
     private var lastOpenedProduct: NeuInternalName? = null
-    private var orderOptionProduct: NeuInternalName? = null
+    var orderOptionProduct: NeuInternalName? = null
 
     private val patternGroup = RepoPattern.group("inventory.bazaar")
 
@@ -141,11 +141,14 @@ object BazaarApi {
             } else if (itemName.contains("BUY")) {
                 // pickup items from bazaar order
                 OwnInventoryData.ignoreItem(1.seconds) { it == internalName }
+                // prepare for cancel buy order as well
+                orderOptionProduct = internalName
             }
         }
         if (InventoryUtils.openInventoryName() == "Order options" && itemName == "§cCancel Order") {
             // pickup items from own bazaar order
             OwnInventoryData.ignoreItem(1.seconds) { it == orderOptionProduct }
+
         }
 
         if (inBazaarInventory) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -2,19 +2,16 @@ package at.hannibal2.skyhanni.features.inventory.bazaar
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.features.chat.ShortenCoins.formatChatCoins
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.itemName
 import at.hannibal2.skyhanni.utils.ItemUtils.name
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.OSUtils
@@ -55,7 +52,6 @@ object BazaarCancelledBuyOrderClipboard {
     )
 
     private var latestAmount: Int? = null
-    private var lastClickedItem: NeuInternalName? = null
 
     @HandleEvent
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
@@ -83,17 +79,6 @@ object BazaarCancelledBuyOrderClipboard {
     }
 
     @HandleEvent
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!BazaarApi.isBazaarOrderInventory(InventoryUtils.openInventoryName())) return
-        val item = event.slot?.stack ?: return
-
-        val name = lastItemClickedPattern.matchMatcher(item.name) {
-            group("name")
-        } ?: return
-        lastClickedItem = NeuInternalName.fromItemName(name)
-    }
-
-    @HandleEvent
     fun onChat(event: SkyHanniChatEvent) {
         if (!isEnabled()) return
         val coins = cancelledMessagePattern.matchMatcher(event.message) {
@@ -102,7 +87,8 @@ object BazaarCancelledBuyOrderClipboard {
 
         val latestAmount = latestAmount ?: return
         event.blockedReason = "bazaar cancelled buy order clipboard"
-        val lastClicked = lastClickedItem ?: error("last clicked bz item is null")
+        val lastClicked = BazaarApi.orderOptionProduct
+            ?: ErrorManager.skyHanniError("Cancel buy order clipboard could not detect the last bazaar product.")
 
         val message = "Bazaar buy order cancelled. Click to re-order.\n" +
             "§e(§8${latestAmount.addSeparators()}x §r${lastClicked.itemName}§e for ${coins.formatChatCoins()} coins§e)"

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -43,14 +43,6 @@ object BazaarCancelledBuyOrderClipboard {
         "Order options",
     )
 
-    /**
-     * REGEX-TEST: §a§lBUY §5Giant Killer VII
-     */
-    private val lastItemClickedPattern by patternGroup.pattern(
-        "lastitemclicked",
-        "§a§lBUY (?<name>.*)",
-    )
-
     private var latestAmount: Int? = null
 
     @HandleEvent


### PR DESCRIPTION
## What
Fixed the way bazaar cancel detects products

## Changelog Fixes
+ Fixed Bazaar cancel items appearing in chat as new book drops. - hannibal2
+ Fixed potential "Bazaar cancel buy order clipboard" error. - hannibal2