### PR TITLE
Backend: Make RenderSystems (GlStateManager) do nothing on modern

### DIFF
--- a/versions/1.21.5/buildpaths.txt
+++ b/versions/1.21.5/buildpaths.txt
@@ -76,6 +76,7 @@ at/hannibal2/skyhanni/utils/compat/TextCompat.kt
 at/hannibal2/skyhanni/utils/system/ModVersion.kt
 at/hannibal2/skyhanni/utils/compat/NbtCompat.kt
 at.hannibal2.skyhanni.utils.system.PlatformUtils.kt
+at/hannibal2/skyhanni/utils/render.ModernGlStateManager.kt
 
 
 

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/render/ModernGlStateManager.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/render/ModernGlStateManager.kt
@@ -1,0 +1,66 @@
+package at.hannibal2.skyhanni.utils.render
+
+/**
+ * This object holds all the methods of RenderSystem (GlStateManager), as time goes on they will be implemented but for
+ * now they are just here so that the mod can compile.
+ */
+object ModernGlStateManager {
+
+    fun color(f1: Float, f2: Float, f3: Float) {
+    }
+
+    fun color(f1: Float, f2: Float, f3: Float, f4: Float) {
+    }
+
+    fun disableLighting() {
+    }
+
+    fun enableBlend() {
+    }
+
+    fun blendFuncSeparate(glSrcAlpha: Int, glOneMinusSrcAlpha: Int, i: Int, i1: Int) {
+    }
+
+    fun enableDepthTest() {
+    }
+
+    fun disableRescaleNormal() {
+    }
+
+    fun disableDepthTest() {
+    }
+
+    fun enableLighting() {
+    }
+
+    fun enableRescaleNormal() {
+    }
+
+    fun disableBlend() {
+    }
+
+    fun enableCull() {
+    }
+
+    fun disableCull() {
+    }
+
+    fun blendFunc(glSrcAlpha: Int, glOneMinusSrcAlpha: Int) {
+    }
+
+    fun pushAttrib() {
+    }
+
+    fun popAttrib() {
+    }
+
+    fun disableTexture2D() {
+    }
+
+    fun enableTexture2D() {
+    }
+
+    fun disableAlpha() {
+    }
+
+}

--- a/versions/mapping-1.21.5-1.16.5-fabric.txt
+++ b/versions/mapping-1.21.5-1.16.5-fabric.txt
@@ -1,4 +1,6 @@
 
+at.hannibal2.skyhanni.utils.render.ModernGlStateManager com.mojang.blaze3d.systems.RenderSystem
+
 net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext at.hannibal2.skyhanni.utils.compat.WorldRenderContext
 
 net.minecraft.client.gui.DrawContext at.hannibal2.skyhanni.utils.compat.DrawContext


### PR DESCRIPTION
## What
Made GlStateManager calls do nothing on modern versions as rendering has changed significantly. Once the game can be opened on 1.21 so we can actually start testing stuff these will slowly be replaced but for now this just fixes 210 errors


## Changelog Technical Details
+ Make RenderSystem (GlStateManager) do nothing on modern versions. - CalMWolfs

