### PR TITLE
Backend: `ProfileJoinEvent` Fix

### DIFF
--- a/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/PrimaryFunction.kt
+++ b/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/PrimaryFunction.kt
@@ -1,0 +1,11 @@
+package at.hannibal2.skyhanni.skyhannimodule
+
+/**
+ * This is used in parameterless @HandleEvent annotations.
+ * e.g., IslandChangEvent -> onIslandChange to allow for
+ * @HandleEvent
+ * fun onIslandChange() { ... }
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PrimaryFunction(val value: String)

--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvent.kt
@@ -3,16 +3,7 @@ package at.hannibal2.skyhanni.api.event
 /**
  * Use @[HandleEvent]
  */
-abstract class SkyHanniEvent protected constructor(primaryName: String? = null) {
-
-    /**
-     * This is used in parameterless @HandleEvent annotations.
-     * e.g., IslandChangEvent -> onIslandChange to allow for
-     * @HandleEvent
-     * fun onIslandChange() { ... }
-     */
-    open val primaryFunctionName: String? = primaryName
-
+abstract class SkyHanniEvent protected constructor() {
     // TODO: This should only be accessible in the cancellable interface
     var isCancelled: Boolean = false
         private set

--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -45,26 +45,15 @@ object SkyHanniEvents {
         registerMultipleEventTypes(options, method, instance)
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private val eventPrimaryFunctionNames: Map<String, Class<SkyHanniEvent>> by lazy {
-        getEventClasses(SkyHanniEvent::class.java).mapNotNull {
-            val eventClass = it as Class<SkyHanniEvent>
-            val primaryFunctionName = it.getDeclaredMethod("primaryFunctionName").invoke(null) as String?
-                ?: return@mapNotNull null
-            primaryFunctionName to eventClass
-        }.toMap()
-    }
+    @JvmStatic
+    val eventPrimaryFunctionNames: Map<String, Class<out SkyHanniEvent>> =
+        GeneratedEventPrimaryFunctionNames.map
 
-    fun getEventClassByPrimaryNameOrNull(primaryName: String) =
-        eventPrimaryFunctionNames[primaryName]
-
-    @Suppress("UNCHECKED_CAST")
     private fun registerNoEventType(options: HandleEvent, method: Method, instance: Any) {
         val eventType = eventPrimaryFunctionNames[method.name] ?: return
         if (!SkyHanniEvent::class.java.isAssignableFrom(eventType)) return
         listeners.getOrPut(eventType) { EventListeners(eventType) }
-        registerSingleEventType(options, method, instance)
-        registerMultipleEventTypes(options, method, instance)
+            .addListener(method, instance, options)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -427,6 +427,7 @@ object HypixelData {
             wasOnHypixel && !nowOnHypixel -> {
                 if (skyBlock) {
                     skyBlock = false
+                    profileName = ""
                     SkyBlockLeaveEvent.post()
                 }
                 HypixelLeaveEvent.post()
@@ -441,10 +442,9 @@ object HypixelData {
         if (inSkyBlock) {
             checkSidebar()
             checkCurrentServerId()
-        } else {
-            if (!skyBlock) {
-                SkyBlockLeaveEvent.post()
-            }
+        } else if (!skyBlock) {
+            profileName = ""
+            SkyBlockLeaveEvent.post()
         }
 
         if (inSkyBlock == skyBlock) return

--- a/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
@@ -2,5 +2,7 @@ package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
-class IslandChangeEvent(val newIsland: IslandType, val oldIsland: IslandType) : SkyHanniEvent("onIslandChange")
+@PrimaryFunction("onIslandChange")
+class IslandChangeEvent(val newIsland: IslandType, val oldIsland: IslandType) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniTickEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniTickEvent.kt
@@ -1,8 +1,10 @@
 package at.hannibal2.skyhanni.events.minecraft
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
-class SkyHanniTickEvent(private val tick: Int) : SkyHanniEvent("onTick") {
+@PrimaryFunction("onTick")
+class SkyHanniTickEvent(private val tick: Int) : SkyHanniEvent() {
 
     fun isMod(i: Int, offset: Int = 0) = (tick + offset) % i == 0
 

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/WorldChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/WorldChangeEvent.kt
@@ -1,5 +1,7 @@
 package at.hannibal2.skyhanni.events.minecraft
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
-class WorldChangeEvent : SkyHanniEvent("onWorldChange")
+@PrimaryFunction("onWorldChange")
+class WorldChangeEvent : SkyHanniEvent()


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni/pull/3722

## What
`ProfileJoinEvent` wasn't getting fired if you left the server and came back, as we were never resetting `profileName`. In actuality this is just a follow-up fix to #3236, as this came up there first.

exclude_from_changelog
