### PR TITLE
Fix: Uploading Jacob Contests Error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ApiUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ApiUtils.kt
@@ -185,7 +185,11 @@ object ApiUtils {
         }
     }
 
-    private fun readResponse(entity: HttpEntity): JsonObject {
+    private fun readResponse(entity: HttpEntity?): JsonObject {
+        if (entity == null || entity.contentLength == 0L) {
+            return JsonObject() // Handle responses without a body
+        }
+
         val retSrc = EntityUtils.toString(entity) ?: return JsonObject()
 
         try {


### PR DESCRIPTION
## What
This PR fixes the user getting multiple errors in chat after submitting Jacob contests to Elite. These errors are caused by the API returning `204 No Content` which, as it implies, has no response body. The code couldn't handle a response without a body and threw an error even though the response was successful.

Reported Here:
https://discord.com/channels/997079228510117908/1365732261005234257
https://discord.com/channels/997079228510117908/1355731546581241876

## Changelog Fixes
+ Fixed chat error after sharing Jacob contests. - Ke5o