### PR TITLE
Backend + Fix: Create KeyDownEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/KeyDownEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/KeyDownEvent.kt
@@ -1,0 +1,6 @@
+package at.hannibal2.skyhanni.events.minecraft
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+/** Gets posted when a key is first pressed, use this for taps*/
+class KeyDownEvent(val keyCode: Int) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/KeyPressEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/KeyPressEvent.kt
@@ -2,4 +2,5 @@ package at.hannibal2.skyhanni.events.minecraft
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
+/** Gets posted each tick it's pressed down*/
 class KeyPressEvent(val keyCode: Int) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingTimer.kt
@@ -11,12 +11,11 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.fishing.SeaCreatureFishEvent
-import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
+import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
-import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -167,13 +166,13 @@ object FishingTimer {
     }
 
     @HandleEvent
-    fun onKeyPress(event: KeyPressEvent) {
+    fun onKeyDown(event: KeyDownEvent) {
         if (!isEnabled()) return
         if (Minecraft.getMinecraft().currentScreen != null) return
-        if (config.manualResetTimer.isKeyClicked()) {
-            mobDespawnTime.replaceAll { _, _ ->
-                SimpleTimeMark.now()
-            }
+        if (event.keyCode != config.manualResetTimer) return
+
+        mobDespawnTime.replaceAll { _, _ ->
+            SimpleTimeMark.now()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.garden
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
-import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
+import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
 import at.hannibal2.skyhanni.features.misc.LockMouseLook
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -58,7 +58,7 @@ object GardenWarpCommands {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onKeyPress(event: KeyPressEvent) {
+    fun onKeyDown(event: KeyDownEvent) {
         if (Minecraft.getMinecraft().currentScreen != null) return
         if (NeuItems.neuHasFocus()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FocusMode.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.inventory
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
+import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.isTopInventory
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.KeyboardManager
-import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sublistAfter
@@ -61,10 +60,10 @@ object FocusMode {
     }
 
     @HandleEvent
-    fun onTick(event: SkyHanniTickEvent) {
+    fun onKeyDown(event: KeyDownEvent) {
         if (!isEnabled()) return
         if (config.alwaysEnabled) return
-        if (!config.toggleKey.isKeyClicked()) return
+        if (event.keyCode != config.toggleKey) return
         active = !active
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.model.TextInput
+import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -56,6 +57,37 @@ object KeyboardManager {
      */
     fun getModifierKeyName(): String = if (SystemUtils.IS_OS_MAC) "Command" else "Control"
 
+    private data class EventKey(val key: Int, val pressed: Boolean)
+
+    private fun getEventKey(): EventKey? {
+        if (MouseCompat.getEventButton() != -1) {
+            val key = MouseCompat.getEventButton() - 100
+            lastClickedMouseButton = key
+            return EventKey(key, MouseCompat.getEventButtonState())
+        }
+
+        if (Keyboard.getEventKey() != 0) {
+            lastClickedMouseButton = -1
+            return EventKey(Keyboard.getEventKey(), Keyboard.getEventKeyState())
+        }
+
+        if (MouseCompat.getEventButton() == -1 && lastClickedMouseButton != -1) {
+            if (lastClickedMouseButton.isKeyHeld()) {
+                return EventKey(lastClickedMouseButton, true)
+            } else {
+                lastClickedMouseButton = -1
+            }
+        }
+
+        // This is needed because of other keyboards that don't have a key code for the key, but is read as a character
+        if (Keyboard.getEventKey() == 0) {
+            return EventKey(Keyboard.getEventCharacter().code + 256, Keyboard.getEventKeyState())
+        }
+        return null
+    }
+
+    val clickedKeys = mutableSetOf<Int>()
+
     @HandleEvent(priority = HandleEvent.LOWEST)
     fun onTick(event: SkyHanniTickEvent) {
         //#if MC < 1.16
@@ -64,44 +96,39 @@ object KeyboardManager {
         if (isConfigScreen) return
         if (currentScreen is GuiChat) return
 
+        val (key, pressed) = getEventKey() ?: return
 
-        if (MouseCompat.getEventButtonState() && MouseCompat.getEventButton() != -1) {
-            val key = MouseCompat.getEventButton() - 100
-            postEvent(key)
-            lastClickedMouseButton = key
-            return
-        }
-
-        if (Keyboard.getEventKeyState() && Keyboard.getEventKey() != 0) {
-            postEvent(Keyboard.getEventKey())
-            lastClickedMouseButton = -1
-            return
-        }
-
-        if (MouseCompat.getEventButton() == -1 && lastClickedMouseButton != -1) {
-            if (lastClickedMouseButton.isKeyHeld()) {
-                postEvent(lastClickedMouseButton)
-                return
+        if (pressed) {
+            postKeyPressEvent(key)
+            if (!clickedKeys.contains(key)) {
+                postKeyDownEvent(key)
+                clickedKeys.add(key)
             }
-            lastClickedMouseButton = -1
-        }
-
-        // This is needed because of other keyboards that don't have a key code for the key, but is read as a character
-        if (Keyboard.getEventKey() == 0) {
-            postEvent(Keyboard.getEventCharacter().code + 256)
+        } else {
+            clickedKeys.remove(key)
         }
         //#else
         //$$ // todo use fabric event or whatnot
         //#endif
     }
 
-    private fun postEvent(keyCode: Int) {
+    private fun postKeyPressEvent(keyCode: Int) {
         // This cooldown is here to make sure the Text input features in graph editor
         // and in renderable calls have time to react first,
         // and lock this key press event properly
         DelayedRun.runDelayed(50.milliseconds) {
             if (TextInput.isActive()) return@runDelayed
             KeyPressEvent(keyCode).post()
+        }
+    }
+
+    private fun postKeyDownEvent(keyCode: Int) {
+        // This cooldown is here to make sure the Text input features in graph editor
+        // and in renderable calls have time to react first,
+        // and lock this key press event properly
+        DelayedRun.runDelayed(50.milliseconds) {
+            if (TextInput.isActive()) return@runDelayed
+            KeyDownEvent(keyCode).post()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -168,7 +168,10 @@ object KeyboardManager {
 
     private val pressedKeys = mutableMapOf<Int, Boolean>()
 
-    /** Can only be used once per click. Since the function locks itself until the key is no longer held*/
+    /**
+     * Can only be used once per click, since the function locks itself until the key is no longer held.
+     * Do not use in KeyPressEvent, since it won't be unlocked again, use KeyDownEvent instead.
+     * */
     fun Int.isKeyClicked(): Boolean = if (this.isKeyHeld()) {
         if (pressedKeys[this] != true) {
             pressedKeys[this] = true

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -16,6 +16,7 @@ import net.minecraft.client.settings.KeyBinding
 import org.apache.commons.lang3.SystemUtils
 import org.lwjgl.input.Keyboard
 import kotlin.time.Duration.Companion.milliseconds
+
 //#if MC > 1.21
 //$$ import net.minecraft.client.util.InputUtil
 //#endif


### PR DESCRIPTION
## What
KeyDownEvent is to be used when we only want to listen to a single tap, not every tick that it's pressed.
KeyPressEvent used in conjunction with .isKeyClicked() shouldn't have worked, as there was no way for .isKeyClicked() to reset

## Changelog Fixes
+ Fixed Garden `/sethome` Hotkey triggering multiple times. - rueblimaster

## Changelog Technical Details
+ Created `KeyDownEvent`. - rueblimaster
    * Replaced `KeyPressEvent` used in conjunction with `.isKeyClicked()`.

