### PR TITLE
Fix: Item NBT Data not saving in config (/ff or wardrobe)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
@@ -163,9 +163,9 @@ object EnoughUpdatesManager {
         json.addProperty("itemid", stack.item.getIdentifierString())
         json.addProperty("displayname", stack.displayName)
         //#if MC < 1.21
-        //$$ // todo nbt tag doesnt exist on modern
-        //$$ json.addProperty("nbttag", tag.toString())
-        //$$ json.addProperty("damage", stack.itemDamage)
+        // todo nbt tag doesnt exist on modern
+        json.addProperty("nbttag", tag.toString())
+        json.addProperty("damage", stack.itemDamage)
         //#endif
 
         val jsonLore = JsonArray()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CaptureFarmingGear.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -151,6 +152,18 @@ object CaptureFarmingGear {
 
         strengthPattern.firstMatcher(TabListData.getTabList()) {
             GardenApi.storage?.fortune?.farmingStrength = group("strength").toInt()
+        }
+    }
+
+    fun removeInvalidItems() {
+        val storage = GardenApi.storage?.fortune ?: return
+
+        for ((itemType, stack) in storage.farmingItems.toMap()) {
+            if (stack.getInternalNameOrNull() == null) {
+                storage.farmingItems.remove(itemType)
+                storage.outdatedItems[itemType] = true
+                ChatUtils.debug("removed invalid farming item: $itemType (${stack.displayName})")
+            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FFGuideGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FFGuideGui.kt
@@ -35,6 +35,7 @@ class FFGuideGui : GuideGui<FFGuideGui.FortuneGuidePage>(FortuneGuidePage.OVERVI
 
         fun open() {
             CaptureFarmingGear.captureFarmingGear()
+            CaptureFarmingGear.removeInvalidItems()
             SkyHanniMod.screenToOpen = FFGuideGui()
         }
 


### PR DESCRIPTION
## What
Item NBT data is not properly getting saved in the config.
This caused features that save ItemStacks in the config to break (e.g. ff or wardrobe)
This PR fixed the issue.

## Changelog Fixes
+ Fixed saving of item data in /ff and Wardrobe. - nopo
    * Takes effect after the second startup, once the data has been reloaded.