### PR TITLE
Backend: Inventories Compat + HighlightMissingRepoItems

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -305,8 +305,8 @@ fun includeBuildPaths(buildPathsFile: File, sourceSet: Provider<SourceSet>) {
         }
     }
 }
-// includeBuildPaths(file("buildpaths.txt"), sourceSets.main)
-// includeBuildPaths(file("buildpaths-test.txt"), sourceSets.test)
+includeBuildPaths(file("buildpaths.txt"), sourceSets.main)
+includeBuildPaths(file("buildpaths-test.txt"), sourceSets.test)
 
 tasks.withType<KotlinCompile> {
     compilerOptions.jvmTarget.set(JvmTarget.fromTarget(target.minecraftVersion.formattedJavaLanguageVersion))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -305,8 +305,8 @@ fun includeBuildPaths(buildPathsFile: File, sourceSet: Provider<SourceSet>) {
         }
     }
 }
-includeBuildPaths(file("buildpaths.txt"), sourceSets.main)
-includeBuildPaths(file("buildpaths-test.txt"), sourceSets.test)
+// includeBuildPaths(file("buildpaths.txt"), sourceSets.main)
+// includeBuildPaths(file("buildpaths-test.txt"), sourceSets.test)
 
 tasks.withType<KotlinCompile> {
     compilerOptions.jvmTarget.set(JvmTarget.fromTarget(target.minecraftVersion.formattedJavaLanguageVersion))

--- a/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.network.play.client.C0EPacketClickWindow
@@ -112,7 +113,7 @@ object OwnInventoryData {
 
     @HandleEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
-        val item = Minecraft.getMinecraft().thePlayer.inventory.itemStack ?: return
+        val item = Minecraft.getMinecraft().thePlayer.getItemOnCursor() ?: return
         val internalNameOrNull = item.getInternalNameOrNull() ?: return
         ignoreItem(500.milliseconds, internalNameOrNull)
     }

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.utils.GuiRenderUtils
-import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.compat.clickInventorySlot
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.inventory.Container
 import net.minecraft.inventory.Slot
@@ -79,7 +79,7 @@ abstract class GuiContainerEvent(open val gui: GuiContainer, open val container:
         fun makePickblock() {
             if (this.clickedButton == 2 && this.clickType == ClickType.MIDDLE) return
             slot?.slotNumber?.let { slotNumber ->
-                InventoryUtils.clickSlot(slotNumber, container.windowId, 2, 3)
+                clickInventorySlot(slotNumber, container.windowId, 2, 3)
                 cancel()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardTips.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardTips.kt
@@ -99,8 +99,7 @@ object BingoCardTips {
         if (!isEnabled()) return
         if (!inventoryPattern.matches(InventoryUtils.openInventoryName())) return
 
-        val guiChest = event.gui
-        val chest = guiChest.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
         for ((slot, _) in chest.getAllItems()) {
             val goal = BingoApi.bingoGoals[slot.slotNumber] ?: continue
             if (config.hideDoneDifficulty && goal.done) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
 import net.minecraft.item.ItemStack
 import java.net.URLEncoder
 
@@ -59,7 +60,7 @@ object WikiManager {
     @HandleEvent(onlyOnSkyblock = true)
     fun onKeybind(event: GuiKeyPressEvent) {
         if (NeuItems.neuHasFocus()) return
-        val stack = event.guiContainer.slotUnderMouse?.stack ?: return
+        val stack = slotUnderCursor()?.stack ?: return
 
         if (!config.wikiKeybind.isKeyHeld()) return
         wikiTheItem(stack, config.menuOpenWiki)

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -228,10 +228,8 @@ object CityProjectFeatures {
         if (!config.showReady) return
         if (!inInventory) return
 
-
         if (event.gui !is GuiChest) return
-        val guiChest = event.gui
-        val chest = guiChest.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
 
         for ((slot, stack) in chest.getUpperItems()) {
             val lore = stack.getLore()

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -230,8 +230,7 @@ object CityProjectFeatures {
 
 
         if (event.gui !is GuiChest) return
-        val guiChest = event.gui
-        val chest = guiChest.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
 
         for ((slot, stack) in chest.getUpperItems()) {
             val lore = stack.getLore()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/GardenComposterInventoryFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/GardenComposterInventoryFeatures.kt
@@ -78,8 +78,7 @@ object GardenComposterInventoryFeatures {
 
         if (InventoryUtils.openInventoryName() == "Composter Upgrades") {
             if (event.gui !is GuiChest) return
-            val guiChest = event.gui
-            val chest = guiChest.inventorySlots as ContainerChest
+            val chest = event.container as ContainerChest
 
             for ((slot, stack) in chest.getUpperItems()) {
                 if (stack.getLore().any { it == "§eClick to upgrade!" }) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -167,8 +167,7 @@ object JacobFarmingContestsInventory {
         if (hideEverything) return
 
         if (event.gui !is GuiChest) return
-        val guiChest = event.gui
-        val chest = guiChest.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
 
         for ((slot, stack) in chest.getUpperItems()) {
             if (stack.getLore().any { it == "§eClick to claim reward!" }) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
@@ -31,8 +31,8 @@ object VisitorRewardWarning {
         if (!VisitorApi.inInventory) return
 
         val visitor = VisitorApi.getVisitor(lastClickedNpc) ?: return
-        val refuseOfferSlot = event.gui.inventorySlots.getSlot(REFUSE_SLOT)
-        val acceptOfferSlot = event.gui.inventorySlots.getSlot(ACCEPT_SLOT)
+        val refuseOfferSlot = event.container.getSlot(REFUSE_SLOT)
+        val acceptOfferSlot = event.container.getSlot(ACCEPT_SLOT)
         val blockReason = visitor.blockReason ?: return
 
         if (blockReason.blockRefusing) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ActiveBeaconEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ActiveBeaconEffect.kt
@@ -62,7 +62,7 @@ object ActiveBeaconEffect {
         if (!isEnabled()) return
         val slot = slot ?: return
 
-        event.gui.inventorySlots.getSlot(slot) highlight LorenzColor.GREEN
+        event.container.getSlot(slot) highlight LorenzColor.GREEN
     }
 
     fun isEnabled() = IslandType.PRIVATE_ISLAND.isInIsland() && config.highlightActiveBeaconEffect

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
@@ -37,8 +37,7 @@ object AuctionsHighlighter {
         if (!config.highlightAuctions) return
         if (event.gui !is GuiChest) return
 
-        val guiChest = event.gui
-        val chest = guiChest.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
         if (chest.getInventoryName() != "Manage Auctions") return
 
         for ((slot, stack) in chest.getUpperItems()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
@@ -28,7 +28,7 @@ object FavoritePowerStone {
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!isEnabled() || !inInventory) return
 
-        highlightedSlots.forEach { event.gui.inventorySlots.inventorySlots[it] highlight LorenzColor.AQUA }
+        highlightedSlots.forEach { event.container.inventorySlots[it] highlight LorenzColor.AQUA }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
+import at.hannibal2.skyhanni.utils.compat.clickInventorySlot
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
@@ -74,7 +75,7 @@ object HarpFeatures {
 
             event.cancel()
 
-            InventoryUtils.clickSlot(37 + index, chest.inventorySlots.windowId, 2, 3)
+            clickInventorySlot(37 + index, chest.inventorySlots.windowId, 2, 3)
             lastClick = SimpleTimeMark.now()
             break
         }
@@ -176,7 +177,7 @@ object HarpFeatures {
         }.takeIf { it != -1 }?.let {
             val clickType = event.clickType?.id ?: return
             event.cancel()
-            InventoryUtils.clickSlot(it, event.container.windowId, event.clickedButton, clickType)
+            clickInventorySlot(it, event.container.windowId, event.clickedButton, clickType)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -114,8 +114,7 @@ object HideNotClickableItems {
         if (!isEnabled()) return
         if (bypassActive()) return
         if (event.gui !is GuiChest) return
-        val guiChest = event.gui
-        val chest = guiChest.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
         val chestName = chest.getInventoryName()
 
         for ((slot, stack) in chest.getLowerItems()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HighlightBonzoMasks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HighlightBonzoMasks.kt
@@ -47,7 +47,7 @@ object HighlightBonzoMasks {
     @HandleEvent
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!config.depletedBonzosMasks) return
-        for (slot in event.gui.inventorySlots.inventorySlots) {
+        for (slot in event.container.inventorySlots) {
             val internalName = slot.stack?.getInternalName() ?: continue
             val maskType = MaskType.getByInternalName(internalName) ?: continue
             val readyAt = maskTimers[maskType] ?: continue

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -28,6 +28,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getExtraAttributes
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
@@ -153,7 +154,7 @@ object ItemPickupLog {
             itemList.clear()
 
             val inventoryItems = InventoryUtils.getItemsInOwnInventory().toMutableList()
-            val cursorItem = Minecraft.getMinecraft().thePlayer?.inventory?.itemStack
+            val cursorItem = Minecraft.getMinecraft().thePlayer?.getItemOnCursor()
 
             if (cursorItem != null) {
                 val hash = cursorItem.hash()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/PageScrolling.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/PageScrolling.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.compat.MouseCompat
+import at.hannibal2.skyhanni.utils.compat.clickInventorySlot
 import at.hannibal2.skyhanni.utils.renderables.ScrollValue
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.seconds
@@ -77,7 +78,7 @@ object PageScrolling {
         val slot = InventoryUtils.getItemsInOpenChest().firstOrNull {
             patterns.matches(it.stack?.displayName)
         } ?: return
-        InventoryUtils.clickSlot(slot.slotNumber)
+        clickInventorySlot(slot.slotNumber)
 
         currentlyScrollable = false
         cooldown = 1.0.seconds.fromNow()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/PowerStoneGuideFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/PowerStoneGuideFeatures.kt
@@ -50,7 +50,7 @@ object PowerStoneGuideFeatures {
         if (!isEnabled()) return
         if (!inInventory) return
 
-        event.gui.inventorySlots.inventorySlots
+        event.container.inventorySlots
             .filter { missing.containsKey(it.slotNumber) }
             .forEach { it highlight LorenzColor.RED }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/QuickCraftFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/QuickCraftFeatures.kt
@@ -59,7 +59,7 @@ object QuickCraftFeatures {
         val inventoryType = getInventoryType() ?: return
         if (KeyboardManager.isModifierKeyDown()) return
         if (event.gui !is GuiChest) return
-        val chest = event.gui.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
 
         for ((slot, stack) in chest.getAllItems()) {
             if (inventoryType.ignoreSlot(slot.slotNumber)) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
@@ -101,7 +101,7 @@ class SkyblockGuideHighlightFeature private constructor(
             if (!isEnabled()) return
             if (activeObject == null) return
 
-            event.gui.inventorySlots.inventorySlots
+            event.container.inventorySlots
                 .filter { missing.contains(it.slotNumber) }
                 .forEach { it highlight LorenzColor.RED }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SnakeGame.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SnakeGame.kt
@@ -6,11 +6,11 @@ import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.compat.clickInventorySlot
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
@@ -48,7 +48,7 @@ object SnakeGame {
             if (key?.isKeyHeld() == false) continue
             event.cancel()
 
-            InventoryUtils.clickSlot(slot, chest.inventorySlots.windowId, 2, 3)
+            clickInventorySlot(slot, chest.inventorySlots.windowId, 2, 3)
 
             lastClick = SimpleTimeMark.now()
             break

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseCopyUnderbidPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/auctionhouse/AuctionHouseCopyUnderbidPrice.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -71,7 +72,7 @@ object AuctionHouseCopyUnderbidPrice {
     fun onKeybind(event: GuiKeyPressEvent) {
         if (!config.copyUnderbidKeybind.isKeyHeld()) return
         if (!allowedInventoriesPattern.matches(InventoryUtils.openInventoryName())) return
-        val stack = event.guiContainer.slotUnderMouse?.stack ?: return
+        val stack = slotUnderCursor()?.stack ?: return
 
         auctionPricePattern.firstMatcher(stack.getLore()) {
             val underbid = group("coins").formatLong() - 1

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -185,8 +185,7 @@ object BazaarApi {
         if (currentSearchedItem == "") return
 
         if (event.gui !is GuiChest) return
-        val guiChest = event.gui
-        val chest = guiChest.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
 
         for ((slot, stack) in chest.getUpperItems()) {
             if (chest.inventorySlots.indexOf(slot) !in 9..44) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderHelper.kt
@@ -51,8 +51,7 @@ object BazaarOrderHelper {
         if (!SkyHanniMod.feature.inventory.bazaar.orderHelper) return
         if (event.gui !is GuiChest) return
 
-        val guiChest = event.gui
-        val chest = guiChest.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
         val inventoryName = chest.getInventoryName()
         if (!BazaarApi.isBazaarOrderInventory(inventoryName)) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryKeybinds.kt
@@ -4,9 +4,9 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.compat.clickInventorySlot
 import net.minecraft.client.gui.inventory.GuiChest
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -30,7 +30,7 @@ object ChocolateFactoryKeybinds {
 
             event.cancel()
 
-            InventoryUtils.clickSlot(28 + index, chest.inventorySlots.windowId, 2, 3)
+            clickInventorySlot(28 + index, chest.inventorySlots.windowId, 2, 3)
             break
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -32,6 +32,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
 import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColorInt
+import at.hannibal2.skyhanni.utils.compat.clickInventorySlot
 import at.hannibal2.skyhanni.utils.compat.getTooltipCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraft.client.Minecraft
@@ -415,7 +416,7 @@ object CustomWardrobe {
         val backButton = createLabeledButton(
             "§aBack",
             onClick = {
-                InventoryUtils.clickSlot(48)
+                clickInventorySlot(48)
                 reset()
                 WardrobeApi.currentPage = null
             },
@@ -423,7 +424,7 @@ object CustomWardrobe {
         val exitButton = createLabeledButton(
             "§cClose",
             onClick = {
-                InventoryUtils.clickSlot(49)
+                clickInventorySlot(49)
                 reset()
                 WardrobeApi.currentPage = null
             },
@@ -612,16 +613,16 @@ object CustomWardrobe {
         if (isInCurrentPage()) {
             if (isEmpty() || locked || waitingForInventoryUpdate) return
             WardrobeApi.currentSlot = if (isCurrentSlot()) null else id
-            InventoryUtils.clickSlot(inventorySlot)
+            clickInventorySlot(inventorySlot)
         } else {
             if (page < wardrobePage) {
                 WardrobeApi.currentPage = wardrobePage - 1
                 waitingForInventoryUpdate = true
-                InventoryUtils.clickSlot(previousPageSlot)
+                clickInventorySlot(previousPageSlot)
             } else if (page > wardrobePage) {
                 WardrobeApi.currentPage = wardrobePage + 1
                 waitingForInventoryUpdate = true
-                InventoryUtils.clickSlot(nextPageSlot)
+                clickInventorySlot(nextPageSlot)
             }
         }
         update()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TabWidgetSettings.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TabWidgetSettings.kt
@@ -117,7 +117,7 @@ object TabWidgetSettings {
         if (!isEnabled()) return
         if (!inInventory) return
 
-        event.gui.inventorySlots.inventorySlots
+        event.container.inventorySlots
             .associateWith { highlights[it.slotNumber] }
             .forEach { (slot, color) ->
                 color?.let { slot.highlight(it) }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -127,7 +127,7 @@ object DailyQuestHelper {
         if (!isEnabled()) return
 
         if (event.gui !is GuiChest) return
-        val chest = event.gui.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
         val chestName = chest.getInventoryName()
 
         if (chestName == "Challenges") {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/EnigmaSoulWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/EnigmaSoulWaypoints.kt
@@ -141,8 +141,7 @@ object EnigmaSoulWaypoints {
         if (!isEnabled() || !inInventory) return
 
         if (event.gui !is GuiChest) return
-        val guiChest = event.gui
-        val chest = guiChest.inventorySlots as ContainerChest
+        val chest = event.container as ContainerChest
 
         for ((slot, stack) in chest.getAllItems()) {
             for (soul in trackedSouls) {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
@@ -16,11 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
 
 class GuiContainerHook(guiAny: Any) {
 
-    val gui: GuiContainer
-
-    init {
-        gui = guiAny as GuiContainer
-    }
+    val gui: GuiContainer = guiAny as GuiContainer
 
     fun closeWindowPressed(ci: CallbackInfo) {
         if (CloseWindowEvent(gui, gui.inventorySlots).post()) ci.cancel()

--- a/src/main/java/at/hannibal2/skyhanni/test/HighlightMissingRepoItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/HighlightMissingRepoItems.kt
@@ -5,12 +5,11 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiInventory
 import net.minecraft.inventory.Slot
@@ -25,22 +24,19 @@ object HighlightMissingRepoItems {
         val gui = event.gui
 
         if (gui is GuiChest) {
-            highlightItems(gui.inventorySlots.inventorySlots)
+            highlightItems(event.container.inventorySlots)
         } else if (gui is GuiInventory) {
-            val player = Minecraft.getMinecraft().thePlayer
-            highlightItems(player.inventoryContainer.inventorySlots)
+            highlightItems(InventoryUtils.getSlotsInOwnInventory())
         }
     }
 
-    @Suppress("LoopWithTooManyJumpStatements")
     private fun highlightItems(slots: Iterable<Slot>) {
         if (NeuItems.allInternalNames.isEmpty()) return
         for (slot in slots) {
             val internalName = slot.stack?.getInternalNameOrNull() ?: continue
-            if (internalName in NeuItems.allInternalNames) continue
-            if (internalName in ItemUtils.itemNameCache) continue
 
             if (NeuItems.ignoreItemsFilter.match(internalName.asString())) continue
+            if (NeuItems.allInternalNames.contains(internalName)) continue
 
             slot highlight LorenzColor.RED
         }

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -56,6 +56,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStringsAndItems
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
 import at.hannibal2.skyhanni.utils.renderables.DragNDrop
 import at.hannibal2.skyhanni.utils.renderables.Droppable
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -366,7 +367,7 @@ object SkyHanniDebugsAndTests {
     @HandleEvent
     fun onKeybind(event: GuiKeyPressEvent) {
         if (!debugConfig.copyInternalName.isKeyHeld()) return
-        val focussedSlot = event.guiContainer.slotUnderMouse ?: return
+        val focussedSlot = slotUnderCursor() ?: return
         val stack = focussedSlot.stack ?: return
         val internalName = stack.getInternalNameOrNull() ?: return
         val rawInternalName = internalName.asString()

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -3,6 +3,8 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.EntityUtils.getArmorInventory
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.compat.containerSlots
+import at.hannibal2.skyhanni.utils.compat.normalizeAsArray
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates
 import net.minecraft.client.Minecraft
@@ -16,10 +18,6 @@ import net.minecraft.inventory.IInventory
 import net.minecraft.inventory.Slot
 import net.minecraft.item.ItemStack
 import kotlin.time.Duration.Companion.seconds
-
-//#if MC > 1.12
-//$$ import net.minecraft.inventory.ClickType
-//#endif
 
 @Suppress("TooManyFunctions", "Unused", "MemberVisibilityCanBePrivate")
 object InventoryUtils {
@@ -35,7 +33,7 @@ object InventoryUtils {
 
     fun getItemsInOpenChestWithNull(): List<Slot> {
         val guiChest = Minecraft.getMinecraft().currentScreen as? GuiChest ?: return emptyList()
-        return guiChest.inventorySlots.inventorySlots
+        return guiChest.containerSlots()
             .filter { it.inventory !is InventoryPlayer }
     }
 
@@ -48,7 +46,7 @@ object InventoryUtils {
     // only works while not in an inventory
     fun getSlotsInOwnInventory(): List<Slot> {
         val guiInventory = Minecraft.getMinecraft().currentScreen as? GuiContainer ?: return emptyList()
-        return guiInventory.inventorySlots.inventorySlots
+        return guiInventory.containerSlots()
             .filter { it.inventory is InventoryPlayer && it.stack != null }
     }
 
@@ -66,12 +64,11 @@ object InventoryUtils {
 
     fun ContainerChest.getInventoryName() = this.lowerChestInventory.displayName.unformattedText.trim()
 
-    fun getWindowId(): Int? = (Minecraft.getMinecraft().currentScreen as? GuiChest)?.inventorySlots?.windowId
-
     fun getItemsInOwnInventory(): List<ItemStack> =
         getItemsInOwnInventoryWithNull()?.filterNotNull().orEmpty()
 
-    fun getItemsInOwnInventoryWithNull(): Array<ItemStack?>? = Minecraft.getMinecraft().thePlayer?.inventory?.mainInventory
+    fun getItemsInOwnInventoryWithNull(): Array<ItemStack?>? =
+        Minecraft.getMinecraft().thePlayer?.inventory?.mainInventory?.normalizeAsArray()
 
     // TODO use this instead of getItemsInOwnInventory() for many cases, e.g. vermin tracker, diana spade, etc
     fun getItemsInHotbar(): List<ItemStack> =
@@ -88,9 +85,9 @@ object InventoryUtils {
             it.contains("Ender Chest") || it.contains("Backpack")
     }
 
-    fun getItemInHand(): ItemStack? = Minecraft.getMinecraft().thePlayer.heldItem
+    fun getItemInHand(): ItemStack? = Minecraft.getMinecraft().thePlayer?.heldItem
 
-    fun getArmor(): Array<ItemStack?> = Minecraft.getMinecraft().thePlayer.getArmorInventory() ?: arrayOfNulls(4)
+    fun getArmor(): Array<ItemStack?> = Minecraft.getMinecraft().thePlayer?.getArmorInventory() ?: arrayOfNulls(4)
 
     fun getHelmet(): ItemStack? = getArmor()[3]
     fun getChestplate(): ItemStack? = getArmor()[2]

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -162,16 +162,6 @@ object InventoryUtils {
 
     fun NeuInternalName.getAmountInInventory(): Int = countItemsInLowerInventory { it.getInternalNameOrNull() == this }
 
-    fun clickSlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int = 0, mode: Int = 0) {
-        windowId ?: return
-        val controller = Minecraft.getMinecraft().playerController
-        //#if MC < 1.12
-        controller.windowClick(windowId, slot, mouseButton, mode, Minecraft.getMinecraft().thePlayer)
-        //#else
-        //$$ controller.windowClick(windowId, slot, mouseButton, ClickType.entries[mode], Minecraft.getMinecraft().player)
-        //#endif
-    }
-
     fun Slot.isTopInventory() = inventory.isTopInventory()
 
     fun IInventory.isTopInventory() = this is ContainerLocalMenu

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils.getArmorInventory
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.compat.containerSlots
 import at.hannibal2.skyhanni.utils.compat.normalizeAsArray
+import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates
 import net.minecraft.client.Minecraft
@@ -113,8 +114,7 @@ object InventoryUtils {
     }
 
     fun isSlotInPlayerInventory(itemStack: ItemStack): Boolean {
-        val screen = Minecraft.getMinecraft().currentScreen as? GuiContainer ?: return false
-        val slotUnderMouse = screen.slotUnderMouse ?: return false
+        val slotUnderMouse = slotUnderCursor() ?: return false
         return slotUnderMouse.inventory is InventoryPlayer && slotUnderMouse.stack == itemStack
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -116,10 +116,6 @@ object ItemNameResolver {
             return it
         }
 
-        if (NeuItems.allInternalNames.isEmpty()) {
-            NeuItems.readAllNeuItems()
-        }
-
         // supports colored names, rarities
         NeuItems.allItemsCache[itemName]?.let {
             itemNameCache[itemName] = it

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -38,6 +38,7 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.onClick
 import at.hannibal2.skyhanni.utils.chat.TextHelper.onHover
 import at.hannibal2.skyhanni.utils.chat.TextHelper.send
+import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import kotlinx.coroutines.launch
@@ -214,8 +215,9 @@ object ItemUtils {
             }
         }
 
-        if (withCursorItem && player.inventory != null && player.inventory.itemStack != null) {
-            list.add(player.inventory.itemStack)
+        val cursorStack = player.getItemOnCursor()
+        if (withCursorItem && cursorStack != null) {
+            list.add(cursorStack)
         }
         return list
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.StringUtils.toDashlessUUID
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
+import at.hannibal2.skyhanni.utils.compat.clickInventorySlot
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import com.google.gson.JsonPrimitive
 import net.minecraft.client.Minecraft
@@ -213,7 +214,7 @@ object LorenzUtils {
     fun GuiContainerEvent.SlotClickEvent.makeShiftClick() {
         if (this.clickedButton == 1 && slot?.stack?.getItemCategoryOrNull() == ItemCategory.SACK) return
         slot?.slotNumber?.let { slotNumber ->
-            InventoryUtils.clickSlot(slotNumber, container.windowId, 0, 1)
+            clickInventorySlot(slotNumber, container.windowId, 0, 1)
             this.cancel()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -64,14 +64,16 @@ object NeuItems {
         readAllNeuItems()
     }
 
-    fun readAllNeuItems() {
+    private fun readAllNeuItems() {
         val map = mutableMapOf<String, NeuInternalName>()
+        val names = mutableSetOf<NeuInternalName>()
         for (rawInternalName in allNeuRepoItems().keys) {
             val internalName = rawInternalName.toInternalName()
             var name = internalName.getItemStackOrNull()?.displayName?.lowercase() ?: run {
                 ChatUtils.debug("skipped `$rawInternalName` from readAllNeuItems")
                 continue
             }
+            names.add(internalName)
 
             // we ignore all builder blocks from the item name -> internal name cache
             // because builder blocks can have the same display name as normal items.
@@ -90,7 +92,7 @@ object NeuItems {
             }
             map[name] = internalName
         }
-        allInternalNames = map.values.toSet()
+        allInternalNames = names
         allItemsCache = map
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -1,16 +1,34 @@
 package at.hannibal2.skyhanni.utils.compat
 
-import at.hannibal2.skyhanni.utils.InventoryUtils.getWindowId
 import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.inventory.GuiChest
+import net.minecraft.client.gui.inventory.GuiContainer
+import net.minecraft.inventory.Slot
+//#if FABRIC
+//$$ import net.minecraft.screen.slot.SlotActionType
+//#endif
 
 fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int = 0, mode: Int = 0) {
     windowId ?: return
     val controller = Minecraft.getMinecraft().playerController ?: return
-    //#if MC < 1.12
-    controller.windowClick(windowId, slot, mouseButton, mode, Minecraft.getMinecraft().thePlayer)
+    val player = Minecraft.getMinecraft().thePlayer ?: return
+    //#if FORGE
+    controller.windowClick(windowId, slot, mouseButton, mode, player)
     //#else
-    //$$ controller.windowClick(windowId, slot, mouseButton, ClickType.entries[mode], Minecraft.getMinecraft().player)
+    //$$ controller.clickSlot(windowId, slot, mouseButton, SlotActionType.entries[mode], player)
     //#endif
 }
 
+fun GuiContainer.containerSlots(): List<Slot> =
+    //#if FORGE
+    inventorySlots.inventorySlots
+//#else
+//$$ screenHandler.slots
+//#endif
 
+fun getWindowId(): Int? =
+    //#if FORGE
+    (Minecraft.getMinecraft().currentScreen as? GuiChest)?.inventorySlots?.windowId
+//#else
+//$$ (Minecraft.getInstance().currentScreen as? GenericContainerScreen)?.screenHandler?.syncId
+//#endif

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -1,0 +1,16 @@
+package at.hannibal2.skyhanni.utils.compat
+
+import at.hannibal2.skyhanni.utils.InventoryUtils.getWindowId
+import net.minecraft.client.Minecraft
+
+fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int = 0, mode: Int = 0) {
+    windowId ?: return
+    val controller = Minecraft.getMinecraft().playerController ?: return
+    //#if MC < 1.12
+    controller.windowClick(windowId, slot, mouseButton, mode, Minecraft.getMinecraft().thePlayer)
+    //#else
+    //$$ controller.windowClick(windowId, slot, mouseButton, ClickType.entries[mode], Minecraft.getMinecraft().player)
+    //#endif
+}
+
+

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -2,6 +2,8 @@ package at.hannibal2.skyhanni.utils.compat
 
 import at.hannibal2.skyhanni.utils.InventoryUtils.getWindowId
 import net.minecraft.client.Minecraft
+import net.minecraft.client.entity.EntityPlayerSP
+import net.minecraft.item.ItemStack
 
 fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int = 0, mode: Int = 0) {
     windowId ?: return
@@ -13,4 +15,13 @@ fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: I
     //#endif
 }
 
+fun EntityPlayerSP.getItemOnCursor(): ItemStack? {
+    //#if MC < 1.21
+    return this.inventory?.itemStack
+    //#else
+    //$$ val stack = this.currentScreenHandler?.cursorStack
+    //$$ if (stack?.isEmpty == true) return null
+    //$$ return stack
+    //#endif
+}
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -1,9 +1,11 @@
 package at.hannibal2.skyhanni.utils.compat
 
 import net.minecraft.client.Minecraft
+import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.inventory.Slot
+import net.minecraft.item.ItemStack
 //#if FABRIC
 //$$ import net.minecraft.screen.slot.SlotActionType
 //#endif
@@ -26,9 +28,28 @@ fun GuiContainer.containerSlots(): List<Slot> =
 //$$ screenHandler.slots
 //#endif
 
-fun getWindowId(): Int? =
+private fun getWindowId(): Int? =
     //#if FORGE
     (Minecraft.getMinecraft().currentScreen as? GuiChest)?.inventorySlots?.windowId
 //#else
-//$$ (Minecraft.getInstance().currentScreen as? GenericContainerScreen)?.screenHandler?.syncId
+//$$ (MinecraftClient.getInstance().currentScreen as? GenericContainerScreen)?.screenHandler?.syncId
 //#endif
+
+fun EntityPlayerSP.getItemOnCursor(): ItemStack? {
+    //#if MC < 1.21
+    return this.inventory?.itemStack
+    //#else
+    //$$ val stack = this.currentScreenHandler?.cursorStack
+    //$$ if (stack?.isEmpty == true) return null
+    //$$ return stack
+    //#endif
+}
+
+fun slotUnderCursor(): Slot? {
+    val screen = Minecraft.getMinecraft().currentScreen as? GuiContainer ?: return null
+    //#if FORGE
+    return screen.slotUnderMouse
+    //#else
+    //$$ return screen.getSlotUnderMouse()
+    //#endif
+}

--- a/versions/1.16.5-forge/src/main/java/at/hannibal2/skyhanni/utils/compat/ScreenAlias.kt
+++ b/versions/1.16.5-forge/src/main/java/at/hannibal2/skyhanni/utils/compat/ScreenAlias.kt
@@ -1,8 +1,5 @@
 package at.hannibal2.skyhanni.utils.compat
 
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
-import net.minecraft.world.inventory.AbstractContainerMenu
 
-typealias SkyHanniGuiContainer = AbstractContainerScreen<AbstractContainerMenu>
-
-// typealias SkyHanniContainer = AbstractContainerMenu
+typealias SkyHanniGuiContainer = AbstractContainerScreen<*>

--- a/versions/1.16.5-forge/src/main/java/at/hannibal2/skyhanni/utils/compat/ScreenAlias.kt
+++ b/versions/1.16.5-forge/src/main/java/at/hannibal2/skyhanni/utils/compat/ScreenAlias.kt
@@ -1,0 +1,8 @@
+package at.hannibal2.skyhanni.utils.compat
+
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
+import net.minecraft.world.inventory.AbstractContainerMenu
+
+typealias SkyHanniGuiContainer = AbstractContainerScreen<AbstractContainerMenu>
+
+// typealias SkyHanniContainer = AbstractContainerMenu

--- a/versions/1.21.4/buildpaths.txt
+++ b/versions/1.21.4/buildpaths.txt
@@ -1,5 +1,6 @@
 # at/hannibal2/skyhanni/SkyHanniMod.kt
 # at/hannibal2/skyhanni/skyhannimodule/LoadedModules.kt
+# at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
 # at/hannibal2/skyhanni/utils/compat/PacketCompat.kt
 
 at/hannibal2/skyhanni/TestingModFeatures.kt
@@ -53,5 +54,4 @@ at/hannibal2/skyhanni/utils/compat/ItemCompat.kt
 at/hannibal2/skyhanni/utils/compat/MouseCompat.kt
 at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
 at/hannibal2/skyhanni/utils/compat/TextCompat.kt
-at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
 at/hannibal2/skyhanni/utils/system/ModVersion.kt

--- a/versions/1.21.4/buildpaths.txt
+++ b/versions/1.21.4/buildpaths.txt
@@ -53,4 +53,5 @@ at/hannibal2/skyhanni/utils/compat/ItemCompat.kt
 at/hannibal2/skyhanni/utils/compat/MouseCompat.kt
 at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
 at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
 at/hannibal2/skyhanni/utils/system/ModVersion.kt

--- a/versions/1.21.4/buildpaths.txt
+++ b/versions/1.21.4/buildpaths.txt
@@ -2,6 +2,8 @@
 # at/hannibal2/skyhanni/skyhannimodule/LoadedModules.kt
 # at/hannibal2/skyhanni/utils/compat/PacketCompat.kt
 
+at/hannibal2/skyhanni/TestingModFeatures.kt
+
 at/hannibal2/skyhanni/SkyHanniModLoader.kt
 at/hannibal2/skyhanni/data/jsonobjects/repo/AnitaUpgradeCostsJson.kt
 at/hannibal2/skyhanni/data/jsonobjects/repo/ArmorDropsJson.kt

--- a/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/SkyHanniModLoader.kt
+++ b/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/SkyHanniModLoader.kt
@@ -10,6 +10,7 @@ class SkyHanniModLoader : ModInitializer {
 //         SkyHanniMod.init()
         println("skyhanni loaded")
         loadedClasses.clear()
+        TestingModFeatures
     }
 
     companion object {

--- a/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/TestingModFeatures.kt
+++ b/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/TestingModFeatures.kt
@@ -1,0 +1,32 @@
+package at.hannibal2.skyhanni
+
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
+import net.minecraft.client.MinecraftClient
+
+object TestingModFeatures {
+
+    init {
+        println("TestingModFeatures loaded")
+
+
+        ClientTickEvents.START_WORLD_TICK.register(
+            ClientTickEvents.StartWorldTick {
+                MinecraftClient.getInstance().player ?: return@StartWorldTick
+
+                println("screen class: ${MinecraftClient.getInstance().currentScreen?.javaClass?.name}")
+                println("screen title: ${MinecraftClient.getInstance().currentScreen?.title}")
+
+                // gets inventory stacks
+//                 val size = MinecraftClient.getInstance().player?.currentScreenHandler?.slots?.size ?: 0
+//                 for (i in 0 until size) {
+//                     val slot = MinecraftClient.getInstance().player?.currentScreenHandler?.slots?.get(i)
+//                     println(slot?.stack?.name.formattedTextCompat())
+//                 }
+            },
+        )
+
+
+    }
+
+
+}

--- a/versions/mapping-1.16.5-forge-1.12.2.txt
+++ b/versions/mapping-1.16.5-forge-1.12.2.txt
@@ -460,3 +460,4 @@ at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer net.minecraft.client.gui
 net.minecraft.world.inventory.AbstractContainerMenu net.minecraft.inventory.Container
 
 net.minecraft.world.inventory.AbstractContainerMenu containerId windowId
+net.minecraft.world.inventory.AbstractContainerMenu slots inventorySlots

--- a/versions/mapping-1.16.5-forge-1.12.2.txt
+++ b/versions/mapping-1.16.5-forge-1.12.2.txt
@@ -455,3 +455,8 @@ org.lwjgl.glfw.GLFW GLFW_KEY_X KEY_X
 org.lwjgl.glfw.GLFW GLFW_KEY_Y KEY_Y
 org.lwjgl.glfw.GLFW GLFW_KEY_Z KEY_Z
 
+at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer net.minecraft.client.gui.inventory.GuiContainer
+
+net.minecraft.world.inventory.AbstractContainerMenu net.minecraft.inventory.Container
+
+net.minecraft.world.inventory.AbstractContainerMenu containerId windowId

--- a/versions/mapping-1.16.5-forge-1.12.2.txt
+++ b/versions/mapping-1.16.5-forge-1.12.2.txt
@@ -460,3 +460,6 @@ at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer net.minecraft.client.gui
 net.minecraft.world.inventory.AbstractContainerMenu net.minecraft.inventory.Container
 
 net.minecraft.world.inventory.AbstractContainerMenu containerId windowId
+net.minecraft.world.inventory.AbstractContainerMenu slots inventorySlots
+
+net.minecraft.client.gui.screens.inventory.ContainerScreen menu inventorySlots


### PR DESCRIPTION
## What
Fixed highlight missing repo items not working on many items
- NeuItems.allInternalNames did not actually have all items

Added more mappings and compat methods related to inventories on modern versions
- Usage of `event.gui.inventorySlots.inventorySlots` is replaced with `event.container.inventorySlots` as these do the same thing
- Made some more inventory compat methods and used them + moved `InventoryUtils.clickSlot()` to `InventoryComapt` and renamed it `clickInventorySlot()`
- Made `SkyHanniGuiContainer` typealias which is used for mappings as you cant map directly to `AbstractContainerScreen<*>`

## Changelog Technical Details
+ Added mappings for inventories on modern versions. - CalMWolfs & nopo
    * Replaced usage of `event.gui.inventorySlots.inventorySlots` with `event.container.inventorySlots`.
+ Fixed missing repo item highlight on many items. - CalMWolfs

