### PR TITLE
Improvement: Treasure Hook Detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -70,6 +70,7 @@ object FishingApi {
 
     private var lavaRods = listOf<NeuInternalName>()
     private var waterRods = listOf<NeuInternalName>()
+    private val TREASURE_HOOK = "TREASURE_HOOK".toInternalName()
 
     var bobber: EntityFishHook? = null
         private set
@@ -130,7 +131,7 @@ object FishingApi {
 
     fun NeuInternalName.isWaterRod() = this in waterRods
 
-    fun ItemStack.getRodPart(part: RodPart): NeuInternalName? =
+    fun ItemStack.getFishingRodPart(part: RodPart): NeuInternalName? =
         getExtraAttributes()?.getCompoundTag(part.tagName)?.getString("part")?.toInternalName()
 
     fun ItemStack.isBait(): Boolean = stackSize == 1 && getItemCategoryOrNull() == ItemCategory.BAIT
@@ -144,7 +145,7 @@ object FishingApi {
 
         if (holdingRod) {
             // If the player is not holding a rod, we want to just save the last state
-            hasTreasureHook = InventoryUtils.getItemInHand()?.getRodPart(RodPart.HOOK) == "TREASURE_HOOK".toInternalName()
+            hasTreasureHook = InventoryUtils.getItemInHand()?.getFishingRodPart(RodPart.HOOK) == TREASURE_HOOK
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -19,8 +19,10 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getExtraAttributes
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat.isLocalPlayer
 import at.hannibal2.skyhanni.utils.compat.addLavas
 import at.hannibal2.skyhanni.utils.compat.addWaters
@@ -32,6 +34,14 @@ import net.minecraft.item.ItemStack
 
 @SkyHanniModule
 object FishingApi {
+    enum class RodPart {
+        HOOK,
+        LINE,
+        SINKER,
+        ;
+
+        val tagName get() = name.lowercase()
+    }
 
     /**
      * REGEX-TEST: BRONZE_HUNTER_HELMET
@@ -48,17 +58,26 @@ object FishingApi {
     private val waterBlocks = buildList { addWaters() }
 
     var lastCastTime = SimpleTimeMark.farPast()
+        private set
     var holdingRod = false
+        private set
     var holdingLavaRod = false
+        private set
     var holdingWaterRod = false
+        private set
+    var hasTreasureHook = false
+        private set
 
     private var lavaRods = listOf<NeuInternalName>()
     private var waterRods = listOf<NeuInternalName>()
 
     var bobber: EntityFishHook? = null
+        private set
     var bobberHasTouchedLiquid = false
+        private set
 
     var wearingTrophyArmor = false
+        private set
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onJoinWorld(event: EntityEnterWorldEvent<EntityFishHook>) {
@@ -111,6 +130,9 @@ object FishingApi {
 
     fun NeuInternalName.isWaterRod() = this in waterRods
 
+    fun ItemStack.getRodPart(part: RodPart): NeuInternalName? =
+        getExtraAttributes()?.getCompoundTag(part.tagName)?.getString("part")?.toInternalName()
+
     fun ItemStack.isBait(): Boolean = stackSize == 1 && getItemCategoryOrNull() == ItemCategory.BAIT
 
     @HandleEvent
@@ -119,6 +141,11 @@ object FishingApi {
         holdingRod = event.newItem.isFishingRod()
         holdingLavaRod = event.newItem.isLavaRod()
         holdingWaterRod = event.newItem.isWaterRod()
+
+        if (holdingRod) {
+            // If the player is not holding a rod, we want to just save the last state
+            hasTreasureHook = InventoryUtils.getItemInHand()?.getRodPart(RodPart.HOOK) == "TREASURE_HOOK".toInternalName()
+        }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/SeaCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/SeaCreatureTracker.kt
@@ -205,5 +205,6 @@ object SeaCreatureTracker {
         }
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && !FishingApi.wearingTrophyArmor && !LorenzUtils.inKuudraFight
+    private fun isEnabled() =
+        LorenzUtils.inSkyBlock && !FishingApi.hasTreasureHook && !FishingApi.wearingTrophyArmor && !LorenzUtils.inKuudraFight
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
@@ -262,6 +262,7 @@ object TrophyFishDisplay {
         if (!canRender()) return
         if (EstimatedItemValue.isCurrentlyShowing()) return
 
+        if (FishingApi.hasTreasureHook) return
         if (config.requireHunterArmor.get() && !FishingApi.wearingTrophyArmor) return
 
         config.position.renderRenderables(


### PR DESCRIPTION
## What
Added API for getting rod parts and detection to automatically hide Sea Creature Tracker and Trophy Fish Display when using a rod with Treasure Hook (which prevents the player from catching Sea Creatures and Trophy Fish). Also made some setters on FishingApi fields private.

## Changelog Improvements
+ Sea Creature Tracker and Trophy Fish Display are now hidden when using a rod with Treasure Hook. - Luna
