### PR TITLE
Fix: Stray Timer Inventory Closure Reset

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/ChocolateFactoryStrayTimer.kt
@@ -61,6 +61,7 @@ object ChocolateFactoryStrayTimer {
         if (!isEnabled()) return
         // Reset the timer when the inventory is closed prematurely
         timer = 30.seconds
+        lastTimerSubtraction = null
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
The timer was resetting to 30s, but the last sub mark wasn't reset, so it was still continuing to subtract until you opened an inventory again.

This is a massive PR I know.

## Changelog Fixes
+ Fixed stray timer not resetting correctly on inventory closure. - Daveed

