### PR TITLE
Fix: Add pure quartz to flowstate helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/BlockStrengthGuide.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/BlockStrengthGuide.kt
@@ -66,6 +66,7 @@ object BlockStrengthGuide {
                 OreBlock.PURE_GOLD,
                 OreBlock.PURE_EMERALD,
                 OreBlock.PURE_DIAMOND,
+                OreBlock.PURE_QUARTZ,
                 OreBlock.PURE_REDSTONE,
             ),
         ),

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreBlock.kt
@@ -97,6 +97,7 @@ enum class OreBlock(
     PURE_REDSTONE(Blocks.redstone_block, { inDwarvenMines || inCrystalHollows }, OreCategory.ORE, hasInitSound = false),
     PURE_EMERALD(Blocks.emerald_block, { inDwarvenMines || inCrystalHollows }, OreCategory.ORE, hasInitSound = false),
     PURE_DIAMOND(Blocks.diamond_block, { inDwarvenMines || inCrystalHollows }, OreCategory.ORE, hasInitSound = false),
+    PURE_QUARTZ(Blocks.quartz_block, { inDwarvenMines || inCrystalHollows }, OreCategory.ORE),
 
     // GEMSTONES
     RUBY(EnumDyeColor.RED, { inCrystalHollows || inGlacite }, OreCategory.GEMSTONE),


### PR DESCRIPTION
## What
Added PURE_QUARTZ to the oreBlock file so flowstate helper detects when its mined.

## Changelog Fixes
+ Fixed Flowstate helper not working with Pure Quartz Ore. - NeoNyaa