### PR TITLE
Fix: Composter Display update

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -121,13 +121,6 @@ object ComposterDisplay {
             }
         }
 
-        for (type in DataType.entries) {
-            if (!newData.containsKey(type)) {
-                tabListData = emptyMap()
-                return
-            }
-        }
-
         tabListData = newData
     }
 


### PR DESCRIPTION
## What
The code cleared the map when one entry was missing. this is surely not intentional.
Reported: https://discord.com/channels/997079228510117908/1362758075039092876

## Changelog Fixes
+ Fixed Composter display not updating when a Composter Tab List widget item is disabled. - hannibal2