### PR TITLE
Feature: Dungeon Low Health Alert

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.kt
@@ -165,6 +165,11 @@ class DungeonConfig {
     var terminalWaypoints: Boolean = true
 
     @Expose
+    @ConfigOption(name = "Low Health Alert", desc = "")
+    @Accordion
+    var lowHealthAlert: LowHealthAlertConfig = LowHealthAlertConfig()
+
+    @Expose
     @ConfigOption(name = "Dungeon Races Guide", desc = "")
     @Accordion
     var dungeonsRaceGuide: DungeonsRaceGuideConfig = DungeonsRaceGuideConfig()

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/LowHealthAlertConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/LowHealthAlertConfig.kt
@@ -21,5 +21,5 @@ class LowHealthAlertConfig {
     @Expose
     @ConfigOption(name = "Sound Settings", desc = "")
     @Accordion
-    var lowHealthAlertSoundConfig: LowHealthAlertSoundConfig = LowHealthAlertSoundConfig()
+    var lowHealthAlertSound: LowHealthAlertSoundConfig = LowHealthAlertSoundConfig()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/LowHealthAlertConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/LowHealthAlertConfig.kt
@@ -1,0 +1,25 @@
+package at.hannibal2.skyhanni.config.features.dungeon
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class LowHealthAlertConfig {
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Shows a title and plays a sound when a teammate's health is low.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enabled: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Only while being Healer", desc = "Only show the alert if you're playing a healer.")
+    @ConfigEditorBoolean
+    var onlyWhileHealer: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Sound Settings", desc = "")
+    @Accordion
+    var lowHealthAlertSoundConfig: LowHealthAlertSoundConfig = LowHealthAlertSoundConfig()
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/LowHealthAlertSoundConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/LowHealthAlertSoundConfig.kt
@@ -1,0 +1,34 @@
+package at.hannibal2.skyhanni.config.features.dungeon
+
+import at.hannibal2.skyhanni.features.dungeon.LowHealthAlert
+import at.hannibal2.skyhanni.utils.OSUtils
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class LowHealthAlertSoundConfig {
+    @Expose
+    @ConfigOption(name = "Alert Sound", desc = "The sound that plays for the alert.")
+    @ConfigEditorText
+    var alertSound: String = "random.anvil_land"
+
+    @Expose
+    @ConfigOption(name = "Pitch", desc = "The pitch of the alert sound.")
+    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.0f, minStep = 0.1f)
+    var pitch: Float = 1.0f
+
+    @ConfigOption(name = "Test Sound", desc = "Test current sound settings.")
+    @ConfigEditorButton(buttonText = "Test")
+    var testSound: Runnable = Runnable(LowHealthAlert::playTestSound)
+
+    @Expose
+    @ConfigOption(name = "Repeat Sound", desc = "How many times the sound should be repeated.")
+    @ConfigEditorSlider(minValue = 1f, maxValue = 20f, minStep = 1f)
+    var repeatSound: Int = 5
+
+    @ConfigOption(name = "Sounds", desc = "Click to open the list of available sounds.")
+    @ConfigEditorButton(buttonText = "OPEN")
+    var sounds: Runnable = Runnable(OSUtils::openSoundsListInBrowser)
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -67,6 +67,7 @@ object DungeonApi {
         private set
     var roomId: String? = null
         private set
+    val active get() = started && !completed
 
     val bossStorage: MutableMap<DungeonFloor, Int>? get() = ProfileStorageData.profileSpecific?.dungeons?.bosses
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
@@ -1,0 +1,53 @@
+package at.hannibal2.skyhanni.features.dungeon
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.TitleManager
+import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
+import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.SoundUtils.playSound
+import kotlin.time.Duration.Companion.seconds
+
+@SkyHanniModule
+object LowHealthAlert {
+
+    private val config get() = SkyHanniMod.feature.dungeon.lowHealthAlert
+    private val soundConfig get() = config.lowHealthAlertSoundConfig
+    private var lastAlert = SimpleTimeMark.farPast()
+
+    @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
+    fun onScoreboardChange(event: ScoreboardUpdateEvent) {
+        for (line in event.added.map { it }) {
+            ScoreboardPattern.teammatesPattern.matchMatcher(line) {
+                val username = group("username")
+                val color = group("color")
+                val health = group("health")
+                if (color == "c" && health != null && health != "DEAD") {
+                    val isHealer = DungeonApi.playerClass == DungeonApi.DungeonClass.HEALER
+                    val shouldAlert = isEnabled() && (!config.onlyWhileHealer || isHealer) && lastAlert.passedSince() > 1.5.seconds
+
+                    if (shouldAlert) {
+                        lastAlert = SimpleTimeMark.now()
+                        val alertSound = SoundUtils.createSound(soundConfig.alertSound, soundConfig.pitch)
+                        SoundUtils.repeatSound(100, soundConfig.repeatSound, alertSound)
+                        TitleManager.sendTitle("§c$username §ais low", "§c${health}❤", 2.seconds)
+                    }
+                }
+            }
+        }
+    }
+
+    @JvmStatic
+    fun playTestSound() {
+        with(soundConfig) {
+            SoundUtils.createSound(alertSound, pitch).playSound()
+        }
+    }
+
+    private fun isEnabled() = config.enabled
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
@@ -7,8 +7,7 @@ import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.RegexUtils.matchAll
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import kotlin.time.Duration.Companion.seconds
@@ -17,27 +16,23 @@ import kotlin.time.Duration.Companion.seconds
 object LowHealthAlert {
 
     private val config get() = SkyHanniMod.feature.dungeon.lowHealthAlert
-    private val soundConfig get() = config.lowHealthAlertSoundConfig
-    private var lastAlert = SimpleTimeMark.farPast()
+    private val soundConfig get() = config.lowHealthAlertSound
+    private var lastAlert: TitleManager.TitleContext? = null
 
     @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {
-        for (line in event.added) {
-            ScoreboardPattern.teammatesPattern.matchMatcher(line) {
-                val username = group("username")
-                val color = group("color")
-                val health = group("health")
-                if (color == "c" && health != null && health != "DEAD") {
-                    val isHealer = DungeonApi.playerClass == DungeonApi.DungeonClass.HEALER
-                    val shouldAlert = isEnabled() && (!config.onlyWhileHealer || isHealer) && lastAlert.passedSince() > 1.5.seconds
+        if (!isEnabled()) return
+        ScoreboardPattern.teammatesPattern.matchAll(event.added) {
+            val username = group("username")
+            val color = group("color")
+            val health = group("health")
+            if (color != "c" || health == "DEAD") return
 
-                    if (shouldAlert) {
-                        lastAlert = SimpleTimeMark.now()
-                        val alertSound = SoundUtils.createSound(soundConfig.alertSound, soundConfig.pitch)
-                        SoundUtils.repeatSound(100, soundConfig.repeatSound, alertSound)
-                        TitleManager.sendTitle("§c$username §ais low", "§c$health❤", 2.seconds)
-                    }
-                }
+            val alertSound = SoundUtils.createSound(soundConfig.alertSound, soundConfig.pitch)
+            SoundUtils.repeatSound(100, soundConfig.repeatSound, alertSound)
+            lastAlert?.stop()
+            TitleManager.sendTitle("§c$username §ais low", "§c$health❤", 1.seconds)?.let {
+                lastAlert = it
             }
         }
     }
@@ -49,5 +44,6 @@ object LowHealthAlert {
         }
     }
 
-    private fun isEnabled() = config.enabled
+    private fun isEnabled() =
+        config.enabled && DungeonApi.active && (!config.onlyWhileHealer || DungeonApi.playerClass == DungeonApi.DungeonClass.HEALER)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
@@ -22,7 +22,7 @@ object LowHealthAlert {
 
     @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {
-        for (line in event.added.map { it }) {
+        for (line in event.added) {
             ScoreboardPattern.teammatesPattern.matchMatcher(line) {
                 val username = group("username")
                 val color = group("color")
@@ -35,7 +35,7 @@ object LowHealthAlert {
                         lastAlert = SimpleTimeMark.now()
                         val alertSound = SoundUtils.createSound(soundConfig.alertSound, soundConfig.pitch)
                         SoundUtils.repeatSound(100, soundConfig.repeatSound, alertSound)
-                        TitleManager.sendTitle("§c$username §ais low", "§c${health}❤", 2.seconds)
+                        TitleManager.sendTitle("§c$username §ais low", "§c$health❤", 2.seconds)
                     }
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -200,7 +200,7 @@ object ScoreboardPattern {
     @Suppress("MaxLineLength")
     val teammatesPattern by dungeonSB.pattern(
         "teammates",
-        "(?:§.)*(?<classAbbv>\\[\\w]) (?:§.)*(?<username>\\w{2,16}) (?:(?:§.)*(?<classLevel>\\[Lvl?(?<level>[\\w,.]+)?]?)|(?:§.)*(?<health>[\\w,.]+)(?:§.)*.?)",
+        "(?:§.)*(?<classAbbv>\\[\\w]) (?:§.)*(?<username>\\w{2,16}) (?:(?:§.)*(?<classLevel>\\[Lvl?(?<level>[\\w,.]+)?]?)|(?:§(?<color>.))*(?<health>[\\w,.]+)(?:§.)*.?)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -197,6 +197,10 @@ object ScoreboardPattern {
         "§3§lSolo",
     )
 
+    /**
+     * REGEX-TEST: §a[H] §6Eisengolem §7[Lv48]
+     * REGEX-TEST: §e[M] §b04032006 §a7,361§c❤
+     */
     @Suppress("MaxLineLength")
     val teammatesPattern by dungeonSB.pattern(
         "teammates",


### PR DESCRIPTION
## What
Shows a title and plays a sound when a mate has low health in dungeons (Maybe some healer finally learn how to press their drop key)

Maybe this could get a detection if the ult is ready at a later point but eh. 

Surely this code is fine and doesnt have any detekt issues 
![grafik](https://github.com/user-attachments/assets/a52820ad-ec5e-4987-ae3f-3bfde7f1eb4e)


## Changelog New Features
+ Added Dungeon Low Health Alert. - jani
    * Shows a title and plays a sound when a teammate's health is low.

