### PR TITLE
Fix: Charged Bottle Notification warning with empty bottle in Inventory

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ChargeBottleNotification.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ChargeBottleNotification.kt
@@ -22,6 +22,12 @@ object ChargeBottleNotification {
 
     private val config get() = SkyHanniMod.feature.misc
 
+    private val emptyBottles = setOf(
+        "THUNDER_IN_A_BOTTLE_EMPTY",
+        "STORM_IN_A_BOTTLE_EMPTY",
+        "HURRICANE_IN_A_BOTTLE_EMPTY",
+    ).toInternalNames()
+
     private val bottles = setOf(
         "THUNDER_IN_A_BOTTLE",
         "STORM_IN_A_BOTTLE",
@@ -37,6 +43,7 @@ object ChargeBottleNotification {
 
         lastChecked = SimpleTimeMark.now()
         if (!isFishing) return
+        if (emptyBottles.any { InventoryUtils.isItemInInventory(it) }) return
         val bottlesInInventory = bottles.filter { InventoryUtils.isItemInInventory(it) }
             .map { it.itemNameWithoutColor }
         if (bottlesInInventory.isEmpty()) return


### PR DESCRIPTION
## What
Fixes Charged Bottle Notification warning the user that their bottles are full, even if they have an empty bottle in their Inventory.

## Changelog Fixes
+ Fixed Charged Bottle Notification showing even with an empty bottle. - Helium9
