### PR TITLE
Feature: Navigation x Dungeon

### DIFF
--- a/docs/OPEN_SOURCE_SOFTWARE.md
+++ b/docs/OPEN_SOURCE_SOFTWARE.md
@@ -14,3 +14,4 @@ SkyHanni would not be possible without the following open source software:
 | [SoopyV2](https://github.com/Soopyboo32/SoopyV2)                               | [GPL 3.0](https://github.com/Soopyboo32/SoopyV2/blob/master/LICENSE)                                              |
 | [DiscordIPC](https://github.com/jagrosh/DiscordIPC)                            | [Apache 2.0](https://github.com/jagrosh/DiscordIPC/blob/master/LICENSE)                                           |
 | [SkyblockAddons](https://github.com/BiscuitDevelopment/SkyblockAddons/)        | [MIT](https://github.com/BiscuitDevelopment/SkyblockAddons/blob/e9fd003f359b357f52b7430c24e64a4c8192a868/LICENSE) |
+| [DungeonRoomsMod](https://github.com/Quantizr/DungeonRoomsMod/)                | [GNU v3.0](https://github.com/Quantizr/DungeonRoomsMod/blob/4d9ce89042c5bbf11b6f5a9bcf689c84e521aeb0/LICENSE)     |

--- a/docs/OPEN_SOURCE_SOFTWARE.md
+++ b/docs/OPEN_SOURCE_SOFTWARE.md
@@ -14,4 +14,4 @@ SkyHanni would not be possible without the following open source software:
 | [SoopyV2](https://github.com/Soopyboo32/SoopyV2)                               | [GPL 3.0](https://github.com/Soopyboo32/SoopyV2/blob/master/LICENSE)                                              |
 | [DiscordIPC](https://github.com/jagrosh/DiscordIPC)                            | [Apache 2.0](https://github.com/jagrosh/DiscordIPC/blob/master/LICENSE)                                           |
 | [SkyblockAddons](https://github.com/BiscuitDevelopment/SkyblockAddons/)        | [MIT](https://github.com/BiscuitDevelopment/SkyblockAddons/blob/e9fd003f359b357f52b7430c24e64a4c8192a868/LICENSE) |
-| [DungeonRoomsMod](https://github.com/Quantizr/DungeonRoomsMod/)                | [GNU v3.0](https://github.com/Quantizr/DungeonRoomsMod/blob/4d9ce89042c5bbf11b6f5a9bcf689c84e521aeb0/LICENSE)     |
+| [DungeonRoomsMod](https://github.com/Quantizr/DungeonRoomsMod/)                | [GPL 3.0](https://github.com/Quantizr/DungeonRoomsMod/blob/4d9ce89042c5bbf11b6f5a9bcf689c84e521aeb0/LICENSE)      |

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
@@ -3,10 +3,12 @@ package at.hannibal2.skyhanni.config.features.dev
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.features.dev.minecraftconsole.MinecraftConsoleConfig
+import at.hannibal2.skyhanni.utils.OSUtils.openBrowser
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.Category
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
@@ -142,6 +144,19 @@ class DevConfig {
     )
     @ConfigEditorBoolean
     var damageIndicatorBackend: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Dungeon Room Detection",
+        desc = "Using data from §eDungeon Room Mod §7to detect the dungeon room for §e/shnavigate §7support in dungeon. " +
+            "§cOnly works when DRM is installed!",
+    )
+    @ConfigEditorBoolean
+    var dungeonRoomDetection: Boolean = true
+
+    @ConfigOption(name = "Download DRM", desc = "Click here to open the Dungeon Room Mod GitHub page.")
+    @ConfigEditorButton(buttonText = "Source")
+    var dungeonRoomDownload: Runnable = Runnable { openBrowser("https://github.com/Quantizr/DungeonRoomsMod/") }
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -15,9 +15,11 @@ import at.hannibal2.skyhanni.events.entity.EntityMoveEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.misc.IslandAreas
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.test.graph.DungeonGraphs.revertDungeon
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.GraphUtils
@@ -270,7 +272,11 @@ object IslandGraphs {
 
         val graph = RepoUtils.getConstant(RepoManager.repoLocation, constant, Graph.gson, Graph::class.java)
         IslandAreas.display = null
-        setNewGraph(graph)
+        if (DungeonApi.inDungeon()) {
+            setNewGraph(graph.revertDungeon())
+        } else {
+            setNewGraph(graph)
+        }
     }
 
     fun setNewGraph(graph: Graph) {

--- a/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
@@ -22,7 +22,7 @@ value class Graph(
 
     override fun containsAll(elements: Collection<GraphNode>) = nodes.containsAll(elements)
 
-    override fun get(index: Int) = nodes.get(index)
+    override fun get(index: Int) = nodes[index]
 
     override fun isEmpty() = nodes.isEmpty()
 
@@ -36,6 +36,19 @@ value class Graph(
     override fun subList(fromIndex: Int, toIndex: Int) = nodes.subList(fromIndex, toIndex)
 
     override fun lastIndexOf(element: GraphNode) = nodes.lastIndexOf(element)
+
+    fun transformNodes(function: (LorenzVec) -> LorenzVec): Graph {
+        val newNodes = mutableMapOf<GraphNode, GraphNode>()
+        for (node in nodes) {
+            newNodes[node] = GraphNode(node.id, function(node.position), node.name, node.tagNames)
+        }
+        for ((old, new) in newNodes) {
+            new.neighbours = old.neighbours.mapKeys { newNodes[it.key]!! }
+
+        }
+
+        return Graph(newNodes.values.toList())
+    }
 
     companion object {
         val gson = GsonBuilder().setPrettyPrinting().registerTypeAdapter<Graph>(
@@ -154,7 +167,7 @@ class GraphNode(val id: Int, val position: LorenzVec, val name: String? = null, 
     var enabled = true
 
     /** Keys are the neighbours and value the edge weight (e.g. Distance) */
-    lateinit var neighbours: Map<GraphNode, Double>
+    var neighbours = emptyMap<GraphNode, Double>()
 
     override fun hashCode(): Int {
         return id

--- a/src/main/java/at/hannibal2/skyhanni/data/model/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/GraphNodeTag.kt
@@ -111,6 +111,102 @@ enum class GraphNodeTag(
         "A Fairy Soul.",
     ),
 
+    DUNGEON_SECRET_BAT(
+        "dungeon_secret_bat",
+        LorenzColor.GOLD,
+        "Dungeon Secret Bat",
+        "A bat that is a secret in a dungeon room.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_SECRET_ITEM(
+        "dungeon_secret_item",
+        LorenzColor.WHITE,
+        "Dungeon Secret Item",
+        "A item on the ground spawnsx here.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_SECRET_CHEST(
+        "dungeon_secret_chest",
+        LorenzColor.YELLOW,
+        "Dungeon Secret Chest",
+        "A secret chest spawns here when getting close.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_SECRET_ESSENCE(
+        "dungeon_secret_essence",
+        LorenzColor.BLACK,
+        "Dungeon Secret Essence",
+        "Here is a secret essence.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_RED_SKULL(
+        "dungeon_red_skull",
+        LorenzColor.DARK_RED,
+        "Dungeon Red Skull",
+        "Here is a red skull that needs to be placed on a redstone block.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_ENTRANCE(
+        "dungeon_entrance",
+        LorenzColor.GREEN,
+        "Dungeon Entrance",
+        "A door to another dungeon room.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_LEVER(
+        "dungeon_lever",
+        LorenzColor.GRAY,
+        "Dungeon Lever",
+        "A lever that opens somehing somewhere else.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_CRYPT(
+        "dungeon_crypt",
+        LorenzColor.DARK_GRAY,
+        "Dungeon Crypt",
+        "A crypt that needs superbooming.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_CRACKED_WALL(
+        "dungeon_cracked_wall",
+        LorenzColor.GRAY,
+        "Cracked Wall",
+        "A weak wall that wants to get blowen up since somehting interesting lies behind.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_MINI_BOSS(
+        "dungeon_mini_boss",
+        LorenzColor.RED,
+        "Mini Boss",
+        "A mini boss spawns here.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_EHERWARP_SPOT(
+        "dungeon_etherwarp",
+        LorenzColor.DARK_BLUE,
+        "Etherwarp Spot",
+        "A spot where to etherwarp to.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
+    DUNGEON_STONK(
+        "dungeon_stonk",
+        LorenzColor.LIGHT_PURPLE,
+        "Stonk Spot",
+        "A spot where you can use ghost pickaxe / a stonking mechanic to click or go through.",
+        onlyIsland = IslandType.CATACOMBS,
+    ),
+
     ;
 
     val displayName: String = color.getChatColor() + cleanName

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
@@ -289,6 +289,7 @@ object IslandAreas {
         it in (if (config.includeSmallAreas || !useConfig) allAreas else onlyLargeAreas)
     }
 
+    @Suppress("DEPRECATION")
     private fun setTarget(node: GraphNode) {
         targetNode = node
         val tag = node.getAreaTag() ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -33,6 +33,19 @@ object NavigationHelper {
         GraphNodeTag.GRIND_CROPS,
         GraphNodeTag.MINES_EMISSARY,
         GraphNodeTag.CRIMSON_MINIBOSS,
+
+        GraphNodeTag.DUNGEON_ENTRANCE,
+        GraphNodeTag.DUNGEON_SECRET_ITEM,
+        GraphNodeTag.DUNGEON_SECRET_CHEST,
+        GraphNodeTag.DUNGEON_CRYPT,
+        GraphNodeTag.DUNGEON_SECRET_BAT,
+        GraphNodeTag.DUNGEON_SECRET_ESSENCE,
+        GraphNodeTag.DUNGEON_LEVER,
+        GraphNodeTag.DUNGEON_STONK,
+        GraphNodeTag.DUNGEON_EHERWARP_SPOT,
+        GraphNodeTag.DUNGEON_MINI_BOSS,
+        GraphNodeTag.DUNGEON_CRACKED_WALL,
+        GraphNodeTag.DUNGEON_RED_SKULL,
     )
 
     fun onCommand(args: Array<String>) {

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/DungeonGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/DungeonGraphs.kt
@@ -1,0 +1,217 @@
+package at.hannibal2.skyhanni.test.graph
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.model.Graph
+import at.hannibal2.skyhanni.data.repo.RepoManager
+import at.hannibal2.skyhanni.data.repo.RepoUtils
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonApi
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
+import java.awt.Point
+import java.io.File
+
+@SkyHanniModule
+object DungeonGraphs {
+
+    private var currentRoomName: String? = null
+    private var currentRoomDirection: String? = null
+    private var currentRoomCorner: LorenzVec? = null
+    private var usingDrm = true
+
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Dungeon Room Graph")
+        if (!DungeonApi.inDungeon()) {
+            event.addIrrelevant("not in dungeon.")
+        }
+
+        if (!config.dungeonRoomDetection) {
+            event.addData("disabled in settings.")
+        }
+
+        if (!usingDrm) {
+            event.addData("Not using Dungeon Room Mod")
+        }
+
+        event.addData {
+            add("room name: $currentRoomName")
+            add("room direction: $currentRoomDirection")
+            add("room corner: $currentRoomCorner")
+        }
+    }
+
+    private val config get() = SkyHanniMod.feature.dev
+
+    @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
+    fun onTick(event: SkyHanniTickEvent) {
+        if (!usingDrm) return
+        if (!event.isMod(2)) return
+        if (!config.dungeonRoomDetection) return
+
+        val (newRoomName, newDirection, newCorner) = readRoomData() ?: run {
+            usingDrm = false
+            return
+        }
+
+        val oldRoomName = currentRoomName
+        if (oldRoomName == newRoomName) return
+
+        oldRoomName?.let {
+            if (currentRoomCorner != null) {
+                saveRoom(it)
+            }
+        }
+
+        currentRoomName = newRoomName
+        currentRoomDirection = newDirection
+        currentRoomCorner = newCorner
+
+        newRoomName?.let {
+            if (currentRoomCorner == null) {
+                GraphEditor.clear()
+            } else {
+                loadRoom(it)
+            }
+        }
+    }
+
+    // TODO use mixin
+    private fun readRoomData(): Triple<String?, String?, LorenzVec?>? =
+        Class.forName("io.github.quantizr.dungeonrooms.dungeons.catacombs.RoomDetection")?.let { detection ->
+            val name = detection.getField("roomName").get(null) as String?
+            val direction = detection.getField("roomDirection").get(null) as String?
+            val corner = (detection.getField("roomCorner").get(null) as Point?)?.let { LorenzVec(it.x, 0, it.y) }
+
+            Triple(name, direction, corner)
+        }
+
+    @HandleEvent
+    fun onIslandChange(event: IslandChangeEvent) {
+        if (event.oldIsland != IslandType.CATACOMBS) return
+        if (currentRoomCorner != null) {
+            currentRoomName?.let {
+                saveRoom(it)
+                GraphEditor.clear()
+            }
+        }
+
+        currentRoomName = null
+        currentRoomDirection = null
+        currentRoomCorner = null
+    }
+
+    private fun loadRoom(roomName: String) {
+        val file = File("config/skyhanni/repo/constants/island_graphs/dungeon_rooms/$roomName.json")
+        if (!file.isFile) {
+            GraphEditor.clear()
+            return
+        }
+        val graph = RepoUtils.getConstant(RepoManager.repoLocation, "island_graphs/dungeon_rooms/$roomName", Graph.gson, Graph::class.java)
+        if (graph.nodes.isEmpty()) {
+            GraphEditor.clear()
+        } else {
+            IslandGraphs.loadLobby("dungeon_rooms/$roomName")
+            if (!GraphEditor.isEnabled()) return
+            ChatUtils.chat("loadDungeonRoom $roomName")
+            GraphEditor.import(graph.revertDungeon())
+        }
+    }
+
+    private fun saveRoom(roomName: String) {
+        if (!GraphEditor.isEnabled()) return
+        val compileGraph = GraphEditor.compileGraph()
+        if (compileGraph.nodes.isEmpty()) return
+        val json = compileGraph.applyDungeon().toJson()
+        val file = File("config/skyhanni/repo/constants/island_graphs/dungeon_rooms/$roomName.json")
+        file.parentFile?.mkdirs()
+        file.writeText(json)
+        ChatUtils.chat("saveDungeonRoom $roomName")
+    }
+
+    fun Graph.revertDungeon(): Graph {
+        val direction = currentRoomDirection ?: return this
+        val corner = currentRoomCorner ?: return this
+
+        return transformNodes { relativeToActual(it, direction, corner) }
+    }
+
+    private fun Graph.applyDungeon(): Graph {
+        val direction = currentRoomDirection ?: return this
+        val corner = currentRoomCorner ?: return this
+
+        return transformNodes { actualToRelative(it, direction, corner) }
+    }
+
+    // Taken from DRM
+    private fun relativeToActual(
+        relative: LorenzVec,
+        cornerDirection: String,
+        locationOfCorner: LorenzVec,
+    ): LorenzVec = when (cornerDirection) {
+        "NW" -> LorenzVec(
+            x = relative.x + locationOfCorner.x,
+            y = relative.y,
+            z = relative.z + locationOfCorner.z,
+        )
+
+        "NE" -> LorenzVec(
+            x = -(relative.z - locationOfCorner.x),
+            y = relative.y,
+            z = relative.x + locationOfCorner.z,
+        )
+
+        "SE" -> LorenzVec(
+            x = -(relative.x - locationOfCorner.x),
+            y = relative.y,
+            z = -(relative.z - locationOfCorner.z),
+        )
+
+        "SW" -> LorenzVec(
+            x = relative.z + locationOfCorner.x,
+            y = relative.y,
+            z = -(relative.x - locationOfCorner.z),
+        )
+
+        else -> throw IllegalArgumentException("Unknown corner direction: $cornerDirection")
+    }
+
+    // Taken from DRM
+    private fun actualToRelative(
+        actual: LorenzVec,
+        cornerDirection: String,
+        locationOfCorner: LorenzVec,
+    ): LorenzVec = when (cornerDirection) {
+        "NW" -> LorenzVec(
+            x = actual.x - locationOfCorner.x,
+            y = actual.y,
+            z = actual.z - locationOfCorner.z,
+        )
+
+        "NE" -> LorenzVec(
+            x = actual.z - locationOfCorner.z,
+            y = actual.y,
+            z = -(actual.x - locationOfCorner.x),
+        )
+
+        "SE" -> LorenzVec(
+            x = -(actual.x - locationOfCorner.x),
+            y = actual.y,
+            z = -(actual.z - locationOfCorner.z),
+        )
+
+        "SW" -> LorenzVec(
+            x = -(actual.z - locationOfCorner.z),
+            y = actual.y,
+            z = actual.x - locationOfCorner.x,
+        )
+
+        else -> throw IllegalArgumentException("Unknown corner direction: $cornerDirection")
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
@@ -604,6 +604,14 @@ object GraphEditor {
     private fun handleNameShortcut(name: String?): Pair<GraphNodeTag, String>? = when (name) {
         "fsoul" -> GraphNodeTag.FAIRY_SOUL to "Fairy Soul"
         "na" -> GraphNodeTag.AREA to "no_area"
+        "e" -> GraphNodeTag.DUNGEON_ENTRANCE to "Entrance"
+        "s i" -> GraphNodeTag.DUNGEON_SECRET_ITEM to "Item Drop"
+        "s ch" -> GraphNodeTag.DUNGEON_SECRET_CHEST to "Chest"
+        "s cr" -> GraphNodeTag.DUNGEON_CRYPT to "Crypt"
+        "s b" -> GraphNodeTag.DUNGEON_SECRET_BAT to "Bat"
+        "s e" -> GraphNodeTag.DUNGEON_SECRET_ESSENCE to "Essence"
+        "d l" -> GraphNodeTag.DUNGEON_LEVER to "Lever"
+        "d w" -> GraphNodeTag.DUNGEON_CRACKED_WALL to "Cracked Wall"
         else -> null
     }
 
@@ -822,7 +830,7 @@ object GraphEditor {
         )
     }
 
-    private fun clear() {
+    fun clear() {
         id = 0
         nodes.clear()
         edges.clear()

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+    <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>ArrayPrimitive:LorenzVec.kt$Array&lt;Double&gt;</ID>
     <ID>ArrayPrimitive:LorenzVec.kt$LorenzVec$Array&lt;Double&gt;</ID>

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -13,7 +13,6 @@
     <ID>CyclomaticComplexMethod:EnoughUpdatesManager.kt$EnoughUpdatesManager$private fun getPetLoreReplacements(petName: String?, tier: String?, level: Int): Map&lt;String, String&gt;</ID>
     <ID>CyclomaticComplexMethod:GardenCropMilestoneDisplay.kt$GardenCropMilestoneDisplay$private fun drawProgressDisplay(crop: CropType): List&lt;Renderable&gt;</ID>
     <ID>CyclomaticComplexMethod:GardenVisitorFeatures.kt$GardenVisitorFeatures$private fun readToolTip(visitor: VisitorApi.Visitor, itemStack: ItemStack?, toolTip: MutableList&lt;String&gt;)</ID>
-    <ID>CyclomaticComplexMethod:GardenVisitorTimer.kt$GardenVisitorTimer$@HandleEvent fun onSecondPassed(event: SecondPassedEvent)</ID>
     <ID>CyclomaticComplexMethod:GraphEditor.kt$GraphEditor$private fun input()</ID>
     <ID>CyclomaticComplexMethod:ItemAbilityCooldown.kt$ItemAbilityCooldown$@HandleEvent fun onPlaySound(event: PlaySoundEvent)</ID>
     <ID>CyclomaticComplexMethod:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$private fun getStackTip(item: ItemStack): String?</ID>
@@ -216,7 +215,6 @@
     <ID>ReturnCount:BingoNextStepHelper.kt$BingoNextStepHelper$private fun readDescription(description: String): NextStep?</ID>
     <ID>ReturnCount:BroodmotherFeatures.kt$BroodmotherFeatures$private fun onStageUpdate()</ID>
     <ID>ReturnCount:ChatPeek.kt$ChatPeek$@JvmStatic fun peek(): Boolean</ID>
-    <ID>ReturnCount:ChestValue.kt$ChestValue$private fun isValidStorage(): Boolean</ID>
     <ID>ReturnCount:CollectionTracker.kt$CollectionTracker$private fun command(args: Array&lt;String&gt;)</ID>
     <ID>ReturnCount:CompactBingoChat.kt$CompactBingoChat$private fun onSkyBlockLevelUp(message: String): Boolean</ID>
     <ID>ReturnCount:CrimsonMinibossRespawnTimer.kt$CrimsonMinibossRespawnTimer$private fun updateArea()</ID>
@@ -260,8 +258,6 @@
     <ID>TooManyFunctions:MobFinder.kt$MobFinder</ID>
     <ID>TooManyFunctions:NumberUtil.kt$NumberUtil</ID>
     <ID>TooManyFunctions:RegexUtils.kt$RegexUtils</ID>
-    <ID>TooManyFunctions:Renderable.kt$Renderable$Companion</ID>
-    <ID>TooManyFunctions:SkyBlockItemModifierUtils.kt$SkyBlockItemModifierUtils</ID>
     <ID>TooManyFunctions:SkyHanniTracker.kt$SkyHanniTracker&lt;Data : TrackerData&gt;</ID>
     <ID>TooManyFunctions:StringUtils.kt$StringUtils</ID>
     <ID>UnsafeCallOnNullableType:BucketedItemTrackerData.kt$BucketedItemTrackerData$it.value[internalName]?.hidden!!</ID>
@@ -300,6 +296,7 @@
     <ID>UnsafeCallOnNullableType:GardenCropMilestoneDisplay.kt$GardenCropMilestoneDisplay$cultivatingData[crop]!!</ID>
     <ID>UnsafeCallOnNullableType:GardenCropMilestonesCommunityFix.kt$GardenCropMilestonesCommunityFix$map[crop]!!</ID>
     <ID>UnsafeCallOnNullableType:GardenPlotIcon.kt$GardenPlotIcon$originalStack[index]!!</ID>
+    <ID>UnsafeCallOnNullableType:Graph.kt$Graph$newNodes[it.key]!!</ID>
     <ID>UnsafeCallOnNullableType:Graph.kt$Graph.Companion$position!!</ID>
     <ID>UnsafeCallOnNullableType:Graph.kt$distances.distances[end]!!</ID>
     <ID>UnsafeCallOnNullableType:GriffinBurrowHelper.kt$GriffinBurrowHelper$particleBurrows[targetLocation]!!</ID>


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/404

## What is this?
#### This is NO secret routes feature!

This PR adds graph editor and `/shnavigate` support for navigation inside the dungeon, nothing else so far!

If you want to do dungeons without learning secrets, please consider using [DG](https://github.com/Dungeons-Guide/Skyblock-Dungeons-Guide) or [SRM](https://github.com/yourboykyle/SecretRoutes)

## Technical Stuff
We use [Dungeon Rooms Mod](https://github.com/Quantizr/DungeonRoomsMod/) as soft dependency for room detection.

To fix the room position data being dynamic, we use the same math that DRM has to store the absolute location of room data relative to the room corner location.
When creating graphs, you don't need to think of this, as the PR handles this automatic for you.

In its current form, this PR only enables the `/shnavigate` command to show saved waypoints, like room entrances.
This is so far totally useless (except you get lost in a big room you don't know very well, and you just want to find the closest exit).

## What is this feature used for?
I'm not fully clear how to use this data, ideally. I just know that I don't want to compete with existing dungeon mods in showing pathfinding for secrets in a way that is useful for speed runs. Adding some sort of "how to get from door to secret" for learning purposes is something I'm not sure if we want to add it, and if, how exactly (for the reasons above)
I rather want to focus on useful features for early game dungeon players, similar to this copilot Feature:
![grafik](https://github.com/user-attachments/assets/ef32fbd6-436a-47f2-880e-654216a5a4e1)
(shows you a text display telling you what to do next, e.g., kill star mobs, pick up key, open next door, clear rooms, go into the boss room).

## What I intend to add
- A way of connecting all known room navigations in the current dungeon session into one big graph: 
- - Allows to create temporary area navigation like infos that lets you pick the room name and then pathfind there.
- - Allows to navigate to the start point, boss room, next door (if we want to connect to Skytils for this, not sure), any NPC or Fairy Soul in any room the user has entered (looking at you, trinity).
- Showing a path find to the lever when you click on a locked-up part of the room. (chest, iron bars, wooden door)
- Showing path find to other player locations (we can know their locations even behind blocks, see the "render dungeon teammate outline" feature for the legality on this) (ik this is super useless since teleport pearls exist, but once the full dungeon is mapped out, this is easy to add)
- Showing path find to Mort, blood room, fairy room.

## Volunteers wanted!
This feature requires a lot of manual editing of room data.
The PR allows creating those data via the graph editor, and handles the loading/saving of this data on world/room switch.
Still, I need others to help me create pathfindings for all rooms, and this will take a long time.
If you are interested in helping, please contact me in [SkyHanni discord](https://discord.gg/skyhanni-997079228510117908), and ill show you how to use the graph editor.

<details>
<summary>Images</summary>

![grafik](https://github.com/user-attachments/assets/15a3e308-e60f-4600-ae98-79cc409adfd7)
![grafik](https://github.com/user-attachments/assets/3a278659-fc16-4005-a907-53846507be04)

</details>

## Changelog New Features
+ `/shnavigate` support for dungeons. - hannibal2
    * Does not allow to instantly pahtfind to all secrets.
    * Allows to find NPC's, room entrances, 