### PR TITLE
Backend: remove unused RenderUtils functions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -23,7 +23,6 @@ import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.createResourceLocation
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderXAligned
-import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderYAligned
 import at.hannibal2.skyhanni.utils.shader.ShaderManager
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Gui
@@ -517,60 +516,6 @@ object RenderUtils {
         }
         GlStateManager.popMatrix()
         if (addToGuiManager) GuiEditManager.add(this, posLabel, renderable.width, renderable.height)
-    }
-
-    /** This function is discouraged to be used. Please use renderRenderables with List<Renderable> instead with horizontal container.*/
-    private fun Position.renderRenderablesDouble(
-        renderables: List<List<Renderable>>,
-        extraSpace: Int = 0,
-        posLabel: String,
-        addToGuiManager: Boolean = true,
-    ) {
-        if (renderables.isEmpty()) return
-        var longestY = 0
-        var longestX = 0
-        GlStateManager.pushMatrix()
-        val (x, y) = transform()
-        Renderable.withMousePosition(x, y) {
-            for (line in renderables) {
-                GlStateManager.pushMatrix()
-                GlStateManager.translate(0f, longestY.toFloat(), 0F)
-                val lineY = line.maxOf { it.height }
-                var lineX = 0
-                for (element in line) {
-                    element.renderYAligned(lineX, longestY, lineY)
-                    GlStateManager.translate(element.width.toFloat(), 0f, 0f)
-                    lineX += element.width
-                }
-                longestY += lineY + extraSpace + 2
-                longestX = max(longestX, lineX)
-                GlStateManager.popMatrix()
-            }
-        }
-        GlStateManager.popMatrix()
-        if (addToGuiManager) GuiEditManager.add(this, posLabel, longestX, longestY)
-    }
-
-    /**
-     * Accepts a list of lines to print.
-     * Each line is a list of things to print. Can print String or ItemStack objects.
-     */
-    @Deprecated("use List<List<Renderable>>", ReplaceWith("this.renderRenderablesDouble(list,extraSpace,posLabel)"))
-    fun Position.renderStringsAndItems(
-        list: List<List<Any?>>,
-        extraSpace: Int = 0,
-        itemScale: Double = NeuItems.ITEM_FONT_SIZE,
-        posLabel: String,
-    ) {
-        if (list.isEmpty()) return
-
-        val render = list.map { listEntry ->
-            listEntry.map {
-                Renderable.fromAny(it, itemScale = itemScale) ?: throw RuntimeException("Unknown render object: $it")
-            }
-        }
-
-        this.renderRenderablesDouble(render, extraSpace, posLabel, true)
     }
 
     // totally not modified Autumn Client's TargetStrafe


### PR DESCRIPTION
## What
Follow up of #3607, remove these 2 unneeded functions
excluding as this shouldve been done in that pr and matches those notes

exclude_from_changelog

