### PR TITLE
Improvement: Keep trophy fish symbol in custom catch messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
@@ -72,7 +72,7 @@ object TrophyFishMessages {
 
         if (config.enabled) {
             edited = (
-                "§6§lTROPHY FISH! " + when (config.design) {
+                "§6♔ §6§lTROPHY FISH! " + when (config.design) {
                     DesignFormat.STYLE_1 -> if (amount == 1) "§c§lFIRST §r$displayRarity $displayName"
                     else "§7$amount${amount.ordinal()} §r$displayRarity $displayName"
 


### PR DESCRIPTION
## What
Added the trophy fish symbol (which was added by Hypixel in the Backwater Bayou update) to our custom trophy fish catch messages so that they look nicer, especially among treasure catch messages.

## Changelog Improvements
+ Updated custom Trophy Fish catch messages (with Trophy Counter enabled) to retain Hypixel's trophy fish symbol. - Luna