### PR TITLE
Backend: toString TimeLimitedSet

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedSet.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeLimitedSet.kt
@@ -68,4 +68,6 @@ class TimeLimitedSet<T : Any>(
         }
         return value
     }
+
+    override fun toString(): String = cache.keys.toString()
 }


### PR DESCRIPTION
## What
Added `toString` function to `TimeLimitedSet`.

Let's assume
`private var recentBabyMagmaSlugs = TimeLimitedSet<Mob>(2.seconds)`
This changes the output of
`add("recentBabyMagmaSlugs: $recentBabyMagmaSlugs")`
from
`recentBabyMagmaSlugs: at.hannibal2.skyhanni.utils.TimeLimitedSet@6e0e81d3`
to 
`recentBabyMagmaSlugs: []`

Reported: https://discord.com/channels/997079228510117908/1359808934957023272

## Changelog Technical Details
+ Added `toString` function to `TimeLimitedSet`. - hannibal2