### PR TITLE
Backend: ChatHistoryGui

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -150,17 +150,17 @@ object ChatManager {
             return null to true
         }
 
-        val eventComponent = chatEvent.chatComponent
+        val modifiedComponent = chatEvent.chatComponent
         var modified = false
         loggerAllowed.log("[allowed] $message")
         loggerAll.log("[allowed] $message")
-        if (eventComponent.formattedText != component.formattedText) {
+        if (modifiedComponent.formattedText != component.formattedText) {
             modified = true
-            component = chatEvent.chatComponent
             loggerModified.log(" ")
             loggerModified.log("[original] " + component.formattedText)
-            loggerModified.log("[modified] " + eventComponent.formattedText)
-            messageHistory[key] = MessageFilteringResult(component, ActionKind.MODIFIED, null, eventComponent)
+            loggerModified.log("[modified] " + modifiedComponent.formattedText)
+            messageHistory[key] = MessageFilteringResult(component, ActionKind.MODIFIED, null, modifiedComponent)
+            component = modifiedComponent
         } else {
             messageHistory[key] = MessageFilteringResult(component, ActionKind.ALLOWED, null, null)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatHistoryGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatHistoryGui.kt
@@ -54,7 +54,7 @@ class ChatHistoryGui(private val history: List<ChatManager.MessageFilteringResul
             msg.actionReason?.let { GuiRenderUtils.drawString(it, ChatManager.ActionKind.maxLength + 5, 0, -1) }
             var size = drawMultiLineText(msg.message, ChatManager.ActionKind.maxLength + reasonMaxLength + 10)
             msg.modified?.let {
-                GuiRenderUtils.drawString("§e§lNEW TEXT", 0, size * 10, -1)
+                GuiRenderUtils.drawString("§e§lNEW TEXT", 0, 0, -1)
                 size += drawMultiLineText(it, ChatManager.ActionKind.maxLength + reasonMaxLength + 10)
             }
             val isHovered = mouseX in 0..w && mouseY in 0..(size * 10)


### PR DESCRIPTION
## What
Fixed the new text label overlapping in /shchathistory.
Fixed /shchathistory not showing the proper original text.

<details>
<summary>Images</summary>

Chat history new text label
Old (broken):
![image](https://github.com/user-attachments/assets/2d289d63-6400-48b3-9402-59085b69f316)
New:
![image](https://github.com/user-attachments/assets/fb73cd62-e289-4bf3-8fff-eb0d1b74e214)
Modified text
Old (broken):
![image](https://github.com/user-attachments/assets/997c3b10-26d5-4f13-8647-133650537a56)
New: 
![image](https://github.com/user-attachments/assets/4f471277-fb7d-4ed3-8807-bc0e9479bf4d)



</details>

## Changelog Technical Details
+ Fixed new text label overlapping in `/shchathistory`. - CalMWolfs
+ Fixed `/shchathistory` not showing the proper original text. - CalMWolfs

