### PR TITLE
Fix: Block Opening CF features not working on uppercase commands

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
@@ -37,10 +37,11 @@ object CFBlockOpen {
      * REGEX-TEST: /chocolatefactory
      * REGEX-TEST: /chocolatefactory123456789
      * REGEX-TEST: /factory
+     * REGEX-TEST: /CF
      */
     private val commandPattern by RepoPattern.pattern(
         "inventory.chocolatefactory.opencommand",
-        "\\/(?:cf|(?:chocolate)?factory)(?: .*)?",
+        "(?i)\\/(?:cf|(?:chocolate)?factory)(?: .*)?",
     )
 
     /**


### PR DESCRIPTION
## What
Fixed Block Opening CF not working on uppercase commands.


## Changelog Fixes
+ Fixed Block Opening CF not working on uppercase commands. - CalMWolfs
