### PR TITLE
Fix: Composter empty outside garden

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.garden.GardenApi
@@ -163,14 +162,11 @@ object ComposterDisplay {
         if (GardenApi.inGarden() && config.displayEnabled) {
             config.displayPos.renderRenderable(display, posLabel = "Composter Display")
         }
+
+        checkWarningsAndOutsideGarden()
     }
 
-    @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
-        if (!event.repeatSeconds(5)) return
-        @Suppress("InSkyBlockEarlyReturn")
-        if (!LorenzUtils.inSkyBlock && !OutsideSBFeature.COMPOSTER_TIME.isSelected()) return
-
+    private fun checkWarningsAndOutsideGarden() {
         val format = GardenApi.storage?.let {
             if (!it.composterEmptyTime.isFarPast()) {
                 val duration = it.composterEmptyTime.timeUntil()
@@ -202,6 +198,7 @@ object ComposterDisplay {
         val storage = GardenApi.storage ?: return
 
         if (ReminderUtils.isBusy()) return
+
         if (storage.lastComposterEmptyWarningTime.passedSince() < 2.0.minutes) return
         storage.lastComposterEmptyWarningTime = SimpleTimeMark.now()
         if (IslandType.GARDEN.isInIsland()) {


### PR DESCRIPTION
## What
Reverted the cleanup from #3818 that broke it.

## Changelog Fixes
+ Fixed Composter Empty Display not showing outside garden. - hannibal2