### PR TITLE
Fix: Dragon Profit tracker overwriting edit commands for other Trackers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFightAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFightAPI.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.features.misc.IslandAreas
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFightAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFightAPI.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import at.hannibal2.skyhanni.features.misc.IslandAreas
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
@@ -57,7 +58,7 @@ object DragonFightAPI {
 
     private val nestAreaPattern by group.pattern("area.nest", "Dragon's Nest")
 
-    fun inNestArea() = IslandType.THE_END.isInIsland() && nestAreaPattern.matches(LorenzUtils.skyBlockArea)
+    fun inNestArea() = IslandType.THE_END.isInIsland() && nestAreaPattern.matches(IslandAreas.currentAreaName)
 
     @HandleEvent
     fun onChat(event: SystemMessageEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
@@ -120,7 +120,7 @@ object DragonProfitTracker {
 
     @HandleEvent
     fun onItemAdd(event: ItemAddEvent) {
-        if (!config.enabled || event.source != ItemAddManager.Source.COMMAND) return
+        if (!isEnabled() || event.source != ItemAddManager.Source.COMMAND) return
         with(tracker) { event.addItemFromEvent() }
         ChatUtils.debug("Added item to tracker: ${event.internalName} (amount: ${event.amount})")
     }


### PR DESCRIPTION
## What
Fixes Dragon Profit tracker overwriting edit commands for other Trackers. (I used the wrong enabled 💀)

## Changelog Fixes
+ Fixed Dragon Profit tracker overwriting edit commands for other Trackers. - Helium9

