### PR TITLE
Fix: Effects not being detected in "Active Effects" inventory

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -248,7 +248,7 @@ object EffectApi {
             } ?: false
 
     private fun ItemStack.getNonGodPotEffectOrNull(): NonGodPotEffect? = NonGodPotEffect.entries.firstOrNull {
-        it.inventoryItemName == displayName
+        displayName.contains(it.inventoryItemName)
     }
 
     @HandleEvent(onlyOnSkyblock = true)


### PR DESCRIPTION
## What
Title.

## Changelog Fixes
+ Fixed effects not detected in Active Effects inventory. - SuperClash
