### PR TITLE
Fix + Backend: shortened party commands

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/PartyApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PartyApi.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.hypixel.chat.event.PartyChatEvent
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -291,4 +292,26 @@ object PartyApi {
             callback { listMembers() }
         }
     }
+
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Party")
+        event.addIrrelevant {
+            val size = partyMembers.size
+            if (size == 0) {
+                add("No tracked party members!")
+            } else {
+                add("Tracked party members ($size)")
+                for (member in partyMembers) {
+                    add(" - $member" + if (partyLeader == member) " (Leader)" else "")
+                }
+            }
+
+            if (partyLeader == LorenzUtils.getPlayerName()) {
+                add("")
+                add("You are leader")
+            }
+        }
+    }
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyCommands.kt
@@ -26,25 +26,21 @@ object PartyCommands {
 
     private fun kickOffline() {
         if (!config.shortCommands) return
-        if (PartyApi.partyMembers.isEmpty()) return
         HypixelCommands.partyKickOffline()
     }
 
     private fun disband() {
         if (!config.shortCommands) return
-        if (PartyApi.partyMembers.isEmpty()) return
         HypixelCommands.partyDisband()
     }
 
     private fun warp() {
         if (!config.shortCommands) return
-        if (PartyApi.partyMembers.isEmpty()) return
         HypixelCommands.partyWarp()
     }
 
     private fun kick(args: Array<String>) {
         if (!config.shortCommands) return
-        if (PartyApi.partyMembers.isEmpty()) return
         if (args.isEmpty()) return
         val kickedPlayer = args[0]
         val kickedReason = args.drop(1).joinToString(" ").trim()
@@ -64,20 +60,17 @@ object PartyCommands {
             return
         }
         if (!config.shortCommands) return
-        if (PartyApi.partyMembers.isEmpty()) return
         HypixelCommands.partyTransfer(args[0])
     }
 
     private fun promote(args: Array<String>) {
         if (!config.shortCommands) return
-        if (PartyApi.partyMembers.isEmpty()) return
         if (args.isEmpty()) return
         HypixelCommands.partyPromote(args[0])
     }
 
     private fun reverseTransfer() {
         if (!config.reversePT.command) return
-        if (PartyApi.partyMembers.isEmpty()) return
         val prevPartyLeader = PartyApi.prevPartyLeader ?: return
 
         autoPartyTransfer(prevPartyLeader)


### PR DESCRIPTION
## What
Instead of checking the internal party state (and not returnig any infos when the state is wrong)
we now just execute the hypixel command so that the user sees those error messages instead.

## Changelog Fixes
+ Fixed errors with shortened party command. - hannibal2

## Changelog Technical Details
+ Added party infos to `/shdebug`. - hannibal2