### PR TITLE
Backend: pr changelog guildelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ _A more in-depth explanation of how to use IntelliJ and branches will follow som
 Please use a prefix for the PR name (e.g., Feature, Improvement, Fix, Backend, etc.).
 
 When writing the PR description, ensure you fill out the template with all the necessary information.
-In the `## What` section, write technical details or explanations that don't belong in the changelog.
+In the **What** section, write technical details or explanations that don't belong in the changelog.
 Including that field is optional for small changes.
 
 If your PR relies on another PR, please include this information at the beginning of the description. Use the format `- #<pr number>`
@@ -159,6 +159,7 @@ side).
 Some changes don't fit any categories.
 E.g. when reverting pull requests or doing quick fixes to PRs merged immediately beforehand but not yet released in a beta.
 To tell the changelog build this, write either `exclude_from_changelog` or `ignore_from_changelog` in one line.
+Make sure such pull requests have a good explanation in the **What** section.
 
 ## Coding Styles and Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,8 @@ Please use a prefix for the PR name (e.g., Feature, Improvement, Fix, Backend, e
 When writing the PR description, ensure you fill out the template with all the necessary information, including the "WHAT" section and the
 changelog entries.
 
-If your PR relies on another PR, please include this information at the beginning of the description. Consider using a
-format like "- #821" to illustrate the dependency.
+If your PR relies on another PR, please include this information at the beginning of the description. Please use the format `- #<pr number>` for the
+dependency, or `- <url>` for REPO dependencies.
 
 ### Changelog Builder
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,11 +100,12 @@ _A more in-depth explanation of how to use IntelliJ and branches will follow som
 
 Please use a prefix for the PR name (e.g., Feature, Improvement, Fix, Backend, etc.).
 
-When writing the PR description, ensure you fill out the template with all the necessary information, including the "WHAT" section and the
-changelog entries.
+When writing the PR description, ensure you fill out the template with all the necessary information.
+In the `## What` section, write technical details or explanations that don't belong in the changelog.
+Including that field is optional for small changes.
 
-If your PR relies on another PR, please include this information at the beginning of the description. Please use the format `- #<pr number>` for the
-dependency, or `- <url>` for REPO dependencies.
+If your PR relies on another PR, please include this information at the beginning of the description. Use the format `- #<pr number>`
+for the dependency, or `- <url>` for REPO dependencies.
 
 ### Changelog Builder
 
@@ -124,7 +125,7 @@ category.
 
 Changes that improve or expand the code's logic and have a visible impact on users. This category is for enhancements, not for fixing
 incorrect logic.
-The line between bug fixes and improvements is sometimes not clear.If you are unsure whether a change is an improvement or a bug fix, ask
+The line between bug fixes and improvements is sometimes not clear. If you are unsure whether a change is an improvement or a bug fix, ask
 for guidance.
 
 #### Fixes
@@ -144,7 +145,7 @@ Internal changes that do not impact the end user. Examples include:
 - API updates
 - Minor performance improvements
 - Preparations for 1.21
-- Documentation changes to markdown files. E.g. in `/docs` or this file.
+- Documentation changes to markdown files, e.g., in `/docs` or this file.
 
 #### Removed Features
 
@@ -154,7 +155,7 @@ side).
 #### No category
 
 Some changes don't fit any categories.
-E.g. when reverting pull requests or doing quick fixes to prs merged immediately beforehand but not yet released in a beta.
+E.g. when reverting pull requests or doing quick fixes to PRs merged immediately beforehand but not yet released in a beta.
 To tell the changelog build this, write either `exclude_from_changelog` or `ignore_from_changelog` in one line.
 
 ## Coding Styles and Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,8 @@ out [their guide](https://github.com/NotEnoughUpdates/NotEnoughUpdates/blob/mast
 
 ## Pull Requests
 
+General infos about Pull Request can be found on [Github Docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests).
+
 ### Creating a Pull Request
 
 If you are not very familiar with git, you might want to try this out: https://learngitbranching.js.org/.
@@ -96,7 +98,7 @@ You can do this by following the instructions within the IntelliJ window in the 
 
 _A more in-depth explanation of how to use IntelliJ and branches will follow someday._
 
