### PR TITLE
Backend: Replace Blossom with KSP

### DIFF
--- a/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
+++ b/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
@@ -19,6 +19,7 @@ import java.io.OutputStreamWriter
 class ModuleProcessor(
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
+    private val modVersion: String,
     private val mcVersion: String,
     private val buildPaths: String?,
 ) : SymbolProcessor {
@@ -35,6 +36,7 @@ class ModuleProcessor(
         if (!processedVersions.add(mcVersion)) {
             return emptyList()
         }
+        generateVersionConstants()
 
         skyHanniEvent =
             resolver.getClassDeclarationByName("at.hannibal2.skyhanni.api.event.SkyHanniEvent")?.asStarProjectedType()
@@ -159,5 +161,23 @@ class ModuleProcessor(
         }
 
         logger.warn("Generated LoadedModules file with ${symbols.size} modules")
+    }
+
+    private fun generateVersionConstants() {
+
+        val file = codeGenerator.createNewFile(
+            Dependencies(false),
+            "at.hannibal2.skyhanni.utils",
+            "VersionConstants",
+        )
+
+        OutputStreamWriter(file).use {
+            it.write("package at.hannibal2.skyhanni.utils\n\n")
+            it.write("object VersionConstants {\n")
+            it.write("    const val MOD_VERSION = \"$modVersion\"\n")
+            it.write("    const val MC_VERSION = \"$mcVersion\"\n")
+            it.write("}\n")
+        }
+        logger.warn("Generated VersionConstants file with mod version $modVersion and mc version $mcVersion")
     }
 }

--- a/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProvider.kt
+++ b/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProvider.kt
@@ -10,7 +10,7 @@ class ModuleProvider : SymbolProcessorProvider {
             environment.codeGenerator,
             environment.logger,
             environment.options["skyhanni.modver"] ?: "0.0.0",
-            environment.options["skyhanni.sourceset"] ?: "1.8.9",
+            environment.options["skyhanni.mcver"] ?: "1.8.9",
             environment.options["skyhanni.buildpaths"],
         )
     }

