### PR TITLE
Backend: Fix Spongepowered Repo

### DIFF
--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -30,7 +30,7 @@ allprojects {
                 artifact() // We love missing POMs
             }
         }
-        maven("https://repo.spongepowered.org/maven/") // mixin
+        maven("https://repo.spongepowered.org/repository/maven-public/") // mixin
         maven("https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1") // DevAuth
         maven("https://jitpack.io") {
             // NotEnoughUpdates (compiled against)


### PR DESCRIPTION
## What
Apparently we've been using a deprecated maven repo for spongepowered which is why we keep getting 500 errors in github workflows.
https://docs.spongepowered.org/stable/en/plugin/project/maven.html

## Changelog Technical Details
+ Updated repository for SpongePowered. - Daveed
