### PR TITLE
Backend: Add warning to shdebug if optifine or patcher are not installed

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
@@ -11,7 +11,10 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
+//#if MC == 1.8.9
 import net.minecraftforge.fml.client.FMLClientHandler
+import net.minecraftforge.fml.common.Loader
+//#endif
 import java.lang.management.ManagementFactory
 import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.hours
@@ -27,7 +30,9 @@ object ComputerEnvDebug {
         launcher(event)
         ram(event)
         uptime(event)
+        //#if MC == 1.8.9
         optifine(event)
+        //#endif
     }
 
     private fun launcher(event: DebugDataCollectEvent) {
@@ -218,16 +223,30 @@ object ComputerEnvDebug {
 
     private fun getUptime() = ManagementFactory.getRuntimeMXBean().uptime.milliseconds
 
+    //#if MC == 1.8.9
     private fun optifine(event: DebugDataCollectEvent) {
         if (PlatformUtils.isDevEnvironment) return
         val hasOptifine = FMLClientHandler.instance().hasOptifine()
+        val hasPatcher = Loader.isModLoaded("patcher")
         event.title("Optifine")
         if (hasOptifine) {
             event.addIrrelevant("Optifine is installed")
         } else {
             event.addData("Optifine is not installed")
         }
+        if (hasPatcher) {
+            event.addIrrelevant("Patcher is installed")
+        } else {
+            event.addData("Patcher is not installed")
+        }
+        if (!hasOptifine || !hasPatcher) {
+            event.addData("Optifine or Patcher are not installed")
+            event.addData("These mods greatly improve performance and are almost required to play 1.8.9 Minecraft")
+            event.addData("https://optifine.net/downloadx?f=preview_OptiFine_1.8.9_HD_U_M6_pre2.jar")
+            event.addData("https://modrinth.com/mod/patcher")
+        }
     }
+    //#endif
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
@@ -31,7 +31,7 @@ object ComputerEnvDebug {
         ram(event)
         uptime(event)
         //#if MC == 1.8.9
-        optifine(event)
+        performanceMods(event)
         //#endif
     }
 
@@ -224,7 +224,7 @@ object ComputerEnvDebug {
     private fun getUptime() = ManagementFactory.getRuntimeMXBean().uptime.milliseconds
 
     //#if MC == 1.8.9
-    private fun optifine(event: DebugDataCollectEvent) {
+    private fun performanceMods(event: DebugDataCollectEvent) {
         if (PlatformUtils.isDevEnvironment) return
         val hasOptifine = FMLClientHandler.instance().hasOptifine()
         val hasPatcher = Loader.isModLoaded("patcher")

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
@@ -231,20 +231,19 @@ object ComputerEnvDebug {
         event.title("Performance Mods")
         if (!hasOptifine || !hasPatcher) {
             event.addData {
+                add("Optifine is ${if (hasOptifine) "" else "not"} installed")
+                add("Patcher is ${if (hasPatcher) "" else "not"} installed")
+                add("These mods greatly improve performance and are almost required to play 1.8.9 Minecraft")
                 if (!hasOptifine) {
-                    add("Optifine is not installed")
+                    add("https://optifine.net/downloadx?f=preview_OptiFine_1.8.9_HD_U_M6_pre2.jar")
                 }
                 if (!hasPatcher) {
-                    add("Patcher is not installed")
+                    add("https://modrinth.com/mod/patcher")
                 }
-                add("These mods greatly improve performance and are almost required to play 1.8.9 Minecraft")
-                add("https://optifine.net/downloadx?f=preview_OptiFine_1.8.9_HD_U_M6_pre2.jar")
-                add("https://modrinth.com/mod/patcher")
             }
         } else {
             event.addIrrelevant {
-                add("Optifine is installed")
-                add("Patcher is installed")
+                add("Optifine and Patcher are installed")
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
+import net.minecraftforge.fml.client.FMLClientHandler
 import java.lang.management.ManagementFactory
 import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.hours
@@ -26,6 +27,7 @@ object ComputerEnvDebug {
         launcher(event)
         ram(event)
         uptime(event)
+        optifine(event)
     }
 
     private fun launcher(event: DebugDataCollectEvent) {
@@ -215,6 +217,17 @@ object ComputerEnvDebug {
     }
 
     private fun getUptime() = ManagementFactory.getRuntimeMXBean().uptime.milliseconds
+
+    private fun optifine(event: DebugDataCollectEvent) {
+        if (PlatformUtils.isDevEnvironment) return
+        val hasOptifine = FMLClientHandler.instance().hasOptifine()
+        event.title("Optifine")
+        if (hasOptifine) {
+            event.addIrrelevant("Optifine is installed")
+        } else {
+            event.addData("Optifine is not installed")
+        }
+    }
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
@@ -228,22 +228,24 @@ object ComputerEnvDebug {
         if (PlatformUtils.isDevEnvironment) return
         val hasOptifine = FMLClientHandler.instance().hasOptifine()
         val hasPatcher = Loader.isModLoaded("patcher")
-        event.title("Optifine")
-        if (hasOptifine) {
-            event.addIrrelevant("Optifine is installed")
-        } else {
-            event.addData("Optifine is not installed")
-        }
-        if (hasPatcher) {
-            event.addIrrelevant("Patcher is installed")
-        } else {
-            event.addData("Patcher is not installed")
-        }
+        event.title("Performance Mods")
         if (!hasOptifine || !hasPatcher) {
-            event.addData("Optifine or Patcher are not installed")
-            event.addData("These mods greatly improve performance and are almost required to play 1.8.9 Minecraft")
-            event.addData("https://optifine.net/downloadx?f=preview_OptiFine_1.8.9_HD_U_M6_pre2.jar")
-            event.addData("https://modrinth.com/mod/patcher")
+            event.addData {
+                if (!hasOptifine) {
+                    add("Optifine is not installed")
+                }
+                if (!hasPatcher) {
+                    add("Patcher is not installed")
+                }
+                add("These mods greatly improve performance and are almost required to play 1.8.9 Minecraft")
+                add("https://optifine.net/downloadx?f=preview_OptiFine_1.8.9_HD_U_M6_pre2.jar")
+                add("https://modrinth.com/mod/patcher")
+            }
+        } else {
+            event.addIrrelevant {
+                add("Optifine is installed")
+                add("Patcher is installed")
+            }
         }
     }
     //#endif


### PR DESCRIPTION
## What
Adds a thingy to shdebug if you dont have optifine or patcher installed

## Changelog Technical Details
+ Added warning in `/shdebug` if Optifine or Patcher isn’t installed. - nopo
