### PR TITLE
Backend: command /shdebugrecentitemadds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils.collection
 
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import java.util.Collections
 import java.util.EnumMap
 import java.util.PriorityQueue
@@ -388,4 +389,12 @@ object CollectionUtils {
             return removedValue
         }
     }
+
+    fun <K> MutableMap<K, SimpleTimeMark>.evictOldestEntry(cap: Int) {
+        if (size > cap) {
+            val oldestKey = minByOrNull { it.value }?.key
+            oldestKey?.let { remove(it) }
+        }
+    }
+
 }


### PR DESCRIPTION
## What
Added a debug command `/shdebugrecentitemadds` to allow easily tracking the recent item add events, so that we can debug problems with item trackers more easily.
Also included that info in /shdebug for 20s atm. Time might be changed, idk yet.

```
= Debug Information for SkyHanni 2.8.0 =

search 'item':

== Recent Item Adds ==
 Brown Mushroom (x27) Went into Sacks 6m 50s ago (2025-04-05T00:14:01.102Z)
 Brown Mushroom (x15) Went into Sacks 6m 3s ago (2025-04-05T00:14:48.487Z)

== Missing Repo Items ==
 No Repo Item fails detected.
```

![image](https://github.com/user-attachments/assets/ea8d2452-5dd2-404e-bd5c-2629c1b5ef14)

could easily be expanded into a user facing /shitempickups command or something.

## Changelog Technical Details
+ Added debug command `/shdebugrecentitemadds`. - hannibal2