### PR TITLE
Fix: Lane Switch Title Weights

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -142,6 +142,7 @@ object FarmingLaneFeatures {
                 null -> TitleManager.sendTitle(
                     text.replace("&", "§"),
                     duration = secondsBefore.seconds,
+                    weight = 1.1,
                 )
                 else -> titleContext.takeIf { it?.ended == false }
             }


### PR DESCRIPTION
## What
Similarly to #3741 - this sets the weight of lane switch titles to be higher than normal so they take priority in the queue.

## Changelog Fixes
+ Fixed lane switch titles sometimes being hidden by other messages. - Daveed

