### PR TITLE
Backend: Make CleanupMappingFiles only modify changed files

### DIFF
--- a/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
+++ b/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
@@ -33,7 +33,7 @@ class ModuleProcessor(
     private val warnings = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        if (!processedVersions.add(mcVersion)) {
+        if (!processedVersions.add(mcVersion) || modVersion == "0.0.0") {
             return emptyList()
         }
         generateVersionConstants()

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
@@ -30,8 +30,9 @@ abstract class CleanupMappingFiles : DefaultTask() {
         val comments = mutableMapOf<String, String>()
 
         var savedComment: String? = null
+        val oldText = file.readText()
 
-        file.forEachLine { line ->
+        oldText.lines().forEach { line ->
             if (line.isNotBlank()) {
                 savedComment?.let {
                     comments[line] = it
@@ -48,7 +49,12 @@ abstract class CleanupMappingFiles : DefaultTask() {
             .mapValues { it.value.map { it.second }.sorted() }
             .toSortedMap()
 
-        writeMappings(file, sortedLines, comments)
+        val newText = writeMappings(sortedLines, comments)
+        if (oldText.lines() != newText.lines()) {
+            println("writing to ${file.name}")
+
+            file.writeText(newText)
+        }
     }
 
     private fun String.isComment() = trim().startsWith("#")
@@ -76,18 +82,20 @@ abstract class CleanupMappingFiles : DefaultTask() {
         }
     }
 
-    private fun writeMappings(file: File, sortedLines: Map<String, List<String>>, comments: Map<String, String>) {
+    private fun writeMappings(sortedLines: Map<String, List<String>>, comments: Map<String, String>): String {
         val lineSeparator = "\n"
-        file.writeText(lineSeparator)
+        val newText = StringBuilder()
+        newText.append(lineSeparator)
 
         for ((_, value) in sortedLines) {
             for (line in value) {
                 comments[line]?.let {
-                    file.appendText("$it$lineSeparator")
+                    newText.append("$it$lineSeparator")
                 }
-                file.appendText("$line$lineSeparator")
+                newText.append("$line$lineSeparator")
             }
-            file.appendText(lineSeparator)
+            newText.append(lineSeparator)
         }
+        return newText.toString()
     }
 }

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/CleanupMappingFiles.kt
@@ -51,8 +51,6 @@ abstract class CleanupMappingFiles : DefaultTask() {
 
         val newText = writeMappings(sortedLines, comments)
         if (oldText.lines() != newText.lines()) {
-            println("writing to ${file.name}")
-
             file.writeText(newText)
         }
     }

--- a/versions/mapping-1.16.5-forge-1.12.2.txt
+++ b/versions/mapping-1.16.5-forge-1.12.2.txt
@@ -405,6 +405,7 @@ net.minecraft.world.item.DyeColor LIGHT_GRAY SILVER
 
 net.minecraft.world.item.Item byBlock() getItemFromBlock()
 
+net.minecraft.world.item.ItemStack count stackSize
 net.minecraft.world.item.ItemStack getTag() getTagCompound()
 net.minecraft.world.item.ItemStack isEnchanted() isItemEnchanted()
 


### PR DESCRIPTION
## What
The `cleanupMappingFiles` gradle task now only edits modifies mapping files that need changes which results in a faster build after cleaning up the files as they dont all get treated as modified.

## Changelog Technical Details
+ Changed `CleanupMappingFiles` to only edit mapping files requiring changes. - CalMWolfs