### PR TITLE
Fix: Prevent burrows from being removed incorrectly

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/diana/BurrowGuessEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/diana/BurrowGuessEvent.kt
@@ -3,4 +3,4 @@ package at.hannibal2.skyhanni.events.diana
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.utils.LorenzVec
 
-class BurrowGuessEvent(val guessLocation: LorenzVec, val precise: Boolean) : SkyHanniEvent()
+class BurrowGuessEvent(val guessLocation: LorenzVec, val precise: Boolean, val new: Boolean) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -147,7 +147,7 @@ object GriffinBurrowHelper {
         val newLocation = calculateNewTarget()
         if (targetLocation != newLocation) {
             targetLocation = newLocation
-            // add island graphs here some day when the hub is fully added in the graph
+            // TODO: add island graphs here some day when the hub is fully added in the graph
 //             newLocation?.let {
 //                 IslandGraphs.find(it)
 //             }
@@ -189,12 +189,8 @@ object GriffinBurrowHelper {
         if (newLocation.distance(playerLocation) < 6) return
 
         latestGuess?.let {
-            if (it.precise && config.multiGuesses) {
-                if (event.new) {
-                    if (it.getLocation() !in particleBurrows) {
-                        additionalGuesses.add(it)
-                    }
-                }
+            if (it.precise && config.multiGuesses && event.new && it.getLocation() !in particleBurrows) {
+                additionalGuesses.add(it)
             }
         }
 
@@ -214,10 +210,8 @@ object GriffinBurrowHelper {
 
     private fun removePreciseGuess(location: LorenzVec) {
         latestGuess?.let {
-            if (it.precise) {
-                if (location == it.getLocation()) {
-                    latestGuess = null
-                }
+            if (it.precise && location == it.getLocation()) {
+                latestGuess = null
             }
         }
         additionalGuesses.removeIf { it.getLocation() == location }
@@ -430,11 +424,9 @@ object GriffinBurrowHelper {
 
         if (particleBurrows.containsKey(location)) {
             DelayedRun.runDelayed(1.seconds) {
-                if (BurrowApi.lastBurrowRelatedChatMessage.passedSince() > 2.seconds) {
-                    if (particleBurrows.containsKey(location)) {
-                        // workaround
-                        particleBurrows = particleBurrows.editCopy { keys.remove(location) }
-                    }
+                if (BurrowApi.lastBurrowRelatedChatMessage.passedSince() > 2.seconds && particleBurrows.containsKey(location)) {
+                    // workaround
+                    particleBurrows = particleBurrows.editCopy { keys.remove(location) }
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -180,8 +180,6 @@ object GriffinBurrowHelper {
         return newLocation
     }
 
-    private var correctCounter = 0
-
     @HandleEvent
     fun onBurrowGuess(event: BurrowGuessEvent) {
         EntityMovementData.addToTrack(MinecraftCompat.localPlayer)
@@ -192,16 +190,10 @@ object GriffinBurrowHelper {
 
         latestGuess?.let {
             if (it.precise && config.multiGuesses) {
-                if (it.getLocation() == newLocation) {
-                    correctCounter++
-                } else {
-                    if (correctCounter > 5) {
-                        config.guess
-                        if (it.getLocation() !in particleBurrows) {
-                            additionalGuesses.add(it)
-                        }
+                if (event.new) {
+                    if (it.getLocation() !in particleBurrows) {
+                        additionalGuesses.add(it)
                     }
-                    correctCounter = 0
                 }
             }
         }
@@ -225,7 +217,6 @@ object GriffinBurrowHelper {
             if (it.precise) {
                 if (location == it.getLocation()) {
                     latestGuess = null
-                    correctCounter = 0
                 }
             }
         }
@@ -238,7 +229,6 @@ object GriffinBurrowHelper {
         val location = guess.getLocation()
         if (particleBurrows.any { location.distance(it.key) < distance }) {
             latestGuess = null
-            correctCounter = 0
         }
     }
 
@@ -273,7 +263,6 @@ object GriffinBurrowHelper {
 
     private fun resetAllData() {
         latestGuess = null
-        correctCounter = 0
         additionalGuesses.clear()
         targetLocation = null
         particleBurrows = emptyMap()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -23,7 +23,6 @@ import at.hannibal2.skyhanni.utils.TimeUtils.inWholeTicks
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.init.Blocks
 import net.minecraft.util.EnumParticleTypes
-import kotlin.math.ceil
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -207,13 +207,11 @@ object GriffinBurrowParticleFinder {
         var burrowTimeToLive: Int = 1,
     ) {
 
-        fun getType(): BurrowType {
-            return when (this.type) {
-                0 -> BurrowType.START
-                1 -> BurrowType.MOB
-                2 -> BurrowType.TREASURE
-                else -> BurrowType.UNKNOWN
-            }
+        fun getType(): BurrowType = when (this.type) {
+            0 -> BurrowType.START
+            1 -> BurrowType.MOB
+            2 -> BurrowType.TREASURE
+            else -> BurrowType.UNKNOWN
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.diana.BurrowDetectEvent
 import at.hannibal2.skyhanni.events.diana.BurrowDugEvent
 import at.hannibal2.skyhanni.features.event.diana.DianaApi.isDianaSpade
+import at.hannibal2.skyhanni.features.misc.CurrentPing
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
 import at.hannibal2.skyhanni.utils.DelayedRun
@@ -18,9 +19,11 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeLimitedSet
+import at.hannibal2.skyhanni.utils.TimeUtils.inWholeTicks
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.init.Blocks
 import net.minecraft.util.EnumParticleTypes
+import kotlin.math.ceil
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -204,7 +207,7 @@ object GriffinBurrowParticleFinder {
         var hasEnchant: Boolean = false,
         var type: Int = -1,
         var found: Boolean = false,
-        var burrowTimeToLive: Int = 1,
+        var burrowTimeToLive: Int = CurrentPing.averagePing.inWholeTicks + 1
     ) {
 
         fun getType(): BurrowType {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -94,10 +94,10 @@ object GriffinBurrowParticleFinder {
     fun onTick() {
         val isSpade = InventoryUtils.getItemInHand()?.isDianaSpade ?: false
         if (isSpade) {
-            burrows.filter { (location, burrow) ->
+            for ((location, burrow) in burrows) {
+                if (location.distanceSqToPlayer() > 256) continue
                 burrow.burrowTimeToLive -= 1
-                location.distanceSqToPlayer() < 256 && burrow.burrowTimeToLive < 0
-            }.forEach { (location, burrow) ->
+                if (burrow.burrowTimeToLive >= 0) continue
                 BurrowDugEvent(location).post()
                 burrows.remove(location)
                 lastDugParticleBurrow = null
@@ -204,7 +204,7 @@ object GriffinBurrowParticleFinder {
         var hasEnchant: Boolean = false,
         var type: Int = -1,
         var found: Boolean = false,
-        var burrowTimeToLive: Int = 0,
+        var burrowTimeToLive: Int = 1,
     ) {
 
         fun getType(): BurrowType {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -90,6 +90,8 @@ object GriffinBurrowParticleFinder {
 
     private fun workaround(location: LorenzVec) = location.toBlockPos().down().toLorenzVec()
 
+    // TODO this funciton needs upgrades: currently only counts down the tile alive for burrows while holding a spade,
+    //  and instead of ticks alive, should use found time stamp and use passed since > 1.min
     @HandleEvent(onlyOnIsland = IslandType.HUB)
     fun onTick() {
         val isSpade = InventoryUtils.getItemInHand()?.isDianaSpade ?: false
@@ -98,6 +100,8 @@ object GriffinBurrowParticleFinder {
                 if (location.distanceSqToPlayer() > 256) continue
                 burrow.burrowTimeToLive -= 1
                 if (burrow.burrowTimeToLive >= 0) continue
+                // TODO differentiate between user clicking the burrow and the burrow dissapears after a while,
+                //  important bc of wasCorrectPetAlready in GriffinPetWarning
                 BurrowDugEvent(location).post()
                 burrows.remove(location)
                 lastDugParticleBurrow = null

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
@@ -23,10 +23,12 @@ object PreciseGuessBurrow {
     private val config get() = SkyHanniMod.feature.event.diana
 
     private val bezierFitter = ParticlePathBezierFitter(3)
+    private var newBurrow = true
 
     @HandleEvent(onlyOnIsland = IslandType.HUB)
     fun onIslandChange() {
         bezierFitter.reset()
+        newBurrow = true
     }
 
     @HandleEvent(onlyOnIsland = IslandType.HUB, receiveCancelled = true)
@@ -51,7 +53,8 @@ object PreciseGuessBurrow {
 
         val guessPosition = guessBurrowLocation() ?: return
 
-        BurrowGuessEvent(guessPosition.down(0.5).roundLocationToBlock(), precise = true).post()
+        BurrowGuessEvent(guessPosition.down(0.5).roundLocationToBlock(), precise = true, new = newBurrow).post()
+        newBurrow = false
     }
 
     private fun guessBurrowLocation(): LorenzVec? = bezierFitter.solve()
@@ -71,6 +74,7 @@ object PreciseGuessBurrow {
         }
         bezierFitter.reset()
         lastDianaSpade = SimpleTimeMark.now()
+        newBurrow = true
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/SoopyGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/SoopyGuessBurrow.kt
@@ -233,7 +233,7 @@ object SoopyGuessBurrow {
                         } else {
                             LorenzVec(floor(p2.x), 255.0, floor(p2.z))
                         }
-                        BurrowGuessEvent(finalLocation, precise = false).post()
+                        BurrowGuessEvent(finalLocation, precise = false, new = false).post()
                     }
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/SoopyGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/SoopyGuessBurrow.kt
@@ -144,113 +144,112 @@ object SoopyGuessBurrow {
                 run = true
             }
         }
-        if (run) {
-            if (locations.size < 100 && locations.isEmpty() || locations.last().distance(currLoc) != 0.0) {
-                var distMultiplier = 1.0
-                if (locations.size > 2) {
-                    val predictedDist = 0.06507 * locations.size + 0.259
-                    val lastPos = locations.last()
-                    val actualDist = currLoc.distance(lastPos)
-                    distMultiplier = actualDist / predictedDist
+        if (!run) return
+        if (locations.size < 100 && locations.isEmpty() || locations.last().distance(currLoc) != 0.0) {
+            var distMultiplier = 1.0
+            if (locations.size > 2) {
+                val predictedDist = 0.06507 * locations.size + 0.259
+                val lastPos = locations.last()
+                val actualDist = currLoc.distance(lastPos)
+                distMultiplier = actualDist / predictedDist
+            }
+            locations.add(currLoc)
+
+            if (locations.size > 5 && guessPoint != null) {
+
+                val slopeThing = locations.zipWithNext { a, b ->
+                    atan((a.x - b.x) / (a.z - b.z))
                 }
-                locations.add(currLoc)
 
-                if (locations.size > 5 && guessPoint != null) {
+                val (a, b, c) = solveEquationThing(
+                    LorenzVec(slopeThing.size - 5, slopeThing.size - 3, slopeThing.size - 1),
+                    LorenzVec(
+                        slopeThing[slopeThing.size - 5],
+                        slopeThing[slopeThing.size - 3],
+                        slopeThing[slopeThing.size - 1],
+                    ),
+                )
 
-                    val slopeThing = locations.zipWithNext { a, b ->
-                        atan((a.x - b.x) / (a.z - b.z))
-                    }
+                val pr1 = mutableListOf<LorenzVec>()
+                val pr2 = mutableListOf<LorenzVec>()
 
-                    val (a, b, c) = solveEquationThing(
-                        LorenzVec(slopeThing.size - 5, slopeThing.size - 3, slopeThing.size - 1),
-                        LorenzVec(
-                            slopeThing[slopeThing.size - 5],
-                            slopeThing[slopeThing.size - 3],
-                            slopeThing[slopeThing.size - 1],
-                        ),
-                    )
+                val start = slopeThing.size - 1
+                val lastPos = locations[start].toDoubleArray()
+                val lastPos2 = locations[start].toDoubleArray()
 
-                    val pr1 = mutableListOf<LorenzVec>()
-                    val pr2 = mutableListOf<LorenzVec>()
+                var distCovered = 0.0
 
-                    val start = slopeThing.size - 1
-                    val lastPos = locations[start].toDoubleArray()
-                    val lastPos2 = locations[start].toDoubleArray()
+                val ySpeed = locations[locations.size - 1].x - locations[locations.size - 2].x / hypot(
+                    locations[locations.size - 1].x - locations[locations.size - 2].x,
+                    locations[locations.size - 1].z - locations[locations.size - 2].x,
+                )
 
-                    var distCovered = 0.0
+                var i = start + 1
+                while (distCovered < distance2!! && i < 10000) {
+                    val y = b / (i + a) + c
+                    val dist = distMultiplier * (0.06507 * i + 0.259)
 
-                    val ySpeed = locations[locations.size - 1].x - locations[locations.size - 2].x / hypot(
-                        locations[locations.size - 1].x - locations[locations.size - 2].x,
-                        locations[locations.size - 1].z - locations[locations.size - 2].x,
-                    )
+                    val xOff = dist * sin(y)
+                    val zOff = dist * cos(y)
 
-                    var i = start + 1
-                    while (distCovered < distance2!! && i < 10000) {
-                        val y = b / (i + a) + c
-                        val dist = distMultiplier * (0.06507 * i + 0.259)
+                    val density = 5
 
-                        val xOff = dist * sin(y)
-                        val zOff = dist * cos(y)
+                    for (o in 0..density) {
+                        lastPos[0] += xOff / density
+                        lastPos[2] += zOff / density
 
-                        val density = 5
+                        lastPos[1] += ySpeed * dist / density
+                        lastPos2[1] += ySpeed * dist / density
 
-                        for (o in 0..density) {
-                            lastPos[0] += xOff / density
-                            lastPos[2] += zOff / density
+                        lastPos2[0] -= xOff / density
+                        lastPos2[2] -= zOff / density
 
-                            lastPos[1] += ySpeed * dist / density
-                            lastPos2[1] += ySpeed * dist / density
-
-                            lastPos2[0] -= xOff / density
-                            lastPos2[2] -= zOff / density
-
-                            pr1.add(lastPos.toLorenzVec())
-                            pr2.add(lastPos2.toLorenzVec())
+                        pr1.add(lastPos.toLorenzVec())
+                        pr2.add(lastPos2.toLorenzVec())
 
 
-                            lastSoundPoint?.let {
-                                distCovered = hypot(lastPos[0] - it.x, lastPos[2] - it.z)
-                            }
-
-                            if (distCovered > distance2!!) break
+                        lastSoundPoint?.let {
+                            distCovered = hypot(lastPos[0] - it.x, lastPos[2] - it.z)
                         }
-                        i++
+
+                        if (distCovered > distance2!!) break
                     }
+                    i++
+                }
 
-                    // Why does this happen?
-                    if (pr1.isEmpty()) return
+                // Why does this happen?
+                if (pr1.isEmpty()) return
 
-                    val p1 = pr1.last()
-                    val p2 = pr2.last()
+                val p1 = pr1.last()
+                val p2 = pr2.last()
 
 
-                    guessPoint?.let {
-                        val d1 = ((p1.x - it.x).times(2 + (p1.z - it.z))).pow(2)
-                        val d2 = ((p2.x - it.x).times(2 + (p2.z - it.z))).pow(2)
+                guessPoint?.let {
+                    val d1 = ((p1.x - it.x).times(2 + (p1.z - it.z))).pow(2)
+                    val d2 = ((p2.x - it.x).times(2 + (p2.z - it.z))).pow(2)
 
-                        val finalLocation = if (d1 < d2) {
-                            LorenzVec(floor(p1.x), 255.0, floor(p1.z))
-                        } else {
-                            LorenzVec(floor(p2.x), 255.0, floor(p2.z))
-                        }
-                        BurrowGuessEvent(finalLocation, precise = false, new = false).post()
+                    val finalLocation = if (d1 < d2) {
+                        LorenzVec(floor(p1.x), 255.0, floor(p1.z))
+                    } else {
+                        LorenzVec(floor(p2.x), 255.0, floor(p2.z))
                     }
+                    BurrowGuessEvent(finalLocation, precise = false, new = false).post()
                 }
             }
-
-            if (lastParticlePoint == null) {
-                firstParticlePoint = currLoc.clone()
-            }
-
-            lastParticlePoint2 = lastParticlePoint
-            lastParticlePoint = particlePoint
-
-            particlePoint = currLoc.clone()
-
-            if (lastParticlePoint2 == null || firstParticlePoint == null || distance2 == null || lastSoundPoint == null) return
-
-            calcNewGuessPoint()
         }
+
+        if (lastParticlePoint == null) {
+            firstParticlePoint = currLoc.clone()
+        }
+
+        lastParticlePoint2 = lastParticlePoint
+        lastParticlePoint = particlePoint
+
+        particlePoint = currLoc.clone()
+
+        if (lastParticlePoint2 == null || firstParticlePoint == null || distance2 == null || lastSoundPoint == null) return
+
+        calcNewGuessPoint()
     }
 
     private fun calcNewGuessPoint() {


### PR DESCRIPTION
## What
This PR _should_ fix the issue, might cause a `ConcurrentModificationException` due to editing a map while iterating over that map

## Changelog Fixes
+ Fixed burrows being removed incorrectly when more than 16 blocks away. - bloxigus
+ Fixed Multi Guess not saving guess locations sometimes. - bloxigus