### PR TITLE
Fix: Attribute combo being incorrectly greyed out

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -170,11 +170,11 @@ object EstimatedItemValueCalculator {
             return 0.0
         }
         if (attributes.size != 2) return 0.0
-        val basePrice = internalName.getPrice()
+        val basePrice = internalNameString.toInternalName().getPrice()
         var subTotal = 0.0
         val combo = ("$internalNameString+ATTRIBUTE_${attributes[0].first}+ATTRIBUTE_${attributes[1].first}")
         val comboPrice = combo.toInternalName().getPriceOrNull()
-
+        
         if (comboPrice != null) {
             val useless = isUselessAttribute(combo)
             val gray = comboPrice <= basePrice || useless

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -174,7 +174,7 @@ object EstimatedItemValueCalculator {
         var subTotal = 0.0
         val combo = ("$internalNameString+ATTRIBUTE_${attributes[0].first}+ATTRIBUTE_${attributes[1].first}")
         val comboPrice = combo.toInternalName().getPriceOrNull()
-        
+
         if (comboPrice != null) {
             val useless = isUselessAttribute(combo)
             val gray = comboPrice <= basePrice || useless


### PR DESCRIPTION
## What
Fixes attribute combo being incorrectly greyed out.

## Changelog Fixes
+ Fixed attribute combo being incorrectly greyed out. - SuperClash

