### PR TITLE
Fix: Remove redundant space in ultra-rare discovery message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
@@ -62,7 +62,7 @@ object ExperimentsDryStreakDisplay {
                 ChatUtils.chat(
                     "§a§lDRY-STREAK ENDED! §eYou have (finally) " +
                         "found a §5ULTRA-RARE §eafter §3${storage.xpSince.shortFormat()} Enchanting Exp " +
-                        "§e and §2${storage.attemptsSince} attempts§e!",
+                        "§eand §2${storage.attemptsSince} attempts§e!",
                 )
                 storage.attemptsSince = 0
                 storage.xpSince = 0


### PR DESCRIPTION
## What
Removed a redundant space in the ultra-rare discovery chat message to improve formatting.

## Changelog Fixes
+ Fixed spacing in ultra-rare discovery message. - kwissss

