### PR TITLE
Fix: Aquamarine Gemstone missing from Sacks overlay

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
@@ -94,14 +94,14 @@ object SackApi {
      * REGEX-TEST: §f❤ Rough Ruby Gemstone
      * REGEX-TEST: §f❂ Rough Opal Gemstone
      * REGEX-TEST: §f☠ Rough Onyx Gemstone
-     * REGEX-TEST: §fα Rough Aquamarine Gemstone
+     * REGEX-TEST: §f☂ Rough Aquamarine Gemstone
      * REGEX-TEST: §a☘ Flawed Citrine Gemstone
      * REGEX-TEST: §9☘ Fine Peridot Gemstone
      * REGEX-TEST: §eTopaz Gemstones
      */
     private val gemstoneItemNamePattern by patternGroup.pattern(
         "gemstone.name",
-        "(?:§.)+(?:[❤❈☘⸕✎✧❁☠❂α] )?(?:(?:Rough|Flawed|Fine) )?(?<gem>[^ ]+) Gemstones?",
+        "(?:§.)+(?:[❤❈☘⸕✎✧❁☠❂☂] )?(?:(?:Rough|Flawed|Fine) )?(?<gem>[^ ]+) Gemstones?",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -50,7 +50,7 @@ object ItemNameResolver {
                         "topaz" -> '✧'
                         "onyx" -> '☠'
                         "sapphire" -> '✎'
-                        "aquamarine" -> 'α'
+                        "aquamarine" -> '☂'
                         "jasper" -> '❁'
                         else -> ' '
                     }


### PR DESCRIPTION
## What
Fixes a bug where the Aquamarine Gemstone wouldnt show up in the Sacks overlay if you changed the filter.

Also changed the icon in the query. I know it has nothing to do with the bug, but why not change it at the same time.


## Changelog Fixes
+ Fixed Aquamarine Gemstone not showing in Sacks Overlay when a filter was selected. - jani

