### PR TITLE
Backend: Make mixins work on modern versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -302,7 +302,7 @@ fun includeBuildPaths(buildPathsFile: File, sourceSet: Provider<SourceSet>) {
     if (buildPathsFile.exists()) {
         sourceSet.get().apply {
             val buildPaths = buildPathsFile.readText().lineSequence()
-                .map { it.substringBefore("#").trim() }
+                .map { it.substringBefore("#").trim().replace(Regex("\\.(?!kt|java|\\()"), "/") }
                 .filter { it.isNotBlank() }
                 .toSet()
             kotlin.include(buildPaths)

--- a/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
@@ -122,13 +122,15 @@ public class SkyhanniMixinPlugin implements IMixinConfigPlugin {
         }
     }
 
+    //#if MC < 1.21
     @Override
-    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
-
-    }
-
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
     @Override
-    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
-
-    }
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+    //#else
+    //$$ @Override
+    //$$ public void preApply(String targetClassName, org.objectweb.asm.tree.ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+    //$$ @Override
+    //$$ public void postApply(String targetClassName, org.objectweb.asm.tree.ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+    //#endif
 }

--- a/versions/1.21.4/buildpaths.txt
+++ b/versions/1.21.4/buildpaths.txt
@@ -15,7 +15,12 @@ at/hannibal2/skyhanni/config/HasLegacyId.java
 # at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
 # at/hannibal2/skyhanni/utils/compat/PacketCompat.kt
 
+# at/hannibal2/skyhanni/mixins/transformers/MixinClientConnection.java
+
 at/hannibal2/skyhanni/TestingModFeatures.kt
+
+at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
+at/hannibal2/skyhanni/mixins/init/BeforeForLoopInjectionPoint.java
 
 at/hannibal2/skyhanni/SkyHanniModLoader.kt
 at/hannibal2/skyhanni/data/jsonobjects/repo/AnitaUpgradeCostsJson.kt

--- a/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/mixins/init/BeforeForLoopInjectionPoint.java
+++ b/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/mixins/init/BeforeForLoopInjectionPoint.java
@@ -1,0 +1,58 @@
+package at.hannibal2.skyhanni.mixins.init;
+
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.injection.InjectionPoint;
+import org.spongepowered.asm.mixin.injection.struct.InjectionPointData;
+
+import java.util.Collection;
+
+/**
+ * Inject just before a for loop which iterates over a local variable containing an array.
+ *
+ * <pre>{@code
+ * String [] s = new String[10];
+ *
+ * // <-- Injection point here
+ * for (String e : s) {
+ *
+ * }
+ * }
+ * </pre>
+ * Does not work for more complex instructions which call functions or do other operations inside the for loop header.
+ * Does not work for {@link java.util.Iterator iterators}.
+ *
+ * <p>Set the lvIndex arg to specify which lvIndex to search for when selecting the loop.</p>
+ *
+ *
+ * <pre>{@code
+ * @Inject(method = "...", at = @At(value = "SKYHANNI_FORLOOP_LOCAL_VAR", args = "lvIndex=1"))
+ * }</pre>
+ */
+@InjectionPoint.AtCode("SKYHANNI_FORLOOP_LOCAL_VAR")
+public class BeforeForLoopInjectionPoint extends InjectionPoint {
+    private final int lvIndex;
+
+    public BeforeForLoopInjectionPoint(InjectionPointData data) {
+        lvIndex = data.get("lvIndex", -1);
+    }
+
+    @Override
+    public boolean find(String desc, org.objectweb.asm.tree.InsnList insns, Collection<org.objectweb.asm.tree.AbstractInsnNode> nodes) {
+        for (org.objectweb.asm.tree.AbstractInsnNode p = insns.getFirst(); p != null; p = p.getNext()) {
+            if (p.getOpcode() != Opcodes.ARRAYLENGTH) {
+                continue;
+            }
+            org.objectweb.asm.tree.AbstractInsnNode loadLoopVar = p.getPrevious();
+            if (loadLoopVar == null || loadLoopVar.getOpcode() != Opcodes.ALOAD) continue;
+            org.objectweb.asm.tree.AbstractInsnNode storeLoopVar = loadLoopVar.getPrevious();
+            if (storeLoopVar == null || storeLoopVar.getOpcode() != Opcodes.ASTORE) continue;
+            AbstractInsnNode loadLoopArg = storeLoopVar.getPrevious();
+            if (loadLoopArg == null || loadLoopArg.getOpcode() != Opcodes.ALOAD) continue;
+            if (lvIndex != -1 && ((VarInsnNode) loadLoopArg).var != lvIndex) continue;
+            nodes.add(loadLoopArg);
+        }
+        return false;
+    }
+}

--- a/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinClientConnection.java
+++ b/versions/1.21.4/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinClientConnection.java
@@ -1,0 +1,19 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.listener.PacketListener;
+import net.minecraft.network.packet.Packet;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientConnection.class)
+public class MixinClientConnection {
+
+    @Inject(method = "handlePacket", at = @At(value = "HEAD"))
+    private static void handlePacket$Inject$HEAD(Packet<?> packet, PacketListener listener, CallbackInfo ci) {
+        new PacketReceivedEvent(packet).post();
+    }
+}

--- a/versions/1.21.4/src/main/resources/fabric.mod.json
+++ b/versions/1.21.4/src/main/resources/fabric.mod.json
@@ -7,6 +7,9 @@
     "icon": "assets/skyhanni/logo.png",
     "authors": [],
     "environment": "client",
+    "mixins": [
+        "mixins.skyhanni.json"
+    ],
     "entrypoints": {
         "main": [
             "at.hannibal2.skyhanni.SkyHanniModLoader"

--- a/versions/1.21.4/src/main/resources/mixins.skyhanni.json
+++ b/versions/1.21.4/src/main/resources/mixins.skyhanni.json
@@ -1,0 +1,9 @@
+{
+    "package": "at.hannibal2.skyhanni.mixins.transformers",
+    "refmap": "mixins.skyhanni.refmap.json",
+    "plugin": "at.hannibal2.skyhanni.mixins.init.SkyhanniMixinPlugin",
+    "compatibilityLevel": "JAVA_21",
+    "injectors": {
+        "maxShiftBy": 2
+    }
+}


### PR DESCRIPTION
## What
Mixins now work on modern versions, there sure are a lot of packets that get received. This works for mixins both in the src dircetory and the build/preprocessed directory.
Also fixes forgetting to change `.` to `/` in the buildpaths file

## Changelog Technical Details
+ Makes mixins work with our mixin plugin on modern versions. - CalMWolfs
