### PR TITLE
Fix: Crop Icons Round Two

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.GardenJson
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GardenToolChangeEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
@@ -72,7 +73,7 @@ object GardenApi {
                 storage?.experience = it
             }
         }
-    private val cropIconCache: MutableMap<CropType, TimeLimitedCache<String, ItemStack>> = mutableMapOf()
+    private val cropIconCache: TimeLimitedCache<String, ItemStack> = TimeLimitedCache(10.minutes)
     private val barnArea = AxisAlignedBB(35.5, 70.0, -4.5, -32.5, 100.0, -46.5)
 
     // TODO USE SH-REPO
@@ -120,6 +121,21 @@ object GardenApi {
         checkItemInHand()
     }
 
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("GardenApi")
+        if (!inGarden()) return event.addIrrelevant("Not in garden")
+        if (cropIconCache.isEmpty()) return event.addIrrelevant("cropIconCache is empty")
+
+        event.addData(
+            "cropIconCache:\n" +
+                cropIconCache.map { (key, value) ->
+                    "$key: ${value.getInternalName()}"
+                }.joinToString("\n") +
+                "\n\n"
+        )
+    }
+
     private fun updateGardenTool() {
         GardenToolChangeEvent(cropInHand, itemInHand).post()
     }
@@ -163,10 +179,7 @@ object GardenApi {
 
     fun readCounter(itemStack: ItemStack): Long? = itemStack.getHoeCounter() ?: itemStack.getCultivatingCounter()
 
-    fun CropType.getItemStackCopy(iconId: String): ItemStack {
-        val cropCache = cropIconCache.getOrPut(this) { TimeLimitedCache(10.minutes) }
-        return cropCache.getOrPut(iconId) { icon.copy() }
-    }
+    fun CropType.getItemStackCopy(iconId: String): ItemStack = cropIconCache.getOrPut(iconId) { icon.copy() }
 
     fun hideExtraGuis() = ComposterOverlay.inInventory ||
         AnitaMedalProfit.inInventory ||

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -40,12 +40,9 @@ import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getCultivatingCounter
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHoeCounter
 import at.hannibal2.skyhanni.utils.TimeLimitedCache
-import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
-import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraft.client.Minecraft
 import net.minecraft.item.ItemStack
 import net.minecraft.network.play.client.C09PacketHeldItemChange
@@ -75,8 +72,7 @@ object GardenApi {
                 storage?.experience = it
             }
         }
-    private val cropIconCache: TimeLimitedCache<CropType, ItemStack> = TimeLimitedCache(10.minutes)
-
+    private val cropIconCache: MutableMap<CropType, TimeLimitedCache<String, ItemStack>> = mutableMapOf()
     private val barnArea = AxisAlignedBB(35.5, 70.0, -4.5, -32.5, 100.0, -46.5)
 
     // TODO USE SH-REPO
@@ -167,13 +163,9 @@ object GardenApi {
 
     fun readCounter(itemStack: ItemStack): Long? = itemStack.getHoeCounter() ?: itemStack.getCultivatingCounter()
 
-    fun MutableList<Renderable>.addCropIcon(
-        crop: CropType,
-        scale: Double = NeuItems.ITEM_FONT_SIZE,
-        highlight: Boolean = false,
-    ) {
-        val cropIcon = cropIconCache.getOrPut(crop) { crop.icon.copy() }
-        addItemStack(cropIcon, highlight = highlight, scale = scale)
+    fun CropType.getItemStackCopy(iconId: String): ItemStack {
+        val cropCache = cropIconCache.getOrPut(this) { TimeLimitedCache(10.minutes) }
+        return cropCache.getOrPut(iconId) { icon.copy() }
     }
 
     fun hideExtraGuis() = ComposterOverlay.inInventory ||

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
+import at.hannibal2.skyhanni.features.garden.GardenApi.getItemStackCopy
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ApiUtils
@@ -400,7 +401,8 @@ object GardenNextJacobContest {
         }
         for (crop in nextContest.crops) {
             val isBoosted = crop == boostedCrop
-            val stack = Renderable.itemStack(crop.icon, 1.0, highlight = isBoosted)
+            val cropStack = crop.getItemStackCopy("garden_next_jacob:$crop-$isBoosted-$activeContest")
+            val stack = Renderable.itemStack(cropStack, 1.0, highlight = isBoosted)
             if (config.additionalBoostedHighlight && isBoosted) {
                 add(stack.renderBounds(config.additionalBoostedHighlightColor.toSpecialColor()))
             } else add(stack)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBestCropTime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBestCropTime.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.data.GardenCropMilestones.getCounter
 import at.hannibal2.skyhanni.data.GardenCropMilestones.isMaxed
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.GardenApi
-import at.hannibal2.skyhanni.features.garden.GardenApi.addCropIcon
 import at.hannibal2.skyhanni.features.garden.GardenNextJacobContest
 import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed.getSpeed
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -17,6 +16,7 @@ import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sorted
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import kotlin.time.Duration.Companion.milliseconds
@@ -119,7 +119,7 @@ object GardenBestCropTime {
             if (!config.next.bestCompact) {
                 addString("§7$index# ")
             }
-            addCropIcon(crop)
+            addItemStack(crop.icon)
 
             val color = if (isCurrent) "§e" else "§7"
             val contestFormat = if (GardenNextJacobContest.isNextCrop(crop)) "§n" else ""

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.events.garden.farming.CropMilestoneUpdateEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.FarmingFortuneDisplay
 import at.hannibal2.skyhanni.features.garden.GardenApi
-import at.hannibal2.skyhanni.features.garden.GardenApi.addCropIcon
 import at.hannibal2.skyhanni.features.garden.GardenApi.getCropType
 import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed.setSpeed
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -36,6 +35,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import kotlin.time.Duration.Companion.milliseconds
@@ -156,7 +156,7 @@ object GardenCropMilestoneDisplay {
         nextTier = if (useCustomGoal) customTargetLevel else nextTier
 
         lineMap[MilestoneTextEntry.MILESTONE_TIER] = Renderable.line {
-            addCropIcon(crop)
+            addItemStack(crop.icon)
             if (crop.isMaxed(overflowDisplay) && !overflowDisplay) {
                 addString("§7" + crop.cropName + " §eMAXED")
             } else {
@@ -302,7 +302,7 @@ object GardenCropMilestoneDisplay {
 
         lineMap[MushroomTextEntry.TITLE] = Renderable.string("§6Mooshroom Cow Perk")
         lineMap[MushroomTextEntry.MUSHROOM_TIER] = Renderable.line {
-            addCropIcon(mushroom)
+            addItemStack(mushroom.icon)
             addString("§7Mushroom Milestone $nextTier")
         }
 


### PR DESCRIPTION
## What
Guess it doesn't help to implement a caching system when the main thing that's doing enchanting doesn't use said caching system. Anyways the old system was cringe and bad, I replaced it with something much simpler.

(This was an extracted fix from #3703)

## Changelog Fixes
+ Fixed crop icons being incorrectly enchanted in some GUIs. - Daveed

