### PR TITLE
Feature + Remove: Queue `/ah` & `/bz` on World Change

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
@@ -84,7 +84,11 @@ class CommandsConfig {
     var transferCooldown: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Transfer Cooldown Message", desc = "Sends a message in chat when the transfer cooldown ends.")
+    @ConfigOption(
+        name = "Fix AH/BZ Cooldown",
+        desc = "Waits for world-change cooldown to complete if you try to open Bazaar or Auction House."
+    )
     @ConfigEditorBoolean
-    var transferCooldownMessage: Boolean = false
+    @FeatureToggle
+    var auctionBazaarCooldown: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/cooldown/AuctionBazaarCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/cooldown/AuctionBazaarCooldown.kt
@@ -1,0 +1,83 @@
+package at.hannibal2.skyhanni.features.commands.cooldown
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.MessageSendToServerEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import kotlin.time.Duration.Companion.seconds
+
+@SkyHanniModule
+object AuctionBazaarCooldown {
+
+    private val patternGroup = RepoPattern.group("misc.commands.auction-bazaar")
+
+    /**
+     * REGEX-TEST: /ah
+     * REGEX-TEST: /ahs test
+     * REGEX-TEST: /auction
+     * REGEX-TEST: /auctions
+     * REGEX-TEST: /ah oBlazin
+     */
+    private val auctionHouseCommands by patternGroup.pattern(
+        "auction-house",
+        "\\/(?<command>ahs?|auctions?)(?: (?<searchTerm>.*))?"
+    )
+
+    /**
+     * REGEX-TEST: /bz
+     * REGEX-TEST: /baz
+     * REGEX-TEST: /bazaar
+     * REGEX-TEST: /bz coal
+     * REGEX-TEST: /bazaar wheat
+     */
+    private val bazaarCommands by patternGroup.pattern(
+        "bazaar",
+        "\\/ba?z(?:aar)?(?: (?<product>.*))?"
+    )
+
+    private val config get() = SkyHanniMod.feature.misc.commands
+    private var lastRunCompleted: SimpleTimeMark = SimpleTimeMark.farPast()
+    private var action: (() -> Unit)? = null
+
+    @HandleEvent
+    fun onWorldChange() {
+        if (!config.auctionBazaarCooldown || lastRunCompleted.isInFuture()) return
+        lastRunCompleted = DelayedRun.runDelayed(4.seconds) {
+            action?.invoke()
+            action = null
+        }
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onCommand(event: MessageSendToServerEvent) {
+        if (!config.auctionBazaarCooldown || lastRunCompleted.isInPast()) return
+        auctionHouseCommands.matchMatcher(event.message) {
+            val searchTerm = groupOrNull("searchTerm")
+            action = when (searchTerm) {
+                null -> HypixelCommands::ah
+                else -> when (group("command")) {
+                    // AHS is the only exception to the rule of 'look up the player'
+                    "ahs" -> { -> HypixelCommands.auctionSearch(searchTerm) }
+                    else -> { -> HypixelCommands.ah(searchTerm) }
+                }
+            }
+        }
+
+        bazaarCommands.matchMatcher(event.message) {
+            val product = groupOrNull("product")
+            action = when (product) {
+                null -> HypixelCommands::bz
+                else -> { -> HypixelCommands.bazaar(product) }
+            }
+        }
+
+        if (action != null) event.cancel()
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/cooldown/TransferCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/cooldown/TransferCooldown.kt
@@ -1,19 +1,16 @@
-package at.hannibal2.skyhanni.features.commands
+package at.hannibal2.skyhanni.features.commands.cooldown
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object TransferCooldown {
-
     private val config get() = SkyHanniMod.feature.misc.commands
     private var lastRunCompleted: SimpleTimeMark = SimpleTimeMark.farPast()
     private var action: (() -> Unit)? = null
@@ -22,9 +19,6 @@ object TransferCooldown {
     fun onWorldChange() {
         if (!config.transferCooldown || lastRunCompleted.isInFuture()) return
         lastRunCompleted = DelayedRun.runDelayed(3.seconds) {
-            if (config.transferCooldownMessage && LorenzUtils.inSkyBlock) {
-                ChatUtils.chat("§aPlayer Transfer Cooldown has ended.")
-            }
             action?.invoke()
             action = null
         }
@@ -33,28 +27,16 @@ object TransferCooldown {
     @HandleEvent(onlyOnSkyblock = true)
     fun onCommand(event: MessageSendToServerEvent) {
         if (!config.transferCooldown || lastRunCompleted.isInPast()) return
-        when (event.splitMessage[0]) {
-            "/is" -> {
-                event.cancel()
-                action = { HypixelCommands.island() }
+        action = when (event.splitMessage[0]) {
+            "/is" -> HypixelCommands::island
+            "/warp" -> { ->
+                val warpDestination = event.splitMessage.subList(1, event.splitMessage.size).joinToString(" ")
+                HypixelCommands.warp(warpDestination)
             }
-
-            "/warp" -> {
-                event.cancel()
-                action = {
-                    HypixelCommands.warp(event.splitMessage.subList(1, event.splitMessage.size).joinToString(" "))
-                }
-            }
-
-            "/warpforge" -> {
-                event.cancel()
-                action = { HypixelCommands.warp("forge") }
-            }
-
-            "/hub" -> {
-                event.cancel()
-                action = { HypixelCommands.warp("hub") }
-            }
+            "/warpforge" -> { -> HypixelCommands.warp("forge") }
+            "/hub" -> { ->  HypixelCommands.warp("hub") }
+            else -> null
         }
+        if (action != null) event.cancel()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -10,8 +10,19 @@ object HypixelCommands {
         send("skyblock")
     }
 
+    fun bz() {
+        send("bz")
+    }
+
     fun bazaar(searchTerm: String) {
         send("bz $searchTerm")
+    }
+
+    fun ah(player: String? = null) {
+        when (player) {
+            null -> send("ah")
+            else -> send("ah $player")
+        }
     }
 
     fun auctionSearch(searchTerm: String) {


### PR DESCRIPTION
## What
Similar to transfer cooldown, will queue the usage of `/ah` and `/bz` (as well as their varying alternative commands) when joining a new world. Refactored the TransferCooldown object a bunch.

Removed the option to "get a warning in chat when transfer cooldown was over". It only ran when the queuing was enabled, and since it's queuing a world transfer event, I think that'd be indication enough 🥺

## Changelog New Features
+ Added option to queue Auction House and Bazaar commands when joining a new world. - Daveed
    * This will also work for "ahs", "ah [player]", and searching for specific products with bazaar commands.

## Changelog Removed Features
+ Removed option to get a chat message when your queued world transfer was taking place. - Daveed

