### PR TITLE
Fix: Lane Switch notification for farms with soulsand

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
@@ -12,6 +12,7 @@ import kotlin.math.abs
 import kotlin.math.absoluteValue
 import kotlin.math.acos
 import kotlin.math.cos
+import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
@@ -32,7 +33,7 @@ data class LorenzVec(
 
     constructor(x: Float, y: Float, z: Float) : this(x.toDouble(), y.toDouble(), z.toDouble())
 
-    fun toBlockPos(): BlockPos = BlockPos(x.toInt(), y.toInt(), z.toInt())
+    fun toBlockPos(): BlockPos = BlockPos(floor(x).toInt(), floor(y).toInt(), floor(z).toInt())
 
     fun toVec3(): Vec3 = Vec3(x, y, z)
 


### PR DESCRIPTION
## What
Minecrafts constructor for when there are doubles floors before converting to int so we should do the same.

As can be seen to match the top you must do the bottom
![image](https://github.com/user-attachments/assets/023b450f-ca4e-4e84-8019-4044722bab12)


## Changelog Fixes
+ Fixed Lane Switch notification not working for farms with soulsand. - CalMWolfs

## Changelog Technical Details
+ Floor before converting to ints for LorenzVec -> BlockPos. - CalMWolfs

