### PR TITLE
Backend: Edit parkours via graph editor

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.features.dev.GraphConfig
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.TitleManager
@@ -50,9 +51,9 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object GraphEditor {
 
-    val config get() = SkyHanniMod.feature.dev.devTool.graph
+    val config: GraphConfig get() = SkyHanniMod.feature.dev.devTool.graph
 
-    fun isEnabled() = config != null && config.enabled
+    fun isEnabled(): Boolean = config.enabled
 
     private var id = 0
 
@@ -391,11 +392,7 @@ object GraphEditor {
                 return
             }
         }
-        if (!config.enabled) {
-            config.enabled = true
-            ChatUtils.chat("Graph Editor is now active.")
-        }
-
+        enable()
         import(graph)
         ChatUtils.chat("Graph Editor loaded this island!")
     }
@@ -710,7 +707,7 @@ object GraphEditor {
             edges.add(edge)
         } else false
 
-    private fun compileGraph(): Graph {
+    fun compileGraph(): Graph {
         val indexedTable = nodes.mapIndexed { index, node -> node.id to index }.toMap()
         val nodes = nodes.mapIndexed { index, node ->
             GraphNode(
@@ -820,6 +817,13 @@ object GraphEditor {
     fun distanceToPlayer(location: LorenzVec): Double {
         val playerPosition = ghostPosition ?: LocationUtils.playerLocation()
         return location.distanceSq(playerPosition)
+    }
+
+    fun enable() {
+        if (!config.enabled) {
+            config.enabled = true
+            ChatUtils.chat("Graph Editor is now active.")
+        }
     }
 }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphParkour.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphParkour.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandGraphs
-import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.model.Graph
 import at.hannibal2.skyhanni.data.model.GraphNode
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -18,6 +17,7 @@ import at.hannibal2.skyhanni.utils.OSUtils
 
 @SkyHanniModule
 object GraphParkour {
+
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.register("shgraphloadparkour") {
@@ -119,7 +119,7 @@ object GraphParkour {
     }
 
     private fun showErrorAt(vec: LorenzVec) {
-        pathFind(
+        IslandGraphs.pathFind(
             vec, "Node error",
             LorenzColor.RED.toColor(),
             condition = { isEnabled() },
@@ -162,6 +162,7 @@ object GraphParkour {
                 },
             )
         }
+
         for (node in nodes) {
             nodes.getOrNull(node.id - 1)?.let { previous ->
                 val distance = previous.position.distance(node.position)

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphParkour.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphParkour.kt
@@ -1,0 +1,187 @@
+package at.hannibal2.skyhanni.test.graph
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
+import at.hannibal2.skyhanni.data.model.Graph
+import at.hannibal2.skyhanni.data.model.GraphNode
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.graph.GraphEditor.isEnabled
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.LorenzVec.Companion.toLorenzVec
+import at.hannibal2.skyhanni.utils.OSUtils
+
+@SkyHanniModule
+object GraphParkour {
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.register("shgraphloadparkour") {
+            description = "Loads the current clipboard as parkour into the graph editor."
+            category = CommandCategory.DEVELOPER_TEST
+            callback {
+                SkyHanniMod.launchCoroutine {
+                    loadParkour()
+                }
+            }
+        }
+        event.register("shgraphexportasparkour") {
+            description = "Saves the graph editor as parkour into the clipboard."
+            category = CommandCategory.DEVELOPER_TEST
+            callback { saveParkour() }
+        }
+    }
+
+    private fun saveParkour() {
+        val graph = GraphEditor.compileGraph()
+
+        val list = graphToList(graph) ?: return
+
+        val resultList = mutableListOf<String>()
+        for (location in list) {
+            val x = location.x.toString().replace(",", ".")
+            val y = location.y.toString().replace(",", ".")
+            val z = location.z.toString().replace(",", ".")
+            resultList.add("\"$x:$y:$z\"".replace(".0", ""))
+        }
+        OSUtils.copyToClipboard(resultList.joinToString((",\n")))
+        ChatUtils.chat("Saved graph as parkour to clipboard!")
+    }
+
+    private fun graphToList(graph: Graph): List<LorenzVec>? {
+        val starts = graph.nodes.filter { it.name == "start" }
+        if (starts.isEmpty()) {
+            ChatUtils.userError("No start node found!")
+            return null
+        }
+        if (starts.size > 1) {
+            ChatUtils.userError("More than one start node found!")
+            return null
+        }
+        val ends = graph.nodes.filter { it.name == "end" }
+        if (ends.isEmpty()) {
+            ChatUtils.userError("No end node found!")
+            return null
+        }
+        if (ends.size > 1) {
+            ChatUtils.userError("More than one end node found!")
+            return null
+        }
+
+        val start = starts.first()
+        val startN = start.neighbours.entries
+        if (startN.isEmpty()) {
+            ChatUtils.userError("Start has no neighbours!")
+            return null
+        }
+        if (startN.size != 1) {
+            ChatUtils.userError("Start has more than one neighbours!")
+            return null
+        }
+
+        val list = mutableListOf<GraphNode>()
+        list.add(start)
+
+        var current = startN.first().key
+
+        while (list.size != graph.nodes.size - 1) {
+            val neighbours = current.neighbours.filter { it.key !in list }.keys
+            if (neighbours.size > 1) {
+                ChatUtils.userError("One node has more than two neighbours!")
+                showErrorAt(current.position)
+                return null
+            }
+            if (neighbours.isEmpty()) {
+                ChatUtils.userError("One node has only one neighbour!")
+                showErrorAt(current.position)
+                return null
+            }
+            if (current.name == "end") {
+                ChatUtils.userError("End node has two neighbours!")
+                showErrorAt(current.position)
+                return null
+            }
+            list.add(current)
+            current = neighbours.first()
+        }
+        if (current.name != "end") {
+            ChatUtils.userError("Last node does not have the name end!")
+            showErrorAt(current.position)
+            return null
+        }
+        list.add(current)
+
+        return list.map { it.position }
+    }
+
+    private fun showErrorAt(vec: LorenzVec) {
+        pathFind(
+            vec, "Node error",
+            LorenzColor.RED.toColor(),
+            condition = { isEnabled() },
+        )
+    }
+
+    private suspend fun loadParkour() {
+        val locations = readListFromClipboard() ?: return
+        val graph = listToGraph(locations)
+        GraphEditor.enable()
+        GraphEditor.import(graph)
+        IslandGraphs.pathFind(
+            locations.first(),
+            "Start of parkour",
+            condition = { isEnabled() },
+        )
+        ChatUtils.chat("Graph Editor loaded a parkour from clipboard!")
+    }
+
+    private suspend fun readListFromClipboard(): List<LorenzVec>? {
+        val clipboard = OSUtils.readFromClipboard() ?: return null
+        return clipboard.split("\n").map { line ->
+            val raw = line.replace("\"", "").replace(",", "")
+            raw.split(":").map { it.toDouble() }.toLorenzVec()
+        }
+    }
+
+    private fun listToGraph(locations: List<LorenzVec>): Graph {
+        val nodes = mutableListOf<GraphNode>()
+
+        for ((index, location) in locations.withIndex()) {
+            val name = when (index) {
+                0 -> "start"
+                locations.size - 1 -> "end"
+                else -> null
+            }
+            nodes.add(
+                GraphNode(index, location, name = name).also {
+                    it.neighbours = emptyMap()
+                },
+            )
+        }
+        for (node in nodes) {
+            nodes.getOrNull(node.id - 1)?.let { previous ->
+                val distance = previous.position.distance(node.position)
+                addNeighbour(node, previous, distance)
+                addNeighbour(previous, node, distance)
+            }
+            nodes.getOrNull(node.id + 1)?.let { next ->
+                val distance = next.position.distance(node.position)
+                addNeighbour(node, next, distance)
+                addNeighbour(next, node, distance)
+            }
+        }
+
+        return Graph(nodes)
+    }
+
+    private fun addNeighbour(a: GraphNode, b: GraphNode, distance: Double) {
+        val neighbours = mutableMapOf<GraphNode, Double>()
+        neighbours.putAll(a.neighbours)
+        neighbours[b] = distance
+        a.neighbours = neighbours
+    }
+}

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -34,7 +34,6 @@
     <ID>CyclomaticComplexMethod:VisualWordGui.kt$VisualWordGui$override fun drawScreen(unusedX: Int, unusedY: Int, partialTicks: Float)</ID>
     <ID>InjectDispatcher:ClipboardUtils.kt$ClipboardUtils$IO</ID>
     <ID>InjectDispatcher:SkyHanniMod.kt$SkyHanniMod$IO</ID>
-    <ID>LargeClass:ItemUtils.kt$ItemUtils</ID>
     <ID>LongMethod:CropMoneyDisplay.kt$CropMoneyDisplay$private fun drawDisplay(): List&lt;List&lt;Any&gt;&gt;</ID>
     <ID>LongMethod:DamageIndicatorManager.kt$DamageIndicatorManager$@HandleEvent fun onRenderWorld(event: SkyHanniRenderWorldEvent)</ID>
     <ID>LongMethod:GraphEditor.kt$GraphEditor$private fun input()</ID>
@@ -56,7 +55,6 @@
     <ID>MaxLineLength:ItemUtils.kt$ItemUtils$"ewogICJ0aW1lc3RhbXAiIDogMTYzNTk1NzQ4ODQxNywKICAicHJvZmlsZUlkIiA6ICJmNThkZWJkNTlmNTA0MjIyOGY2MDIyMjExZDRjMTQwYyIsCiAgInByb2ZpbGVOYW1lIiA6ICJ1bnZlbnRpdmV0YWxlbnQiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2I5NTFmZWQ2YTdiMmNiYzIwMzY5MTZkZWM3YTQ2YzRhNTY0ODE1NjRkMTRmOTQ1YjZlYmMwMzM4Mjc2NmQzYiIsCiAgICAgICJtZXRhZGF0YSIgOiB7CiAgICAgICAgIm1vZGVsIiA6ICJzbGltIgogICAgICB9CiAgICB9CiAgfQp9"</ID>
     <ID>MaxLineLength:ItemUtils.kt$ItemUtils$"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTM4MDcxNzIxY2M1YjRjZDQwNmNlNDMxYTEzZjg2MDgzYTg5NzNlMTA2NGQyZjg4OTc4Njk5MzBlZTZlNTIzNyJ9fX0="</ID>
     <ID>MaxLineLength:ItemUtils.kt$ItemUtils$"eyJ0aW1lc3RhbXAiOjE2MzU5NTczOTM4MDMsInByb2ZpbGVJZCI6ImJiN2NjYTcxMDQzNDQ0MTI4ZDMwODllMTNiZGZhYjU5IiwicHJvZmlsZU5hbWUiOiJsYXVyZW5jaW8zMDMiLCJzaWduYXR1cmVSZXF1aXJlZCI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2M5Yjc3OTk5ZmVkM2EyNzU4YmZlYWYwNzkzZTUyMjgzODE3YmVhNjQwNDRiZjQzZWYyOTQzM2Y5NTRiYjUyZjYiLCJtZXRhZGF0YSI6eyJtb2RlbCI6InNsaW0ifX19fQo="</ID>
-    <ID>MaxLineLength:Renderable.kt$Renderable.Companion$isGuiScreen &amp;&amp; isGuiPositionEditor &amp;&amp; inMenu &amp;&amp; isNotInSignAndOnSlot &amp;&amp; isConfigScreen &amp;&amp; !isInNeuPv &amp;&amp; !isInSkytilsPv &amp;&amp; !neuFocus &amp;&amp; !isInSkytilsSettings &amp;&amp; !isInNeuSettings</ID>
     <ID>MemberNameEqualsClassName:CaptureFarmingGear.kt$CaptureFarmingGear$fun captureFarmingGear()</ID>
     <ID>MemberNameEqualsClassName:FameRanks.kt$FameRanks$var fameRanks = emptyMap&lt;String, FameRank&gt;() private set</ID>
     <ID>MemberNameEqualsClassName:FirstMinionTier.kt$FirstMinionTier$fun firstMinionTier( otherItems: Map&lt;NeuInternalName, Int&gt;, minions: MutableMap&lt;String, NeuInternalName&gt;, tierOneMinions: MutableList&lt;NeuInternalName&gt;, tierOneMinionsDone: MutableSet&lt;NeuInternalName&gt;, )</ID>
@@ -64,7 +62,6 @@
     <ID>MemberNameEqualsClassName:PestSpawn.kt$PestSpawn$private fun pestSpawn(amount: Int, plotNames: List&lt;String&gt;, unknownAmount: Boolean)</ID>
     <ID>MemberNameEqualsClassName:Shimmy.kt$Shimmy.Companion$private fun shimmy(source: Any?, fieldName: String): Any?</ID>
     <ID>MemberNameEqualsClassName:TestBingo.kt$TestBingo$var testBingo = false</ID>
-    <ID>MemberNameEqualsClassName:Text.kt$Text$fun text(text: String, init: IChatComponent.() -&gt; Unit = {})</ID>
     <ID>NoNameShadowing:BucketedItemTrackerData.kt$BucketedItemTrackerData${ it.hidden = !it.hidden }</ID>
     <ID>NoNameShadowing:ContributorManager.kt$ContributorManager${ it.isAllowed() }</ID>
     <ID>NoNameShadowing:Graph.kt$Graph.Companion${ out.name("Name").value(it) }</ID>
@@ -72,8 +69,6 @@
     <ID>NoNameShadowing:HoppityCollectionStats.kt$HoppityCollectionStats${ val displayAmount = it.amount.shortFormat() val operationFormat = when (milestoneType) { HoppityEggType.CHOCOLATE_SHOP_MILESTONE -&gt; "spending" HoppityEggType.CHOCOLATE_FACTORY_MILESTONE -&gt; "reaching" else -&gt; "" // Never happens } // List indexing is weird existingLore[replaceIndex - 1] = "§7Obtained by $operationFormat §6$displayAmount" existingLore[replaceIndex] = "§7all-time §6Chocolate." return existingLore }</ID>
     <ID>NoNameShadowing:LorenzVec.kt$LorenzVec.Companion$pitch</ID>
     <ID>NoNameShadowing:LorenzVec.kt$LorenzVec.Companion$yaw</ID>
-    <ID>NoNameShadowing:Renderable.kt$Renderable.Companion.&lt;no name provided&gt;$posX</ID>
-    <ID>NoNameShadowing:Renderable.kt$Renderable.Companion.&lt;no name provided&gt;$posY</ID>
     <ID>NoNameShadowing:RenderableUtils.kt$RenderableUtils${ it != null }</ID>
     <ID>NoNameShadowing:ReplaceRomanNumerals.kt$ReplaceRomanNumerals${ it.isValidRomanNumeral() &amp;&amp; it.removeFormatting().romanToDecimal() != 2000 }</ID>
     <ID>NoNameShadowing:RepoManager.kt$RepoManager${ unsuccessfulConstants.add(it) }</ID>
@@ -245,6 +240,7 @@
     <ID>ReturnCount:FishingApi.kt$FishingApi$fun seaCreatureCount(entity: EntityArmorStand): Int</ID>
     <ID>ReturnCount:GardenVisitorFeatures.kt$GardenVisitorFeatures$private fun showGui(): Boolean</ID>
     <ID>ReturnCount:GraphEditor.kt$GraphEditor$private fun input()</ID>
+    <ID>ReturnCount:GraphParkour.kt$GraphParkour$private fun graphToList(graph: Graph): List&lt;LorenzVec&gt;?</ID>
     <ID>ReturnCount:HideNotClickableItems.kt$HideNotClickableItems$private fun hideSalvage(chestName: String, stack: ItemStack): Boolean</ID>
     <ID>ReturnCount:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$private fun getStackTip(item: ItemStack): String?</ID>
     <ID>ReturnCount:ItemNameResolver.kt$ItemNameResolver$internal fun getInternalNameOrNull(itemName: String): NeuInternalName?</ID>
@@ -276,18 +272,15 @@
     <ID>TooManyFunctions:HypixelCommands.kt$HypixelCommands</ID>
     <ID>TooManyFunctions:ItemResolutionQuery.kt$ItemResolutionQuery</ID>
     <ID>TooManyFunctions:LocationUtils.kt$LocationUtils</ID>
-    <ID>TooManyFunctions:LorenzUtils.kt$LorenzUtils</ID>
     <ID>TooManyFunctions:LorenzVec.kt$LorenzVec</ID>
     <ID>TooManyFunctions:MobFinder.kt$MobFinder</ID>
     <ID>TooManyFunctions:NumberUtil.kt$NumberUtil</ID>
     <ID>TooManyFunctions:RegexUtils.kt$RegexUtils</ID>
     <ID>TooManyFunctions:Renderable.kt$Renderable$Companion</ID>
-    <ID>TooManyFunctions:RenderableUtils.kt$RenderableUtils</ID>
     <ID>TooManyFunctions:SkyBlockItemModifierUtils.kt$SkyBlockItemModifierUtils</ID>
     <ID>TooManyFunctions:SkyHanniTracker.kt$SkyHanniTracker&lt;Data : TrackerData&gt;</ID>
     <ID>TooManyFunctions:StringUtils.kt$StringUtils</ID>
     <ID>UnsafeCallOnNullableType:BucketedItemTrackerData.kt$BucketedItemTrackerData$it.value[internalName]?.hidden!!</ID>
-    <ID>UnsafeCallOnNullableType:ChatHoverEvent.kt$ChatHoverEvent$component.chatStyle.chatHoverEvent!!</ID>
     <ID>UnsafeCallOnNullableType:ChocolateFactoryDataLoader.kt$ChocolateFactoryDataLoader$upgradeCost!!</ID>
     <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Double::plus)!!</ID>
     <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Float::plus)!!</ID>
@@ -365,7 +358,6 @@
     <ID>UnsafeCallOnNullableType:SuperpairsClicksAlert.kt$SuperpairsClicksAlert$match.groups[1]!!</ID>
     <ID>UnsafeCallOnNullableType:TiaRelayWaypoints.kt$TiaRelayWaypoints$waypointName!!</ID>
     <ID>UnsafeCallOnNullableType:Translator.kt$Translator$messageContentRegex.find(message)!!</ID>
-    <ID>UnsafeCallOnNullableType:TunnelsMaps.kt$TunnelsMaps$campfire.name!!</ID>
     <ID>UnsafeCallOnNullableType:UpdateManager.kt$UpdateManager$potentialUpdate!!</ID>
     <ID>UnsafeCallOnNullableType:VisitorRewardWarning.kt$VisitorRewardWarning$visitor.totalPrice!!</ID>
     <ID>UnsafeCallOnNullableType:VisitorRewardWarning.kt$VisitorRewardWarning$visitor.totalReward!!</ID>


### PR DESCRIPTION
## What
Allow to load, edit and save a parkour via the graph editor.

![image](https://github.com/user-attachments/assets/6456836d-b01b-4352-846d-9148a30fb822)


## Changelog Technical Details
+ Allowed loading, editing, and saving a Parkour via the Graph Editor. - hannibal2
    * `/shgraphloadparkour` loads the current clipboard as Parkour into the Graph Editor.
    * `/shgraphexportasparkour` exports the Graph Editor as Parkour to the clipboard.