### PR TITLE
Backend: Closed inventory name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.events.utils.PreInitFinishedEvent
 import at.hannibal2.skyhanni.skyhannimodule.LoadedModules
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.InventoryUtils.getTitle
 import at.hannibal2.skyhanni.utils.MinecraftConsoleFilter.Companion.initLogging
 import at.hannibal2.skyhanni.utils.VersionConstants
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
@@ -69,9 +68,8 @@ object SkyHanniMod {
         screenToOpen?.let {
             screenTicks++
             if (screenTicks == 5) {
-                val title = Minecraft.getMinecraft().currentScreen?.getTitle()
                 MinecraftCompat.localPlayer.closeScreen()
-                OtherInventoryData.close(title)
+                OtherInventoryData.close()
                 Minecraft.getMinecraft().displayGuiScreen(it)
                 screenTicks = 0
                 screenToOpen = null

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.events.utils.PreInitFinishedEvent
 import at.hannibal2.skyhanni.skyhannimodule.LoadedModules
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.MinecraftConsoleFilter.Companion.initLogging
 import at.hannibal2.skyhanni.utils.VersionConstants
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
@@ -68,8 +69,9 @@ object SkyHanniMod {
         screenToOpen?.let {
             screenTicks++
             if (screenTicks == 5) {
+                val title = InventoryUtils.openInventoryName()
                 MinecraftCompat.localPlayer.closeScreen()
-                OtherInventoryData.close()
+                OtherInventoryData.close(title)
                 Minecraft.getMinecraft().displayGuiScreen(it)
                 screenTicks = 0
                 screenToOpen = null

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -51,7 +51,7 @@ class GuiPositionEditor(
         for (position in positions) {
             position.clicked = false
         }
-        OtherInventoryData.close("ShPositionEditor")
+        OtherInventoryData.close()
     }
 
     override fun onDrawScreen(originalMouseX: Int, originalMouseY: Int, partialTicks: Float) {

--- a/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
@@ -7,8 +7,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.InventoryUtils.getTitle
-import net.minecraft.client.Minecraft
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import net.minecraft.item.ItemStack
 import net.minecraft.network.play.server.S2DPacketOpenWindow
 import net.minecraft.network.play.server.S2EPacketCloseWindow
@@ -23,11 +22,11 @@ object OtherInventoryData {
 
     @HandleEvent
     fun onCloseWindow(event: GuiContainerEvent.CloseWindowEvent) {
-        close(event.gui.getTitle())
+        close()
     }
 
-    fun close(title: String?, reopenSameName: Boolean = false) {
-        InventoryCloseEvent(title ?: "Null", reopenSameName).post()
+    fun close(reopenSameName: Boolean = false) {
+        InventoryCloseEvent(InventoryUtils.openInventoryName(), reopenSameName).post()
         currentInventory = null
     }
 
@@ -44,14 +43,14 @@ object OtherInventoryData {
         val packet = event.packet
 
         if (packet is S2EPacketCloseWindow) {
-            close(Minecraft.getMinecraft().currentScreen?.getTitle())
+            close()
         }
 
         if (packet is S2DPacketOpenWindow) {
             val windowId = packet.windowId
             val title = packet.windowTitle.unformattedText
             val slotCount = packet.slotCount
-            close(title, reopenSameName = title == currentInventory?.title)
+            close(reopenSameName = title == currentInventory?.title)
 
             currentInventory = Inventory(windowId, title, slotCount)
             acceptItems = true

--- a/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
@@ -25,8 +25,8 @@ object OtherInventoryData {
         close()
     }
 
-    fun close(reopenSameName: Boolean = false) {
-        InventoryCloseEvent(InventoryUtils.openInventoryName(), reopenSameName).post()
+    fun close(title: String = InventoryUtils.openInventoryName(), reopenSameName: Boolean = false) {
+        InventoryCloseEvent(title, reopenSameName).post()
         currentInventory = null
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -13,19 +13,16 @@ import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import io.github.moulberry.notenoughupdates.NotEnoughUpdates
 import net.minecraft.client.Minecraft
-import net.minecraft.client.gui.Gui
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.gui.inventory.GuiInventory
 import net.minecraft.client.player.inventory.ContainerLocalMenu
 import net.minecraft.client.resources.I18n
-import net.minecraft.entity.IMerchant
 import net.minecraft.entity.player.InventoryPlayer
 import net.minecraft.inventory.ContainerChest
 import net.minecraft.inventory.IInventory
 import net.minecraft.inventory.Slot
 import net.minecraft.item.ItemStack
-import net.minecraft.world.IWorldNameable
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("TooManyFunctions", "Unused", "MemberVisibilityCanBePrivate")
@@ -152,18 +149,6 @@ object InventoryUtils {
             val stack = slot.stack ?: continue
             this[slot] = stack
         }
-    }
-
-    fun Gui.getTitle(): String = when (this) {
-        is IWorldNameable -> {
-            name
-        }
-
-        is IMerchant -> {
-            displayName.unformattedText
-        }
-
-        else -> ""
     }
 
     fun ContainerChest.getAllSlots(): Map<Slot, ItemStack?> = buildMap {

--- a/versions/mapping-1.21.5-1.16.5-fabric.txt
+++ b/versions/mapping-1.21.5-1.16.5-fabric.txt
@@ -24,3 +24,5 @@ net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext at.hannibal2.skyh
 
 net.minecraft.client.util.math.MatrixStack push() pushMatrix()
 net.minecraft.client.util.math.MatrixStack pop() popMatrix()
+
+net.minecraft.entity.player.PlayerInventory mainStacks main


### PR DESCRIPTION
## What
Changed the way we get closed inventory name to use InventoryCompat and removed the now unused function.
Also remove the one instance where we were naming the screen we were closing (as its inventory close event not screen close event)

## Changelog Technical Details
+ Changed closed-inventory name retrieval to use `InventoryCompat`. - CalMWolfs
