### PR TITLE
Backend + Fix: Crash on wrong config link

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/Position.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/Position.kt
@@ -218,6 +218,7 @@ class Position @JvmOverloads constructor(
                 "owner" to configLink.owner,
                 "field" to configLink.field,
             )
+            ErrorManager.crashInDevEnv("Couldn't set config links") { e }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestsConfig.java
@@ -61,7 +61,7 @@ public class PestsConfig {
     public boolean pestChanceDisplay = false;
 
     @Expose
-    @ConfigLink(owner = GardenConfig.class, field = "pestChanceDisplay")
+    @ConfigLink(owner = PestsConfig.class, field = "pestChanceDisplay")
     public Position pestChanceDisplayPosition = new Position(5, -115, false, true);
 }
 


### PR DESCRIPTION
## What
Crash build in dev env if configLink is not set, sadly this does not cause github build to fail as the game doesnt launch in github but id expect most features would require at least 1 launch to test and that should show this error.
I also fixed the config link that wasnt properly set.

## Changelog Fixes
+ Fixed not being able to navigate to the Pest Chance Display config from the Position Editor. - CalMWolfs

## Changelog Technical Details
+ Crashes build in dev env if configLink is not set. - CalMWolfs

