### PR TITLE
Fix: issues with other mods setting middle click

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(GuiContainer.class)
+@Mixin(value = GuiContainer.class, priority = 499)
 public abstract class MixinGuiContainer extends GuiScreen {
 
     @Unique
@@ -65,8 +65,9 @@ public abstract class MixinGuiContainer extends GuiScreen {
         skyHanni$hook.onDrawSlotPost(slot);
     }
 
-    @Inject(method = "handleMouseClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/PlayerControllerMP;windowClick(IIIILnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;"), cancellable = true)
+    @Inject(method = "handleMouseClick", at = @At(value = "HEAD"), cancellable = true)
     private void onMouseClick(Slot slot, int slotId, int clickedButton, int clickType, CallbackInfo ci) {
+        if (slot == null) return;
         skyHanni$hook.onMouseClick(slot, slotId, clickedButton, clickType, ci);
     }
 


### PR DESCRIPTION
## What
Fixes other mods changing clicks to be middle clicks breaking our slot click event (didnt test with skytils)
if someone (hannibal) wants to edit the changelog to mention an actual feature it fixes that would be nice
replaces [3872](https://github.com/hannibal002/SkyHanni/pull/3872)

## Changelog Fixes
+ Fixed conflicts with other mods blocking inventory-click detection. - nopo
    * Notably `Cancelled Buy Order Clipboard` with Enchanted Books, and `Visitor Accept` clicks when Skytils’ `Middle Click GUI Items` is enabled.
