### PR TITLE
Fix: CustomScoreboard ChunkedStats Motes wrong color

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ChunkedStatsLine.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ChunkedStatsLine.kt
@@ -39,7 +39,7 @@ enum class ChunkedStatsLine(
         configLine = "§6Purse",
     ),
     MOTES(
-        displayPair = { "§b${getMotes()}" },
+        displayPair = { "§d${getMotes()}" },
         showWhen = { !(hideEmptyLines && getMotes() == "0") && ScoreboardElementMotes.showWhen() },
         showIsland = { ScoreboardElementMotes.showIsland() },
         configLine = "§dMotes",


### PR DESCRIPTION
## Changelog Fixes
+ Fixed Custom Scoreboard Chunked Stats using the wrong color for motes. - j10a1n15

