### PR TITLE
Fix: Eyes placed tab widget

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
@@ -207,7 +207,7 @@ enum class TabWidget(
     ),
     EYES_PLACED(
         // language=RegExp
-        "Eyes placed: (?:§.)*(?<amount>\\d).*|(?:§.)*Dragon spawned!|(?:§.)*Egg respawning!",
+        "(?:Eyes placed: (?:§.)*(?<amount>\\d).*|(?:§.)*Dragon spawned!|(?:§.)*Egg respawning!)",
     ),
     PROTECTOR(
         // language=RegExp


### PR DESCRIPTION
## What
Closes #3991 as this actually fixes the 1 widget that is broken rather than messing with every other widget for no good reason

This fixes it because the whitespace that is added to the beggining of the pattern only applies to the first part of the or in regex. Making a non capturing group fixes this
![image](https://github.com/user-attachments/assets/1b8e781b-8b72-494c-bc56-9498db7d14e3)

## Changelog Fixes
+ Fixed eyes placed tab widget not showing when dragon is spawned or respawning. - CalMWolfs

