### PR TITLE
Fix: Performance problems with Skytils

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HotmData.kt
@@ -30,6 +30,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.allLettersFirstUppercase
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.inventory.Slot
+import net.minecraft.item.ItemStack
 import kotlin.math.pow
 
 private fun calculateCoreOfTheMountainLoot(level: Int): Map<HotmReward, Double> = buildMap {
@@ -398,6 +399,9 @@ enum class HotmData(
     var slot: Slot? = null
         private set
 
+    var item: ItemStack? = null
+        private set
+
     fun getLevelUpCost() = costFun(rawLevel)
 
     fun getReward() = if (enabled) rewardFun(activeLevel) else emptyMap()
@@ -576,6 +580,7 @@ enum class HotmData(
 
             val entry = entries.firstOrNull { it.guiNamePattern.matches(item.displayName) } ?: return
             entry.slot = this
+            entry.item = item
 
             val lore = item.getLore().takeIf { it.isNotEmpty() } ?: return
 
@@ -699,7 +704,10 @@ enum class HotmData(
         fun onInventoryClose(event: InventoryCloseEvent) {
             if (!inInventory) return
             inInventory = false
-            entries.forEach { it.slot = null }
+            entries.forEach {
+                it.slot = null
+                it.item = null
+            }
             heartItem = null
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotmFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotmFeatures.kt
@@ -38,7 +38,7 @@ object HotmFeatures {
     private fun handleLevelStackSize(event: RenderItemTipEvent) {
         if (!config.levelStackSize) return
         HotmData.entries.firstOrNull {
-            event.stack == it.slot?.stack
+            event.stack == it.item
         }?.let {
             event.stackTip = if (it.activeLevel == 0 || it.activeLevel == it.maxLevel) "" else
                 "§e${it.activeLevel}"


### PR DESCRIPTION
## What
A mod compatibility problem with Skytils:

![image](https://github.com/user-attachments/assets/625f7e36-3080-4a10-9b9d-6bafd17a726e)

in the Hotm Ffeatures class, Skyhanni uses `Slot.getStack()` every frame.
Skytils mixins into this function. this then calls NEU/mc/skyhanni code further down.
All this cuases performance issues.
The easy fix for Skyhanni is to store the item stack info once and dont use the slot object to get the item stack in a function that gets heavily called like this.


proof of the bug: https://spark.lucko.me/r6TVNux1Tl

![image](https://github.com/user-attachments/assets/625f7e36-3080-4a10-9b9d-6bafd17a726e)

reported: https://discord.com/channels/997079228510117908/1000669238035497022/1377252300191436832

## Changelog Fixes
+ Fixed performance issue when using SkyHanni's HOTM and Skytils' Terminal features. - hannibal2