### PR TITLE
Backend: Deprecate LorenzUtils, Adding SkyBlockUtils

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -150,6 +150,7 @@ object HypixelData {
 
     var lastLocRaw = SimpleTimeMark.farPast()
     private var hasScoreboardUpdated = false
+    val connectedToHypixel get() = hypixelLive || hypixelAlpha
 
     var hypixelLive = false
     var hypixelAlpha = false

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LocationUtils.isInside
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import net.minecraft.util.AxisAlignedBB
 
 enum class IslandType(private val nameFallback: String) {
@@ -112,6 +113,9 @@ enum class IslandType(private val nameFallback: String) {
             maxPlayersMega = data.maxPlayersMega
         }
     }
+
+    // TODO rename to isInIsland once the funciton in lorenz utils is gone
+    fun isCurrent() = SkyBlockUtils.inSkyBlock && SkyBlockUtils.currentIsland == this
 }
 
 data class IslandData(

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -61,7 +62,10 @@ object KuudraApi {
     var kuudraTier: Int? = null
         private set
 
+    @Deprecated("moved", ReplaceWith("inKuudra"))
     fun inKuudra() = kuudraTier != null
+
+    val inKuudra get() = SkyBlockUtils.inSkyBlock && kuudraTier != null
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -23,6 +23,7 @@ import at.hannibal2.skyhanni.features.garden.GardenNextJacobContest
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorColorNames
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.getBazaarData
 import at.hannibal2.skyhanni.features.mining.OreBlock
+import at.hannibal2.skyhanni.features.misc.visualwords.ModifyVisualWords
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
@@ -42,6 +43,7 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzDebug
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.LorenzUtils.onHypixel
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
@@ -54,6 +56,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
@@ -73,6 +76,8 @@ import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.common.MinecraftForge
 import java.io.File
+import java.time.LocalDate
+import java.time.Month
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -102,6 +107,23 @@ object SkyHanniDebugsAndTests {
     private fun print(text: String) {
         LorenzDebug.log(text)
     }
+
+    private var previousApril = false
+
+    val isAprilFoolsDay: Boolean
+        get() {
+            val itsTime = LocalDate.now().let { it.month == Month.APRIL && it.dayOfMonth == 1 }
+            val always = SkyHanniMod.feature.dev.debug.alwaysFunnyTime
+            val never = SkyHanniMod.feature.dev.debug.neverFunnyTime
+            val result = (!never && (always || itsTime))
+            if (previousApril != result) {
+                ModifyVisualWords.update()
+            }
+            previousApril = result
+            return result
+        }
+
+    val enabled get() = SkyBlockUtils.onHypixel && SkyHanniMod.feature.dev.debug.enabled
 
     private var testLocation: LorenzVec? = null
 

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -23,7 +23,6 @@ import at.hannibal2.skyhanni.features.garden.GardenNextJacobContest
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorColorNames
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.getBazaarData
 import at.hannibal2.skyhanni.features.mining.OreBlock
-import at.hannibal2.skyhanni.features.misc.visualwords.ModifyVisualWords
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -116,9 +116,6 @@ object SkyHanniDebugsAndTests {
             val always = SkyHanniMod.feature.dev.debug.alwaysFunnyTime
             val never = SkyHanniMod.feature.dev.debug.neverFunnyTime
             val result = (!never && (always || itsTime))
-            if (previousApril != result) {
-                ModifyVisualWords.update()
-            }
             previousApril = result
             return result
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -25,6 +25,7 @@ import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.client.multiplayer.WorldClient
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
+import net.minecraft.entity.SharedMonsterAttributes
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.monster.EntityEnderman
 import net.minecraft.entity.player.EntityPlayer
@@ -196,4 +197,12 @@ object EntityUtils {
     fun EntityLivingBase.isRunicAndCorrupt() = baseMaxHealth == health.toInt().derpy() * 3 * 4
 
     fun Entity.cleanName() = this.name.removeColor()
+
+    // TODO use derpy() on every use case
+    val EntityLivingBase.baseMaxHealth: Int
+        //#if MC < 1.21
+        get() = this.getEntityAttribute(SharedMonsterAttributes.maxHealth).baseValue.toInt()
+    //#else
+    //$$ get() = this.getAttributeValue(EntityAttributes.MAX_HEALTH).toInt()
+    //#endif
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzUtils.kt
@@ -4,16 +4,14 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.features.misc.IslandAreas
-import at.hannibal2.skyhanni.features.misc.visualwords.ModifyVisualWords
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.test.SkyBlockIslandTest
+import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.test.TestBingo
 import at.hannibal2.skyhanni.utils.StringUtils.toDashlessUUID
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.entity.EntityLivingBase
 import java.text.SimpleDateFormat
-import java.time.LocalDate
-import java.time.Month
 import java.util.UUID
 //#if MC < 1.21
 import net.minecraft.entity.SharedMonsterAttributes
@@ -21,65 +19,70 @@ import net.minecraft.entity.SharedMonsterAttributes
 //$$ import net.minecraft.entity.attribute.EntityAttributes
 //#endif
 
+// Dont use. prefer SkyBlockUtils or other utils classes
+@Suppress("DEPRECATION")
+@Deprecated("Use SkyBlockUtils or other utils classes. 450 usages prevent us from doing so in one push.")
 object LorenzUtils {
 
-    val connectedToHypixel get() = HypixelData.hypixelLive || HypixelData.hypixelAlpha
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.onHypixel"))
+    val onHypixel get() = HypixelData.connectedToHypixel && MinecraftCompat.localPlayerExists
 
-    val onHypixel get() = connectedToHypixel && MinecraftCompat.localPlayerExists
-
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.isOnAlphaServer"))
     val isOnAlphaServer get() = onHypixel && HypixelData.hypixelAlpha
 
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.inSkyBlock"))
     val inSkyBlock get() = onHypixel && HypixelData.skyBlock
 
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.inHypixelLobby"))
     val inHypixelLobby get() = onHypixel && HypixelData.inLobby
 
     /**
      * Consider using [IslandType.isInIsland] instead
      */
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.currentIsland"))
     val skyBlockIsland get() = SkyBlockIslandTest.testIsland ?: HypixelData.skyBlockIsland
 
-    @Deprecated("Scoreboard data is updating delayed while moving, dont use.", ReplaceWith("IslandAreas.currentAreaName"))
+    @Deprecated("Scoreboard data is updating delayed while moving, dont use.", ReplaceWith("SkyBlockUtils.graphArea"))
     val skyBlockArea get() = scoreboardArea
 
     // almost always prefer this over scoreboardArea
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.graphArea"))
     val graphArea get() = if (inSkyBlock) IslandAreas.currentArea else null
 
     // Only use scoreboardArea if graph data is not useable in this scenario.
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.scoreboardArea"))
     val scoreboardArea get() = if (inSkyBlock) HypixelData.skyBlockArea else null
 
-    val inKuudraFight get() = inSkyBlock && KuudraApi.inKuudra()
+    @Deprecated("moved", ReplaceWith("KuudraApi.inKuudra"))
+    val inKuudraFight get() = inSkyBlock && KuudraApi.kuudraTier != null
 
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.noTradeMode"))
     val noTradeMode get() = HypixelData.noTrade
 
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.isStrandedProfile"))
     val isStrandedProfile get() = inSkyBlock && HypixelData.stranded
 
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.isBingoProfile"))
     val isBingoProfile get() = inSkyBlock && (HypixelData.bingo || TestBingo.testBingo)
 
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.isIronmanProfile"))
     val isIronmanProfile get() = inSkyBlock && HypixelData.ironman
 
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.lastWorldSwitch"))
     val lastWorldSwitch get() = HypixelData.joinedWorld
 
-    private var previousApril = false
+    @Deprecated("moved", ReplaceWith("SkyHanniDebugsAndTests.isAprilFoolsDay"))
+    val isAprilFoolsDay get() = SkyHanniDebugsAndTests.isAprilFoolsDay
 
-    val isAprilFoolsDay: Boolean
-        get() {
-            val itsTime = LocalDate.now().let { it.month == Month.APRIL && it.dayOfMonth == 1 }
-            val always = SkyHanniMod.feature.dev.debug.alwaysFunnyTime
-            val never = SkyHanniMod.feature.dev.debug.neverFunnyTime
-            val result = (!never && (always || itsTime))
-            if (previousApril != result) {
-                ModifyVisualWords.update()
-            }
-            previousApril = result
-            return result
-        }
-
+    @Deprecated("moved", ReplaceWith("SkyHanniDebugsAndTests.enabled"))
     val debug: Boolean get() = onHypixel && SkyHanniMod.feature.dev.debug.enabled
 
     // TODO move into lorenz logger. then rewrite lorenz logger and use something different entirely
+    @Deprecated("moved to TimeUtils", ReplaceWith(""))
     fun SimpleDateFormat.formatCurrentTime(): String = this.format(System.currentTimeMillis())
 
     // TODO use derpy() on every use case
+    @Deprecated("moved to EntityUtils", ReplaceWith(""))
     val EntityLivingBase.baseMaxHealth: Int
         //#if MC < 1.21
         get() = this.getEntityAttribute(SharedMonsterAttributes.maxHealth).baseValue.toInt()
@@ -87,14 +90,21 @@ object LorenzUtils {
     //$$ get() = this.getAttributeValue(EntityAttributes.MAX_HEALTH).toInt()
     //#endif
 
+    @Deprecated("moved", ReplaceWith("PlayerUtils.getUuid"))
     fun getPlayerUuid() = getRawPlayerUuid().toDashlessUUID()
 
+    @Deprecated("moved", ReplaceWith("PlayerUtils.getRawUuid"))
     fun getRawPlayerUuid(): UUID = MinecraftCompat.localPlayer.uniqueID
 
+    @Deprecated("moved", ReplaceWith("PlayerUtils.getName"))
     fun getPlayerName(): String = MinecraftCompat.localPlayer.name
 
+    @Deprecated("moved into IslandType", ReplaceWith("this.isCurrent()"))
     fun IslandType.isInIsland() = inSkyBlock && skyBlockIsland == this
 
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.inAnyIsland(islandTypes)"))
     fun inAnyIsland(vararg islandTypes: IslandType) = inSkyBlock && HypixelData.skyBlockIsland in islandTypes
+
+    @Deprecated("moved", ReplaceWith("SkyBlockUtils.inAnyIsland(islandTypes)"))
     fun inAnyIsland(islandTypes: Collection<IslandType>) = inSkyBlock && HypixelData.skyBlockIsland in islandTypes
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -1,7 +1,10 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.utils.StringUtils.toDashlessUUID
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.client.Minecraft
+import java.util.UUID
+
 //#if MC > 1.21
 //$$ import net.minecraft.entity.attribute.EntityAttributes
 //#endif
@@ -45,4 +48,10 @@ object PlayerUtils {
         //$$ return MinecraftCompat.localPlayer.getAttributeValue(EntityAttributes.MOVEMENT_SPEED).toInt()
         //#endif
     }
+
+    fun getUuid() = getRawUuid().toDashlessUUID()
+
+    fun getRawUuid(): UUID = MinecraftCompat.localPlayer.uniqueID
+
+    fun getName(): String = MinecraftCompat.localPlayer.name
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockUtils.kt
@@ -1,0 +1,49 @@
+package at.hannibal2.skyhanni.utils
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.HypixelData
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.features.misc.IslandAreas
+import at.hannibal2.skyhanni.test.SkyBlockIslandTest
+import at.hannibal2.skyhanni.test.TestBingo
+import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+
+object SkyBlockUtils {
+
+    val onHypixel get() = HypixelData.connectedToHypixel && MinecraftCompat.localPlayerExists
+
+    val isOnAlphaServer get() = onHypixel && HypixelData.hypixelAlpha
+
+    val inSkyBlock get() = onHypixel && HypixelData.skyBlock
+
+    val inHypixelLobby get() = onHypixel && HypixelData.inLobby
+
+    /**
+     * Consider using [IslandType.isInIsland] instead
+     */
+    val currentIsland get() = SkyBlockIslandTest.testIsland ?: HypixelData.skyBlockIsland
+
+    // almost always prefer this over scoreboardArea
+    val graphArea get() = if (inSkyBlock) IslandAreas.currentArea else null
+
+    // Only use scoreboardArea if graph data is not useable in this scenario.
+    val scoreboardArea get() = if (inSkyBlock) HypixelData.skyBlockArea else null
+
+    val noTradeMode get() = HypixelData.noTrade
+
+    val isStrandedProfile get() = inSkyBlock && HypixelData.stranded
+
+    val isBingoProfile get() = inSkyBlock && (HypixelData.bingo || TestBingo.testBingo)
+
+    val isIronmanProfile get() = inSkyBlock && HypixelData.ironman
+
+    val lastWorldSwitch get() = HypixelData.joinedWorld
+
+    val debug: Boolean get() = onHypixel && SkyHanniMod.feature.dev.debug.enabled
+
+    fun inAnyIsland(vararg islandTypes: IslandType) = inSkyBlock && currentIsland in islandTypes
+
+
+    fun inAnyIsland(islandTypes: Collection<IslandType>) = inSkyBlock && currentIsland in islandTypes
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.mixins.hooks.tryToReplaceScoreboardLine
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -191,6 +192,9 @@ object TimeUtils {
     val Int.ticks get() = (this * 50).milliseconds
 
     val Float.minutes get() = toDouble().minutes
+
+    // TODO move into lorenz logger. then rewrite lorenz logger and use something different entirely
+    fun SimpleDateFormat.formatCurrentTime(): String = this.format(System.currentTimeMillis())
 }
 
 private const val FACTOR_SECONDS = 1000L


### PR DESCRIPTION
## What
The class is a "core utils" since the beginning.
Over time, some other functions landed there that obviously should belong somewhere else.

This PR moves all functions into better, more precise other files.
For the remaining core utils, we now have a new `SkyBlockUtils` class.

Since it's practically impossible to move all the 450 affected lines in one PR, we rather make everything deprecated, and use the new functions over time.

## Changelog Technical Details
+ Deprecated `LorenzUtils`. - hannibal2
+ Created `SkyBlockUtils`. - hannibal2