### PR TITLE
Improvement: Added an Ironman Option to Profit Trackers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.java
@@ -9,6 +9,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableLi
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink;
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+import io.github.notenoughupdates.moulconfig.observer.Property;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,10 +33,9 @@ public class ExperimentsProfitTrackerConfig {
     public int timeDisplayed = 30;
 
     @Expose
-    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the Cost of Experience Bottles from Profit Calculations. (Requires Restart)")
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the Cost of Experience Bottles from Profit Calculations.")
     @ConfigEditorBoolean
-    public boolean isIronman = false;
-    // Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
+    public Property<Boolean> isIronman = Property.of(false);
 
     @Expose
     @ConfigLink(owner = ExperimentsProfitTrackerConfig.class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.java
@@ -32,6 +32,12 @@ public class ExperimentsProfitTrackerConfig {
     public int timeDisplayed = 30;
 
     @Expose
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the Cost of Experience Bottles from Profit Calculations. (Requires Restart)")
+    @ConfigEditorBoolean
+    public boolean isIronman = false;
+    //Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
+
+    @Expose
     @ConfigLink(owner = ExperimentsProfitTrackerConfig.class, field = "enabled")
     public Position position = new Position(20, 20);
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.java
@@ -35,7 +35,7 @@ public class ExperimentsProfitTrackerConfig {
     @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the Cost of Experience Bottles from Profit Calculations. (Requires Restart)")
     @ConfigEditorBoolean
     public boolean isIronman = false;
-    //Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
+    // Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
 
     @Expose
     @ConfigLink(owner = ExperimentsProfitTrackerConfig.class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.java
@@ -33,9 +33,9 @@ public class ExperimentsProfitTrackerConfig {
     public int timeDisplayed = 30;
 
     @Expose
-    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the Cost of Experience Bottles from Profit Calculations.")
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes Experience Bottles from Profit Calculations. (Ironman only)")
     @ConfigEditorBoolean
-    public Property<Boolean> isIronman = Property.of(false);
+    public Property<Boolean> isIronman = Property.of(true);
 
     @Expose
     @ConfigLink(owner = ExperimentsProfitTrackerConfig.class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
@@ -6,6 +6,7 @@ import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
 
 class ExcavatorProfitTrackerConfig {
     @Expose
@@ -32,8 +33,7 @@ class ExcavatorProfitTrackerConfig {
     var position: Position = Position(-380, 150)
 
     @Expose
-    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of Scrap from Profit Calculations. (Requires Restart)")
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of Scrap from Profit Calculations.")
     @ConfigEditorBoolean
-    var isIronman: Boolean = false
-    // Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
+    var isIronman: Property<Boolean> = Property.of(false)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
@@ -30,4 +30,10 @@ class ExcavatorProfitTrackerConfig {
     @Expose
     @ConfigLink(owner = ExcavatorProfitTrackerConfig::class, field = "enabled")
     var position: Position = Position(-380, 150)
+
+    @Expose
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of Scrap from Profit Calculations. (Requires Restart)")
+    @ConfigEditorBoolean
+    var isIronman: Boolean = false
+    //Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
@@ -33,7 +33,7 @@ class ExcavatorProfitTrackerConfig {
     var position: Position = Position(-380, 150)
 
     @Expose
-    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of Scrap from Profit Calculations.")
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of Scrap from Profit Calculations. (Ironman only)")
     @ConfigEditorBoolean
-    var isIronman: Property<Boolean> = Property.of(false)
+    var isIronman: Property<Boolean> = Property.of(true)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
@@ -35,5 +35,5 @@ class ExcavatorProfitTrackerConfig {
     @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of Scrap from Profit Calculations. (Requires Restart)")
     @ConfigEditorBoolean
     var isIronman: Boolean = false
-    //Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
+    // Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
 
 class FossilExcavatorConfig {
     @Expose
@@ -30,6 +31,12 @@ class FossilExcavatorConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var profitPerExcavation: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the price of Scrap form calculations. (Ironman only)")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var isIronman: Property<Boolean> = Property.of(true)
 
     @Expose
     @ConfigOption(name = "Glacite Powder Stack", desc = "Show Glacite Powder as stack size in the Fossil Excavator.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -27,6 +27,12 @@ class CrystalNucleusTrackerConfig {
     var showOutsideNucleus: Boolean = false
 
     @Expose
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of the Jungle Keys & Automaton Parts from Profit Calculations. (Requires Restart)")
+    @ConfigEditorBoolean
+    var isIronman: Boolean = false
+    //Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
+
+    @Expose
     @ConfigOption(name = "Profit Per", desc = "Show profit summary message for the completed nucleus run.")
     @ConfigEditorBoolean
     var profitPer: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -27,8 +27,7 @@ class CrystalNucleusTrackerConfig {
     var showOutsideNucleus: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of the Jungle Keys & Automaton Parts " +
-        "from Profit Calculations. (Requires Restart)")
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes Jungle Keys & Automaton Part cost from profit. (Restart required)")
     @ConfigEditorBoolean
     var isIronman: Boolean = false
     // Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -27,9 +27,9 @@ class CrystalNucleusTrackerConfig {
     var showOutsideNucleus: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes Jungle Keys & Automaton Part cost from profit.")
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes Jungle Keys & Automaton Part cost from profit. (Ironman only)")
     @ConfigEditorBoolean
-    var isIronman: Property<Boolean> = Property.of(false)
+    var isIronman: Property<Boolean> = Property.of(true)
 
     @Expose
     @ConfigOption(name = "Profit Per", desc = "Show profit summary message for the completed nucleus run.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -27,10 +27,9 @@ class CrystalNucleusTrackerConfig {
     var showOutsideNucleus: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes Jungle Keys & Automaton Part cost from profit. (Restart required)")
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes Jungle Keys & Automaton Part cost from profit.")
     @ConfigEditorBoolean
-    var isIronman: Boolean = false
-    // Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
+    var isIronman: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Profit Per", desc = "Show profit summary message for the completed nucleus run.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -30,7 +30,7 @@ class CrystalNucleusTrackerConfig {
     @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of the Jungle Keys & Automaton Parts from Profit Calculations. (Requires Restart)")
     @ConfigEditorBoolean
     var isIronman: Boolean = false
-    //Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
+    // Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note
 
     @Expose
     @ConfigOption(name = "Profit Per", desc = "Show profit summary message for the completed nucleus run.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -27,7 +27,8 @@ class CrystalNucleusTrackerConfig {
     var showOutsideNucleus: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of the Jungle Keys & Automaton Parts from Profit Calculations. (Requires Restart)")
+    @ConfigOption(name = "Ironman Profit Calculations", desc = "Removes the cost of the Jungle Keys & Automaton Parts " +
+        "from Profit Calculations. (Requires Restart)")
     @ConfigEditorBoolean
     var isIronman: Boolean = false
     // Unable to make the Overlay update automatically, needs fixing!! Therefore the "Requires Restart" note

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -31,6 +31,7 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -239,7 +240,18 @@ object ExperimentsProfitTracker {
 
     private fun drawDisplay(data: Data): List<Searchable> = buildList {
         addSearchString("§e§lExperiments Profit Tracker")
-        if (!config.isIronman.get()) {
+        if (config.isIronman.get() && LorenzUtils.isIronmanProfile) {
+            val profit = tracker.drawItems(data, { true }, this)
+
+            val experimentsDone = data.experimentsDone
+            addSearchString("§eExperiments Done: §a${experimentsDone.addSeparators()}")
+            val startCostFormat = data.startCost.absoluteValue.shortFormat()
+            val bitCostFormat = data.bitCost.shortFormat()
+            add(tracker.addTotalProfit(profit, data.experimentsDone, "experiment"))
+            addSearchString("§eTotal Enchanting Exp: §b${data.xpGained.shortFormat()}")
+
+            tracker.addPriceFromButton(this)
+        } else {
             val profit = tracker.drawItems(data, { true }, this) + data.startCost
 
             val experimentsDone = data.experimentsDone
@@ -255,17 +267,6 @@ object ExperimentsProfitTracker {
                     ),
                 ).toSearchable(),
             )
-            add(tracker.addTotalProfit(profit, data.experimentsDone, "experiment"))
-            addSearchString("§eTotal Enchanting Exp: §b${data.xpGained.shortFormat()}")
-
-            tracker.addPriceFromButton(this)
-        } else {
-            val profit = tracker.drawItems(data, { true }, this)
-
-            val experimentsDone = data.experimentsDone
-            addSearchString("§eExperiments Done: §a${experimentsDone.addSeparators()}")
-            val startCostFormat = data.startCost.absoluteValue.shortFormat()
-            val bitCostFormat = data.bitCost.shortFormat()
             add(tracker.addTotalProfit(profit, data.experimentsDone, "experiment"))
             addSearchString("§eTotal Enchanting Exp: §b${data.xpGained.shortFormat()}")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -232,25 +232,39 @@ object ExperimentsProfitTracker {
 
     private fun drawDisplay(data: Data): List<Searchable> = buildList {
         addSearchString("§e§lExperiments Profit Tracker")
-        val profit = tracker.drawItems(data, { true }, this) + data.startCost
+        if (!config.isIronman) {
+            val profit = tracker.drawItems(data, { true }, this) + data.startCost
 
-        val experimentsDone = data.experimentsDone
-        addSearchString("§eExperiments Done: §a${experimentsDone.addSeparators()}")
-        val startCostFormat = data.startCost.absoluteValue.shortFormat()
-        val bitCostFormat = data.bitCost.shortFormat()
-        add(
-            Renderable.hoverTips(
-                "§eTotal Cost: §c-$startCostFormat§e/§b-$bitCostFormat",
-                listOf(
-                    "§7You paid §c$startCostFormat §7coins and", "§b$bitCostFormat §7bits for starting",
-                    "§7experiments.",
-                ),
-            ).toSearchable(),
-        )
-        add(tracker.addTotalProfit(profit, data.experimentsDone, "experiment"))
-        addSearchString("§eTotal Enchanting Exp: §b${data.xpGained.shortFormat()}")
+            val experimentsDone = data.experimentsDone
+            addSearchString("§eExperiments Done: §a${experimentsDone.addSeparators()}")
+            val startCostFormat = data.startCost.absoluteValue.shortFormat()
+            val bitCostFormat = data.bitCost.shortFormat()
+            add(
+                Renderable.hoverTips(
+                    "§eTotal Cost: §c-$startCostFormat§e/§b-$bitCostFormat",
+                    listOf(
+                        "§7You paid §c$startCostFormat §7coins and", "§b$bitCostFormat §7bits for starting",
+                        "§7experiments.",
+                    ),
+                ).toSearchable(),
+            )
+            add(tracker.addTotalProfit(profit, data.experimentsDone, "experiment"))
+            addSearchString("§eTotal Enchanting Exp: §b${data.xpGained.shortFormat()}")
 
-        tracker.addPriceFromButton(this)
+            tracker.addPriceFromButton(this)
+        } else {
+            val profit = tracker.drawItems(data, { true }, this)
+
+            val experimentsDone = data.experimentsDone
+            addSearchString("§eExperiments Done: §a${experimentsDone.addSeparators()}")
+            val startCostFormat = data.startCost.absoluteValue.shortFormat()
+            val bitCostFormat = data.bitCost.shortFormat()
+            add(tracker.addTotalProfit(profit, data.experimentsDone, "experiment"))
+            addSearchString("§eTotal Enchanting Exp: §b${data.xpGained.shortFormat()}")
+
+            tracker.addPriceFromButton(this)
+        }
+
     }
 
     init {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
@@ -23,6 +24,7 @@ import at.hannibal2.skyhanni.features.inventory.experimentationtable.Experimenta
 import at.hannibal2.skyhanni.features.inventory.experimentationtable.ExperimentationTableApi.experimentsDropPattern
 import at.hannibal2.skyhanni.features.inventory.experimentationtable.ExperimentationTableApi.inventoriesPattern
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
@@ -230,9 +232,14 @@ object ExperimentsProfitTracker {
         }
     }
 
+    @HandleEvent
+    fun onConfigLoad(event: ConfigLoadEvent) {
+        config.isIronman.onToggle(tracker::update)
+    }
+
     private fun drawDisplay(data: Data): List<Searchable> = buildList {
         addSearchString("§e§lExperiments Profit Tracker")
-        if (!config.isIronman) {
+        if (!config.isIronman.get()) {
             val profit = tracker.drawItems(data, { true }, this) + data.startCost
 
             val experimentsDone = data.experimentsDone

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
@@ -44,7 +44,7 @@ object CrystalNucleusProfitPer {
         map.filter { it.key !in hover }.takeIf { it.isNotEmpty() }?.let {
             hover.add("§7${it.size} cheap items are hidden §7(§6${it.values.sum().shortFormat()}§7).")
         }
-        if (config.isIronman.get() && LorenzUtils.isIronmanProfile){
+        if (config.isIronman.get() && LorenzUtils.isIronmanProfile) {
 
             val profitPrefix = if (totalProfit < 0) "§c" else "§6"
             val totalMessage = "Profit for Crystal Nucleus Run§e: $profitPrefix${totalProfit.shortFormat()}"

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
@@ -43,20 +44,32 @@ object CrystalNucleusProfitPer {
         map.filter { it.key !in hover }.takeIf { it.isNotEmpty() }?.let {
             hover.add("§7${it.size} cheap items are hidden §7(§6${it.values.sum().shortFormat()}§7).")
         }
+        if (config.isIronman.get() && LorenzUtils.isIronmanProfile){
 
-        val jungleKeyCost = JUNGLE_KEY_ITEM.getPrice()
-        val partsCost = CrystalNucleusApi.getPrecursorRunPrice()
-        totalProfit -= (jungleKeyCost + partsCost)
+            val profitPrefix = if (totalProfit < 0) "§c" else "§6"
+            val totalMessage = "Profit for Crystal Nucleus Run§e: $profitPrefix${totalProfit.shortFormat()}"
 
-        val profitPrefix = if (totalProfit < 0) "§c" else "§6"
-        val totalMessage = "Profit for Crystal Nucleus Run§e: $profitPrefix${totalProfit.shortFormat()}"
+            hover.add("§e$totalMessage")
 
-        hover.add("")
-        hover.add("§cUsed §5Jungle Key§7: §c-${jungleKeyCost.shortFormat()}")
-        hover.add("§cUsed §9Robot Parts§7: §c-${partsCost.shortFormat()}")
-        hover.add("")
-        hover.add("§e$totalMessage")
+            ChatUtils.hoverableChat(totalMessage, hover)
 
-        ChatUtils.hoverableChat(totalMessage, hover)
+        } else {
+
+            val jungleKeyCost = JUNGLE_KEY_ITEM.getPrice()
+            val partsCost = CrystalNucleusApi.getPrecursorRunPrice()
+            totalProfit -= (jungleKeyCost + partsCost)
+
+            val profitPrefix = if (totalProfit < 0) "§c" else "§6"
+            val totalMessage = "Profit for Crystal Nucleus Run§e: $profitPrefix${totalProfit.shortFormat()}"
+
+            hover.add("")
+            hover.add("§cUsed §5Jungle Key§7: §c-${jungleKeyCost.shortFormat()}")
+            hover.add("§cUsed §9Robot Parts§7: §c-${partsCost.shortFormat()}")
+            hover.add("")
+            hover.add("§e$totalMessage")
+
+            ChatUtils.hoverableChat(totalMessage, hover)
+
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -34,6 +34,7 @@ import at.hannibal2.skyhanni.utils.renderables.toSearchable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
+import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import com.google.gson.annotations.Expose
 
 @SkyHanniModule
@@ -127,18 +128,21 @@ object CrystalNucleusTracker {
         val runsCompleted = data.runsCompleted
         if (runsCompleted > 0) {
             var profit = tracker.drawItems(data, { true }, this)
-            val jungleKeyCost: Double = JUNGLE_KEY_ITEM.getPrice() * runsCompleted
-            profit -= jungleKeyCost
-            val jungleKeyCostFormat = jungleKeyCost.shortFormat()
-            add(
-                Renderable.hoverTips(
-                    " §7${runsCompleted}x §5Jungle Key§7: §c-$jungleKeyCostFormat",
-                    tips = listOf(
-                        "§7You lost §c$jungleKeyCostFormat §7of total profit",
-                        "§7due to §5Jungle Keys§7.",
-                    ),
-                ).toSearchable("Jungle Key"),
-            )
+            if (!config.isIronman){
+                val jungleKeyCost: Double = JUNGLE_KEY_ITEM.getPrice() * runsCompleted
+                profit -= jungleKeyCost
+                val jungleKeyCostFormat = jungleKeyCost.shortFormat()
+                add(
+                    Renderable.hoverTips(
+                        " §7${runsCompleted}x §5Jungle Key§7: §c-$jungleKeyCostFormat",
+                        tips = listOf(
+                            "§7You lost §c$jungleKeyCostFormat §7of total profit",
+                            "§7due to §5Jungle Keys§7.",
+                        ),
+                    ).toSearchable("Jungle Key"),
+                )
+            }
+
 
             val usesApparatus = CrystalNucleusApi.usesApparatus()
             val partsCost = CrystalNucleusApi.getPrecursorRunPrice()
@@ -150,19 +154,22 @@ object CrystalNucleusTracker {
                 "§5Precursor Apparatuses",
             )
             else rawConfigString
-            val usageTotal = if (usesApparatus) runsCompleted else runsCompleted * 6
+            if (!config.isIronman) {
+                val usageTotal = if (usesApparatus) runsCompleted else runsCompleted * 6
 
-            profit -= totalSapphireCost
-            val totalSapphireCostFormat = totalSapphireCost.shortFormat()
-            add(
-                Renderable.hoverTips(
-                    " §7${usageTotal}x $usageString§7: §c-$totalSapphireCostFormat",
-                    tips = listOf(
-                        "§7You lost §c$totalSapphireCostFormat §7of total profit",
-                        "§7due to $usageString§7.",
-                    ),
-                ).toSearchable(usageString.removeColor()),
-            )
+                profit -= totalSapphireCost
+                val totalSapphireCostFormat = totalSapphireCost.shortFormat()
+                add(
+                    Renderable.hoverTips(
+                        " §7${usageTotal}x $usageString§7: §c-$totalSapphireCostFormat",
+                        tips = listOf(
+                            "§7You lost §c$totalSapphireCostFormat §7of total profit",
+                            "§7due to $usageString§7.",
+                        ),
+                    ).toSearchable(usageString.removeColor()),
+                )
+            }
+
 
             add(
                 Renderable.hoverTips(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -34,7 +34,6 @@ import at.hannibal2.skyhanni.utils.renderables.toSearchable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
-import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import com.google.gson.annotations.Expose
 
 @SkyHanniModule
@@ -128,7 +127,7 @@ object CrystalNucleusTracker {
         val runsCompleted = data.runsCompleted
         if (runsCompleted > 0) {
             var profit = tracker.drawItems(data, { true }, this)
-            if (!config.isIronman){
+            if (!config.isIronman) {
                 val jungleKeyCost: Double = JUNGLE_KEY_ITEM.getPrice() * runsCompleted
                 profit -= jungleKeyCost
                 val jungleKeyCostFormat = jungleKeyCost.shortFormat()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -35,7 +35,6 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import com.google.gson.annotations.Expose
-import io.github.notenoughupdates.moulconfig.observer.Property
 
 @SkyHanniModule
 object CrystalNucleusTracker {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -128,7 +128,9 @@ object CrystalNucleusTracker {
         val runsCompleted = data.runsCompleted
         if (runsCompleted > 0) {
             var profit = tracker.drawItems(data, { true }, this)
-            if (!config.isIronman.get()) {
+            if (config.isIronman.get() && LorenzUtils.isIronmanProfile) {
+                // Leave Empty, nothing is supposed to happen when the player is Ironman and has this enabled
+            } else {
                 val jungleKeyCost: Double = JUNGLE_KEY_ITEM.getPrice() * runsCompleted
                 profit -= jungleKeyCost
                 val jungleKeyCostFormat = jungleKeyCost.shortFormat()
@@ -154,7 +156,9 @@ object CrystalNucleusTracker {
                 "§5Precursor Apparatuses",
             )
             else rawConfigString
-            if (!config.isIronman.get()) {
+            if (config.isIronman.get() && LorenzUtils.isIronmanProfile) {
+                // Leave Empty, nothing is supposed to happen when the player is Ironman and has this enabled
+            } else {
                 val usageTotal = if (usesApparatus) runsCompleted else runsCompleted * 6
 
                 profit -= totalSapphireCost

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -35,6 +35,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.observer.Property
 
 @SkyHanniModule
 object CrystalNucleusTracker {
@@ -119,6 +120,7 @@ object CrystalNucleusTracker {
     @HandleEvent
     fun onConfigLoad(event: ConfigLoadEvent) {
         config.professorUsage.onToggle(tracker::update)
+        config.isIronman.onToggle(tracker::update)
     }
 
     private fun drawDisplay(data: Data): List<Searchable> = buildList {
@@ -127,7 +129,7 @@ object CrystalNucleusTracker {
         val runsCompleted = data.runsCompleted
         if (runsCompleted > 0) {
             var profit = tracker.drawItems(data, { true }, this)
-            if (!config.isIronman) {
+            if (!config.isIronman.get()) {
                 val jungleKeyCost: Double = JUNGLE_KEY_ITEM.getPrice() * runsCompleted
                 profit -= jungleKeyCost
                 val jungleKeyCostFormat = jungleKeyCost.shortFormat()
@@ -153,7 +155,7 @@ object CrystalNucleusTracker {
                 "§5Precursor Apparatuses",
             )
             else rawConfigString
-            if (!config.isIronman) {
+            if (!config.isIronman.get()) {
                 val usageTotal = if (usesApparatus) runsCompleted else runsCompleted * 6
 
                 profit -= totalSapphireCost

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -145,19 +145,24 @@ object ExcavatorProfitTracker {
     ): Double {
         if (timesExcavated <= 0) return profit
         // TODO use same price source as profit tracker
-        val scrapPrice = timesExcavated * scrapItem.getPrice()
-        val name = StringUtils.pluralize(timesExcavated.toInt(), scrapItem.repoItemName)
-        add(
-            Renderable.hoverTips(
-                "$name §7price: §c-${scrapPrice.shortFormat()}",
-                listOf(
-                    "§7You paid §c${scrapPrice.shortFormat()} coins §7in total",
-                    "§7for all §e$timesExcavated $name",
-                    "§7you have used.",
-                ),
-            ).toSearchable("Scrap"),
-        )
-        return profit - scrapPrice
+
+        if (!config.isIronman) {
+            val scrapPrice = timesExcavated * scrapItem.getPrice()
+            val name = StringUtils.pluralize(timesExcavated.toInt(), scrapItem.repoItemName)
+            add(
+                Renderable.hoverTips(
+                    "$name §7price: §c-${scrapPrice.shortFormat()}",
+                    listOf(
+                        "§7You paid §c${scrapPrice.shortFormat()} coins §7in total",
+                        "§7for all §e$timesExcavated $name",
+                        "§7you have used.",
+                    ),
+                ).toSearchable("Scrap"),
+            )
+            return profit - scrapPrice
+        } else {
+            return profit
+        }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -153,7 +153,9 @@ object ExcavatorProfitTracker {
         if (timesExcavated <= 0) return profit
         // TODO use same price source as profit tracker
 
-        if (!config.isIronman.get()) {
+        if (config.isIronman.get() && LorenzUtils.isIronmanProfile) {
+            return profit
+        } else {
             val scrapPrice = timesExcavated * scrapItem.getPrice()
             val name = StringUtils.pluralize(timesExcavated.toInt(), scrapItem.repoItemName)
             add(
@@ -167,8 +169,6 @@ object ExcavatorProfitTracker {
                 ).toSearchable("Scrap"),
             )
             return profit - scrapPrice
-        } else {
-            return profit
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -6,11 +6,14 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.mining.FossilExcavationEvent
+import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusTracker
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.LorenzUtils
@@ -76,6 +79,11 @@ object ExcavatorProfitTracker {
     }
 
     private val scrapItem get() = FossilExcavatorApi.scrapItem
+
+    @HandleEvent
+    fun onConfigLoad(event: ConfigLoadEvent) {
+        config.isIronman.onToggle(tracker::update)
+    }
 
     private fun drawDisplay(data: Data): List<Searchable> = buildList {
         addSearchString("§e§lFossil Excavation Profit Tracker")
@@ -146,7 +154,7 @@ object ExcavatorProfitTracker {
         if (timesExcavated <= 0) return profit
         // TODO use same price source as profit tracker
 
-        if (!config.isIronman) {
+        if (!config.isIronman.get()) {
             val scrapPrice = timesExcavated * scrapItem.getPrice()
             val name = StringUtils.pluralize(timesExcavated.toInt(), scrapItem.repoItemName)
             add(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.mining.FossilExcavationEvent
-import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusTracker
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
@@ -40,7 +40,7 @@ object ProfitPerExcavation {
         val scrapPrice = scrapItem.getPrice()
         map["${scrapItem.repoItemName}: §c-${scrapPrice.shortFormat()}"] = -scrapPrice
 
-        if (config.isIronman.get() && LorenzUtils.isIronmanProfile){
+        if (config.isIronman.get() && LorenzUtils.isIronmanProfile) {
             // Empty: Removes Scrap from calculations
         } else {
             totalProfit -= scrapPrice

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
@@ -15,7 +16,6 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
 @SkyHanniModule
 object ProfitPerExcavation {
     private val config get() = SkyHanniMod.feature.mining.fossilExcavator
-
     @HandleEvent
     fun onFossilExcavation(event: FossilExcavationEvent) {
         if (!config.profitPerExcavation) return
@@ -39,7 +39,13 @@ object ProfitPerExcavation {
 
         val scrapPrice = scrapItem.getPrice()
         map["${scrapItem.repoItemName}: §c-${scrapPrice.shortFormat()}"] = -scrapPrice
-        totalProfit -= scrapPrice
+
+        if (config.isIronman.get() && LorenzUtils.isIronmanProfile){
+            // Empty: Removes Scrap from calculations
+        } else {
+            totalProfit -= scrapPrice
+        }
+
 
         val hover = map.sortedDesc().keys.toMutableList()
         val profitPrefix = if (totalProfit < 0) "§c" else "§6"


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by a plus. For example, `Feature + Fix: Add new command and fix bug in command`.
Commonly used labels are Improvement, Backend, Feature and Fix.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

-->

## What
Added a toggle in the settings for the Crystal Nucleus, Fossil Excavator and Enchanting Table.
Changing the way Profits are being calculated.

Crystal Nucleus Tracker:
- Removed the inclusion of the Jungle Key & Automaton Parts from the Total Profit

<details>
<summary>Images</summary>

![Screenshot 2025-05-01 153750](https://github.com/user-attachments/assets/c47ea6c0-2eaf-4d2f-ae58-31bf0673defe)
![Screenshot 2025-05-01 153821](https://github.com/user-attachments/assets/9e53a7dc-0689-450b-9e2b-60b643b3521d)

</details>

Fossil Excavator:
- Removed the inclusion of Scrap from the Total Profit

<details>
<summary>Images</summary>

![Screenshot 2025-05-01 154138](https://github.com/user-attachments/assets/0021e7b2-7047-44b1-823b-ab2210357523)
![Screenshot 2025-05-01 154349](https://github.com/user-attachments/assets/e8bf3b28-7109-4dac-b846-97b5885c82b4)


</details>

Enchanting Table:
- Removed the starting cost from the Total Profit

<details>
<summary>Images</summary>

![Screenshot 2025-05-01 153902](https://github.com/user-attachments/assets/f7b798f6-4cf1-4630-8e9d-e48d09064ae7)
![Screenshot 2025-05-01 154016](https://github.com/user-attachments/assets/8ab3368b-19ce-4fd3-95ed-37f2099827a0)

</details>

## Changelog Improvements
+ Different Profit Calculations for Ironman. - Mayhan


