### PR TITLE
Fix: chimera values

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FixChimeraDescription.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FixChimeraDescription.kt
@@ -1,0 +1,51 @@
+package at.hannibal2.skyhanni.features.misc.items.enchants
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NumberUtil.formatIntOrNull
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object FixChimeraDescription {
+    private val patternGroup = RepoPattern.group("data.collection.api")
+
+    /**
+     * REGEX-TEST: Copies §a60% §7of your active
+     * REGEX-TEST: Copies §a80% §7of your active
+     */
+    private val percentagePattern by patternGroup.pattern(
+        "fix.chimera-description",
+        ".*Copies §a(?<percentage>.*)% §7of your active.*",
+    )
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onTooltipEvent(event: ItemHoverEvent) {
+        // We don't need to always fix this
+        if (!LorenzUtils.isAprilFoolsDay) return
+
+        for ((index, line) in event.toolTip.withIndex()) {
+            // hypixel doesn't show the 100% for chimera 5
+            if (line.contains("Copies your active pet's stats.")) {
+                event.toolTip[index] = line.replace("Copies your active pet's stats.", "Copies §a75% §7of your active pet's stats.")
+            }
+            percentagePattern.matchMatcher(line) {
+                group("percentage").formatIntOrNull()?.let { old ->
+                    val new = newChimeraValue(old)
+                    event.toolTip[index] = line.replace("$old", "$new")
+                }
+            }
+        }
+    }
+
+    private fun newChimeraValue(old: Int): Int = when (old) {
+        100 -> 75
+        80 -> 60
+        60 -> 45
+        40 -> 25
+        20 -> 10
+        else -> old
+    }
+}


### PR DESCRIPTION
## What
The Chimera's "copy stats" values have changed:
```
100% -> 75%
80% -> 60%
60% -> 45%
40% -> 25%
20% -> 10%
```

Somehow Hypixel doesn't show the updated percentages in the item lore, this seems like a shadow patch.😠 
I tested around a lot and found the new values for all five tiers of chimera!🥳
This PR makes this change visible to everyone, no more secrets!👻

Link to the official changelog: [hypixel.net/threads/hypixel-skyblock-patch-0-23-0-overall-changes.50804949/](https://hypixels.org/threads/hypixel-skyblock-patch-0-23-0-overall-changes.50804949/)

Thanks SnowflakeKiwi for bringing this to my attention!🙏

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/34a88881-6907-43b6-a9f3-319ef7e479de)
![image](https://github.com/user-attachments/assets/68f44690-364f-42f8-8238-09a4bfa80a85)
![image](https://github.com/user-attachments/assets/6c63fd92-edee-4d8e-b9ba-77c04261ad9e)

</details>

## Changelog Fixes
+ Fixed NEU Item List + Hypixel Item Description showing wrong percentages for Chimera. - hannibal2