### PR TITLE
Backend: /shdebug warns for wrong graph data

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.data.model.Graph
 import at.hannibal2.skyhanni.data.model.GraphNode
 import at.hannibal2.skyhanni.data.repo.RepoManager
 import at.hannibal2.skyhanni.data.repo.RepoUtils
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.IslandGraphReloadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
@@ -31,6 +32,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.RenderUtils.draw3DPathWithWaypoint
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.onClick
 import at.hannibal2.skyhanni.utils.chat.TextHelper.send
@@ -103,6 +105,9 @@ import kotlin.time.Duration.Companion.milliseconds
 @SkyHanniModule
 object IslandGraphs {
     var currentIslandGraph: Graph? = null
+    private var lastLoadedIslandType = "nothing"
+    private var lastLoadedTime = SimpleTimeMark.farPast()
+
     var disabledNodesReason: String? = null
         private set
 
@@ -177,7 +182,7 @@ object IslandGraphs {
         reset()
     }
 
-    fun isGlaciteTunnelsArea(area: String?): Boolean = glaciteTunnelsPattern.matches(area)
+    private fun isGlaciteTunnelsArea(area: String?): Boolean = glaciteTunnelsPattern.matches(area)
 
     @HandleEvent
     fun onAreaChange(event: ScoreboardAreaChangeEvent) {
@@ -187,8 +192,7 @@ object IslandGraphs {
         }
 
         // can not use IslandAreas for area detection here. It HAS TO be the scoreboard
-        @Suppress("DEPRECATION")
-        val now = isGlaciteTunnelsArea(LorenzUtils.skyBlockArea)
+        @Suppress("DEPRECATION") val now = isGlaciteTunnelsArea(LorenzUtils.skyBlockArea)
         if (inGlaciteTunnels != now) {
             inGlaciteTunnels = now
             loadDwarvenMines()
@@ -201,8 +205,7 @@ object IslandGraphs {
 
     private fun loadDwarvenMines() {
         // can not use IslandAreas for area detection here. It HAS TO be the scoreboard
-        @Suppress("DEPRECATION")
-        if (isGlaciteTunnelsArea(LorenzUtils.skyBlockArea)) {
+        @Suppress("DEPRECATION") if (isGlaciteTunnelsArea(LorenzUtils.skyBlockArea)) {
             reloadFromJson("GLACITE_TUNNELS")
         } else {
             reloadFromJson("DWARVEN_MINES")
@@ -217,7 +220,45 @@ object IslandGraphs {
         }
     }
 
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Island Graphs")
+        val islandType = LorenzUtils.skyBlockIsland.name
+        val important = LorenzUtils.inSkyBlock && lastLoadedIslandType != islandType
+        val list = buildList {
+            if (important) {
+                add("")
+                add("wrong island!")
+            } else {
+                add("")
+                add("island is correct!")
+            }
+            add("")
+            add("lastLoadedIslandType: $lastLoadedIslandType")
+            if (important) {
+                add("current islandType: $islandType")
+            }
+
+            add("")
+            add("lastLoadedTime: ${lastLoadedTime.passedSince()}")
+            if (important) {
+                add("last world switch: ${LorenzUtils.lastWorldSwitch.passedSince()}")
+            }
+
+            add("")
+            add("currentIslandGraph is null: ${currentIslandGraph == null}")
+        }
+        if (important) {
+            event.addData(list)
+        } else {
+            event.addIrrelevant(list)
+        }
+    }
+
     private fun reloadFromJson(islandName: String) {
+        lastLoadedIslandType = islandName
+        lastLoadedTime = SimpleTimeMark.now()
+
         val constant = "island_graphs/$islandName"
         val name = "constants/$constant.json"
         val jsonFile = File(RepoManager.repoLocation, name)
@@ -365,7 +406,7 @@ object IslandGraphs {
 
     private fun setFastestPath(path: Pair<Graph, Double>, setPath: Boolean = true) {
         // TODO cleanup
-        val (fastestPath, distance) = path.takeIf { it.first.isNotEmpty() } ?: return
+        val (fastestPath, _) = path.takeIf { it.first.isNotEmpty() } ?: return
         val nodes = fastestPath.nodes.toMutableList()
         if (MinecraftCompat.localPlayer.onGround) {
             nodes.add(0, GraphNode(0, LocationUtils.playerLocation()))
@@ -373,7 +414,7 @@ object IslandGraphs {
         renderPath(setPath, nodes)
     }
 
-    fun renderPath(
+    private fun renderPath(
         setPath: Boolean = true,
         nodes: List<GraphNode>,
     ) {
@@ -597,9 +638,7 @@ object IslandGraphs {
         if (args.isEmpty()) {
             ChatUtils.userError("Usage: /shreportlocation <reason>")
             ChatUtils.chat(
-                "Give a reason that explains what's wrong at this location, e.g.: " +
-                    "pathfinding goes through wall, ignores obvious shortcut, " +
-                    "missing npc/fishing hotspot/skyblock area name in /shnavigate..",
+                "Give a reason that explains what's wrong at this location, e.g.: " + "pathfinding goes through wall, ignores obvious shortcut, " + "missing npc/fishing hotspot/skyblock area name in /shnavigate..",
             )
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -192,7 +192,8 @@ object IslandGraphs {
         }
 
         // can not use IslandAreas for area detection here. It HAS TO be the scoreboard
-        @Suppress("DEPRECATION") val now = isGlaciteTunnelsArea(LorenzUtils.skyBlockArea)
+        @Suppress("DEPRECATION")
+        val now = isGlaciteTunnelsArea(LorenzUtils.skyBlockArea)
         if (inGlaciteTunnels != now) {
             inGlaciteTunnels = now
             loadDwarvenMines()
@@ -205,7 +206,8 @@ object IslandGraphs {
 
     private fun loadDwarvenMines() {
         // can not use IslandAreas for area detection here. It HAS TO be the scoreboard
-        @Suppress("DEPRECATION") if (isGlaciteTunnelsArea(LorenzUtils.skyBlockArea)) {
+        @Suppress("DEPRECATION")
+        if (isGlaciteTunnelsArea(LorenzUtils.skyBlockArea)) {
             reloadFromJson("GLACITE_TUNNELS")
         } else {
             reloadFromJson("DWARVEN_MINES")
@@ -226,11 +228,9 @@ object IslandGraphs {
         val islandType = LorenzUtils.skyBlockIsland.name
         val important = LorenzUtils.inSkyBlock && lastLoadedIslandType != islandType
         val list = buildList {
+            add("")
             if (important) {
-                add("")
                 add("wrong island!")
-            } else {
-                add("")
                 add("island is correct!")
             }
             add("")
@@ -638,7 +638,9 @@ object IslandGraphs {
         if (args.isEmpty()) {
             ChatUtils.userError("Usage: /shreportlocation <reason>")
             ChatUtils.chat(
-                "Give a reason that explains what's wrong at this location, e.g.: " + "pathfinding goes through wall, ignores obvious shortcut, " + "missing npc/fishing hotspot/skyblock area name in /shnavigate..",
+                "Give a reason that explains what's wrong at this location, e.g.: " +
+                    "pathfinding goes through wall, ignores obvious shortcut, " +
+                    "missing npc/fishing hotspot/skyblock area name in /shnavigate..",
             )
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -36,6 +36,15 @@ enum class IslandType(private val nameFallback: String) {
     UNKNOWN("???"),
     ;
 
+    fun isValidIsland(): Boolean = when (this) {
+        NONE,
+        ANY,
+        UNKNOWN,
+        -> false
+
+        else -> true
+    }
+
     fun guestVariant(): IslandType = when (this) {
         PRIVATE_ISLAND -> PRIVATE_ISLAND_GUEST
         GARDEN -> GARDEN_GUEST


### PR DESCRIPTION
## What
There were reports of /shnavigate or fairy soul pathfinding showing a line ot another island, isntead of navigating around on the current island.
notable with gold mines and the path is to the hub.
my guess is that the data doesnt update somehow.
since i cant reporduce that, this pr now keeps track of the time of last data load and last data name loaded, and shows that via /shdebug


## Changelog Technical Details
+ Included Navigation Graph data in `/shdebug`. - hannibal2