### PR TITLE
Improvement: Kick Timer only First Kick

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
@@ -52,7 +52,6 @@ object SkyBlockKickDuration {
         if (!isEnabled()) return
 
         if (kickPattern.matches(event.message) && !showTime) {
-
             if (SkyBlockUtils.onHypixel && !SkyBlockUtils.inSkyBlock) {
                 kickMessage = false
                 showTime = true

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
@@ -49,9 +49,9 @@ object SkyBlockKickDuration {
 
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent) {
-        if (!isEnabled()) return
+        if (!isEnabled() && !showTime) return
 
-        if (kickPattern.matches(event.message) && !showTime) {
+        if (kickPattern.matches(event.message)) {
             if (SkyBlockUtils.onHypixel && !SkyBlockUtils.inSkyBlock) {
                 kickMessage = false
                 showTime = true
@@ -61,7 +61,7 @@ object SkyBlockKickDuration {
             }
         }
 
-        if (problemJoiningPattern.matches(event.message) && !showTime) {
+        if (problemJoiningPattern.matches(event.message)) {
             kickMessage = false
             showTime = true
             lastKickTime = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
@@ -51,7 +51,7 @@ object SkyBlockKickDuration {
     fun onChat(event: SkyHanniChatEvent) {
         if (!isEnabled()) return
 
-        if (kickPattern.matches(event.message)) {
+        if (kickPattern.matches(event.message) && !showTime) {
             if (LorenzUtils.onHypixel && !LorenzUtils.inSkyBlock) {
                 kickMessage = false
                 showTime = true
@@ -61,7 +61,7 @@ object SkyBlockKickDuration {
             }
         }
 
-        if (problemJoiningPattern.matches(event.message)) {
+        if (problemJoiningPattern.matches(event.message) && !showTime) {
             kickMessage = false
             showTime = true
             lastKickTime = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
@@ -52,6 +52,7 @@ object SkyBlockKickDuration {
         if (!isEnabled()) return
 
         if (kickPattern.matches(event.message) && !showTime) {
+
             if (LorenzUtils.onHypixel && !LorenzUtils.inSkyBlock) {
                 kickMessage = false
                 showTime = true

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
@@ -6,10 +6,10 @@ import at.hannibal2.skyhanni.data.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -53,7 +53,7 @@ object SkyBlockKickDuration {
 
         if (kickPattern.matches(event.message) && !showTime) {
 
-            if (LorenzUtils.onHypixel && !LorenzUtils.inSkyBlock) {
+            if (SkyBlockUtils.onHypixel && !SkyBlockUtils.inSkyBlock) {
                 kickMessage = false
                 showTime = true
                 lastKickTime = SimpleTimeMark.now()
@@ -83,10 +83,10 @@ object SkyBlockKickDuration {
     @HandleEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
-        if (!LorenzUtils.onHypixel) return
+        if (!SkyBlockUtils.onHypixel) return
         if (!showTime) return
 
-        if (LorenzUtils.inSkyBlock) {
+        if (SkyBlockUtils.inSkyBlock) {
             showTime = false
         }
 
@@ -103,7 +103,7 @@ object SkyBlockKickDuration {
 
         val format = lastKickTime.passedSince().format()
         config.position.renderString(
-            "§cLast kicked from SkyBlock §b$format ago",
+            "§cKicked from SkyBlock §b$format ago",
             posLabel = "SkyBlock Kick Duration",
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SkyBlockKickDuration.kt
@@ -49,7 +49,7 @@ object SkyBlockKickDuration {
 
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent) {
-        if (!isEnabled() && !showTime) return
+        if (!isEnabled() || !showTime) return
 
         if (kickPattern.matches(event.message)) {
             if (SkyBlockUtils.onHypixel && !SkyBlockUtils.inSkyBlock) {


### PR DESCRIPTION
## What
Makes Kick Timer only Count from first kick (makes ability to join SB notification more accurate if Pleaders keep trying to warp after kick)

This changelog is stupidly long for a change that is smaller than this entire description

## Changelog Improvements
+ Made Last Kicked from Skyblock feature count only first kick. - Fazfoxy
    * Only First Kick Counts for Rejoin cooldown so this makes rejoin notification more accurate.
