### PR TITLE
Fix: Slayer features broken in End

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
@@ -12,7 +12,7 @@ class SlayerProfitTrackerConfig {
     @ConfigOption(
         name = "Enabled",
         desc = "Count all items you pick up while doing slayer, " +
-            "keeping track of how much you pay for starting slayers and calculating the overall profit."
+                "keeping track of how much you pay for starting slayers and calculating the overall profit.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -22,11 +22,21 @@ class SlayerProfitTrackerConfig {
     @ConfigLink(owner = SlayerProfitTrackerConfig::class, field = "enabled")
     var pos: Position = Position(20, 20, false, true)
 
+    // TODO move out of slayer profit tracker and into the generic slayer config.
     @Expose
     @ConfigOption(
         name = "Voidgloom in Dragon's Nest",
-        desc = "Show the Voidgloom Tracker in the Dragon's Nest.",
+        desc = "Show all Enderman Slayer Features while in the Dragon's Nest.",
     )
     @ConfigEditorBoolean
     var voidgloomInNest: Boolean = false
+
+    // TODO move out of slayer profit tracker and into the generic slayer config.
+    @Expose
+    @ConfigOption(
+        name = "Voidgloom Everywhere",
+        desc = "Show all Enderman Slayer Features while outside of Void Sepulture and Zealot Bruiser Hideout.",
+    )
+    @ConfigEditorBoolean
+    var voidgloomInNoArea: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
@@ -12,7 +12,7 @@ class SlayerProfitTrackerConfig {
     @ConfigOption(
         name = "Enabled",
         desc = "Count all items you pick up while doing slayer, " +
-                "keeping track of how much you pay for starting slayers and calculating the overall profit.",
+            "keeping track of how much you pay for starting slayers and calculating the overall profit.",
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerProfitTrackerConfig.kt
@@ -39,4 +39,13 @@ class SlayerProfitTrackerConfig {
     )
     @ConfigEditorBoolean
     var voidgloomInNoArea: Boolean = true
+
+    // TODO move out of slayer profit tracker and into the generic slayer config.
+    @Expose
+    @ConfigOption(
+        name = "Revenant In Graveyard",
+        desc = "Show all Revenant Slayer Features while inside the Graveyard.",
+    )
+    @ConfigEditorBoolean
+    var revenantInGraveyard: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RecalculatingValue
@@ -154,14 +155,12 @@ object SlayerApi {
         "Howling Cave",
         -> SlayerType.SVEN
 
-        in listOf(
-            "The End",
-            "Void Sepulture",
-            "Zealot Bruiser Hideout",
-        ).let {
-            if (trackerConfig.voidgloomInNest) it + "Dragon's Nest" else it
-        },
+        "Void Sepulture",
+        "Zealot Bruiser Hideout",
         -> SlayerType.VOID
+
+        "Dragon's Nest" -> if (trackerConfig.voidgloomInNest) SlayerType.VOID else null
+        "no_area" -> if (trackerConfig.voidgloomInNoArea && IslandType.THE_END.isInIsland()) SlayerType.VOID else null
 
         "Stronghold",
         "The Wasteland",

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -140,10 +140,8 @@ object SlayerApi {
 
     // TODO USE SH-REPO
     private fun checkSlayerTypeForCurrentArea() = when (IslandAreas.currentAreaName) {
-        "Graveyard",
-        "Coal Mine",
-        "Revenant Cave",
-        -> SlayerType.REVENANT
+        "Graveyard" -> if (trackerConfig.revenantInGraveyard && IslandType.HUB.isInIsland()) SlayerType.REVENANT else null
+        "Revenant Cave" -> SlayerType.REVENANT
 
         "Spider Mound",
         "Arachne's Burrow",
@@ -159,7 +157,7 @@ object SlayerApi {
         "Zealot Bruiser Hideout",
         -> SlayerType.VOID
 
-        "Dragon's Nest" -> if (trackerConfig.voidgloomInNest) SlayerType.VOID else null
+        "Dragon's Nest" -> if (trackerConfig.voidgloomInNest && IslandType.THE_END.isInIsland()) SlayerType.VOID else null
         "no_area" -> if (trackerConfig.voidgloomInNoArea && IslandType.THE_END.isInIsland()) SlayerType.VOID else null
 
         "Stronghold",


### PR DESCRIPTION
## What
slayer detection got moved from scoreboard area to graph area.
this meant that the ender slayer area broke down entirely outside of the three small areas in the end (Void Sepulture, Zealot Bruiser Hideout and Dragon's Nest)
This pr fixes this so per default the end slayer features show up everywhere on end again, and added an toggle to disable the end slayer features "generally" to not clash with end node tracker or if the user only does eman slayer in the speciifc areas and dont care about the feature outside.

## Changelog Improvements
+ Added option to disable Ender Slayer features outside specific areas in the End. - hannibal2
    * This was only a problem when outside of Void Sepulture, Zealot Bruiser Hideout and Dragon's Nest.
+ Added option to disable Revenant Slayer features in Graveyard. - hannibal2

## Changelog Fixes
+ Fixed Ender Slayer features showing outside designated areas. - hannibal2
    * Void Sepulture, Zealot Bruiser Hideout and Dragon's Nest.
    * Mainly affected Slayer Profit Tracker.