### PR TITLE
Fix: TitleManagerV2

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.enumMapOf
@@ -24,6 +25,7 @@ import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.renderer.GlStateManager
 import org.lwjgl.opengl.GL11
 import kotlin.math.min
+import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -192,41 +194,40 @@ object TitleManager {
         GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0)
         GlStateManager.pushMatrix()
 
-        val mainTextRenderable = Renderable.string(
+        val mainTextRenderable = Renderable.wrappedString(
             titleText,
-            scale = factor * fontSize,
+            width = (globalTitleWidth * fontSize).toInt(),
+            scale = (factor * fontSize),
+            horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
+        )
+
+        val subtitleRenderable: Renderable? = subtitleText?.let {
+            Renderable.wrappedString(
+                it,
+                width = (globalTitleWidth * fontSize * 0.75f).toInt(),
+                scale = (factor * fontSize * 0.75f),
+                horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
+            )
+        }
+
+        val targetRenderable = if (subtitleRenderable == null) mainTextRenderable
+        else Renderable.verticalContainer(
+            listOf(mainTextRenderable, subtitleRenderable),
             horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
             verticalAlign = RenderUtils.VerticalAlignment.CENTER,
         )
 
-        val renderableWidth = mainTextRenderable.width
-        val renderableHeight = mainTextRenderable.height
-        val posX: Int = (-guiWidth / 2) - renderableWidth
-        val posY = -guiHeight / 2
+        val renderableWidth = targetRenderable.width
+        val renderableHeight = targetRenderable.height
 
-        // Translate the origin to the adjustedPosition
-        val translationX = (guiWidth / 2f) - (renderableWidth / 2f)
-        val translationY = (guiHeight / 2f) - (renderableHeight * 2f)
-        GlStateManager.translate(translationX, translationY, 0f)
+        val posX = (guiWidth - renderableWidth) / 2
+        val posY = (guiHeight - (renderableHeight * 4)) / 2
 
-        if (subtitleText == null) {
-            mainTextRenderable.renderXYAligned(posX, posY, guiWidth, guiHeight)
-        } else {
-            val subText: String = subtitleText ?: return
-            val subtitleScale = factor * fontSize * 0.75f
-            val subtitleRenderable = Renderable.wrappedString(
-                subText,
-                width = (globalTitleWidth * fontSize).toInt(),
-                scale = subtitleScale,
-                horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
-                verticalAlign = RenderUtils.VerticalAlignment.CENTER,
-            )
-            val container = Renderable.verticalContainer(listOf(mainTextRenderable, subtitleRenderable))
-            container.renderXYAligned(posX, posY, guiWidth, guiHeight)
-        }
-
+        GlStateManager.translate(posX.toFloat(), posY.toFloat(), 0f)
+        targetRenderable.renderXYAligned(0, 0, renderableWidth, renderableHeight)
         GlStateManager.popMatrix()
     }
+
 
     @HandleEvent
     fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils
@@ -173,6 +174,7 @@ object TitleManager {
 
     @HandleEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (InventoryUtils.inInventory()) return
         val globalTitle = currentTitles[TitleLocation.GLOBAL] ?: return
         globalTitle.tryRenderGlobalTitle()
     }
@@ -186,8 +188,6 @@ object TitleManager {
         var factor = globalTitleWidth / stringWidth.toDouble()
         factor = min(factor, 1.0)
 
-        val adjustedHeight = (guiHeight / height) * 2
-
         GlStateManager.enableBlend()
         GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0)
         GlStateManager.pushMatrix()
@@ -199,8 +199,19 @@ object TitleManager {
             verticalAlign = RenderUtils.VerticalAlignment.CENTER,
         )
 
-        if (subtitleText == null) mainTextRenderable.renderXYAligned(0, 50, guiWidth, adjustedHeight.toInt())
-        else {
+        val renderableWidth = mainTextRenderable.width
+        val renderableHeight = mainTextRenderable.height
+        val posX: Int = (-guiWidth / 2) - renderableWidth
+        val posY = -guiHeight / 2
+
+        // Translate the origin to the adjustedPosition
+        val translationX = (guiWidth / 2f) - (renderableWidth / 2f)
+        val translationY = (guiHeight / 2f) - (renderableHeight * 2f)
+        GlStateManager.translate(translationX, translationY, 0f)
+
+        if (subtitleText == null) {
+            mainTextRenderable.renderXYAligned(posX, posY, guiWidth, guiHeight)
+        } else {
             val subText: String = subtitleText ?: return
             val subtitleScale = factor * fontSize * 0.75f
             val subtitleRenderable = Renderable.wrappedString(
@@ -211,7 +222,7 @@ object TitleManager {
                 verticalAlign = RenderUtils.VerticalAlignment.CENTER,
             )
             val container = Renderable.verticalContainer(listOf(mainTextRenderable, subtitleRenderable))
-            container.renderXYAligned(0, 50, guiWidth, adjustedHeight.toInt())
+            container.renderXYAligned(posX, posY, guiWidth, guiHeight)
         }
 
         GlStateManager.popMatrix()
@@ -219,6 +230,7 @@ object TitleManager {
 
     @HandleEvent
     fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+        if (!InventoryUtils.inInventory()) return
         val inventoryTitle = currentTitles[TitleLocation.INVENTORY] ?: return
         inventoryTitle.tryRenderInventoryTitle()
     }
@@ -234,7 +246,11 @@ object TitleManager {
                 Renderable.verticalContainer(
                     listOf(
                         baseStringRenderable,
-                        Renderable.string(displaySubText, 1.0),
+                        Renderable.string(
+                            displaySubText,
+                            scale = 1.0,
+                            horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
+                        ),
                     ),
                     horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
                 )
@@ -242,8 +258,8 @@ object TitleManager {
         }
 
         val heightTranslation = when (subtitleText) {
-            null -> 150f
-            else -> 200f
+            null -> 100f
+            else -> 150f
         }
 
         GlStateManager.pushMatrix()

--- a/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/TitleManager.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.enumMapOf
@@ -25,7 +24,6 @@ import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.renderer.GlStateManager
 import org.lwjgl.opengl.GL11
 import kotlin.math.min
-import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 


### PR DESCRIPTION
## What
There were issues with both the global and the inventory title render locations.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/864df2a4-5d72-4306-8c25-5bcc28e085bf)

![image](https://github.com/user-attachments/assets/a2fcf07b-85f5-44f6-95b8-d8f7bb5b8c99)

![image](https://github.com/user-attachments/assets/59fa122a-ffa5-42e0-acd2-1a33a93e04b5)


</details>

## Changelog Fixes
+ Fixed titles appearing in wrong locations. - Daveed
