### PR TITLE
Backend: event execution time regression

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/EventListeners.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/EventListeners.kt
@@ -70,14 +70,17 @@ class EventListeners private constructor(val name: String, private val isGeneric
             }
         }
 
-        return { _: Any -> method.invoke(instance) }
+        val runnable = ReflectionUtils.createRunnableFromMethod(instance, method)
+        return { _: Any -> runnable.run() }
     }
 
     private fun createSingleParameterConsumer(method: Method, instance: Any): (Any) -> Unit {
         require(SkyHanniEvent::class.java.isAssignableFrom(method.parameterTypes[0])) {
             "Method ${method.name} parameter must be a subclass of SkyHanniEvent."
         }
-        return { event -> method.invoke(instance, event) }
+
+        val consumer = ReflectionUtils.createConsumerFromMethod(instance, method)
+        return { event -> consumer.accept(event) }
     }
 
     private fun resolveGenericType(method: Method): Class<*> =

--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -170,6 +170,7 @@ object SkyHanniEvents {
         classes.add(clazz)
 
         var current = clazz
+        @Suppress("LoopWithTooManyJumpStatements")
         while (current.superclass != null) {
             val superClass = current.superclass
             if (superClass == SkyHanniEvent::class.java) break

--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -174,6 +174,7 @@ object SkyHanniEvents {
             val superClass = current.superclass
             if (superClass == SkyHanniEvent::class.java) break
             if (superClass == GenericSkyHanniEvent::class.java) break
+            if (superClass == RenderingSkyHanniEvent::class.java) break
             if (superClass == CancellableSkyHanniEvent::class.java) break
             classes.add(superClass)
             current = superClass

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -32,13 +32,20 @@ object ErrorManager {
         "at net.minecraftforge.fml.common.eventhandler.EventBus.post",
         "at at.hannibal2.skyhanni.mixins.hooks.NetHandlerPlayClientHookKt.onSendPacket",
         "at net.minecraft.client.main.Main.main",
+        "at.hannibal2.skyhanni.api.event.EventListeners.createZeroParameterConsumer",
+        "at.hannibal2.skyhanni.api.event.EventListeners.createSingleParameterConsumer",
     )
 
     private val replace = mapOf(
-        "at.hannibal2.skyhanni" to "SH",
-        "io.moulberry.notenoughupdates" to "NEU",
+        "at.hannibal2.skyhanni." to "SH.",
+        "io.moulberry.notenoughupdates." to "NEU.",
         "net.minecraft." to "MC.",
         "net.minecraftforge.fml." to "FML.",
+    )
+
+    private val replaceEntirely = mapOf(
+        "at.hannibal2.skyhanni.api.event.EventListeners.createZeroParameterConsumer" to "<Skyhanni event post>",
+        "at.hannibal2.skyhanni.api.event.EventListeners.createSingleParameterConsumer" to "<Skyhanni event post>",
     )
 
     private val ignored = listOf(
@@ -65,12 +72,12 @@ object ErrorManager {
 
     // this hides the whole stack trace of one error of the list of all errors in the error message
     // where the error class name is the key and the first line contains one of the entries in the list of values
-    private val skipErrorEntry = mapOf(
-        "java.lang.reflect.InvocationTargetException" to listOf(
-            "EventListeners.createZeroParameterConsumer",
-            "EventListeners.createSingleParameterConsumer",
-        ),
-    )
+    private val skipErrorEntry = emptyMap<String, List<String>>()
+//         "java.lang.reflect.InvocationTargetException" to listOf(
+//             "EventListeners.createZeroParameterConsumer",
+//             "EventListeners.createSingleParameterConsumer",
+//         ),
+//     )
 
     fun resetCache() {
         cache.clear()
@@ -287,6 +294,12 @@ object ErrorManager {
             }
             var visualText = text
             if (!fullStackTrace) {
+                for ((from, to) in replaceEntirely) {
+                    if (visualText.contains(from)) {
+                        visualText = to
+                        break
+                    }
+                }
                 for ((from, to) in replace) {
                     visualText = visualText.replace(from, to)
                 }


### PR DESCRIPTION
## What
Fixes a regression that happened in #3064 where execution was changed to method invoke which is significantly slower than lambda meta factory by a significant amount as lambda meta factory is almost as fast as direct method execution call while method invoke has to check security manager and and access which makes its best case like 2x slower (you will rarely ever get JIT to reach this state) and its worse in the 100s of times slower.

## Changelog Technical Details
+ Improved event execution speed. - ThatGravyBoat
+ Fixed event-fail invocation wrapping errors. - ThatGravyBoat