### PR TITLE
Improvement: Fishing Hotspot pathfind

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.java
@@ -101,4 +101,9 @@ public class FishingConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean guessHotspotRadar = true;
+
+    @Expose
+    @ConfigOption(name = "Pathfind to Hotspots", desc = "Add a path to the Hotspot after using teh Radar Guesser.")
+    @ConfigEditorBoolean
+    public boolean guessHotspotRadarPathFind = true;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.java
@@ -103,7 +103,7 @@ public class FishingConfig {
     public boolean guessHotspotRadar = true;
 
     @Expose
-    @ConfigOption(name = "Pathfind to Hotspots", desc = "Add a path to the Hotspot after using teh Radar Guesser.")
+    @ConfigOption(name = "Pathfind to Hotspots", desc = "When the Hotspot Radar Guesser feature finds a target, shows a pathfind to that Fishing Hotspot.")
     @ConfigEditorBoolean
     public boolean guessHotspotRadarPathFind = true;
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -387,6 +387,7 @@ object IslandGraphs {
         allowRerouting: Boolean = false,
         condition: () -> Boolean,
     ) {
+        if (isActive(position, label)) return
         reset()
         currentTargetNode = this
         shouldAllowRerouting = allowRerouting
@@ -409,6 +410,7 @@ object IslandGraphs {
         onFound: () -> Unit = {},
         condition: () -> Boolean,
     ) {
+        if (isActive(location, label)) return
         require(label.isNotEmpty()) { "Label cannot be empty." }
         reset()
         shouldAllowRerouting = false
@@ -524,4 +526,11 @@ object IslandGraphs {
     }
 
     fun isActive(testTarget: LorenzVec, testLabel: String): Boolean = testTarget == currentTarget && testLabel == label
+
+    fun findClosestNode(location: LorenzVec, condition: (GraphNode) -> Boolean, radius: Double = 100.0): GraphNode? {
+        val graph = currentIslandGraph ?: return null
+
+        val found = graph.nodes.filter { condition(it) }.minBy { it.position.distanceSq(location) }
+        return found.takeIf { it.position.distance(location) < radius }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemClickData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemClickData.kt
@@ -23,11 +23,12 @@ object ItemClickData {
         val packet = event.packet
         val cancelled = when {
             packet is C08PacketPlayerBlockPlacement -> {
+                val clickCancelled = ItemClickEvent(InventoryUtils.getItemInHand(), ClickType.RIGHT_CLICK).post()
                 if (packet.placedBlockDirection != 255) {
                     val position = packet.position.toLorenzVec()
-                    BlockClickEvent(ClickType.RIGHT_CLICK, position, packet.getUsedItem()).post()
+                    BlockClickEvent(ClickType.RIGHT_CLICK, position, packet.getUsedItem()).post() || clickCancelled
                 } else {
-                    ItemClickEvent(InventoryUtils.getItemInHand(), ClickType.RIGHT_CLICK).post()
+                    clickCancelled
                 }
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
@@ -171,6 +171,8 @@ class GraphNode(val id: Int, val position: LorenzVec, val name: String? = null, 
 
     fun sameNameAndTags(other: GraphNode): Boolean = name == other.name && allowedTags == other.allowedTags
 
+    fun hasTag(tag: GraphNodeTag): Boolean = tag in tags
+
     private val allowedTags get() = tags.filter { it in NavigationHelper.allowedTags }
 }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/model/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/GraphNodeTag.kt
@@ -9,7 +9,8 @@ enum class GraphNodeTag(
     val cleanName: String,
     val description: String,
     val onlyIsland: IslandType? = null,
-    val onlySkyblock: Boolean? = true
+    val onlyIslands: Set<IslandType> = emptySet(),
+    val onlySkyblock: Boolean? = true,
 ) {
     DEV("dev", LorenzColor.WHITE, "Dev", "Intentionally marked as dev.", onlySkyblock = null), // E.g. Spawn points, todos, etc
 
@@ -94,6 +95,15 @@ enum class GraphNodeTag(
         "A Basket during the Halloween Event.",
         onlySkyblock = false,
     ),
+
+    FISHING_HOTSPOT(
+        "fishing_hotspot",
+        LorenzColor.AQUA,
+        "Fishing Hotspot",
+        "A possible hotspot where you can fish",
+        onlyIslands = setOf(IslandType.BACKWATER_BAYOU, IslandType.HUB, IslandType.CRIMSON_ISLE),
+    )
+
     ;
 
     val displayName: String = color.getChatColor() + cleanName

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -184,7 +184,6 @@ object HoppityEggLocator {
         val location = possibleEggLocations.firstOrNull() ?: return
 
         val color = config.waypointColor.toSpecialColor()
-        if (IslandGraphs.isActive(location, "Hoppity Egg")) return
 
         IslandGraphs.pathFind(location, "Hoppity Egg", color, condition = { config.showPathFinder })
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/lobby/waypoints/halloween/BasketWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/lobby/waypoints/halloween/BasketWaypoints.kt
@@ -139,7 +139,7 @@ object BasketWaypoints {
         if (isActive != newIsActive && newIsActive) {
             IslandGraphs.loadLobby("MAIN_LOBBY")
 
-            val nodeList = IslandGraphs.currentIslandGraph?.nodes?.filter { GraphNodeTag.HALLOWEEN_BASKET in it.tags }.orEmpty()
+            val nodeList = IslandGraphs.currentIslandGraph?.nodes?.filter { it.hasTag(GraphNodeTag.HALLOWEEN_BASKET) }.orEmpty()
             basketList.clear()
             nodeList.forEach { node ->
                 basketList.add(EventWaypoint(position = node.position, isFound = false))
@@ -170,7 +170,7 @@ object BasketWaypoints {
 
     private fun getClosest(nodeList: List<GraphNode>? = null): EventWaypoint? {
         val nodes = nodeList ?: IslandGraphs.currentIslandGraph?.nodes?.filter {
-            GraphNodeTag.HALLOWEEN_BASKET in it.tags
+            it.hasTag(GraphNodeTag.HALLOWEEN_BASKET)
         }.orEmpty()
 
         val unFoundBaskets = basketList.filter { !it.isFound }.map { it.position }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
@@ -3,12 +3,17 @@ package at.hannibal2.skyhanni.features.fishing
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ClickType
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
@@ -52,6 +57,42 @@ object FishingHotspotRadar {
         bezierFitter.addPoint(currLoc)
 
         hotspotLocation = bezierFitter.solve() ?: return
+        hotspotLocation?.let {
+            DelayedRun.runNextTick {
+                pathFind(it)
+            }
+        }
+    }
+
+    private fun pathFind(location: LorenzVec) {
+        if (!config.guessHotspotRadarPathFind) return
+        val found = IslandGraphs.findClosestNode(
+            location,
+            condition = { it.hasTag(GraphNodeTag.FISHING_HOTSPOT) },
+            radius = 15.0,
+        ) ?: run {
+            // TODO reuse again once this doesnt cause StackOverflowError anymore
+//             ErrorManager.logErrorStateWithData(
+//                 "No path to fishing hotspot found",
+//                 "no node with tag 'fishing hotspot' found near the radar hotspot target",
+//                 "location" to location,
+//                 "island" to LorenzUtils.skyBlockIsland.name,
+//             )
+            IslandGraphs.pathFind(
+                location, "§cUnknown Fishing Hotspot", LorenzColor.RED.toColor(),
+                condition = {
+                    config.guessHotspotRadarPathFind
+                },
+            )
+            return
+        }
+        found.pathFind(
+            "§bFishing Hotspot",
+            LorenzColor.AQUA.toColor(),
+            condition = {
+                config.guessHotspotRadarPathFind
+            },
+        )
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
@@ -84,7 +84,7 @@ object WoodenButtonsHelper {
         val graph = IslandGraphs.currentIslandGraph ?: return
 
         val closestNode = graph.nodes
-            .filter { it.tags.contains(GraphNodeTag.RIFT_BUTTONS_QUEST) }
+            .filter { it.hasTag(GraphNodeTag.RIFT_BUTTONS_QUEST) }
             .filter { node ->
                 val spotName = "${node.name}:${node.position}"
                 val buttonsAtSpot = buttonLocations[spotName] ?: return@filter false

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.graph.GraphEditor.distanceToPlayer
 import at.hannibal2.skyhanni.utils.CollectionUtils.addString
 import at.hannibal2.skyhanni.utils.CollectionUtils.sortedDesc
+import at.hannibal2.skyhanni.utils.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -155,7 +156,10 @@ object GraphNodeEditor {
     private fun checkIsland(tag: GraphNodeTag): Boolean {
         val islandMatches = tag.onlyIsland?.let {
             it == LorenzUtils.skyBlockIsland
+        } ?: tag.onlyIslands.takeIfNotEmpty()?.let {
+            LorenzUtils.skyBlockIsland in it
         } ?: true
+
         val skyblockMatches = tag.onlySkyblock?.let {
             it == LorenzUtils.inSkyBlock
         } ?: true

--- a/src/main/java/at/hannibal2/skyhanni/utils/RaycastUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RaycastUtils.kt
@@ -66,6 +66,7 @@ object RaycastUtils {
         }
     }
 
+    // TODO make private or no longer generic
     fun <T : Any> List<T>.findClosestPointToRay(ray: Ray, positionExtractor: (T) -> LorenzVec): T? {
         return minByOrNull(createDistanceToRayEstimator(ray, positionExtractor))
     }


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/357

## What
define spots in the graph as fishing hotspots and pathfind to them.
they only exist in hub, backwater bayu and crimson isle

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/aea3afe8-b44d-4aa4-9d09-34a0c57723c8)

</details>

## Changelog Improvements
+ Added pathfinding to Hotspots. - hannibal2
    * Displays pathfinding to fishing hotspots when Hotspot Radar Guesser detects them.