### PR TITLE
Fix: Hoppity Meal Order

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -84,7 +84,7 @@ object HoppityEggDisplayManager {
                     !it.isClaimed() // Or eggs that have not been claimed
             }.let { entries ->
                 if (unclaimedEggsConfig.displayOrder == SOONEST_FIRST) entries.sortedBy { it.timeUntil }
-                else entries
+                else entries.sortedWith(compareBy<HoppityEggType> { it.altDay }.thenBy { it.resetsAt })
             }.forEach {
                 val (color, timeFormat) = if (it.hasRemainingSpawns()) {
                     it.mealColor to it.timeUntil.format()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
@@ -117,9 +117,7 @@ enum class HoppityEggType(
                 profileStorage?.mealNextSpawn?.set(key, newMark)
             },
         )
-        val resettingEntries = entries
-            .filter { it.resetsAt != -1 }
-            .sortedWith(compareBy<HoppityEggType> { it.altDay }.thenBy { it.resetsAt })
+        val resettingEntries = entries.filter { it.resetsAt != -1 }.sortedBy { it.resetsAt }
 
         fun markAllFound() = resettingEntries.forEach { it.markClaimed() }
         fun anyEggsUnclaimed(): Boolean = resettingEntries.any { !it.claimed }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
@@ -117,7 +117,9 @@ enum class HoppityEggType(
                 profileStorage?.mealNextSpawn?.set(key, newMark)
             },
         )
-        val resettingEntries = entries.filter { it.resetsAt != -1 }.sortedBy { it.resetsAt }
+        val resettingEntries = entries
+            .filter { it.resetsAt != -1 }
+            .sortedWith(compareBy<HoppityEggType> { it.altDay }.thenBy { it.resetsAt })
 
         fun markAllFound() = resettingEntries.forEach { it.markClaimed() }
         fun anyEggsUnclaimed(): Boolean = resettingEntries.any { !it.claimed }


### PR DESCRIPTION
## What
Fixed Meal Order for Hoppity interleaving the alternate day eggs instead of putting them after the primary day.

## Changelog Fixes
+ Fixed incorrect order for Unclaimed Eggs when set to Meal Order. - Luna
