### PR TITLE
Fix: Burrow types not showing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/PlaySoundEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/PlaySoundEvent.kt
@@ -10,7 +10,7 @@ class PlaySoundEvent(val soundName: String, val location: LorenzVec, val pitch: 
     val distanceToPlayer by lazy { location.distanceToPlayer() }
     override fun toString(): String {
         return "PlaySoundEvent(soundName='$soundName', pitch=$pitch, volume=$volume, location=${location.roundTo(1)}, distanceToPlayer=${
-            distanceToPlayer.roundTo(1)
+            distanceToPlayer.roundTo(2)
         })"
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/ReceiveParticleEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/ReceiveParticleEvent.kt
@@ -21,11 +21,11 @@ class ReceiveParticleEvent(
     override fun toString(): String {
         return "ReceiveParticleEvent(type='$type', location=${location.roundTo(1)}, count=$count, speed=$speed, offset=${
             offset.roundTo(
-                1
+                2
             )
         }, longDistance=$longDistance, particleArgs=${particleArgs.contentToString()}, distanceToPlayer=${
             distanceToPlayer.roundTo(
-                1
+                2
             )
         })"
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeLimitedSet
+import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.init.Blocks
 import net.minecraft.util.EnumParticleTypes
 import kotlin.time.Duration.Companion.minutes
@@ -64,7 +65,7 @@ object GriffinBurrowParticleFinder {
 
         val type = ParticleType.entries.firstOrNull { it.check(event) } ?: return
 
-        val location = event.location
+        val location = event.location.toBlockPos().down().toLorenzVec()
         val burrow = burrows.getOrPut(location) { Burrow(location) }
         val oldBurrowType = burrow.type
 
@@ -103,19 +104,25 @@ object GriffinBurrowParticleFinder {
 
     private enum class ParticleType(val check: ReceiveParticleEvent.() -> Boolean) {
         EMPTY(
-            { type == EnumParticleTypes.CRIT_MAGIC && count == 4 && speed == 0.01f && offset == LorenzVec(0.5, 0.1, 0.5) },
+            { type == EnumParticleTypes.CRIT_MAGIC && count == 4 && speed == 0.01f && offset.roundTo(2) == LorenzVec(0.5, 0.1, 0.5) },
         ),
         MOB(
-            { type == EnumParticleTypes.CRIT && count == 3 && speed == 0.01f && offset == LorenzVec(0.5, 0.1, 0.5) },
+            { type == EnumParticleTypes.CRIT && count == 3 && speed == 0.01f && offset.roundTo(2) == LorenzVec(0.5, 0.1, 0.5) },
         ),
         TREASURE(
-            { type == EnumParticleTypes.DRIP_LAVA && count == 2 && speed == 0.01f && offset == LorenzVec(0.35, 0.1, 0.35) },
+            { type == EnumParticleTypes.DRIP_LAVA && count == 2 && speed == 0.01f && offset.roundTo(2) == LorenzVec(0.35, 0.1, 0.35) },
         ),
         FOOTSTEP(
-            { type == EnumParticleTypes.FOOTSTEP && count == 1 && speed == 0.0f && offset == LorenzVec(0.05, 0.0, 0.05) },
+            { type == EnumParticleTypes.FOOTSTEP && count == 1 && speed == 0.0f && offset.roundTo(2) == LorenzVec(0.05, 0.0, 0.05) },
         ),
         ENCHANT(
-            { type == EnumParticleTypes.ENCHANTMENT_TABLE && count == 5 && speed == 0.05f && offset == LorenzVec(0.5, 0.4, 0.5) },
+            {
+                type == EnumParticleTypes.ENCHANTMENT_TABLE && count == 5 && speed == 0.05f && offset.roundTo(2) == LorenzVec(
+                    0.5,
+                    0.4,
+                    0.5,
+                )
+            },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -65,7 +65,8 @@ object GriffinBurrowParticleFinder {
 
         val type = ParticleType.entries.firstOrNull { it.check(event) } ?: return
 
-        val location = event.location.toBlockPos().down().toLorenzVec()
+        // TODO remove the workaround once we know what is going on exactly and can fix this properly
+        val location = workaround(event.location)
         val burrow = burrows.getOrPut(location) { Burrow(location) }
         val oldBurrowType = burrow.type
 
@@ -87,6 +88,8 @@ object GriffinBurrowParticleFinder {
         }
     }
 
+    private fun workaround(location: LorenzVec) = location.toBlockPos().down().toLorenzVec()
+
     @HandleEvent(onlyOnIsland = IslandType.HUB)
     fun onTick() {
         val isSpade = InventoryUtils.getItemInHand()?.isDianaSpade ?: false
@@ -102,6 +105,7 @@ object GriffinBurrowParticleFinder {
         }
     }
 
+    // TODO remove the roundTo calls as they are only workarounds
     private enum class ParticleType(val check: ReceiveParticleEvent.() -> Boolean) {
         EMPTY(
             { type == EnumParticleTypes.CRIT_MAGIC && count == 4 && speed == 0.01f && offset.roundTo(2) == LorenzVec(0.5, 0.1, 0.5) },


### PR DESCRIPTION
## What
There was a floating point error converting floats to doubles. So we round to 2 decimal places. Also the rounding to block location was removed at some point so thats back (probably my fault)

## Changelog Fixes
+ Fixed burrows not showing their type. - CalMWolfs

