### PR TITLE
Fix: Garden Sethome Key Preventing Warp

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
@@ -67,6 +67,7 @@ object GardenWarpCommands {
         when (event.keyCode) {
             config.homeHotkey -> {
                 HypixelCommands.warp("garden")
+                lastWarpTime = SimpleTimeMark.now()
             }
 
             config.sethomeHotkey -> {
@@ -76,10 +77,10 @@ object GardenWarpCommands {
             config.barnHotkey -> {
                 LockMouseLook.autoDisable()
                 HypixelCommands.teleportToPlot("barn")
+                lastWarpTime = SimpleTimeMark.now()
             }
 
             else -> return
         }
-        lastWarpTime = SimpleTimeMark.now()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
@@ -62,12 +62,12 @@ object GardenWarpCommands {
         if (Minecraft.getMinecraft().currentScreen != null) return
         if (NeuItems.neuHasFocus()) return
 
-        if (lastWarpTime.passedSince() < 2.seconds) return
-
         when (event.keyCode) {
             config.homeHotkey -> {
-                HypixelCommands.warp("garden")
+                if (lastWarpTime.passedSince() < 2.seconds) return
                 lastWarpTime = SimpleTimeMark.now()
+
+                HypixelCommands.warp("garden")
             }
 
             config.sethomeHotkey -> {
@@ -75,9 +75,11 @@ object GardenWarpCommands {
             }
 
             config.barnHotkey -> {
+                if (lastWarpTime.passedSince() < 2.seconds) return
+                lastWarpTime = SimpleTimeMark.now()
+
                 LockMouseLook.autoDisable()
                 HypixelCommands.teleportToPlot("barn")
-                lastWarpTime = SimpleTimeMark.now()
             }
 
             else -> return


### PR DESCRIPTION
## What
Fixed Sethome Hotkey in Garden Commands to not affect, nor be affected by, the warp cooldown, as it does not perform a warp.

## Changelog Fixes
+ Fixed Garden Commands issue preventing warp (barn/home) and sethome hotkeys from triggering within 2 seconds. - Luna