### PR TITLE
Improvement: Option to enable Voidgloom Tracker in Dragon's Nest and made Dragon Tracker always render everything

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
@@ -24,7 +24,7 @@ class SlayerProfitTrackerConfig {
 
     @Expose
     @ConfigOption(
-        name = "Show Voidgloom Tracker in Dragon's Nest",
+        name = "Voidgloom in Dragon's Nest",
         desc = "Show the Voidgloom Tracker in the Dragon's Nest.",
     )
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
@@ -21,4 +21,12 @@ class SlayerProfitTrackerConfig {
     @Expose
     @ConfigLink(owner = SlayerProfitTrackerConfig::class, field = "enabled")
     var pos: Position = Position(20, 20, false, true)
+
+    @Expose
+    @ConfigOption(
+        name = "Show Voidgloom Tracker in Dragon's Nest",
+        desc = "Show the Voidgloom Tracker in the Dragon's Nest.",
+    )
+    @ConfigEditorBoolean
+    var voidgloomInNest: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.data
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.SlayerQuestCompleteEvent
@@ -7,6 +8,7 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.slayer.SlayerChangeEvent
 import at.hannibal2.skyhanni.events.slayer.SlayerProgressChangeEvent
+import at.hannibal2.skyhanni.features.misc.IslandAreas
 import at.hannibal2.skyhanni.features.slayer.SlayerType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
@@ -26,6 +28,7 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object SlayerApi {
 
+    private val trackerConfig get() = SkyHanniMod.feature.slayer.itemProfitTracker
     private val nameCache = TimeLimitedCache<Pair<NeuInternalName, Int>, Pair<String, Double>>(1.minutes)
 
     var questStartTime = SimpleTimeMark.farPast()
@@ -130,7 +133,7 @@ object SlayerApi {
     }
 
     // TODO USE SH-REPO
-    fun getSlayerTypeForCurrentArea() = when (LorenzUtils.skyBlockArea) {
+    fun getSlayerTypeForCurrentArea() = when (IslandAreas.currentAreaName) {
         "Graveyard",
         "Coal Mine",
         -> SlayerType.REVENANT
@@ -145,10 +148,13 @@ object SlayerApi {
         "Howling Cave",
         -> SlayerType.SVEN
 
-        "The End",
-        "Dragon's Nest",
-        "Void Sepulture",
-        "Zealot Bruiser Hideout",
+        in listOf(
+            "The End",
+            "Void Sepulture",
+            "Zealot Bruiser Hideout"
+        ).let {
+            if (trackerConfig.voidgloomInNest) it + "Dragon's Nest" else it
+        }
         -> SlayerType.VOID
 
         "Stronghold",
@@ -162,4 +168,5 @@ object SlayerApi {
 
         else -> null
     }
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
@@ -91,7 +91,7 @@ object DragonProfitTracker {
         val eyePrice = SUMMONING_EYE.getPrice()
         val totalEyePrice = eyePrice * bucketData.eyesPlaced
         profit -= totalEyePrice
-        val eyeFormat = "§7${bucketData.eyesPlaced}x §5Summoning Eye §c-${totalEyePrice.shortFormat()}"
+        val eyeFormat = "§7${bucketData.eyesPlaced}x §5Summoning Eye §c${(totalEyePrice*-1).shortFormat()}"
         add(
             Renderable.string(eyeFormat).toSearchable("Summoning Eye"),
         )

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
@@ -84,8 +84,6 @@ object DragonProfitTracker {
         addSearchString("§b§lDragon Profit Tracker")
         tracker.addBucketSelector(this, bucketData, "Dragon Type")
 
-        if (bucketData.getTotalDragonCount() == 0L) return@buildList
-
         var profit = tracker.drawItems(bucketData, { true }, this)
 
         val eyePrice = SUMMONING_EYE.getPrice()

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
@@ -91,7 +91,7 @@ object DragonProfitTracker {
         val eyePrice = SUMMONING_EYE.getPrice()
         val totalEyePrice = eyePrice * bucketData.eyesPlaced
         profit -= totalEyePrice
-        val eyeFormat = "§7${bucketData.eyesPlaced}x §5Summoning Eye §c${(totalEyePrice*-1).shortFormat()}"
+        val eyeFormat = "§7${bucketData.eyesPlaced}x §5Summoning Eye §c${(-totalEyePrice).shortFormat()}"
         add(
             Renderable.string(eyeFormat).toSearchable("Summoning Eye"),
         )


### PR DESCRIPTION
## What
Adds an option to Disable/Enable voidgloom tracker in Dragon's Nest (disabled by default) as it could be in the way of the Dragon Profit Tracker. Also made Dragon Profit Tracker render everything even if there is nothing tracket yet.

## Changelog Improvements
+ Improved Dragon Profit Tracker to now always render everything. - Helium9
+ Added option to enable Voidgloom Tracker in Dragon's Nest. - Helium9
    * Disabled by default to avoid interference with Dragon Tracker.


