### PR TITLE
Fix: No hub warps unlocked error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/Commands.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.features.commands.PartyChatCommands
 import at.hannibal2.skyhanni.features.commands.WikiManager
 import at.hannibal2.skyhanni.features.dungeon.CroesusChestTracker
 import at.hannibal2.skyhanni.features.dungeon.floor7.TerminalInfo
-import at.hannibal2.skyhanni.features.event.diana.BurrowWarpHelper
 import at.hannibal2.skyhanni.features.event.diana.GriffinBurrowHelper
 import at.hannibal2.skyhanni.features.event.diana.InquisitorWaypointShare
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityCollectionStats
@@ -205,11 +204,6 @@ object Commands {
             description = "Resets the saved values of the applied kismet feathers in Croesus"
             category = CommandCategory.USERS_RESET
             callback { CroesusChestTracker.resetChest() }
-        }
-        event.register("shresetburrowwarps") {
-            description = "Manually resetting disabled diana burrow warp points"
-            category = CommandCategory.USERS_RESET
-            callback { BurrowWarpHelper.resetDisabledWarps() }
         }
         event.register("shresetcontestdata") {
             description = "Resets Jacob's Contest Data"

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
@@ -2,6 +2,8 @@ package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -113,9 +115,16 @@ object BurrowWarpHelper {
         WarpPoint.entries.filter { it.unlocked && !it.ignored() }.map { it to it.distance(location) }
             .sorted().firstOrNull()?.first
 
-    fun resetDisabledWarps() {
-        WarpPoint.entries.forEach { it.unlocked = true }
-        ChatUtils.chat("Reset disabled burrow warps.")
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.register("shresetburrowwarps") {
+            description = "Manually resetting disabled diana burrow warp points"
+            category = CommandCategory.USERS_RESET
+            callback {
+                WarpPoint.entries.forEach { it.unlocked = true }
+                ChatUtils.chat("Reset disabled burrow warps.")
+            }
+        }
     }
 
     enum class WarpPoint(
@@ -125,7 +134,6 @@ object BurrowWarpHelper {
         val ignored: () -> Boolean = { false },
         var unlocked: Boolean = true,
     ) {
-
         HUB("Hub", LorenzVec(-3, 70, -70), 2),
         CASTLE("Castle", LorenzVec(-250, 130, 45), 10),
         CRYPT("Crypt", LorenzVec(-190, 74, -88), 15, { config.ignoredWarps.crypt }),

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
@@ -96,7 +96,10 @@ object BurrowWarpHelper {
         debug?.add("target: ${target.printWithAccuracy(1)}")
         val playerLocation = LocationUtils.playerLocation()
         debug?.add("playerLocation: ${playerLocation.printWithAccuracy(1)}")
-        val warpPoint = getNearestWarpPoint(target)
+        val warpPoint = getNearestWarpPoint(target) ?: run {
+            debug?.add("no nearest warp point found (everything disabled/not unlocked with tp scrolls)")
+            return
+        }
         debug?.add("warpPoint: ${warpPoint.displayName}")
 
         val playerDistance = playerLocation.distance(target)
@@ -110,9 +113,9 @@ object BurrowWarpHelper {
         currentWarp = if (setWarpPoint) warpPoint else null
     }
 
-    private fun getNearestWarpPoint(location: LorenzVec) =
+    private fun getNearestWarpPoint(location: LorenzVec): WarpPoint? =
         WarpPoint.entries.filter { it.unlocked && !it.ignored() }.map { it to it.distance(location) }
-            .sorted().first().first
+            .sorted().firstOrNull()?.first
 
     fun resetDisabledWarps() {
         WarpPoint.entries.forEach { it.unlocked = true }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
@@ -121,7 +121,7 @@ object BurrowWarpHelper {
             description = "Manually resetting disabled diana burrow warp points"
             category = CommandCategory.USERS_RESET
             callback {
-                WarpPoint.entries.forEach { it.unlocked = true }
+                WarpPoint.entries.forEach { point -> point.unlocked = true }
                 ChatUtils.chat("Reset disabled burrow warps.")
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
@@ -35,31 +35,27 @@ object BurrowWarpHelper {
         if (event.keyCode != config.keyBindWarp) return
         if (Minecraft.getMinecraft().currentScreen != null) return
 
-        currentWarp?.let {
-            if (lastWarpTime.passedSince() > 1.seconds) {
-                lastWarpTime = SimpleTimeMark.now()
-                HypixelCommands.warp(it.name)
-                lastWarp = currentWarp
-                GriffinBurrowHelper.lastTitleSentTime = SimpleTimeMark.now() + 2.seconds
-                TitleManager.conditionallyStopTitle { currentTitle ->
-                    currentTitle.startsWith("§bWarp to ")
-                }
-            }
+        val warp = currentWarp ?: return
+        if (lastWarpTime.passedSince() < 1.seconds) return
+        lastWarpTime = SimpleTimeMark.now()
+        HypixelCommands.warp(warp.name)
+        lastWarp = currentWarp
+        GriffinBurrowHelper.lastTitleSentTime = SimpleTimeMark.now() + 2.seconds
+        TitleManager.conditionallyStopTitle { currentTitle ->
+            currentTitle.startsWith("§bWarp to ")
         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onChat(event: SkyHanniChatEvent) {
-        if (event.message == "§cYou haven't unlocked this fast travel destination!") {
-            if (lastWarpTime.passedSince() < 1.seconds) {
-                lastWarp?.let {
-                    it.unlocked = false
-                    ChatUtils.chat("Detected not having access to warp point §b${it.displayName}§e!")
-                    ChatUtils.chat("Use §c/shresetburrowwarps §eonce you have activated this travel scroll.")
-                    lastWarp = null
-                    currentWarp = null
-                }
-            }
+        if (event.message != "§cYou haven't unlocked this fast travel destination!") return
+        if (lastWarpTime.passedSince() > 1.seconds) return
+        lastWarp?.let {
+            it.unlocked = false
+            ChatUtils.chat("Detected not having access to warp point §b${it.displayName}§e!")
+            ChatUtils.chat("Use §c/shresetburrowwarps §eonce you have activated this travel scroll.")
+            lastWarp = null
+            currentWarp = null
         }
     }
 


### PR DESCRIPTION
## What
Fixed an error message when trying to warp with no hub warp point unlocked

Just a workaround, in fact, there is no chance that `/hub` gets marked as not unlocked. idk whats going on exactly

## Changelog Fixes
+ Fixed error message when warping to a burrow with no unlocked hub warp point. - hannibal2