### PR TITLE
Backend: reset error standalone command

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoManager.kt
@@ -243,8 +243,6 @@ object RepoManager {
 
     private fun reloadRepository(answerMessage: String = "") {
         if (!shouldManuallyReload) return
-        // TODO move away
-        ErrorManager.resetCache()
         error = false
         successfulConstants.clear()
         unsuccessfulConstants.clear()

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -2,6 +2,8 @@ package at.hannibal2.skyhanni.test.command
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ChangedChatErrorsJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.RepoErrorData
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
@@ -79,8 +81,13 @@ object ErrorManager {
 //         ),
 //     )
 
-    fun resetCache() {
-        cache.clear()
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.register("shtestreseterrorcache") {
+            description = "Resets the cache of errors."
+            category = CommandCategory.DEVELOPER_TEST
+            callback { cache.clear() }
+        }
     }
 
     // Extra data from last thrown error


### PR DESCRIPTION
## What
the error cache was so far only getting reset on a repo reload.
This had the effect that I always reset the cache by running `/shreloadlocalrepo`.

This is not intended to be the final solution, therefore the new command `/shtestreseterrorcache`.

## Changelog Technical Details
+ Added standalone `/shtestreseterrorcache` command. - hannibal2