### PR TITLE
Fix: NPE in SlotClickEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -87,7 +87,7 @@ object JacobFarmingContestsInventory {
         if (!config.openOnElite.isKeyHeld()) return
 
         val slot = event.slot ?: return
-        val itemName = slot.stack.displayName
+        val itemName = slot.stack?.displayName ?: return
 
         when (val chestName = InventoryUtils.openInventoryName()) {
             "Your Contests" -> {


### PR DESCRIPTION
## What
Fixed an NPE in GuiContainerEvent.SlotClickEvent in JacobFarmingContestsInventory.

```
SkyHanni 2.0.1: Caught a NullPointerException in at.hannibal2.skyhanni.features.garden.contest.JacobFarmingContestsInventory.onSlotClick(at.hannibal2.skyhanni.events.GuiContainerEvent$SlotClickEvent) at GuiContainerEvent.SlotClickEvent: getStack(...) must not be null
 
Caused by java.lang.NullPointerException: getStack(...) must not be null
    at SH.features.garden.contest.JacobFarmingContestsInventory.onSlotClick(JacobFarmingContestsInventory.kt:90)
    at SH.api.event.EventListeners$$Lambda$1867/1287967155.accept(Unknown Source)
    at SH.mixins.hooks.GuiContainerHook.onMouseClick(GuiContainerHook.kt:72)
    at MC.client.gui.inventory.GuiContainer.handler$bnk001$onMouseClick(GuiContainer.java:5820)
    at MC.client.gui.inventory.GuiContainer.func_146984_a(GuiContainer.java:629)
    at MC.client.gui.inventory.GuiContainer.func_73864_a(GuiContainer.java:388)
    at MC.client.gui.GuiScreen.func_146274_d(GuiScreen.java:555)
    at MC.client.gui.GuiScreen.func_146269_k(GuiScreen.java:524)
    at MC.client.Minecraft.func_71407_l(Minecraft.java:1674)
    at MC.client.Minecraft.func_71411_J(Minecraft.java:1024)
    at MC.client.Minecraft.func_99999_d(Minecraft.java:349)
    at MC.client.main.Main.main(SourceFile:124)
```


Reported: https://discord.com/channels/997079228510117908/1000669238035497022/1360255255182577826

## Changelog Fixes
+ Fixed error message when clicking in Jacob Contest overview menu. - hannibal2