-### General Guidelines for Pull Requests
+### Guidelines for Pull Requests
 
 Please use a prefix for the PR name (e.g., Feature, Improvement, Fix, Backend, etc.).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ If you are not very familiar with git, you might want to try this out: https://l
 
 Proposed changes are best made in their own branch, as this makes development easier for both you and the maintainers of this repository.
 You can do this by following the instructions within the IntelliJ window in the open SkyHanni project:
+
 - Click the beta dropdown at the top of IntelliJ.
 - Click **New branch**.
 - Give the branch a name related to the changes you plan to make.
@@ -99,7 +100,8 @@ _A more in-depth explanation of how to use IntelliJ and branches will follow som
 
 Please use a prefix for the PR name (e.g., Feature, Improvement, Fix, Backend, etc.).
 
-When writing the PR description, ensure you fill out the template with all the necessary information, including the "WHAT" section and the changelog entries.
+When writing the PR description, ensure you fill out the template with all the necessary information, including the "WHAT" section and the
+changelog entries.
 
 If your PR relies on another PR, please include this information at the beginning of the description. Consider using a
 format like "- #821" to illustrate the dependency.
@@ -115,29 +117,45 @@ Here is an explanation of which changes belong to each category:
 
 #### New Features
 
-New standalone features that are independent of existing features. Additional settings for existing features belong in the **Improvements** category.
+New standalone features that are independent of existing features. Additional settings for existing features belong in the **Improvements**
+category.
 
 #### Improvements
 
-Changes that improve or expand the code's logic and have a visible impact on users. This category is for enhancements, not for fixing incorrect logic.
-The line between bug fixes and improvements is sometimes not clear.If you are unsure whether a change is an improvement or a bug fix, ask for guidance.
+Changes that improve or expand the code's logic and have a visible impact on users. This category is for enhancements, not for fixing
+incorrect logic.
+The line between bug fixes and improvements is sometimes not clear.If you are unsure whether a change is an improvement or a bug fix, ask
+for guidance.
+
 #### Fixes
 
-Bug fixes, including typos (only those visible to the user, e.g., in config or chat messages), missing checks that cause incorrect behavior under specific conditions, or logic errors.
-Only significant performance issues are considered bugs; otherwise, they fall under **Technical Details**. If the code does not behave as intended by the original developer, it is a bug. If the original code had logical errors, it is a bug. If the original code lacks nuance but is not incorrect, it is not a bug.
+Bug fixes, including typos (only those visible to the user, e.g., in config or chat messages), missing checks that cause incorrect behavior
+under specific conditions, or logic errors.
+Only significant performance issues are considered bugs; otherwise, they fall under **Technical Details**. If the code does not behave as
+intended by the original developer, it is a bug. If the original code had logical errors, it is a bug. If the original code lacks nuance but
+is not incorrect, it is not a bug.
 
 #### Technical Details
 
 Internal changes that do not impact the end user. Examples include:
+
 - Refactoring (renaming or moving members, functions, classes, files or packages)
 - Typos in object names (which the end user will not see)
 - API updates
 - Minor performance improvements
 - Preparations for 1.21
+- Documentation changes to markdown files. E.g. in `/docs` or this file.
 
 #### Removed Features
 
-Features that have merged with existing features (in the config) or have become obsolete (e.g., if Hypixel implements them on the server side).
+Features that have merged with existing features (in the config) or have become obsolete (e.g., if Hypixel implements them on the server
+side).
+
+#### No category
+
+Some changes don't fit any categories.
+E.g. when reverting pull requests or doing quick fixes to prs merged immediately beforehand but not yet released in a beta.
+To tell the changelog build this, write either `exclude_from_changelog` or `ignore_from_changelog` in one line.
 
 ## Coding Styles and Conventions
 
@@ -312,7 +330,8 @@ to make mappings translate more easily (more on that later).
 
 ## Discord Bot
 
