### PR TITLE
Backend: Fix Ide no longer dies in K2 mode with live plugin

### DIFF
--- a/.live-plugins/event/plugin.kts
+++ b/.live-plugins/event/plugin.kts
@@ -74,7 +74,7 @@ class HandleEventInspectionKotlin : AbstractKotlinInspection() {
                 // Check if the function's parameter is a SkyHanniEvent or its subtype
                 // TODO fix it for K2 mode instead of leaving the function (the try catch)
                 val isEvent = try{function.valueParameters.firstOrNull()?.type()?.supertypes()
-                    ?.any { it.fqName?.asString() == skyhanniEvent }}catch (e: Throwable){null} ?: false
+                    ?.any { it.fqName?.asString() == skyhanniEvent }}catch (e: Throwable){return} ?: false
 
                 // Find the annotation entry
                 val annotationEntry = function.annotationEntries

--- a/.live-plugins/event/plugin.kts
+++ b/.live-plugins/event/plugin.kts
@@ -72,8 +72,9 @@ class HandleEventInspectionKotlin : AbstractKotlinInspection() {
                 val isPrimaryName = primaryNameMap.containsKey(functionName)
 
                 // Check if the function's parameter is a SkyHanniEvent or its subtype
-                val isEvent = function.valueParameters.firstOrNull()?.type()?.supertypes()
-                    ?.any { it.fqName?.asString() == skyhanniEvent } ?: false
+                // TODO fix it for K2 mode instead of leaving the function (the try catch)
+                val isEvent = try{function.valueParameters.firstOrNull()?.type()?.supertypes()
+                    ?.any { it.fqName?.asString() == skyhanniEvent }}catch (e: Throwable){null} ?: false
 
                 // Find the annotation entry
                 val annotationEntry = function.annotationEntries

--- a/.live-plugins/event/plugin.kts
+++ b/.live-plugins/event/plugin.kts
@@ -73,8 +73,11 @@ class HandleEventInspectionKotlin : AbstractKotlinInspection() {
 
                 // Check if the function's parameter is a SkyHanniEvent or its subtype
                 // TODO fix it for K2 mode instead of leaving the function (the try catch)
-                val isEvent = try{function.valueParameters.firstOrNull()?.type()?.supertypes()
-                    ?.any { it.fqName?.asString() == skyhanniEvent }}catch (e: Throwable){return} ?: false
+                val isEvent = try {
+                    function.valueParameters.firstOrNull()?.type()?.supertypes()?.any { it.fqName?.asString() == skyhanniEvent }
+                } catch (e: Throwable) {
+                    return
+                } ?: false
 
                 // Find the annotation entry
                 val annotationEntry = function.annotationEntries

--- a/.live-plugins/module/plugin.kts
+++ b/.live-plugins/module/plugin.kts
@@ -32,7 +32,11 @@ fun isEvent(function: KtNamedFunction): Boolean {
 
 fun isRepoPattern(property: KtProperty): Boolean {
     // TODO fix it for K2 mode instead of leaving the function (the try catch)
-    val type = try{ property.type()?.fqName?.asString()}catch (e: Throwable){null} ?: return false
+    val type = try {
+        property.type()?.fqName?.asString()
+    } catch (e: Throwable) {
+        null
+    } ?: return false
     if (type == patternGroup) return true
     if (type == pattern && property.hasDelegate()) return true
     return false

--- a/.live-plugins/module/plugin.kts
+++ b/.live-plugins/module/plugin.kts
@@ -31,7 +31,8 @@ fun isEvent(function: KtNamedFunction): Boolean {
 }
 
 fun isRepoPattern(property: KtProperty): Boolean {
-    val type = property.type()?.fqName?.asString() ?: return false
+    // TODO fix it for K2 mode instead of leaving the function (the try catch)
+    val type = try{ property.type()?.fqName?.asString()}catch (e: Throwable){null} ?: return false
     if (type == patternGroup) return true
     if (type == pattern && property.hasDelegate()) return true
     return false


### PR DESCRIPTION
## What
Not really a fix. It just hides the error and softly errors instead of killing the whole kotlin plugin.

## Changelog Technical Details
+ K2 mode & live plugins no longer error. - Thunderblade73
    * The errors are just silents, so the someone should fix them.


