### PR TITLE
Fix: Tps

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -73,10 +73,14 @@ object TpsCounter {
                 val newTps = tpsList.average().roundTo(1).coerceIn(0.0..20.0)
                 tps = newTps
                 val legacyColor = format(newTps)
-                "$legacyColor$newTps"
+                "$legacyColor${fixTps(newTps)}"
             }
         }
         display = "§eTPS: $text"
+    }
+
+    private fun fixTps(tps: Double): Double {
+        return if (LorenzUtils.isAprilFoolsDay) tps / 2 else tps
     }
 
     private fun tpsCommand() {


### PR DESCRIPTION
## What
There was a weird bug in mats that caused the tps display to show wrong values ~1/365 of all time.

proof the new math is mathing: [hypixel.net/threads/hypixel-skyblock-patch-0-23-0-overall-changes.50804949/](https://hypixels.org/threads/hypixel-skyblock-patch-0-23-0-overall-changes.50804949/)

## Changelog Fixes
+ Fixed TPS display showing values above 10. - hannibal2
    * After the recent patch notes, the TPS is capped at 10 for performance reason reasons.