### PR TITLE
Fix: XP display missing in renew experiments menu

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/XPInInventories.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/XPInInventories.kt
@@ -20,8 +20,7 @@ object XPInInventories {
      */
     private val xpLevelsPattern by RepoPattern.list(
         "misc.xp-in-inventory.exp-levels",
-        "(?:§.)*(?<xp>\\d+) Exp Levels",
-        "(?:§.)*(?<xp>\\d+) XP Levels",
+        "(?:§.)*(?<xp>\\d+) (Exp|XP) Levels",
         "(?:§.)*Starting cost: §b(?<xp>\\d+) XP Levels",
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/XPInInventories.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/XPInInventories.kt
@@ -15,11 +15,13 @@ object XPInInventories {
 
     /**
      * REGEX-TEST: §310 Exp Levels
+     * REGEX-TEST: §310 XP Levels
      * REGEX-TEST:§7Starting cost: §b350 XP Levels
      */
     private val xpLevelsPattern by RepoPattern.list(
         "misc.xp-in-inventory.exp-levels",
         "(?:§.)*(?<xp>\\d+) Exp Levels",
+        "(?:§.)*(?<xp>\\d+) XP Levels",
         "(?:§.)*Starting cost: §b(?<xp>\\d+) XP Levels",
     )
 


### PR DESCRIPTION
(hypixel moment)


## What
The experimentation table's menu for renewing the experiments (after the initial three charges have been used up) also has an XP cost, and wasn't covered by the feature previously, since Hypixel annoyingly uses both "XP" and "Exp".
This meant players wouldn't see their current XP level at all when displaying Skyblock XP on the Minecraft XP bar was enabled.

<details>
<summary>Images</summary>

Before:
![image](https://github.com/user-attachments/assets/4286c6d8-6340-4469-8fb1-8358482d2643)

After:
![image](https://github.com/user-attachments/assets/7eb56182-d1d4-4500-bd95-b4aad80fd0b8)

</details>


## Changelog Fixes
+ Fixed XP in Inventory not displaying for Renew Experiments menu. - aphased
