### PR TITLE
Fix: RenderUtils boxes again

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -191,6 +191,7 @@ object RenderUtils {
             AxisAlignedBB(x, y, z, x + 1, y + 1, z + 1).expandBlock(),
             color,
             realAlpha,
+            true,
         )
         GlStateManager.disableTexture2D()
         if (distSq > 5 * 5 && beacon) renderBeaconBeam(x, y + 1, z, color.rgb)


### PR DESCRIPTION
## What
Fixed some waypoints rendering in the wrong position.
This is why there never should have been 3 functions that have the same purpose that all had different default arguments. Not impressed


## Changelog Fixes
+ Fixed some waypoints rendering in the wrong position. - CalMWolfs
    * Waypoints for Hoppity, Diana and Clicked Dungeon Blocks.

