### PR TITLE
Fix: Double Events

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -51,6 +51,7 @@ object SkyHanniEvents {
         GeneratedEventPrimaryFunctionNames.map
 
     private fun registerNoEventType(options: HandleEvent, method: Method, instance: Any) {
+        if (method.parameterTypes.any()) return
         val eventType = eventPrimaryFunctionNames[method.name] ?: return
         if (!SkyHanniEvent::class.java.isAssignableFrom(eventType)) return
         listeners.getOrPut(eventType) { EventListeners(eventType) }


### PR DESCRIPTION
## What
Fixes events having primary names causing them to go stupid crazy mode.


## Changelog Fixes
+ Fixed some features triggering twice as often. - Daveed
