### PR TITLE
Backend: Make class names a bit more specific

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventHandler.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.StringUtils
-import at.hannibal2.skyhanni.utils.chat.Text
+import at.hannibal2.skyhanni.utils.chat.TextHelper
 
 class EventHandler<T : SkyHanniEvent> private constructor(
     val name: String,
@@ -49,7 +49,7 @@ class EventHandler<T : SkyHanniEvent> private constructor(
         if (errors > 3) {
             val hiddenErrors = errors - 3
             ChatUtils.chat(
-                Text.text(
+                TextHelper.text(
                     "§c[SkyHanni/${SkyHanniMod.VERSION}] $hiddenErrors more errors in $name are hidden!",
                 ),
             )

--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.ReflectionUtils.getClassInstance
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
-import at.hannibal2.skyhanni.utils.chat.Text.send
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.system.PlatformUtils.getModInstance
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.ChatLine

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -29,10 +29,10 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DPathWithWaypoint
-import at.hannibal2.skyhanni.utils.chat.Text.asComponent
-import at.hannibal2.skyhanni.utils.chat.Text.hover
-import at.hannibal2.skyhanni.utils.chat.Text.onClick
-import at.hannibal2.skyhanni.utils.chat.Text.send
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.hover
+import at.hannibal2.skyhanni.utils.chat.TextHelper.onClick
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityPlayerSP

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
@@ -26,8 +26,8 @@ import at.hannibal2.skyhanni.utils.StringUtils.applyFormattingFrom
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.toCleanChatComponent
-import at.hannibal2.skyhanni.utils.chat.Text
-import at.hannibal2.skyhanni.utils.chat.Text.style
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.style
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonArray
 import com.google.gson.JsonNull
@@ -92,7 +92,7 @@ object PlayerNameFormatter {
         if (!isEnabled()) return
         event.chatComponent = StringUtils.replaceIfNeeded(
             event.chatComponent,
-            Text.text("§bCo-op > ") {
+            TextHelper.text("§bCo-op > ") {
                 appendSibling(nameFormat(event.authorComponent))
                 appendText("§f: ")
                 appendSibling(event.messageComponent.intoComponent())
@@ -105,7 +105,7 @@ object PlayerNameFormatter {
         if (!isEnabled()) return
         event.chatComponent = StringUtils.replaceIfNeeded(
             event.chatComponent,
-            Text.text("§2Guild > ") {
+            TextHelper.text("§2Guild > ") {
                 appendSibling(nameFormat(event.authorComponent, guildRank = event.guildRank))
                 appendText("§f: ")
                 appendSibling(event.messageComponent.intoComponent())
@@ -118,7 +118,7 @@ object PlayerNameFormatter {
         if (!isEnabled()) return
         event.chatComponent = StringUtils.replaceIfNeeded(
             event.chatComponent,
-            Text.text("§9Party §8> ") {
+            TextHelper.text("§9Party §8> ") {
                 appendSibling(nameFormat(event.authorComponent))
                 appendText("§f: ")
                 appendSibling(event.messageComponent.intoComponent())
@@ -131,7 +131,7 @@ object PlayerNameFormatter {
         if (!isEnabled()) return
         event.chatComponent = StringUtils.replaceIfNeeded(
             event.chatComponent,
-            Text.text("§d${event.direction}") {
+            TextHelper.text("§d${event.direction}") {
                 appendText(" ")
                 appendSibling(nameFormat(event.authorComponent))
                 appendText("§f: ")
@@ -145,7 +145,7 @@ object PlayerNameFormatter {
         if (!isEnabled()) return
         event.chatComponent = StringUtils.replaceIfNeeded(
             event.chatComponent,
-            Text.text("") {
+            TextHelper.text("") {
                 appendSibling(
                     nameFormat(
                         event.authorComponent,

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -8,9 +8,9 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.chat.Text
-import at.hannibal2.skyhanni.utils.chat.Text.asComponent
-import at.hannibal2.skyhanni.utils.chat.Text.send
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import com.google.gson.JsonObject
 import net.minecraft.util.IChatComponent
 import org.apache.commons.io.FileUtils
@@ -266,7 +266,7 @@ object RepoManager {
                 for (constant in unsuccessfulConstants) {
                     text.add("   §e- §7$constant".asComponent())
                 }
-                Text.multiline(text).send()
+                TextHelper.multiline(text).send()
             }
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -23,7 +23,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.isVowel
-import at.hannibal2.skyhanni.utils.chat.Text.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.util.ChatComponentText
 import kotlin.time.Duration.Companion.seconds

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
@@ -6,9 +6,9 @@ import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.StringUtils.splitLines
-import at.hannibal2.skyhanni.utils.chat.Text
-import at.hannibal2.skyhanni.utils.chat.Text.hover
-import at.hannibal2.skyhanni.utils.chat.Text.suggest
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.hover
+import at.hannibal2.skyhanni.utils.chat.TextHelper.suggest
 import net.minecraft.util.IChatComponent
 
 @SkyHanniModule
@@ -24,8 +24,8 @@ object HelpCommand {
         val categoryDescription = category.description.splitLines(200).replace("§r", "§7")
         val aliases = command.aliases
 
-        return Text.text("§7 - $color${command.name}") {
-            this.hover = Text.multiline(
+        return TextHelper.text("§7 - $color${command.name}") {
+            this.hover = TextHelper.multiline(
                 "§e/${command.name}",
                 if (aliases.isNotEmpty()) "§7Aliases: §e/${aliases.joinToString("§7, §e/")}" else null,
                 if (description.isNotEmpty()) description.prependIndent("  ") else null,
@@ -46,7 +46,7 @@ object HelpCommand {
 
         val title = if (search.isBlank()) "SkyHanni Commands" else "SkyHanni Commands Matching: \"$search\""
 
-        Text.displayPaginatedList(
+        TextHelper.displayPaginatedList(
             title,
             filtered,
             chatLineId = messageId,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -44,7 +44,7 @@ object ChestValue {
 
     private val config get() = SkyHanniMod.feature.inventory.chestValueConfig
     private var display = emptyList<Renderable>()
-    private var chestItems = mapOf<String, Item>()
+    private var chestItems = mapOf<String, ChestItem>()
     private val inInventory get() = isValidStorage()
     private var inOwnInventory = false
     private val scrollValue = ScrollValue()
@@ -195,7 +195,7 @@ object ChestValue {
                 put(it.slotIndex, it.stack)
             }
         }
-        val items = mutableMapOf<String, Item>()
+        val items = mutableMapOf<String, ChestItem>()
         for ((i, stack) in stacks) {
             val internalName = stack.getInternalNameOrNull() ?: continue
             if (internalName.getItemStackOrNull() == null) continue
@@ -207,7 +207,7 @@ object ChestValue {
             list.add("§aTotal: §6§l${total.formatPrice()} coins")
             if (total == 0.0) continue
             val item = items.getOrPut(key) {
-                Item(mutableListOf(), 0, stack, 0.0, list)
+                ChestItem(mutableListOf(), 0, stack, 0.0, list)
             }
             item.index.add(i)
             item.amount += stack.stackSize
@@ -269,7 +269,7 @@ object ChestValue {
         return currentString
     }
 
-    data class Item(
+    private data class ChestItem(
         val index: MutableList<Int>,
         var amount: Int,
         val stack: ItemStack,

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -23,8 +23,8 @@ import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
-import at.hannibal2.skyhanni.utils.chat.Text
-import at.hannibal2.skyhanni.utils.chat.Text.hover
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.hover
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import com.google.gson.annotations.Expose
 import net.minecraft.block.BlockStone
@@ -141,8 +141,8 @@ object MineshaftPityDisplay {
 
             resetCounter()
 
-            val newComponent = Text.text(message) {
-                hover = Text.multiline(hoverText)
+            val newComponent = TextHelper.text(message) {
+                hover = TextHelper.multiline(hoverText)
             }
 
             if (config.modifyChatMessage) event.chatComponent = newComponent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -12,11 +12,11 @@ import at.hannibal2.skyhanni.utils.CollectionUtils.takeIfAllNotNull
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.LorenzVec.Companion.toLorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
-import at.hannibal2.skyhanni.utils.chat.Text
-import at.hannibal2.skyhanni.utils.chat.Text.asComponent
-import at.hannibal2.skyhanni.utils.chat.Text.hover
-import at.hannibal2.skyhanni.utils.chat.Text.onClick
-import at.hannibal2.skyhanni.utils.chat.Text.send
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.hover
+import at.hannibal2.skyhanni.utils.chat.TextHelper.onClick
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import kotlinx.coroutines.launch
 
 object NavigationHelper {
@@ -63,7 +63,7 @@ object NavigationHelper {
         }
         val title = if (searchTerm.isBlank()) "SkyHanni Navigation Locations" else "SkyHanni Navigation Locations Matching: \"$searchTerm\""
 
-        Text.displayPaginatedList(
+        TextHelper.displayPaginatedList(
             title,
             locations,
             chatLineId = messageId,

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pets/PetNametag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pets/PetNametag.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrEmpty
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.chat.Text.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.entity.item.EntityArmorStand
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
@@ -11,13 +11,13 @@ import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.minutes
-import at.hannibal2.skyhanni.utils.chat.Text
-import at.hannibal2.skyhanni.utils.chat.Text.asComponent
-import at.hannibal2.skyhanni.utils.chat.Text.command
-import at.hannibal2.skyhanni.utils.chat.Text.hover
-import at.hannibal2.skyhanni.utils.chat.Text.send
-import at.hannibal2.skyhanni.utils.chat.Text.suggest
-import at.hannibal2.skyhanni.utils.chat.Text.wrap
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.command
+import at.hannibal2.skyhanni.utils.chat.TextHelper.hover
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
+import at.hannibal2.skyhanni.utils.chat.TextHelper.suggest
+import at.hannibal2.skyhanni.utils.chat.TextHelper.wrap
 import net.minecraft.util.IChatComponent
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -37,7 +37,7 @@ object ReminderManager {
 
     private fun getSortedReminders() = storage.entries.sortedBy { it.value.remindAt }
 
-    private fun sendMessage(message: String) = Text.join("§e[Reminder]", " ", message).send(REMINDERS_ACTION_ID)
+    private fun sendMessage(message: String) = TextHelper.join("§e[Reminder]", " ", message).send(REMINDERS_ACTION_ID)
 
     private fun parseDuration(text: String): Duration? = try {
         val duration = TimeUtils.getDuration(text)
@@ -47,7 +47,7 @@ object ReminderManager {
     }
 
     private fun listReminders(page: Int) {
-        Text.displayPaginatedList(
+        TextHelper.displayPaginatedList(
             "SkyHanni Reminders",
             getSortedReminders(),
             chatLineId = REMINDERS_LIST_ID,
@@ -57,7 +57,7 @@ object ReminderManager {
         ) { reminderEntry ->
             val id = reminderEntry.key
             val reminder = reminderEntry.value
-            Text.join(
+            TextHelper.join(
                 "§c✕".asComponent {
                     hover = "§7Click to remove".asComponent()
                     command = "/shremind remove -l $id"
@@ -142,7 +142,7 @@ object ReminderManager {
     }
 
     private fun help() {
-        Text.createDivider().send()
+        TextHelper.createDivider().send()
         "§6SkyHanni Reminder Commands:".asComponent().send()
         "§e/shremind <time> <reminder> - §bCreates a new reminder".asComponent().send()
         "§e/shremind list <page> - §bLists all reminders".asComponent().send()
@@ -150,7 +150,7 @@ object ReminderManager {
         "§e/shremind edit <id> <reminder> - §bEdits a reminder".asComponent().send()
         "§e/shremind move <id> <time> - §bMoves a reminder".asComponent().send()
         "§e/shremind help - §bShows this help message".asComponent().send()
-        Text.createDivider().send()
+        TextHelper.createDivider().send()
     }
 
     @HandleEvent
@@ -163,7 +163,7 @@ object ReminderManager {
             var actionsComponent: IChatComponent? = null
 
             if (!config.autoDeleteReminders) {
-                actionsComponent = Text.join(
+                actionsComponent = TextHelper.join(
                     " ",
                     "§a✔".asComponent {
                         hover = "§7Click to dismiss".asComponent()
@@ -180,7 +180,7 @@ object ReminderManager {
             }
 
             remindersToSend.add(
-                Text.join(
+                TextHelper.join(
                     "§e[Reminder]".asComponent {
                         hover = "§7Reminders by SkyHanni".asComponent()
                     },
@@ -193,7 +193,7 @@ object ReminderManager {
 
         if (remindersToSend.isNotEmpty()) {
             val id = if (config.autoDeleteReminders) 0 else REMINDERS_MESSAGE_ID
-            Text.join(remindersToSend, separator = Text.NEWLINE).send(id)
+            TextHelper.join(remindersToSend, separator = TextHelper.NEWLINE).send(id)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -12,14 +12,14 @@ import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
-import at.hannibal2.skyhanni.utils.chat.Text
-import at.hannibal2.skyhanni.utils.chat.Text.asComponent
-import at.hannibal2.skyhanni.utils.chat.Text.command
-import at.hannibal2.skyhanni.utils.chat.Text.hover
-import at.hannibal2.skyhanni.utils.chat.Text.onClick
-import at.hannibal2.skyhanni.utils.chat.Text.prefix
-import at.hannibal2.skyhanni.utils.chat.Text.send
-import at.hannibal2.skyhanni.utils.chat.Text.url
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.command
+import at.hannibal2.skyhanni.utils.chat.TextHelper.hover
+import at.hannibal2.skyhanni.utils.chat.TextHelper.onClick
+import at.hannibal2.skyhanni.utils.chat.TextHelper.prefix
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
+import at.hannibal2.skyhanni.utils.chat.TextHelper.url
 import at.hannibal2.skyhanni.utils.compat.getFormattedTextCompat
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.ChatLine
@@ -169,7 +169,7 @@ object ChatUtils {
         val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
 
         val rawText = msgPrefix + message
-        val text = Text.text(rawText) {
+        val text = TextHelper.text(rawText) {
             this.onClick(expireAt, oneTimeClick, onClick)
             this.hover = hover.asComponent()
         }
@@ -211,8 +211,8 @@ object ChatUtils {
         val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
 
         chat(
-            Text.text(msgPrefix + message) {
-                this.hover = Text.multiline(hover)
+            TextHelper.text(msgPrefix + message) {
+                this.hover = TextHelper.multiline(hover)
                 if (command != null) {
                     this.command = command
                 }
@@ -241,7 +241,7 @@ object ChatUtils {
     ) {
         val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
         chat(
-            Text.text(msgPrefix + message) {
+            TextHelper.text(msgPrefix + message) {
                 this.url = url
                 this.hover = "$prefixColor$hover".asComponent()
             },
@@ -263,7 +263,7 @@ object ChatUtils {
         prefixColor: String = "§e",
     ) {
         val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
-        chat(Text.join(components).prefix(msgPrefix))
+        chat(TextHelper.join(components).prefix(msgPrefix))
     }
 
     private val chatGui get() = Minecraft.getMinecraft().ingameGUI.chatGUI

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -33,11 +33,11 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnchantments
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRecombobulated
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
-import at.hannibal2.skyhanni.utils.chat.Text
-import at.hannibal2.skyhanni.utils.chat.Text.asComponent
-import at.hannibal2.skyhanni.utils.chat.Text.onClick
-import at.hannibal2.skyhanni.utils.chat.Text.onHover
-import at.hannibal2.skyhanni.utils.chat.Text.send
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.onClick
+import at.hannibal2.skyhanni.utils.chat.TextHelper.onHover
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import kotlinx.coroutines.launch
@@ -634,7 +634,7 @@ object ItemUtils {
         }
 
         val input = args.joinToString(" ")
-        Text.text("§eProcessing..").send(testItemMessageId)
+        TextHelper.text("§eProcessing..").send(testItemMessageId)
 
         // running .getPrice() on thousands of items may take ~500ms
         SkyHanniMod.coroutineScope.launch {

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils.chat
 
+import at.hannibal2.skyhanni.features.inventory.ChestValue
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraft.client.Minecraft
 import net.minecraft.event.ClickEvent
@@ -9,7 +10,7 @@ import net.minecraft.util.ChatStyle
 import net.minecraft.util.EnumChatFormatting
 import net.minecraft.util.IChatComponent
 
-object Text {
+object TextHelper {
 
     val NEWLINE = "\n".asComponent()
     val HYPHEN = "-".asComponent()

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.utils.chat
 
-import at.hannibal2.skyhanni.features.inventory.ChestValue
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraft.client.Minecraft
 import net.minecraft.event.ClickEvent

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -270,7 +270,7 @@
     <ID>SpacingAroundCurly:Renderable.kt$Renderable.Companion.&lt;no name provided&gt;$}</ID>
     <ID>SpreadOperator:ItemUtils.kt$ItemUtils$(tag, displayName, *lore.toTypedArray())</ID>
     <ID>SpreadOperator:LimboPlaytime.kt$LimboPlaytime$( itemID.getItemStack().item, ITEM_NAME, *createItemLore() )</ID>
-    <ID>SpreadOperator:Text.kt$TextHelper$(*component.toTypedArray(), separator = separator)</ID>
+    <ID>SpreadOperator:TextHelper.kt$TextHelper$(*component.toTypedArray(), separator = separator)</ID>
     <ID>TooManyFunctions:CollectionUtils.kt$CollectionUtils</ID>
     <ID>TooManyFunctions:EstimatedItemValueCalculator.kt$EstimatedItemValueCalculator</ID>
     <ID>TooManyFunctions:HypixelCommands.kt$HypixelCommands</ID>

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -270,7 +270,7 @@
     <ID>SpacingAroundCurly:Renderable.kt$Renderable.Companion.&lt;no name provided&gt;$}</ID>
     <ID>SpreadOperator:ItemUtils.kt$ItemUtils$(tag, displayName, *lore.toTypedArray())</ID>
     <ID>SpreadOperator:LimboPlaytime.kt$LimboPlaytime$( itemID.getItemStack().item, ITEM_NAME, *createItemLore() )</ID>
-    <ID>SpreadOperator:Text.kt$Text$(*component.toTypedArray(), separator = separator)</ID>
+    <ID>SpreadOperator:Text.kt$TextHelper$(*component.toTypedArray(), separator = separator)</ID>
     <ID>TooManyFunctions:CollectionUtils.kt$CollectionUtils</ID>
     <ID>TooManyFunctions:EstimatedItemValueCalculator.kt$EstimatedItemValueCalculator</ID>
     <ID>TooManyFunctions:HypixelCommands.kt$HypixelCommands</ID>


### PR DESCRIPTION
made class names a bit more specific so the wrong one isnt imported or we dont have conflicts on later versions

## Changelog Technical Details
+ Renamed Text to TextHelper and ChestValue's Item to ChestItem. - CalMWolfs
    * Clarified imports and fixed class name overlaps on modern versions.