### PR TITLE
Improvement + Fix: Title Scaling

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -107,6 +107,7 @@ class ConfigManager {
         "features.misc.MiscConfig.collectionCounterPos",
         "features.misc.MiscConfig.carryPosition",
         "features.misc.MiscConfig.lockedMouseDisplay",
+        "features.gui.GuiConfig.titlePosition",
 
         // debug features
         "features.dev.DebugConfig.trackSoundPosition",

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/TimerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/TimerConfig.java
@@ -24,6 +24,7 @@ public class TimerConfig {
     @ConfigOption(name = "Sixth Visitor Warning", desc = "Notify when it is believed that the sixth visitor has arrived.\n" +
         "§eMay be inaccurate with co-op members farming simultaneously.")
     @ConfigEditorBoolean
+    @FeatureToggle
     public boolean sixthVisitorWarning = true;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
@@ -163,4 +163,7 @@ class GuiConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var configButtonOnPause: Boolean = true
+
+    @Expose
+    var titlePosition: Position = Position(0, 160)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonShadowAssassinNotification.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonShadowAssassinNotification.kt
@@ -25,7 +25,7 @@ object DungeonShadowAssassinNotification {
         val warningTime = packet.warningTime
 
         if (action == S44PacketWorldBorder.Action.INITIALIZE && warningTime == 10000) {
-            TitleManager.sendTitle("§cShadow Assassin Jumping!", height = 3.6, fontSize = 7.0f)
+            TitleManager.sendTitle("§cShadow Assassin Jumping!")
             SoundUtils.playBeepSound()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -462,7 +462,7 @@ object GriffinBurrowHelper {
         } else ""
         if (lastTitleSentTime.passedSince() > 2.seconds) {
             lastTitleSentTime = SimpleTimeMark.now()
-            TitleManager.sendTitle(text + keybindSuffix, duration = 2.seconds, fontSize = 3f)
+            TitleManager.sendTitle(text + keybindSuffix, duration = 2.seconds)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -298,7 +298,7 @@ object InquisitorWaypointShare {
         if (!waypoints.containsKey(name)) {
             ChatUtils.chat("$displayName §l§efound an inquisitor at §l§c${x.toInt()} ${y.toInt()} ${z.toInt()}!")
             if (name != LorenzUtils.getPlayerName()) {
-                TitleManager.sendTitle("§dINQUISITOR §efrom §b$displayName", duration = 5.seconds)
+                TitleManager.sendTitle("§dINQUISITOR §efrom §b$displayName")
                 playUserSound()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -292,7 +292,7 @@ object HoppityEggsManager {
                 action = action,
             )
         } else ChatUtils.chat(message, replaceSameMessage = true)
-        TitleManager.sendTitle("§e$amount Hoppity Eggs!", duration = 5.seconds)
+        TitleManager.sendTitle("§e$amount Hoppity Eggs!")
         SoundUtils.repeatSound(100, 10, SoundUtils.plingSound)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -71,7 +71,7 @@ object SeaCreatureFeatures {
         if (config.alertOtherCatches && shouldNotify) {
             val text = if (config.creatureName) "${creature.displayName} NEARBY!"
             else "${creature.rarity.chatColorCode}RARE SEA CREATURE!"
-            TitleManager.sendTitle(text, duration = 1.5.seconds, height = 3.6, fontSize = 7f)
+            TitleManager.sendTitle(text, duration = 1.5.seconds)
             if (config.playSound) SoundUtils.playBeepSound()
         }
     }
@@ -87,7 +87,7 @@ object SeaCreatureFeatures {
         if (config.alertOwnCatches) {
             val text = if (config.creatureName) "${event.seaCreature.displayName}!"
             else "${event.seaCreature.rarity.chatColorCode}RARE CATCH!"
-            TitleManager.sendTitle(text, height = 2.8, fontSize = 7f)
+            TitleManager.sendTitle(text)
             if (config.playSound) SoundUtils.playBeepSound()
             lastRareCatch = SimpleTimeMark.now()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -159,7 +159,7 @@ object TotemOfCorruption {
             val timeToWarn = config.warnWhenAboutToExpire.seconds
             if (timeToWarn > 0.seconds && timeRemaining <= timeToWarn && totem.uniqueID !in warnedTotems) {
                 playBeepSound(0.5f)
-                TitleManager.sendTitle("§c§lTotem of Corruption §eabout to expire!", duration = 5.seconds)
+                TitleManager.sendTitle("§c§lTotem of Corruption §eabout to expire!")
                 warnedTotems.add(totem.uniqueID)
             }
             Totem(totem.getLorenzVec(), timeRemaining, owner)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
@@ -254,7 +254,7 @@ object GoldenFishTimer {
     private fun rodWarning() {
         if (!config.throwRodWarning || hasWarnedRod) return
         hasWarnedRod = true
-        TitleManager.sendTitle("§cThrow your rod!", duration = 5.seconds, height = 3.6, fontSize = 7.0f)
+        TitleManager.sendTitle("§cThrow your rod!")
         SoundUtils.repeatSound(100, 10, SoundUtils.plingSound)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishMessages.kt
@@ -103,7 +103,7 @@ object TrophyFishMessages {
 
     private fun sendTitle(displayName: String, displayRarity: String?, amount: Int) {
         val text = "$displayName $displayRarity §8$amount§c!"
-        TitleManager.sendTitle(text, height = 2.8, fontSize = 7f)
+        TitleManager.sendTitle(text)
     }
 
     private fun shouldBlockTrophyFish(rarity: TrophyRarity, amount: Int) =

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -436,7 +436,7 @@ object GardenNextJacobContest {
         lastWarningTime = SimpleTimeMark.now()
         val cropText = crops.joinToString("§7, ") { (if (it == boostedCrop) "§6" else "§a") + it.cropName }
         ChatUtils.chat("Next farming contest: $cropText")
-        TitleManager.sendTitle("§eFarming Contest!", duration = 5.seconds)
+        TitleManager.sendTitle("§eFarming Contest!")
         SoundUtils.playBeepSound()
 
         val cropTextNoColor = crops.joinToString(", ") {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object GardenBurrowingSporesNotifier {
@@ -16,7 +15,7 @@ object GardenBurrowingSporesNotifier {
         if (!GardenApi.config.burrowingSporesNotification) return
 
         if (event.message.endsWith("§6§lVERY RARE CROP! §r§f§r§9Burrowing Spores")) {
-            TitleManager.sendTitle("§9Burrowing Spores!", duration = 5.seconds)
+            TitleManager.sendTitle("§9Burrowing Spores!")
             // would be sent too often, nothing special then
 //            ItemBlink.setBlink(NEUItems.getItemStackOrNull("BURROWING_SPORES"), 5_000)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -79,6 +79,8 @@ object GardenVisitorTimer {
         sixthVisitorReady = false
     }
 
+    // TODO split up into multiple smaller functions
+    @Suppress("CyclomaticComplexMethod")
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onSecondPassed(event: SecondPassedEvent) {
         var visitorsAmount = VisitorApi.visitorsInTabList(TabListData.getTabList()).size

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.garden.visitor
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -78,10 +79,8 @@ object GardenVisitorTimer {
         sixthVisitorReady = false
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!isEnabled()) return
-
         var visitorsAmount = VisitorApi.visitorsInTabList(TabListData.getTabList()).size
         var visitorInterval = visitorInterval ?: return
         var millis = visitorInterval

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverWarning.kt
@@ -58,7 +58,7 @@ object QuiverWarning {
             val rarity = arrowType.internalName.getItemStackOrNull()?.getItemRarityOrNull()?.chatColorCode ?: "§f"
             "$rarity${arrowType.arrow}"
         }.createCommaSeparatedList()
-        TitleManager.sendTitle("§cLow on arrows!", duration = 5.seconds, height = 3.6, fontSize = 7f)
+        TitleManager.sendTitle("§cLow on arrows!")
         ChatUtils.chat("Low on $arrowsText!")
         SoundUtils.repeatSound(100, 30, SoundUtils.plingSound)
     }
@@ -66,7 +66,7 @@ object QuiverWarning {
     private fun lowQuiverAlert(amount: Int) {
         if (lastLowQuiverReminder.passedSince() < 30.seconds) return
         lastLowQuiverReminder = SimpleTimeMark.now()
-        TitleManager.sendTitle("§cLow on arrows!", duration = 5.seconds, height = 3.6, fontSize = 7f)
+        TitleManager.sendTitle("§cLow on arrows!")
         ChatUtils.chat("Low on arrows §e(${amount.addSeparators()} left)")
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionOutbidWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionOutbidWarning.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object AuctionOutbidWarning {
@@ -26,7 +25,7 @@ object AuctionOutbidWarning {
         if (!SkyHanniMod.feature.inventory.auctions.auctionOutbid) return
         if (!outbidPattern.matches(event.message)) return
 
-        TitleManager.sendTitle("§cYou have been outbid!", duration = 5.seconds, height = 3.6, fontSize = 7f)
+        TitleManager.sendTitle("§cYou have been outbid!")
         SoundUtils.playBeepSound()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NoBitsWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NoBitsWarning.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.createSound
-import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object NoBitsWarning {
@@ -29,7 +28,7 @@ object NoBitsWarning {
                 }, "§eClick to run /bz booster cookie!"
             )
             // TODO use reminder utils
-            TitleManager.sendTitle("§bNo Bits Available", duration = 5.seconds)
+            TitleManager.sendTitle("§bNo Bits Available")
             if (config.notificationSound) SoundUtils.repeatSound(100, 10, createSound("note.pling", 0.6f))
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -144,7 +144,7 @@ object TrevorFeatures {
         mobDiedPattern.matchMatcher(event.message) {
             TrevorSolver.resetLocation()
             if (config.trapperMobDiedMessage) {
-                TitleManager.sendTitle("§2Mob Died ", duration = 5.seconds)
+                TitleManager.sendTitle("§2Mob Died ")
                 SoundUtils.playBeepSound()
             }
             trapperReady = true

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -143,7 +143,6 @@ object VampireSlayerFeatures {
                         TitleManager.sendTitle(
                             "§6§lTWINCLAWS",
                             duration = (1750 - config.twinclawsDelay).milliseconds,
-                            height = 2.6,
                         )
                         nextClawSend = System.currentTimeMillis() + 5_000
                     }
@@ -179,7 +178,7 @@ object VampireSlayerFeatures {
                 else canUseSteak && configCoopBoss.steakAlert && containCoop
 
             if (shouldSendSteakTitle) {
-                TitleManager.sendTitle("§c§lSTEAK!", duration = 300.milliseconds, height = 2.6)
+                TitleManager.sendTitle("§c§lSTEAK!", duration = 300.milliseconds)
             }
 
             if (shouldRender) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -243,7 +243,7 @@ open class SkyHanniTracker<Data : TrackerData>(
             ChatUtils.chat("§a+Tracker Drop§7: §r$itemName")
         }
         if (config.warnings.title && price >= config.warnings.minimumTitle) {
-            TitleManager.sendTitle("§a+ $itemName", duration = 5.seconds, weight = price)
+            TitleManager.sendTitle("§a+ $itemName", weight = price)
         }
     }
 


### PR DESCRIPTION
## What
Removed `height` and `fontSize` parameters from `TitleManager.sendTitle()`.
Added a new position element in the `GuiConfig`.
Changed default duration from 3s to 5s.
Added debug command option `/shsendtitle reset`.

## Changelog Improvements
+ Improved titles sent by SH features. - hannibal2
    * All titles now share size and position; no more dynamic scaling.
    * Size and vertical position adjustable via the position editor; full opacity enforced.

## Changelog Fixes
+ Fixed titles exceeding display size. - hannibal2