--- a/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProvider.kt
+++ b/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProvider.kt
@@ -9,6 +9,7 @@ class ModuleProvider : SymbolProcessorProvider {
         return ModuleProcessor(
             environment.codeGenerator,
             environment.logger,
+            environment.options["skyhanni.modver"] ?: "0.0.0",
             environment.options["skyhanni.sourceset"] ?: "1.8.9",
             environment.options["skyhanni.buildpaths"],
         )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -244,7 +244,7 @@ afterEvaluate {
     }
     tasks.named("kspKotlin", KspTaskJvm::class) {
         this.options.add(SubpluginOption("apoption", "skyhanni.modver=$version"))
-        this.options.add(SubpluginOption("apoption", "skyhanni.sourceset=${target.minecraftVersion.versionName}"))
+        this.options.add(SubpluginOption("apoption", "skyhanni.mcver=${target.minecraftVersion.versionName}"))
         this.options.add(SubpluginOption("apoption", "skyhanni.buildpaths=${project.file("buildpaths.txt").absolutePath}"))
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ plugins {
     `maven-publish`
     id("moe.nea.shot") version "1.0.0"
     id("io.gitlab.arturbosch.detekt")
-    id("net.kyori.blossom")
 }
 
 val target = ProjectTarget.values().find { it.projectPath == project.path }!!
@@ -244,6 +243,7 @@ afterEvaluate {
         programArgs("--mods", devenvMod.resolve().joinToString(",") { it.relativeTo(runDirectory).path })
     }
     tasks.named("kspKotlin", KspTaskJvm::class) {
+        this.options.add(SubpluginOption("apoption", "skyhanni.modver=$version"))
         this.options.add(SubpluginOption("apoption", "skyhanni.sourceset=${target.minecraftVersion.versionName}"))
         this.options.add(SubpluginOption("apoption", "skyhanni.buildpaths=${project.file("buildpaths.txt").absolutePath}"))
     }
@@ -402,11 +402,6 @@ preprocess {
     vars.put("FORGE", if (target.isForge) 1 else 0)
     vars.put("FABRIC", if (target.isFabric) 1 else 0)
     vars.put("JAVA", target.minecraftVersion.javaVersion)
-}
-
-blossom {
-    replaceToken("@MOD_VERSION@", version)
-    replaceToken("@MC_VERSION@", target.minecraftVersion.versionName)
 }
 
 val sourcesJar by tasks.creating(Jar::class) {

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -3,7 +3,6 @@ import com.replaymod.gradle.preprocess.Node
 
 plugins {
     id("com.github.SkyHanniStudios.SkyHanni-Preprocessor") version "20415a5ee3"
-    id("net.kyori.blossom") version "1.3.2" apply false
     id("gg.essential.loom") version "1.9.26" apply false
     kotlin("jvm") version "2.0.0" apply false
     kotlin("plugin.power-assert") version "2.0.0" apply false

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -3,7 +3,7 @@ import com.replaymod.gradle.preprocess.Node
 
 plugins {
     id("com.github.SkyHanniStudios.SkyHanni-Preprocessor") version "20415a5ee3"
-    id("net.kyori.blossom") version "1.3.2" apply false
+    id("net.kyori.blossom") version "1.3.1" apply false
     id("gg.essential.loom") version "1.9.26" apply false
     kotlin("jvm") version "2.0.0" apply false
     kotlin("plugin.power-assert") version "2.0.0" apply false

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -3,7 +3,7 @@ import com.replaymod.gradle.preprocess.Node
 
 plugins {
     id("com.github.SkyHanniStudios.SkyHanni-Preprocessor") version "20415a5ee3"
-    id("net.kyori.blossom") version "1.3.1" apply false
+    id("net.kyori.blossom") version "1.3.2" apply false
     id("gg.essential.loom") version "1.9.26" apply false
     kotlin("jvm") version "2.0.0" apply false
     kotlin("plugin.power-assert") version "2.0.0" apply false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,6 @@ pluginManagement {
         maven("https://repo.nea.moe/releases")
         maven("https://repo.sk1er.club/repository/maven-releases/")
         maven("https://maven.deftu.dev/releases")
-        maven("https://maven.teamresourceful.com/repository/maven-private/") // Blossom
         maven("https://jitpack.io") {
             content {
                 includeGroupByRegex("(com|io)\\.github\\..*")

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.skyhannimodule.LoadedModules
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.MinecraftConsoleFilter.Companion.initLogging
+import at.hannibal2.skyhanni.utils.VersionConstants
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.system.ModVersion
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
@@ -78,7 +79,7 @@ object SkyHanniMod {
     }
 
     const val MODID: String = "skyhanni"
-    const val VERSION: String = "@MOD_VERSION@"
+    const val VERSION: String = VersionConstants.MOD_VERSION
 
     val modVersion: ModVersion = ModVersion.fromString(VERSION)
 

--- a/src/main/java/at/hannibal2/skyhanni/tweaker/ModLoadingTweaker.java
+++ b/src/main/java/at/hannibal2/skyhanni/tweaker/ModLoadingTweaker.java
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.tweaker;
 
-
+import at.hannibal2.skyhanni.utils.VersionConstants;
 import net.minecraft.launchwrapper.ITweaker;
 import net.minecraft.launchwrapper.LaunchClassLoader;
 import net.minecraftforge.fml.relauncher.CoreModManager;
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * The mod loading tweaker makes sure that we are recognized as a Forge Mod, despite having a Tweaker.
  * We also add ourselves as a mixin container for integration with other mixin loaders.
- *
+ * <p>
  * Taken from https://github.com/NotEnoughUpdates/NotEnoughUpdates/blob/20821e63057add096e314310ea8fa8e0c411e964/src/main/java/io/github/moulberry/notenoughupdates/loader/ModLoadingTweaker.java
  */
 public class ModLoadingTweaker implements ITweaker {
@@ -29,7 +29,7 @@ public class ModLoadingTweaker implements ITweaker {
             CoreModManager.getIgnoredMods().remove(file);
             CoreModManager.getReparseableCoremods().add(file);
         } catch (URISyntaxException e) {
-            System.err.println("SkyHanni-@MOD_VERSION@ could not re-add itself as mod.");
+            System.err.println("SkyHanni-" + VersionConstants.MOD_VERSION + " could not re-add itself as mod.");
             e.printStackTrace();
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/system/PlatformUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/system/PlatformUtils.kt
@@ -5,6 +5,7 @@ import net.minecraftforge.fml.common.ModContainer
 import at.hannibal2.skyhanni.data.NotificationManager
 import at.hannibal2.skyhanni.data.SkyHanniNotification
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.VersionConstants
 import kotlin.time.Duration.Companion.INFINITE
 import net.minecraft.launchwrapper.Launch
 import net.minecraftforge.fml.common.FMLCommonHandler
@@ -22,7 +23,7 @@ import net.minecraftforge.fml.common.Loader
  */
 object PlatformUtils {
 
-    const val MC_VERSION = "@MC_VERSION@"
+    const val MC_VERSION = VersionConstants.MC_VERSION
 
     val isDevEnvironment: Boolean by lazy {
         //#if MC < 1.16
@@ -36,7 +37,7 @@ object PlatformUtils {
 
     fun shutdownMinecraft(reason: String? = null) {
         val reasonLine = reason?.let { " Reason: $it" }.orEmpty()
-        System.err.println("SkyHanni-@MOD_VERSION@ ${"forced the game to shutdown.$reasonLine"}")
+        System.err.println("SkyHanni-${VersionConstants.MOD_VERSION} ${"forced the game to shutdown.$reasonLine"}")
 
         //#if FORGE
         FMLCommonHandler.instance().handleExit(-1)

--- a/versions/1.21.4/buildpaths.txt
+++ b/versions/1.21.4/buildpaths.txt
@@ -21,6 +21,7 @@ at/hannibal2/skyhanni/TestingModFeatures.kt
 
 at/hannibal2/skyhanni/mixins/init/SkyhanniMixinPlugin.java
 at/hannibal2/skyhanni/mixins/init/BeforeForLoopInjectionPoint.java
+at/hannibal2/skyhanni/utils/VersionConstants.kt
 
 at/hannibal2/skyhanni/SkyHanniModLoader.kt
 at/hannibal2/skyhanni/data/jsonobjects/repo/AnitaUpgradeCostsJson.kt


### PR DESCRIPTION
## What
Better alternative to #3712 
Replaces blossom with just creating a file with KSP that has the version constants that we need. This means only the 1 version number needs to be changed still.
I dont see any reason to go back to blossom as this here works just as well

## Changelog Technical Details
+ Replaced Blossom with KSP. - CalMWolfs

