### PR TITLE
Fix: GuildAPI reading from /g online

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/GuildApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuildApi.kt
@@ -24,7 +24,7 @@ object GuildApi {
             list.clear()
             return
         }
-        if (inGuildMessage && message == "§b§m-----------------------------------------------------§r") {
+        if (inGuildMessage && message == "§b§m-----------------------------------------------------") {
             inGuildMessage = false
             ProfileStorageData.playerSpecific?.guildMembers?.let {
                 it.clear()

--- a/src/main/java/at/hannibal2/skyhanni/data/GuildApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuildApi.kt
@@ -19,7 +19,12 @@ object GuildApi {
             list.clear()
             return
         }
-        if (message.startsWith("§eTotal Members: ")) {
+        if (message.startsWith("§eOffline Members: ")) {
+            inGuildMessage = false
+            list.clear()
+            return
+        }
+        if (inGuildMessage && message == "§b§m-----------------------------------------------------§r") {
             inGuildMessage = false
             ProfileStorageData.playerSpecific?.guildMembers?.let {
                 it.clear()


### PR DESCRIPTION
## What
Fixes GuildAPI reading guild members from /g online instead of only /g list.

## Changelog Fixes
+ Fixed GuildAPI reading guild members from /g online instead of only /g list. - SuperClash

