### PR TITLE
Fix: Hitman Calculation

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
@@ -77,10 +77,8 @@ object HitmanApi {
     /**
      * Return the time until the given number of rabbits can be hunted.
      */
-    private fun getTimeToHuntCount(targetHuntCount: Int): Duration {
-        // Determine how many hunts we need to perform
-        var huntsToPerform = (targetHuntCount)
-        if (huntsToPerform <= 0) return Duration.ZERO
+    private fun getTimeToHuntCount(targetHunts: Int): Duration {
+        var huntsToPerform = targetHunts.takeIf { it > 0 } ?: return Duration.ZERO
 
         // Determine which pre-available meals we have, to determine better the first hunt
         val initialClaimable = sortedEntries.filter {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
@@ -142,7 +142,7 @@ object HitmanApi {
             it.isInFuture()
         }?.timeUntil() ?: return purchasedHitmanSlots
         val slotsOnCooldown = ceil(allSlotsCooldownDuration.inPartialMinutes / MINUTES_PER_DAY).toInt()
-        return purchasedHitmanSlots - slotsOnCooldown - availableHitmanEggs
+        return purchasedHitmanSlots - slotsOnCooldown
     }
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
@@ -77,9 +77,9 @@ object HitmanApi {
     /**
      * Return the time until the given number of rabbits can be hunted.
      */
-    private fun HitmanStatsStorage.getTimeToHuntCount(targetHuntCount: Int): Duration {
+    private fun getTimeToHuntCount(targetHuntCount: Int): Duration {
         // Determine how many hunts we need to perform
-        var huntsToPerform = (targetHuntCount - availableHitmanEggs)
+        var huntsToPerform = (targetHuntCount)
         if (huntsToPerform <= 0) return Duration.ZERO
 
         // Determine which pre-available meals we have, to determine better the first hunt
@@ -142,10 +142,8 @@ object HitmanApi {
             it.isInFuture()
         }?.timeUntil() ?: return purchasedHitmanSlots
         val slotsOnCooldown = ceil(allSlotsCooldownDuration.inPartialMinutes / MINUTES_PER_DAY).toInt()
-        return purchasedHitmanSlots - slotsOnCooldown
+        return purchasedHitmanSlots - slotsOnCooldown - availableHitmanEggs
     }
-
-    fun HitmanStatsStorage.getSlotsNotOnCooldown(): Int = getOpenSlots() - availableHitmanEggs
 
     /**
      * Get the time until slots are full (number of spawns 'catches up' to number of slots).
@@ -187,7 +185,7 @@ object HitmanApi {
         val eventEndMark = HoppityApi.getEventEndMark() ?: return Pair(Duration.ZERO, false)
 
         val timeToSlots = getTimeToNumSlots(purchasedHitmanSlots)
-        val timeToHunt = getTimeToHuntCount(purchasedHitmanSlots)
+        val timeToHunt = getTimeToHuntCount(purchasedHitmanSlots - availableHitmanEggs)
 
         // Figure out which timer is the inhibitor
         val longerTime = if (timeToSlots > timeToHunt) timeToSlots else timeToHunt

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
@@ -145,6 +145,8 @@ object HitmanApi {
         return purchasedHitmanSlots - slotsOnCooldown
     }
 
+    fun HitmanStatsStorage.getSlotsNotOnCooldown(): Int = getOpenSlots() - availableHitmanEggs
+
     /**
      * Get the time until slots are full (number of spawns 'catches up' to number of slots).
      * If the event ends before the slots are full, the time until the event ends is returned.


### PR DESCRIPTION
## What
The number of available hitman eggs was incorrectly being subtracted from a calculation based on cooldown. This fixes that. See images for practical before/after.

<details>
<summary>Images</summary>

Before:
![image](https://github.com/user-attachments/assets/b18827e0-43b4-4faf-b028-de602ec454c3)

After:
![image](https://github.com/user-attachments/assets/4f74f35a-6a3b-4b7f-bf9b-534a0937c50f)

</details>

## Changelog Fixes
+ Fixed incorrect Hitman times when eggs were claimable. - Daveed
