### PR TITLE
Improvement + Fix:  Update Repo and report locations

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -153,7 +153,7 @@ object RepoManager {
             ) {
                 if (command) {
                     ChatUtils.hoverableChat(
-                        "§7The repo is already up to date! (hover for infos)",
+                        "§7The repo is already up to date! (hover for info)",
                         hover = buildList {
                             add("§7latest commit sha: §e$currentDownloadedCommit")
                             latestRepoCommitTime?.let { latestTime ->
@@ -168,7 +168,7 @@ object RepoManager {
             }
             if (command) {
                 ChatUtils.hoverableChat(
-                    "Repo is outdated, updating.. (hover for infos)",
+                    "Repo is outdated, updating.. (hover for info)",
                     hover = buildList {
                         add("§7local commit sha: §e$latestRepoCommit")
                         currentDownloadedCommitTime?.let { localTime ->

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -8,6 +8,8 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.asTimeMark
+import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.send
@@ -26,7 +28,7 @@ import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-import kotlin.time.Duration.Companion.minutes
+import java.time.Instant
 
 @SkyHanniModule
 object RepoManager {
@@ -82,6 +84,8 @@ object RepoManager {
     private var shouldManuallyReload = false
 
     private var currentlyFetching = false
+    var commitTime: SimpleTimeMark? = null
+        private set
 
     @JvmStatic
     fun updateRepo() {
@@ -121,13 +125,17 @@ object RepoManager {
 
     private fun doTheFetching(command: Boolean) {
         try {
-            val currentDownloadedCommit = readCurrentCommit()
+            val (currentDownloadedCommit, currentDownloadedCommitTime) = readCurrentCommit() ?: (null to null)
+            commitTime = currentDownloadedCommitTime
             var latestRepoCommit: String? = null
+            var latestRepoCommitTime: SimpleTimeMark? = null
             try {
                 InputStreamReader(URL(getCommitApiUrl()).openStream())
                     .use { inReader ->
                         val commits: JsonObject = gson.fromJson(inReader, JsonObject::class.java)
                         latestRepoCommit = commits["sha"].asString
+                        val formattedDate = commits["commit"].asJsonObject["committer"].asJsonObject["date"].asString
+                        latestRepoCommitTime = Instant.parse(formattedDate).toEpochMilli().asTimeMark()
                     }
             } catch (e: Exception) {
                 ErrorManager.logErrorWithData(
@@ -141,14 +149,45 @@ object RepoManager {
 
             if (repoLocation.exists() &&
                 currentDownloadedCommit == latestRepoCommit &&
-                unsuccessfulConstants.isEmpty() &&
-                lastRepoUpdate.passedSince() < 1.minutes
+                unsuccessfulConstants.isEmpty()
             ) {
                 if (command) {
-                    ChatUtils.chat("§7The repo is already up to date!")
+                    ChatUtils.hoverableChat(
+                        "§7The repo is already up to date! (hover for infos)",
+                        hover = buildList {
+                            add("§7latest commit sha: §e$currentDownloadedCommit")
+                            latestRepoCommitTime?.let { latestTime ->
+                                add("§7latest commit time: §b$latestTime")
+                                add("  §7(§b${latestTime.passedSince().format()} ago§7)")
+                            }
+                        },
+                    )
                     shouldManuallyReload = false
                 }
                 return
+            }
+            if (command) {
+                ChatUtils.hoverableChat(
+                    "Repo is outdated, updating.. (hover for infos)",
+                    hover = buildList {
+                        add("§7local commit sha: §e$latestRepoCommit")
+                        currentDownloadedCommitTime?.let { localTime ->
+                            add("§7local commit time: §b$localTime")
+                            add("  §7(§b${localTime.passedSince().format()} ago§7)")
+                        }
+                        add("")
+                        add("§7latest commit sha: §e$currentDownloadedCommit")
+                        latestRepoCommitTime?.let<SimpleTimeMark, Unit> { latestTime ->
+                            add("§7latest commit time: §b$latestTime")
+                            add("  §7(§b${latestTime.passedSince().format()} ago§7)")
+                            currentDownloadedCommitTime?.let<SimpleTimeMark, Unit> { localTime ->
+                                val outdatedDuration = latestTime - localTime
+                                add("")
+                                add("§7outdated by: §b${outdatedDuration.format()}")
+                            }
+                        }
+                    },
+                )
             }
             lastRepoUpdate = SimpleTimeMark.now()
 
@@ -165,9 +204,9 @@ object RepoManager {
             repoLocation.mkdirs()
 
             try {
-                urlConnection.getInputStream().use { `is` ->
+                urlConnection.getInputStream().use { stream ->
                     FileUtils.copyInputStreamToFile(
-                        `is`,
+                        stream,
                         itemsZip,
                     )
                 }
@@ -186,8 +225,9 @@ object RepoManager {
                 repoLocation.absolutePath,
             )
             if (currentDownloadedCommit == null || currentDownloadedCommit != latestRepoCommit) {
-                writeCurrentCommit(latestRepoCommit)
+                writeCurrentCommit(latestRepoCommit, latestRepoCommitTime)
             }
+            commitTime = latestRepoCommitTime
         } catch (e: Exception) {
             ErrorManager.logErrorWithData(
                 e,
@@ -195,6 +235,7 @@ object RepoManager {
                 "command" to command,
             )
             repoDownloadFailed = true
+            return
         }
         repoDownloadFailed = false
         usingBackupRepo = false
@@ -234,18 +275,23 @@ object RepoManager {
         }
     }
 
-    private fun writeCurrentCommit(commit: String?) {
+    private fun writeCurrentCommit(commit: String?, time: SimpleTimeMark?) {
         val newCurrentCommitJSON = JsonObject()
         newCurrentCommitJSON.addProperty("sha", commit)
+        time?.let {
+            newCurrentCommitJSON.addProperty("time", it.toMillis())
+        }
         try {
             writeJson(newCurrentCommitJSON, File(configLocation, "currentCommit.json"))
         } catch (ignored: IOException) {
         }
     }
 
-    private fun readCurrentCommit(): String? {
+    private fun readCurrentCommit(): Pair<String, SimpleTimeMark>? {
         val currentCommitJSON: JsonObject? = getJsonFromFile(File(configLocation, "currentCommit.json"))
-        return currentCommitJSON?.get("sha")?.asString
+        val sha = currentCommitJSON?.get("sha")?.asString
+        val time = currentCommitJSON?.get("time")?.asLong?.asTimeMark() ?: SimpleTimeMark.farPast()
+        return sha?.let { it to time }
     }
 
     fun displayRepoStatus(joinEvent: Boolean) {
@@ -379,7 +425,7 @@ object RepoManager {
 
             Files.copy(inputStream, destinationPath, StandardCopyOption.REPLACE_EXISTING)
             RepoUtils.unzipIgnoreFirstFolder(destinationPath.toAbsolutePath().toString(), repoLocation.absolutePath)
-            writeCurrentCommit("backup-repo")
+            writeCurrentCommit("backup-repo", time = null)
 
             println("Successfully switched to backup repo")
         } catch (e: Exception) {


### PR DESCRIPTION
## What
repo update and fishing report features

## Changelog Improvements
+ Command `/shrepoupdate` now shows on hover exact information on the old and new repo state. - hannibal2
+ Fishing Hotspots now warn in chat when an unknown Hotspot Location was found. - hannibal2
    * Clicking on the message allows sharing the data in Discord, so we can easily fix the bug.
+ Added command `/shreportlocation`. - hannibal2
    * Allows reporting an error with pathfinding at the current location.
    * Useful when the pathfinding goes through walls, misses paths, or for any location in `/shnavigate`.

## Changelog Fixes
+ Fixed `/shrepoupdate` displaying "Repo updated successfully" even when no update is necessary. - hannibal2

## Changelog Technical Details
+ Added `IslandGraphs.reportLocation()`. - hannibal2
    * Allows sending a custom location error in chat for easy copy-pasting.