### PR TITLE
Improvement: Ghost Leap Overlay

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -124,7 +124,7 @@ object DungeonApi {
     @Suppress("MaxLineLength")
     val playerDungeonTeamPattern by patternGroup.pattern(
         "tablist.playerteam",
-        "^(?:§.)*(?<sbLevel>\\[(?:§.)*\\d+(?:§.)*]) (?<rank>(?:§.)*\\[(?:§.)*[^]]+(?:§.)*])? ?(?<playerName>\\S+) (?<symbols>[^(]*)\\((?:§.)*(?:(?<className>\\S+) (?<classLevel>[CLXVI0]+)|(?<playerDead>DEAD))(?:§.)*\\)(?:§.)*\$",
+        "^(?:§.)*(?<sbLevel>\\[(?:§.)*\\d+(?:§.)*]) (?<rank>(?:§.)*\\[(?:§.)*[^]]+(?:§.)*])? ?(?<playerName>\\S+)\\s?(?<symbols>[^(]*) §r§f\\((?:§.)*(?:(?<className>\\S+) (?<classLevel>[CLXVI0]+)|(?<playerDead>DEAD))(?:§.)*\\)(?:§.)*\$",
     )
 
     enum class DungeonBlessings(var power: Int) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SpecialColor.toSpecialColor
+import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import net.minecraft.client.gui.inventory.GuiChest
@@ -37,7 +38,7 @@ object DungeonSpiritLeapOverlay {
         if (!isEnabled()) return
 
         val gui = event.gui
-        if (gui !is GuiChest || InventoryUtils.openInventoryName().removeColor() != "Spirit Leap") return
+        if (gui !is GuiChest || InventoryUtils.openInventoryName().removeColor() !in setOf("Spirit Leap", "Teleport to Player")) return
         containerWidth = gui.width
         containerHeight = gui.height
         scaleFactor = min(containerWidth, containerHeight).toDouble() / max(containerWidth, containerHeight).toDouble()
@@ -48,7 +49,7 @@ object DungeonSpiritLeapOverlay {
             for ((slot, stack) in chest.getUpperItems()) {
                 val lore = stack.getLore()
                 if (lore.isNotEmpty()) {
-                    val playerInfo = DungeonApi.getPlayerInfo(stack.displayName)
+                    val playerInfo = DungeonApi.getPlayerInfo(stack.displayName.cleanPlayerName())
                     add(PlayerStackInfo(playerInfo, stack, slot.slotNumber))
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
@@ -30,6 +30,7 @@ object DungeonSpiritLeapOverlay {
     private var overlayPosition: Position? = null
     private var containerWidth = 0
     private var containerHeight = 0
+    private val validInventoryNames = setOf("Spirit Leap", "Teleport to Player")
 
     data class PlayerStackInfo(val playerInfo: DungeonApi.TeamMember?, val stack: ItemStack, val slotNumber: Int)
 
@@ -38,7 +39,7 @@ object DungeonSpiritLeapOverlay {
         if (!isEnabled()) return
 
         val gui = event.gui
-        if (gui !is GuiChest || InventoryUtils.openInventoryName().removeColor() !in setOf("Spirit Leap", "Teleport to Player")) return
+        if (gui !is GuiChest || InventoryUtils.openInventoryName().removeColor() !in validInventoryNames) return
         containerWidth = gui.width
         containerHeight = gui.height
         scaleFactor = min(containerWidth, containerHeight).toDouble() / max(containerWidth, containerHeight).toDouble()


### PR DESCRIPTION
## What
Makes Spirit Leap overlay work when player is dead/ghost.

## Changelog Improvements
+ Added Ghost support for Spirit Leap Overlay. - Ovi_1
    * Spirit Leap Overlay works when dead, as a ghost.