### PR TITLE
Backend: Add fabric's repo as higher priority than sponge

### DIFF
--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -30,6 +30,7 @@ allprojects {
                 artifact() // We love missing POMs
             }
         }
+        maven("https://maven.fabricmc.net/") // backup for fabricmc when sponge dies
         maven("https://repo.spongepowered.org/maven/") // mixin
         maven("https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1") // DevAuth
         maven("https://jitpack.io") {


### PR DESCRIPTION
## What
Even with sponge's new url, still failing (though, less frequently 🙏), to download the fabric mappings:
https://github.com/hannibal002/SkyHanni/actions/runs/15483223814/job/43592750332?pr=3965

This adds fabric's maven repo as a higher priority so we attempt pulling from them first.

## Changelog Technical Details
+ Prefer Fabric's Maven repo over Sponge's. - Daveed
