### PR TITLE
Improvement: CH names in core

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsNamesInCore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsNamesInCore.kt
@@ -3,11 +3,12 @@ package at.hannibal2.skyhanni.features.mining.crystalhollows
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
+import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LocationUtils
-import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayerSqIgnoreY
+import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
@@ -20,27 +21,32 @@ object CrystalHollowsNamesInCore {
         LorenzVec(550, 116, 550) to "§8Precursor Remnants",
         LorenzVec(552, 116, 474) to "§bMithril Deposits",
         LorenzVec(477, 116, 476) to "§aJungle",
-        LorenzVec(474, 116, 554) to "§6Goblin Holdout"
+        LorenzVec(474, 116, 554) to "§6Goblin Holdout",
     )
 
     private var showWaypoints = false
+    private var inNucleus = false
 
     @HandleEvent
-    fun onTick(event: SkyHanniTickEvent) {
-        if (!isEnabled()) return
+    fun onAreaChange(event: GraphAreaChangeEvent) {
+        inNucleus = event.area == "Crystal Nucleus"
+        update()
+    }
 
-        if (event.isMod(10)) {
-            val center = LorenzVec(514.3, 106.0, 514.3)
-            showWaypoints = center.distanceToPlayerSqIgnoreY() < 1100 && LocationUtils.playerLocation().y > 65
-        }
+    private fun update() {
+        showWaypoints = inNucleus && LocationUtils.playerLocation().y > 65
+    }
+
+    @HandleEvent(SecondPassedEvent::class, onlyOnSkyblock = true)
+    fun onSecondPassed() {
+        if (isEnabled()) update()
     }
 
     @HandleEvent
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
-        if (!isEnabled()) return
-
-        if (showWaypoints) {
-            for ((location, name) in coreLocations) {
+        if (!isEnabled() || !showWaypoints) return
+        for ((location, name) in coreLocations) {
+            if (location.distanceSqToPlayer() > 50) {
                 event.drawDynamicText(location, name, 2.5)
             }
         }


### PR DESCRIPTION
## What
Updated the area check from "distance to center" to area navigation.
This allows when at one corner to show the names of the other 3 areas earlier.
We need to check the min distance, though, to avoid rendering the title too big when the player moves into it.

## Changelog Improvements
+ Improved Crystal Hollows Names in Nucleus Core to show the other three area names sooner. - hannibal2