### PR TITLE
Fix: /shupdate not letting you update to beta from a full release

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -179,7 +179,9 @@ object UpdateManager {
             ChatUtils.clickableChat(
                 "Are you sure you want to switch to beta? These versions may be less stable.",
                 onClick = {
-                    checkUpdate(true, updateStream)
+                    val newUpdateStream = SkyHanniMod.feature.about.updateStream
+                    newUpdateStream.set(UpdateStream.BETA)
+                    checkUpdate(true, newUpdateStream.get())
                 },
                 "§eClick to confirm!",
                 oneTimeClick = true,


### PR DESCRIPTION
## What
Fix the message you get when you do /shupdate on a full version not changing you to beta

## Changelog Fixes
+ Fixed `/shupdate` not allowing update to Beta from a full release. - nopo
