### PR TITLE
Improvement: Cooldown on Base Camp Hotkey

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -80,6 +80,7 @@ object TunnelsMaps {
     private var possibleLocations = mapOf<String, List<GraphNode>>()
     private val cooldowns = mutableMapOf<GraphNode, SimpleTimeMark>()
     private var active: String = ""
+    private var lastBaseCampWarp: SimpleTimeMark = SimpleTimeMark.farPast()
 
     private lateinit var fairySouls: Map<String, GraphNode>
 
@@ -488,11 +489,9 @@ object TunnelsMaps {
 
     private fun campfireKey(event: KeyPressEvent) {
         if (event.keyCode != config.campfireKey) return
-        if (config.travelScroll) {
-            HypixelCommands.warp("basecamp")
-        } else {
-            campfireOverride()
-        }
+        if (lastBaseCampWarp.passedSince() < 2.seconds) return
+        lastBaseCampWarp = SimpleTimeMark.now()
+        if (config.travelScroll) HypixelCommands.warp("basecamp") else campfireOverride()
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1293346467553087498
Makes the base camp warp key non-spammable.

## Changelog Improvements
+ Added cooldown to Base Camp warp hotkey. - Daveed

