### PR TITLE
Backend: Modern version build action & label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
             - "*"
         paths-ignore:
             - ".gitignore"
-    pull_request:
+    pull_request_target:
         branches:
             - "*"
         paths-ignore:
@@ -20,6 +20,10 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4
+                with:
+                    ref: ${{ github.event.pull_request.head.ref }}
+                    repository: ${{ github.event.pull_request.head.repo.full_name }}
+
             -   uses: ./.github/actions/setup-normal-workspace
             -   name: Build with Gradle
                 run: ./gradlew assemble -x test --stacktrace
@@ -43,6 +47,10 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4
+                with:
+                    ref: ${{ github.event.pull_request.head.ref }}
+                    repository: ${{ github.event.pull_request.head.repo.full_name }}
+
             -   uses: ./.github/actions/setup-normal-workspace
             -   name: Enable preprocessor
                 run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,24 @@ jobs:
                     echo skyhanni.multi-version=compile > .gradle/private.properties
             -   name: Build with Gradle
                 run: ./gradlew build --stacktrace -PskipDetekt=true
+
+            -   name: Add label if build fails
+                if: ${{ failure() && github.event_name == 'pull_request' && github.event.pull_request.state == 'open' }}
+                uses: actions-ecosystem/action-add-labels@v1
+                with:
+                    github_token: ${{ secrets.GITHUB_TOKEN }}
+                    labels: 'Fails Multi-Version'
+
+            -   name: Remove label if build passes
+                if: ${{ success() && github.event_name == 'pull_request' && github.event.pull_request.state == 'open' }}
+                uses: actions-ecosystem/action-remove-labels@v1
+                with:
+                    github_token: ${{ secrets.GITHUB_TOKEN }}
+                    labels: 'Fails Multi-Version'
+
+            -   name: Upload multi-version build
+                uses: actions/upload-artifact@v4
+                if: ${{ !cancelled() }}
+                with:
+                    name: "Multi-version Development Build"
+                    path: build/libs/*.jar


### PR DESCRIPTION
## What
We currently dont require build multiversion to pass before merging a pr but in a few weeks we should make that required. For now this pr just uploads the modern jars and adds labels to prs that fails multiversion. 
Once we have more stuff working on modern, ill make it also send a comment on the pr but that isnt necessary just yet.
Then finally a bit after that we can make it a required check.

We check that its a pull request before adding the label as this action also runs on push which shouldnt have labels.

## Changelog Technical Details
+ Upload modern JARs to GitHub Actions and add label if modern build fails. - CalMWolfs

