### PR TITLE
Improvement: Double Hook Rare Sea Creature Announcer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -94,7 +94,11 @@ object SeaCreatureFeatures {
         }
         if (config.announceRareInParty && PartyApi.isInParty()) {
             val name = event.seaCreature.name
-            HypixelCommands.partyChat("I caught ${StringUtils.optionalAn(name)} $name!")
+            val message = buildString {
+                if (event.doubleHook) append("DOUBLE HOOK: ")
+                append("I caught ${StringUtils.optionalAn(name)} $name!")
+            }
+            HypixelCommands.partyChat(message)
         }
     }
 


### PR DESCRIPTION
## What
Adds a double hook text when fishing up a rare sea creature and triggering double hook in the party chat announcer.

## Changelog Improvements
+ Added Double Hook text to Rare Sea Creature Party Announcer. - Empa