### PR TITLE
Backend: Add + Cleanup Mappings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -455,6 +455,8 @@ files, so you might be fixing issues in files you didn't even look at. It will e
 (consider using the method descriptor instead of just the method name for your mixin). However, if something aside from the name changed,
 this will not suffice.
 
+After adding new mappings to the mappings file don't forget to run `./gradlew cleanupMappingFiles` to automatically sort the mappings file.
+
 #### Custom mappings
 
 If you need to do a bit more advanced remapping that requires an import to be added to the file, you can add a custom mapping. This is

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import skyhannibuildsystem.ChangelogVerification
+import skyhannibuildsystem.CleanupMappingFiles
 import skyhannibuildsystem.DownloadBackupRepo
 import java.io.Serializable
 import java.nio.file.Path
@@ -120,6 +121,10 @@ val headlessLwjgl by configurations.creating {
 val includeBackupRepo by tasks.registering(DownloadBackupRepo::class) {
     this.outputDirectory.set(layout.buildDirectory.dir("downloadedRepo"))
     this.branch = "main"
+}
+
+val cleanupMappingFiles by tasks.registering(CleanupMappingFiles::class) {
+    this.mappingsDirectory.set(layout.projectDirectory.asFile.parentFile)
 }
 
 tasks.runClient {

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
@@ -14,8 +14,6 @@ abstract class CleanupMappingFiles : DefaultTask() {
     @TaskAction
     fun cleanupMappingFiles() {
         val mappingsDir = mappingsDirectory.get().asFile
-        println("full path for mapping task: ${mappingsDir.absolutePath}")
-
         val mappingsFiles = mappingsDir.listFiles() ?: return
 
         for (file in mappingsFiles) {

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
@@ -27,9 +27,17 @@ abstract class CleanupMappingFiles : DefaultTask() {
         val isPatternMapping = file.name.startsWith("pattern-")
 
         val lines = mutableSetOf<Pair<String, String>>()
+        val comments = mutableMapOf<String, String>()
+
+        var savedComment: String? = null
 
         file.forEachLine { line ->
             if (line.isNotBlank()) {
+                savedComment?.let {
+                    comments[line] = it
+                    savedComment = null
+                }
+                if (line.isComment()) savedComment = line
                 findSection(line, isPatternMapping)?.let { parts ->
                     lines.add(Pair(parts, line))
                 }
@@ -40,8 +48,10 @@ abstract class CleanupMappingFiles : DefaultTask() {
             .mapValues { it.value.map { it.second }.sorted() }
             .toSortedMap()
 
-        writeMappings(file, sortedLines)
+        writeMappings(file, sortedLines, comments)
     }
+
+    private fun String.isComment() = startsWith("#")
 
     private fun findSection(line: String, isPatternMapping: Boolean): String? {
         val parts = line.split(" ")
@@ -66,15 +76,18 @@ abstract class CleanupMappingFiles : DefaultTask() {
         }
     }
 
-    private fun writeMappings(file: File, sortedLines: Map<String, List<String>>) {
-        file.delete()
-        file.writeText("\n")
+    private fun writeMappings(file: File, sortedLines: Map<String, List<String>>, comments: Map<String, String>) {
+        val lineSeparator = "\n" // Use Unix-style line endings explicitly
+        file.writeText(lineSeparator)
 
         for ((_, value) in sortedLines) {
             for (line in value) {
-                file.appendText("$line\n")
+                comments[line]?.let {
+                    file.appendText("$it$lineSeparator")
+                }
+                file.appendText("$line$lineSeparator")
             }
-            file.appendText("\n")
+            file.appendText(lineSeparator)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
@@ -51,7 +51,7 @@ abstract class CleanupMappingFiles : DefaultTask() {
         writeMappings(file, sortedLines, comments)
     }
 
-    private fun String.isComment() = startsWith("#")
+    private fun String.isComment() = trim().startsWith("#")
 
     private fun findSection(line: String, isPatternMapping: Boolean): String? {
         val parts = line.split(" ")

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
@@ -77,7 +77,7 @@ abstract class CleanupMappingFiles : DefaultTask() {
     }
 
     private fun writeMappings(file: File, sortedLines: Map<String, List<String>>, comments: Map<String, String>) {
-        val lineSeparator = "\n" // Use Unix-style line endings explicitly
+        val lineSeparator = "\n"
         file.writeText(lineSeparator)
 
         for ((_, value) in sortedLines) {

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
@@ -39,7 +39,7 @@ abstract class CleanupMappingFiles : DefaultTask() {
         }
 
         val sortedLines: Map<String, List<String>> = lines.groupBy { it.first }
-            .mapValues { it.value.map { it.second } }
+            .mapValues { it.value.map { it.second }.sorted() }
             .toSortedMap()
 
         writeMappings(file, sortedLines)

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
@@ -1,0 +1,82 @@
+package skyhannibuildsystem
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+abstract class CleanupMappingFiles : DefaultTask() {
+
+    @get:OutputDirectory
+    abstract val mappingsDirectory: DirectoryProperty
+
+    @TaskAction
+    fun cleanupMappingFiles() {
+        val mappingsDir = mappingsDirectory.get().asFile
+        println("full path for mapping task: ${mappingsDir.absolutePath}")
+
+        val mappingsFiles = mappingsDir.listFiles() ?: return
+
+        for (file in mappingsFiles) {
+            if (file.isFile && file.extension == "txt" && file.name.contains("mapping")) {
+                processMappingFile(file)
+            }
+        }
+    }
+
+    private fun processMappingFile(file: File) {
+        val isPatternMapping = file.name.startsWith("pattern-")
+
+        val lines = mutableSetOf<Pair<String, String>>()
+
+        file.forEachLine { line ->
+            if (line.isNotBlank()) {
+                findSection(line, isPatternMapping)?.let { parts ->
+                    lines.add(Pair(parts, line))
+                }
+            }
+        }
+
+        val sortedLines: Map<String, List<String>> = lines.groupBy { it.first }
+            .mapValues { it.value.map { it.second } }
+            .toSortedMap()
+
+        writeMappings(file, sortedLines)
+    }
+
+    private fun findSection(line: String, isPatternMapping: Boolean): String? {
+        val parts = line.split(" ")
+        when (parts.size) {
+            2 -> {
+                if (isPatternMapping) return null
+                val path = parts.first().split(".").dropLast(1).joinToString(".")
+                return path
+            }
+
+            3 -> {
+                if (isPatternMapping) return null
+                return parts[0]
+            }
+
+            5 -> {
+                if (!isPatternMapping) return null
+                return parts[0]
+            }
+
+            else -> return null
+        }
+    }
+
+    private fun writeMappings(file: File, sortedLines: Map<String, List<String>>) {
+        file.delete()
+        file.writeText("\n")
+
+        for ((_, value) in sortedLines) {
+            for (line in value) {
+                file.appendText("$line\n")
+            }
+            file.appendText("\n")
+        }
+    }
+}

--- a/versions/1.21.5/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.5/src/main/resources/skyhanni.accesswidener
@@ -1,3 +1,7 @@
 accessWidener v2 named
 accessible field net/minecraft/entity/LivingEntity equipment Lnet/minecraft/entity/EntityEquipment;
 accessible field net/minecraft/entity/EntityEquipment map Ljava/util/EnumMap;
+accessible field net/minecraft/client/option/KeyBinding boundKey Lnet/minecraft/client/util/InputUtil$Key;
+accessible field net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket type Lnet/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractTypeHandler;
+accessible class net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractType
+accessible method net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractTypeHandler getType ()Lnet/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractType;

--- a/versions/mapping-1.12.2-1.8.9.txt
+++ b/versions/mapping-1.12.2-1.8.9.txt
@@ -55,9 +55,9 @@ net.minecraft.network.play.server.SPacketTitle net.minecraft.network.play.server
 net.minecraft.network.play.server.SPacketUpdateScore net.minecraft.network.play.server.S3CPacketUpdateScore
 net.minecraft.network.play.server.SPacketWorldBorder net.minecraft.network.play.server.S44PacketWorldBorder
 
-net.minecraft.network.play.server.SPacketScoreboardObjective getRenderType() func_179817_d()
 net.minecraft.network.play.server.SPacketScoreboardObjective getObjectiveName() func_149339_c()
 net.minecraft.network.play.server.SPacketScoreboardObjective getObjectiveValue() func_149337_d()
+net.minecraft.network.play.server.SPacketScoreboardObjective getRenderType() func_179817_d()
 
 net.minecraft.scoreboard.IScoreCriteria net.minecraft.scoreboard.IScoreObjectiveCriteria
 

--- a/versions/mapping-1.12.2-1.8.9.txt
+++ b/versions/mapping-1.12.2-1.8.9.txt
@@ -8,11 +8,6 @@ net.minecraft.client.renderer.entity.RenderLivingBase net.minecraft.client.rende
 
 net.minecraft.entity.player.EntityPlayer getHeldItemMainhand() getHeldItem()
 
-# Workaround for it not letting stackSize be mapped to count.
-temp.net.minecraft.item.ItemStack net.minecraft.item.ItemStack
-temp.net.minecraft.item.ItemStack count stackSize
-net.minecraft.item.ItemStack temp.net.minecraft.item.ItemStack
-
 net.minecraft.network.play.client.CPacketAnimation net.minecraft.network.play.client.C0APacketAnimation
 net.minecraft.network.play.client.CPacketChatMessage net.minecraft.network.play.client.C01PacketChatMessage
 net.minecraft.network.play.client.CPacketClickWindow net.minecraft.network.play.client.C0EPacketClickWindow
@@ -74,7 +69,6 @@ net.minecraft.util.math.MathHelper net.minecraft.util.MathHelper
 net.minecraft.util.math.RayTraceResult net.minecraft.util.MovingObjectPosition
 net.minecraft.util.math.RayTraceResult$Type net.minecraft.util.math.RayTraceResult$MovingObjectType
 net.minecraft.util.math.Rotations net.minecraft.util.Rotations
-net.minecraft.util.math.Vec3d net.minecraft.util.Vec3
 net.minecraft.util.math.Vec3d net.minecraft.util.Vec3
 
 net.minecraft.util.text.ITextComponent net.minecraft.util.IChatComponent

--- a/versions/mapping-1.16.5-fabric-1.16.5-forge.txt
+++ b/versions/mapping-1.16.5-fabric-1.16.5-forge.txt
@@ -6,15 +6,15 @@ net.fabricmc.loader.api.ModContainer net.minecraftforge.fml.ModContainer
 
 net.minecraft.client.network.ClientPlayerEntity net.minecraft.client.player.LocalPlayer
 
-net.minecraft.client.network.ClientPlayerEntity sendChatMessage() chat()
 net.minecraft.client.network.ClientPlayerEntity networkHandler connection
+net.minecraft.client.network.ClientPlayerEntity sendChatMessage() chat()
 net.minecraft.client.network.ClientPlayerEntity setExperience() setExperienceValues()
 
-net.minecraft.client.option.Perspective net.minecraft.client.CameraType
 net.minecraft.client.option.KeyBinding net.minecraft.client.KeyMapping
+net.minecraft.client.option.Perspective net.minecraft.client.CameraType
 
-net.minecraft.client.option.KeyBinding unpressAll() releaseAll()
 net.minecraft.client.option.KeyBinding isPressed() isDown()
+net.minecraft.client.option.KeyBinding unpressAll() releaseAll()
 
 net.minecraft.client.option.Perspective isFrontView() isMirrored()
 
@@ -24,8 +24,8 @@ net.minecraft.client.util.Window getHandle() getWindow()
 
 net.minecraft.entity.decoration.ArmorStandEntity net.minecraft.world.entity.decoration.ArmorStand
 
-net.minecraft.entity.decoration.ArmorStandEntity shouldShowArms() isShowArms()
 net.minecraft.entity.decoration.ArmorStandEntity shouldHideBasePlate() isNoBasePlate()
+net.minecraft.entity.decoration.ArmorStandEntity shouldShowArms() isShowArms()
 
 net.minecraft.entity.passive.VillagerEntity net.minecraft.world.entity.npc.Villager
 
@@ -48,20 +48,20 @@ net.minecraft.screen.slot.Slot hasStack() hasItem()
 
 net.minecraft.server.network.ServerPlayerEntity net.minecraft.server.level.ServerPlayer
 
-net.minecraft.text.Style net.minecraft.network.chat.Style
 net.minecraft.text.MutableText net.minecraft.network.chat.MutableComponent
+net.minecraft.text.Style net.minecraft.network.chat.Style
 
 net.minecraft.text.MutableText setStyle() setStyle()
 
-net.minecraft.text.Style withStrikethrough() setStrikethrough()
-net.minecraft.text.Style withUnderline() setUnderlined()
 net.minecraft.text.Style withObfuscated() setObfuscated()
 net.minecraft.text.Style withParent() applyTo()
+net.minecraft.text.Style withStrikethrough() setStrikethrough()
+net.minecraft.text.Style withUnderline() setUnderlined()
 
 net.minecraft.util.hit.HitResult net.minecraft.world.phys.HitResult
 
-net.minecraft.util.math.Vec3d net.minecraft.world.phys.Vec3
 net.minecraft.util.math.Box net.minecraft.world.phys.AABB
+net.minecraft.util.math.Vec3d net.minecraft.world.phys.Vec3
 
 net.minecraft.util.math.Box contains() contains()
 net.minecraft.util.math.Box offset() move()

--- a/versions/mapping-1.16.5-fabric-1.16.5-forge.txt
+++ b/versions/mapping-1.16.5-fabric-1.16.5-forge.txt
@@ -11,36 +11,62 @@ net.minecraft.client.network.ClientPlayerEntity networkHandler connection
 net.minecraft.client.network.ClientPlayerEntity setExperience() setExperienceValues()
 
 net.minecraft.client.option.Perspective net.minecraft.client.CameraType
+net.minecraft.client.option.KeyBinding net.minecraft.client.KeyMapping
+
+net.minecraft.client.option.KeyBinding unpressAll() releaseAll()
+net.minecraft.client.option.KeyBinding isPressed() isDown()
+
 net.minecraft.client.option.Perspective isFrontView() isMirrored()
 
 net.minecraft.client.render.WorldRenderer reload() allChanged()
 
 net.minecraft.client.util.Window getHandle() getWindow()
 
-net.minecraft.item.ItemStack net.minecraft.world.item.ItemsStack
-net.minecraft.item.ItemStack getName() getDisplayName()
-
-net.minecraft.entity.passive.VillagerEntity net.minecraft.world.entity.npc.Villager
 net.minecraft.entity.decoration.ArmorStandEntity net.minecraft.world.entity.decoration.ArmorStand
+
 net.minecraft.entity.decoration.ArmorStandEntity shouldShowArms() isShowArms()
 net.minecraft.entity.decoration.ArmorStandEntity shouldHideBasePlate() isNoBasePlate()
 
-net.minecraft.server.network.ServerPlayerEntity net.minecraft.server.level.ServerPlayer
+net.minecraft.entity.passive.VillagerEntity net.minecraft.world.entity.npc.Villager
+
+net.minecraft.item.ItemStack net.minecraft.world.item.ItemsStack
+
+net.minecraft.item.ItemStack getName() getDisplayName()
+
+net.minecraft.network.packet.s2c.play.MobSpawnS2CPacket net.minecraft.network.protocol.game.ClientboundAddPlayerPacket
+
+net.minecraft.screen.ScreenHandler net.minecraft.world.inventory.AbstractContainerMenu
+
+net.minecraft.screen.ScreenHandler getSlot() getSlot()
+net.minecraft.screen.ScreenHandler syncId containerId
 
 net.minecraft.screen.slot.Slot net.minecraft.world.inventory.Slot
+
 net.minecraft.screen.slot.Slot getIndex() getSlotIndex()
 net.minecraft.screen.slot.Slot getStack() getItem()
 net.minecraft.screen.slot.Slot hasStack() hasItem()
 
-net.minecraft.screen.ScreenHandler net.minecraft.world.inventory.AbstractContainerMenu
-net.minecraft.screen.ScreenHandler getSlot() getSlot()
-net.minecraft.screen.ScreenHandler syncId containerId
+net.minecraft.server.network.ServerPlayerEntity net.minecraft.server.level.ServerPlayer
+
 net.minecraft.text.Style net.minecraft.network.chat.Style
+net.minecraft.text.MutableText net.minecraft.network.chat.MutableComponent
+
+net.minecraft.text.MutableText setStyle() setStyle()
 
 net.minecraft.text.Style withStrikethrough() setStrikethrough()
 net.minecraft.text.Style withUnderline() setUnderlined()
 net.minecraft.text.Style withObfuscated() setObfuscated()
 net.minecraft.text.Style withParent() applyTo()
 
-net.minecraft.text.MutableText net.minecraft.network.chat.MutableComponent
-net.minecraft.text.MutableText setStyle() setStyle()
+net.minecraft.util.hit.HitResult net.minecraft.world.phys.HitResult
+
+net.minecraft.util.math.Vec3d net.minecraft.world.phys.Vec3
+net.minecraft.util.math.Box net.minecraft.world.phys.AABB
+
+net.minecraft.util.math.Box contains() contains()
+net.minecraft.util.math.Box offset() move()
+
+net.minecraft.util.math.Vec3d squaredDistanceTo() distanceToSqr()
+
+net.minecraft.world.phys.HitResult getPos() getLocation()
+

--- a/versions/mapping-1.16.5-forge-1.12.2.txt
+++ b/versions/mapping-1.16.5-forge-1.12.2.txt
@@ -1,44 +1,44 @@
 
 com.mojang.blaze3d.platform.Lighting net.minecraft.client.renderer.RenderHelper
 
-com.mojang.blaze3d.platform.Lighting turnOff() disableStandardItemLighting()
-com.mojang.blaze3d.platform.Lighting turnBackOn() enableStandardItemLighting()
 com.mojang.blaze3d.platform.Lighting setupFor3DItems() enableGUIStandardItemLighting()
+com.mojang.blaze3d.platform.Lighting turnBackOn() enableStandardItemLighting()
+com.mojang.blaze3d.platform.Lighting turnOff() disableStandardItemLighting()
 
 com.mojang.blaze3d.systems.RenderSystem net.minecraft.client.renderer.GlStateManager
 
-com.mojang.blaze3d.systems.RenderSystem enableDepthTest() enableDepth()
-com.mojang.blaze3d.systems.RenderSystem disableDepthTest() disableDepth()
 com.mojang.blaze3d.systems.RenderSystem blendFuncSeparate() tryBlendFuncSeparate()
+com.mojang.blaze3d.systems.RenderSystem disableDepthTest() disableDepth()
+com.mojang.blaze3d.systems.RenderSystem enableDepthTest() enableDepth()
 
 com.mojang.math.Matrix3f org.lwjgl.util.vector.Matrix3f
 com.mojang.math.Matrix4f org.lwjgl.util.vector.Matrix4f
 
 net.minecraft.block.ChestBlock net.minecraft.block.BlockChest
 
-net.minecraft.client.Options net.minecraft.client.settings.GameSettings
 net.minecraft.client.KeyMapping net.minecraft.client.settings.KeyBinding
+net.minecraft.client.Options net.minecraft.client.settings.GameSettings
 
 net.minecraft.client.KeyMapping boundKey.getCode() getKeyCode()
-net.minecraft.client.KeyMapping releaseAll() unPressAllKeys()
 net.minecraft.client.KeyMapping isDown() isKeyDown()
+net.minecraft.client.KeyMapping releaseAll() unPressAllKeys()
 
 net.minecraft.client.Minecraft isSameThread() isCallingFromMinecraftThread()
 net.minecraft.client.Minecraft setScreen() displayGuiScreen()
 net.minecraft.client.Minecraft submit() addScheduledTask()
 
-net.minecraft.client.Options keyUp keyBindForward
+net.minecraft.client.Options getSoundSourceVolume() getSoundLevel()
+net.minecraft.client.Options keyAttack keyBindAttack
 net.minecraft.client.Options keyDown keyBindBack
+net.minecraft.client.Options keyFullscreen keyBindFullscreen
+net.minecraft.client.Options keyInventory keyBindInventory
+net.minecraft.client.Options keyJump keyBindJump
 net.minecraft.client.Options keyLeft keyBindLeft
 net.minecraft.client.Options keyRight keyBindRight
-net.minecraft.client.Options keyJump keyBindJump
-net.minecraft.client.Options keyShift keyBindSneak
-net.minecraft.client.Options keyAttack keyBindAttack
-net.minecraft.client.Options keyUse keyBindUseItem
-net.minecraft.client.Options keyInventory keyBindInventory
 net.minecraft.client.Options keyScreenshot keyBindScreenshot
-net.minecraft.client.Options keyFullscreen keyBindFullscreen
-net.minecraft.client.Options getSoundSourceVolume() getSoundLevel()
+net.minecraft.client.Options keyShift keyBindSneak
+net.minecraft.client.Options keyUp keyBindForward
+net.minecraft.client.Options keyUse keyBindUseItem
 
 net.minecraft.client.gui.Gui net.minecraft.client.gui.GuiIngame
 
@@ -47,9 +47,9 @@ net.minecraft.client.gui.Gui getChat() getChatGUI()
 net.minecraft.client.gui.components.ChatComponent net.minecraft.client.gui.GuiNewChat
 
 net.minecraft.client.gui.components.ChatComponent allMessages chatLines
-net.minecraft.client.gui.components.ChatComponent trimmedMessages drawnChatLines
-net.minecraft.client.gui.components.ChatComponent rescaleChat() refreshChat()
 net.minecraft.client.gui.components.ChatComponent getWidth() getChatWidth()
+net.minecraft.client.gui.components.ChatComponent rescaleChat() refreshChat()
+net.minecraft.client.gui.components.ChatComponent trimmedMessages drawnChatLines
 
 net.minecraft.client.gui.screens.ChatScreen net.minecraft.client.gui.GuiChat
 net.minecraft.client.gui.screens.Screen net.minecraft.client.gui.GuiScreen
@@ -62,8 +62,8 @@ net.minecraft.client.gui.screens.inventory.SignEditScreen net.minecraft.client.g
 
 net.minecraft.client.gui.screens.inventory.ContainerScreen menu inventorySlots
 
-net.minecraft.client.gui.screens.inventory.SignEditScreen sign tileSign
 net.minecraft.client.gui.screens.inventory.SignEditScreen line editLine
+net.minecraft.client.gui.screens.inventory.SignEditScreen sign tileSign
 
 net.minecraft.client.multiplayer.ClientLevel net.minecraft.client.multiplayer.WorldClient
 net.minecraft.client.multiplayer.ClientPacketListener net.minecraft.client.network.NetHandlerPlayClient
@@ -120,27 +120,27 @@ net.minecraft.nbt.CompoundTag net.minecraft.nbt.NBTTagCompound
 net.minecraft.nbt.ListTag net.minecraft.nbt.NBTTagList
 net.minecraft.nbt.StringTag net.minecraft.nbt.NBTTagString
 
-net.minecraft.nbt.CompoundTag getCompound() getCompoundTag()
-net.minecraft.nbt.CompoundTag getList() getTagList()
-net.minecraft.nbt.CompoundTag getKeys() getKeySet()
 net.minecraft.nbt.CompoundTag contains() hasKey()
-net.minecraft.nbt.CompoundTag put() setTag()
 net.minecraft.nbt.CompoundTag get() getTag()
+net.minecraft.nbt.CompoundTag getCompound() getCompoundTag()
+net.minecraft.nbt.CompoundTag getInt() getInteger()
+net.minecraft.nbt.CompoundTag getKeys() getKeySet()
+net.minecraft.nbt.CompoundTag getList() getTagList()
+net.minecraft.nbt.CompoundTag put() setTag()
 net.minecraft.nbt.CompoundTag putBoolean() setBoolean()
 net.minecraft.nbt.CompoundTag putInt() setInteger()
-net.minecraft.nbt.CompoundTag getInt() getInteger()
 net.minecraft.nbt.CompoundTag putString() setString()
 net.minecraft.nbt.CompoundTag remove() removeTag()
 
 net.minecraft.nbt.ListTag add() appendTag()
+net.minecraft.nbt.ListTag getCompound() getCompoundTagAt()
 net.minecraft.nbt.ListTag getSize() tagCount()
 net.minecraft.nbt.ListTag getString() getStringTagAt()
-net.minecraft.nbt.ListTag getCompound() getCompoundTagAt()
 
+net.minecraft.network.chat.BaseComponent net.minecraft.util.text.TextComponentBase
 net.minecraft.network.chat.Component net.minecraft.util.text.ITextComponent
 net.minecraft.network.chat.Style net.minecraft.util.text.Style
 net.minecraft.network.chat.TextComponent net.minecraft.util.text.TextComponentString
-net.minecraft.network.chat.BaseComponent net.minecraft.util.text.TextComponentBase
 
 net.minecraft.network.chat.BaseComponent append() appendSibling()
 
@@ -148,10 +148,10 @@ net.minecraft.network.chat.Component copy() createCopy()
 
 net.minecraft.network.chat.MutableComponent append() appendSibling()
 
+net.minecraft.network.chat.Style applyTo() setParentStyle()
+net.minecraft.network.chat.Style withBold() setBold()
 net.minecraft.network.chat.Style withColor() setColor()
 net.minecraft.network.chat.Style withItalic() setItalic()
-net.minecraft.network.chat.Style withBold() setBold()
-net.minecraft.network.chat.Style applyTo() setParentStyle()
 
 net.minecraft.network.protocol.Packet net.minecraft.network.Packet
 
@@ -166,6 +166,7 @@ net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket net.minecr
 net.minecraft.network.protocol.game.ClientboundEntityEventPacket net.minecraft.network.play.server.SPacketEntityStatus
 net.minecraft.network.protocol.game.ClientboundLevelEventPacket net.minecraft.network.play.server.SPacketEffect
 net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket net.minecraft.network.play.server.SPacketParticles
+net.minecraft.network.protocol.game.ClientboundLoginPacket net.minecraft.network.play.server.SPacketJoinGame
 net.minecraft.network.protocol.game.ClientboundMoveEntityPacket net.minecraft.network.play.server.SPacketEntity
 net.minecraft.network.protocol.game.ClientboundOpenScreenPacket net.minecraft.network.play.server.SPacketOpenWindow
 net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket net.minecraft.network.play.server.SPacketPlayerListItem
@@ -191,9 +192,8 @@ net.minecraft.network.protocol.game.ServerboundContainerClickPacket net.minecraf
 net.minecraft.network.protocol.game.ServerboundInteractPacket net.minecraft.network.play.client.CPacketUseEntity
 net.minecraft.network.protocol.game.ServerboundMovePlayerPacket net.minecraft.network.play.client.CPacketPlayer
 net.minecraft.network.protocol.game.ServerboundPickItemPacket net.minecraft.network.play.client.CPacketHeldItemChange
-net.minecraft.network.protocol.game.ServerboundUseItemOnPacket net.minecraft.network.play.client.CPacketPlayerTryUseItemOnBlock
-net.minecraft.network.protocol.game.ClientboundLoginPacket net.minecraft.network.play.server.SPacketJoinGame
 net.minecraft.network.protocol.game.ServerboundPlayerActionPacket net.minecraft.network.play.client.CPacketPlayerDigging
+net.minecraft.network.protocol.game.ServerboundUseItemOnPacket net.minecraft.network.play.client.CPacketPlayerTryUseItemOnBlock
 
 net.minecraft.network.protocol.game.ClientboundAddEntityPacket getId() getEntityID()
 
@@ -267,13 +267,21 @@ net.minecraft.world.entity.Entity deltaMovement.y motionY
 net.minecraft.world.entity.Entity deltaMovement.z motionZ
 net.minecraft.world.entity.Entity getAllSlots() getEquipmentAndArmor()
 net.minecraft.world.entity.Entity getBoundingBox() getEntityBoundingBox()
+net.minecraft.world.entity.Entity getCustomName() getCustomNameTag()
 net.minecraft.world.entity.Entity getEyePosition() getPositionEyes()
 net.minecraft.world.entity.Entity getId() getEntityId()
 net.minecraft.world.entity.Entity getLookAngle() getLookVec()
+net.minecraft.world.entity.Entity getPosition() getPositionVector()
 net.minecraft.world.entity.Entity getUUID() getUniqueID()
+net.minecraft.world.entity.Entity getVehicle() getRidingEntity()
 net.minecraft.world.entity.Entity isOnFire() isBurning()
+net.minecraft.world.entity.Entity isOnGround onGround
 net.minecraft.world.entity.Entity level world
+net.minecraft.world.entity.Entity position.x posX
+net.minecraft.world.entity.Entity position.y posY
+net.minecraft.world.entity.Entity position.z posZ
 net.minecraft.world.entity.Entity removed isDead
+net.minecraft.world.entity.Entity setCustomName() setCustomNameTag()
 net.minecraft.world.entity.Entity tickCount ticksExisted
 net.minecraft.world.entity.Entity xOld prevPosX
 net.minecraft.world.entity.Entity xRot rotationPitch
@@ -283,22 +291,14 @@ net.minecraft.world.entity.Entity yRot rotationYaw
 net.minecraft.world.entity.Entity yo posY
 net.minecraft.world.entity.Entity zOld prevPosZ
 net.minecraft.world.entity.Entity zo posZ
-net.minecraft.world.entity.Entity isOnGround onGround
-net.minecraft.world.entity.Entity getVehicle() getRidingEntity()
-net.minecraft.world.entity.Entity setCustomName() setCustomNameTag()
-net.minecraft.world.entity.Entity getCustomName() getCustomNameTag()
-net.minecraft.world.entity.Entity position.z posZ
-net.minecraft.world.entity.Entity position.y posY
-net.minecraft.world.entity.Entity position.x posX
-net.minecraft.world.entity.Entity getPosition() getPositionVector()
 
-net.minecraft.world.entity.LivingEntity isAlive() isEntityAlive()
 net.minecraft.world.entity.LivingEntity getEffect() getActivePotionEffect()
 net.minecraft.world.entity.LivingEntity getItemBySlot() getItemStackFromSlot()
 net.minecraft.world.entity.LivingEntity getItemInHand() getHeldItem()
 net.minecraft.world.entity.LivingEntity getMainHandItem() getHeldItemMainhand()
 net.minecraft.world.entity.LivingEntity getOffhandItem() getHeldItemOffhand()
 net.minecraft.world.entity.LivingEntity hasEffect() isPotionActive()
+net.minecraft.world.entity.LivingEntity isAlive() isEntityAlive()
 net.minecraft.world.entity.LivingEntity isBaby() isChild()
 
 net.minecraft.world.entity.ambient.Bat net.minecraft.entity.passive.EntityBat
@@ -328,8 +328,8 @@ net.minecraft.world.entity.decoration.ArmorStand net.minecraft.entity.item.Entit
 net.minecraft.world.entity.decoration.ItemFrame net.minecraft.entity.item.EntityItemFrame
 
 net.minecraft.world.entity.decoration.ArmorStand getArmorSlots() getArmorInventoryList()
-net.minecraft.world.entity.decoration.ArmorStand isShowArms() getShowArms()
 net.minecraft.world.entity.decoration.ArmorStand isNoBasePlate() hasNoBasePlate()
+net.minecraft.world.entity.decoration.ArmorStand isShowArms() getShowArms()
 
 net.minecraft.world.entity.item.ItemEntity net.minecraft.entity.item.EntityItem
 
@@ -368,10 +368,10 @@ net.minecraft.world.entity.player.Inventory getCarried() getItemStack()
 net.minecraft.world.entity.player.Inventory getSelected() getCurrentItem()
 net.minecraft.world.entity.player.Inventory items mainInventory
 
-net.minecraft.world.entity.player.Player isModelPartShown() isWearing()
 net.minecraft.world.entity.player.Player containerMenu openContainer
-net.minecraft.world.entity.player.Player totalExperience experienceTotal
 net.minecraft.world.entity.player.Player experienceProgress experience
+net.minecraft.world.entity.player.Player isModelPartShown() isWearing()
+net.minecraft.world.entity.player.Player totalExperience experienceTotal
 
 net.minecraft.world.entity.projectile.Arrow net.minecraft.entity.projectile.EntityArrow
 net.minecraft.world.entity.projectile.Fireball net.minecraft.entity.projectile.EntityFireball
@@ -380,9 +380,9 @@ net.minecraft.world.entity.projectile.SmallFireball net.minecraft.entity.project
 
 net.minecraft.world.entity.projectile.FishingHook getPlayerOwner() getAngler()
 
+net.minecraft.world.inventory.AbstractContainerMenu net.minecraft.inventory.Container
 net.minecraft.world.inventory.ChestMenu net.minecraft.inventory.ContainerChest
 net.minecraft.world.inventory.Slot net.minecraft.inventory.Slot
-net.minecraft.world.inventory.AbstractContainerMenu net.minecraft.inventory.Container
 
 net.minecraft.world.inventory.AbstractContainerMenu containerId windowId
 net.minecraft.world.inventory.AbstractContainerMenu slots inventorySlots
@@ -396,20 +396,20 @@ net.minecraft.world.inventory.Slot x xPos
 net.minecraft.world.inventory.Slot y yPos
 
 net.minecraft.world.item.BowItem net.minecraft.item.ItemBow
-net.minecraft.world.item.Item net.minecraft.item.Item
-net.minecraft.world.item.Items net.minecraft.init.Items
-net.minecraft.world.item.ItemStack net.minecraft.item.ItemStack
 net.minecraft.world.item.DyeColor net.minecraft.item.EnumDyeColor
+net.minecraft.world.item.Item net.minecraft.item.Item
+net.minecraft.world.item.ItemStack net.minecraft.item.ItemStack
+net.minecraft.world.item.Items net.minecraft.init.Items
 
 net.minecraft.world.item.DyeColor LIGHT_GRAY SILVER
 
 net.minecraft.world.item.Item byBlock() getItemFromBlock()
 
-net.minecraft.world.item.ItemStack isEnchanted() isItemEnchanted()
 net.minecraft.world.item.ItemStack getTag() getTagCompound()
+net.minecraft.world.item.ItemStack isEnchanted() isItemEnchanted()
 
-net.minecraft.world.item.Items PLAYER_HEAD SKULL
 net.minecraft.world.item.Items COD FISH
+net.minecraft.world.item.Items PLAYER_HEAD SKULL
 net.minecraft.world.item.Items SUGAR_CANE REEDS
 
 net.minecraft.world.item.enchantment.Enchantments net.minecraft.init.Enchantments
@@ -418,38 +418,38 @@ net.minecraft.world.item.enchantment.Enchantments ALL_DAMAGE_PROTECTION PROTECTI
 
 net.minecraft.world.level.Level net.minecraft.world.World
 
-net.minecraft.world.level.Level getEntity() getEntityByID()
 net.minecraft.world.level.Level getBlockEntity() getTileEntity()
 net.minecraft.world.level.Level getDayTime() getWorldTime()
+net.minecraft.world.level.Level getEntity() getEntityByID()
 
 net.minecraft.world.level.block.Blocks net.minecraft.init.Blocks
 net.minecraft.world.level.block.StainedGlassBlock net.minecraft.block.BlockStainedGlass
 net.minecraft.world.level.block.StainedGlassPaneBlock net.minecraft.block.BlockStainedGlassPane
 
-net.minecraft.world.level.block.Blocks PLAYER_HEAD SKULL
-net.minecraft.world.level.block.Blocks DANDELION YELLOW_FLOWER
-net.minecraft.world.level.block.Blocks NETHER_QUARTZ_ORE QUARTZ_ORE
-net.minecraft.world.level.block.Blocks SUGAR_CANE REEDS
-net.minecraft.world.level.block.Blocks MELON MELON_BLOCK
-net.minecraft.world.level.block.Blocks TERRACOTTA HARDENED_CLAY
 net.minecraft.world.level.block.Blocks COBBLESTONE_STAIRS STONE_STAIRS
+net.minecraft.world.level.block.Blocks DANDELION YELLOW_FLOWER
+net.minecraft.world.level.block.Blocks MELON MELON_BLOCK
+net.minecraft.world.level.block.Blocks NETHER_QUARTZ_ORE QUARTZ_ORE
+net.minecraft.world.level.block.Blocks PLAYER_HEAD SKULL
+net.minecraft.world.level.block.Blocks SUGAR_CANE REEDS
+net.minecraft.world.level.block.Blocks TERRACOTTA HARDENED_CLAY
 
+net.minecraft.world.level.block.entity.BeaconBlockEntity net.minecraft.tileentity.TileEntityBeacon
 net.minecraft.world.level.block.entity.SignBlockEntity net.minecraft.tileentity.TileEntitySign
 net.minecraft.world.level.block.entity.SkullBlockEntity net.minecraft.tileentity.TileEntitySkull
-net.minecraft.world.level.block.entity.BeaconBlockEntity net.minecraft.tileentity.TileEntityBeacon
 
 net.minecraft.world.level.block.state.BlockState net.minecraft.block.state.IBlockState
 
-net.minecraft.world.level.block.state.properties.IntegerProperty net.minecraft.block.properties.PropertyInteger
-net.minecraft.world.level.block.state.properties.EnumProperty net.minecraft.block.properties.PropertyEnum
 net.minecraft.world.level.block.state.properties.BooleanProperty net.minecraft.block.properties.PropertyBool
 net.minecraft.world.level.block.state.properties.DirectionProperty net.minecraft.block.properties.PropertyDirection
+net.minecraft.world.level.block.state.properties.EnumProperty net.minecraft.block.properties.PropertyEnum
+net.minecraft.world.level.block.state.properties.IntegerProperty net.minecraft.block.properties.PropertyInteger
 
-net.minecraft.world.phys.Vec3 net.minecraft.util.math.Vec3d
 net.minecraft.world.phys.HitResult net.minecraft.util.math.RayTraceResult
+net.minecraft.world.phys.Vec3 net.minecraft.util.math.Vec3d
 
-net.minecraft.world.phys.HitResult type typeOfHit
 net.minecraft.world.phys.HitResult getLocation() getBlockPos()
+net.minecraft.world.phys.HitResult type typeOfHit
 
 net.minecraft.world.phys.Vec3 distanceToSqr() squareDistanceTo()
 
@@ -484,9 +484,6 @@ org.lwjgl.glfw.GLFW GLFW_KEY_7 KEY_7
 org.lwjgl.glfw.GLFW GLFW_KEY_8 KEY_8
 org.lwjgl.glfw.GLFW GLFW_KEY_9 KEY_9
 org.lwjgl.glfw.GLFW GLFW_KEY_A KEY_A
-org.lwjgl.glfw.GLFW GLFW_KEY_KP_ADD KEY_ADD
-org.lwjgl.glfw.GLFW GLFW_KEY_LEFT_ALT KEY_LMENU
-org.lwjgl.glfw.GLFW GLFW_KEY_RIGHT_ALT KEY_RMENU
 org.lwjgl.glfw.GLFW GLFW_KEY_B KEY_B
 org.lwjgl.glfw.GLFW GLFW_KEY_BACKSPACE KEY_BACK
 org.lwjgl.glfw.GLFW GLFW_KEY_C KEY_C
@@ -495,8 +492,8 @@ org.lwjgl.glfw.GLFW GLFW_KEY_DOWN KEY_DOWN
 org.lwjgl.glfw.GLFW GLFW_KEY_E KEY_E
 org.lwjgl.glfw.GLFW GLFW_KEY_END KEY_END
 org.lwjgl.glfw.GLFW GLFW_KEY_ENTER KEY_RETURN
-org.lwjgl.glfw.GLFW GLFW_KEY_ESCAPE KEY_ESCAPE
 org.lwjgl.glfw.GLFW GLFW_KEY_EQUAL KEY_EQUALS
+org.lwjgl.glfw.GLFW GLFW_KEY_ESCAPE KEY_ESCAPE
 org.lwjgl.glfw.GLFW GLFW_KEY_F KEY_F
 org.lwjgl.glfw.GLFW GLFW_KEY_F3 KEY_F3
 org.lwjgl.glfw.GLFW GLFW_KEY_G KEY_G
@@ -505,23 +502,26 @@ org.lwjgl.glfw.GLFW GLFW_KEY_HOME KEY_HOME
 org.lwjgl.glfw.GLFW GLFW_KEY_I KEY_I
 org.lwjgl.glfw.GLFW GLFW_KEY_J KEY_J
 org.lwjgl.glfw.GLFW GLFW_KEY_K KEY_K
+org.lwjgl.glfw.GLFW GLFW_KEY_KP_ADD KEY_ADD
 org.lwjgl.glfw.GLFW GLFW_KEY_KP_SUBTRACT KEY_SUBTRACT
 org.lwjgl.glfw.GLFW GLFW_KEY_L KEY_L
 org.lwjgl.glfw.GLFW GLFW_KEY_LEFT KEY_LEFT
+org.lwjgl.glfw.GLFW GLFW_KEY_LEFT_ALT KEY_LMENU
 org.lwjgl.glfw.GLFW GLFW_KEY_LEFT_CONTROL KEY_LCONTROL
 org.lwjgl.glfw.GLFW GLFW_KEY_LEFT_SHIFT KEY_LSHIFT
+org.lwjgl.glfw.GLFW GLFW_KEY_LEFT_SUPER KEY_LMETA
 org.lwjgl.glfw.GLFW GLFW_KEY_M KEY_M
 org.lwjgl.glfw.GLFW GLFW_KEY_MINUS KEY_MINUS
-org.lwjgl.glfw.GLFW GLFW_KEY_LEFT_SUPER KEY_LMETA
-org.lwjgl.glfw.GLFW GLFW_KEY_RIGHT_SUPER KEY_RMETA
 org.lwjgl.glfw.GLFW GLFW_KEY_N KEY_N
 org.lwjgl.glfw.GLFW GLFW_KEY_O KEY_O
 org.lwjgl.glfw.GLFW GLFW_KEY_P KEY_P
 org.lwjgl.glfw.GLFW GLFW_KEY_Q KEY_Q
 org.lwjgl.glfw.GLFW GLFW_KEY_R KEY_R
 org.lwjgl.glfw.GLFW GLFW_KEY_RIGHT KEY_RIGHT
+org.lwjgl.glfw.GLFW GLFW_KEY_RIGHT_ALT KEY_RMENU
 org.lwjgl.glfw.GLFW GLFW_KEY_RIGHT_CONTROL KEY_RCONTROL
 org.lwjgl.glfw.GLFW GLFW_KEY_RIGHT_SHIFT KEY_RSHIFT
+org.lwjgl.glfw.GLFW GLFW_KEY_RIGHT_SUPER KEY_RMETA
 org.lwjgl.glfw.GLFW GLFW_KEY_S KEY_S
 org.lwjgl.glfw.GLFW GLFW_KEY_SPACE KEY_SPACE
 org.lwjgl.glfw.GLFW GLFW_KEY_T KEY_T

--- a/versions/mapping-1.16.5-forge-1.12.2.txt
+++ b/versions/mapping-1.16.5-forge-1.12.2.txt
@@ -1,6 +1,11 @@
 
-com.mojang.blaze3d.systems.RenderSystem net.minecraft.client.renderer.GlStateManager
+com.mojang.blaze3d.platform.Lighting net.minecraft.client.renderer.RenderHelper
 
+com.mojang.blaze3d.platform.Lighting turnOff() disableStandardItemLighting()
+com.mojang.blaze3d.platform.Lighting turnBackOn() enableStandardItemLighting()
+com.mojang.blaze3d.platform.Lighting setupFor3DItems() enableGUIStandardItemLighting()
+
+com.mojang.blaze3d.systems.RenderSystem net.minecraft.client.renderer.GlStateManager
 
 com.mojang.blaze3d.systems.RenderSystem enableDepthTest() enableDepth()
 com.mojang.blaze3d.systems.RenderSystem disableDepthTest() disableDepth()
@@ -12,6 +17,15 @@ com.mojang.math.Matrix4f org.lwjgl.util.vector.Matrix4f
 net.minecraft.block.ChestBlock net.minecraft.block.BlockChest
 
 net.minecraft.client.Options net.minecraft.client.settings.GameSettings
+net.minecraft.client.KeyMapping net.minecraft.client.settings.KeyBinding
+
+net.minecraft.client.KeyMapping boundKey.getCode() getKeyCode()
+net.minecraft.client.KeyMapping releaseAll() unPressAllKeys()
+net.minecraft.client.KeyMapping isDown() isKeyDown()
+
+net.minecraft.client.Minecraft isSameThread() isCallingFromMinecraftThread()
+net.minecraft.client.Minecraft setScreen() displayGuiScreen()
+net.minecraft.client.Minecraft submit() addScheduledTask()
 
 net.minecraft.client.Options keyUp keyBindForward
 net.minecraft.client.Options keyDown keyBindBack
@@ -25,10 +39,6 @@ net.minecraft.client.Options keyInventory keyBindInventory
 net.minecraft.client.Options keyScreenshot keyBindScreenshot
 net.minecraft.client.Options keyFullscreen keyBindFullscreen
 net.minecraft.client.Options getSoundSourceVolume() getSoundLevel()
-
-net.minecraft.client.Minecraft isSameThread() isCallingFromMinecraftThread()
-net.minecraft.client.Minecraft setScreen() displayGuiScreen()
-net.minecraft.client.Minecraft submit() addScheduledTask()
 
 net.minecraft.client.gui.Gui net.minecraft.client.gui.GuiIngame
 
@@ -46,12 +56,11 @@ net.minecraft.client.gui.screens.Screen net.minecraft.client.gui.GuiScreen
 
 net.minecraft.client.gui.screens.Screen isPauseScreen() doesGuiPauseGame()
 
-net.minecraft.client.renderer.LevelRenderer net.minecraft.client.renderer.RenderGlobal
-net.minecraft.client.renderer.LevelRenderer allChanged() loadRenderers()
-
 net.minecraft.client.gui.screens.inventory.ContainerScreen net.minecraft.client.gui.inventory.GuiChest
 net.minecraft.client.gui.screens.inventory.InventoryScreen net.minecraft.client.gui.inventory.GuiInventory
 net.minecraft.client.gui.screens.inventory.SignEditScreen net.minecraft.client.gui.inventory.GuiEditSign
+
+net.minecraft.client.gui.screens.inventory.ContainerScreen menu inventorySlots
 
 net.minecraft.client.gui.screens.inventory.SignEditScreen sign tileSign
 net.minecraft.client.gui.screens.inventory.SignEditScreen line editLine
@@ -105,9 +114,10 @@ net.minecraft.core.particles.ParticleTypes POOF EXPLOSION_NORMAL
 net.minecraft.core.particles.ParticleTypes SMOKE SMOKE_NORMAL
 net.minecraft.core.particles.ParticleTypes WITCH SPELL_WITCH
 
+net.minecraft.entity.projectile.EntityArrow owner shootingEntity
+
 net.minecraft.nbt.CompoundTag net.minecraft.nbt.NBTTagCompound
 net.minecraft.nbt.ListTag net.minecraft.nbt.NBTTagList
-net.minecraft.nbt.ListTag add() appendTag()
 net.minecraft.nbt.StringTag net.minecraft.nbt.NBTTagString
 
 net.minecraft.nbt.CompoundTag getCompound() getCompoundTag()
@@ -122,6 +132,7 @@ net.minecraft.nbt.CompoundTag getInt() getInteger()
 net.minecraft.nbt.CompoundTag putString() setString()
 net.minecraft.nbt.CompoundTag remove() removeTag()
 
+net.minecraft.nbt.ListTag add() appendTag()
 net.minecraft.nbt.ListTag getSize() tagCount()
 net.minecraft.nbt.ListTag getString() getStringTagAt()
 net.minecraft.nbt.ListTag getCompound() getCompoundTagAt()
@@ -131,9 +142,10 @@ net.minecraft.network.chat.Style net.minecraft.util.text.Style
 net.minecraft.network.chat.TextComponent net.minecraft.util.text.TextComponentString
 net.minecraft.network.chat.BaseComponent net.minecraft.util.text.TextComponentBase
 
+net.minecraft.network.chat.BaseComponent append() appendSibling()
+
 net.minecraft.network.chat.Component copy() createCopy()
 
-net.minecraft.network.chat.BaseComponent append() appendSibling()
 net.minecraft.network.chat.MutableComponent append() appendSibling()
 
 net.minecraft.network.chat.Style withColor() setColor()
@@ -153,7 +165,6 @@ net.minecraft.network.protocol.game.ClientboundContainerClosePacket net.minecraf
 net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket net.minecraft.network.play.server.SPacketSetSlot
 net.minecraft.network.protocol.game.ClientboundEntityEventPacket net.minecraft.network.play.server.SPacketEntityStatus
 net.minecraft.network.protocol.game.ClientboundLevelEventPacket net.minecraft.network.play.server.SPacketEffect
-net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket net.minecraft.network.play.server.SPacketParticles
 net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket net.minecraft.network.play.server.SPacketParticles
 net.minecraft.network.protocol.game.ClientboundMoveEntityPacket net.minecraft.network.play.server.SPacketEntity
 net.minecraft.network.protocol.game.ClientboundOpenScreenPacket net.minecraft.network.play.server.SPacketOpenWindow
@@ -181,8 +192,8 @@ net.minecraft.network.protocol.game.ServerboundInteractPacket net.minecraft.netw
 net.minecraft.network.protocol.game.ServerboundMovePlayerPacket net.minecraft.network.play.client.CPacketPlayer
 net.minecraft.network.protocol.game.ServerboundPickItemPacket net.minecraft.network.play.client.CPacketHeldItemChange
 net.minecraft.network.protocol.game.ServerboundUseItemOnPacket net.minecraft.network.play.client.CPacketPlayerTryUseItemOnBlock
-
-net.minecraft.network.protocol.game.ServerboundUseItemOnPacket hitResult.getBlockPos() getPos()
+net.minecraft.network.protocol.game.ClientboundLoginPacket net.minecraft.network.play.server.SPacketJoinGame
+net.minecraft.network.protocol.game.ServerboundPlayerActionPacket net.minecraft.network.play.client.CPacketPlayerDigging
 
 net.minecraft.network.protocol.game.ClientboundAddEntityPacket getId() getEntityID()
 
@@ -230,11 +241,15 @@ net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket getId() getE
 
 net.minecraft.network.protocol.game.ServerboundInteractPacket getTarget() getEntityFromWorld()
 
+net.minecraft.network.protocol.game.ServerboundPlayerActionPacket getPos() getPosition()
+
 net.minecraft.network.protocol.game.ServerboundUseItemOnPacket hitResult.getBlockPos() getPos()
+
+net.minecraft.server.level.ServerPlayer net.minecraft.entity.player.EntityPlayerMP
 
 net.minecraft.server.packs.resources.ResourceManager net.minecraft.client.resources.IResourceManager
 
-net.minecraft.server.level.ServerPlayer net.minecraft.entity.player.EntityPlayerMP
+net.minecraft.world.SimpleContainer net.minecraft.client.player.inventory.ContainerLocalMenu
 
 net.minecraft.world.effect.MobEffect net.minecraft.potion.Potion
 net.minecraft.world.effect.MobEffectInstance net.minecraft.potion.PotionEffect
@@ -245,8 +260,6 @@ net.minecraft.world.entity.EquipmentSlot net.minecraft.inventory.EntityEquipment
 net.minecraft.world.entity.ExperienceOrb net.minecraft.entity.item.EntityXPOrb
 net.minecraft.world.entity.LivingEntity net.minecraft.entity.EntityLivingBase
 net.minecraft.world.entity.Mob net.minecraft.entity.EntityLiving
-
-net.minecraft.world.entity.LivingEntity isAlive() isEntityAlive()
 
 net.minecraft.world.entity.Entity customName setCustomNameTag()
 net.minecraft.world.entity.Entity deltaMovement.x motionX
@@ -274,14 +287,18 @@ net.minecraft.world.entity.Entity isOnGround onGround
 net.minecraft.world.entity.Entity getVehicle() getRidingEntity()
 net.minecraft.world.entity.Entity setCustomName() setCustomNameTag()
 net.minecraft.world.entity.Entity getCustomName() getCustomNameTag()
+net.minecraft.world.entity.Entity position.z posZ
+net.minecraft.world.entity.Entity position.y posY
+net.minecraft.world.entity.Entity position.x posX
+net.minecraft.world.entity.Entity getPosition() getPositionVector()
 
+net.minecraft.world.entity.LivingEntity isAlive() isEntityAlive()
 net.minecraft.world.entity.LivingEntity getEffect() getActivePotionEffect()
 net.minecraft.world.entity.LivingEntity getItemBySlot() getItemStackFromSlot()
 net.minecraft.world.entity.LivingEntity getItemInHand() getHeldItem()
 net.minecraft.world.entity.LivingEntity getMainHandItem() getHeldItemMainhand()
 net.minecraft.world.entity.LivingEntity getOffhandItem() getHeldItemOffhand()
 net.minecraft.world.entity.LivingEntity hasEffect() isPotionActive()
-net.minecraft.world.entity.LivingEntity isAlive() isEntityAlive()
 net.minecraft.world.entity.LivingEntity isBaby() isChild()
 
 net.minecraft.world.entity.ambient.Bat net.minecraft.entity.passive.EntityBat
@@ -304,6 +321,7 @@ net.minecraft.world.entity.animal.horse.Horse net.minecraft.entity.passive.Entit
 net.minecraft.world.entity.boss.enderdragon.EnderDragon net.minecraft.entity.boss.EntityDragon
 
 net.minecraft.world.entity.boss.wither.WitherBoss net.minecraft.entity.boss.EntityWither
+
 net.minecraft.world.entity.boss.wither.WitherBoss getInvulnerableTicks() getInvulTime()
 
 net.minecraft.world.entity.decoration.ArmorStand net.minecraft.entity.item.EntityArmorStand
@@ -327,14 +345,17 @@ net.minecraft.world.entity.monster.MagmaCube net.minecraft.entity.monster.Entity
 net.minecraft.world.entity.monster.Silverfish net.minecraft.entity.monster.EntitySilverfish
 net.minecraft.world.entity.monster.Skeleton net.minecraft.entity.monster.EntitySkeleton
 net.minecraft.world.entity.monster.Slime net.minecraft.entity.monster.EntitySlime
-net.minecraft.world.entity.monster.Slime getSize() getSlimeSize()
 net.minecraft.world.entity.monster.Spider net.minecraft.entity.monster.EntitySpider
 net.minecraft.world.entity.monster.Witch net.minecraft.entity.monster.EntityWitch
 net.minecraft.world.entity.monster.WitherSkeleton net.minecraft.entity.monster.EntityWitherSkeleton
 net.minecraft.world.entity.monster.Zombie net.minecraft.entity.monster.EntityZombie
 net.minecraft.world.entity.monster.ZombifiedPiglin net.minecraft.entity.monster.EntityPigZombie
 
+net.minecraft.world.entity.monster.Creeper isPowered() getPowered()
+
 net.minecraft.world.entity.monster.EnderMan getCarriedBlock() getHeldBlockState()
+
+net.minecraft.world.entity.monster.Slime getSize() getSlimeSize()
 
 net.minecraft.world.entity.npc.Villager net.minecraft.entity.passive.EntityVillager
 
@@ -360,9 +381,13 @@ net.minecraft.world.entity.projectile.SmallFireball net.minecraft.entity.project
 net.minecraft.world.entity.projectile.FishingHook getPlayerOwner() getAngler()
 
 net.minecraft.world.inventory.ChestMenu net.minecraft.inventory.ContainerChest
-net.minecraft.world.inventory.ChestMenu getContainer() getLowerChestInventory()
-
 net.minecraft.world.inventory.Slot net.minecraft.inventory.Slot
+net.minecraft.world.inventory.AbstractContainerMenu net.minecraft.inventory.Container
+
+net.minecraft.world.inventory.AbstractContainerMenu containerId windowId
+net.minecraft.world.inventory.AbstractContainerMenu slots inventorySlots
+
+net.minecraft.world.inventory.ChestMenu getContainer() getLowerChestInventory()
 
 net.minecraft.world.inventory.Slot getItem() getStack()
 net.minecraft.world.inventory.Slot hasItem() getHasStack()
@@ -374,14 +399,14 @@ net.minecraft.world.item.BowItem net.minecraft.item.ItemBow
 net.minecraft.world.item.Item net.minecraft.item.Item
 net.minecraft.world.item.Items net.minecraft.init.Items
 net.minecraft.world.item.ItemStack net.minecraft.item.ItemStack
-net.minecraft.world.item.ItemStack isEnchanted() isItemEnchanted()
-net.minecraft.world.item.ItemStack getTag() getTagCompound()
-net.minecraft.world.item.BowItem net.minecraft.item.ItemBow
+net.minecraft.world.item.DyeColor net.minecraft.item.EnumDyeColor
+
+net.minecraft.world.item.DyeColor LIGHT_GRAY SILVER
 
 net.minecraft.world.item.Item byBlock() getItemFromBlock()
 
-net.minecraft.world.item.DyeColor net.minecraft.item.EnumDyeColor
-net.minecraft.world.item.DyeColor LIGHT_GRAY SILVER
+net.minecraft.world.item.ItemStack isEnchanted() isItemEnchanted()
+net.minecraft.world.item.ItemStack getTag() getTagCompound()
 
 net.minecraft.world.item.Items PLAYER_HEAD SKULL
 net.minecraft.world.item.Items COD FISH
@@ -392,11 +417,15 @@ net.minecraft.world.item.enchantment.Enchantments net.minecraft.init.Enchantment
 net.minecraft.world.item.enchantment.Enchantments ALL_DAMAGE_PROTECTION PROTECTION
 
 net.minecraft.world.level.Level net.minecraft.world.World
+
 net.minecraft.world.level.Level getEntity() getEntityByID()
 net.minecraft.world.level.Level getBlockEntity() getTileEntity()
 net.minecraft.world.level.Level getDayTime() getWorldTime()
 
 net.minecraft.world.level.block.Blocks net.minecraft.init.Blocks
+net.minecraft.world.level.block.StainedGlassBlock net.minecraft.block.BlockStainedGlass
+net.minecraft.world.level.block.StainedGlassPaneBlock net.minecraft.block.BlockStainedGlassPane
+
 net.minecraft.world.level.block.Blocks PLAYER_HEAD SKULL
 net.minecraft.world.level.block.Blocks DANDELION YELLOW_FLOWER
 net.minecraft.world.level.block.Blocks NETHER_QUARTZ_ORE QUARTZ_ORE
@@ -405,13 +434,9 @@ net.minecraft.world.level.block.Blocks MELON MELON_BLOCK
 net.minecraft.world.level.block.Blocks TERRACOTTA HARDENED_CLAY
 net.minecraft.world.level.block.Blocks COBBLESTONE_STAIRS STONE_STAIRS
 
-net.minecraft.world.level.block.StainedGlassBlock net.minecraft.block.BlockStainedGlass
-net.minecraft.world.level.block.StainedGlassPaneBlock net.minecraft.block.BlockStainedGlassPane
-
-net.minecraft.block.ChestBlock net.minecraft.block.BlockChest
-
 net.minecraft.world.level.block.entity.SignBlockEntity net.minecraft.tileentity.TileEntitySign
 net.minecraft.world.level.block.entity.SkullBlockEntity net.minecraft.tileentity.TileEntitySkull
+net.minecraft.world.level.block.entity.BeaconBlockEntity net.minecraft.tileentity.TileEntityBeacon
 
 net.minecraft.world.level.block.state.BlockState net.minecraft.block.state.IBlockState
 
@@ -421,13 +446,18 @@ net.minecraft.world.level.block.state.properties.BooleanProperty net.minecraft.b
 net.minecraft.world.level.block.state.properties.DirectionProperty net.minecraft.block.properties.PropertyDirection
 
 net.minecraft.world.phys.Vec3 net.minecraft.util.math.Vec3d
+net.minecraft.world.phys.HitResult net.minecraft.util.math.RayTraceResult
+
+net.minecraft.world.phys.HitResult type typeOfHit
+net.minecraft.world.phys.HitResult getLocation() getBlockPos()
+
+net.minecraft.world.phys.Vec3 distanceToSqr() squareDistanceTo()
+
+net.minecraft.world.scores.Team net.minecraft.scoreboard.Team
+net.minecraft.world.scores.Team$Visibility net.minecraft.scoreboard.Team$EnumVisible
 
 net.minecraft.world.scores.criteria.ObjectiveCriteria net.minecraft.scoreboard.IScoreCriteria
 net.minecraft.world.scores.criteria.ObjectiveCriteria$RenderType net.minecraft.scoreboard.IScoreCriteria$EnumRenderType
-
-net.minecraft.world.scores.Team net.minecraft.scoreboard.Team
-
-net.minecraft.world.scores.Team$Visibility net.minecraft.scoreboard.Team$EnumVisible
 
 net.minecraftforge.api.distmarker.Dist net.minecraftforge.fml.relauncher.Side
 net.minecraftforge.api.distmarker.OnlyIn net.minecraftforge.fml.relauncher.SideOnly
@@ -505,21 +535,3 @@ org.lwjgl.glfw.GLFW GLFW_KEY_X KEY_X
 org.lwjgl.glfw.GLFW GLFW_KEY_Y KEY_Y
 org.lwjgl.glfw.GLFW GLFW_KEY_Z KEY_Z
 
-net.minecraft.world.inventory.AbstractContainerMenu net.minecraft.inventory.Container
-
-net.minecraft.world.inventory.AbstractContainerMenu containerId windowId
-net.minecraft.world.inventory.AbstractContainerMenu slots inventorySlots
-
-net.minecraft.client.gui.screens.inventory.ContainerScreen menu inventorySlots
-
-net.minecraft.entity.projectile.EntityArrow owner shootingEntity
-
-com.mojang.blaze3d.systems.RenderSystem enableDepthTest() enableDepth()
-com.mojang.blaze3d.systems.RenderSystem disableDepthTest() disableDepth()
-com.mojang.blaze3d.systems.RenderSystem blendFuncSeparate() tryBlendFuncSeparate()
-
-com.mojang.blaze3d.platform.Lighting net.minecraft.client.renderer.RenderHelper
-
-com.mojang.blaze3d.platform.Lighting turnOff() disableStandardItemLighting()
-com.mojang.blaze3d.platform.Lighting turnBackOn() enableStandardItemLighting()
-com.mojang.blaze3d.platform.Lighting setupFor3DItems() enableGUIStandardItemLighting()

--- a/versions/mapping-1.21.5-1.16.5-fabric.txt
+++ b/versions/mapping-1.21.5-1.16.5-fabric.txt
@@ -1,26 +1,40 @@
 
+net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext at.hannibal2.skyhanni.utils.compat.WorldRenderContext
+
+net.minecraft.client.gui.DrawContext at.hannibal2.skyhanni.utils.compat.DrawContext
+
 net.minecraft.client.gui.hud.ChatHudLine getContent() getChatComponent()
 
+net.minecraft.client.gui.screen.ingame.SignEditScreen blockEntity sign
+
 net.minecraft.client.network.ClientPlayerEntity net.minecraft.client.network.ClientPlayerEntity
+
 net.minecraft.client.network.ClientPlayerEntity networkHandler.sendChatMessage() sendChatMessage()
+
+net.minecraft.client.util.math.MatrixStack at.hannibal2.skyhanni.utils.compat.MatrixStack
+
+net.minecraft.client.util.math.MatrixStack push() pushMatrix()
+net.minecraft.client.util.math.MatrixStack pop() popMatrix()
 
 net.minecraft.entity.Entity getEquippedItems() getItemsEquipped()
 net.minecraft.entity.Entity getId() getEntityId()
 
 net.minecraft.entity.decoration.ArmorStandEntity shouldShowBasePlate().not() shouldHideBasePlate()
 
+net.minecraft.entity.mob.CreeperEntity isCharged() shouldRenderOverlay()
+
+net.minecraft.entity.player.PlayerInventory mainStacks main
+
 net.minecraft.item.ItemStack getName() toHoverableText()
 net.minecraft.item.ItemStack getComponents() getTag()
 
-net.minecraft.client.gui.screen.ingame.SignEditScreen blockEntity sign
+net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket$InteractType net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket$InteractionType
+
+net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket type.getType() getType()
+
+net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket net.minecraft.network.packet.s2c.play.MobSpawnS2CPacket
+
+net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket getEntityId() getId()
 
 net.minecraft.text.Text net.minecraft.text.LiteralText
 
-net.minecraft.client.gui.DrawContext at.hannibal2.skyhanni.utils.compat.DrawContext
-
-net.minecraft.client.util.math.MatrixStack at.hannibal2.skyhanni.utils.compat.MatrixStack
-
-net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext at.hannibal2.skyhanni.utils.compat.WorldRenderContext
-
-net.minecraft.client.util.math.MatrixStack push() pushMatrix()
-net.minecraft.client.util.math.MatrixStack pop() popMatrix()

--- a/versions/mapping-1.21.5-1.16.5-fabric.txt
+++ b/versions/mapping-1.21.5-1.16.5-fabric.txt
@@ -13,8 +13,8 @@ net.minecraft.client.network.ClientPlayerEntity networkHandler.sendChatMessage()
 
 net.minecraft.client.util.math.MatrixStack at.hannibal2.skyhanni.utils.compat.MatrixStack
 
-net.minecraft.client.util.math.MatrixStack push() pushMatrix()
 net.minecraft.client.util.math.MatrixStack pop() popMatrix()
+net.minecraft.client.util.math.MatrixStack push() pushMatrix()
 
 net.minecraft.entity.Entity getEquippedItems() getItemsEquipped()
 net.minecraft.entity.Entity getId() getEntityId()
@@ -25,8 +25,8 @@ net.minecraft.entity.mob.CreeperEntity isCharged() shouldRenderOverlay()
 
 net.minecraft.entity.player.PlayerInventory mainStacks main
 
-net.minecraft.item.ItemStack getName() toHoverableText()
 net.minecraft.item.ItemStack getComponents() getTag()
+net.minecraft.item.ItemStack getName() toHoverableText()
 
 net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket$InteractType net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket$InteractionType
 

--- a/versions/pattern-mappings-1.16.5-forge-1.12.2.txt
+++ b/versions/pattern-mappings-1.16.5-forge-1.12.2.txt
@@ -1,12 +1,12 @@
 
 at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer net.minecraft.client.gui.inventory.GuiContainer container inventorySlots at.hannibal2.skyhanni.utils.compat.container
 
-net.minecraft.network.chat.Component net.minecraft.util.text.ITextComponent unformattedTextForChatCompat() getUnformattedComponentText() at.hannibal2.skyhanni.utils.compat.unformattedTextForChatCompat
-net.minecraft.network.chat.Component net.minecraft.util.text.ITextComponent unformattedTextCompat() getUnformattedText() at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
 net.minecraft.network.chat.Component net.minecraft.util.text.ITextComponent formattedTextCompat() getFormattedText() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+net.minecraft.network.chat.Component net.minecraft.util.text.ITextComponent unformattedTextCompat() getUnformattedText() at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
+net.minecraft.network.chat.Component net.minecraft.util.text.ITextComponent unformattedTextForChatCompat() getUnformattedComponentText() at.hannibal2.skyhanni.utils.compat.unformattedTextForChatCompat
 
-net.minecraft.network.chat.Style net.minecraft.util.text.Style returnThis() createShallowCopy() at.hannibal2.skyhanni.utils.compat.returnThis
 net.minecraft.network.chat.Style net.minecraft.util.text.Style returnThis() createDeepCopy() at.hannibal2.skyhanni.utils.compat.returnThis
+net.minecraft.network.chat.Style net.minecraft.util.text.Style returnThis() createShallowCopy() at.hannibal2.skyhanni.utils.compat.returnThis
 
 net.minecraft.network.protocol.game.ClientboundSetObjectivePacket net.minecraft.network.play.server.SPacketScoreboardObjective displayName.formattedTextCompat() getObjectiveValue() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 

--- a/versions/pattern-mappings-1.16.5-forge-1.12.2.txt
+++ b/versions/pattern-mappings-1.16.5-forge-1.12.2.txt
@@ -1,13 +1,23 @@
 
+at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer net.minecraft.client.gui.inventory.GuiContainer container inventorySlots at.hannibal2.skyhanni.utils.compat.container
+
 net.minecraft.network.chat.Component net.minecraft.util.text.ITextComponent unformattedTextForChatCompat() getUnformattedComponentText() at.hannibal2.skyhanni.utils.compat.unformattedTextForChatCompat
 net.minecraft.network.chat.Component net.minecraft.util.text.ITextComponent unformattedTextCompat() getUnformattedText() at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
 net.minecraft.network.chat.Component net.minecraft.util.text.ITextComponent formattedTextCompat() getFormattedText() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-net.minecraft.network.protocol.game.ClientboundSetObjectivePacket net.minecraft.network.play.server.SPacketScoreboardObjective displayName.formattedTextCompat() getObjectiveValue() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-net.minecraft.world.entity.Entity net.minecraft.entity.Entity customName.formattedTextCompat() getCustomNameTag() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-net.minecraft.world.entity.Entity net.minecraft.entity.Entity name.formattedTextCompat() getName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-net.minecraft.world.entity.player.Player net.minecraft.entity.player.EntityPlayer name.formattedTextCompat() getName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-net.minecraft.world.item.ItemStack net.minecraft.item.ItemStack displayName.formattedTextCompat() getDisplayName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-net.minecraft.world.scores.Objective net.minecraft.scoreboard.ScoreObjective displayName.formattedTextCompat() getDisplayName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer net.minecraft.client.gui.inventory.GuiContainer container inventorySlots at.hannibal2.skyhanni.utils.compat.container
+
 net.minecraft.network.chat.Style net.minecraft.util.text.Style returnThis() createShallowCopy() at.hannibal2.skyhanni.utils.compat.returnThis
 net.minecraft.network.chat.Style net.minecraft.util.text.Style returnThis() createDeepCopy() at.hannibal2.skyhanni.utils.compat.returnThis
+
+net.minecraft.network.protocol.game.ClientboundSetObjectivePacket net.minecraft.network.play.server.SPacketScoreboardObjective displayName.formattedTextCompat() getObjectiveValue() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+
+net.minecraft.world.entity.Entity net.minecraft.entity.Entity customName.formattedTextCompat() getCustomNameTag() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+net.minecraft.world.entity.Entity net.minecraft.entity.Entity name.formattedTextCompat() getName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+
+net.minecraft.world.entity.player.Player net.minecraft.entity.player.EntityPlayer name.formattedTextCompat() getName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+
+net.minecraft.world.item.ItemStack net.minecraft.item.ItemStack displayName.formattedTextCompat() getDisplayName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+
+net.minecraft.world.scores.Objective net.minecraft.scoreboard.ScoreObjective displayName.formattedTextCompat() getDisplayName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+
+net.minecraft.world.scores.PlayerTeam net.minecraft.scoreboard.ScorePlayerTeam playerPrefix.formattedTextCompat() getPrefix() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+

--- a/versions/pattern-mappings-1.21.5-1.16.5-fabric.txt
+++ b/versions/pattern-mappings-1.21.5-1.16.5-fabric.txt
@@ -1,1 +1,3 @@
+
 net.minecraft.entity.Entity net.minecraft.entity.Entity deceased removed at.hannibal2.skyhanni.utils.compat.deceased
+


### PR DESCRIPTION
## What
Added a custom gradle task to automaticaly sort mappings because finding where to put the mappings is boring so why dont we have gradle do that for us, thanks gradle.
This is only available to run manually because this task is only needed to run ocassionally
This pr also adds some more 1.21.5 mappings while cleaning up the last month or so of modern development

## Changelog Technical Details
+ Added custom Gradle task to automatically sort mappings. - CalMWolfs
    * Run `./gradlew cleanupMappingFiles` after editing the mappings files.
+ Added more mappings for modern versions. - CalMWolfs & nopo

