### PR TITLE
Fix: Cs LobbyCode Roomid showing twice

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -192,11 +192,11 @@ object MiningApi {
 
     @HandleEvent
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {
+        if (!inColdIsland()) return
+
         dungeonRoomPattern.firstMatcher(event.full) {
             groupOrNull("roomId")?.let { mineshaftRoomId = it }
         }
-
-        if (!inColdIsland()) return
 
         val newCold = coldPattern.firstMatcher(event.added) {
             group("cold").toInt().absoluteValue

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementLobbyCode.kt
@@ -16,7 +16,7 @@ object ScoreboardElementLobbyCode : ScoreboardElement() {
             HypixelData.serverId,
             DungeonApi.roomId,
             MiningApi.mineshaftRoomId,
-        ).forEach { append(" §8$it") }
+        ).distinct().forEach { append(" §8$it") }
     }.trim()
 
     override val configLine = "§7${DateFormat.US_SLASH_MMDDYYYY} §8mega77CK"


### PR DESCRIPTION
## Changelog Fixes
+ Fixed Custom Scoreboard showing the Dungeon Room ID twice. - j10a1n15
