### PR TITLE
Fix: Copy Chat line includes color codes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
@@ -37,7 +37,7 @@ object CopyChat {
 
             KeyboardManager.isShiftKeyDown() -> (ModifyVisualWords.modifyText(formatted)?.removeColor() ?: formatted) to "modified message"
 
-            KeyboardManager.isControlKeyDown() -> chatLine.chatComponent.unformattedText to "line"
+            KeyboardManager.isControlKeyDown() -> chatLine.chatComponent.unformattedText.removeColor() to "line"
 
             else -> formatted.removeColor() to "message"
         }


### PR DESCRIPTION
## What
i can't believe empa got trolled by unformattedText

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fixed Copy Chat including color codes. - martimavocado
