### PR TITLE
Backend: Floats cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/Position.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/Position.kt
@@ -225,7 +225,7 @@ class Position @JvmOverloads constructor(
     companion object {
         const val DEFAULT_SCALE = 1f
         const val MIN_SCALE = 0.1f
-        const val MAX_SCALE = 10.0f
+        const val MAX_SCALE = 10f
 
         private class FieldNotFoundException(field: String, owner: Class<*>) :
             Exception("Config Link for field $field in class $owner not found")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/broodmother/BroodmotherSpawnAlertConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/broodmother/BroodmotherSpawnAlertConfig.kt
@@ -16,8 +16,8 @@ class BroodmotherSpawnAlertConfig {
 
     @Expose
     @ConfigOption(name = "Pitch", desc = "The pitch of the alert sound.")
-    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.0f, minStep = 0.1f)
-    var pitch: Float = 1.0f
+    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2f, minStep = 0.1f)
+    var pitch: Float = 1f
 
     @ConfigOption(name = "Test Sound", desc = "Test current sound settings.")
     @ConfigEditorButton(buttonText = "Test")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/LowHealthAlertSoundConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/LowHealthAlertSoundConfig.kt
@@ -16,8 +16,8 @@ class LowHealthAlertSoundConfig {
 
     @Expose
     @ConfigOption(name = "Pitch", desc = "The pitch of the alert sound.")
-    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.0f, minStep = 0.1f)
-    var pitch: Float = 1.0f
+    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2f, minStep = 0.1f)
+    var pitch: Float = 1f
 
     @ConfigOption(name = "Test Sound", desc = "Test current sound settings.")
     @ConfigEditorButton(buttonText = "Test")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/SecretChimeConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/SecretChimeConfig.kt
@@ -45,8 +45,8 @@ class SecretChimeConfig {
 
     @Expose
     @ConfigOption(name = "Pitch", desc = "The pitch of the secret chime sound.")
-    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.0f, minStep = 0.1f)
-    var soundPitch: Float = 1.0f
+    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2f, minStep = 0.1f)
+    var soundPitch: Float = 1f
 
     @ConfigOption(
         name = "Sounds",

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/InquisitorSoundConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/InquisitorSoundConfig.kt
@@ -16,8 +16,8 @@ class InquisitorSoundConfig {
 
     @Expose
     @ConfigOption(name = "Pitch", desc = "The pitch of the sound.")
-    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.0f, minStep = 0.1f)
-    var pitch: Float = 1.0f
+    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2f, minStep = 0.1f)
+    var pitch: Float = 1f
 
     @ConfigOption(name = "Test Sound", desc = "Test current sound settings.")
     @ConfigEditorButton(buttonText = "Test")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.java
