### PR TITLE
Fix: Ironman

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementProfile.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementProfile.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboard
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
+import at.hannibal2.skyhanni.features.inventory.FixIronman
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 
 // internal and scoreboard
@@ -15,7 +16,7 @@ object ScoreboardElementProfile : ScoreboardElement() {
             append(HypixelData.profileName.firstLetterUppercase())
         } else {
             when {
-                HypixelData.ironman -> append("Ironman")
+                HypixelData.ironman -> append(FixIronman.getIronmanName())
                 HypixelData.stranded -> append("Stranded")
                 HypixelData.bingo -> append("Bingo")
                 else -> append("Normal")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FixIronman.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FixIronman.kt
@@ -1,0 +1,65 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
+import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryDetector
+import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+
+@SkyHanniModule
+object FixIronman {
+    private val selectModeInventory = InventoryDetector { name -> name == "Select a Special Mode" }
+    private val profileManagementInventory = InventoryDetector { name -> name == "Profile Management" }
+    private val visitInventory = InventoryDetector { name -> name.startsWith("Visit ") }
+    private val sbLevelingInventory = InventoryDetector { name -> name == "SkyBlock Leveling" }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onTooltipEvent(event: ItemHoverEvent) {
+        // We don't need to always fix this
+        if (!LorenzUtils.isAprilFoolsDay) return
+
+        if (!profileManagementInventory.isInside() &&
+            !selectModeInventory.isInside() &&
+            !visitInventory.isInside() &&
+            !sbLevelingInventory.isInside()
+        ) return
+
+        for ((index, line) in event.toolTip.withIndex()) {
+            if (line.contains("Ironman")) {
+                event.toolTip[index] = line.replace("Ironman", "Ironperson")
+            }
+        }
+
+        if (selectModeInventory.isInside()) {
+            for ((index, line) in event.toolTip.withIndex()) {
+                if (line.contains("No Auction House!")) {
+                    event.toolTip[index] = line.replace("No Auction House!", "Ironperson-Only Auction House!")
+                }
+            }
+        }
+    }
+
+    @HandleEvent
+    fun onChat(event: SystemMessageEvent) {
+        // We don't need to always fix this
+        if (!LorenzUtils.isAprilFoolsDay) return
+
+        if (event.message.contains("Ironman")) {
+            event.chatComponent = event.message.replace("Ironman", "Ironperson").asComponent()
+        }
+    }
+
+    fun fixScoreboard(text: String): String? {
+        return if (LorenzUtils.isAprilFoolsDay && text.contains("Ironman")) {
+            text.replace("Ironman", "Ironperson")
+        } else null
+    }
+
+    fun getIronmanName(): String {
+        return if (LorenzUtils.isAprilFoolsDay) {
+            "Ironperson"
+        } else "Ironman"
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiIngameHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiIngameHook.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.mixins.hooks
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.PurseApi
+import at.hannibal2.skyhanni.features.inventory.FixIronman
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import net.minecraft.client.gui.FontRenderer
@@ -28,7 +29,7 @@ fun tryToReplaceScoreboardLine(text: String): String? {
         ErrorManager.logErrorWithData(
             t,
             "Error while changing the scoreboard text.",
-            "text" to text
+            "text" to text,
         )
         return text
     }
@@ -51,6 +52,9 @@ private fun tryToReplaceScoreboardLineHarder(text: String): String? {
                 return season.colorCode + text
             }
         }
+    }
+    FixIronman.fixScoreboard(text)?.let {
+        return it
     }
 
     return text


### PR DESCRIPTION
## What
According to the recent patch notes, the Ironman Mode got renamed to Ironperson Mode. 👀 
This PR reflects the change in game so that users dont need to wait for an updated lobby! 🥳 

Changed the wording in chat messages from Hypixel, the scoreboard, and the inventories profile manager, visit and SkyBlock leveling.
Also mentioned the "ironperson-only ah" in the profile manager page.

Link to the official changelog: [hypixel.net/threads/hypixel-skyblock-patch-0-23-0-overall-changes.50804949/](https://hypixels.org/threads/hypixel-skyblock-patch-0-23-0-overall-changes.50804949/)

Thanks again SnowflakeKiwi for bringing this to my attention!🙏

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/988a6a79-ebb4-411e-8f78-8079dec650ac)
![image](https://github.com/user-attachments/assets/2ab44da3-209f-4d86-aded-8d322c21d2c9)
![image](https://github.com/user-attachments/assets/34a8d690-85e3-41cc-84a0-9eb019f3af40)
![image](https://github.com/user-attachments/assets/e7c9a63a-4a44-492d-b313-32d3821c1f0e)
![image](https://github.com/user-attachments/assets/31147c31-cd27-449a-9cc2-d37eb976a68c)

</details>

## Changelog Fixes
+ Fixed outdated spelling of Ironman Mode. - hannibal2