### PR TITLE
Fix: Change tablist error time to 3 seconds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
@@ -87,7 +87,7 @@ object ProfileStorageData {
             if (it.multipleProfiles && !hypixelDataLoaded) return
         }
 
-        if (noTabListTime.passedSince() < 2.seconds) return
+        if (noTabListTime.passedSince() < 3.seconds) return
         noTabListTime = SimpleTimeMark.now()
         val foundSkyBlockTabList = TabListData.getTabList().any { it.contains("§b§lArea:") }
         if (foundSkyBlockTabList) {


### PR DESCRIPTION
## What
Changes the time until skyhanni gives the lovely tablist chat message to 3 seconds

## Changelog Fixes
+ Fixed SkyHanni warning incorrectly about invalid tablist. - nopo
