### PR TITLE
Backend: Fill out ClientEvents in 1.21

### DIFF
--- a/versions/1.21.5/buildpaths.txt
+++ b/versions/1.21.5/buildpaths.txt
@@ -7,7 +7,7 @@ at/hannibal2/skyhanni/utils/ConditionalUtils.kt
 at/hannibal2/skyhanni/utils/Quad.kt
 at/hannibal2/skyhanni/utils/TimeLimitedSet.kt
 at/hannibal2/skyhanni/utils/TimeLimitedCache.kt
-at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+#at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
 at/hannibal2/skyhanni/utils/ReflectionUtils.kt
 at/hannibal2/skyhanni/config/HasLegacyId.java
 

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -1,6 +1,14 @@
 package at.hannibal2.skyhanni.api.minecraftevents
 
+import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientWorldEvents
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents
 
 @SkyHanniModule
 object ClientEvents {
@@ -10,13 +18,30 @@ object ClientEvents {
     init {
 
         // Tick event
+        ClientTickEvents.START_WORLD_TICK.register(
+            ClientTickEvents.StartWorldTick {
+                if (!MinecraftCompat.localPlayerExists) return@StartWorldTick
+                if (!MinecraftCompat.localWorldExists) return@StartWorldTick
+
+                DelayedRun.checkRuns()
+                totalTicks++
+                SkyHanniTickEvent(totalTicks).post()
+            },
+        )
 
         // Disconnect event
+        ClientPlayConnectionEvents.DISCONNECT.register(
+            ClientPlayConnectionEvents.Disconnect { _, _ ->
+                ClientDisconnectEvent.post()
+            },
+        )
 
         // World change event
-
-        // Chat receive event
-
+        ClientWorldEvents.AFTER_CLIENT_WORLD_CHANGE.register(
+            ClientWorldEvents.AfterClientWorldChange { client, world ->
+                WorldChangeEvent().post()
+            },
+        )
     }
 
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
@@ -1,0 +1,33 @@
+package at.hannibal2.skyhanni.mixins.hooks
+
+import at.hannibal2.skyhanni.data.ActionBarData
+import at.hannibal2.skyhanni.data.ChatManager
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation
+import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.gui.hud.ChatHudLine
+import net.minecraft.client.gui.hud.MessageIndicator
+import net.minecraft.text.Text
+
+fun onGameMessage(message: Text, actionBar: Boolean, original: Operation<Void>) {
+    if (actionBar) {
+        ActionBarData.onChatReceive(message)?.let { result ->
+            original.call(result, actionBar)
+        }
+    }
+    val (result, cancel) = ChatManager.onChatReceive(message)
+    result?.let {
+        original.call(it, actionBar)
+    }
+    if (cancel) {
+        // We want to still log the message even if we cancel it
+        val inGameHud = MinecraftClient.getInstance().inGameHud
+        val chatHudLine = ChatHudLine(inGameHud.ticks, message, null, MessageIndicator.system())
+        inGameHud.chatHud.logChatMessage(chatHudLine)
+
+        // We also want to send the fabric canceled chat message event just to be nice
+        ClientReceiveMessageEvents.GAME_CANCELED.invoker().onReceiveGameMessageCanceled(message, actionBar)
+        return
+    }
+    original.call(message, actionBar);
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
@@ -14,10 +14,12 @@ fun onGameMessage(message: Text, actionBar: Boolean, original: Operation<Void>) 
         ActionBarData.onChatReceive(message)?.let { result ->
             original.call(result, actionBar)
         }
+        return
     }
     val (result, cancel) = ChatManager.onChatReceive(message)
     result?.let {
         original.call(it, actionBar)
+        return
     }
     if (cancel) {
         // We want to still log the message even if we cancel it

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMessageHandler.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMessageHandler.java
@@ -10,8 +10,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @Mixin(value = MessageHandler.class, priority = 500)
 public class MixinMessageHandler {
 
-	@WrapMethod(method = "onGameMessage")
-	private void onGameMessage(Text message, boolean actionBar, Operation<Void> original) {
+    @WrapMethod(method = "onGameMessage")
+    private void onGameMessage(Text message, boolean actionBar, Operation<Void> original) {
         MessageHandlerHookKt.onGameMessage(message, actionBar, original);
-	}
+    }
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMessageHandler.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMessageHandler.java
@@ -1,0 +1,17 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.mixins.hooks.MessageHandlerHookKt;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import net.minecraft.client.network.message.MessageHandler;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(value = MessageHandler.class, priority = 500)
+public class MixinMessageHandler {
+
+	@WrapMethod(method = "onGameMessage")
+	private void onGameMessage(Text message, boolean actionBar, Operation<Void> original) {
+        MessageHandlerHookKt.onGameMessage(message, actionBar, original);
+	}
+}

--- a/versions/1.21.5/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.5/src/main/resources/skyhanni.accesswidener
@@ -5,3 +5,4 @@ accessible field net/minecraft/client/option/KeyBinding boundKey Lnet/minecraft/
 accessible field net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket type Lnet/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractTypeHandler;
 accessible class net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractType
 accessible method net/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractTypeHandler getType ()Lnet/minecraft/network/packet/c2s/play/PlayerInteractEntityC2SPacket$InteractType;
+accessible method net/minecraft/client/gui/hud/ChatHud logChatMessage (Lnet/minecraft/client/gui/hud/ChatHudLine;)V


### PR DESCRIPTION
## What
This adds support for Tick Event, Disconnect Event, World Change Event, ActionBar Event and Chat Event
the chat event is more complex than the others because the built in fabric chat event doesnt work for what we are doing

## Changelog Technical Details
+ Ported tick, disconnect, world change, actionbar, and chat events to 1.21. - nopo
