### PR TITLE
Backend: Lorenz utils cleanup part 1

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.CollectionUtils.enumMapOf
 import at.hannibal2.skyhanni.utils.IdentityCharacteristics
 import at.hannibal2.skyhanni.utils.LorenzLogger
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.ReflectionUtils.makeAccessible
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -161,7 +160,7 @@ class ConfigManager {
             println("2. Either add the Config Link.")
             println("3. Or add the name to ignoredMissingConfigLinks.")
             println("")
-            LorenzUtils.shutdownMinecraft("Missing Config Link")
+            PlatformUtils.shutdownMinecraft("Missing Config Link")
         }
     }
 
@@ -185,7 +184,7 @@ class ConfigManager {
                             run()
                         } catch (e: Throwable) {
                             logger.log(e.stackTraceToString())
-                            LorenzUtils.shutdownMinecraft("Config is corrupt inside development environment.")
+                            PlatformUtils.shutdownMinecraft("Config is corrupt inside development environment.")
                         }
                     } else {
                         run()

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.config
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.features.misc.limbo.LimboTimeTracker
 import at.hannibal2.skyhanni.utils.LorenzLogger
-import at.hannibal2.skyhanni.utils.LorenzUtils.asIntOrNull
+import at.hannibal2.skyhanni.utils.json.asIntOrNull
 import at.hannibal2.skyhanni.utils.json.shDeepCopy
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject

--- a/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
@@ -125,7 +125,7 @@ object ProfileStorageData {
 
     @HandleEvent
     fun onHypixelJoin(event: HypixelJoinEvent) {
-        val playerUuid = LorenzUtils.getRawPlayerUuid()
+        val playerUuid = LorenzUtils.getRawPlayerUuid() ?: return
         playerSpecific = SkyHanniMod.feature.storage.players.getOrPut(playerUuid) { PlayerSpecificStorage() }
         sackPlayers = SkyHanniMod.sackData.players.getOrPut(playerUuid) { SackData.PlayerSpecific() }
         ConfigLoadEvent.post()

--- a/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
@@ -25,12 +25,7 @@ object TitleManager {
     private var heightModifier = 1.8
     private var fontSizeModifier = 4f
 
-    @Deprecated("Use LorenzUtils instead", ReplaceWith("LorenzUtils.sendTitle(text, duration, height, fontSize)"))
-    fun sendTitle(text: String, duration: Duration, height: Double, fontSize: Float) {
-        setTitle(text, duration, height, fontSize)
-    }
-
-    fun setTitle(text: String, duration: Duration, height: Double, fontSize: Float) {
+    fun sendTitle(text: String, duration: Duration, height: Double = 1.8, fontSize: Float = 4f) {
         currentText = text
         display = "§f$text"
         endTime = SimpleTimeMark.now() + duration

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -22,6 +22,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.getLorenzVec
+import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
@@ -69,7 +70,7 @@ object MobDetection {
 
     // TODO this is a unused debug function. maybe connect with a debug commmand or remove
     private fun watchdog() {
-        val world = LorenzUtils.getPlayer()?.worldObj ?: return
+        val world = Minecraft.getMinecraft().thePlayer?.worldObj ?: return
         if (MobData.retries.any { it.value.entity.worldObj != world }) {
             ChatUtils.chat("Watchdog: Retires")
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.bingo
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
@@ -251,7 +252,7 @@ object MinionCraftHelper {
     private fun notify(minionName: String) {
         if (alreadyNotified.contains(minionName)) return
 
-        LorenzUtils.sendTitle("Can craft $minionName", 3.seconds)
+        TitleManager.sendTitle("Can craft $minionName", 3.seconds)
         alreadyNotified.add(minionName)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils.passedSinceSent
 import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
-import at.hannibal2.skyhanni.utils.LorenzUtils.colorCodeToRarity
+import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.LorenzUtils.inAnyIsland
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -106,7 +106,7 @@ object RareDropMessages {
         petPatterns.matchMatchers(event.message) {
             var start = group("start")
             val rarityColor = group("rarityColor")
-            val rarityName = colorCodeToRarity(rarityColor.first()).uppercase()
+            val rarityName = LorenzRarity.colorCodeToRarity(rarityColor.first()).uppercase()
             val petName = group("petName")
             val end = group("end")
             if (start.endsWith("a ") && rarityName.first().isVowel())

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.combat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -11,7 +12,6 @@ import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -115,7 +115,7 @@ object BroodmotherFeatures {
             feature = config::alertOnSpawn
             val alertSound = SoundUtils.createSound(spawnAlertConfig.alertSound, spawnAlertConfig.pitch)
             SoundUtils.repeatSound(100, spawnAlertConfig.repeatSound, alertSound)
-            LorenzUtils.sendTitle(spawnAlertConfig.text.replace("&", "§"), 3.seconds)
+            TitleManager.sendTitle(spawnAlertConfig.text.replace("&", "§"), 3.seconds)
         } else {
             feature = config::stages
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/FlareDisplay.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.combat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.combat.FlareConfig
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -13,7 +14,6 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
@@ -120,12 +120,12 @@ object FlareDisplay {
                 }
 
                 FlareConfig.AlertType.TITLE -> {
-                    LorenzUtils.sendTitle(message, 1.seconds)
+                    TitleManager.sendTitle(message, 1.seconds)
                 }
 
                 FlareConfig.AlertType.CHAT_TITLE -> {
                     ChatUtils.chat(message)
-                    LorenzUtils.sendTitle(message, 1.seconds)
+                    TitleManager.sendTitle(message, 1.seconds)
                 }
 
                 else -> {}

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonArchitectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonArchitectFeatures.kt
@@ -4,9 +4,9 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.GetFromSackApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacks
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.makePrimitiveStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -54,7 +54,7 @@ object DungeonArchitectFeatures {
                 "§eClick here to get §5Architect's First Draft §7(§e${architectItemAmount}x left§7)"
         )
 
-        LorenzUtils.sendTitle("§c§lPUZZLE FAILED!", 3.seconds)
+        TitleManager.sendTitle("§c§lPUZZLE FAILED!", 3.seconds)
         event.blockedReason = "puzzle_fail"
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.ElectionCandidate
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -29,7 +30,6 @@ import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -459,7 +459,7 @@ object GriffinBurrowHelper {
         } else ""
         if (lastTitleSentTime.passedSince() > 2.seconds) {
             lastTitleSentTime = SimpleTimeMark.now()
-            LorenzUtils.sendTitle(text + keybindSuffix, 2.seconds, fontSize = 3f)
+            TitleManager.sendTitle(text + keybindSuffix, 2.seconds, fontSize = 3f)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinPetWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinPetWarning.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.diana.BurrowDugEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
@@ -9,7 +10,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import kotlin.time.Duration.Companion.seconds
 
@@ -60,7 +60,7 @@ object GriffinPetWarning {
         )
         if (lastWarnTime.passedSince() > 30.seconds) {
             lastWarnTime = SimpleTimeMark.now()
-            LorenzUtils.sendTitle("§cGriffin Pet!", 3.seconds)
+            TitleManager.sendTitle("§cGriffin Pet!", 3.seconds)
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.event.diana
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.diana.InquisitorFoundEvent
@@ -298,7 +299,7 @@ object InquisitorWaypointShare {
         if (!waypoints.containsKey(name)) {
             ChatUtils.chat("$displayName §l§efound an inquisitor at §l§c${x.toInt()} ${y.toInt()} ${z.toInt()}!")
             if (name != LorenzUtils.getPlayerName()) {
-                LorenzUtils.sendTitle("§dINQUISITOR §efrom §b$displayName", 5.seconds)
+                TitleManager.sendTitle("§dINQUISITOR §efrom §b$displayName", 5.seconds)
                 playUserSound()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.renderables.Renderable
+import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.entity.player.EntityPlayer
 import org.lwjgl.opengl.GL11
@@ -30,7 +31,7 @@ object HoppityEggDisplayManager {
 
     private fun canChangeOpacity(entity: EntityPlayer): Boolean {
         if (!HoppityEggLocator.isEnabled()) return false
-        if (entity == LorenzUtils.getPlayer()) return false
+        if (entity == Minecraft.getMinecraft().thePlayer) return false
         if (!entity.isRealPlayer()) return false
         return config.playerOpacity < 100
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.event.hoppity
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.hoppity.EggFoundEvent
@@ -250,7 +251,7 @@ object HoppityEggsManager {
                 action = action,
             )
         } else ChatUtils.chat(message, replaceSameMessage = true)
-        LorenzUtils.sendTitle("§e$amount Hoppity Eggs!", 5.seconds)
+        TitleManager.sendTitle("§e$amount Hoppity Eggs!", 5.seconds)
         SoundUtils.repeatSound(100, 10, SoundUtils.plingSound)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/MythicRabbitPetWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/MythicRabbitPetWarning.kt
@@ -1,8 +1,8 @@
 package at.hannibal2.skyhanni.features.event.hoppity
 
 import at.hannibal2.skyhanni.data.PetApi
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import kotlin.time.Duration.Companion.seconds
 
@@ -25,6 +25,6 @@ object MythicRabbitPetWarning {
 
     private fun warn() {
         ChatUtils.chat("Use a §dMythic Rabbit Pet §efor more chocolate!")
-        LorenzUtils.sendTitle("§cNo Rabbit Pet!", 3.seconds)
+        TitleManager.sendTitle("§cNo Rabbit Pet!", 3.seconds)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingBaitWarnings.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingBaitWarnings.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.fishing
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.fishing.FishingBobberInLiquidEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
@@ -11,7 +12,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeLimitedSet
@@ -88,13 +88,13 @@ object FishingBaitWarnings {
 
     private fun showBaitChangeWarning(before: String, after: String) {
         SoundUtils.playClickSound()
-        LorenzUtils.sendTitle("§eBait changed!", 2.seconds)
+        TitleManager.sendTitle("§eBait changed!", 2.seconds)
         ChatUtils.chat("Fishing Bait changed: $before §e-> $after")
     }
 
     private fun showNoBaitWarning() {
         SoundUtils.playErrorSound()
-        LorenzUtils.sendTitle("§cNo bait is used!", 2.seconds)
+        TitleManager.sendTitle("§cNo bait is used!", 2.seconds)
         ChatUtils.chat("You're not using any fishing baits!")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -80,7 +81,7 @@ object FishingTimer {
         if (config.wormLimitAlert && IslandType.CRYSTAL_HOLLOWS.isInIsland()) {
             if (currentCount >= 20) {
                 playSound()
-                LorenzUtils.sendTitle("§cWORM CAP FULL!!!", 2.seconds)
+                TitleManager.sendTitle("§cWORM CAP FULL!!!", 2.seconds)
             }
         } else if (config.fishingCapAlert && currentCount >= currentCap) {
             playSound()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.combat.damageindicator.DamageIndicatorConfig
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
@@ -63,7 +64,7 @@ object SeaCreatureFeatures {
         if (config.alertOtherCatches && shouldNotify) {
             val text = if (config.creatureName) "${creature.displayName} NEARBY!"
             else "${creature.rarity.chatColorCode}RARE SEA CREATURE!"
-            LorenzUtils.sendTitle(text, 1.5.seconds, 3.6, 7f)
+            TitleManager.sendTitle(text, 1.5.seconds, 3.6, 7f)
             if (config.playSound) SoundUtils.playBeepSound()
         }
     }
@@ -80,7 +81,7 @@ object SeaCreatureFeatures {
         if (event.seaCreature.rare) {
             val text = if (config.creatureName) "${event.seaCreature.displayName}!"
             else "${event.seaCreature.rarity.chatColorCode}RARE CATCH!"
-            LorenzUtils.sendTitle(text, 3.seconds, 2.8, 7f)
+            TitleManager.sendTitle(text, 3.seconds, 2.8, 7f)
             if (config.playSound) SoundUtils.playBeepSound()
             lastRareCatch = SimpleTimeMark.now()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.fishing
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.fishing.TotemOfCorruptionConfig.OutlineType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
@@ -14,7 +15,6 @@ import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.sendTitle
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -160,7 +160,7 @@ object TotemOfCorruption {
             val timeToWarn = config.warnWhenAboutToExpire.seconds
             if (timeToWarn > 0.seconds && timeRemaining <= timeToWarn && totem.uniqueID !in warnedTotems) {
                 playPlingSound()
-                sendTitle("§c§lTotem of Corruption §eabout to expire!", 5.seconds)
+                TitleManager.sendTitle("§c§lTotem of Corruption §eabout to expire!", 5.seconds)
                 warnedTotems.add(totem.uniqueID)
             }
             Totem(totem.getLorenzVec(), timeRemaining, owner)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.fishing.trophy
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -254,7 +255,7 @@ object GoldenFishTimer {
     private fun rodWarning() {
         if (!config.throwRodWarning || hasWarnedRod) return
         hasWarnedRod = true
-        LorenzUtils.sendTitle("§cThrow your rod!", 5.seconds, 3.6, 7.0f)
+        TitleManager.sendTitle("§cThrow your rod!", 5.seconds, 3.6, 7.0f)
         SoundUtils.repeatSound(100, 10, SoundUtils.plingSound)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.fishing.trophyfishing.ChatMessagesConfig.DesignFormat
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.fishing.TrophyFishCaughtEvent
 import at.hannibal2.skyhanni.features.fishing.trophy.TrophyFishManager.getTooltip
@@ -11,7 +12,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.CollectionUtils.sumAllValues
 import at.hannibal2.skyhanni.utils.ConfigUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.ordinal
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -95,7 +95,7 @@ object TrophyFishMessages {
 
     private fun sendTitle(displayName: String, displayRarity: String?, amount: Int) {
         val text = "$displayName $displayRarity §8$amount§c!"
-        LorenzUtils.sendTitle(text, 3.seconds, 2.8, 7f)
+        TitleManager.sendTitle(text, 3.seconds, 2.8, 7f)
     }
 
     val regex = "[- ]".toRegex()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.config.features.garden.NextJacobContestConfig.ShareContestsEntry
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -205,7 +206,7 @@ object GardenNextJacobContest {
         if (!config.display) return
         monthPattern.matchMatcher(event.inventoryName) {
             inCalendar = true
-            val month = LorenzUtils.getSBMonthByName(group("month"))
+            val month = SkyBlockTime.getSBMonthByName(group("month"))
             val year = group("year").toInt()
 
             readCalendar(event.inventoryItems.values, year, month)
@@ -430,7 +431,7 @@ object GardenNextJacobContest {
         lastWarningTime = SimpleTimeMark.now()
         val cropText = crops.joinToString("§7, ") { (if (it == boostedCrop) "§6" else "§a") + it.cropName }
         ChatUtils.chat("Next farming contest: $cropText")
-        LorenzUtils.sendTitle("§eFarming Contest!", 5.seconds)
+        TitleManager.sendTitle("§eFarming Contest!", 5.seconds)
         SoundUtils.playBeepSound()
 
         val cropTextNoColor = crops.joinToString(", ") {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.garden
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GardenToolChangeEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -17,7 +18,6 @@ import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
@@ -191,7 +191,7 @@ object GardenOptimalSpeed {
         if (!ranchersEquipped && config.onlyWarnRanchers) return
 
         lastWarnTime = SimpleTimeMark.now()
-        LorenzUtils.sendTitle("§cWrong speed!", 3.seconds)
+        TitleManager.sendTitle("§cWrong speed!", 3.seconds)
         val cropInHand = cropInHand ?: return
 
         val text = "§cWrong speed while farming ${cropInHand.cropName} detected!" +

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
@@ -132,7 +133,7 @@ object ComposterDisplay {
 
         if (ComposterApi.getOrganicMatter() <= config.notifyLow.organicMatter && storage.informedAboutLowMatter.isInPast()) {
             if (config.notifyLow.title) {
-                LorenzUtils.sendTitle("§cYour Organic Matter is low", 4.seconds)
+                TitleManager.sendTitle("§cYour Organic Matter is low", 4.seconds)
             }
             ChatUtils.chat("§cYour Organic Matter is low!")
             storage.informedAboutLowMatter = 5.0.minutes.fromNow()
@@ -140,7 +141,7 @@ object ComposterDisplay {
 
         if (ComposterApi.getFuel() <= config.notifyLow.fuel && storage.informedAboutLowFuel.isInPast()) {
             if (config.notifyLow.title) {
-                LorenzUtils.sendTitle("§cYour Fuel is low", 4.seconds)
+                TitleManager.sendTitle("§cYour Fuel is low", 4.seconds)
             }
             ChatUtils.chat("§cYour Fuel is low!")
             storage.informedAboutLowFuel = 5.0.minutes.fromNow()
@@ -201,7 +202,7 @@ object ComposterDisplay {
                 action = { HypixelCommands.warp("garden") },
             )
         }
-        LorenzUtils.sendTitle("§eComposter Warning!", 3.seconds)
+        TitleManager.sendTitle("§eComposter Warning!", 3.seconds)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestApi.kt
@@ -132,7 +132,7 @@ object FarmingContestApi {
 
     fun getSBTimeFor(text: String): Long? {
         val (year, month, day) = getSBDateFromItemName(text) ?: return null
-        val monthNr = LorenzUtils.getSBMonthByName(month)
+        val monthNr = SkyBlockTime.getSBMonthByName(month)
 
         return SkyBlockTime(year.toInt(), monthNr, day.toInt()).toMillis()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -108,7 +108,7 @@ object JacobFarmingContestsInventory {
     }
 
     private fun openContest(year: String, month: String, day: String) {
-        val date = "$year/${LorenzUtils.getSBMonthByName(month)}/$day"
+        val date = "$year/${SkyBlockTime.getSBMonthByName(month)}/$day"
         OSUtils.openBrowser("https://elitebot.dev/contests/$date")
         ChatUtils.chat("Opening contest in elitebot.dev")
     }
@@ -146,7 +146,7 @@ object JacobFarmingContestsInventory {
             val day = GardenNextJacobContest.dayPattern.matchMatcher(itemName) { group("day") } ?: return
             val year = group("year")
             val month = group("month")
-            val time = SkyBlockTime(year.toInt(), LorenzUtils.getSBMonthByName(month), day.toInt()).toMillis()
+            val time = SkyBlockTime(year.toInt(), SkyBlockTime.getSBMonthByName(month), day.toInt()).toMillis()
             if (time < SkyBlockTime.now().toMillis()) {
                 openContest(year, month, day)
             } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
@@ -2,10 +2,10 @@ package at.hannibal2.skyhanni.features.garden.farming
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -16,7 +16,7 @@ object GardenBurrowingSporesNotifier {
         if (!GardenApi.config.burrowingSporesNotification) return
 
         if (event.message.endsWith("§6§lVERY RARE CROP! §r§f§r§9Burrowing Spores")) {
-            LorenzUtils.sendTitle("§9Burrowing Spores!", 5.seconds)
+            TitleManager.sendTitle("§9Burrowing Spores!", 5.seconds)
             // would be sent too often, nothing special then
 //            ItemBlink.setBlink(NEUItems.getItemStackOrNull("BURROWING_SPORES"), 5_000)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.data.GardenCropMilestones.isMaxed
 import at.hannibal2.skyhanni.data.GardenCropMilestones.setCounter
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
@@ -256,7 +257,7 @@ object GardenCropMilestoneDisplay {
             SoundUtils.playBeepSound()
         }
         if (!needsInventory) {
-            LorenzUtils.sendTitle(title, 1.5.seconds)
+            TitleManager.sendTitle(title, 1.5.seconds)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/WrongFungiCutterWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/WrongFungiCutterWarning.kt
@@ -2,13 +2,13 @@ package at.hannibal2.skyhanni.features.garden.farming
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ClickType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.GardenToolChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.garden.farming.CropClickEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getFungiCutterMode
 import at.hannibal2.skyhanni.utils.SoundUtils
 import net.minecraft.item.ItemStack
@@ -48,7 +48,7 @@ object WrongFungiCutterWarning {
     private fun notifyWrong() {
         if (!GardenApi.config.fungiCutterWarn) return
 
-        LorenzUtils.sendTitle("§cWrong Fungi Cutter Mode!", 2.seconds)
+        TitleManager.sendTitle("§cWrong Fungi Cutter Mode!", 2.seconds)
         if (System.currentTimeMillis() > lastPlaySoundTime + 3_00) {
             lastPlaySoundTime = System.currentTimeMillis()
             SoundUtils.playBeepSound()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.garden.farming.lane
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.GardenToolChangeEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.garden.farming.FarmingLaneSwitchEvent
@@ -14,7 +15,6 @@ import at.hannibal2.skyhanni.features.misc.MovementSpeedDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
@@ -138,7 +138,7 @@ object FarmingLaneFeatures {
     private fun showWarning() {
         with(config.laneSwitchNotification) {
             if (enabled) {
-                LorenzUtils.sendTitle(text.replace("&", "§"), 2.seconds)
+                TitleManager.sendTitle(text.replace("&", "§"), 2.seconds)
                 if (lastPlaySound.passedSince() >= sound.repeatDuration.ticks) {
                     lastPlaySound = SimpleTimeMark.now()
                     playUserSound()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.garden.pests
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.garden.pests.PestFinderConfig.VisibilityType
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -21,7 +22,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -196,7 +196,7 @@ object PestFinder {
     fun onChat(event: SkyHanniChatEvent) {
         if (!config.noPestTitle) return
 
-        if (PestApi.noPestsChatPattern.matches(event.message)) LorenzUtils.sendTitle("§eNo pests!", 2.seconds)
+        if (PestApi.noPestsChatPattern.matches(event.message)) TitleManager.sendTitle("§eNo pests!", 2.seconds)
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -5,13 +5,13 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.garden.pests.PestSpawnConfig
 import at.hannibal2.skyhanni.config.features.garden.pests.PestSpawnConfig.ChatMessageFormatEntry
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestSpawnEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -98,7 +98,7 @@ object PestSpawn {
         val message = "§e$amount §a$pestName Spawned in §b$plotName§a!"
 
         if (config.showTitle) {
-            LorenzUtils.sendTitle(message, 7.seconds)
+            TitleManager.sendTitle(message, 7.seconds)
         }
 
         if (config.chatMessageFormat == PestSpawnConfig.ChatMessageFormatEntry.COMPACT) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.config.features.garden.visitor.VisitorConfig.Highli
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacks
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacksOrNull
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
@@ -527,7 +528,7 @@ object GardenVisitorFeatures {
         val recentWorldSwitch = LorenzUtils.lastWorldSwitch.passedSince() < 2.seconds
 
         if (config.notificationTitle && !recentWorldSwitch) {
-            LorenzUtils.sendTitle("§eNew Visitor", 5.seconds)
+            TitleManager.sendTitle("§eNew Visitor", 5.seconds)
         }
         if (config.notificationChat) {
             val displayName = GardenVisitorColorNames.getColoredName(name)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.garden.visitor
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.garden.farming.CropClickEvent
@@ -13,7 +14,6 @@ import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
@@ -132,7 +132,7 @@ object GardenVisitorTimer {
                 if (!sixthVisitorReady) {
                     sixthVisitorReady = true
                     if (isSixthVisitorWarningEnabled()) {
-                        LorenzUtils.sendTitle("§a6th Visitor Ready", 5.seconds)
+                        TitleManager.sendTitle("§a6th Visitor Ready", 5.seconds)
                         SoundUtils.playBeepSound()
                     }
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.makeShiftClick
+import at.hannibal2.skyhanni.utils.InventoryUtils.makeShiftClick
 import net.minecraft.client.gui.inventory.GuiChest
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickEquipment.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickEquipment.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.makeShiftClick
+import at.hannibal2.skyhanni.utils.InventoryUtils.makeShiftClick
 import net.minecraft.client.gui.inventory.GuiChest
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNpcSell.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNpcSell.kt
@@ -6,9 +6,9 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils.makeShiftClick
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.makeShiftClick
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningNotifications.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningNotifications.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.MiningApi
 import at.hannibal2.skyhanni.data.MiningApi.inGlaciteArea
 import at.hannibal2.skyhanni.data.MiningApi.lastColdReset
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ColdUpdateEvent
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -106,7 +107,7 @@ object MiningNotifications {
 
     private fun sendNotification(type: MiningNotificationList) {
         if (type !in config.notifications) return
-        LorenzUtils.sendTitle(type.notification, 1500.milliseconds)
+        TitleManager.sendTitle(type.notification, 1500.milliseconds)
         if (config.playSound) SoundUtils.playPlingSound()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
@@ -5,8 +5,8 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LocationUtils.getCornersAtHeight
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils.getCorners
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils
@@ -126,9 +126,10 @@ object CrystalHollowsWalls {
     }
 
     private fun drawNucleus(event: SkyHanniRenderWorldEvent) {
-        val (southEastCorner, southWestCorner, northWestCorner, northEastCorner) = nucleusBBInflate.getCorners(nucleusBBInflate.minY)
+        val (southEastCorner, southWestCorner, northWestCorner, northEastCorner) =
+            nucleusBBInflate.getCornersAtHeight(nucleusBBInflate.minY)
         val (southEastTopCorner, southWestTopCorner, northWestTopCorner, northEastTopCorner) =
-            nucleusBBInflate.getCorners(nucleusBBInflate.maxY)
+            nucleusBBInflate.getCornersAtHeight(nucleusBBInflate.maxY)
 
         RenderUtils.QuadDrawer.draw3D(event.partialTicks) {
             draw(

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.jsonobjects.repo.CarryTrackerJson
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
@@ -14,7 +15,6 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.CollectionUtils.addString
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.KeyboardManager
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDoubleOrUserError
 import at.hannibal2.skyhanni.utils.NumberUtil.formatIntOrUserError
@@ -81,7 +81,7 @@ object CarryTracker {
         carry.done++
         if (carry.done == carry.requested) {
             ChatUtils.chat("Carry done for ${customer.name}!")
-            LorenzUtils.sendTitle("§eCarry done!", 3.seconds)
+            TitleManager.sendTitle("§eCarry done!", 3.seconds)
         }
         update()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.model.Graph
 import at.hannibal2.skyhanni.data.model.GraphNode
 import at.hannibal2.skyhanni.data.model.GraphNodeTag
@@ -239,7 +240,7 @@ object IslandAreas {
         // when this is a small area and small areas are disabled via config
         if (event.onlyInternal) return
         if (inAnArea && config.enterTitle) {
-            LorenzUtils.sendTitle("§aEntered $name!", 3.seconds)
+            TitleManager.sendTitle("§aEntered $name!", 3.seconds)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NoBitsWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NoBitsWarning.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.BitsUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -29,7 +30,7 @@ object NoBitsWarning {
                 }, "§eClick to run /bz booster cookie!"
             )
             // TODO use reminder utils
-            LorenzUtils.sendTitle("§bNo Bits Available", 5.seconds)
+            TitleManager.sendTitle("§bNo Bits Available", 5.seconds)
             if (config.notificationSound) SoundUtils.repeatSound(100, 10, createSound("note.pling", 0.6f))
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NonGodPotEffectDisplay.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -219,7 +220,7 @@ object NonGodPotEffectDisplay {
         effectDuration.sorted().forEach { (effect, time) ->
             if (time.remaining.inWholeSeconds != config.expireWarnTime.toLong()) return
 
-            if (effectWarning) LorenzUtils.sendTitle(effect.tabListName, 3.seconds)
+            if (effectWarning) TitleManager.sendTitle(effect.tabListName, 3.seconds)
             if (effectSound) repeat(5) { playPlingSound() }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ServerRestartTitle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ServerRestartTitle.kt
@@ -3,9 +3,9 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ScoreboardData
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -44,7 +44,7 @@ object ServerRestartTitle {
             val totalTime = minutes + seconds
             if (totalTime > 2.minutes && totalTime.inWholeSeconds % 30 != 0L) return
             val time = totalTime.format()
-            LorenzUtils.sendTitle("§cServer Restart in §b$time", 2.seconds)
+            TitleManager.sendTitle("§cServer Restart in §b$time", 2.seconds)
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
@@ -108,7 +109,7 @@ object SkyBlockKickDuration {
     }
 
     private fun warn() {
-        LorenzUtils.sendTitle("§eTry rejoining SkyBlock now!", 3.seconds)
+        TitleManager.sendTitle("§eTry rejoining SkyBlock now!", 3.seconds)
         SoundUtils.playBeepSound()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ThunderBottleNotification.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ThunderBottleNotification.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -24,7 +25,7 @@ object ThunderBottleNotification {
         if (!isEnabled()) return
 
         if (thunderBottleChargedPattern.matches(event.message)) {
-            LorenzUtils.sendTitle("§eThunder Bottle Charged!", 3.seconds)
+            TitleManager.sendTitle("§eThunder Bottle Charged!", 3.seconds)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
@@ -18,8 +18,8 @@ import at.hannibal2.skyhanni.features.misc.compacttablist.AdvancedPlayerList
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.extraAttributes
+import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.colorCodeToRarity
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
@@ -78,7 +78,7 @@ fun getPetDisplay(): String = PetApi.currentPet?.let {
     val petName = it.substring(2).removeColor()
     val petLevel = if (PlatformUtils.isNeuLoaded()) getCurrentPet()?.petLevel?.currentLevel ?: "?" else "?"
 
-    "[Lvl $petLevel] ${colorCodeToRarity(colorCode)} $petName"
+    "[Lvl $petLevel] ${LorenzRarity.colorCodeToRarity(colorCode)} $petName"
 } ?: "No pet equipped"
 
 enum class DiscordStatus(private val displayMessageSupplier: (() -> String?)) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.misc.TrevorTheTrapperConfig.TrackerEntry
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.Perk
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.mob.MobData
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -144,7 +145,7 @@ object TrevorFeatures {
         mobDiedPattern.matchMatcher(event.message) {
             TrevorSolver.resetLocation()
             if (config.trapperMobDiedMessage) {
-                LorenzUtils.sendTitle("§2Mob Died ", 5.seconds)
+                TitleManager.sendTitle("§2Mob Died ", 5.seconds)
                 SoundUtils.playBeepSound()
             }
             trapperReady = true
@@ -224,7 +225,7 @@ object TrevorFeatures {
 
         if (timeUntilNextReady <= 0 && trapperReady) {
             if (timeUntilNextReady == 0) {
-                LorenzUtils.sendTitle("§2Trapper Ready", 3.seconds)
+                TitleManager.sendTitle("§2Trapper Ready", 3.seconds)
                 SoundUtils.playBeepSound()
             }
             currentStatus = TrapperStatus.READY

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.misc.trevor
 
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.data.mob.MobData
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -7,7 +8,6 @@ import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.LorenzUtils.derpy
 import at.hannibal2.skyhanni.utils.LorenzVec
@@ -72,7 +72,7 @@ object TrevorSolver {
                     val canSee = entity.canBeSeen() && dist < currentMob.renderDistance
                     if (canSee) {
                         if (mobLocation != TrapperMobArea.FOUND) {
-                            LorenzUtils.sendTitle("§2Saw ${currentMob.mobName}!", 3.seconds)
+                            TitleManager.sendTitle("§2Saw ${currentMob.mobName}!", 3.seconds)
                         }
                         mobLocation = TrapperMobArea.FOUND
                         mobCoordinates = entity.position.toLorenzVec()

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/quest/DojoQuest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/quest/DojoQuest.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.features.nether.reputationhelper.dailyquest.quest
 
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName
 
@@ -10,12 +9,25 @@ class DojoQuest(
     displayItem: NeuInternalName,
     dojoRankGoal: String,
     state: QuestState,
-) :
-    Quest(
-        displayItem,
-        location,
-        QuestCategory.DOJO,
-        "$dojoName Rank $dojoRankGoal",
-        state,
-        "$dojoName §7(§e" + LorenzUtils.getPointsForDojoRank(dojoRankGoal) + " points§7)"
-    )
+) : Quest(
+    displayItem,
+    location,
+    QuestCategory.DOJO,
+    "$dojoName Rank $dojoRankGoal",
+    state,
+    "$dojoName §7(§e" + getPointsForDojoRank(dojoRankGoal) + " points§7)",
+) {
+    companion object {
+        fun getPointsForDojoRank(rank: String): Int {
+            return when (rank) {
+                "S" -> 1000
+                "A" -> 800
+                "B" -> 600
+                "C" -> 400
+                "D" -> 200
+                "F" -> 0
+                else -> 0
+            }
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/ShyCruxWarnings.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/ShyCruxWarnings.kt
@@ -3,12 +3,12 @@ package at.hannibal2.skyhanni.features.rift.area.wyldwoods
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
@@ -25,7 +25,7 @@ object ShyCruxWarnings {
 
     private fun checkForShy() {
         if (EntityUtils.getAllEntities().any { it.name in shyNames && it.distanceToPlayer() < 8 }) {
-            LorenzUtils.sendTitle("§eLook away!", 150.milliseconds)
+            TitleManager.sendTitle("§eLook away!", 150.milliseconds)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerBossSpawnSoon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerBossSpawnSoon.kt
@@ -3,9 +3,9 @@ package at.hannibal2.skyhanni.features.slayer
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SlayerApi
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.slayer.SlayerProgressChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SoundUtils
@@ -38,7 +38,7 @@ object SlayerBossSpawnSoon {
         if (completion > config.percent / 100.0) {
             if (!warned || (config.repeat && completion != lastCompletion)) {
                 SoundUtils.playBeepSound()
-                LorenzUtils.sendTitle("§eSlayer boss soon!", 2.seconds)
+                TitleManager.sendTitle("§eSlayer boss soon!", 2.seconds)
                 warned = true
             }
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.SlayerApi
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent
@@ -108,7 +109,7 @@ object SlayerQuestWarning {
         ChatUtils.chat(chatMessage)
 
         if (config.questWarningTitle) {
-            LorenzUtils.sendTitle("§e$titleMessage", 2.seconds)
+            TitleManager.sendTitle("§e$titleMessage", 2.seconds)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.SlayerApi
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuRNGScore
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
@@ -114,7 +115,7 @@ object SlayerRngMeterDisplay {
             val hasItemSelected = item != "" && item != "?"
             if (!hasItemSelected && config.warnEmpty) {
                 ChatUtils.userError("No Slayer RNG Meter Item selected!")
-                LorenzUtils.sendTitle("§cNo RNG Meter Item!", 3.seconds)
+                TitleManager.sendTitle("§cNo RNG Meter Item!", 3.seconds)
             }
             var blockChat = config.hideChat && hasItemSelected
             val diff = currentMeter - old

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
@@ -27,7 +28,6 @@ import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.RenderUtils.drawColor
@@ -141,7 +141,7 @@ object VampireSlayerFeatures {
                 if (!shouldSendTitle) continue
                 DelayedRun.runDelayed(config.twinclawsDelay.milliseconds) {
                     if (nextClawSend < System.currentTimeMillis()) {
-                        LorenzUtils.sendTitle(
+                        TitleManager.sendTitle(
                             "§6§lTWINCLAWS",
                             (1750 - config.twinclawsDelay).milliseconds,
                             2.6,
@@ -180,7 +180,7 @@ object VampireSlayerFeatures {
                 else canUseSteak && configCoopBoss.steakAlert && containCoop
 
             if (shouldSendSteakTitle) {
-                LorenzUtils.sendTitle("§c§lSTEAK!", 300.milliseconds, 2.6)
+                TitleManager.sendTitle("§c§lSTEAK!", 300.milliseconds, 2.6)
             }
 
             if (shouldRender) {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerFirePitsWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerFirePitsWarning.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.slayer.blaze
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.BossHealthChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.combat.damageindicator.BossType
@@ -22,7 +23,7 @@ object BlazeSlayerFirePitsWarning {
     private var lastFirePitsWarning = SimpleTimeMark.farPast()
 
     private fun fireFirePits() {
-        LorenzUtils.sendTitle("§cFire Pits!", 2.seconds)
+        TitleManager.sendTitle("§cFire Pits!", 2.seconds)
         lastFirePitsWarning = SimpleTimeMark.now()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
@@ -20,7 +21,6 @@ import at.hannibal2.skyhanni.utils.LocationUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzLogger
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
@@ -74,7 +74,7 @@ object EndermanSlayerFeatures {
                         beaconConfig.highlightBeacon
                     }
                     if (beaconConfig.showWarning) {
-                        LorenzUtils.sendTitle("§4Beacon", 2.seconds)
+                        TitleManager.sendTitle("§4Beacon", 2.seconds)
                     }
                     logger.log("Added flying beacons at ${entity.getLorenzVec()}")
                 }

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.model.Graph
 import at.hannibal2.skyhanni.data.model.GraphNode
 import at.hannibal2.skyhanni.data.model.GraphNodeTag
@@ -24,7 +25,6 @@ import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
@@ -35,7 +35,11 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.drawPyramid
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
+import at.hannibal2.skyhanni.utils.TimeUtils.ticks
 import kotlinx.coroutines.runBlocking
+import net.minecraft.client.Minecraft
 import net.minecraft.client.settings.KeyBinding
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 import java.awt.Color
@@ -220,7 +224,7 @@ object GraphEditor {
         if (nodesToFind.isEmpty()) {
             currentNodeToFind = null
             ChatUtils.chat("Found all nodes on this island")
-            LorenzUtils.sendTitle("§eAll Found!", 3.seconds)
+            TitleManager.sendTitle("§eAll Found!", 3.seconds)
             active = false
             return
         }
@@ -397,7 +401,7 @@ object GraphEditor {
     )
 
     private fun input() {
-        if (LorenzUtils.isAnyGuiActive()) return
+        if (isAnyGuiActive()) return
         if (config.exitKey.isKeyClicked()) {
             if (inTextMode) {
                 inTextMode = false
@@ -598,6 +602,16 @@ object GraphEditor {
                 }\n" + "§eNodes: ${nodes.size.addSeparators()}\n" + "§eEdges: ${edges.size.addSeparators()}\n" + "§eLength: $length",
             )
         }
+    }
+
+    private var lastGuiTime = SimpleTimeMark.farPast()
+
+    private fun isAnyGuiActive(): Boolean {
+        val gui = Minecraft.getMinecraft().currentScreen != null
+        if (gui) {
+            lastGuiTime = 3.ticks.fromNow()
+        }
+        return !lastGuiTime.isInPast()
     }
 
     private fun editModeClicks() {

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -1,8 +1,11 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.EntityUtils.getArmorInventory
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
+import at.hannibal2.skyhanni.utils.compat.clickInventorySlot
 import at.hannibal2.skyhanni.utils.compat.containerSlots
 import at.hannibal2.skyhanni.utils.compat.normalizeAsArray
 import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
@@ -94,6 +97,14 @@ object InventoryUtils {
     fun getChestplate(): ItemStack? = getArmor()[2]
     fun getLeggings(): ItemStack? = getArmor()[1]
     fun getBoots(): ItemStack? = getArmor()[0]
+
+    fun GuiContainerEvent.SlotClickEvent.makeShiftClick() {
+        if (this.clickedButton == 1 && slot?.stack?.getItemCategoryOrNull() == ItemCategory.SACK) return
+        slot?.slotNumber?.let { slotNumber ->
+            clickInventorySlot(slotNumber, container.windowId, 0, 1)
+            this.cancel()
+        }
+    }
 
     val isNeuStorageEnabled by RecalculatingValue(10.seconds) {
         if (!PlatformUtils.isNeuLoaded()) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -207,4 +207,13 @@ object LocationUtils {
         }
         return guessPitch
     }
+
+    fun AxisAlignedBB.getCornersAtHeight(y: Double): List<LorenzVec> {
+        val cornerOne = LorenzVec(minX, y, minZ)
+        val cornerTwo = LorenzVec(minX, y, maxZ)
+        val cornerThree = LorenzVec(maxX, y, maxZ)
+        val cornerFour = LorenzVec(maxX, y, minZ)
+
+        return listOf(cornerOne, cornerTwo, cornerThree, cornerFour)
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzRarity.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzRarity.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
+import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 
 // TODO: replace id with ordinal
 enum class LorenzRarity(val color: LorenzColor, val id: Int) {
@@ -20,6 +22,7 @@ enum class LorenzRarity(val color: LorenzColor, val id: Int) {
 
     val chatColorCode get() = color.getChatColor()
     val rawName = name.replace("_", " ")
+    val formattedName = rawName.firstLetterUppercase()
 
     fun oneBelow(logError: Boolean = true): LorenzRarity? {
         val rarityBelow = getById(ordinal - 1)
@@ -52,5 +55,14 @@ enum class LorenzRarity(val color: LorenzColor, val id: Int) {
         fun getById(id: Int) = if (entries.size > id) entries[id] else null
 
         fun getByName(name: String): LorenzRarity? = entries.find { it.name.equals(name, ignoreCase = true) }
+
+        private fun getByColor(color: LorenzColor?): LorenzRarity? = entries.find { it.color == color }
+
+        private fun getByColorCode(colorCode: Char): LorenzRarity? = getByColor(colorCode.toLorenzColor())
+
+        fun colorCodeToRarity(colorCode: Char): String {
+            val rarity = getByColorCode(colorCode) ?: SPECIAL
+            return rarity.formattedName
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -53,6 +53,8 @@ object LorenzUtils {
 
     val lastWorldSwitch get() = HypixelData.joinedWorld
 
+    private var previousApril = false
+
     val isAprilFoolsDay: Boolean
         get() {
             val itsTime = LocalDate.now().let { it.month == Month.APRIL && it.dayOfMonth == 1 }
@@ -67,8 +69,6 @@ object LorenzUtils {
         }
 
     val debug: Boolean get() = onHypixel && SkyHanniMod.feature.dev.debug.enabled
-
-    private var previousApril = false
 
     // TODO move into lorenz logger. then rewrite lorenz logger and use something different entirely
     fun SimpleDateFormat.formatCurrentTime(): String = this.format(System.currentTimeMillis())

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -5,31 +5,20 @@ import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.MiningApi
 import at.hannibal2.skyhanni.data.Perk
-import at.hannibal2.skyhanni.data.TitleManager
-import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.features.misc.visualwords.ModifyVisualWords
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.test.SkyBlockIslandTest
 import at.hannibal2.skyhanni.test.TestBingo
-import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
-import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.StringUtils.toDashlessUUID
-import at.hannibal2.skyhanni.utils.TimeUtils.ticks
-import at.hannibal2.skyhanni.utils.compat.clickInventorySlot
 import at.hannibal2.skyhanni.utils.renderables.Renderable
-import com.google.gson.JsonPrimitive
 import net.minecraft.client.Minecraft
-import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.SharedMonsterAttributes
-import net.minecraft.util.AxisAlignedBB
-import net.minecraftforge.fml.common.FMLCommonHandler
 import java.text.DecimalFormat
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.Month
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 object LorenzUtils {
@@ -99,38 +88,11 @@ object LorenzUtils {
         SkyHanniMod.consoleLog(text)
     }
 
-    // TODO move into crimson api
-    fun getPointsForDojoRank(rank: String): Int {
-        return when (rank) {
-            "S" -> 1000
-            "A" -> 800
-            "B" -> 600
-            "C" -> 400
-            "D" -> 200
-            "F" -> 0
-            else -> 0
-        }
-    }
-
-    // TODO move into time utils
-    fun getSBMonthByName(month: String): Int {
-        var monthNr = 0
-        for (i in 1..12) {
-            val monthName = SkyBlockTime.monthName(i)
-            if (month == monthName) {
-                monthNr = i
-            }
-        }
-        return monthNr
-    }
-
     fun getPlayerUuid() = getRawPlayerUuid().toDashlessUUID()
 
     fun getRawPlayerUuid() = Minecraft.getMinecraft().thePlayer.uniqueID
 
     fun getPlayerName(): String = Minecraft.getMinecraft().thePlayer.name
-
-    fun getPlayer(): EntityPlayerSP? = Minecraft.getMinecraft()?.thePlayer
 
     // TODO move into renderable utils
     fun fillTable(
@@ -154,21 +116,6 @@ object LorenzUtils {
             outerList.add(listOf(item, left, right))
         }
         return Renderable.table(outerList, xPadding = 5, yPadding = padding)
-    }
-
-    // TODO move into string api
-    fun colorCodeToRarity(colorCode: Char): String {
-        return when (colorCode) {
-            'f' -> "Common"
-            'a' -> "Uncommon"
-            '9' -> "Rare"
-            '5' -> "Epic"
-            '6' -> "Legendary"
-            'd' -> "Mythic"
-            'b' -> "Divine"
-            '4' -> "Supreme" // legacy items
-            else -> "Special"
-        }
     }
 
     @Deprecated("Use List<Renderable>.addButton() instead", ReplaceWith(""))
@@ -211,14 +158,6 @@ object LorenzUtils {
     fun inAnyIsland(vararg islandTypes: IslandType) = inSkyBlock && HypixelData.skyBlockIsland in islandTypes
     fun inAnyIsland(islandTypes: Collection<IslandType>) = inSkyBlock && HypixelData.skyBlockIsland in islandTypes
 
-    fun GuiContainerEvent.SlotClickEvent.makeShiftClick() {
-        if (this.clickedButton == 1 && slot?.stack?.getItemCategoryOrNull() == ItemCategory.SACK) return
-        slot?.slotNumber?.let { slotNumber ->
-            clickInventorySlot(slotNumber, container.windowId, 0, 1)
-            this.cancel()
-        }
-    }
-
     // TODO move into mayor api
     val isDerpy by RecalculatingValue(1.seconds) { Perk.DOUBLE_MOBS_HP.isActive }
 
@@ -228,39 +167,5 @@ object LorenzUtils {
     // TODO move into mayor api
     fun Int.ignoreDerpy() = if (isDerpy) this * 2 else this
 
-    // TODO move into json api
-    val JsonPrimitive.asIntOrNull get() = takeIf { it.isNumber }?.asInt
-
-    fun sendTitle(text: String, duration: Duration, height: Double = 1.8, fontSize: Float = 4f) {
-        TitleManager.setTitle(text, duration, height, fontSize)
-    }
-
-    fun shutdownMinecraft(reason: String? = null) {
-        val reasonLine = reason?.let { " Reason: $it" }.orEmpty()
-        System.err.println("SkyHanni-@MOD_VERSION@ ${"forced the game to shutdown.$reasonLine"}")
-
-        FMLCommonHandler.instance().handleExit(-1)
-    }
-
     fun inMiningIsland() = IslandType.GOLD_MINES.isInIsland() || IslandType.DEEP_CAVERNS.isInIsland() || MiningApi.inAdvancedMiningIsland()
-
-    private var lastGuiTime = SimpleTimeMark.farPast()
-
-    fun isAnyGuiActive(): Boolean {
-        val gui = Minecraft.getMinecraft().currentScreen != null
-        if (gui) {
-            lastGuiTime = 3.ticks.fromNow()
-        }
-        return !lastGuiTime.isInPast()
-    }
-
-    // TODO move into location utils
-    fun AxisAlignedBB.getCorners(y: Double): List<LorenzVec> {
-        val cornerOne = LorenzVec(minX, y, minZ)
-        val cornerTwo = LorenzVec(minX, y, maxZ)
-        val cornerThree = LorenzVec(maxX, y, maxZ)
-        val cornerFour = LorenzVec(maxX, y, minZ)
-
-        return listOf(cornerOne, cornerTwo, cornerThree, cornerFour)
-    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -16,8 +16,8 @@ import at.hannibal2.skyhanni.features.misc.RoundedTextureShader
 import at.hannibal2.skyhanni.utils.CollectionUtils.zipWithNext3
 import at.hannibal2.skyhanni.utils.ColorUtils.getFirstColorCode
 import at.hannibal2.skyhanni.utils.LocationUtils.calculateEdges
+import at.hannibal2.skyhanni.utils.LocationUtils.getCornersAtHeight
 import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils.getCorners
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
 import at.hannibal2.skyhanni.utils.compat.createResourceLocation
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -1665,7 +1665,7 @@ object RenderUtils {
         color: Color,
         depth: Boolean,
     ) {
-        val (cornerOne, cornerTwo, cornerThree, cornerFour) = boundingBox.getCorners(boundingBox.maxY)
+        val (cornerOne, cornerTwo, cornerThree, cornerFour) = boundingBox.getCornersAtHeight(boundingBox.maxY)
         this.draw3DLine(cornerOne, cornerTwo, color, lineWidth, depth)
         this.draw3DLine(cornerTwo, cornerThree, color, lineWidth, depth)
         this.draw3DLine(cornerThree, cornerFour, color, lineWidth, depth)
@@ -1723,8 +1723,8 @@ object RenderUtils {
         color: Color,
         depth: Boolean,
     ) {
-        val cornersTop = boundingBox.getCorners(boundingBox.maxY)
-        val cornersBottom = boundingBox.getCorners(boundingBox.minY)
+        val cornersTop = boundingBox.getCornersAtHeight(boundingBox.maxY)
+        val cornersBottom = boundingBox.getCornersAtHeight(boundingBox.minY)
 
         // Draw lines for the top and bottom faces
         for (i in 0..3) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockTime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockTime.kt
@@ -126,6 +126,17 @@ data class SkyBlockTime(
         }
 
         fun isDay(): Boolean = Minecraft.getMinecraft().theWorld.worldTime % 24000 in 1..12000
+
+        fun getSBMonthByName(month: String): Int {
+            var monthNr = 0
+            for (i in 1..12) {
+                val monthName = monthName(i)
+                if (month == monthName) {
+                    monthNr = i
+                }
+            }
+            return monthNr
+        }
     }
 }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/JsonUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/JsonUtils.kt
@@ -5,6 +5,7 @@ import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
 import java.io.File
 import java.io.Reader
 import kotlin.reflect.jvm.javaType
@@ -53,3 +54,5 @@ fun Iterable<JsonElement>.toJsonArray(): JsonArray = JsonArray().also {
         it.add(jsonElement)
     }
 }
+
+val JsonPrimitive.asIntOrNull get() = takeIf { it.isNumber }?.asInt

--- a/src/main/java/at/hannibal2/skyhanni/utils/system/PlatformUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/system/PlatformUtils.kt
@@ -8,10 +8,12 @@ import net.minecraftforge.fml.common.ModContainer
 import kotlin.time.Duration.Companion.INFINITE
 //#if MC < 1.16
 import net.minecraft.launchwrapper.Launch
+import net.minecraftforge.fml.common.FMLCommonHandler
 //#elseif FORGE
 //$$ import net.minecraftforge.fml.loading.FMLEnvironment
 //#else
 //$$ import net.fabricmc.loader.api.FabricLoader
+//$$ import kotlin.system.exitProcess
 //#endif
 
 /**
@@ -29,6 +31,17 @@ object PlatformUtils {
         //$$ FMLEnvironment.production.not()
         //#else
         //$$ FabricLoader.getInstance().isDevelopmentEnvironment
+        //#endif
+    }
+
+    fun shutdownMinecraft(reason: String? = null) {
+        val reasonLine = reason?.let { " Reason: $it" }.orEmpty()
+        System.err.println("SkyHanni-@MOD_VERSION@ ${"forced the game to shutdown.$reasonLine"}")
+
+        //#if FORGE
+        FMLCommonHandler.instance().handleExit(-1)
+        //#else
+        //$$ exitProcess(-1)
         //#endif
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.RenderData
 import at.hannibal2.skyhanni.data.SlayerApi
+import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.TrackerManager
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -13,7 +14,6 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.ItemPriceSource
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
@@ -243,7 +243,7 @@ open class SkyHanniTracker<Data : TrackerData>(
             ChatUtils.chat("§a+Tracker Drop§7: §r$itemName")
         }
         if (config.warnings.title && price >= config.warnings.minimumTitle) {
-            LorenzUtils.sendTitle("§a+ $itemName", 5.seconds)
+            TitleManager.sendTitle("§a+ $itemName", 5.seconds)
         }
     }
 

--- a/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/TestingModFeatures.kt
+++ b/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/TestingModFeatures.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni
 
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.minecraft.client.MinecraftClient
+import kotlin.system.exitProcess
 
 object TestingModFeatures {
 


### PR DESCRIPTION
## What
Part 1 of moving methods away from LorenzUtils and into more appropriate classes.
There is no reason for these methods to be in LorenzUtils instead of their specific classes. Some stuff can stay in LorenzUtils (at least for now).
Moving these methods out also makes modern version development much easier as there are less errors in LorenzUtils which everything uses

## Changelog Technical Details
+ Moved methods from LorenzUtils to more appropriate classes. - CalMWolfs

