### PR TITLE
Fix: ViewRecipe Command for certain items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.NumberUtil.isInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -26,7 +27,7 @@ object ViewRecipeCommand {
         "\\/viewrecipe (?<item>.*)"
     )
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onMessageSendToServer(event: MessageSendToServerEvent) {
         if (!config.viewRecipeLowerCase) return
         if (event.senderIsSkyhanni()) return
@@ -37,14 +38,15 @@ object ViewRecipeCommand {
 
         val args = input.split(" ")
         val endsWithPageNumber = args.last().isInt()
-        val finalCommand = if (endsWithPageNumber) {
-            "${args.dropLast(1).joinToString("_")} ${args.last()}"
+
+        val (item, page) = if (endsWithPageNumber) {
+            args.dropLast(1).joinToString("_") to args.last().toInt()
         } else {
-            input.replace(" ", "_")
+            input.replace(" ", "_") to 1
         }
 
         event.cancel()
-        HypixelCommands.viewRecipe(finalCommand)
+        HypixelCommands.viewRecipe(item.toInternalName(), page)
     }
 
     val list by lazy {

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
@@ -41,7 +41,6 @@ object ViewRecipeCommand {
         val endsWithPageNumber = args.last().isInt()
 
         val (item, page) = if (endsWithPageNumber) {
-
             val testItem = args.joinToString(" ").toInternalName().getItemStackOrNull()
             if (testItem == null) {
                 args.dropLast(1).joinToString("_") to args.last().toInt()

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems
+import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.isInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -40,7 +41,13 @@ object ViewRecipeCommand {
         val endsWithPageNumber = args.last().isInt()
 
         val (item, page) = if (endsWithPageNumber) {
-            args.dropLast(1).joinToString("_") to args.last().toInt()
+
+            val testItem = args.joinToString(" ").toInternalName().getItemStackOrNull()
+            if (testItem == null) {
+                args.dropLast(1).joinToString("_") to args.last().toInt()
+            } else {
+                input.replace(" ", "_") to 1
+            }
         } else {
             input.replace(" ", "_") to 1
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -295,7 +295,7 @@ object GardenVisitorFeatures {
                         if (Minecraft.getMinecraft().currentScreen is GuiEditSign) {
                             SignUtils.setTextIntoSign("$leftToCraft")
                         } else {
-                            HypixelCommands.viewRecipe(internalName.asString())
+                            HypixelCommands.viewRecipe(internalName)
                         }
                     },
                 ) { GardenApi.inGarden() && !NeuItems.neuHasFocus() },

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorSupercraft.kt
@@ -26,7 +26,7 @@ object GardenVisitorSupercraft {
 
     private var hasIngredients = false
     private var lastClick = SimpleTimeMark.farPast()
-    private var lastSuperCraftMaterial = ""
+    private var lastSuperCraftMaterial = NeuInternalName.NONE
 
     private val superCraftItem by lazy {
         ItemUtils.createItemStack(
@@ -84,7 +84,7 @@ object GardenVisitorSupercraft {
         hasIngredients = true
         for ((key, value) in requiredIngredients) {
             val sackItem = key.getAmountInSacks()
-            lastSuperCraftMaterial = internalName.asString()
+            lastSuperCraftMaterial = internalName
             if (sackItem < value * (amount - amountInSacks)) {
                 hasIngredients = false
                 break

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
@@ -128,7 +128,7 @@ object CraftableItemList {
             "§8x$amountFormat $itemName",
             tips = tooltip,
             onLeftClick = {
-                HypixelCommands.viewRecipe(internalName.asString())
+                HypixelCommands.viewRecipe(internalName)
             },
         ).toSearchable(itemName)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -30,8 +30,8 @@ object HypixelCommands {
         send("skills")
     }
 
-    fun viewRecipe(itemName: String) {
-        send("viewrecipe $itemName")
+    fun viewRecipe(itemId: NeuInternalName, page: Int = 1) {
+        send("viewrecipe ${itemId.skyblockCommandId} $page")
     }
 
     fun recipe(itemName: String) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetExp
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetItem
 import net.minecraft.init.Items
 
 class NeuInternalName private constructor(private val internalName: String) {
@@ -27,7 +26,7 @@ class NeuInternalName private constructor(private val internalName: String) {
             if (it.contains("§") || it.contains("&") || it.contains("'")) {
                 ErrorManager.skyHanniError(
                     "Internal name found with color codes",
-                    "Internal Name" to it, "Original String" to this
+                    "Internal Name" to it, "Original String" to this,
                 )
             }
             internalNameMap.getOrPut(it) { NeuInternalName(it) }
@@ -99,6 +98,6 @@ class NeuInternalName private constructor(private val internalName: String) {
     private val isPet: Boolean
         get() = getItemStackOrNull()?.getPetExp() != null
 
-    private val isEnchantedBook : Boolean
+    private val isEnchantedBook: Boolean
         get() = getItemStackOrNull()?.item == Items.enchanted_book
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -2,6 +2,9 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetExp
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetItem
+import net.minecraft.init.Items
 
 class NeuInternalName private constructor(private val internalName: String) {
 
@@ -79,4 +82,27 @@ class NeuInternalName private constructor(private val internalName: String) {
         internalName.replace(oldValue, newValue, ignoreCase = true).toInternalName()
 
     fun isKnownItem(): Boolean = getItemStackOrNull() != null || this == SKYBLOCK_COIN
+
+    /**
+     * This is because skyblock has special ids in commands such as /viewrecipe for items like enchanted books and pets
+     */
+    val skyblockCommandId: String
+        get() = run {
+            println("doing for item $internalName")
+            when {
+                isPet -> internalName.split(";").first()
+                isEnchantedBook -> {
+                    val (name, level) = internalName.split(";", limit = 2)
+                    "ENCHANTED_BOOK_${name}_$level"
+                }
+
+                else -> internalName
+            }
+        }
+
+    private val isPet: Boolean
+        get() = getItemStackOrNull()?.getPetExp() != null
+
+    private val isEnchantedBook : Boolean
+        get() = getItemStackOrNull()?.item == Items.enchanted_book
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -87,17 +87,13 @@ class NeuInternalName private constructor(private val internalName: String) {
      * This is because skyblock has special ids in commands such as /viewrecipe for items like enchanted books and pets
      */
     val skyblockCommandId: String
-        get() = run {
-            println("doing for item $internalName")
-            when {
-                isPet -> internalName.split(";").first()
-                isEnchantedBook -> {
-                    val (name, level) = internalName.split(";", limit = 2)
-                    "ENCHANTED_BOOK_${name}_$level"
-                }
-
-                else -> internalName
+        get() = when {
+            isPet -> internalName.split(";").first()
+            isEnchantedBook -> {
+                val (name, level) = internalName.split(";", limit = 2)
+                "ENCHANTED_BOOK_${name}_$level"
             }
+            else -> internalName
         }
 
     private val isPet: Boolean


### PR DESCRIPTION
## What
Fixed craftable item list attempting to open invalid pet and enchanted book recipes.
HypixelCommands.viewRecipe now takes in NeuInternalName + page number instead of a String
Also fixed not being able to /viewrecipe recipies ending in a number

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/fc860db5-c3eb-4a7d-8bd3-7132ffbf249d)
![image](https://github.com/user-attachments/assets/73cad597-406c-468e-95d0-7ee078891438)


</details>

## Changelog Fixes
+ Fixed craftable Item list opening invalid Pet and Enchanted Book recipes. - CalMWolfs
+ Fixed lowercase `/viewrecipe` feature not working on items ending in numbers. - CalMWolfs

## Changelog Technical Details
+ `HypixelCommands.viewRecipe` now takes `NeuInternalName` and page number instead of a String. - CalMWolfs

