### PR TITLE
Improvement: Enable all trackers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/SeaCreatureTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/SeaCreatureTrackerConfig.kt
@@ -24,11 +24,11 @@ class SeaCreatureTrackerConfig {
     @ConfigEditorBoolean
     var showPercentage: Property<Boolean> = Property.of(false)
 
+    // TODO move into sea creature category as this is now independent of the tracker
     @Expose
     @ConfigOption(name = "Hide Chat", desc = "Hide the chat messages when catching a sea creature.")
     @ConfigEditorBoolean
     @FeatureToggle
-    // TODO move into sea creature category as this is now independent of the tracker
     var hideChat: Boolean = false
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/SeaCreatureTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/SeaCreatureTrackerConfig.kt
@@ -27,6 +27,8 @@ class SeaCreatureTrackerConfig {
     @Expose
     @ConfigOption(name = "Hide Chat", desc = "Hide the chat messages when catching a sea creature.")
     @ConfigEditorBoolean
+    @FeatureToggle
+    // TODO move into sea creature category as this is now independent of the tracker
     var hideChat: Boolean = false
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/DicerRngDropTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/DicerRngDropTrackerConfig.java
@@ -13,6 +13,7 @@ public class DicerRngDropTrackerConfig {
     @ConfigOption(name = "Enable Tracker", desc = "Track RNG drops for Melon Dicer and Pumpkin Dicer.")
     @ConfigEditorBoolean
     @FeatureToggle
+    // TODO rename to display for consistency with other trackers
     public boolean display = true;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -118,13 +117,13 @@ object DragonProfitTracker {
 
     @HandleEvent
     fun onItemAdd(event: ItemAddEvent) {
-        if (!isEnabled() || event.source != ItemAddManager.Source.COMMAND) return
+        if (!DragonFightAPI.inNestArea() || event.source != ItemAddManager.Source.COMMAND) return
         with(tracker) { event.addItemFromEvent() }
         ChatUtils.debug("Added item to tracker: ${event.internalName} (amount: ${event.amount})")
     }
 
     init {
-        tracker.initRenderer({ config.position }) { isEnabled() }
+        tracker.initRenderer({ config.position }) { config.enabled && DragonFightAPI.inNestArea() }
     }
 
     fun addEyes(amount: Int) {
@@ -175,9 +174,6 @@ object DragonProfitTracker {
 
         ChatUtils.hoverableChat(totalMessage, hover)
     }
-
-    fun isEnabled() =
-        LorenzUtils.inSkyBlock && config.enabled && DragonFightAPI.inNestArea()
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/endernodetracker/EnderNodeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/endernodetracker/EnderNodeTracker.kt
@@ -178,7 +178,7 @@ object EnderNodeTracker {
     }
 
     init {
-        tracker.initRenderer({ config.position }) { isEnabled() }
+        tracker.initRenderer({ config.position }) { config.enabled && isEnabled() }
     }
 
     @HandleEvent
@@ -215,7 +215,7 @@ object EnderNodeTracker {
         return newProfit
     }
 
-    private fun isEnabled() = IslandType.THE_END.isInIsland() && config.enabled && (!config.onlyPickaxe || hasItemInHand())
+    private fun isEnabled() = IslandType.THE_END.isInIsland() && (!config.onlyPickaxe || hasItemInHand())
 
     private fun hasItemInHand() = ItemCategory.miningTools.containsItem(InventoryUtils.getItemInHand())
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
@@ -180,7 +180,7 @@ object GhostTracker {
 
     @HandleEvent
     fun onSkillExp(event: SkillExpGainEvent) {
-        if (!isEnabled()) return
+        if (!inArea) return
         if (event.gained > 10_000) return
         tracker.modify {
             it.combatXpGained += event.gained.toLong()
@@ -212,14 +212,14 @@ object GhostTracker {
 
     @HandleEvent
     fun onItemAdd(event: ItemAddEvent) {
-        if (!isEnabled() || event.source != ItemAddManager.Source.COMMAND) return
+        if (!inArea || event.source != ItemAddManager.Source.COMMAND) return
 
         tracker.addItem(event.internalName, event.amount, command = true)
     }
 
     @HandleEvent
     fun onPurseChange(event: PurseChangeEvent) {
-        if (!isEnabled()) return
+        if (!inArea) return
         if (event.reason != PurseChangeCause.GAIN_MOB_KILL) return
         if (event.coins !in 200.0..2_000.0) return
         tracker.addCoins(event.coins.toInt(), false)
@@ -227,7 +227,7 @@ object GhostTracker {
 
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent) {
-        if (!isEnabled()) return
+        if (!inArea) return
         itemDropPattern.matchMatcher(event.message) {
             val internalName = NeuInternalName.fromItemNameOrNull(group("item")) ?: return
             val mf = group("mf").formatInt()
@@ -288,7 +288,7 @@ object GhostTracker {
     @HandleEvent
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.BESTIARY)) return
-        if (isMaxBestiary || !isEnabled()) return
+        if (isMaxBestiary || !inArea) return
         parseBestiaryWidget(event.lines)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
@@ -114,9 +114,11 @@ object DianaProfitTracker {
 
     @HandleEvent
     fun onItemAdd(event: ItemAddEvent) {
-        if (!(DianaApi.isDoingDiana() && config.enabled)) return
+        if (!(DianaApi.isDoingDiana())) return
+        val isCommand = event.source == ItemAddManager.Source.COMMAND
+        if (isCommand && !config.enabled) return
 
-        tryAddItem(event.internalName, event.amount, event.source == ItemAddManager.Source.COMMAND)
+        tryAddItem(event.internalName, event.amount, isCommand)
     }
 
     private fun tryAddItem(internalName: NeuInternalName, amount: Int, command: Boolean) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
@@ -52,7 +52,7 @@ object FishingProfitTracker {
      */
     private val coinsChatPattern by RepoPattern.pattern(
         "fishing.tracker.chat.coins",
-        "§(?<colorCode>.*)⛃ §r(?<catch>.*) CATCH! §r§fYou caught §r§6(?<coins>[\\d,]+) Coins§r§f!"
+        "§(?<colorCode>.*)⛃ §r(?<catch>.*) CATCH! §r§fYou caught §r§6(?<coins>[\\d,]+) Coins§r§f!",
     )
 
     private var lastCatchTime = SimpleTimeMark.farPast()
@@ -200,6 +200,7 @@ object FishingProfitTracker {
         if (!isEnabled()) return
 
         if (event.source == ItemAddManager.Source.COMMAND) {
+            if (!config.enabled) return
             tryAddItem(event.internalName, event.amount, command = true)
             return
         }
@@ -228,7 +229,7 @@ object FishingProfitTracker {
         RenderDisplayHelper(
             outsideInventory = true,
             inOwnInventory = true,
-            condition = { isEnabled() },
+            condition = { isEnabled() && config.enabled },
             onRender = {
                 val recentPickup = config.showWhenPickup && lastCatchTime.passedSince() < 3.seconds
                 if (recentPickup || FishingApi.isFishing(checkRodInHand = false)) {
@@ -261,7 +262,7 @@ object FishingProfitTracker {
         tracker.firstUpdate()
     }
 
-    fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled && !LorenzUtils.inKuudraFight
+    private fun isEnabled() = LorenzUtils.inSkyBlock && !LorenzUtils.inKuudraFight
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/SeaCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/SeaCreatureTracker.kt
@@ -189,6 +189,7 @@ object SeaCreatureTracker {
     }
 
     private fun shouldShowDisplay(): Boolean {
+        if (!config.enabled) return false
         if (!isEnabled()) return false
         if (!FishingApi.isFishing(checkRodInHand = false)) return false
 
@@ -204,5 +205,5 @@ object SeaCreatureTracker {
         }
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled && !FishingApi.wearingTrophyArmor && !LorenzUtils.inKuudraFight
+    private fun isEnabled() = LorenzUtils.inSkyBlock && !FishingApi.wearingTrophyArmor && !LorenzUtils.inKuudraFight
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/ArmorDropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/ArmorDropTracker.kt
@@ -76,11 +76,10 @@ object ArmorDropTracker {
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent) {
         for (dropType in ArmorDropType.entries) {
-            if (dropType.chatMessage == event.message) {
-                addDrop(dropType)
-                if (config.hideChat) {
-                    event.blockedReason = "farming_armor_drops"
-                }
+            if (dropType.chatMessage != event.message) continue
+            addDrop(dropType)
+            if (config.hideChat) {
+                event.blockedReason = "farming_armor_drops"
             }
         }
     }
@@ -121,8 +120,6 @@ object ArmorDropTracker {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!config.enabled) return
-
         checkArmor()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/DicerRngDropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/DicerRngDropTracker.kt
@@ -103,8 +103,6 @@ object DicerRngDropTracker {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onChat(event: SkyHanniChatEvent) {
-        if (!config.hideChat && !config.display) return
-
         val message = event.message
         for (drop in itemDrops) {
             drop.pattern.matchMatcher(message) {
@@ -181,7 +179,7 @@ object DicerRngDropTracker {
 
     class ItemDrop(val crop: CropType, val rarity: DropRarity, val pattern: Pattern)
 
-    fun isEnabled() = GardenApi.inGarden() && config.display
+    private fun isEnabled() = GardenApi.inGarden() && config.display
 
     @HandleEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -135,8 +135,9 @@ object PestProfitTracker {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onItemAdd(event: ItemAddEvent) {
-        if (!config.enabled || event.source != ItemAddManager.Source.COMMAND) return
-        with(tracker) { event.addItemFromEvent() }
+        if (config.enabled && event.source == ItemAddManager.Source.COMMAND) {
+            with(tracker) { event.addItemFromEvent() }
+        }
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
@@ -156,7 +157,6 @@ object PestProfitTracker {
             val amount = group("amount").toInt().fixAmount(internalName, pest)
 
             if (config.hideChat) blockedReason = "pest_drop"
-            if (!config.enabled) return
 
             tracker.addItem(pest, internalName, amount)
 
@@ -176,7 +176,6 @@ object PestProfitTracker {
             }
 
             // Happens here so that the amount is fixed independently of tracker being enabled
-            if (!config.enabled) return
 
             tracker.addItem(pest, internalName, amount)
             // Pests always have guaranteed loot, therefore there's no need to add kill here
@@ -184,7 +183,6 @@ object PestProfitTracker {
     }
 
     private fun SkyHanniChatEvent.checkSprayChats() {
-        if (!config.enabled) return
         sprayonatorUsedPattern.matchGroup(message, "spray")?.let {
             SprayType.getByNameOrNull(it)?.addSprayUsed()
         }
@@ -282,7 +280,7 @@ object PestProfitTracker {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onPurseChange(event: PurseChangeEvent) {
-        if (!config.enabled || event.reason != PurseChangeCause.GAIN_MOB_KILL || lastPestKillTimes.isEmpty()) return
+        if (event.reason != PurseChangeCause.GAIN_MOB_KILL || lastPestKillTimes.isEmpty()) return
         val coins = event.coins.takeIf { it in 1000.0..10000.0 } ?: return
 
         // Get a list of all that have been killed in the last 2 seconds, it will
@@ -357,6 +355,4 @@ object PestProfitTracker {
             )
         }
     }
-
-    fun isEnabled() = GardenApi.inGarden() && config.enabled
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayTracker.kt
@@ -307,7 +307,7 @@ object CFStrayTracker {
         tracker.initRenderer(
             { config.strayRabbitTrackerPosition },
             CFApi.mainInventory,
-        ) { isEnabled() }
+        ) { config.strayRabbitTracker && isEnabled() }
     }
 
     @HandleEvent
@@ -364,5 +364,5 @@ object CFStrayTracker {
         }
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.strayRabbitTracker && CFApi.inChocolateFactory
+    private fun isEnabled() = LorenzUtils.inSkyBlock && CFApi.inChocolateFactory
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -162,6 +162,7 @@ object ExcavatorProfitTracker {
 
     @HandleEvent
     fun onItemAdd(event: ItemAddEvent) {
+        if (!config.enabled) return
         if (!isEnabled()) return
 
         val internalName = event.internalName
@@ -217,6 +218,7 @@ object ExcavatorProfitTracker {
     }
 
     private fun shouldShowDisplay(): Boolean {
+        if (!config.enabled) return false
         if (!isEnabled()) return false
         val inChest = Minecraft.getMinecraft().currentScreen is GuiChest
         // Only show in excavation menu
@@ -232,8 +234,7 @@ object ExcavatorProfitTracker {
         }
     }
 
-    fun isEnabled() = IslandType.DWARVEN_MINES.isInIsland() && config.enabled &&
-        LorenzUtils.skyBlockArea == "Fossil Research Center"
+    private fun isEnabled() = IslandType.DWARVEN_MINES.isInIsland() && LorenzUtils.skyBlockArea == "Fossil Research Center"
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseTracker.kt
@@ -76,8 +76,9 @@ object CorpseTracker {
 
     @HandleEvent
     fun onItemAdd(event: ItemAddEvent) {
-        if (!isEnabled() || event.source != ItemAddManager.Source.COMMAND) return
-        with(tracker) { event.addItemFromEvent() }
+        if (isEnabled() && event.source == ItemAddManager.Source.COMMAND) {
+            with(tracker) { event.addItemFromEvent() }
+        }
     }
 
     @HandleEvent
@@ -158,7 +159,7 @@ object CorpseTracker {
         }
     }
 
-    fun isEnabled() =
+    private fun isEnabled() =
         LorenzUtils.inSkyBlock && config.enabled && (
             IslandType.MINESHAFT.isInIsland() ||
                 (!config.onlyInMineshaft && MiningApi.inGlacialTunnels())

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/TimiteTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/TimiteTracker.kt
@@ -97,6 +97,7 @@ object TimiteTracker {
         }
     }
 
+    // TODO use RenderDisplayHelper
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onRender(event: GuiRenderEvent) {
         if (!isEnabled()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -157,6 +157,7 @@ object SlayerProfitTracker {
 
     @HandleEvent
     fun onItemAdd(event: ItemAddEvent) {
+        // TODO remove is config enabled check for tracker
         if (!isEnabled()) return
         if (!SlayerApi.isInCorrectArea) return
         if (!SlayerApi.hasActiveSlayerQuest()) return


### PR DESCRIPTION
## What
This PR enables the backend logic of all trackers always, ignoring the config setting
the config setting's job is only to enable the rendering and allow /shedittracker

## Changelog Improvements
+ All Trackers now count items even when disabled. - hannibal2
    * Config option now only toggles display.