### PR TITLE
Fix: Golden Goblin Line

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/LineToMobHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/LineToMobHandler.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.data.mob
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.exactPlayerEyeLocation
@@ -30,6 +31,12 @@ object LineToMobHandler {
     @HandleEvent
     fun onMobDeSpawn(event: MobEvent.DeSpawn) {
         lines.remove(event.mob)
+    }
+
+    // TODO remove workaround once we can confirm why lines show up after world switch
+    @HandleEvent(WorldChangeEvent::class)
+    fun onWorldChange() {
+        lines.clear()
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -259,7 +259,7 @@ class Mob(
     }
 
     // TODO add max distance
-    fun lineToPlayer(color: Color, lineWidth: Int = 2, depth: Boolean = true, condition: () -> Boolean = { true }) =
+    fun lineToPlayer(color: Color, lineWidth: Int = 2, depth: Boolean = true, condition: () -> Boolean) =
         LineToMobHandler.register(this, color, lineWidth, depth, condition)
 
     fun distanceToPlayer(): Double = baseEntity.distanceToPlayer()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/GoldenGoblinHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/GoldenGoblinHighlight.kt
@@ -60,7 +60,7 @@ object GoldenGoblinHighlight {
         val goblin = lastGoblin ?: return
         goblin.highlight(LorenzColor.GREEN.toColor())
         if (config.lineToYourGoldenGoblin) {
-            goblin.lineToPlayer(LorenzColor.GREEN.toColor())
+            goblin.lineToPlayer(LorenzColor.GREEN.toColor()) { config.lineToYourGoldenGoblin }
         }
         lastGoblin = null
     }


### PR DESCRIPTION
## What
Fixed line to golden goblin not dissapearing when the feature gets disabled.
Fixed `LineToMobHandler` somehow(tm) still rendering lines after world switch when the mob should long be gone. (maybe mob detection errors?)

Reported: https://discord.com/channels/997079228510117908/1362830865000038410

## Changelog Fixes
+ Fixed Line to Golden Goblin tooltip occasionally not disappearing. - hannibal2