-While not directly part of the Minecraft mod, it is useful to know that we have a [Discord Bot](https://github.com/SkyHanniStudios/DiscordBot) that helps with small tasks related to PRs.
+While not directly part of the Minecraft mod, it is useful to know that we have
+a [Discord Bot](https://github.com/SkyHanniStudios/DiscordBot) that helps with small tasks related to PRs.
 
 ### Goals
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,23 +81,63 @@ Now that we are done with that, you should be able to launch your game from your
 SkyHanni's Gradle configuration is very similar to the one used in **NotEnoughUpdates**, so if you want to look at another guide, check
 out [their guide](https://github.com/NotEnoughUpdates/NotEnoughUpdates/blob/master/CONTRIBUTING.md).
 
-## Creating a Pull Request
+## Pull Requests
+
+### Creating a Pull Request
 
 If you are not very familiar with git, you might want to try this out: https://learngitbranching.js.org/.
 
-Proposed changes are better off being in their own branch as this makes development easier for both you and the maintainers of this repository, you can do this by following the instructions from within the IntelliJ window with the SkyHanni project already open.
-- Click the beta dropdown at the top of IntelliJ
-- Click new branch
-- Give the branch a name relating to the changes you plan to make
+Proposed changes are best made in their own branch, as this makes development easier for both you and the maintainers of this repository.
+You can do this by following the instructions within the IntelliJ window in the open SkyHanni project:
+- Click the beta dropdown at the top of IntelliJ.
+- Click **New branch**.
+- Give the branch a name related to the changes you plan to make.
 
-_A more in depth explanation how to use intellij and branches will follow here soon._
+_A more in-depth explanation of how to use IntelliJ and branches will follow someday._
 
-Please use a prefix for the name of the PR (E.g. Feature, Improvement, Fix, Backend, ...).
+### General Guidelines for Pull Requests
 
-When writing the description of the PR, ensure you fill out the template with the necessary information, including the "WHAT" section, and the changelog entries.
+Please use a prefix for the PR name (e.g., Feature, Improvement, Fix, Backend, etc.).
+
+When writing the PR description, ensure you fill out the template with all the necessary information, including the "WHAT" section and the changelog entries.
 
 If your PR relies on another PR, please include this information at the beginning of the description. Consider using a
 format like "- #821" to illustrate the dependency.
+
+### Changelog Builder
+
+The PR description is processed by our [ChangeLog Builder](https://github.com/SkyHanniStudios/SkyHanniChangelogBuilder).
+
+- Follow the format examples from the template and remove the categories that do not apply to your PR.
+- A PR might include multiple changelog categories simultaneously.
+
+Here is an explanation of which changes belong to each category:
+
+#### New Features
+
+New standalone features that are independent of existing features. Additional settings for existing features belong in the **Improvements** category.
+
+#### Improvements
+
+Changes that improve or expand the code's logic and have a visible impact on users. This category is for enhancements, not for fixing incorrect logic.
+The line between bug fixes and improvements is sometimes not clear.If you are unsure whether a change is an improvement or a bug fix, ask for guidance.
+#### Fixes
+
+Bug fixes, including typos (only those visible to the user, e.g., in config or chat messages), missing checks that cause incorrect behavior under specific conditions, or logic errors.
+Only significant performance issues are considered bugs; otherwise, they fall under **Technical Details**. If the code does not behave as intended by the original developer, it is a bug. If the original code had logical errors, it is a bug. If the original code lacks nuance but is not incorrect, it is not a bug.
+
+#### Technical Details
+
+Internal changes that do not impact the end user. Examples include:
+- Refactoring (renaming or moving members, functions, classes, files or packages)
+- Typos in object names (which the end user will not see)
+- API updates
+- Minor performance improvements
+- Preparations for 1.21
+
+#### Removed Features
+
+Features that have merged with existing features (in the config) or have become obsolete (e.g., if Hypixel implements them on the server side).
 
 ## Coding Styles and Conventions
 
@@ -269,6 +309,10 @@ different Minecraft versions.
 
 Note also that the only targets we consider are 1.8.9 and 1.21 (or whatever the latest version we may target). The other versions are only there
 to make mappings translate more easily (more on that later).
+
+## Discord Bot
+
+While not directly part of the Minecraft mod, it is useful to know that we have a [Discord Bot](https://github.com/SkyHanniStudios/DiscordBot) that helps with small tasks related to PRs.
 
 ### Goals
 


### PR DESCRIPTION
## What
Expanded and improved the contributing guidelines around pull requests.
Included examples and broad rules what belong in what category of the changelog.
Linking to the Changelog Builder and Discord Bot.

exclude_from_changelog