### PR TITLE
Fix: Ghost Tracker Kill Combo not saving for combos over 1,000 kills

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
@@ -139,7 +139,7 @@ object GhostTracker {
 
     /**
      * REGEX-TEST: §cYour Kill Combo has expired! You reached a 32 Kill Combo!
-     * REGEX-TEST: §cYour Kill Combo has expired! You reached a 3.312 Kill Combo!
+     * REGEX-TEST: §cYour Kill Combo has expired! You reached a 1,187 Kill Combo!
      */
     private val killComboEndPattern by patternGroup.pattern(
         "killcombo.end",

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
@@ -139,10 +139,11 @@ object GhostTracker {
 
     /**
      * REGEX-TEST: §cYour Kill Combo has expired! You reached a 32 Kill Combo!
+     * REGEX-TEST: §cYour Kill Combo has expired! You reached a 3.312 Kill Combo!
      */
     private val killComboEndPattern by patternGroup.pattern(
         "killcombo.end",
-        "§cYour Kill Combo has expired! You reached a (?<kill>\\d+) Kill Combo!",
+        "§cYour Kill Combo has expired! You reached a (?<kill>[\\d,.]+) Kill Combo!",
     )
     private val bagOfCashPattern by patternGroup.pattern(
         "bagofcash",


### PR DESCRIPTION
## What
This PR fixes the Ghost Tracker Kill Combo not saving for combos over 1,000 kills.

## Changelog Fixes
+ Fixed Ghost Tracker Kill Combo not saving for combos over 1,000 kills. - jani

