### PR TITLE
Fix: Async chat access

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -311,7 +311,7 @@ object ChatUtils {
     ) {
         //#if TODO
         chatLines.editChatLine(component, predicate, reason)
-        chatGui.refreshChat()
+        refreshChat()
         //#endif
     }
 
@@ -325,8 +325,14 @@ object ChatUtils {
     ) {
         //#if TODO
         chatLines.deleteChatLine(amount, reason, predicate)
-        chatGui.refreshChat()
+        refreshChat()
         //#endif
+    }
+
+    private fun refreshChat() {
+        DelayedRun.onThread.execute {
+            chatGui.refreshChat()
+        }
     }
 
     private var deleteNext: Pair<String, (String) -> Boolean>? = null


### PR DESCRIPTION
## What
When we try to delete/modify the chat lines, we sometimes get a ConcurrentModificationException when done from outside the main thread.

<details>
<summary>Example Stack Trace</summary>

```
SkyHanni 3.0.0: Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.chat.StashCompact.onChat(at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent) at SkyHanniChatEvent: null
 
Caused by java.util.ConcurrentModificationException: null
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:911)
    at java.util.ArrayList$Itr.next(ArrayList.java:861)
    at SH.data.ChatManager.deleteChatLine(ChatManager.kt:239)
    at SH.utils.ChatUtils.deleteMessage(ChatUtils.kt:310)
    at SH.features.chat.StashCompact.onChat(StashCompact.kt:112)
<Skyhanni event post>
```

</details>

Reported: https://discord.com/channels/997079228510117908/1373908796631678982

## Changelog Fixes
+ Fixed rare error messages in compact chat features. - hannibal2