### PR TITLE
Improvement: Hide Compact Tab main background

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/compacttablist/CompactTabListConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/compacttablist/CompactTabListConfig.java
@@ -31,9 +31,14 @@ public class CompactTabListConfig {
     public boolean hideAdverts = false;
 
     @Expose
-    @ConfigOption(name = "Hide Fire Sale Adverts", desc = "Hide fire sales from the tablist")
+    @ConfigOption(name = "Hide Fire Sale Adverts", desc = "Hide fire sales from the tablist.")
     @ConfigEditorBoolean
     public boolean hideFiresales = false;
+
+    @Expose
+    @ConfigOption(name = "Hide Tab Background", desc = "Hides the main background in tab.")
+    @ConfigEditorBoolean
+    public boolean hideTabBackground = false;
 
     @Expose
     @ConfigOption(name = "Advanced Player List", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -104,13 +104,15 @@ object TabListRenderer {
         val x = screenWidth - totalWidth / 2
         val y = 10
 
-        GuiRenderUtils.drawRect(
-            x - COLUMN_SPACING,
-            y - TAB_PADDING,
-            screenWidth + totalWidth / 2 + COLUMN_SPACING,
-            10 + totalHeight + TAB_PADDING,
-            -0x80000000,
-        )
+        if (!config.hideTabBackground) {
+            GuiRenderUtils.drawRect(
+                x - COLUMN_SPACING,
+                y - TAB_PADDING,
+                screenWidth + totalWidth / 2 + COLUMN_SPACING,
+                10 + totalHeight + TAB_PADDING,
+                -0x80000000,
+            )
+        }
 
         var headerY = y
         if (header.isNotEmpty()) {
@@ -165,7 +167,7 @@ object TabListRenderer {
                 middleY - TAB_PADDING + 1,
                 middleX + column.getMaxWidth() + TAB_PADDING - 2,
                 middleY + column.size() * LINE_HEIGHT + TAB_PADDING - 2,
-                0x20AAAAAA,
+                if (config.hideTabBackground) 0x8F262626.toInt() else 0x20AAAAAA,
             )
 
             for (tabLine in column.lines) {


### PR DESCRIPTION
## What
bluesoul asked me to do this

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/04b4d538-ae10-4388-821b-ef34fef0daed)

</details>

## Changelog Improvements
+ Added option to remove the main background in Compact Tab. - martimavocado
