### PR TITLE
Improvement: lines only show when the entity is visible

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -8,9 +8,9 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
+import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.EntityUtils.hasNameTagWith
-import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.RenderUtils.drawLineToEye
@@ -104,7 +104,7 @@ object MobHighlight {
             return
         }
 
-        if (arachne.distanceToPlayer() > 10) return
+        if (!arachne.canBeSeen(10)) return
 
         event.drawLineToEye(
             arachne.getLorenzVec().up(),

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -259,15 +259,14 @@ object VampireSlayerFeatures {
         if (config.drawLine) {
             for (it in EntityUtils.getEntities<EntityOtherPlayerMP>()) {
                 if (!it.isHighlighted()) continue
+                if (!it.canBeSeen(15)) continue
                 val vec = event.exactLocation(it)
-                if (vec.distanceToPlayer() < 15) {
-                    event.drawLineToEye(
-                        vec.up(1.54),
-                        config.lineColor.toSpecialColor(),
-                        config.lineWidth,
-                        true,
-                    )
-                }
+                event.drawLineToEye(
+                    vec.up(1.54),
+                    config.lineColor.toSpecialColor(),
+                    config.lineWidth,
+                    true,
+                )
             }
         }
         if (!configBloodIchor.highlight && !configKillerSpring.highlight) return
@@ -299,14 +298,16 @@ object VampireSlayerFeatures {
                     ignoreBlocks = false,
                 )
                 for ((player, stand2) in standList) {
-                    if ((configBloodIchor.showLines && isIchor) || (configKillerSpring.showLines && isSpring))
-                        event.draw3DLine(
-                            event.exactPlayerEyeLocation(player),
-                            event.exactPlayerEyeLocation(stand2),
-                            linesColorStart,
-                            3,
-                            true,
-                        )
+                    if (!(configBloodIchor.showLines && isIchor) && !(configKillerSpring.showLines && isSpring)) continue
+                    if (!player.canBeSeen()) continue
+                    if (!stand2.canBeSeen()) continue
+                    event.draw3DLine(
+                        event.exactPlayerEyeLocation(player),
+                        event.exactPlayerEyeLocation(stand2),
+                        linesColorStart,
+                        3,
+                        true,
+                    )
 
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.EntityUtils.hasSkullTexture
-import at.hannibal2.skyhanni.utils.LocationUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzLogger
@@ -38,6 +37,7 @@ import net.minecraft.entity.monster.EntityEnderman
 import net.minecraft.init.Blocks
 import kotlin.time.Duration.Companion.seconds
 
+// TODO replace all drawLineToEye with LineToMobHandler
 @SkyHanniModule
 object EndermanSlayerFeatures {
 
@@ -92,8 +92,6 @@ object EndermanSlayerFeatures {
 
     private fun hasBeaconInHand(enderman: EntityEnderman) = enderman.getBlockInHand()?.block == Blocks.beacon
 
-    private fun canSee(b: LorenzVec) = b.canBeSeen(15.0)
-
     private fun showBeacon() = beaconConfig.highlightBeacon || beaconConfig.showWarning || beaconConfig.showLine
 
     @HandleEvent(onlyOnIsland = IslandType.THE_END)
@@ -125,8 +123,8 @@ object EndermanSlayerFeatures {
             }
             if (config.drawLineToNukekebi) {
                 val skullLocation = event.exactLocation(skull)
-                if (skullLocation.distanceToPlayer() > 20) continue
-                if (!skullLocation.canBeSeen()) continue
+                // TODO remove visibility check once the skull stops moving
+                if (!skull.canBeSeen(viewDistance = 20)) continue
                 event.drawLineToEye(
                     skullLocation.up(),
                     LorenzColor.GOLD.toColor(),
@@ -139,7 +137,7 @@ object EndermanSlayerFeatures {
 
     private fun drawFlyingBeacon(event: SkyHanniRenderWorldEvent) {
         for (beacon in flyingBeacons) {
-            if (beacon.isDead) continue
+            if (!beacon.canBeSeen()) continue
             if (beaconConfig.highlightBeacon) {
                 val beaconLocation = event.exactLocation(beacon)
                 event.drawDynamicText(beaconLocation.add(y = 1), "§4Beacon", 1.8)

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -18,11 +18,11 @@ import at.hannibal2.skyhanni.utils.compat.getHandItem
 import at.hannibal2.skyhanni.utils.compat.getLoadedPlayers
 import at.hannibal2.skyhanni.utils.compat.getStandHelmet
 import at.hannibal2.skyhanni.utils.compat.normalizeAsArray
+import at.hannibal2.skyhanni.utils.render.FrustumUtils
 import net.minecraft.block.state.IBlockState
 import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.client.multiplayer.WorldClient
-import net.minecraft.client.renderer.culling.Frustum
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
@@ -182,12 +182,10 @@ object EntityUtils {
         if (Minecraft.getMinecraft().isCallingFromMinecraftThread) it else it.toMutableList()
     }?.asSequence()?.filterNotNull().orEmpty()
 
-    private val frustum = Frustum()
-
     fun Entity.canBeSeen(viewDistance: Number = 150.0): Boolean {
         if (isDead) return false
         // TODO add cache that only updates e.g. 10 times a second
-        if (!frustum.isBoundingBoxInFrustum(entityBoundingBox)) return false
+        if (!FrustumUtils.isVisible(entityBoundingBox)) return false
         return getLorenzVec().up(0.5).canBeSeen(viewDistance)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -22,6 +22,7 @@ import net.minecraft.block.state.IBlockState
 import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.client.multiplayer.WorldClient
+import net.minecraft.client.renderer.culling.Frustum
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
@@ -181,7 +182,14 @@ object EntityUtils {
         if (Minecraft.getMinecraft().isCallingFromMinecraftThread) it else it.toMutableList()
     }?.asSequence()?.filterNotNull().orEmpty()
 
-    fun Entity.canBeSeen(viewDistance: Number = 150.0) = getLorenzVec().up(0.5).canBeSeen(viewDistance)
+    private val frustum = Frustum()
+
+    fun Entity.canBeSeen(viewDistance: Number = 150.0): Boolean {
+        if (isDead) return false
+        // TODO add cache that only updates e.g. 10 times a second
+        if (!frustum.isBoundingBoxInFrustum(entityBoundingBox)) return false
+        return getLorenzVec().up(0.5).canBeSeen(viewDistance)
+    }
 
     fun getEntityByID(entityId: Int) = MinecraftCompat.localPlayerOrNull?.getEntityLevel()?.getEntityByID(entityId)
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -54,8 +54,7 @@ object LocationUtils {
         val b = this
         val noBlocks = canSee(a, b, offset)
         val notTooFar = a.distance(b) < viewDistance.toDouble()
-        val inFov = true // TODO add Frustum "Frustum().isBoundingBoxInFrustum(entity.entityBoundingBox)"
-        return noBlocks && notTooFar && inFov
+        return noBlocks && notTooFar
     }
 
     fun LorenzVec.canBeSeen(yOffsetRange: IntRange, radius: Double = 150.0): Boolean =

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/FrustumUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/FrustumUtils.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.utils.render
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils
 import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.culling.Frustum
@@ -12,20 +11,15 @@ import net.minecraft.util.AxisAlignedBB
 @SkyHanniModule
 object FrustumUtils {
 
-    private var lastRenderEntityPos = LorenzVec(0.0, 0.0, 0.0)
-
-    private val frustum
-        get(): Frustum =
-            //#if MC < 1.21
-            Frustum().also { it.setPosition(lastRenderEntityPos.x, lastRenderEntityPos.y, lastRenderEntityPos.z) }
+    //#if MC < 1.21
+    private var frustum: Frustum? = null
     //#else
-    //$$ MinecraftClient.getInstance().worldRenderer.frustum
+    //$$ private val frustum get() = MinecraftClient.getInstance().worldRenderer.frustum
     //#endif
-
 
     fun isVisible(box: AxisAlignedBB): Boolean =
         //#if MC < 1.21
-        frustum.isBoundingBoxInFrustum(box)
+        frustum?.isBoundingBoxInFrustum(box) ?: false
     //#else
     //$$ frustum.isVisible(box)
     //#endif
@@ -39,7 +33,8 @@ object FrustumUtils {
      */
     @HandleEvent(priority = HandleEvent.HIGHEST)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
-        lastRenderEntityPos = RenderUtils.exactLocation(Minecraft.getMinecraft().renderViewEntity, event.partialTicks)
+        val pos = RenderUtils.exactLocation(Minecraft.getMinecraft().renderViewEntity, event.partialTicks)
+        frustum = Frustum().also { it.setPosition(pos.x, pos.y, pos.z) }
     }
     //#endif
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/FrustumUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/FrustumUtils.kt
@@ -1,0 +1,46 @@
+package at.hannibal2.skyhanni.utils.render
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.RenderUtils
+import net.minecraft.client.Minecraft
+import net.minecraft.client.renderer.culling.Frustum
+import net.minecraft.util.AxisAlignedBB
+
+@SkyHanniModule
+object FrustumUtils {
+
+    private var lastRenderEntityPos = LorenzVec(0.0, 0.0, 0.0)
+
+    private val frustum
+        get(): Frustum =
+            //#if MC < 1.21
+            Frustum().also { it.setPosition(lastRenderEntityPos.x, lastRenderEntityPos.y, lastRenderEntityPos.z) }
+    //#else
+    //$$ MinecraftClient.getInstance().worldRenderer.frustum
+    //#endif
+
+
+    fun isVisible(box: AxisAlignedBB): Boolean =
+        //#if MC < 1.21
+        frustum.isBoundingBoxInFrustum(box)
+    //#else
+    //$$ frustum.isVisible(box)
+    //#endif
+
+    fun isVisible(minX: Double, minY: Double, minZ: Double, maxX: Double, maxY: Double, maxZ: Double) =
+        isVisible(AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ))
+
+    //#if MC < 1.21
+    /**
+     * We want to account for the render entity's position which is affected by partial ticks.
+     */
+    @HandleEvent(priority = HandleEvent.HIGHEST)
+    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+        lastRenderEntityPos = RenderUtils.exactLocation(Minecraft.getMinecraft().renderViewEntity, event.partialTicks)
+    }
+    //#endif
+
+}


### PR DESCRIPTION
## What
added frustum check to all entity.canbeseen checks
added can be seen checks to all "line from player eye to entity" features.

reported: https://discord.com/channels/997079228510117908/1365234255692566528

this impacts:
```
spiders den arachne boss
dungeon f5/m5 livid
enderman slayer flying beacon
enderman slayer nukekebi
vampire slayer boss
vampire slayer blood ichor
```

## Changelog Improvements
+ Fixed showing line to a mob while the mob is not in sight. - hannibal2 + CalMWolfs
    * E.g. In Livid Finder, or Eman Slayer Nukekebi.