### PR TITLE
Fix + Backend: Trophy Fish Quest Detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -160,8 +160,7 @@ object DailyQuestHelper {
     fun onChat(event: SkyHanniChatEvent) {
         if (!isEnabled()) return
 
-        val message = event.message
-        chatCompletedPattern.matchMatcher(message) {
+        chatCompletedPattern.matchMatcher(event.message) {
             val type = group("type").lowercase()
             when (type) {
                 "dojo" -> {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.fishing.TrophyFishCaughtEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraTier
 import at.hannibal2.skyhanni.features.nether.reputationhelper.CrimsonIsleReputationHelper
@@ -41,6 +42,7 @@ import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
@@ -72,16 +74,26 @@ object DailyQuestHelper {
      * REGEX-TEST: §7Kill the §cBarbarian Duke X §7miniboss §a2
      */
     val minibossAmountPattern by patternGroup.pattern(
-        "minibossamount",
+        "townboard.minibossamount",
         "(?:§7Kill the §c.+ §7|.*)miniboss §a(?<amount>\\d)(?: §7times?!)?",
     )
 
     /**
      * REGEX-TEST: §a§lCOMPLETE
      */
-    val completedPattern by patternGroup.pattern(
-        "complete",
+    val townBoardCompletedPattern by patternGroup.pattern(
+        "townboard.completed",
         "(?:§.)*COMPLETE",
+    )
+
+    /**
+     * REGEX-TEST: §aYou completed your Dojo quest! Visit the Town Board to claim the rewards.
+     * REGEX-TEST: §aYou completed your rescue quest! Visit the Town Board to claim the rewards,
+     *   (yes, that is a comma at the end)
+     */
+    val chatCompletedPattern by patternGroup.pattern(
+        "chat.completed",
+        "§aYou completed your (?<type>\\w+) quest! Visit the Town Board to claim the rewards.*",
     )
 
     private val config get() = SkyHanniMod.feature.crimsonIsle.reputationHelper
@@ -149,25 +161,34 @@ object DailyQuestHelper {
         if (!isEnabled()) return
 
         val message = event.message
-        if (message == "§aYou completed your Dojo quest! Visit the Town Board to claim the rewards.") {
-            val dojoQuest = getQuest<DojoQuest>() ?: return
-            dojoQuest.state = QuestState.READY_TO_COLLECT
-            update()
-        }
-        if (message == "§aYou completed your rescue quest! Visit the Town Board to claim the rewards,") {
-            val rescueMissionQuest = getQuest<RescueMissionQuest>() ?: return
-            rescueMissionQuest.state = QuestState.READY_TO_COLLECT
-            update()
-        }
-
-        if (message.contains("§6§lTROPHY FISH! §r§bYou caught a")) {
-            val fishQuest = getQuest<TrophyFishQuest>() ?: return
-            if (fishQuest.state != QuestState.ACCEPTED && fishQuest.state != QuestState.READY_TO_COLLECT) return
-            val fishName = fishQuest.fishName
-
-            if (message.contains(fishName)) {
-                updateProcessQuest(fishQuest, fishQuest.haveAmount + 1)
+        chatCompletedPattern.matchMatcher(message) {
+            val type = group("type")
+            when (type.lowercase()) {
+                "dojo" -> {
+                    val dojoQuest = getQuest<DojoQuest>() ?: return
+                    dojoQuest.state = QuestState.READY_TO_COLLECT
+                    update()
+                }
+                "rescue" -> {
+                    val rescueMissionQuest = getQuest<RescueMissionQuest>() ?: return
+                    rescueMissionQuest.state = QuestState.READY_TO_COLLECT
+                    update()
+                }
+                else -> {
+                    ChatUtils.debug("Unhandled quest completion type: $type")
+                }
             }
+        }
+    }
+
+    @HandleEvent
+    fun onTrophyFishCaught(event: TrophyFishCaughtEvent) {
+        val fishQuest = getQuest<TrophyFishQuest>() ?: return
+        if (fishQuest.state != QuestState.ACCEPTED && fishQuest.state != QuestState.READY_TO_COLLECT) return
+        val fishName = fishQuest.fishName
+
+        if (event.trophyFishName == fishName) {
+            updateProcessQuest(fishQuest, fishQuest.haveAmount + 1)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -160,23 +160,23 @@ object DailyQuestHelper {
     fun onChat(event: SkyHanniChatEvent) {
         if (!isEnabled()) return
 
-        chatCompletedPattern.matchMatcher(event.message) {
-            val type = group("type").lowercase()
-            when (type) {
-                "dojo" -> {
-                    val dojoQuest = getQuest<DojoQuest>() ?: return
-                    dojoQuest.state = QuestState.READY_TO_COLLECT
-                    update()
-                }
-                "rescue" -> {
-                    val rescueMissionQuest = getQuest<RescueMissionQuest>() ?: return
-                    rescueMissionQuest.state = QuestState.READY_TO_COLLECT
-                    update()
-                }
-                else -> {
-                    ChatUtils.debug("Unhandled quest completion type: $type")
-                }
+        val type = chatCompletedPattern.matchMatcher(event.message) {
+            group("type").lowercase()
+        } ?: return
+        when (type) {
+            "dojo" -> {
+                val dojoQuest = getQuest<DojoQuest>() ?: return
+                dojoQuest.state = QuestState.READY_TO_COLLECT
+                update()
             }
+
+            "rescue" -> {
+                val rescueMissionQuest = getQuest<RescueMissionQuest>() ?: return
+                rescueMissionQuest.state = QuestState.READY_TO_COLLECT
+                update()
+            }
+
+            else -> ChatUtils.debug("Unhandled quest completion type: $type")
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -162,8 +162,8 @@ object DailyQuestHelper {
 
         val message = event.message
         chatCompletedPattern.matchMatcher(message) {
-            val type = group("type")
-            when (type.lowercase()) {
+            val type = group("type").lowercase()
+            when (type) {
                 "dojo" -> {
                     val dojoQuest = getQuest<DojoQuest>() ?: return
                     dojoQuest.state = QuestState.READY_TO_COLLECT

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/QuestLoader.kt
@@ -146,7 +146,7 @@ object QuestLoader {
             if (!categoryName.equals(name, ignoreCase = true)) continue
             val stack = event.inventoryItems[22] ?: continue
 
-            val completed = stack.getLore().any { DailyQuestHelper.completedPattern.matches(it) }
+            val completed = stack.getLore().any { DailyQuestHelper.townBoardCompletedPattern.matches(it) }
             if (completed && quest.state != QuestState.COLLECTED) {
                 quest.state = QuestState.COLLECTED
                 DailyQuestHelper.update()


### PR DESCRIPTION
## What
Hypixel changed the trophy fish catch message, but DailyQuestHelper had a hardcoded check, so it broke. While we're at it, I also changed it to use TrophyFishCaughtEvent, and the rest to RepoPatterns.

## Changelog Fixes
+ Fixed Trophy Fish quest progress detection. - Luna

## Changelog Technical Details
+ Updated DailyQuestHelper to use RepoPatterns and TrophyFishCaughtEvent. - Luna