### PR TITLE
Fix: `KeyDownEvent` (again) V4

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -118,7 +118,11 @@ object KeyboardManager {
             val isDown = if (keyCode < 0) {
                 Mouse.isButtonDown(keyCode + 100)
             } else {
-                Keyboard.isKeyDown(keyCode)
+                if (keyCode < Keyboard.KEYBOARD_SIZE) {
+                    Keyboard.isKeyDown(keyCode)
+                } else {
+                    false
+                }
             }
 
             if (isDown) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -140,10 +140,12 @@ object KeyboardManager {
         //#endif
     }
 
+    /*
+    The delay below is here to make sure the Text input features in graph editor
+    and in renderable calls have time to react first, and lock this key press event properly
+     */
+
     private fun postKeyPressEvent(keyCode: Int) {
-        // This cooldown is here to make sure the Text input features in graph editor
-        // and in renderable calls have time to react first,
-        // and lock this key press event properly
         DelayedRun.runDelayed(50.milliseconds) {
             if (TextInput.isActive()) return@runDelayed
             KeyPressEvent(keyCode).post()
@@ -151,9 +153,6 @@ object KeyboardManager {
     }
 
     private fun postKeyDownEvent(keyCode: Int) {
-        // This cooldown is here to make sure the Text input features in graph editor
-        // and in renderable calls have time to react first,
-        // and lock this key press event properly
         DelayedRun.runDelayed(50.milliseconds) {
             if (TextInput.isActive()) return@runDelayed
             KeyDownEvent(keyCode).post()
@@ -161,9 +160,6 @@ object KeyboardManager {
     }
 
     private fun postKeyUpEvent(keyCode: Int) {
-        // This cooldown is here to make sure the Text input features in graph editor
-        // and in renderable calls have time to react first,
-        // and lock this key press event properly
         DelayedRun.runDelayed(50.milliseconds) {
             if (TextInput.isActive()) return@runDelayed
             KeyUpEvent(keyCode).post()

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -129,9 +129,7 @@ object KeyboardManager {
                 postKeyPressEvent(keyCode)
             } else {
                 postKeyUpEvent(keyCode)
-                if (pressedKeys.contains(keyCode)) {
-                    pressedKeys.remove(keyCode)
-                }
+                pressedKeys.remove(keyCode)
             }
         }
 


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/396

## What
#3802 doesn't account for the user using keys with without a native keycode.

This is because we create the keycode like this: if the key doesn't have a code so 0, we take the Char.code + 256.
The problem arises when we want to check later if the key is still pressed, because there we do Keyboard.isKeyDown(keyCode) and if the keycode is one that was constructed with the Char.code + 256 we get an IndexOutOfBoundsException.

The current fix is to not go and check if the is still pressed if the keycode is above the keyboard size but instead just say that it isn't pressed anymore. 
This will trigger the attached keybinds multiple times but the effects of this should be mitigated by the existence of cooldowns in the features.

## Changelog Fixes
+ Fixed KeyboardManager errors on certain letters. - rueblimaster
