### PR TITLE
Fix: Sea Creature Highlight

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -47,8 +47,9 @@ object SeaCreatureFeatures {
         rareSeaCreatures.add(mob)
 
         if (!config.highlight) return
-        if (DamageIndicatorConfig.BossCategory.SEA_CREATURES !in damageIndicatorConfig.bossesToShow) return
-        if (seaCreaturesBosses.none { it.fullName.removeColor() == mob.name }) return
+        if (DamageIndicatorConfig.BossCategory.SEA_CREATURES in damageIndicatorConfig.bossesToShow) {
+            if (seaCreaturesBosses.none { it.fullName.removeColor() == mob.name }) return
+        }
         mob.highlight(LorenzColor.GREEN.toColor())
     }
 


### PR DESCRIPTION
## What
In #3634 the damage indicator again became accidentally a precondition on highlighting sea creatures.
This PR reverts this precondition.
This follows a similar PR #1985, that also removed the precondition.

Furthermore, I'm not sure why we even hide the highlight for sea creatures that have a damage indicator tag active.
But that's a discussion for later.

## Changelog Fixes
+ Fixed Sea Creature Highlight not showing up when Damage Indicator is disabled for Sea Creatures. - hannibal2