### PR TITLE
Improvement: Add Toggle for Soul Speed Warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/FarmingLaneConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/FarmingLaneConfig.kt
@@ -37,6 +37,14 @@ class FarmingLaneConfig {
     var distanceDisplay: Boolean = false
 
     @Expose
+    @ConfigOption(
+        name = "Soul Sand Warning",
+        desc = "Show an informational note on distance display while on soul sand, that speed calculations are inaccurate"
+    )
+    @ConfigEditorBoolean
+    var distanceSoulSandWarning: Boolean = true
+
+    @Expose
     @ConfigLink(owner = FarmingLaneConfig::class, field = "distanceDisplay")
     var distanceDisplayPosition: Position = Position(0, 200)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -84,7 +84,7 @@ object FarmingLaneFeatures {
                     " §7(${movementState.label}§7)"
                 } else ""
                 add("§7Time remaining: $color$format$suffix")
-                if (MovementSpeedDisplay.usingSoulsandSpeed) {
+                if (MovementSpeedDisplay.usingSoulsandSpeed && config.distanceSoulSandWarning) {
                     add("§7Using inaccurate soul sand speed!")
                 }
             }


### PR DESCRIPTION
## What
Added a toggle so users can turn off the "inaccurate soul sand speed" warning text in distance display.

## Changelog Improvements
+ Added toggle for 'Inaccurate Soul Sand Speed' text in Lane Switch Distance Display. - Daveed
