### PR TITLE
Fix: Hide Autopet Messages hiding manual summon/despawn messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pets/CurrentPetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pets/CurrentPetDisplay.kt
@@ -61,7 +61,7 @@ object CurrentPetDisplay {
     fun onChat(event: SkyHanniChatEvent) {
         findPetInChat(event.message)?.let {
             PetApi.currentPet = it
-            if (config.hideAutopet) {
+            if (config.hideAutopet && chatPetRulePattern.matches(event.message)) {
                 event.blockedReason = "pets"
             }
         }


### PR DESCRIPTION
## What
See changelog.

## Changelog Fixes
+ Fixed Hide Autopet Messages incorrectly hiding manual pet summon/despawn messages. - Luna
