### PR TITLE
Backend: Particles for modern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -5,12 +5,12 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.diana.BurrowDetectEvent
 import at.hannibal2.skyhanni.events.diana.BurrowDugEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
-import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.features.event.diana.DianaApi.isDianaSpade
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
@@ -19,10 +19,9 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeLimitedSet
-import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.Minecraft
 import net.minecraft.init.Blocks
-import net.minecraft.network.play.server.S2APacketParticles
+import net.minecraft.util.EnumParticleTypes
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -61,38 +60,30 @@ object GriffinBurrowParticleFinder {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.HUB, priority = HandleEvent.LOW, receiveCancelled = true)
-    fun onPacketReceive(event: PacketReceivedEvent) {
+    fun onReceiveParticle(event: ReceiveParticleEvent) {
         if (!isEnabled()) return
         if (!config.guess) return
-        val packet = event.packet
 
-        if (packet is S2APacketParticles) {
+        val type = ParticleTypeCool.entries.firstOrNull { it.check(event) } ?: return
 
-            val particleType = ParticleType.getParticleType(packet)
-            if (particleType != null) {
+        val location = event.location
+        val burrow = burrows.getOrPut(location) { Burrow(location) }
+        val oldBurrowType = burrow.type
 
-                val location = packet.toLorenzVec().toBlockPos().down().toLorenzVec()
-                val burrow = burrows.getOrPut(location) { Burrow(location) }
+        when (type) {
+            ParticleTypeCool.FOOTSTEP -> burrow.hasFootstep = true
+            ParticleTypeCool.ENCHANT -> burrow.hasEnchant = true
+            ParticleTypeCool.EMPTY -> burrow.type = 0
+            ParticleTypeCool.MOB -> burrow.type = 1
+            ParticleTypeCool.TREASURE -> burrow.type = 2
+        }
 
-                val oldBurrowType = burrow.type
-
-                when (particleType) {
-                    ParticleType.FOOTSTEP -> burrow.hasFootstep = true
-                    ParticleType.ENCHANT -> burrow.hasEnchant = true
-                    ParticleType.EMPTY -> burrow.type = 0
-                    ParticleType.MOB -> burrow.type = 1
-                    ParticleType.TREASURE -> burrow.type = 2
-                }
-
-                burrow.burrowTimeToLive += 1
-                if (burrow.burrowTimeToLive > 40) burrow.burrowTimeToLive = 40
-
-                if (burrow.hasEnchant && burrow.hasFootstep && burrow.type != -1) {
-                    if (!burrow.found || burrow.type != oldBurrowType) {
-                        BurrowDetectEvent(burrow.location, burrow.getType()).post()
-                        burrow.found = true
-                    }
-                }
+        burrow.burrowTimeToLive += 1
+        if (burrow.burrowTimeToLive > 40) burrow.burrowTimeToLive = 40
+        if (burrow.hasEnchant && burrow.hasFootstep && burrow.type != -1) {
+            if (!burrow.found || burrow.type != oldBurrowType) {
+                BurrowDetectEvent(burrow.location, burrow.getType()).post()
+                burrow.found = true
             }
         }
     }
@@ -112,51 +103,22 @@ object GriffinBurrowParticleFinder {
         }
     }
 
-    private enum class ParticleType(val check: S2APacketParticles.() -> Boolean) {
+    private enum class ParticleTypeCool(val check: ReceiveParticleEvent.() -> Boolean) {
         EMPTY(
-            {
-                particleType == net.minecraft.util.EnumParticleTypes.CRIT_MAGIC &&
-                    particleCount == 4 && particleSpeed == 0.01f && xOffset == 0.5f && yOffset == 0.1f && zOffset == 0.5f
-            },
+            { type == EnumParticleTypes.CRIT_MAGIC && count == 4 && speed == 0.01f && offset == LorenzVec(0.5, 0.1, 0.5) },
         ),
         MOB(
-            {
-                particleType == net.minecraft.util.EnumParticleTypes.CRIT &&
-                    particleCount == 3 && particleSpeed == 0.01f && xOffset == 0.5f && yOffset == 0.1f && zOffset == 0.5f
-
-            },
+            { type == EnumParticleTypes.CRIT && count == 3 && speed == 0.01f && offset == LorenzVec(0.5, 0.1, 0.5) },
         ),
         TREASURE(
-            {
-                particleType == net.minecraft.util.EnumParticleTypes.DRIP_LAVA &&
-                    particleCount == 2 && particleSpeed == 0.01f && xOffset == 0.35f && yOffset == 0.1f && zOffset == 0.35f
-            },
+            { type == EnumParticleTypes.DRIP_LAVA && count == 2 && speed == 0.01f && offset == LorenzVec(0.35, 0.1, 0.35) },
         ),
         FOOTSTEP(
-            {
-                particleType == net.minecraft.util.EnumParticleTypes.FOOTSTEP &&
-                    particleCount == 1 && particleSpeed == 0.0f && xOffset == 0.05f && yOffset == 0.0f && zOffset == 0.05f
-            },
+            { type == EnumParticleTypes.FOOTSTEP && count == 1 && speed == 0.0f && offset == LorenzVec(0.05, 0.0, 0.05) },
         ),
         ENCHANT(
-            {
-                particleType == net.minecraft.util.EnumParticleTypes.ENCHANTMENT_TABLE &&
-                    particleCount == 5 && particleSpeed == 0.05f && xOffset == 0.5f && yOffset == 0.4f && zOffset == 0.5f
-            },
+            { type == EnumParticleTypes.ENCHANTMENT_TABLE && count == 5 && speed == 0.05f && offset == LorenzVec(0.5, 0.4, 0.5) },
         );
-
-        companion object {
-
-            fun getParticleType(packet: S2APacketParticles): ParticleType? {
-                if (!packet.isLongDistance) return null
-                for (type in entries) {
-                    if (type.check(packet)) {
-                        return type
-                    }
-                }
-                return null
-            }
-        }
     }
 
     @HandleEvent
@@ -233,7 +195,7 @@ object GriffinBurrowParticleFinder {
         var hasEnchant: Boolean = false,
         var type: Int = -1,
         var found: Boolean = false,
-        var burrowTimeToLive: Int = 0
+        var burrowTimeToLive: Int = 0,
     ) {
 
         fun getType(): BurrowType {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -64,18 +64,18 @@ object GriffinBurrowParticleFinder {
         if (!isEnabled()) return
         if (!config.guess) return
 
-        val type = ParticleTypeCool.entries.firstOrNull { it.check(event) } ?: return
+        val type = ParticleType.entries.firstOrNull { it.check(event) } ?: return
 
         val location = event.location
         val burrow = burrows.getOrPut(location) { Burrow(location) }
         val oldBurrowType = burrow.type
 
         when (type) {
-            ParticleTypeCool.FOOTSTEP -> burrow.hasFootstep = true
-            ParticleTypeCool.ENCHANT -> burrow.hasEnchant = true
-            ParticleTypeCool.EMPTY -> burrow.type = 0
-            ParticleTypeCool.MOB -> burrow.type = 1
-            ParticleTypeCool.TREASURE -> burrow.type = 2
+            ParticleType.FOOTSTEP -> burrow.hasFootstep = true
+            ParticleType.ENCHANT -> burrow.hasEnchant = true
+            ParticleType.EMPTY -> burrow.type = 0
+            ParticleType.MOB -> burrow.type = 1
+            ParticleType.TREASURE -> burrow.type = 2
         }
 
         burrow.burrowTimeToLive += 1
@@ -103,7 +103,7 @@ object GriffinBurrowParticleFinder {
         }
     }
 
-    private enum class ParticleTypeCool(val check: ReceiveParticleEvent.() -> Boolean) {
+    private enum class ParticleType(val check: ReceiveParticleEvent.() -> Boolean) {
         EMPTY(
             { type == EnumParticleTypes.CRIT_MAGIC && count == 4 && speed == 0.01f && offset == LorenzVec(0.5, 0.1, 0.5) },
         ),

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -118,7 +118,7 @@ object GriffinBurrowParticleFinder {
         ),
         ENCHANT(
             { type == EnumParticleTypes.ENCHANTMENT_TABLE && count == 5 && speed == 0.05f && offset == LorenzVec(0.5, 0.4, 0.5) },
-        );
+        )
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleLine.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleLine.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.GardenPlotApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
-import at.hannibal2.skyhanni.utils.EnumUtils.isAnyOf
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -49,7 +48,7 @@ object PestParticleLine {
         // TODO time in config
         if (lastPestTrackerUse.passedSince() > 5.seconds) return
 
-        if (event.type.isAnyOf(EnumParticleTypes.ENCHANTMENT_TABLE, EnumParticleTypes.VILLAGER_ANGRY)) {
+        if (event.type == EnumParticleTypes.ENCHANTMENT_TABLE || event.type == EnumParticleTypes.VILLAGER_ANGRY) {
             if (config.hideParticles) event.cancel()
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/PrecisionMiningHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/PrecisionMiningHighlight.kt
@@ -28,7 +28,7 @@ object PrecisionMiningHighlight {
     private var deleteTime: SimpleTimeMark? = null
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onParticle(event: ReceiveParticleEvent) {
+    fun onReceiveParticle(event: ReceiveParticleEvent) {
         if (!isEnabled()) return
         if (!(event.type == EnumParticleTypes.CRIT || event.type == EnumParticleTypes.VILLAGER_HAPPY) ||
             !Minecraft.getMinecraft().gameSettings.keyBindAttack.isKeyDown

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MiscFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MiscFeatures.kt
@@ -32,7 +32,7 @@ object MiscFeatures {
             EnumParticleTypes.EXPLOSION_NORMAL,
             -> event.cancel()
 
-            else -> {}
+            else -> return
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/stillgorechateau/SplatterHearts.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/stillgorechateau/SplatterHearts.kt
@@ -21,7 +21,7 @@ object SplatterHearts {
     private val currentHearts = mutableSetOf<LorenzVec>()
 
     @HandleEvent
-    fun onParticle(event: ReceiveParticleEvent) {
+    fun onReceiveParticle(event: ReceiveParticleEvent) {
         if (!isEnabled()) return
         if (event.type != EnumParticleTypes.HEART) return
         if (event.count != 3 || event.speed != 0f) return

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerHideParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerHideParticles.kt
@@ -34,8 +34,7 @@ object EndermanSlayerHideParticles {
             EnumParticleTypes.SMOKE_LARGE,
             EnumParticleTypes.FLAME,
             EnumParticleTypes.SPELL_WITCH,
-            -> {
-            }
+            -> Unit
 
             else -> return
         }

--- a/versions/mapping-1.16.5-forge-1.12.2.txt
+++ b/versions/mapping-1.16.5-forge-1.12.2.txt
@@ -83,12 +83,18 @@ net.minecraft.core.particles.ParticleTypes net.minecraft.util.EnumParticleTypes
 
 net.minecraft.core.particles.ParticleTypes ANGRY_VILLAGER VILLAGER_ANGRY
 net.minecraft.core.particles.ParticleTypes DRIPPING_LAVA DRIP_LAVA
+net.minecraft.core.particles.ParticleTypes DUST REDSTONE
 net.minecraft.core.particles.ParticleTypes ENCHANT ENCHANTMENT_TABLE
 net.minecraft.core.particles.ParticleTypes ENCHANTED_HIT CRIT_MAGIC
+net.minecraft.core.particles.ParticleTypes ENTITY_EFFECT SPELL_MOB
+net.minecraft.core.particles.ParticleTypes EXPLOSION EXPLOSION_LARGE
+net.minecraft.core.particles.ParticleTypes EXPLOSION_EMITTER EXPLOSION_HUGE
+net.minecraft.core.particles.ParticleTypes FIREWORK FIREWORKS_SPARK
 net.minecraft.core.particles.ParticleTypes HAPPY_VILLAGER VILLAGER_HAPPY
 net.minecraft.core.particles.ParticleTypes LARGE_SMOKE SMOKE_LARGE
+net.minecraft.core.particles.ParticleTypes POOF EXPLOSION_NORMAL
 net.minecraft.core.particles.ParticleTypes SMOKE SMOKE_NORMAL
-net.minecraft.core.particles.ParticleTypes SPELL_MOB ENTITY_EFFECT
+net.minecraft.core.particles.ParticleTypes WITCH SPELL_WITCH
 
 net.minecraft.nbt.CompoundTag net.minecraft.nbt.NBTTagCompound
 net.minecraft.nbt.ListTag net.minecraft.nbt.NBTTagList


### PR DESCRIPTION
## What
Added all remaining particle mappings for modern versions
Cleaned up GriffinBurrowParticleFinder a lot as there was a lot of unnecessary indentation and unnecessary use of raw packet data instead of using the particle event
No longer use fully qualified names for checking particle type

## Changelog Technical Details
+ Added all remaining particle mappings for modern versions. - CalMWolfs
+ Cleaned up GriffinBurrowParticleFinder extensively. - CalMWolfs

