### PR TITLE
Fix: Disable Fix Ghost Entities in Kuudra

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
+import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.MobUtils.isDefaultValue
 import at.hannibal2.skyhanni.utils.compat.getAllEquipment
@@ -33,6 +34,9 @@ object FixGhostEntities {
     @HandleEvent(onlyOnSkyblock = true)
     fun onReceiveCurrentShield(event: PacketReceivedEvent) {
         if (!isEnabled()) return
+        // Disable in Kuudra for now - causes players to randomly disappear in supply phase
+        // TODO: Remove once fixed
+        if (KuudraApi.inKuudra()) return
 
         val packet = event.packet
 


### PR DESCRIPTION
## What
Workaround to stop players from randomly disappearing in Kuudra due to a bug in the Fix Ghost Entities feature, since this has been brought up a while ago but I have no idea how to actually fix it.

## Changelog Fixes
+ Fixed players randomly disappearing in Kuudra. - Luna
