### PR TITLE
Improvement: Add Harvest Harbinger V to Visitor Rewards

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/DropsStatisticsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/DropsStatisticsConfig.kt
@@ -78,6 +78,7 @@ class DropsStatisticsConfig {
         COPPER_DYE("§b1 §8Copper Dye"),
         JUNGLE_KEY("§b1 §5Jungle Key"),
         FRUIT_BOWL("§b1 §9Fruit Bowl"),
+        HARVEST_HARBINGER("§b1 §9Harvest Harbinger V"),
         ;
 
         override fun getLegacyId() = legacyId

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
@@ -25,6 +25,7 @@ enum class VisitorReward(
     COPPER_DYE("DYE_COPPER", "§8Copper Dye"),
     JUNGLE_KEY("JUNGLE_KEY", "§5Jungle Key"),
     FRUIT_BOWL("FRUIT_BOWL", "§9Fruit Bowl"),
+    HARVEST_HARBINGER("POTION_HARVEST_HARBINGER;5", "§9Harvest Harbinger V"),
     ;
 
     private val internalName = rawInternalName.toInternalName()


### PR DESCRIPTION
## What
Meant to add this when I added jungle key and fruit bowl, oops.

## Changelog Improvements
+ Added Harvest Harbinger V potion to Visitor Rewards list. - Daveed
    * Updated Visitor Stats counter and Prevent Denying features accordingly.
