### PR TITLE
Backend: rename OwnInventoryItemUpdateEvent to ItemCollectEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.data
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
-import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.ItemCollectEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.ItemAddInInventoryEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
@@ -55,7 +55,7 @@ object OwnInventoryData {
                 val slot = packet.func_149173_d()
                 val item = packet.func_149174_e() ?: return
                 DelayedRun.runNextTick {
-                    OwnInventoryItemUpdateEvent(item, slot).post()
+                    ItemCollectEvent(item, slot).post()
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/QuiverApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/QuiverApi.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.data
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ArrowTypeJson
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
-import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.ItemCollectEvent
 import at.hannibal2.skyhanni.events.QuiverUpdateEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -231,7 +231,7 @@ object QuiverApi {
     }
 
     @HandleEvent
-    fun onInventoryUpdate(event: OwnInventoryItemUpdateEvent) {
+    fun onInventoryUpdate(event: ItemCollectEvent) {
         if (!isEnabled() && event.slot != 44) return
         val stack = event.itemStack
         if (stack.getExtraAttributes()?.hasKey("quiver_arrow") == true) {

--- a/src/main/java/at/hannibal2/skyhanni/events/ItemCollectEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/ItemCollectEvent.kt
@@ -3,4 +3,4 @@ package at.hannibal2.skyhanni.events
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import net.minecraft.item.ItemStack
 
-data class OwnInventoryItemUpdateEvent(val itemStack: ItemStack, val slot: Int) : SkyHanniEvent()
+data class ItemCollectEvent(val itemStack: ItemStack, val slot: Int) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/endernodetracker/EnderNodeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/endernodetracker/EnderNodeTracker.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
-import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.ItemCollectEvent
 import at.hannibal2.skyhanni.events.SackChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -158,7 +158,7 @@ object EnderNodeTracker {
     }
 
     @HandleEvent
-    fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
+    fun onItemCollect(event: ItemCollectEvent) {
         if (!isEnabled()) return
         if (!ProfileStorageData.loaded) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.ItemCollectEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.garden.farming.CropMilestoneUpdateEvent
 import at.hannibal2.skyhanni.features.garden.CropType
@@ -110,7 +110,7 @@ object GardenCropMilestoneDisplay {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
+    fun onItemCollect(event: ItemCollectEvent) {
 
         try {
             val item = event.itemStack

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.data.SackApi.getAmountInSacksOrNull
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.ItemCollectEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SackDataUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -349,7 +349,7 @@ object GardenVisitorFeatures {
     }
 
     @HandleEvent
-    fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
+    fun onItemCollect(event: ItemCollectEvent) {
         if (GardenApi.onBarnPlot) {
             update()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
-import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.ItemCollectEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -65,7 +65,7 @@ object CrownOfAvariceCounter {
     }
 
     @HandleEvent
-    fun onInventoryUpdated(event: OwnInventoryItemUpdateEvent) {
+    fun onInventoryUpdated(event: ItemCollectEvent) {
         if (!isEnabled() || event.slot != 5) return
         val item = event.itemStack
         if (item.getInternalNameOrNull() != internalName) return

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.mining.nucleus.CrystalNucleusTrackerConfig
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.IslandChangeEvent
-import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.ItemCollectEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.mining.CrystalNucleusLootEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -61,7 +61,7 @@ object CrystalNucleusApi {
     ).map { it.toInternalName() }
 
     @HandleEvent
-    fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
+    fun onItemCollect(event: ItemCollectEvent) {
         if (unCheckedBooks == 0) return
         if (event.itemStack.displayName != "§fEnchanted Book") return
         when (event.itemStack.getHypixelEnchantments()?.keys?.firstOrNull() ?: return) {


### PR DESCRIPTION
## What
The event only gets triggered if the packet gets sent from the server, so the event doesn't trigger if the player moved an item around in their own inventory.

## Changelog Technical Details
+ Renamed OwnInventoryItemUpdateEvent to ItemCollectEvent. - rueblimaster

