### PR TITLE
Backend: Right Click Slot

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -88,7 +88,7 @@ abstract class GuiContainerEvent(open val gui: GuiContainer, open val container:
 
     enum class ClickType(val id: Int) {
         NORMAL(0),
-        SHIFT(1),
+        RIGHT(1),
         HOTBAR(2),
         MIDDLE(3),
         DROP(4),

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
@@ -69,7 +69,7 @@ object VisitorRewardWarning {
         }
 
         // all but shift click types work for accepting visitor
-        if (event.clickType == GuiContainerEvent.ClickType.SHIFT) return
+        if (KeyboardManager.isShiftKeyDown()) return
         if (isRefuseSlot) {
             VisitorApi.changeStatus(visitor, VisitorApi.VisitorStatus.REFUSED, "refused")
             // fallback if tab list is disabled


### PR DESCRIPTION
## What
id `1` was mapped to `SHIFT`, but `1` is the id for a right click.

## Changelog Technical Details
+ Changed `ClickType` enum to have `RIGHT` click instead of `SHIFT`. - Daveed

