### PR TITLE
Backend: Ignore File Annotations in Detekt

### DIFF
--- a/detekt/src/main/kotlin/formatting/CustomAnnotationSpacing.kt
+++ b/detekt/src/main/kotlin/formatting/CustomAnnotationSpacing.kt
@@ -35,7 +35,7 @@ class CustomAnnotationSpacing(config: Config) : SkyHanniRule(config) {
                 is PsiComment -> nextNode.isInvalid()
                 else -> false
             }
-        }
+        } && !annotationEntry.text.contains("file:")
 
         if (hasInvalidSpacing) {
             annotationEntry.reportIssue("Annotations should occur immediately before the annotated construct.")


### PR DESCRIPTION
## What
Prevents file annotations from being incorrectly flagged as 'misplaced' when they're at the top of a file.

## Changelog Technical Details
+ Fixed detekt false-flagging file-wide suppressions. - Daveed
