### PR TITLE
Fix: cs number tracking not using the config, crash when parsing Long

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardNumberTrackingElement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardNumberTrackingElement.kt
@@ -13,6 +13,7 @@ interface CustomScoreboardNumberTrackingElement {
     var currentJob: Job?
 
     fun checkDifference(currentAmount: Long) {
+        if (!SkyHanniMod.feature.gui.customScoreboard.display.showNumberDifference) return
         if (currentAmount != previousAmount) {
             val changeAmount = currentAmount - previousAmount
             showTemporaryChange(changeAmount)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementCopper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementCopper.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils.getCopper
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
 import at.hannibal2.skyhanni.utils.LorenzUtils.inAnyIsland
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import kotlinx.coroutines.Job
 
 // scoreboard
@@ -20,7 +21,7 @@ object ScoreboardElementCopper : ScoreboardElement(), CustomScoreboardNumberTrac
 
     override fun getDisplay(): String? {
         val copper = getCopper()
-        checkDifference(copper.toLong())
+        checkDifference(copper.formatLong())
         val line = formatStringNum(copper) + temporaryChangeDisplay.orEmpty()
         if (informationFilteringConfig.hideEmptyLines && line == "0") return null
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementMotes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementMotes.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils.getMotes
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
 import at.hannibal2.skyhanni.features.rift.RiftApi
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import kotlinx.coroutines.Job
 
 // scoreboard
@@ -19,7 +20,7 @@ object ScoreboardElementMotes : ScoreboardElement(), CustomScoreboardNumberTrack
 
     override fun getDisplay(): String? {
         val motes = getMotes()
-        checkDifference(motes.toLong())
+        checkDifference(motes.formatLong())
         val line = formatStringNum(motes) + temporaryChangeDisplay.orEmpty()
         if (informationFilteringConfig.hideEmptyLines && line == "0") return null
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementSoulflow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementSoulflow.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils.formatStringNum
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils.getSoulflow
 import at.hannibal2.skyhanni.features.rift.RiftApi
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import kotlinx.coroutines.Job
 
 // widget
@@ -18,7 +19,7 @@ object ScoreboardElementSoulflow : ScoreboardElement(), CustomScoreboardNumberTr
 
     override fun getDisplay(): String? {
         val soulflow = getSoulflow()
-        checkDifference(soulflow.toLong())
+        checkDifference(soulflow.formatLong())
         val line = formatStringNum(soulflow) + temporaryChangeDisplay.orEmpty()
 
         if (informationFilteringConfig.hideEmptyLines && line == "0") return null

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
@@ -180,6 +180,11 @@ object WardrobeApi {
     fun onDebug(event: DebugDataCollectEvent) {
         event.title("Wardrobe")
         event.addIrrelevant {
+            if (slots.isEmpty()) {
+                add("No slots")
+                return@addIrrelevant
+            }
+
             for (slot in slots) {
                 val slotInfo = buildString {
                     append("Slot ${slot.id}")


### PR DESCRIPTION
## What
happens + error when parsing a string to long bc it didnt use our cool method + shdebug issue when no wardrobe slots are stored

exclude_from_changelog