@@ -43,7 +43,7 @@ public class SensitivityReducerConfig {
     @Expose
     @ConfigOption(name = "Reducing factor", desc = "Change by how much the sensitivity is lowered by.")
     @ConfigEditorSlider(minValue = 1, maxValue = 50, minStep = 1)
-    public Property<Float> reducingFactor = Property.of(15.0F);
+    public Property<Float> reducingFactor = Property.of(15f);
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/LaneSwitchSoundSettings.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/LaneSwitchSoundSettings.kt
@@ -16,8 +16,8 @@ class LaneSwitchSoundSettings {
 
     @Expose
     @ConfigOption(name = "Pitch", desc = "The pitch of the notification sound.")
-    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.0f, minStep = 0.1f)
-    var pitch: Float = 1.0f
+    @ConfigEditorSlider(minValue = 0.5f, maxValue = 2f, minStep = 0.1f)
+    var pitch: Float = 1f
 
     @ConfigOption(name = "Test Sound", desc = "Test current sound settings.")
     @ConfigEditorButton(buttonText = "Test")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/BackgroundOutlineConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/BackgroundOutlineConfig.kt
@@ -19,7 +19,7 @@ class BackgroundOutlineConfig {
 
     @Expose
     @ConfigOption(name = "Blur", desc = "Amount that the outline is blurred.")
-    @ConfigEditorSlider(minValue = 0.0f, maxValue = 1.0f, minStep = 0.1f)
+    @ConfigEditorSlider(minValue = 0f, maxValue = 1f, minStep = 0.1f)
     var blur: Float = 0.7f
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/TunnelMapsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/TunnelMapsConfig.kt
@@ -77,12 +77,12 @@ class TunnelMapsConfig {
     @Expose
     @ConfigOption(name = "Text Size", desc = "Size of the waypoint texts.")
     @ConfigEditorSlider(minValue = 0.5f, maxValue = 2.5f, minStep = 0.1f)
-    var textSize: Float = 1.0f
+    var textSize: Float = 1f
 
     @Expose
     @ConfigOption(name = "Path width", desc = "Size of the path lines.")
     @ConfigEditorSlider(minValue = 1f, maxValue = 15f, minStep = 1f)
-    var pathWidth: Float = 4.0f
+    var pathWidth: Float = 4f
 
     @Expose
     @ConfigOption(name = "Distance at First", desc = "Show the distance at the first edge instead of the end.")

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -193,7 +193,7 @@ object MobFilter {
 
     fun EntityLivingBase.isDisplayNpc() =
         (this is EntityPlayer && isNpc() && displayNpcNameCheck(this.name)) ||
-            (this is EntityVillager && this.maxHealth == 20.0f) || // Villager NPCs in the Village
+            (this is EntityVillager && this.maxHealth == 20f) || // Villager NPCs in the Village
             (this is EntityWitch && this.entityId <= 500) || // Alchemist NPC
             (this is EntityCow && this.entityId <= 500) || // Shania NPC (in Rift and Outside)
             (this is EntitySnowman && this.entityId <= 500) // Sherry NPC (in Jerry Island)

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneSpawnTimer.kt
@@ -103,7 +103,7 @@ object ArachneSpawnTimer {
 
         val location = event.location.roundTo(2)
         if (arachneAltarLocation.distance(location) > 30) return
-        if (event.type == EnumParticleTypes.REDSTONE && event.speed == 1.0f) {
+        if (event.type == EnumParticleTypes.REDSTONE && event.speed == 1f) {
             particleCounter += 1
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
@@ -63,7 +63,7 @@ object DungeonSecretChime {
         return when (soundName) {
             "random.chestopen" -> volume == 0.5f
             "note.harp" ->
-                volume == 1.0f && pitch in setOf(0.7936508f, 0.8888889f, 1.0f, 1.0952381f, 1.1904762f)
+                volume == 1f && pitch in setOf(0.7936508f, 0.8888889f, 1f, 1.0952381f, 1.1904762f)
 
             else -> false
         }
@@ -71,8 +71,8 @@ object DungeonSecretChime {
 
     private fun PlaySoundEvent.isLeverSound(): Boolean {
         return when (soundName) {
-            "random.anvil_break" -> volume == 1.0f && pitch == 1.6984127f
-            "random.wood_click" -> volume in setOf(1.0f, 2.0f) && pitch == 0.4920635f
+            "random.anvil_break" -> volume == 1f && pitch == 1.6984127f
+            "random.wood_click" -> volume in setOf(1f, 2f) && pitch == 0.4920635f
             else -> false
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -74,7 +74,7 @@ object CarnivalZombieShootout {
 
         lamp?.let {
             if (config.coloredLines) event.draw3DLine(event.exactPlayerEyeLocation(), it.pos.add(0.0, 0.5, 0.0), Color.RED, 3, false)
-            if (config.coloredHitboxes) event.drawWaypointFilled(it.pos, Color.RED, minimumAlpha = 1.0f)
+            if (config.coloredHitboxes) event.drawWaypointFilled(it.pos, Color.RED, minimumAlpha = 1f)
         }
 
         if (!config.coloredHitboxes) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -123,7 +123,7 @@ object GriffinBurrowParticleFinder {
             { type == EnumParticleTypes.DRIP_LAVA && count == 2 && speed == 0.01f && offset.roundTo(2) == LorenzVec(0.35, 0.1, 0.35) },
         ),
         FOOTSTEP(
-            { type == EnumParticleTypes.FOOTSTEP && count == 1 && speed == 0.0f && offset.roundTo(2) == LorenzVec(0.05, 0.0, 0.05) },
+            { type == EnumParticleTypes.FOOTSTEP && count == 1 && speed == 0f && offset.roundTo(2) == LorenzVec(0.05, 0.0, 0.05) },
         ),
         ENCHANT(
             {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -49,7 +49,7 @@ object HoppityEggDisplayManager {
 
         GlStateManager.enableBlend()
         GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA)
-        GlStateManager.color(1.0f, 1.0f, 1.0f, config.playerOpacity / 100f)
+        GlStateManager.color(1f, 1f, 1f, config.playerOpacity / 100f)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -210,7 +210,7 @@ object HoppityEggLocator {
         it.distance(location) < 5.0
     }
 
-    private fun ReceiveParticleEvent.isVillagerParticle() = type == EnumParticleTypes.VILLAGER_HAPPY && speed == 0.0f && count == 1
+    private fun ReceiveParticleEvent.isVillagerParticle() = type == EnumParticleTypes.VILLAGER_HAPPY && speed == 0f && count == 1
 
     fun isEnabled() =
         LorenzUtils.inSkyBlock && config.waypoints.enabled && !GardenApi.inGarden() && !ReminderUtils.isBusy(true) &&

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
@@ -44,7 +44,7 @@ object FishingHotspotRadar {
         if (!isEnabled()) return
         val type = event.type
         if (type != EnumParticleTypes.FLAME) return
-        if (event.count != 1 || event.speed != 0.0f) return
+        if (event.count != 1 || event.speed != 0f) return
 
         lastParticle = SimpleTimeMark.now()
         val currLoc = event.location

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -77,7 +77,7 @@ object TotemOfCorruption {
         if (!config.hideParticles) return
 
         for (totem in totems) {
-            if (event.type == EnumParticleTypes.SPELL_WITCH && event.speed == 0.0f) {
+            if (event.type == EnumParticleTypes.SPELL_WITCH && event.speed == 0f) {
                 if (totem.location.distance(event.location) < 4.0) {
                     event.cancel()
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -77,7 +77,7 @@ object PestParticleWaypoint {
     }
 
     private fun ReceiveParticleEvent.isEnchantmentTable(): Boolean =
-        type == EnumParticleTypes.ENCHANTMENT_TABLE && count == 10 && speed == -2.0f && offset.isZero()
+        type == EnumParticleTypes.ENCHANTMENT_TABLE && count == 10 && speed == -2f && offset.isZero()
 
     private fun ReceiveParticleEvent.isVillagerAngry(): Boolean =
         type == EnumParticleTypes.VILLAGER_ANGRY && count == 1 && speed == 0f && offset.isZero()

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -83,7 +83,7 @@ object ItemAbilityCooldown {
                 ItemAbility.HYPERION.sound()
             }
             // Fire Fury Staff
-            event.soundName == "liquid.lavapop" && event.pitch == 1.0f && event.volume == 1f -> {
+            event.soundName == "liquid.lavapop" && event.pitch == 1f && event.volume == 1f -> {
                 ItemAbility.FIRE_FURY_STAFF.sound()
             }
             // Ice Spray Wand
@@ -129,11 +129,11 @@ object ItemAbilityCooldown {
                 ItemAbility.VOODOO_DOLL.sound()
             }
             // Jinxed Voodoo Doll Hit
-            event.soundName == "random.successful_hit" && event.volume == 1.0f && event.pitch == 0.7936508f -> {
+            event.soundName == "random.successful_hit" && event.volume == 1f && event.pitch == 0.7936508f -> {
                 ItemAbility.VOODOO_DOLL_WILTED.sound()
             }
             // Jinxed Voodoo Doll Miss
-            event.soundName == "mob.ghast.scream" && event.volume == 1.0f && event.pitch >= 1.6 && event.pitch <= 1.7 -> {
+            event.soundName == "mob.ghast.scream" && event.volume == 1f && event.pitch >= 1.6 && event.pitch <= 1.7 -> {
                 if (VOODOO_DOLL_WILTED.recentlyHeld()) {
                     ItemAbility.VOODOO_DOLL_WILTED.sound()
                 }
@@ -152,7 +152,7 @@ object ItemAbilityCooldown {
                 }
             }
             // End Stone Sword
-            event.soundName == "mob.zombie.unfect" && event.pitch == 2.0f && event.volume == 0.3f -> {
+            event.soundName == "mob.zombie.unfect" && event.pitch == 2f && event.volume == 0.3f -> {
                 ItemAbility.END_STONE_SWORD.sound()
             }
             // Soul Esoward
@@ -160,15 +160,15 @@ object ItemAbilityCooldown {
                 ItemAbility.SOUL_ESOWARD.sound()
             }
             // Pigman Sword
-            event.soundName == "mob.zombiepig.zpigangry" && event.pitch == 2.0f && event.volume == 0.3f -> {
+            event.soundName == "mob.zombiepig.zpigangry" && event.pitch == 2f && event.volume == 0.3f -> {
                 ItemAbility.PIGMAN_SWORD.sound()
             }
             // Ember Rod
-            event.soundName == "mob.ghast.fireball" && event.pitch == 1.0f && event.volume == 0.3f -> {
+            event.soundName == "mob.ghast.fireball" && event.pitch == 1f && event.volume == 0.3f -> {
                 ItemAbility.EMBER_ROD.sound()
             }
             // Fire Freeze Staff
-            event.soundName == "mob.guardian.elder.idle" && event.pitch == 2.0f && event.volume == 0.2f -> {
+            event.soundName == "mob.guardian.elder.idle" && event.pitch == 2f && event.volume == 0.2f -> {
                 ItemAbility.FIRE_FREEZE_STAFF.sound()
             }
             // Staff of the Volcano
@@ -176,23 +176,23 @@ object ItemAbilityCooldown {
                 ItemAbility.STAFF_OF_THE_VOLCANO.sound()
             }
             // Staff of the Volcano
-            event.soundName == "random.eat" && event.pitch == 1.0f && event.volume == 1.0f -> {
+            event.soundName == "random.eat" && event.pitch == 1f && event.volume == 1f -> {
                 ItemAbility.STAFF_OF_THE_VOLCANO.sound()
             }
             // Holy Ice
-            event.soundName == "random.drink" && event.pitch.roundTo(1) == 1.8f && event.volume == 1.0f -> {
+            event.soundName == "random.drink" && event.pitch.roundTo(1) == 1.8f && event.volume == 1f -> {
                 ItemAbility.HOLY_ICE.sound()
             }
             // Royal Pigeon
-            event.soundName == "mob.bat.idle" && event.pitch == 0.4920635f && event.volume == 1.0f -> {
+            event.soundName == "mob.bat.idle" && event.pitch == 0.4920635f && event.volume == 1f -> {
                 ItemAbility.ROYAL_PIGEON.sound()
             }
             // Wand of Strength
-            event.soundName == "random.eat" && event.pitch == 0.4920635f && event.volume == 1.0f -> {
+            event.soundName == "random.eat" && event.pitch == 0.4920635f && event.volume == 1f -> {
                 ItemAbility.WAND_OF_STRENGTH.sound()
             }
             // Tactical Insertion
-            event.soundName == "fire.ignite" && event.pitch == 0.74603176f && event.volume == 1.0f -> {
+            event.soundName == "fire.ignite" && event.pitch == 0.74603176f && event.volume == 1f -> {
                 ItemAbility.TACTICAL_INSERTION.activate(LorenzColor.DARK_PURPLE, 3_000)
             }
 
@@ -206,12 +206,12 @@ object ItemAbilityCooldown {
                 }
             }
             // Enrager
-            event.soundName == "mob.enderdragon.growl" && event.pitch == 0.4920635f && event.volume == 2.0f -> {
+            event.soundName == "mob.enderdragon.growl" && event.pitch == 0.4920635f && event.volume == 2f -> {
                 ItemAbility.ENRAGER.sound()
             }
 
             // Blaze Slayer Flares
-            event.soundName == "fireworks.launch" && event.pitch == 1.0f && event.volume == 3.0f -> {
+            event.soundName == "fireworks.launch" && event.pitch == 1f && event.volume == 3f -> {
                 if (WARNING_FLARE.recentlyHeld() || ALERT_FLARE.recentlyHeld()) {
                     ItemAbility.ALERT_FLARE.sound()
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
@@ -84,8 +84,8 @@ object UserLuckBreakdown {
         if (!inMiscStats) return
 
         if (event.slot == replaceSlot && !inCustomBreakdown) {
-            val limboUserLuck = storage?.limbo?.userLuck ?: 0.0f
-            if (limboUserLuck == 0.0f && !showAllStats) return
+            val limboUserLuck = storage?.limbo?.userLuck ?: 0f
+            if (limboUserLuck == 0f && !showAllStats) return
             if (itemCreateCoolDown.passedSince() > 3.seconds) {
                 itemCreateCoolDown = SimpleTimeMark.now()
                 createItems()
@@ -167,7 +167,7 @@ object UserLuckBreakdown {
             skillCalcCoolDown = SimpleTimeMark.now()
             calcSkillLuck()
         }
-        val limboLuck = storage?.limbo?.userLuck?.roundTo(1) ?: 0.0f
+        val limboLuck = storage?.limbo?.userLuck?.roundTo(1) ?: 0f
         when (InventoryUtils.openInventoryName()) {
             "Your Equipment and Stats" -> equipmentMenuTooltip(event, limboLuck)
             "Your Stats Breakdown" -> statsBreakdownLoreTooltip(event, limboLuck)
@@ -177,7 +177,7 @@ object UserLuckBreakdown {
 
     private fun equipmentMenuTooltip(event: ToolTipEvent, limboLuck: Float) {
         if (event.slot.slotIndex != 25) return
-        if (limboLuck == 0.0f && !showAllStats) return
+        if (limboLuck == 0f && !showAllStats) return
 
         val skillLuck = skillOverflowLuck.values.sum()
         var totalLuck = skillLuck + limboLuck
@@ -197,7 +197,7 @@ object UserLuckBreakdown {
             event.toolTip[1] = "§7To Your Stats Breakdown"
         }
         if (event.slot.slotIndex != 4) return
-        if (limboLuck == 0.0f && !showAllStats) return
+        if (limboLuck == 0f && !showAllStats) return
 
         val skillLuck = skillOverflowLuck.values.sum()
         var totalLuck = skillLuck + limboLuck
@@ -234,8 +234,8 @@ object UserLuckBreakdown {
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!config.userluckEnabled) return
         if (!inMiscStats) return
-        val limboUserLuck = storage?.limbo?.userLuck ?: 0.0f
-        if (limboUserLuck == 0.0f && !showAllStats) return
+        val limboUserLuck = storage?.limbo?.userLuck ?: 0f
+        if (limboUserLuck == 0f && !showAllStats) return
 
         if (inCustomBreakdown && event.slotId != 49) event.cancel()
         when (event.slotId) {
@@ -263,7 +263,7 @@ object UserLuckBreakdown {
             15,
         )
 
-        val limboLuck = storage?.limbo?.userLuck ?: 0.0f
+        val limboLuck = storage?.limbo?.userLuck ?: 0f
         val skillLuck = skillOverflowLuck.values.sum()
         var totalLuck = skillLuck + limboLuck
         var jerryLuck = 0f
@@ -296,12 +296,12 @@ object UserLuckBreakdown {
         }
     }
 
-    private fun createItemLore(type: String, luckInput: Float = 0.0f): Array<String> {
+    private fun createItemLore(type: String, luckInput: Float = 0f): Array<String> {
         calcSkillLuck()
         return when (type) {
             "mainMenu" -> {
                 val luckString = tryTruncateFloat(luckInput.roundTo(2))
-                if (luckInput == 0.0f) {
+                if (luckInput == 0f) {
                     arrayOf(
                         "§7SkyHanni User Luck is the best stat.",
                         "",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -179,11 +179,11 @@ object TabListRenderer {
                     if (playerInfo != null) {
                         minecraft.textureManager.bindTexture(playerInfo.locationSkin)
                         GlStateManager.color(1f, 1f, 1f, 1f)
-                        Gui.drawScaledCustomSizeModalRect(middleX, middleY, 8f, 8f, 8, 8, 8, 8, 64.0f, 64.0f)
+                        Gui.drawScaledCustomSizeModalRect(middleX, middleY, 8f, 8f, 8, 8, 8, 8, 64f, 64f)
 
                         val player = tabLine.getEntity(playerInfo)
                         if (player != null && player.isWearing(EnumPlayerModelParts.HAT)) {
-                            Gui.drawScaledCustomSizeModalRect(middleX, middleY, 40.0f, 8f, 8, 8, 8, 8, 64.0f, 64.0f)
+                            Gui.drawScaledCustomSizeModalRect(middleX, middleY, 40f, 8f, 8, 8, 8, 8, 64f, 64f)
                         }
                     }
                     middleX += 8 + 2

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
@@ -34,7 +34,7 @@ object LimboTimeTracker {
     private var inFakeLimbo = false
     private var shownPB = false
     private var oldPB: Duration = 0.seconds
-    private var userLuck: Float = 0.0F
+    private var userLuck: Float = 0f
     private const val USER_LUCK_MULTIPLIER = 0.000810185F
     private const val FIRE_MULTIPLIER = 1.01F
     private var onFire = false

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
@@ -55,7 +55,7 @@ object MatriarchHelper {
         if (config.highlight) {
             val color = config.highlightColor.toSpecialColor()
             pearlList.forEach {
-                event.drawFilledBoundingBox(it.boundingBox.expandBlock(), color, 1.0f)
+                event.drawFilledBoundingBox(it.boundingBox.expandBlock(), color, 1f)
             }
         }
         if (config.line) {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
@@ -118,14 +118,14 @@ object DanceRoomHelper {
     fun onPlaySound(event: PlaySoundEvent) {
         if (!config.enabled || !inRoom) return
         if ((event.soundName == "random.burp" && event.volume == 0.8f) ||
-            (event.soundName == "random.levelup" && event.pitch == 1.8412699f && event.volume == 1.0f)
+            (event.soundName == "random.levelup" && event.pitch == 1.8412699f && event.volume == 1f)
         ) {
             index = 0
             found = false
             countdown = null
             update()
         }
-        if (event.soundName == "note.bassattack" && event.pitch == 0.6984127f && event.volume == 1.0f && !found) {
+        if (event.soundName == "note.bassattack" && event.pitch == 0.6984127f && event.volume == 1f && !found) {
             found = true
             start(2000)
             update()

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RendererLivingEntityHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RendererLivingEntityHook.kt
@@ -16,9 +16,9 @@ object RendererLivingEntityHook {
         val color = EntityOutlineRenderer.getCustomOutlineColor(entity)
 
         if (color != null) {
-            val colorRed = (color shr 16 and 255).toFloat() / 255.0f
-            val colorGreen = (color shr 8 and 255).toFloat() / 255.0f
-            val colorBlue = (color and 255).toFloat() / 255.0f
+            val colorRed = (color shr 16 and 255).toFloat() / 255f
+            val colorGreen = (color shr 8 and 255).toFloat() / 255f
+            val colorBlue = (color and 255).toFloat() / 255f
             GlStateManager.color(colorRed, colorGreen, colorBlue, alpha)
         } else {
             GlStateManager.color(red, green, blue, alpha)

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/ExtendedColorPatch.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/ExtendedColorPatch.java
@@ -113,10 +113,10 @@ public abstract class ExtendedColorPatch {
             textColor = skyhanni$colorSR;
             int shadowDivisor = shadow ? 4 : 1;
             setColor(
-                (skyhanni$colorSR >> 16 & 0xFF) / 255.0f / shadowDivisor,
-                (skyhanni$colorSR >> 8 & 0xFF) / 255.0f / shadowDivisor,
-                (skyhanni$colorSR & 0xFF) / 255.0f / shadowDivisor,
-                (skyhanni$colorState == 8 ? (skyhanni$colorSR >> 24 & 0xFF) / 255.0f : this.alpha)
+                (skyhanni$colorSR >> 16 & 0xFF) / 255f / shadowDivisor,
+                (skyhanni$colorSR >> 8 & 0xFF) / 255f / shadowDivisor,
+                (skyhanni$colorSR & 0xFF) / 255f / shadowDivisor,
+                (skyhanni$colorState == 8 ? (skyhanni$colorSR >> 24 & 0xFF) / 255f : this.alpha)
             );
             skyhanni$colorState = -1;
         } else if (0 <= hexCode && skyhanni$colorState != -1) {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntity.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinEntity.java
@@ -30,6 +30,6 @@ public abstract class MixinEntity {
     @Inject(method = "getBrightness", at = @At("HEAD"), cancellable = true)
     public void onGetBrightness(float p_getBrightness_1_, CallbackInfoReturnable<Float> cir) {
         if (((Entity) (Object) this).worldObj == null)
-            cir.setReturnValue(1.0F);
+            cir.setReturnValue(1f);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
@@ -59,7 +59,7 @@ object EntityOutlineRenderer {
         val main = mc.framebuffer
         val frameBuffer = Framebuffer(main.framebufferTextureWidth, main.framebufferTextureHeight, true)
         frameBuffer.setFramebufferFilter(GL11.GL_NEAREST)
-        frameBuffer.setFramebufferColor(0.0f, 0.0f, 0.0f, 0.0f)
+        frameBuffer.setFramebufferColor(0f, 0f, 0f, 0f)
         return frameBuffer
     }
 
@@ -311,9 +311,9 @@ object EntityOutlineRenderer {
     // Only render if renderManager would render and the world is loaded at the entity
 
     private fun outlineColor(color: Int) {
-        BUF_FLOAT_4.put(0, (color shr 16 and 255).toFloat() / 255.0f)
-        BUF_FLOAT_4.put(1, (color shr 8 and 255).toFloat() / 255.0f)
-        BUF_FLOAT_4.put(2, (color and 255).toFloat() / 255.0f)
+        BUF_FLOAT_4.put(0, (color shr 16 and 255).toFloat() / 255f)
+        BUF_FLOAT_4.put(1, (color shr 8 and 255).toFloat() / 255f)
+        BUF_FLOAT_4.put(2, (color and 255).toFloat() / 255f)
         BUF_FLOAT_4.put(3, 1f)
         GL11.glTexEnv(GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_COLOR, BUF_FLOAT_4)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
@@ -289,7 +289,7 @@ object GuiRenderUtils {
 
         init {
             itemLightBuffer.clear()
-            itemLightBuffer.put(lightIntensity).put(lightIntensity).put(lightIntensity).put(1.0f)
+            itemLightBuffer.put(lightIntensity).put(lightIntensity).put(lightIntensity).put(1f)
             itemLightBuffer.flip()
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
@@ -138,11 +138,11 @@ object HolographicEntities {
 
     private fun interpolateRotation(last: Float, next: Float, progress: Float): Float {
         var direction: Float = next - last
-        while (direction < -180.0f) {
-            direction += 360.0f
+        while (direction < -180f) {
+            direction += 360f
         }
-        while (direction >= 180.0f) {
-            direction -= 360.0f
+        while (direction >= 180f) {
+            direction -= 360f
         }
         return last + progress * direction
     }
@@ -183,7 +183,7 @@ object HolographicEntities {
         val headPitch = 0F
         val scaleFactor = 0.0625f
         renderer.setBrightness_skyhanni(entity, 0f, true)
-        GlStateManager.color(1.0f, 1.0f, 1.0f, holographicness)
+        GlStateManager.color(1f, 1f, 1f, holographicness)
         GlStateManager.depthMask(false)
         GlStateManager.enableBlend()
         GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA)

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -234,8 +234,8 @@ object RenderUtils {
         val tessellator = Tessellator.getInstance()
         val worldRenderer = tessellator.worldRenderer
         Minecraft.getMinecraft().textureManager.bindTexture(beaconBeam)
-        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, 10497.0f)
-        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, 10497.0f)
+        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, 10497f)
+        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, 10497f)
         GlStateManager.disableLighting()
         GlStateManager.enableCull()
         GlStateManager.enableTexture2D()
@@ -262,22 +262,22 @@ object RenderUtils {
         val d14 = -1.0 + d1
         val d15 = height.toDouble() * 2.5 + d14
         worldRenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR)
-        worldRenderer.pos(x + d4, y + topOffset, z + d5).tex(1.0, d15).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d4, y + bottomOffset, z + d5).tex(1.0, d14).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d6, y + bottomOffset, z + d7).tex(0.0, d14).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d6, y + topOffset, z + d7).tex(0.0, d15).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d10, y + topOffset, z + d11).tex(1.0, d15).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d10, y + bottomOffset, z + d11).tex(1.0, d14).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d8, y + bottomOffset, z + d9).tex(0.0, d14).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d8, y + topOffset, z + d9).tex(0.0, d15).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d6, y + topOffset, z + d7).tex(1.0, d15).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d6, y + bottomOffset, z + d7).tex(1.0, d14).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d10, y + bottomOffset, z + d11).tex(0.0, d14).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d10, y + topOffset, z + d11).tex(0.0, d15).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d8, y + topOffset, z + d9).tex(1.0, d15).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d8, y + bottomOffset, z + d9).tex(1.0, d14).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d4, y + bottomOffset, z + d5).tex(0.0, d14).color(r, g, b, 1.0f).endVertex()
-        worldRenderer.pos(x + d4, y + topOffset, z + d5).tex(0.0, d15).color(r, g, b, 1.0f).endVertex()
+        worldRenderer.pos(x + d4, y + topOffset, z + d5).tex(1.0, d15).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d4, y + bottomOffset, z + d5).tex(1.0, d14).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d6, y + bottomOffset, z + d7).tex(0.0, d14).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d6, y + topOffset, z + d7).tex(0.0, d15).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d10, y + topOffset, z + d11).tex(1.0, d15).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d10, y + bottomOffset, z + d11).tex(1.0, d14).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d8, y + bottomOffset, z + d9).tex(0.0, d14).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d8, y + topOffset, z + d9).tex(0.0, d15).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d6, y + topOffset, z + d7).tex(1.0, d15).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d6, y + bottomOffset, z + d7).tex(1.0, d14).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d10, y + bottomOffset, z + d11).tex(0.0, d14).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d10, y + topOffset, z + d11).tex(0.0, d15).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d8, y + topOffset, z + d9).tex(1.0, d15).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d8, y + bottomOffset, z + d9).tex(1.0, d14).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d4, y + bottomOffset, z + d5).tex(0.0, d14).color(r, g, b, 1f).endVertex()
+        worldRenderer.pos(x + d4, y + topOffset, z + d5).tex(0.0, d15).color(r, g, b, 1f).endVertex()
         tessellator.draw()
         GlStateManager.disableCull()
         val d12 = -1.0 + d1
@@ -330,7 +330,7 @@ object RenderUtils {
                 x + 1 + extraSize, y + 1 + extraSizeTopY, z + 1 + extraSize,
             ).expandBlock(),
             color,
-            if (inverseAlphaScale) (1.0f - 0.005f * distSq.toFloat()).coerceAtLeast(minimumAlpha)
+            if (inverseAlphaScale) (1f - 0.005f * distSq.toFloat()).coerceAtLeast(minimumAlpha)
             else (0.1f + 0.005f * distSq.toFloat()).coerceAtLeast(minimumAlpha),
             renderRelativeToCamera = true,
         )
@@ -374,11 +374,11 @@ object RenderUtils {
         GlStateManager.translate(x, y, z)
         GlStateManager.translate(0f, viewer.eyeHeight, 0f)
         drawNametag(text, color)
-        GlStateManager.rotate(-renderManager.playerViewY, 0.0f, 1.0f, 0.0f)
-        GlStateManager.rotate(renderManager.playerViewX, 1.0f, 0.0f, 0.0f)
+        GlStateManager.rotate(-renderManager.playerViewY, 0f, 1f, 0f)
+        GlStateManager.rotate(renderManager.playerViewX, 1f, 0f, 0f)
         GlStateManager.translate(0f, -0.25f, 0f)
-        GlStateManager.rotate(-renderManager.playerViewX, 1.0f, 0.0f, 0.0f)
-        GlStateManager.rotate(renderManager.playerViewY, 0.0f, 1.0f, 0.0f)
+        GlStateManager.rotate(-renderManager.playerViewX, 1f, 0f, 0f)
+        GlStateManager.rotate(renderManager.playerViewY, 0f, 1f, 0f)
         GlStateManager.popMatrix()
         GlStateManager.disableLighting()
 
@@ -396,13 +396,13 @@ object RenderUtils {
         val fontRenderer = Minecraft.getMinecraft().fontRendererObj
         val f1 = 0.02666667f
         GlStateManager.pushMatrix()
-        GL11.glNormal3f(0.0f, 1.0f, 0.0f)
-        GlStateManager.rotate(-Minecraft.getMinecraft().renderManager.playerViewY, 0.0f, 1.0f, 0.0f)
+        GL11.glNormal3f(0f, 1f, 0f)
+        GlStateManager.rotate(-Minecraft.getMinecraft().renderManager.playerViewY, 0f, 1f, 0f)
         GlStateManager.rotate(
             Minecraft.getMinecraft().renderManager.playerViewX,
-            1.0f,
-            0.0f,
-            0.0f,
+            1f,
+            0f,
+            0f,
         )
         GlStateManager.scale(-f1, -f1, f1)
         GlStateManager.disableLighting()
@@ -415,10 +415,10 @@ object RenderUtils {
         val j = fontRenderer.getStringWidth(str) / 2
         GlStateManager.disableTexture2D()
         worldrenderer.begin(7, DefaultVertexFormats.POSITION_COLOR)
-        worldrenderer.pos((-j - 1).toDouble(), (-1 + i).toDouble(), 0.0).color(0.0f, 0.0f, 0.0f, 0.25f).endVertex()
-        worldrenderer.pos((-j - 1).toDouble(), (8 + i).toDouble(), 0.0).color(0.0f, 0.0f, 0.0f, 0.25f).endVertex()
-        worldrenderer.pos((j + 1).toDouble(), (8 + i).toDouble(), 0.0).color(0.0f, 0.0f, 0.0f, 0.25f).endVertex()
-        worldrenderer.pos((j + 1).toDouble(), (-1 + i).toDouble(), 0.0).color(0.0f, 0.0f, 0.0f, 0.25f).endVertex()
+        worldrenderer.pos((-j - 1).toDouble(), (-1 + i).toDouble(), 0.0).color(0f, 0f, 0f, 0.25f).endVertex()
+        worldrenderer.pos((-j - 1).toDouble(), (8 + i).toDouble(), 0.0).color(0f, 0f, 0f, 0.25f).endVertex()
+        worldrenderer.pos((j + 1).toDouble(), (8 + i).toDouble(), 0.0).color(0f, 0f, 0f, 0.25f).endVertex()
+        worldrenderer.pos((j + 1).toDouble(), (-1 + i).toDouble(), 0.0).color(0f, 0f, 0f, 0.25f).endVertex()
         tessellator.draw()
         GlStateManager.enableTexture2D()
         val colorCode = color?.rgb ?: 553648127
@@ -426,7 +426,7 @@ object RenderUtils {
         GlStateManager.depthMask(true)
         fontRenderer.drawString(str, -j, i, -1)
         GlStateManager.enableBlend()
-        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f)
+        GlStateManager.color(1f, 1f, 1f, 1f)
         GlStateManager.popMatrix()
     }
 
@@ -530,7 +530,7 @@ object RenderUtils {
     // totally not modified Autumn Client's TargetStrafe
     fun drawCircle(entity: Entity, partialTicks: Float, rad: Double, color: Color) {
         GlStateManager.pushMatrix()
-        GL11.glNormal3f(0.0f, 1.0f, 0.0f)
+        GL11.glNormal3f(0f, 1f, 0f)
 
         GlStateManager.enableDepth()
         GlStateManager.enableBlend()
@@ -574,7 +574,7 @@ object RenderUtils {
         GlStateManager.enableTexture2D()
         GlStateManager.enableDepth()
         GlStateManager.disableBlend()
-        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f)
+        GlStateManager.color(1f, 1f, 1f, 1f)
         GlStateManager.popMatrix()
     }
 
@@ -656,7 +656,7 @@ object RenderUtils {
         GlStateManager.enableTexture2D()
         GlStateManager.enableCull()
         GlStateManager.disableBlend()
-        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f)
+        GlStateManager.color(1f, 1f, 1f, 1f)
         if (!depth) {
             GL11.glEnable(GL11.GL_DEPTH_TEST)
             GlStateManager.depthMask(true)
@@ -672,7 +672,7 @@ object RenderUtils {
         height: Float,
     ) {
         GlStateManager.pushMatrix()
-        GL11.glNormal3f(0.0f, 1.0f, 0.0f)
+        GL11.glNormal3f(0f, 1f, 0f)
 
         GlStateManager.enableDepth()
         GlStateManager.enableBlend()
@@ -704,7 +704,7 @@ object RenderUtils {
         GlStateManager.enableTexture2D()
         GlStateManager.enableDepth()
         GlStateManager.disableBlend()
-        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f)
+        GlStateManager.color(1f, 1f, 1f, 1f)
         GlStateManager.popMatrix()
     }
 
@@ -724,7 +724,7 @@ object RenderUtils {
         radius: Float,
     ) {
         GlStateManager.pushMatrix()
-        GL11.glNormal3f(0.0f, 1.0f, 0.0f)
+        GL11.glNormal3f(0f, 1f, 0f)
 
         GlStateManager.enableDepth()
         GlStateManager.enableBlend()
@@ -776,7 +776,7 @@ object RenderUtils {
         GlStateManager.enableTexture2D()
         GlStateManager.enableDepth()
         GlStateManager.disableBlend()
-        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f)
+        GlStateManager.color(1f, 1f, 1f, 1f)
         GlStateManager.popMatrix()
     }
 
@@ -796,7 +796,7 @@ object RenderUtils {
         radius: Float,
     ) {
         GlStateManager.pushMatrix()
-        GL11.glNormal3f(0.0f, 1.0f, 0.0f)
+        GL11.glNormal3f(0f, 1f, 0f)
 
         GlStateManager.disableTexture2D()
         color.bindColor()
@@ -846,7 +846,7 @@ object RenderUtils {
         tessellator.draw()
 
         GlStateManager.enableTexture2D()
-        GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f)
+        GlStateManager.color(1f, 1f, 1f, 1f)
         GlStateManager.popMatrix()
     }
 
@@ -938,8 +938,8 @@ object RenderUtils {
             location.z - renderManager.viewerPosZ,
         )
         GlStateManager.color(1f, 1f, 1f, 0.5f)
-        GlStateManager.rotate(-renderManager.playerViewY, 0.0f, 1.0f, 0.0f)
-        GlStateManager.rotate(renderManager.playerViewX, 1.0f, 0.0f, 0.0f)
+        GlStateManager.rotate(-renderManager.playerViewY, 0f, 1f, 0f)
+        GlStateManager.rotate(renderManager.playerViewX, 1f, 0f, 0f)
         GlStateManager.scale(-scale / 25, -scale / 25, scale / 25)
         val stringWidth = fontRenderer.getStringWidth(text)
         if (shadow) {
@@ -1205,8 +1205,8 @@ object RenderUtils {
             bezier2Buffer.flip()
             GL11.glMap1f(
                 GL11.GL_MAP1_VERTEX_3,
-                0.0f,
-                1.0f,
+                0f,
+                1f,
                 3,
                 3,
                 bezier2Buffer,
@@ -1250,7 +1250,7 @@ object RenderUtils {
                 GlStateManager.enableTexture2D()
                 GlStateManager.enableCull()
                 GlStateManager.disableBlend()
-                GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f)
+                GlStateManager.color(1f, 1f, 1f, 1f)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -89,8 +89,8 @@ object SoundUtils {
         }
 
         val soundName = args[0]
-        val pitch = args.getOrNull(1)?.toFloat() ?: 1.0f
-        val volume = args.getOrNull(2)?.toFloat() ?: 50.0f
+        val pitch = args.getOrNull(1)?.toFloat() ?: 1f
+        val volume = args.getOrNull(2)?.toFloat() ?: 50f
 
         createSound(soundName, pitch, volume).playSound()
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -465,11 +465,11 @@ interface Renderable {
                 if (highlight) {
                     item.addEnchantment(EnchantmentsCompat.PROTECTION.enchantment, 1)
                 }
-                item.renderOnScreen(xSpacing / 2.0f, 0F, scaleMultiplier = scale, rescaleSkulls)
+                item.renderOnScreen(xSpacing / 2f, 0F, scaleMultiplier = scale, rescaleSkulls)
             }
         }
 
-        fun Renderable.darken(amount: Float = 1.0f) = object : Renderable {
+        fun Renderable.darken(amount: Float = 1f) = object : Renderable {
             override val width = this@darken.width
             override val height = this@darken.height
             override val horizontalAlign = this@darken.horizontalAlign

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/StringRenderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/StringRenderable.kt
@@ -58,16 +58,16 @@ class WrappedRenderableString(
 
     override fun render(posX: Int, posY: Int) {
         DrawContextUtils.translate(1.0, 1.0, 0.0)
-        DrawContextUtils.scale(scale.toFloat(), scale.toFloat(), 1.0f)
+        DrawContextUtils.scale(scale.toFloat(), scale.toFloat(), 1f)
         map.entries.forEachIndexed { index, (text, size) ->
             GuiRenderUtils.drawString(
                 text,
                 RenderableUtils.calculateAlignmentXOffset(size, rawWidth, internalAlign).toFloat(),
-                index * 10.0f,
+                index * 10f,
                 color.rgb,
             )
         }
-        DrawContextUtils.scale(inverseScale.toFloat(), inverseScale.toFloat(), 1.0f)
+        DrawContextUtils.scale(inverseScale.toFloat(), inverseScale.toFloat(), 1f)
         DrawContextUtils.translate(-1.0, -1.0, 0.0)
     }
 }


### PR DESCRIPTION
## What
For some reason, we started using `0.0f` in the code for floats, even though `0f` represents the same in fewer chars.
And then we kept coping over and over this bad habit.

This PR does the bold action of replacing all such cases everywhere, in the hopes to increase readability.

## Changelog Technical Details
+ Removed unnecessary float decimals. - hannibal2