### PR TITLE
Fix: Burrows being really, really wrong + ConcurrentModificationException

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -2,9 +2,11 @@ package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
+import at.hannibal2.skyhanni.data.jsonobjects.repo.IslandBounds
 import at.hannibal2.skyhanni.data.jsonobjects.repo.IslandTypeJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LorenzVec
 
 enum class IslandType(private val nameFallback: String) {
     PRIVATE_ISLAND("Private Island"),
@@ -62,6 +64,11 @@ enum class IslandType(private val nameFallback: String) {
 
     val displayName: String get() = islandData?.name ?: nameFallback
 
+    fun isInBounds(vec: LorenzVec): Boolean {
+        val bounds = islandData?.bounds ?: return true
+        return vec.x < bounds.maxX && vec.x > bounds.minX && vec.z < bounds.maxZ && vec.z > bounds.minZ
+    }
+
     @SkyHanniModule
     companion object {
         /**
@@ -89,7 +96,7 @@ enum class IslandType(private val nameFallback: String) {
 
             val islandDataMap = data.islands.mapValues {
                 val island = it.value
-                IslandData(island.name, island.apiName, island.maxPlayers ?: data.maxPlayers)
+                IslandData(island.name, island.apiName, island.maxPlayers ?: data.maxPlayers, island.bounds)
             }
 
             entries.forEach { islandType ->
@@ -106,4 +113,5 @@ data class IslandData(
     val name: String,
     val apiName: String?,
     val maxPlayers: Int,
+    val bounds: IslandBounds?
 )

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -6,7 +6,9 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.IslandBounds
 import at.hannibal2.skyhanni.data.jsonobjects.repo.IslandTypeJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LocationUtils.isInside
 import at.hannibal2.skyhanni.utils.LorenzVec
+import net.minecraft.util.AxisAlignedBB
 
 enum class IslandType(private val nameFallback: String) {
     PRIVATE_ISLAND("Private Island"),
@@ -64,9 +66,17 @@ enum class IslandType(private val nameFallback: String) {
 
     val displayName: String get() = islandData?.name ?: nameFallback
 
+    private var boundingBox: AxisAlignedBB? = null
+
     fun isInBounds(vec: LorenzVec): Boolean {
-        val bounds = islandData?.bounds ?: return true
-        return vec.x < bounds.maxX && vec.x > bounds.minX && vec.z < bounds.maxZ && vec.z > bounds.minZ && vec.y > 0 && vec.y < 256
+        val bounds = islandData?.bounds ?: return false
+
+        val box = boundingBox ?: AxisAlignedBB(
+            bounds.minX.toDouble(), 0.0, bounds.minZ.toDouble(),
+            bounds.maxX.toDouble(), 256.0, bounds.maxZ.toDouble(),
+        ).also { boundingBox = it }
+
+        return box.isInside(vec)
     }
 
     @SkyHanniModule
@@ -100,6 +110,7 @@ enum class IslandType(private val nameFallback: String) {
             }
 
             entries.forEach { islandType ->
+                islandType.boundingBox = null
                 islandType.islandData = islandDataMap[islandType.name]
             }
 
@@ -113,5 +124,5 @@ data class IslandData(
     val name: String,
     val apiName: String?,
     val maxPlayers: Int,
-    val bounds: IslandBounds?
+    val bounds: IslandBounds?,
 )

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -66,7 +66,7 @@ enum class IslandType(private val nameFallback: String) {
 
     fun isInBounds(vec: LorenzVec): Boolean {
         val bounds = islandData?.bounds ?: return true
-        return vec.x < bounds.maxX && vec.x > bounds.minX && vec.z < bounds.maxZ && vec.z > bounds.minZ
+        return vec.x < bounds.maxX && vec.x > bounds.minX && vec.z < bounds.maxZ && vec.z > bounds.minZ && vec.y > 0 && vec.y < 256
     }
 
     @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/IslandTypeJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/IslandTypeJson.kt
@@ -13,4 +13,12 @@ data class IslandJson(
     @Expose val name: String,
     @Expose @SerializedName("api_name") val apiName: String? = null,
     @Expose @SerializedName("max_players") val maxPlayers: Int? = null,
+    @Expose val bounds: IslandBounds? = null
+)
+
+data class IslandBounds(
+    @Expose @SerializedName("max_x") val maxX: Int,
+    @Expose @SerializedName("min_x") val minX: Int,
+    @Expose @SerializedName("max_z") val maxZ: Int,
+    @Expose @SerializedName("min_z") val minZ: Int
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -184,7 +184,6 @@ object GriffinBurrowHelper {
     fun onBurrowGuess(event: BurrowGuessEvent) {
         EntityMovementData.addToTrack(MinecraftCompat.localPlayer)
         val newLocation = event.guessLocation
-        if (!IslandType.HUB.isInBounds(newLocation)) return
         val playerLocation = LocationUtils.playerLocation()
 
         if (newLocation.distance(playerLocation) < 6) return
@@ -195,7 +194,8 @@ object GriffinBurrowHelper {
             }
         }
 
-        latestGuess = Guess(newLocation, event.precise)
+        latestGuess = if (IslandType.HUB.isInBounds(newLocation)) Guess(newLocation, event.precise) else null
+
         update()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -184,6 +184,7 @@ object GriffinBurrowHelper {
     fun onBurrowGuess(event: BurrowGuessEvent) {
         EntityMovementData.addToTrack(MinecraftCompat.localPlayer)
         val newLocation = event.guessLocation
+        if (!IslandType.HUB.isInBounds(newLocation)) return
         val playerLocation = LocationUtils.playerLocation()
 
         if (newLocation.distance(playerLocation) < 6) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -98,7 +98,7 @@ object GriffinBurrowParticleFinder {
     fun onTick() {
         val isSpade = InventoryUtils.getItemInHand()?.isDianaSpade ?: false
         if (isSpade) {
-            for ((location, burrow) in burrows) {
+            for ((location, burrow) in burrows.toMutableMap()) {
                 if (location.distanceSqToPlayer() > 256) continue
                 burrow.burrowTimeToLive -= 1
                 if (burrow.burrowTimeToLive >= 0) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
@@ -53,7 +53,7 @@ object PreciseGuessBurrow {
 
         val guessPosition = guessBurrowLocation() ?: return
 
-        BurrowGuessEvent(guessPosition.down(0.5).roundLocationToBlock(), precise = true, new = newBurrow).post()
+        BurrowGuessEvent(guessPosition.down(0.5).roundLocationToBlock(), precise = bezierFitter.count() > 5, new = newBurrow).post()
         newBurrow = false
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
@@ -167,6 +168,7 @@ object HoppityEggLocator {
         bezierFitter.addPoint(event.location)
 
         val guess = guessEggLocation() ?: return
+        if (!LorenzUtils.skyBlockIsland.isInBounds(guess)) return
         possibleEggLocations = listOf(guess)
         drawLocations = true
         if (possibleEggLocations.size == 1) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -159,10 +159,7 @@ object HoppityEggLocator {
             if (lastPoint.distanceSq(event.location) > 9) return
         }
 
-        if (EntityUtils.getEntitiesNearby<EntityFishHook>(event.location, 0.3).any()) {
-            return
-        }
-
+        if (EntityUtils.getEntitiesNearby<EntityFishHook>(event.location, 0.3).any()) return
 
         bezierFitter.addPoint(event.location)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
@@ -60,7 +60,12 @@ object FishingHotspotRadar {
 
         bezierFitter.addPoint(currLoc)
 
-        hotspotLocation = bezierFitter.solve() ?: return
+        val guess = bezierFitter.solve() ?: return
+        if (!LorenzUtils.skyBlockIsland.isInBounds(guess)) {
+            hotspotLocation = null
+            return
+        }
+        hotspotLocation = guess
         isUnknown = false
         lastUpdate = SimpleTimeMark.now()
         hotspotLocation?.let {

--- a/src/main/java/at/hannibal2/skyhanni/utils/PolynomialFitter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PolynomialFitter.kt
@@ -50,6 +50,8 @@ open class BezierFitter(private val degree: Int) {
         return points.isEmpty()
     }
 
+    fun count() = points.size
+
     private var lastCurve: BezierCurve? = null
     fun fit(): BezierCurve? {
         // A Degree n polynomial can be solved with n+1 unique points


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/406

## What
Three fixes:
1. ConcurrentModificationException happened when an element is removed from the map while iterating over that map, which is undesirable

2. As seen [here](https://discord.com/channels/997079228510117908/1366507304190607421/1366555543354867804) sometimes the guesser makes a very wrong guess. Rather than finding the root cause (which is difficult due to being unable to replicate it) simply not showing guesses that are outside the places the player can reach should work the same.

3. Sometimes particles from other sources interfere with guesses ([here](https://discord.com/channels/997079228510117908/1355485985344848055/1355562195420975316)) and make the solver give an invalid solution. Adding bounds checks acts as a sanity check of where the guesses can be.

For testing use the repo https://github.com/Bloxigus/SkyHanni-REPO/tree/island-bounds

## Changelog Fixes
+ Fixed burrows outside island boundaries. - bloxigus
+ Fixed error when removing burrow. - bloxigus
+ Fixed other particles interfering with hotspot guesses. - bloxigus
