### PR TITLE
Fix: add missing rod part category

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
@@ -11,6 +11,7 @@ enum class ItemCategory {
     WAND,
     FISHING_WEAPON,
     FISHING_ROD,
+    ROD_PART,
     AXE,
     GAUNTLET,
     HOE,


### PR DESCRIPTION
## What
the new fishing update has a new item category

i haven't been able to get in the server yet, but i don't think there are more categories
https://discord.com/channels/997079228510117908/1349543141652566070

## Changelog Fixes
+ Fixed missing Rod Part category. - martimavocado