### PR TITLE
Improvement: Hide Far Entities ignore useful mobs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/HideFarEntitiesConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/HideFarEntitiesConfig.java
@@ -8,7 +8,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
 
 public class HideFarEntitiesConfig {
     @Expose
-    @ConfigOption(name = "Enabled", desc = "Hide all entities from rendering except the nearest ones.")
+    @ConfigOption(name = "Enabled", desc = "Hide all unnecessary entities from rendering except the nearest ones.")
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean enabled = false;
@@ -22,14 +22,4 @@ public class HideFarEntitiesConfig {
     @ConfigOption(name = "Max Amount", desc = "Not showing more than this amount of nearest entities.")
     @ConfigEditorSlider(minValue = 1, maxValue = 150, minStep = 1)
     public int maxAmount = 30;
-
-    @Expose
-    @ConfigOption(name = "Exclude Garden", desc = "Disable this feature while in the Garden.")
-    @ConfigEditorBoolean
-    public boolean excludeGarden = false;
-
-    @Expose
-    @ConfigOption(name = "Exclude Dungeon", desc = "Disable this feature while in Dungeon.")
-    @ConfigEditorBoolean
-    public boolean excludeDungeon = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -106,6 +106,8 @@ object DamageIndicatorManager {
             }
     }
 
+    fun getAllMobs(): Collection<EntityLivingBase> = data.values.map { it.entity }
+
     fun getNearestDistanceTo(location: LorenzVec): Double {
         return data.values
             .map { it.entity.getLorenzVec() }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AreaMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/AreaMiniBossFeatures.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.combat.mobs
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SlayerApi
+import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -21,6 +22,7 @@ object AreaMiniBossFeatures {
     private var lastSpawnTime = SimpleTimeMark.farPast()
     private var miniBossType: AreaMiniBossType? = null
     private var respawnCooldown = 11.seconds
+    val currentMobs = mutableSetOf<Mob>()
 
     @HandleEvent
     fun onMobSpawn(event: MobEvent.Spawn.SkyblockMob) {
@@ -35,6 +37,12 @@ object AreaMiniBossFeatures {
         if (config.areaBossHighlight) {
             event.mob.highlight(type.color.addOpacity(type.colorOpacity))
         }
+        currentMobs.add(event.mob)
+    }
+
+    @HandleEvent
+    fun onMobDespawn(event: MobEvent.DeSpawn.SkyblockMob) {
+        currentMobs.remove(event.mob)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
@@ -29,6 +29,7 @@ object DungeonMobManager {
     private val fel get() = config.fel
 
     private val staredInvisible = mutableSetOf<Mob>()
+    val starredVisibleMobs = mutableSetOf<Mob>()
     private val felOnTheGround = mutableSetOf<Mob>()
     private val felMoving = mutableSetOf<Mob>()
 
@@ -62,6 +63,7 @@ object DungeonMobManager {
             staredInvisible.remove(event.mob)
         }
         handleFelDespawn(event.mob)
+        starredVisibleMobs.remove(event.mob)
     }
 
     @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
@@ -147,6 +149,7 @@ object DungeonMobManager {
             return
         }
         mob.highlight(colour)
+        starredVisibleMobs.add(mob)
     }
 
     private fun handleFel(mob: Mob) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -65,6 +65,7 @@ object HideFarEntities {
     private fun updateNeverHide() {
         val list = mutableSetOf<Entity>()
         val allEntities = EntityUtils.getAllEntities()
+
         if (DungeonApi.inDungeon()) {
             list += allEntities.filter { it is EntityWither || it is EntityDragon }
             list += DungeonMobManager.starredVisibleMobs.map { it.baseEntity }
@@ -83,10 +84,10 @@ object HideFarEntities {
             list += allEntities.filter { it is EntityGhast || it is EntityGolem }
         }
 
-        for (member in PartyApi.partyMembers) {
-            list += allEntities.filter { it is EntityOtherPlayerMP || it.name in PartyApi.partyMembers }
-        }
+        // Always show boss bar
+        list += allEntities.filter { it is EntityWither && it.entityId < 0 }
 
+        list += allEntities.filter { it is EntityOtherPlayerMP || it.name in PartyApi.partyMembers }
         list += DamageIndicatorManager.getAllMobs()
         list += AreaMiniBossFeatures.currentMobs.map { it.baseEntity }
 
@@ -97,8 +98,6 @@ object HideFarEntities {
     fun onCheckRender(event: CheckRenderEntityEvent<Entity>) {
         if (!isEnabled()) return
         val entity = event.entity
-        // Always show boss bar
-        if (entity is EntityWither && entity.entityId < 0) return
         if (entity.entityId in ignored) {
             event.cancel()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -90,7 +90,7 @@ object HideFarEntities {
         // Always show boss bar
         list += allEntities.filter { it is EntityWither && it.entityId < 0 }
 
-        list += allEntities.filter { it is EntityOtherPlayerMP || it.name in PartyApi.partyMembers }
+        list += allEntities.filter { it is EntityOtherPlayerMP && it.name in PartyApi.partyMembers }
         list += DamageIndicatorManager.getAllMobs()
         list += AreaMiniBossFeatures.currentMobs.map { it.baseEntity }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -53,6 +53,7 @@ object HideFarEntities {
      * golden/diamond golbins (mining islands)
      * beach ball (great and normal, from year of the seal)
      * worms/scatha in dwarven mines
+     * dungeon wither+blood key
      *
      * add to damage indicator:
      * jerries (from jerry mayor event)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -2,34 +2,90 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
+import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
+import at.hannibal2.skyhanni.features.combat.mobs.AreaMiniBossFeatures
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
-import at.hannibal2.skyhanni.features.garden.GardenApi
+import at.hannibal2.skyhanni.features.dungeon.DungeonMobManager
+import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
-import at.hannibal2.skyhanni.utils.LorenzUtils
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.entity.Entity
+import net.minecraft.entity.boss.EntityDragon
 import net.minecraft.entity.boss.EntityWither
+import net.minecraft.entity.monster.EntityGhast
+import net.minecraft.entity.monster.EntityGolem
+import net.minecraft.entity.monster.EntityMagmaCube
 
 @SkyHanniModule
 object HideFarEntities {
     private val config get() = SkyHanniMod.feature.misc.hideFarEntities
 
     private var ignored = emptySet<Int>()
+    private var neverHide = emptySet<Int>()
 
     @HandleEvent
-    fun onTick() {
+    fun onTick(event: SkyHanniTickEvent) {
         if (!isEnabled()) return
+        if (event.isMod(20)) {
+            updateNeverHide()
+        }
 
         val maxAmount = config.maxAmount.coerceAtLeast(1)
         val minDistance = config.minDistance.coerceAtLeast(3)
 
         ignored = EntityUtils.getAllEntities()
             .map { it.entityId to it.distanceToPlayer() }
-            .filter { it.second > minDistance }
+            .filter { it.second > minDistance && it.first !in neverHide }
             .sortedBy { it.second }.drop(maxAmount)
             .map { it.first }.toSet()
+    }
+
+    /**
+     * TODO mobs to add to never hide list
+     * golden/diamond golbins (mining islands)
+     * beach ball (great and normal, from year of the seal)
+     * worms/scatha in dwarven mines
+     *
+     * add to damage indicator:
+     * jerries (from jerry mayor event)
+     * primal fear (great spook event) - add to damage indicator
+     * special zealots in the end
+     * kuudra boss
+     * dungeon mini bosses: sa, frozen adventurer
+     * 1b hp mob in dungeon
+     */
+    private fun updateNeverHide() {
+        val list = mutableSetOf<Entity>()
+        val allEntities = EntityUtils.getAllEntities()
+        if (DungeonApi.inDungeon()) {
+            list += allEntities.filter { it is EntityWither || it is EntityDragon }
+            list += DungeonMobManager.starredVisibleMobs.map { it.baseEntity }
+            // other party members
+            list += allEntities.filter { it is EntityOtherPlayerMP && !it.isNpc() }
+        }
+        if (KuudraApi.inKuudra) {
+            // other party members
+            list += allEntities.filter { it is EntityOtherPlayerMP && !it.isNpc() }
+        }
+        if (IslandType.WINTER.isCurrent()) {
+            list += allEntities.filter { it is EntityMagmaCube }
+        }
+        if (IslandType.DWARVEN_MINES.isCurrent()) {
+            // powder ghast & golem defender (from goblin raid event)
+            list += allEntities.filter { it is EntityGhast || it is EntityGolem }
+        }
+
+        list += DamageIndicatorManager.getAllMobs()
+        list += AreaMiniBossFeatures.currentMobs.map { it.baseEntity }
+
+        neverHide = list.map { it.entityId }.toSet()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -43,7 +99,5 @@ object HideFarEntities {
         }
     }
 
-    fun isEnabled() = LorenzUtils.inSkyBlock && config.enabled &&
-        (!(GardenApi.inGarden() && config.excludeGarden) && !(DungeonApi.inDungeon() && config.excludeDungeon))
-
+    fun isEnabled() = SkyBlockUtils.inSkyBlock && config.enabled
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -67,12 +67,14 @@ object HideFarEntities {
         val allEntities = EntityUtils.getAllEntities()
 
         if (DungeonApi.inDungeon()) {
+            list += allEntities.filter { it.name == "Mort" }
             list += allEntities.filter { it is EntityWither || it is EntityDragon }
             list += DungeonMobManager.starredVisibleMobs.map { it.baseEntity }
             // other party members
             list += allEntities.filter { it is EntityOtherPlayerMP && !it.isNpc() }
         }
         if (KuudraApi.inKuudra) {
+            list += allEntities.filter { it.name == "Elle" }
             // other party members
             list += allEntities.filter { it is EntityOtherPlayerMP && !it.isNpc() }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
+import at.hannibal2.skyhanni.utils.MobUtils.mob
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.entity.Entity
@@ -68,14 +69,14 @@ object HideFarEntities {
         val allEntities = EntityUtils.getAllEntities()
 
         if (DungeonApi.inDungeon()) {
-            list += allEntities.filter { it.name == "Mort" }
+            list += allEntities.filter { it.mob?.name == "Mort" }
             list += allEntities.filter { it is EntityWither || it is EntityDragon }
             list += DungeonMobManager.starredVisibleMobs.map { it.baseEntity }
             // other party members
             list += allEntities.filter { it is EntityOtherPlayerMP && !it.isNpc() }
         }
         if (KuudraApi.inKuudra) {
-            list += allEntities.filter { it.name == "Elle" }
+            list += allEntities.filter { it.mob?.name == "Elle" }
             // other party members
             list += allEntities.filter { it is EntityOtherPlayerMP && !it.isNpc() }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.PartyApi
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
@@ -80,6 +81,10 @@ object HideFarEntities {
         if (IslandType.DWARVEN_MINES.isCurrent()) {
             // powder ghast & golem defender (from goblin raid event)
             list += allEntities.filter { it is EntityGhast || it is EntityGolem }
+        }
+
+        for (member in PartyApi.partyMembers) {
+            list += allEntities.filter { it is EntityOtherPlayerMP || it.name in PartyApi.partyMembers }
         }
 
         list += DamageIndicatorManager.getAllMobs()


### PR DESCRIPTION
## What
Using existing APIs to filter important mobs out of hide far entities.

## Changelog Improvements
+ Changed Hide Far Entities to always show important mobs. - hannibal2
    * Slayer Bosses, Mini Bosses, Dungeon Bosses, Party Members, Dragons, Pests, and similar mobs are always visible.
    * Manual toggles to fully disable this feature in Garden and Dungeon got removed.