### PR TITLE
Backend: Cache getSlayerTypeForCurrentArea

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerQuestWarning.kt
@@ -123,7 +123,7 @@ object SlayerQuestWarning {
     }
 
     private fun isSlayerMob(entity: EntityLivingBase): Boolean {
-        val slayerType = SlayerApi.getSlayerTypeForCurrentArea() ?: return false
+        val slayerType = SlayerApi.currentAreaType ?: return false
 
         // workaround for rift mob that is unrelated to slayer
         if (entity.name == "Oubliette Guard") return false


### PR DESCRIPTION
## What
getSlayerTypeForCurrentArea() is now a bit more heavy and gets called 4 times a second and on every mob health update. so now we cache it and only update two times per second in total.

## Changelog Technical Details
+ Added cache for `getSlayerTypeForCurrentArea()`. - hannibal2.