### PR TITLE
Backend: Post keyboard events on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -130,10 +130,8 @@ object KeyboardManager {
                 }
             }
         }
-
-        //#else
-        //$$ // todo use fabric event or whatnot
         //#endif
+        // on 1.21 we use MixinKeyboard, it provides all of this
     }
 
     private fun postKeyPressEvent(keyCode: Int) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -95,9 +95,9 @@ object KeyboardManager {
     private fun getSyntheticKeyboardKeyCode(key: Int, char: Char): Int = if (key == 0) char.code + 256 else key
     //#endif
 
+    //#if MC < 1.16
     @HandleEvent(priority = HandleEvent.LOWEST)
     fun onTick() {
-        //#if MC < 1.16
         val currentScreen = Minecraft.getMinecraft().currentScreen
         val isConfigScreen = currentScreen is GuiScreenElementWrapper
         if (isConfigScreen || currentScreen is GuiChat) return
@@ -130,9 +130,9 @@ object KeyboardManager {
                 }
             }
         }
-        //#endif
-        // on 1.21 we use MixinKeyboard, it provides all of this
     }
+    //#endif
+    // on 1.21 we use MixinKeyboard, it provides all of this
 
     private fun postKeyPressEvent(keyCode: Int) {
         // This cooldown is here to make sure the Text input features in graph editor

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyboard.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyboard.java
@@ -28,6 +28,10 @@ public class MixinKeyboard {
             * modifiers = 2: Control
             * modifiers = 4: Alt
          */
+        // todo on 1.8 it first checks TextInput.isActive() before posting, however im not sure if this is needed
+        // and as of now that file would need to be recoded to work with 1.21 so i havent put that here as of now
+        // the extension functions such as isActive() and isKeyHeld() still work from keyboard manager
+        // this only replaces the posting of events
         if (action == 0) new KeyUpEvent(key).post();
         if (action == 1) new KeyDownEvent(key).post();
         if (action == 1) new KeyPressEvent(key).post();

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyboard.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyboard.java
@@ -35,6 +35,6 @@ public class MixinKeyboard {
         // this only replaces the posting of events
         if (action == 0) new KeyUpEvent(key).post();
         if (action == 1) new KeyDownEvent(key).post();
-        if (action == 1) new KeyPressEvent(key).post();
+        if (action == 2) new KeyPressEvent(key).post();
     }
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyboard.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyboard.java
@@ -29,7 +29,8 @@ public class MixinKeyboard {
             * modifiers = 4: Alt
          */
         // todo on 1.8 it first checks TextInput.isActive() before posting, however im not sure if this is needed
-        // and as of now that file would need to be recoded to work with 1.21 so i havent put that here as of now
+        // and as of now that file would need to be recoded to work with 1.21 so it hasn't been put here
+        // there is also an onChar method we could mixin to and use for typing fields and replace TextInput.isActive() with that somehow
         // the extension functions such as isActive() and isKeyHeld() still work from keyboard manager
         // this only replaces the posting of events
         if (action == 0) new KeyUpEvent(key).post();

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyboard.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyboard.java
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent;
+import at.hannibal2.skyhanni.events.minecraft.KeyUpEvent;
+import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent;
+import net.minecraft.client.Keyboard;
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Keyboard.class)
+public class MixinKeyboard {
+
+    @Inject(method = "onKey", at = @At("HEAD"))
+    private void onKey(long window, int key, int scancode, int action, int modifiers, CallbackInfo ci) {
+        if (MinecraftClient.getInstance().player == null) return;
+        //System.out.println("Key: " + key + " Scancode: " + scancode + " Action: " + action + " Modifiers: " + modifiers);
+        /*
+            * action = 0: Key released
+            * action = 1: Key pressed
+            * action = 2: Key held
+            * key = keycode
+            * not entirely sure what scancode means
+            * modifiers = 0: No modifier
+            * modifiers = 1: Shift
+            * modifiers = 2: Control
+            * modifiers = 4: Alt
+         */
+        if (action == 0) new KeyUpEvent(key).post();
+        if (action == 1) new KeyDownEvent(key).post();
+        if (action == 1) new KeyPressEvent(key).post();
+    }
+}


### PR DESCRIPTION
## What
Adds a mixin that will post our keyboard events on 1.21, much nicer than 1.8's keyboard manager.
This isnt added to buildpaths because events dont compile yet

## Changelog Technical Details
+ Ported three keybind events to 1.21. - nopo
