### PR TITLE
Backend: Add MobEvent.KilledByLocalPlayer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
@@ -90,7 +90,15 @@ object MobDebug {
     @HandleEvent
     fun onMobEvent(event: MobEvent) {
         if (!config.logEvents) return
-        val text = "Mob ${if (event is MobEvent.Spawn) "Spawn" else "Despawn"}: ${
+        val eventType = when (event) {
+            is MobEvent.Spawn -> "Spawn"
+            is MobEvent.DeSpawn -> "DeSpawn"
+            is MobEvent.FirstSeen -> "FirstSeen"
+            is MobEvent.Hurt -> "Hurt"
+            else -> "Unknown"
+        }
+
+        val text = "Mob $eventType: ${
             getMobInfo(event.mob).joinToString(", ")
         }"
         MobData.logger.log(text)

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
@@ -94,6 +94,7 @@ object MobDebug {
             is MobEvent.Spawn -> "Spawn"
             is MobEvent.DeSpawn -> "DeSpawn"
             is MobEvent.FirstSeen -> "FirstSeen"
+            is MobEvent.KilledByLocalPlayer -> "KilledByLocalPlayer"
             is MobEvent.Hurt -> "Hurt"
             else -> "Unknown"
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/PlayerMobKillHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/PlayerMobKillHandler.kt
@@ -1,0 +1,62 @@
+package at.hannibal2.skyhanni.data.mob
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.MobEvent
+import at.hannibal2.skyhanni.events.entity.EntityDeathEvent
+import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.MobUtils.mob
+import at.hannibal2.skyhanni.utils.TimeLimitedSet
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat.isLocalPlayer
+import net.minecraft.client.entity.EntityOtherPlayerMP
+import net.minecraft.client.entity.EntityPlayerSP
+import net.minecraft.entity.Entity
+import kotlin.time.Duration.Companion.seconds
+
+@SkyHanniModule
+object PlayerMobKillHandler {
+    private val mobsDamagedByLocalPlayer = TimeLimitedSet<Mob>(30.seconds)
+
+    fun reset() {
+        mobsDamagedByLocalPlayer.clear()
+    }
+
+    // If another player hits a mob, this this event doesn't get triggered
+    @HandleEvent
+    fun onMobHurt(event: MobEvent.Hurt) {
+        if (event.source.entity is EntityOtherPlayerMP) {
+            mobsDamagedByLocalPlayer.remove(event.mob)
+        }
+
+        if (event.source.entity is EntityPlayerSP) {
+            if (event.source.entity.isLocalPlayer) {
+                mobsDamagedByLocalPlayer.add(event.mob)
+            } else {
+                mobsDamagedByLocalPlayer.remove(event.mob)
+            }
+        }
+    }
+
+    @HandleEvent
+    fun onEntityDeath(event: EntityDeathEvent<Entity>) {
+        val mob = event.entity.mob ?: return
+        if (mob in mobsDamagedByLocalPlayer) {
+            mobsDamagedByLocalPlayer.remove(mob)
+            postMobKilledByLocalPlayerEvent(mob)
+        }
+    }
+
+    fun postMobKilledByLocalPlayerEvent(mob: Mob) = when (mob.mobType) {
+        Mob.Type.PLAYER -> MobEvent.KilledByLocalPlayer.Player(mob)
+        Mob.Type.SUMMON -> MobEvent.KilledByLocalPlayer.Summon(mob)
+        Mob.Type.SPECIAL -> MobEvent.KilledByLocalPlayer.Special(mob)
+        Mob.Type.PROJECTILE -> MobEvent.KilledByLocalPlayer.Projectile(mob)
+        Mob.Type.DISPLAY_NPC -> MobEvent.KilledByLocalPlayer.DisplayNpc(mob)
+        Mob.Type.BASIC, Mob.Type.DUNGEON, Mob.Type.BOSS, Mob.Type.SLAYER -> MobEvent.KilledByLocalPlayer.SkyblockMob(mob)
+    }.post()
+
+    @HandleEvent
+    fun onWorldChange(event: WorldChangeEvent) {
+        mobsDamagedByLocalPlayer.clear()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/events/MobEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/MobEvent.kt
@@ -34,7 +34,8 @@ open class MobEvent(val mob: Mob) : SkyHanniEvent() {
 
 
     /** Triggers when the drops should go to the player, so if the player had the last hit.
-     * But because we can't properly detect if another play hit the mob, in those cases this is wrong */ // TODO: Fix this
+     * But because we can't properly detect if another play hit the mob, in those cases this is wrong.
+     * TODO: Fix this ^^ */
     open class KilledByLocalPlayer(mob: Mob) : MobEvent(mob) {
         class SkyblockMob(mob: Mob) : KilledByLocalPlayer(mob)
         class Summon(mob: Mob) : KilledByLocalPlayer(mob)

--- a/src/main/java/at/hannibal2/skyhanni/events/MobEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/MobEvent.kt
@@ -32,6 +32,18 @@ open class MobEvent(val mob: Mob) : SkyHanniEvent() {
         class Projectile(mob: Mob) : FirstSeen(mob)
     }
 
+
+    /** Triggers when the drops should go to the player, so if the player had the last hit.
+     * But because we can't properly detect if another play hit the mob, in those cases this is wrong */ // TODO: Fix this
+    open class KilledByLocalPlayer(mob: Mob) : MobEvent(mob) {
+        class SkyblockMob(mob: Mob) : KilledByLocalPlayer(mob)
+        class Summon(mob: Mob) : KilledByLocalPlayer(mob)
+        class Player(mob: Mob) : KilledByLocalPlayer(mob)
+        class DisplayNpc(mob: Mob) : KilledByLocalPlayer(mob)
+        class Special(mob: Mob) : KilledByLocalPlayer(mob)
+        class Projectile(mob: Mob) : KilledByLocalPlayer(mob)
+    }
+
     open class Hurt(mob: Mob, val source: DamageSource, val amount: Float) : MobEvent(mob) {
         class SkyblockMob(mob: Mob, source: DamageSource, amount: Float) : Hurt(mob, source, amount)
         class Summon(mob: Mob, source: DamageSource, amount: Float) : Hurt(mob, source, amount)


### PR DESCRIPTION
## What
Listens for MobHurt events, then adds the hurt mobs to a TimeLimitedSet, if the source of the MobHurt is the localPlayer.
If the source of the MobHurt can be attributed to another player, the mob is removed from the set again.
(Note: if another player hits the mob, it can't be attributed to the other player, so in that case the MobEvent.KilledByLocalPlayer is falsely triggered)
Then if a mob dies and it's on the list the event gets triggered.

## Changelog Technical Details
+ Added an event for when a mob gets killed by the player. - rueblimaster