### PR TITLE
Fix: Discord Rich Presence crashing on startup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,12 +165,7 @@ dependencies {
     }
 
     // Discord RPC client
-    shadowImpl("com.github.CDAGaming:DiscordIPC:4b62ba3") {
-        exclude(module = "log4j")
-        because("Different version conflicts with Minecraft's Log4J")
-        exclude(module = "gson")
-        because("Different version conflicts with Minecraft's Log4j")
-    }
+    shadowImpl("com.github.caoimhebyrne:KDiscordIPC:0.2.3")
     compileOnly(libs.jbAnnotations)
 
     headlessLwjgl(libs.headlessLwjgl)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,7 +165,7 @@ dependencies {
     }
 
     // Discord RPC client
-    shadowImpl("com.jagrosh:DiscordIPC:0.5.3") {
+    shadowImpl("com.github.CDAGaming:DiscordIPC:4b62ba3") {
         exclude(module = "log4j")
         because("Different version conflicts with Minecraft's Log4J")
         exclude(module = "gson")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -62,7 +62,7 @@ object DiscordRPCManager {
                 updateDebugStatus("Starting...")
                 startTimestamp = System.currentTimeMillis()
                 client = KDiscordIPC(APPLICATION_ID.toString())
-                client?.setup(fromCommand)
+                setup(fromCommand)
             } catch (e: Throwable) {
                 updateDebugStatus("Unexpected error: ${e.message}", error = true)
                 ErrorManager.logErrorWithData(e, "Discord RPC has thrown an unexpected error while trying to start")
@@ -81,10 +81,8 @@ object DiscordRPCManager {
         }
     }
 
-    private suspend fun KDiscordIPC.setup(fromCommand: Boolean) {
-
+    private suspend fun setup(fromCommand: Boolean) {
         try {
-
             client?.on<ReadyEvent> { onReady() }
             client?.on<DisconnectedEvent> { onIPCDisconnect() }
             client?.on<ErrorEvent> { onError(data) }
@@ -112,8 +110,8 @@ object DiscordRPCManager {
 
     private fun isConnected() = client?.connected == true
 
-    @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    @HandleEvent(ConfigLoadEvent::class)
+    fun onConfigLoad() {
         ConditionalUtils.onToggle(config.firstLine, config.secondLine, config.customText) {
             if (isConnected()) {
                 coroutineScope.launch {
@@ -167,13 +165,13 @@ object DiscordRPCManager {
                     largeImage = discordIconKey,
                     largeText = location
                 ),
-                buttons = if (!buttons.isEmpty()) buttons else null
+                buttons = buttons.ifEmpty { null }
             )
         )
     }
 
 
-    fun onReady() {
+    private fun onReady() {
         updateDebugStatus("Discord RPC Ready.")
     }
 
@@ -187,12 +185,12 @@ object DiscordRPCManager {
         }
     }
 
-    fun onIPCDisconnect() {
+    private fun onIPCDisconnect() {
         updateDebugStatus("Discord RPC disconnected.")
         this.client = null
     }
 
-    fun onError(data: ErrorEventData) {
+    private fun onError(data: ErrorEventData) {
         updateDebugStatus("Discord RPC Errored. Error code ${data.code}: ${data.message}", true)
     }
 
@@ -224,8 +222,8 @@ object DiscordRPCManager {
         }
     }
 
-    @HandleEvent
-    fun onDisconnect(event: ClientDisconnectEvent) {
+    @HandleEvent(ClientDisconnectEvent::class)
+    fun onDisconnect() {
         stop()
     }
 
@@ -276,8 +274,8 @@ object DiscordRPCManager {
     }
 
     // Events that change things in DiscordStatus
-    @HandleEvent
-    fun onKeyPress(event: KeyPressEvent) {
+    @HandleEvent(KeyPressEvent::class)
+    fun onKeyPress() {
         if (!isEnabled() || !PriorityEntry.AFK.isSelected()) return // autoPriority 4 is dynamic afk
         beenAfkFor = SimpleTimeMark.now()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -25,14 +25,20 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
-import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
 import com.jagrosh.discordipc.IPCClient
 import com.jagrosh.discordipc.IPCListener
+import com.jagrosh.discordipc.entities.ActivityType
+import com.jagrosh.discordipc.entities.Packet
 import com.jagrosh.discordipc.entities.RichPresence
-import com.jagrosh.discordipc.entities.RichPresenceButton
+import com.jagrosh.discordipc.entities.User
 import com.jagrosh.discordipc.entities.pipe.PipeStatus
+import com.jagrosh.discordipc.exceptions.NoDiscordClientException
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
 
@@ -90,8 +96,7 @@ object DiscordRPCManager : IPCListener {
             // confirm that /shrpcstart worked
             ChatUtils.chat("Successfully started Rich Presence!", prefixColor = "§a")
             updateDebugStatus("Successfully started")
-            status
-        } catch (e: Exception) {
+        } catch (e: NoDiscordClientException) {
             updateDebugStatus("Failed to connect: ${e.message} (discord not started yet?)", error = true)
             ChatUtils.clickableChat(
                 "Discord Rich Presence was unable to start! " +
@@ -99,6 +104,14 @@ object DiscordRPCManager : IPCListener {
                     "Please run /shrpcstart to retry once you have launched Discord.",
                 onClick = { startCommand() },
                 "§eClick to run /shrpcstart!",
+            )
+        } catch (e: Exception) {
+            updateDebugStatus("Failed to connect, not from NoDiscordClientException: ${e.message}", error = true)
+            ErrorManager.logErrorWithData(
+                e,
+                "Discord Rich Presence was unable to start! " +
+                    "This was probably NOT due to something you did. " +
+                    "Please report this and ping NetheriteMiner.",
             )
         }
     }
@@ -127,33 +140,50 @@ object DiscordRPCManager : IPCListener {
     private fun updatePresence() {
         val location = DiscordStatus.LOCATION.getDisplayString()
         val discordIconKey = DiscordLocationKey.getDiscordIconKey(location)
+        val buttons = JsonArray()
+        if (config.showEliteBotButton.get()) {
+            val eliteBotEntry = JsonObject()
+            eliteBotEntry.add(
+                "Open EliteBot",
+                JsonPrimitive("https://elitebot.dev/@${PlayerUtils.getName()}/${HypixelData.profileName}"),
+            )
+            buttons.add(eliteBotEntry)
+        }
+
+        if (config.showSkyCryptButton.get()) {
+            val skyCryptEntry = JsonObject()
+            skyCryptEntry.add(
+                "Open SkyCrypt",
+                JsonPrimitive("https://sky.shiiyu.moe/stats/${PlayerUtils.getName()}/${HypixelData.profileName}"),
+            )
+            buttons.add(skyCryptEntry)
+        }
         client?.sendRichPresence(
             RichPresence.Builder().apply {
+                setActivityType(ActivityType.Playing)
                 setDetails(getStatusByConfigId(config.firstLine.get()).getDisplayString())
                 setState(getStatusByConfigId(config.secondLine.get()).getDisplayString())
                 setStartTimestamp(startTimestamp)
                 setLargeImage(discordIconKey, location)
-
-                if (config.showEliteBotButton.get()) {
-                    addButton(
-                        RichPresenceButton(
-                            "https://elitebot.dev/@${LorenzUtils.getPlayerName()}/${HypixelData.profileName}",
-                            "Open EliteBot",
-                        ),
-                    )
-                }
-
-                if (config.showSkyCryptButton.get()) {
-                    addButton(
-                        RichPresenceButton(
-                            "https://sky.shiiyu.moe/stats/${LorenzUtils.getPlayerName()}/${HypixelData.profileName}",
-                            "Open SkyCrypt",
-                        ),
-                    )
-                }
+                setButtons(buttons)
             }.build(),
         )
     }
+
+    // Required override methods from being an IPCListener
+    override fun onPacketSent(p0: IPCClient?, p1: Packet?) = Unit
+
+    override fun onPacketReceived(p0: IPCClient?, p1: Packet?) = Unit
+
+    override fun onActivityJoin(p0: IPCClient?, p1: String?) = Unit
+
+    override fun onActivitySpectate(p0: IPCClient?, p1: String?) = Unit
+
+    override fun onActivityJoinRequest(
+        p0: IPCClient?,
+        p1: String?,
+        p2: User?,
+    ) = Unit
 
     override fun onReady(client: IPCClient) {
         updateDebugStatus("Discord RPC Ready.")
@@ -188,7 +218,7 @@ object DiscordRPCManager : IPCListener {
         // The mod has already started the connection process. This variable is my way of running a function when
         // the player joins SkyBlock but only running it again once they join and leave.
         if (started || !isEnabled()) return
-        if (LorenzUtils.inSkyBlock) {
+        if (SkyBlockUtils.inSkyBlock) {
             start()
             started = true
         }
@@ -199,7 +229,7 @@ object DiscordRPCManager : IPCListener {
         if (nextUpdate.isInFuture()) return
         // wait 5 seconds to check if the new world is skyblock or not before stopping the function
         nextUpdate = DelayedRun.runDelayed(5.seconds) {
-            if (!LorenzUtils.inSkyBlock) {
+            if (!SkyBlockUtils.inSkyBlock) {
                 stop()
             }
         }
@@ -241,7 +271,7 @@ object DiscordRPCManager : IPCListener {
 
     @HandleEvent
     fun onDebug(event: DebugDataCollectEvent) {
-        event.title("Discord RCP")
+        event.title("Discord RPC")
 
         if (debugError) {
             event.addData {
@@ -290,5 +320,11 @@ object DiscordRPCManager : IPCListener {
             category = CommandCategory.USERS_ACTIVE
             callback { startCommand() }
         }
+//         Debug command
+//         event.register("shrpcstop") {
+//             description = "Manually stops the Discord Rich Presence feature"
+//             category = CommandCategory.DEVELOPER_DEBUG
+//             callback { stop() }
+//         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -28,28 +28,23 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
-import com.google.gson.JsonPrimitive
-import com.jagrosh.discordipc.IPCClient
-import com.jagrosh.discordipc.IPCListener
-import com.jagrosh.discordipc.entities.ActivityType
-import com.jagrosh.discordipc.entities.Packet
-import com.jagrosh.discordipc.entities.RichPresence
-import com.jagrosh.discordipc.entities.User
-import com.jagrosh.discordipc.entities.pipe.PipeStatus
-import com.jagrosh.discordipc.exceptions.NoDiscordClientException
+import dev.cbyrne.kdiscordipc.KDiscordIPC
+import dev.cbyrne.kdiscordipc.core.event.data.ErrorEventData
+import dev.cbyrne.kdiscordipc.core.event.impl.DisconnectedEvent
+import dev.cbyrne.kdiscordipc.core.event.impl.ErrorEvent
+import dev.cbyrne.kdiscordipc.core.event.impl.ReadyEvent
+import dev.cbyrne.kdiscordipc.data.activity.Activity
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
-object DiscordRPCManager : IPCListener {
+object DiscordRPCManager {
 
     private const val APPLICATION_ID = 1093298182735282176L
 
     val config get() = feature.gui.discordRPC
 
-    private var client: IPCClient? = null
+    private var client: KDiscordIPC? = null
     private var startTimestamp: Long = 0
     private var started = false
     private var nextUpdate: SimpleTimeMark = SimpleTimeMark.farPast()
@@ -66,7 +61,7 @@ object DiscordRPCManager : IPCListener {
 
                 updateDebugStatus("Starting...")
                 startTimestamp = System.currentTimeMillis()
-                client = IPCClient(APPLICATION_ID)
+                client = KDiscordIPC(APPLICATION_ID.toString())
                 client?.setup(fromCommand)
             } catch (e: Throwable) {
                 updateDebugStatus("Unexpected error: ${e.message}", error = true)
@@ -80,49 +75,50 @@ object DiscordRPCManager : IPCListener {
         coroutineScope.launch {
             if (isConnected()) {
                 updateDebugStatus("Stopped")
-                client?.close()
+                client?.disconnect()
                 started = false
             }
         }
     }
 
-    private fun IPCClient.setup(fromCommand: Boolean) {
-        setListener(DiscordRPCManager)
+    private suspend fun KDiscordIPC.setup(fromCommand: Boolean) {
 
         try {
-            connect()
+
+            client?.on<ReadyEvent> { onReady() }
+            client?.on<DisconnectedEvent> { onIPCDisconnect() }
+            client?.on<ErrorEvent> { onError(data) }
+            client?.connect()
+            updateDebugStatus("Successfully started")
             if (!fromCommand) return
 
             // confirm that /shrpcstart worked
             ChatUtils.chat("Successfully started Rich Presence!", prefixColor = "§a")
-            updateDebugStatus("Successfully started")
-        } catch (e: NoDiscordClientException) {
-            updateDebugStatus("Failed to connect: ${e.message} (discord not started yet?)", error = true)
-            ChatUtils.clickableChat(
-                "Discord Rich Presence was unable to start! " +
-                    "This usually happens when you join SkyBlock when Discord is not started. " +
-                    "Please run /shrpcstart to retry once you have launched Discord.",
-                onClick = { startCommand() },
-                "§eClick to run /shrpcstart!",
-            )
         } catch (e: Exception) {
-            updateDebugStatus("Failed to connect, not from NoDiscordClientException: ${e.message}", error = true)
+            updateDebugStatus("Failed to connect: ${e.message}", error = true)
             ErrorManager.logErrorWithData(
                 e,
                 "Discord Rich Presence was unable to start! " +
                     "This was probably NOT due to something you did. " +
                     "Please report this and ping NetheriteMiner.",
             )
+            ChatUtils.clickableChat(
+                "Click here to retry.",
+                onClick = { startCommand() },
+                "§eClick to run /shrpcstart!",
+            )
         }
     }
 
-    private fun isConnected() = client?.status == PipeStatus.CONNECTED
+    private fun isConnected() = client?.connected == true
 
     @HandleEvent
     fun onConfigLoad(event: ConfigLoadEvent) {
         ConditionalUtils.onToggle(config.firstLine, config.secondLine, config.customText) {
             if (isConnected()) {
-                updatePresence()
+                coroutineScope.launch {
+                    updatePresence()
+                }
             }
         }
         config.enabled.whenChanged { _, new ->
@@ -137,55 +133,47 @@ object DiscordRPCManager : IPCListener {
         stackingEnchants = event.getConstant<StackingEnchantsJson>("StackingEnchants").enchants
     }
 
-    private fun updatePresence() {
+    private suspend fun updatePresence() {
         val location = DiscordStatus.LOCATION.getDisplayString()
         val discordIconKey = DiscordLocationKey.getDiscordIconKey(location)
-        val buttons = JsonArray()
+        val buttons = mutableListOf<Activity.Button>()
         if (config.showEliteBotButton.get()) {
-            val eliteBotEntry = JsonObject()
-            eliteBotEntry.add(
-                "Open EliteBot",
-                JsonPrimitive("https://elitebot.dev/@${PlayerUtils.getName()}/${HypixelData.profileName}"),
+            buttons.add(
+                Activity.Button(
+                    label = "Open EliteBot",
+                    url = "https://elitebot.dev/@${PlayerUtils.getName()}/${HypixelData.profileName}"
+                )
             )
-            buttons.add(eliteBotEntry)
         }
 
         if (config.showSkyCryptButton.get()) {
-            val skyCryptEntry = JsonObject()
-            skyCryptEntry.add(
-                "Open SkyCrypt",
-                JsonPrimitive("https://sky.shiiyu.moe/stats/${PlayerUtils.getName()}/${HypixelData.profileName}"),
+            buttons.add(
+                Activity.Button(
+                    label = "Open SkyCrypt",
+                    url = "https://sky.shiiyu.moe/stats/${PlayerUtils.getName()}/${HypixelData.profileName}"
+                )
             )
-            buttons.add(skyCryptEntry)
         }
-        client?.sendRichPresence(
-            RichPresence.Builder().apply {
-                setActivityType(ActivityType.Playing)
-                setDetails(getStatusByConfigId(config.firstLine.get()).getDisplayString())
-                setState(getStatusByConfigId(config.secondLine.get()).getDisplayString())
-                setStartTimestamp(startTimestamp)
-                setLargeImage(discordIconKey, location)
-                setButtons(buttons)
-            }.build(),
+
+        client?.activityManager?.setActivity(
+            Activity(
+                details = getStatusByConfigId(config.firstLine.get()).getDisplayString(),
+                state = getStatusByConfigId(config.secondLine.get()).getDisplayString(),
+                timestamps = Activity.Timestamps(
+                    start = startTimestamp,
+                    end = null
+                ),
+                assets = Activity.Assets(
+                    largeImage = discordIconKey,
+                    largeText = location
+                ),
+                buttons = if (!buttons.isEmpty()) buttons else null
+            )
         )
     }
 
-    // Required override methods from being an IPCListener
-    override fun onPacketSent(p0: IPCClient?, p1: Packet?) = Unit
 
-    override fun onPacketReceived(p0: IPCClient?, p1: Packet?) = Unit
-
-    override fun onActivityJoin(p0: IPCClient?, p1: String?) = Unit
-
-    override fun onActivitySpectate(p0: IPCClient?, p1: String?) = Unit
-
-    override fun onActivityJoinRequest(
-        p0: IPCClient?,
-        p1: String?,
-        p2: User?,
-    ) = Unit
-
-    override fun onReady(client: IPCClient) {
+    fun onReady() {
         updateDebugStatus("Discord RPC Ready.")
     }
 
@@ -193,18 +181,19 @@ object DiscordRPCManager : IPCListener {
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!isConnected()) return
         if (event.repeatSeconds(5)) {
-            updatePresence()
+            coroutineScope.launch {
+                updatePresence()
+            }
         }
     }
 
-    override fun onClose(client: IPCClient, json: JsonObject?) {
-        updateDebugStatus("Discord RPC closed.")
+    fun onIPCDisconnect() {
+        updateDebugStatus("Discord RPC disconnected.")
         this.client = null
     }
 
-    override fun onDisconnect(client: IPCClient?, t: Throwable?) {
-        updateDebugStatus("Discord RPC disconnected.")
-        this.client = null
+    fun onError(data: ErrorEventData) {
+        updateDebugStatus("Discord RPC Errored. Error code ${data.code}: ${data.message}", true)
     }
 
     private fun getStatusByConfigId(entry: LineEntry): DiscordStatus {
@@ -320,11 +309,5 @@ object DiscordRPCManager : IPCListener {
             category = CommandCategory.USERS_ACTIVE
             callback { startCommand() }
         }
-//         Debug command
-//         event.register("shrpcstop") {
-//             description = "Manually stops the Discord Rich Presence feature"
-//             category = CommandCategory.DEVELOPER_DEBUG
-//             callback { stop() }
-//         }
     }
 }


### PR DESCRIPTION
## What
This PR cleans up Discord RPC. Notably, it fixes a problem where users would receive an error when the feature crashes, this has been changed to be a different error message that no longer prompts them to retry (as it likely won't help). 

Previously, SkyHanni depended on com.jagrosh:DiscordIPC, which seemed to be from ThatGravyBoat, however, this version was outdated and could not be updated since it was forked from an SBA repository which is probably no longer maintained. I changed it to CDAGaming's github, a version that is still getting updates. This involved changing some of the methods in the code to match that version of DiscordIPC.

I also changed some of the deprecated methods because Intellij told me to.

**The problem**: I am still getting an error NoDiscordClientException (as evidenced by the error message) when launching Discord RPC in a regular Minecraft session after building the project and placing the jar in my mod folder, however I do not get this error in my development environment. I assume I am experiencing this because I am using linux, and I hope that windows users do not have this problem.

I need a contributor that uses windows to test this jar and determine if the error is still there. The ideal scenario is that either you test an existing version, see that it does not work, then test this version and it works without problems, or it works fine with both versions.

## Changelog Fixes
+ Fixed Discord Rich Presence crashing on startup. - NetheriteMiner