### PR TITLE
Fix: Don't override /jerry on private island

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
@@ -29,7 +29,9 @@ object ShortenWarpCommand {
         if (!message.startsWith("/")) return
 
         val command = message.removePrefix("/")
-        // doing /barn in garden should not warp to the farming islands
+
+        // Avoid overriding commands on islands where they have a different use
+        if (command == "jerry" && IslandType.PRIVATE_ISLAND.isInIsland()) return
         if (command == "barn" && IslandType.GARDEN.isInIsland() && SkyHanniMod.feature.garden.gardenCommands.warpCommands) return
 
         if (command in warps) {


### PR DESCRIPTION
## What
Excluded `/jerry` from "Shorten /warp" while on Private Island.

## Changelog Fixes
+ Fixed "Shorten /warp" overriding `/jerry` command on Private Island. - Luna
