### PR TITLE
Fix: Fishing Tracker's Times Fished

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/fishing/FishingCatchEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/fishing/FishingCatchEvent.kt
@@ -1,0 +1,5 @@
+package at.hannibal2.skyhanni.events.fishing
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+object FishingCatchEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -1,12 +1,16 @@
 package at.hannibal2.skyhanni.features.fishing
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ItemsJson
 import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
+import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.WorldClickEvent
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
 import at.hannibal2.skyhanni.events.fishing.FishingBobberInLiquidEvent
+import at.hannibal2.skyhanni.events.fishing.FishingCatchEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.fishing.trophy.TrophyFishManager
@@ -31,6 +35,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.projectile.EntityFishHook
 import net.minecraft.item.ItemStack
+import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object FishingApi {
@@ -58,6 +63,10 @@ object FishingApi {
     private val waterBlocks = buildList { addWaters() }
 
     var lastCastTime = SimpleTimeMark.farPast()
+        private set
+    var lastReelTime = SimpleTimeMark.farPast()
+        private set
+    var lastCatchSound = SimpleTimeMark.farPast()
         private set
     var holdingRod = false
         private set
@@ -109,6 +118,7 @@ object FishingApi {
 
         val bobber = bobber ?: return
         if (bobber.isDead) {
+            if (lastReelTime.passedSince() < .5.seconds && lastCatchSound.passedSince() < .5.seconds) FishingCatchEvent.post()
             resetBobber()
         } else {
             if (!bobberHasTouchedLiquid) {
@@ -122,6 +132,19 @@ object FishingApi {
                 FishingBobberInLiquidEvent(bobber, isWater).post()
             }
         }
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onPlaySound(event: PlaySoundEvent) {
+        if (!holdingRod) return
+        if (event.soundName == "random.orb" && event.volume == .5F) lastCatchSound = SimpleTimeMark.now()
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onClick(event: WorldClickEvent) {
+        if (event.clickType != ClickType.RIGHT_CLICK || !holdingRod || !bobberHasTouchedLiquid) return
+        if (lastReelTime.passedSince() < .3.seconds) return
+        lastReelTime = SimpleTimeMark.now()
     }
 
     fun ItemStack.isFishingRod() = getInternalName().isFishingRod()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -37,6 +37,7 @@ import net.minecraft.entity.projectile.EntityFishHook
 import net.minecraft.item.ItemStack
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("MemberVisibilityCanBePrivate")
 @SkyHanniModule
 object FishingApi {
     enum class RodPart {
@@ -118,20 +119,20 @@ object FishingApi {
 
         val bobber = bobber ?: return
         if (bobber.isDead) {
-            if (lastReelTime.passedSince() < .5.seconds && lastCatchSound.passedSince() < .5.seconds) FishingCatchEvent.post()
+            if (lastReelTime.passedSince() < 0.5.seconds && lastCatchSound.passedSince() < 0.5.seconds) FishingCatchEvent.post()
             resetBobber()
-        } else {
-            if (!bobberHasTouchedLiquid) {
-                val isWater = when {
-                    bobber.isInLava && holdingLavaRod -> false
-                    bobber.isInWater && holdingWaterRod -> true
-                    else -> return
-                }
-
-                bobberHasTouchedLiquid = true
-                FishingBobberInLiquidEvent(bobber, isWater).post()
-            }
+            return
         }
+
+        if (bobberHasTouchedLiquid) return
+        val isWater = when {
+            bobber.isInLava && holdingLavaRod -> false
+            bobber.isInWater && holdingWaterRod -> true
+            else -> return
+        }
+
+        bobberHasTouchedLiquid = true
+        FishingBobberInLiquidEvent(bobber, isWater).post()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -195,28 +196,34 @@ object FishingApi {
         (IsFishingDetection.isFishing || (checkRodInHand && holdingRod)) && !DungeonApi.inDungeon()
 
     fun seaCreatureCount(entity: EntityArmorStand): Int {
+        if (countIsZero(entity)) return 0
+
+        return when (entity.name) {
+            "Sea Emperor", "Rider of the Deep" -> 2
+
+            else -> 1
+        }
+    }
+
+    private val frostyNpcLocation = LorenzVec(-1.5, 76.0, 92.5)
+
+    private fun countIsZero(entity: EntityArmorStand): Boolean {
         val name = entity.name
         // a dragon, will always be fought
-        if (name == "Reindrake") return 0
+        if (name == "Reindrake") return true
 
         // a npc shop
-        if (name == "§5Frosty the Snow Blaster") return 0
+        if (name == "§5Frosty the Snow Blaster") return true
 
         if (name == "Frosty") {
-            val npcLocation = LorenzVec(-1.5, 76.0, 92.5)
-            if (entity.getLorenzVec().distance(npcLocation) < 1) {
-                return 0
+            if (entity.getLorenzVec().distance(frostyNpcLocation) < 1) {
+                return true
             }
         }
 
         val isSummonedSoul = name.contains("'")
         val hasFishingMobName = SeaCreatureManager.allFishingMobs.keys.any { name.contains(it) }
-        if (!hasFishingMobName || isSummonedSoul) return 0
-
-        if (name == "Sea Emperor" || name == "Rider of the Deep") {
-            return 2
-        }
-        return 1
+        return !hasFishingMobName || isSummonedSoul
     }
 
     private fun isWearingTrophyArmor(): Boolean = InventoryUtils.getArmor().all {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
+import at.hannibal2.skyhanni.events.fishing.FishingCatchEvent
 import at.hannibal2.skyhanni.features.fishing.FishingApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -255,7 +256,6 @@ object FishingProfitTracker {
         }
 
         tracker.addItem(internalName, amount, command)
-        addCatch()
     }
 
     private fun isAllowedItem(internalName: NeuInternalName) = itemCategories.any { internalName in it.value }
@@ -263,6 +263,11 @@ object FishingProfitTracker {
     @HandleEvent
     fun onBobberThrow(event: FishingBobberCastEvent) {
         tracker.firstUpdate()
+    }
+
+    @HandleEvent
+    fun onCatch(event: FishingCatchEvent) {
+        addCatch()
     }
 
     private fun isEnabled() = LorenzUtils.inSkyBlock && !LorenzUtils.inKuudraFight

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
 import at.hannibal2.skyhanni.events.fishing.FishingCatchEvent
+import at.hannibal2.skyhanni.events.fishing.SeaCreatureFishEvent
 import at.hannibal2.skyhanni.features.fishing.FishingApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -267,6 +268,11 @@ object FishingProfitTracker {
 
     @HandleEvent
     fun onCatch(event: FishingCatchEvent) {
+        addCatch()
+    }
+
+    @HandleEvent
+    fun onSeaCreatureFish(event: SeaCreatureFishEvent) {
         addCatch()
     }
 


### PR DESCRIPTION
## What
Changes fishing tracker's times fished to actually track times fished instead of how many times something is added to the tracker.

## Changelog Fixes
+ Fixed Fishing Profit Tracker's times-fished count. - Chissl

