### PR TITLE
Fix: Magical Power Display for Celestial Starstone

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MagicalPowerDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MagicalPowerDisplay.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
@@ -15,6 +16,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -128,5 +130,5 @@ object MagicalPowerDisplay {
         return this.getItemRarityOrNull()
     }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled
+    private fun isEnabled() = LorenzUtils.inSkyBlock && !IslandType.THE_RIFT.isInIsland() && config.enabled
 }


### PR DESCRIPTION
## What
There is no magical power in the rift.

## Changelog Fixes
+ Fixed Celestial Starstone causing an error in Magical Power Display. - CalMWolfs

