### PR TITLE
Feature: Rift Enigma Soul Drop Waypoint

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/mountaintop/MountaintopConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/mountaintop/MountaintopConfig.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.config.features.rift.area.mountaintop
 
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class MountaintopConfig {
@@ -15,4 +16,12 @@ class MountaintopConfig {
     @ConfigOption(name = "Timite", desc = "")
     @Accordion
     var timite: TimiteConfig = TimiteConfig()
+
+    @Expose
+    @ConfigOption(
+        name = "Enigma Rose'End Flowerpot",
+        desc = "Show the dropdown location to the hard Flowerpot point while in the Enigma Rose'End quest.",
+    )
+    @ConfigEditorBoolean
+    var enigmaRoseFlowerpot: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/EnigmaRoseFlowerpot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/EnigmaRoseFlowerpot.kt
@@ -1,0 +1,41 @@
+package at.hannibal2.skyhanni.features.rift.area.mountaintop
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LocationUtils.isPlayerInside
+import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
+import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
+import net.minecraft.util.AxisAlignedBB
+
+@SkyHanniModule
+object EnigmaRoseFlowerpot {
+    private val config get() = SkyHanniMod.feature.rift.area.mountaintop
+
+    private val area = AxisAlignedBB(25.0, 165.0, 90.0, 52.0, 185.0, 120.0)
+    private val dropLocation = LorenzVec(40, 161, 116)
+    private var inArea = false
+
+    @HandleEvent
+    fun onTick(event: SkyHanniTickEvent) {
+        if (!isEnabled()) return
+        if (event.isMod(2)) {
+            inArea = area.isPlayerInside()
+        }
+    }
+
+    @HandleEvent
+    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+        if (!isEnabled() && !inArea) return
+
+        event.drawWaypointFilled(dropLocation, LorenzColor.WHITE.toColor(), beacon = true)
+        event.drawDynamicText(dropLocation, "Drop", 1.5)
+    }
+
+    private fun isEnabled() = IslandType.THE_RIFT.isCurrent() && config.enigmaRoseFlowerpot
+}


### PR DESCRIPTION
## What
Added a waypoint that is only visible while in the area

## Changelog New Features
+ Added drop location for Rose'End Flowerpot Enigma Soul on second moving platform. - hannibal2