### PR TITLE
Fix: Composter overlay always showing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -127,7 +127,6 @@ object ComposterOverlay {
 
     @HandleEvent(InventoryFullyOpenedEvent::class, onlyOnIsland = IslandType.GARDEN)
     fun onInventoryFullyOpened() {
-        if (!config.overlay) return
         if (inInventory) {
             update()
         }
@@ -155,6 +154,7 @@ object ComposterOverlay {
     }
 
     private fun update() {
+        if (!config.overlay) return
         val composterUpgrades = ComposterApi.composterUpgrades ?: return
         if (composterUpgrades.isEmpty()) {
             val list = Renderable.string("§cOpen Composter Upgrades!")
@@ -577,7 +577,7 @@ object ComposterOverlay {
     fun onBackgroundDraw() {
         if (EstimatedItemValue.isCurrentlyShowing()) return
 
-        if (!inInventory) return
+        if (!inInventory || !config.overlay) return
         config.overlayOrganicMatterPos.renderRenderable(
             organicMatterDisplay,
             posLabel = "Composter Overlay Organic Matter",


### PR DESCRIPTION
## What
Fixed composter overlay always showing regardless of the option.

## Changelog Fixes
+ Fixed Composter Overlay always visible when disabled. - CalMWolfs
