### PR TITLE
Fix: Accept Last Invite making parties completely un-joinable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/AcceptLastPartyInvite.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/AcceptLastPartyInvite.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.RegexUtils.findMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -46,10 +47,12 @@ object AcceptLastPartyInvite {
         if (!config.acceptLastInvite) return
         inviteReceivedPattern.findMatcher(event.message) {
             lastInviter = group("player")
+            ChatUtils.debug("Party invite received from $lastInviter")
             return
         }
-        inviteExpiredPattern.findMatcher(event.message) {
+        inviteExpiredPattern.matchMatcher(event.message) {
             if (lastInviter == group("player")) {
+                ChatUtils.debug("Party invite from $lastInviter expired")
                 lastInviter = ""
                 return
             }
@@ -61,7 +64,7 @@ object AcceptLastPartyInvite {
         if (!config.acceptLastInvite) return
         if (event.senderIsSkyhanni()) return
         val message = event.message.lowercase()
-        if (!message.startsWith("/party accept") && !message.startsWith("/p accept")) return
+        if (message != "/party accept" && message != "/p accept") return
 
         event.cancel()
         if (lastInviter == "") {


### PR DESCRIPTION
## What
Prevents "Accept Last Invite" feature from interfering with the `/p accept` command when there IS a player specified.
Also adds debug for receiving/expiring party invites (from my testing, the regex seems to work fine at the moment).

## Changelog Fixes
+ Fixed the Accept Last Party Invite feature that completely prevented joining parties. - MTOnline