### PR TITLE
Fix: Skyblock level not displaying in show messages when custom chat formatting is enabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -96,7 +96,7 @@ object PlayerChatManager {
     @Suppress("MaxLineLength")
     private val itemShowPattern by patternGroup.pattern(
         "itemshow",
-        "(?:§8\\[(?<levelColor>§.)(?<level>\\d+)§8] )?(?<author>.*)§.(?: §7♲)*?§7 (?<action>is (?:holding|friends with a|wearing)|has) (?<itemName>.*)",
+        "(?:§8\\[(?<level>§.\\d+)§8] )?(?<author>.*)§.(?: §7♲)*?§7 (?<action>is (?:holding|friends with a|wearing)|has) (?<itemName>.*)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
@@ -149,7 +149,7 @@ object PlayerNameFormatter {
                 appendSibling(
                     nameFormat(
                         event.authorComponent,
-                        levelColor = event.levelComponent?.sampleStyleAtStart()?.color?.toString(),
+                        levelColor = event.levelComponent?.getText()?.substring(0, 2),
                         level = event.levelComponent,
                     ),
                 )

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.features.misc.MarkedPlayerManager
 import at.hannibal2.skyhanni.features.misc.compacttablist.AdvancedPlayerList
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils.changeColor
+import at.hannibal2.skyhanni.utils.ColorUtils.getFirstColorCode
 import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
 import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.matchStyledMatcher
 import at.hannibal2.skyhanni.utils.ComponentSpan
@@ -149,7 +150,7 @@ object PlayerNameFormatter {
                 appendSibling(
                     nameFormat(
                         event.authorComponent,
-                        levelColor = event.levelComponent?.getText()?.substring(0, 2),
+                        levelColor = event.levelComponent?.getText()?.getFirstColorCode()?.let { "§$it" },
                         level = event.levelComponent,
                     ),
                 )


### PR DESCRIPTION
## What
Title. Reported https://discord.com/channels/997079228510117908/1344393606513033278/1344393606513033278.

## Changelog Fixes
+ Fixed SkyBlock Level not displaying in `/show` messages with Custom Chat Formatting enabled. - SuperClash


