### PR TITLE
Backend: Fixed graph node edtior searcahble

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.utils.renderables.SearchTextInput
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.buildSearchableScrollable
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
+import net.minecraft.client.Minecraft
 import kotlin.math.sqrt
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -33,8 +34,19 @@ object GraphNodeEditor {
     private var lastUpdate = SimpleTimeMark.farPast()
     private val tagsToShow: MutableList<GraphNodeTag> = GraphNodeTag.entries.toMutableList()
 
-    @HandleEvent
-    fun onGuiRender(event: GuiRenderEvent) {
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
+    fun onRenderOverlay() {
+        if (Minecraft.getMinecraft().currentScreen == null) {
+            doRender()
+        }
+    }
+
+    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class)
+    fun onBackgroundDraw() {
+        doRender()
+    }
+
+    private fun doRender() {
         if (!isEnabled()) return
 
         config.namedNodesList.renderRenderables(


### PR DESCRIPTION
## What
calling GUI overaly render event in a screen breaks searchable.
This is a workaround to avoid this bug for the graph node editor

## Changelog Technical Details
+ Fixed graph node editor not being searchable. - hannibal2