### PR TITLE
Fix: Show Sulphur Skitter Box without lava

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/SulphurSkitterBox.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/SulphurSkitterBox.kt
@@ -66,12 +66,6 @@ object SulphurSkitterBox {
         spongeLocations = BlockPos.getAllInBox(from, to).filter {
             val loc = it.toLorenzVec()
             loc.getBlockAt() == Blocks.sponge && loc.distanceToPlayer() <= 15
-        }.filter {
-            val pos1 = it.add(-RADIUS, -RADIUS, -RADIUS)
-            val pos2 = it.add(RADIUS, RADIUS, RADIUS)
-            BlockPos.getAllInBox(pos1, pos2).any { pos ->
-                pos.toLorenzVec().getBlockAt() in FishingApi.lavaBlocks
-            }
         }.map { it.toLorenzVec() }
     }
 


### PR DESCRIPTION
## What
Removed the lava check for Sulphur Skitter Box (see changelog for explanation).

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fixed Sulphur Skitter Box not displaying without lava nearby. - Luna
    * The Player must be within 4 blocks, not the bobber, for the box to display.