### PR TITLE
Fix: Dungeon Starred Fel always highlight

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
@@ -69,7 +69,7 @@ object DungeonMobManager {
         val mob = event.entity.mob ?: return
         if (felOnTheGround.remove(mob)) {
             felMoving.add(mob)
-            if (starredConfig.highlight.get()) {
+            if (mob.hasStar && starredConfig.highlight.get()) {
                 mob.highlight(getStarColor())
             }
         }


### PR DESCRIPTION
## What
Reported: https://discord.com/channels/997079228510117908/1360348688987328689

## Changelog Fixes
+ Fixed Highlight Starred Dungeon Mobs always highlighting Fels. - hannibal2