### PR TITLE
Fix: Allow hoppity guesses to guess when close to the egg

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -150,7 +150,7 @@ object HoppityEggLocator {
 
         val lastPoint = bezierFitter.getLastPoint()
         if (lastPoint != null) {
-            if (lastPoint.distanceSq(event.location) > 4) return
+            if (lastPoint.distanceSq(event.location) > 9) return
         }
 
         if (EntityUtils.getEntitiesNearby<EntityFishHook>(event.location, 0.3).any()) {


### PR DESCRIPTION
## What
The previous PR I created was far too strict with how close the particle could be, not allowing for eggs that are too close to be guessed.
This PR changes 1 number

## Changelog Fixes
+ Fixed EggLocator particles being discarded when too close. - bloxigus