### PR TITLE
Improvement: Get From Sacks for Composter Crops

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.composter
 
+import at.hannibal2.skyhanni.api.GetFromSackApi
 import at.hannibal2.skyhanni.api.ItemBuyApi.createBuyTipLine
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
@@ -535,7 +536,7 @@ object ComposterOverlay {
                     }
                 },
                 RIGHT_MOUSE to {
-                    HypixelCommands.getFromSacks(internalName.asString(), itemsNeeded)
+                    GetFromSackApi.getFromSack(internalName, itemsNeeded)
                 }
             ),
             tips = tips,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -531,11 +531,11 @@ object ComposterOverlay {
                     onClick(internalName)
                     if (KeyboardManager.isModifierKeyDown() && lastAttemptTime.passedSince() > 500.milliseconds) {
                         lastAttemptTime = SimpleTimeMark.now()
-                        retrieveMaterials(internalName, itemName, itemsNeeded.toInt())
+                        retrieveMaterials(internalName, itemName, itemsNeeded)
                     }
                 },
                 RIGHT_MOUSE to {
-                    HypixelCommands.getFromSacks(itemName, itemsNeeded)
+                    HypixelCommands.getFromSacks(internalName.asString(), itemsNeeded)
                 }
             ),
             tips = tips,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -34,6 +34,8 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemNameCompact
 import at.hannibal2.skyhanni.utils.KeyboardManager
+import at.hannibal2.skyhanni.utils.KeyboardManager.LEFT_MOUSE
+import at.hannibal2.skyhanni.utils.KeyboardManager.RIGHT_MOUSE
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.NONE
@@ -510,6 +512,9 @@ object ComposterOverlay {
             add("")
             if (selected) {
                 add(internalName.createBuyTipLine("Control + "))
+                internalName.createGfsLine("Right ", itemsNeeded)?.let {
+                    add(it)
+                }
             } else {
                 add("§eClick to select for profit calculations!")
             }
@@ -521,13 +526,18 @@ object ComposterOverlay {
 
         return Renderable.clickable(
             text = "$displayName §8x${itemsNeeded.addSeparators()} ${totalPrice.formatCoinWithBrackets()}",
-            onLeftClick = {
-                onClick(internalName)
-                if (KeyboardManager.isModifierKeyDown() && lastAttemptTime.passedSince() > 500.milliseconds) {
-                    lastAttemptTime = SimpleTimeMark.now()
-                    retrieveMaterials(internalName, itemName, itemsNeeded.toInt())
+            onAnyClick = mapOf(
+                LEFT_MOUSE to {
+                    onClick(internalName)
+                    if (KeyboardManager.isModifierKeyDown() && lastAttemptTime.passedSince() > 500.milliseconds) {
+                        lastAttemptTime = SimpleTimeMark.now()
+                        retrieveMaterials(internalName, itemName, itemsNeeded.toInt())
+                    }
+                },
+                RIGHT_MOUSE to {
+                    HypixelCommands.getFromSacks(itemName, itemsNeeded)
                 }
-            },
+            ),
             tips = tips,
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.data.SackApi
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetExp
 import net.minecraft.init.Items
@@ -81,6 +83,12 @@ class NeuInternalName private constructor(private val internalName: String) {
         internalName.replace(oldValue, newValue, ignoreCase = true).toInternalName()
 
     fun isKnownItem(): Boolean = getItemStackOrNull() != null || this == SKYBLOCK_COIN
+
+    fun createGfsLine(additionalAction: String = "", itemsNeeded: Int): String? = when {
+        this.asString() in SackApi.sackListInternalNames ->
+            "§e${additionalAction}Click to get $repoItemName §8x$itemsNeeded §efrom sacks"
+        else -> null
+    }
 
     /**
      * This is because skyblock has special ids in commands such as /viewrecipe for items like enchanted books and pets


### PR DESCRIPTION
## What
Adds a shortcut to get the required selected crops from sacks as an alternative to searching the bazaar.

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/d742eb94-60e1-41bd-b27c-a401038ed66e)
![image](https://github.com/user-attachments/assets/1c7e9b14-4a2a-4b04-8916-08e38a389cae)
</details>

## Changelog Improvements
+ Added option to get necessary crops to fuel composter from sack. - Daveed
    * Alternative to using the "insert from sacks" which chooses "random" crops.