### PR TITLE
Improvement: Cleanup and more compact the hoppity reward summary

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -97,7 +97,7 @@ object HoppityEggsCompactChat {
 
             fun StringBuilder.formatRabbits(sets: List<HoppityStateDataSet>, text: String) {
                 // Create a Map of LorenzRarity -> Int so we can use the existing EventSummary logic
-                getRabbitsFormat(sets.getGroupedRarityMap(), text).forEach { appendLine(it) }
+                getRabbitsFormat(sets.getGroupedRarityMap(), text) { appendLine(it) }
             }
 
             hitmanCompactDataSets.filter { !it.duplicate }.takeIfNotEmpty()?.let { sets ->

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -95,19 +95,20 @@ object HoppityEggsCompactChat {
             appendLine("§c§lHitman Summary")
             appendLine()
 
-            // Create a Map of LorenzRarity -> Int so we can use the existing EventSummary logic
-            val rarityMap: Map<LorenzRarity, Int> = hitmanCompactDataSets.getGroupedRarityMap()
-            getRabbitsFormat(rarityMap, "Total Hitman").forEach { appendLine(it) }
 
             hitmanCompactDataSets.filter { !it.duplicate }.takeIfNotEmpty()?.let { sets ->
+                // Create a Map of LorenzRarity -> Int so we can use the existing EventSummary logic
+                val rarityMap: Map<LorenzRarity, Int> = hitmanCompactDataSets.getGroupedRarityMap()
+                getRabbitsFormat(rarityMap, "Total Hitman").forEach { appendLine(it) }
                 appendLine()
+
                 // Create a Map of LorenzRarity -> Int so we can use the existing EventSummary logic
                 val newRarityMap: Map<LorenzRarity, Int> = sets.getGroupedRarityMap()
                 getRabbitsFormat(newRarityMap, "New").forEach { appendLine(it) }
+                appendLine()
             }
 
             hitmanCompactDataSets.filter { it.duplicate }.takeIfNotEmpty()?.let { sets ->
-                appendLine()
                 // Create a Map of LorenzRarity -> Int so we can use the existing EventSummary logic
                 val dupeRarityMap: Map<LorenzRarity, Int> = sets.getGroupedRarityMap()
                 getRabbitsFormat(dupeRarityMap, "Duplicate").forEach { appendLine(it) }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsCompactChat.kt
@@ -95,23 +95,21 @@ object HoppityEggsCompactChat {
             appendLine("§c§lHitman Summary")
             appendLine()
 
+            fun StringBuilder.formatRabbits(sets: List<HoppityStateDataSet>, text: String) {
+                // Create a Map of LorenzRarity -> Int so we can use the existing EventSummary logic
+                getRabbitsFormat(sets.getGroupedRarityMap(), text).forEach { appendLine(it) }
+            }
 
             hitmanCompactDataSets.filter { !it.duplicate }.takeIfNotEmpty()?.let { sets ->
-                // Create a Map of LorenzRarity -> Int so we can use the existing EventSummary logic
-                val rarityMap: Map<LorenzRarity, Int> = hitmanCompactDataSets.getGroupedRarityMap()
-                getRabbitsFormat(rarityMap, "Total Hitman").forEach { appendLine(it) }
+                formatRabbits(hitmanCompactDataSets, "Total Hitman")
                 appendLine()
 
-                // Create a Map of LorenzRarity -> Int so we can use the existing EventSummary logic
-                val newRarityMap: Map<LorenzRarity, Int> = sets.getGroupedRarityMap()
-                getRabbitsFormat(newRarityMap, "New").forEach { appendLine(it) }
+                formatRabbits(sets, "New")
                 appendLine()
             }
 
             hitmanCompactDataSets.filter { it.duplicate }.takeIfNotEmpty()?.let { sets ->
-                // Create a Map of LorenzRarity -> Int so we can use the existing EventSummary logic
-                val dupeRarityMap: Map<LorenzRarity, Int> = sets.getGroupedRarityMap()
-                getRabbitsFormat(dupeRarityMap, "Duplicate").forEach { appendLine(it) }
+                formatRabbits(sets, "Duplicate")
 
                 // Add the total amount of chocolate from duplicates
                 val dupeChocolateAmount = sets.sumOf { it.lastDuplicateAmount ?: 0 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
@@ -699,9 +699,7 @@ object HoppityEventSummary {
                 rarityMap = stats.rabbitsFound.mapValues(transform),
                 name = name,
                 countTriple = stats.getPairTriple(year, index),
-            ).forEach {
-                statList.addStr(it)
-            }
+            ) { statList.addStr(it) }
 
 
             put(HoppityStat.NEW_RABBITS) { statList, stats, year ->
@@ -881,21 +879,22 @@ object HoppityEventSummary {
         rarityMap: Map<LorenzRarity, Int>,
         name: String,
         countTriple: Triple<Int, Int, Int> = Triple(0, 0, 0),
-    ): List<String> {
+        action: (String) -> Unit,
+    ) {
         val (prevCount, currCount, sinceCount) = countTriple
         val rabbitsSum = rarityMap.values.sum()
-        if (rabbitsSum == 0) return emptyList()
+        if (rabbitsSum == 0) return
 
         val sinceFormat = if (sinceCount > 0) " §8+$sinceCount§7" else ""
         val countFormat = if (config.eventSummary.showCountDiff && prevCount != 0 && currCount != 0) {
             " §7($prevCount$sinceFormat -> $currCount)"
         } else ""
 
-        return mutableListOf(
+        listOf(
             "§7$name Rabbits: §f${rabbitsSum.addSeparators()}$countFormat",
             HoppityApi.hoppityRarities.joinToString(" §7-") {
                 " ${it.chatColorCode}${(rarityMap[it] ?: 0).addSeparators()}"
             },
-        )
+        ).forEach(action)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEventSummary.kt
@@ -688,35 +688,33 @@ object HoppityEventSummary {
                 }
             }
 
+            fun formatRabbits(
+                stats: HoppityEventStats,
+                transform: (Map.Entry<LorenzRarity, RabbitData>) -> Int,
+                name: String,
+                year: Int,
+                index: Int,
+                statList: MutableList<StatString>,
+            ) = getRabbitsFormat(
+                rarityMap = stats.rabbitsFound.mapValues(transform),
+                name = name,
+                countTriple = stats.getPairTriple(year, index),
+            ).forEach {
+                statList.addStr(it)
+            }
+
+
             put(HoppityStat.NEW_RABBITS) { statList, stats, year ->
-                getRabbitsFormat(
-                    rarityMap = stats.rabbitsFound.mapValues { m -> m.value.uniques },
-                    name = "Unique",
-                    countTriple = stats.getPairTriple(year, 0),
-                ).forEach {
-                    statList.addStr(it)
-                }
+                formatRabbits(stats, { it.value.uniques }, "Unique", year, index = 0, statList)
             }
 
             put(HoppityStat.DUPLICATE_RABBITS) { statList, stats, year ->
-                getRabbitsFormat(
-                    rarityMap = stats.rabbitsFound.mapValues { m -> m.value.dupes },
-                    name = "Duplicate",
-                    countTriple = stats.getPairTriple(year, 1),
-                ).forEach {
-                    statList.addStr(it)
-                }
+                formatRabbits(stats, { it.value.dupes }, "Duplicate", year, index = 1, statList)
                 statList.addExtraChocFormatLine(stats.dupeChocolateGained)
             }
 
             put(HoppityStat.STRAY_RABBITS) { statList, stats, year ->
-                getRabbitsFormat(
-                    rarityMap = stats.rabbitsFound.mapValues { m -> m.value.strays },
-                    name = "Stray",
-                    countTriple = stats.getPairTriple(year, 2),
-                ).forEach {
-                    statList.addStr(it)
-                }
+                formatRabbits(stats, { it.value.strays }, "Stray", year, index = 2, statList)
                 statList.addExtraChocFormatLine(stats.strayChocolateGained)
             }
 


### PR DESCRIPTION
## What
Implemented this suggestion:[ if total and dupe hitmans are the same, hide total](https://discord.com/channels/997079228510117908/1365248148439564319)

Made the code more compact around the `getRabbitsFormat()` function in `HoppityEventSummary.kt`.

## Changelog Improvements
+ Hide "total" Hoppity Stats from chat when no duplicates found in Compact Hitman Message. - hannibal2