### PR TITLE
Feature: Shortened /warp command

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
@@ -43,7 +43,7 @@ class CommandsConfig {
 
     @ConfigOption(
         name = "Shorten §e/warp",
-        desc = "Allows warping without the need for the §ewarp §7prefix.\n§7(/warp wizard -> /wizard)"
+        desc = "Allows warping without the need for the §ewarp §7prefix.\n(§e/warp wizard §7-> §e/wizard§7)"
     )
     @Expose
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
@@ -41,6 +41,15 @@ class CommandsConfig {
     @FeatureToggle
     var partyKickReason: Boolean = true
 
+    @ConfigOption(
+        name = "Shorten §e/warp",
+        desc = "Enables warping without the need for the §ewarp §7prefix.\n§7(/warp wiazrd -> /wizard)"
+    )
+    @Expose
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var shortenWarp: Boolean = true
+
     @Expose
     @ConfigOption(name = "Replace §e/warp is", desc = "Add §e/warp is §7alongside §e/is§7. Idk why. Ask §cKaeso")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
@@ -43,7 +43,7 @@ class CommandsConfig {
 
     @ConfigOption(
         name = "Shorten §e/warp",
-        desc = "Enables warping without the need for the §ewarp §7prefix.\n§7(/warp wiazrd -> /wizard)"
+        desc = "Allows warping without the need for the §ewarp §7prefix.\n§7(/warp wizard -> /wizard)"
     )
     @Expose
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
@@ -2,11 +2,13 @@ package at.hannibal2.skyhanni.features.commands
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.WarpsJson
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 
 @SkyHanniModule
 object ShortenWarpCommand {
@@ -25,6 +27,8 @@ object ShortenWarpCommand {
 
         val message = event.message.lowercase()
         val command = message.removePrefix("/")
+        if(command == "barn" && IslandType.GARDEN.isInIsland()) return
+
         if (command in warps) {
             event.cancel()
             HypixelCommands.warp(command)

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
@@ -27,7 +27,7 @@ object ShortenWarpCommand {
 
         val message = event.message.lowercase()
         val command = message.removePrefix("/")
-        if(command == "barn" && IslandType.GARDEN.isInIsland()) return
+        if (command == "barn" && IslandType.GARDEN.isInIsland()) return
 
         if (command in warps) {
             event.cancel()

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
@@ -26,6 +26,8 @@ object ShortenWarpCommand {
         if (!SkyHanniMod.feature.misc.commands.shortenWarp) return
 
         val message = event.message.lowercase()
+        if (!message.startsWith("/")) return
+
         val command = message.removePrefix("/")
         if (command == "barn" && IslandType.GARDEN.isInIsland()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
 
 @SkyHanniModule
-object ShortenedWarpCommand {
+object ShortenWarpCommand {
 
     private var warps = listOf<String>()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenedWarpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenedWarpCommand.kt
@@ -1,0 +1,33 @@
+package at.hannibal2.skyhanni.features.commands
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.jsonobjects.repo.WarpsJson
+import at.hannibal2.skyhanni.events.MessageSendToServerEvent
+import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.HypixelCommands
+
+@SkyHanniModule
+object ShortenedWarpCommand {
+
+    private var warps = listOf<String>()
+
+    @HandleEvent
+    fun onRepoReload(event: RepositoryReloadEvent) {
+        val data = event.getConstant<WarpsJson>("Warps")
+        warps = data.warpCommands
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onMessageSendToServer(event: MessageSendToServerEvent) {
+        if (!SkyHanniMod.feature.misc.commands.shortenWarp) return
+
+        val message = event.message.lowercase()
+        val command = message.removePrefix("/")
+        if (command in warps) {
+            event.cancel()
+            HypixelCommands.warp(command)
+        }
+    }
+}


### PR DESCRIPTION
## What
Allows warping without the need for the warp prefix. (/warp wizard -> /wizard)

## Changelog New Features
+ Added shorten /warp option. - ksndq

## Info
Needs "rift" added to the Warps repo