### PR TITLE
Improvement: Island Area perf improvement

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/AreaPathfinderConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/AreaPathfinderConfig.java
@@ -15,7 +15,7 @@ public class AreaPathfinderConfig {
     @ConfigOption(name = "Enabled", desc = "While in your invenotry, show all areas of the island. Click on an area to display the path to this area.")
     @ConfigEditorBoolean
     @FeatureToggle
-    public boolean enabled = false;
+    public Property<Boolean> enabled = Property.of(false);
 
     @Expose
     @ConfigOption(name = "Show Always", desc = "Show the list always, also while outside of an inventory.")


### PR DESCRIPTION
## What
As Thunderblade73 found out, the Island Areas display gets recreated every time the player moves, even when the feature is disabled.
This PR fixes it and draws the display when the feature gets enabled.

## Changelog Improvements
+ Improved performance slightly when Island Area feature is disabled. - hannibal2