### PR TITLE
Fix: meowLitten's Attribute Shard in AH

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -54,8 +54,8 @@ object ChestValue {
     private var inOwnInventory = false
     private val scrollValue = ScrollValue()
 
-    @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class)
+    fun onBackgroundDraw() {
         if (!isEnabled()) return
         if (DungeonApi.inDungeon() && !config.enableInDungeons) return
         if (!inOwnInventory) {
@@ -73,7 +73,7 @@ object ChestValue {
         }
     }
 
-    fun featureName() = if (inOwnInventory) "Estimated Inventory Value" else "Estimated Chest Value"
+    private fun featureName() = if (inOwnInventory) "Estimated Inventory Value" else "Estimated Chest Value"
 
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {
@@ -85,8 +85,8 @@ object ChestValue {
         update()
     }
 
-    @HandleEvent
-    fun onInventoryOpen(event: InventoryOpenEvent) {
+    @HandleEvent(InventoryOpenEvent::class)
+    fun onInventoryOpen() {
         if (!isEnabled()) return
         if (inInventory) {
             update()
@@ -237,6 +237,7 @@ object ChestValue {
         }
     }
 
+    @Suppress("ReturnCount")
     private fun isValidStorage(): Boolean {
         if (inOwnInventory) return true
         val name = InventoryUtils.openInventoryName().removeColor()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -205,6 +205,7 @@ object ChestValue {
     fun createItems(stacks: Map<Int, ItemStack>) = buildMap<String, ChestItem> {
         for ((i, stack) in stacks) {
             val internalName = stack.getInternalNameOrNull() ?: continue
+            if (internalName == NeuInternalName.NONE) continue
             if (internalName.getItemStackOrNull() == null) continue
             val list = mutableListOf<String>()
             var total = if (internalName == NeuInternalName.SKYBLOCK_COIN) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -205,7 +205,6 @@ object ChestValue {
     fun createItems(stacks: Map<Int, ItemStack>) = buildMap<String, ChestItem> {
         for ((i, stack) in stacks) {
             val internalName = stack.getInternalNameOrNull() ?: continue
-            if (internalName == NeuInternalName.NONE) continue
             if (internalName.getItemStackOrNull() == null) continue
             val list = mutableListOf<String>()
             var total = if (internalName == NeuInternalName.SKYBLOCK_COIN) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/TradeValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/TradeValue.kt
@@ -9,9 +9,7 @@ import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -67,7 +65,6 @@ object TradeValue {
         // Gets total value of trade
         for (slot in InventoryUtils.getItemsInOpenChest()) {
             val stack = slot.stack
-            if (stack.getInternalNameOrNull() == NeuInternalName.NONE) continue
             // Gets value of their trade
             if (slot.slotIndex in otherList) {
                 otherMap[slot.slotIndex] = slot.stack

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/TradeValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/TradeValue.kt
@@ -9,7 +9,9 @@ import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -64,16 +66,16 @@ object TradeValue {
         val yourMap = mutableMapOf<Int, ItemStack>()
         // Gets total value of trade
         for (slot in InventoryUtils.getItemsInOpenChest()) {
+            val stack = slot.stack
+            if (stack.getInternalNameOrNull() == NeuInternalName.NONE) continue
             // Gets value of their trade
             if (slot.slotIndex in otherList) {
                 otherMap[slot.slotIndex] = slot.stack
-                val stack = slot.stack
                 otherTotal += (EstimatedItemValueCalculator.calculate(stack, mutableListOf()).first * (stack.stackSize))
             }
             // Gets value of your trade
             if (slot.slotIndex in yourList) {
                 yourMap[slot.slotIndex] = slot.stack
-                val stack = slot.stack
                 yourTotal += (EstimatedItemValueCalculator.calculate(stack, mutableListOf()).first * (stack.stackSize))
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/AuctionHousePriceComparison.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/AuctionHousePriceComparison.kt
@@ -11,10 +11,8 @@ import at.hannibal2.skyhanni.features.inventory.AuctionsHighlighter
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -46,8 +44,6 @@ object AuctionHousePriceComparison {
 
         for ((slot, stack) in event.inventoryItems) {
             for (line in stack.getLore()) {
-                // ignore cases where items put intentionally bugged items in ah to break mods
-                if (stack.getInternalName() == NeuInternalName.NONE) continue
                 AuctionsHighlighter.buyItNowPattern.matchMatcher(line) {
                     map.add(stack, group("coins").formatLong(), slot)
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/AuctionHousePriceComparison.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/AuctionHousePriceComparison.kt
@@ -11,8 +11,10 @@ import at.hannibal2.skyhanni.features.inventory.AuctionsHighlighter
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -44,6 +46,8 @@ object AuctionHousePriceComparison {
 
         for ((slot, stack) in event.inventoryItems) {
             for (line in stack.getLore()) {
+                // ignore cases where items put intentionally bugged items in ah to break mods
+                if (stack.getInternalName() == NeuInternalName.NONE) continue
                 AuctionsHighlighter.buyItNowPattern.matchMatcher(line) {
                     map.add(stack, group("coins").formatLong(), slot)
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -868,16 +868,8 @@ object EstimatedItemValueCalculator {
     private fun addBaseItem(stack: ItemStack, list: MutableList<String>): Double {
         val internalName = stack.getInternalName().removeKuudraTier()
 
-        if (internalName == NeuInternalName.NONE) {
-            ErrorManager.logErrorStateWithData(
-                "failed to read item data for estimated item value calculation",
-                "internal name is none!",
-                "name" to stack.displayName,
-                "lore" to stack.getLore(),
-                betaOnly = true,
-            )
-            return 0.0
-        }
+        // ignore cases where players put bugged items in ah/trade/chest to break mods
+        if (internalName == NeuInternalName.NONE) return 0.0
 
         stack.getAttributeFromShard()?.let {
             val price = it.getAttributePrice()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -33,7 +33,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.SKYBLOCK_COIN
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NeuItems.removePrefix
@@ -551,7 +550,7 @@ object EstimatedItemValueCalculator {
         }
 
         price.coinPrice.takeIf { it != 0L }?.let {
-            items[SKYBLOCK_COIN] = it
+            items[NeuInternalName.SKYBLOCK_COIN] = it
         }
 
         for ((materialInternalName, amount) in price.itemPrice) {
@@ -868,6 +867,17 @@ object EstimatedItemValueCalculator {
 
     private fun addBaseItem(stack: ItemStack, list: MutableList<String>): Double {
         val internalName = stack.getInternalName().removeKuudraTier()
+
+        if (internalName == NeuInternalName.NONE) {
+            ErrorManager.logErrorStateWithData(
+                "failed to read item data for estimated item value calculation",
+                "internal name is none!",
+                "name" to stack.displayName,
+                "lore" to stack.getLore(),
+                betaOnly = true,
+            )
+            return 0.0
+        }
 
         stack.getAttributeFromShard()?.let {
             val price = it.getAttributePrice()


### PR DESCRIPTION
## What
tldr:
fixed error messages with ah item with internal name none

<details>
<summary>Long Version</summary>

see the item at
`/ah meowLitten`
![image](https://github.com/user-attachments/assets/ceace37e-1d4e-4bca-bf08-ede75f4b891a)

the data is:

<details>
<summary>Data</summary>

```
internalName:NONE
display name: '§f§f§fAttribute Shard'
minecraft id: 'minecraft:prismarine_shard'
lore:
 '§7Combine with items in the §bAttribute'
 '§bFusion §7menu to apply attributes.'
 ''
 '§f§lCOMMON'
 '§8§m-----------------'
 '§7Seller: §6[MVP§0++§6] meowLitten'
 '§7Buy it now: §66,969,696,969 coins'
 ''
 '§7Ends in: §e13d'
 ''
 '§eClick to inspect!'

getTagCompound
  HideFlags: 254
  display:
    Name: "§f§f§fAttribute Shard"
  ExtraAttributes:
    id: "ATTRIBUTE_SHARD"
    uuid: "01438a99-179c-408e-b381-4bbf375755af"
    timestamp: 1666629840000L
```

</details>


notice the NONE as neu internal name?

this is not good!

this caused errros in the ah price comparison feature:

<details>
<summary>Stack Trace</summary>

```
SkyHanni 2.17.0: Caught a IllegalStateException in at.hannibal2.skyhanni.features.misc.AuctionHousePriceComparison.onInventoryOpen(at.hannibal2.skyhanni.events.InventoryOpenEvent) at InventoryFullyOpenedEvent: NEUInternalName.NONE has no name!
 
Caused by java.lang.IllegalStateException: NEUInternalName.NONE has no name!
at SH.utils.ItemUtils.grabItemName(ItemUtils.kt:630)
at SH.utils.ItemUtils.getRepoItemName(ItemUtils.kt:614)
at SH.features.misc.items.EstimatedItemValueCalculator.addBaseItem(EstimatedItemValueCalculator.kt:897)
at SH.features.misc.items.EstimatedItemValueCalculator.calculate(EstimatedItemValueCalculator.kt:165)
at SH.features.misc.items.EstimatedItemValueCalculator.getTotalPrice(EstimatedItemValueCalculator.kt:157)
at SH.features.misc.AuctionHousePriceComparison.add(AuctionHousePriceComparison.kt:64)
at SH.features.misc.AuctionHousePriceComparison.onInventoryOpen(AuctionHousePriceComparison.kt:48)
<Skyhanni event post>
```

</details>

</details>

this PR hides NONE items from this feature globally, and also shows a more useful error message for future "estimated item value price calculation with none" error messages.

first reported:
https://discord.com/channels/997079228510117908/1364274559360176238

## Changelog Fixes
+ Fixed AH Price Comparison errors for broken Attribute Shards. - hannibal2