### PR TITLE
Fix: Shorten coin working on gold full stops

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -22,10 +22,11 @@ object ShortenCoins {
      * REGEX-TEST: §6§lALLOWANCE! §r§eYou earned §r§650,000 coins§r§e!
      * REGEX-TEST: §6[Bazaar] §r§7§r§eSell Offer Setup! §r§a5§r§7x §r§9Enchanted Melon Block §r§7for §r§6250,303 coins§r§7.
      * REGEX-FAIL: §aYou have withdrawn §r§610.5k coins§r§a! You now have §r§6991.1M coins §r§ain your account!
+     * REGEX-FAIL: §6:typing:  §f-  §e✎§6...
      */
     private val coinsPattern by patternGroup.pattern(
         "format",
-        "§6(?<amount>[\\d,.]+)(?![\\d.,kMB])",
+        "§6(?<amount>\\d[\\d,.]+)(?![\\d.,kMB])",
     )
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.replace
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.style
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -39,8 +40,8 @@ object ShortenCoins {
 
         val originalComponent = event.chatComponent.siblings.firstOrNull() ?: event.chatComponent
 
-        event.chatComponent = modifiedMessage.asComponent().apply {
-            chatStyle = originalComponent.chatStyle
+        event.chatComponent = modifiedMessage.asComponent().style {
+            originalComponent.chatStyle
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.replace
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.chat.TextHelper.style
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -40,8 +40,8 @@ object ShortenCoins {
 
         val originalComponent = event.chatComponent.siblings.firstOrNull() ?: event.chatComponent
 
-        event.chatComponent = modifiedMessage.asComponent().style {
-            originalComponent.chatStyle
+        event.chatComponent = modifiedMessage.asComponent {
+            chatStyle = originalComponent.chatStyle
         }
     }
 


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1355128378369249369 fix emote

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/b7e438a7-73fe-4675-bda7-8cd25d2d6bbb)

</details>

## Changelog Fixes
+ Fixed Shorten Coin Amount in chat triggering on emotes. - nopo
