### PR TITLE
Backend: Bump Moulconfig

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 libautoupdate = "1.3.1"
-moulconfig = "3.6.0"
+moulconfig = "3.9.0"
 headlessLwjgl = "1.7.2"
 jbAnnotations = "24.1.0"
 hypixelmodapi = "1.0.1.2"


### PR DESCRIPTION
## What
Bumps moulconfig to `3.9.0`

## Changelog Technical Details
+ Bumped moulconfig to 3.9.0. - Daveed

