### PR TITLE
Fix + Feature: Add a line to the detected fishing hotspot

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
@@ -111,4 +111,10 @@ class FishingConfig {
     )
     @ConfigEditorBoolean
     var guessHotspotRadarPathFind: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Line to Hotspot", desc = "Draws a line towards the Fishing Hotspot")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var lineToHotspot: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
@@ -113,7 +113,7 @@ class FishingConfig {
     var guessHotspotRadarPathFind: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Line to Hotspot", desc = "Draws a line towards the Fishing Hotspot")
+    @ConfigOption(name = "Line to Hotspot", desc = "Draws a line towards the Fishing Hotspot.")
     @ConfigEditorBoolean
     @FeatureToggle
     var lineToHotspot: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
@@ -20,6 +20,7 @@ import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.ParticlePathBezierFitter
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
+import at.hannibal2.skyhanni.utils.RenderUtils.drawLineToEye
 import at.hannibal2.skyhanni.utils.RenderUtils.exactPlayerEyeLocation
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import net.minecraft.util.EnumParticleTypes
@@ -99,6 +100,9 @@ object FishingHotspotRadar {
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         val location = hotspotLocation ?: return
         val distance = location.distance(event.exactPlayerEyeLocation())
+        if (config.lineToHotspot) {
+            event.drawLineToEye(location, LorenzColor.LIGHT_PURPLE.toColor(), 3, false)
+        }
         if (distance > 10) {
             val formattedDistance = distance.toInt().addSeparators()
             event.drawDynamicText(location.add(-0.5, 1.7, -0.5), "§d§lHOTSPOT", 1.7)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
@@ -123,7 +123,7 @@ object FishingHotspotRadar {
         lastAbilityUse = SimpleTimeMark.now()
     }
 
-    @HandleEvent(onlyOnSkyblock = true)
+    @HandleEvent
     fun onWorldChange(event: WorldChangeEvent) {
         hotspotLocation = null
         bezierFitter.reset()


### PR DESCRIPTION
## What

Also fixes a bug
Apparently `onlyOnSkyblock` fails on world change, so this check makes the world change event do nothing, this has been fixed.

## Changelog New Features
+ Added a line pointing to the detected Hotspot. - bloxigus

## Changelog Fixes
+ Fixed Hotspot Radar guesses not disappearing. - bloxigus

