### PR TITLE
Backend: Detekt rule for MinecraftCompat

### DIFF
--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -5,6 +5,10 @@ GrammarRules:
     AvoidBritishSpelling:
         active: true
 
+CompatRules:
+    MinecraftCompat:
+        active: true
+
 FormattingRules:
     CustomCommentSpacing:
         active: true

--- a/detekt/src/main/kotlin/compat/CompatRuleSetProvider.kt
+++ b/detekt/src/main/kotlin/compat/CompatRuleSetProvider.kt
@@ -1,0 +1,20 @@
+package at.hannibal2.skyhanni.detektrules.compat
+
+import com.google.auto.service.AutoService
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+@AutoService(RuleSetProvider::class)
+class CompatRuleSetProvider : RuleSetProvider {
+    override val ruleSetId: String = "CompatRules"
+
+    override fun instance(config: Config): RuleSet {
+        return RuleSet(
+            ruleSetId,
+            listOf(
+                MinecraftCompat(config),
+            ),
+        )
+    }
+}

--- a/detekt/src/main/kotlin/compat/MinecraftCompat.kt
+++ b/detekt/src/main/kotlin/compat/MinecraftCompat.kt
@@ -1,0 +1,54 @@
+package at.hannibal2.skyhanni.detektrules.compat
+
+import at.hannibal2.skyhanni.detektrules.SkyHanniRule
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtProperty
+
+class MinecraftCompat(config: Config) : SkyHanniRule(config) {
+    override val issue = Issue(
+        "MinecraftCompat",
+        Severity.Style,
+        "Ensure you are using the MinecraftCompat methods",
+        Debt.FIVE_MINS,
+    )
+
+    override fun visitProperty(property: KtProperty) {
+        if (shouldIgnore(property)) return
+        super.visitProperty(property)
+        checkForMinecraftPlayer(property.initializer)
+        checkForMinecraftWorld(property.initializer)
+    }
+
+    override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+        if (shouldIgnore(expression)) return
+        super.visitDotQualifiedExpression(expression)
+        checkForMinecraftPlayer(expression)
+        checkForMinecraftWorld(expression)
+    }
+
+    private fun shouldIgnore(element: KtExpression): Boolean {
+        val filePath = element.containingFile.virtualFile.path
+        return filePath.contains("at\\hannibal2\\skyhanni\\utils\\compat")
+    }
+
+    private fun checkForMinecraftPlayer(element: KtExpression?) {
+        if (element?.text?.contains("Minecraft.getMinecraft().thePlayer") == true) {
+            println("filePath: ${element.containingFile.virtualFile.path}")
+            element.reportIssue("Usage of Minecraft.getMinecraft().thePlayer detected. Please replace this with " +
+                "`MinecraftCompat.localPlayer` instead.")
+        }
+    }
+
+    private fun checkForMinecraftWorld(element: KtExpression?) {
+        if (element?.text?.contains("Minecraft.getMinecraft().theWorld") == true) {
+            println("filePath: ${element.containingFile.virtualFile.path}")
+            element.reportIssue("Usage of Minecraft.getMinecraft().theWorld detected. Please replace this with " +
+                "`MinecraftCompat.world` instead.")
+        }
+    }
+}

--- a/detekt/src/main/kotlin/compat/MinecraftCompat.kt
+++ b/detekt/src/main/kotlin/compat/MinecraftCompat.kt
@@ -19,36 +19,39 @@ class MinecraftCompat(config: Config) : SkyHanniRule(config) {
 
     override fun visitProperty(property: KtProperty) {
         if (shouldIgnore(property)) return
+        if (checkForMinecraftPlayer(property.initializer)) return
+        if (checkForMinecraftWorld(property.initializer)) return
         super.visitProperty(property)
-        checkForMinecraftPlayer(property.initializer)
-        checkForMinecraftWorld(property.initializer)
     }
 
     override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
         if (shouldIgnore(expression)) return
+        if (checkForMinecraftPlayer(expression)) return
+        if (checkForMinecraftWorld(expression)) return
         super.visitDotQualifiedExpression(expression)
-        checkForMinecraftPlayer(expression)
-        checkForMinecraftWorld(expression)
     }
 
     private fun shouldIgnore(element: KtExpression): Boolean {
         val filePath = element.containingFile.virtualFile.path
-        return filePath.contains("at\\hannibal2\\skyhanni\\utils\\compat")
+        return filePath.contains("at\\hannibal2\\skyhanni\\utils\\compat") ||
+            filePath.contains("at/hannibal2/skyhanni/utils/compat")
     }
 
-    private fun checkForMinecraftPlayer(element: KtExpression?) {
+    private fun checkForMinecraftPlayer(element: KtExpression?): Boolean {
         if (element?.text?.contains("Minecraft.getMinecraft().thePlayer") == true) {
-            println("filePath: ${element.containingFile.virtualFile.path}")
             element.reportIssue("Usage of Minecraft.getMinecraft().thePlayer detected. Please replace this with " +
                 "`MinecraftCompat.localPlayer` instead.")
+            return true
         }
+        return false
     }
 
-    private fun checkForMinecraftWorld(element: KtExpression?) {
+    private fun checkForMinecraftWorld(element: KtExpression?): Boolean {
         if (element?.text?.contains("Minecraft.getMinecraft().theWorld") == true) {
-            println("filePath: ${element.containingFile.virtualFile.path}")
             element.reportIssue("Usage of Minecraft.getMinecraft().theWorld detected. Please replace this with " +
                 "`MinecraftCompat.world` instead.")
+            return true
         }
+        return false
     }
 }


### PR DESCRIPTION
## What
Added a detekt rule for MinecraftCompat
Warns when using `Minecraft.getMinecraft().thePlayer` and `Minecraft.getMinecraft().theWorld`

In future more detekt rules for using the correct compat methods may be added but this is the most important compat method rn

## Changelog Technical Details
+ Added a detekt rule for MinecraftCompat. - CalMWolfs & j10a1n15

