### PR TITLE
Fix: Fast Fairy Souls Pathfinder ignoring if all souls are found

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -149,7 +149,9 @@ object FastFairySoulsPathfinder {
 
         fun allFound(state: String) {
             disabled = true
+            println("before ${foundSoulsOnCurrentIsland()}")
             foundSoulsOnCurrentIsland().addAll(route)
+            println("after ${foundSoulsOnCurrentIsland()}")
             debugState = state
         }
 
@@ -323,7 +325,7 @@ object FastFairySoulsPathfinder {
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
-        event.register("shsoulreset") {
+        event.register("shsoulsreset") {
             description = "Reset known Fairy Souls for the current island."
             category = CommandCategory.USERS_RESET
             callback { onResetCommand() }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -24,13 +24,12 @@ import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzUtils
-import at.hannibal2.skyhanni.utils.LorenzUtils.isInIsland
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
@@ -113,9 +112,9 @@ object FastFairySoulsPathfinder {
         fun pathToNext() {
             if (disabled) return
             if (route.isEmpty()) {
-                val message = "§e[SkyHanni] Found all §5$found Fairy Souls §ein ${LorenzUtils.skyBlockIsland.displayName}!"
+                val message = "§e[SkyHanni] Found all §5$found Fairy Souls §ein ${SkyBlockUtils.currentIsland.displayName}!"
                 IslandGraphs.overrideChatMessage(message)
-                allFound("found last soul of ${LorenzUtils.skyBlockIsland}")
+                allFound("found last soul of ${SkyBlockUtils.currentIsland}")
             } else {
                 pathTo(route.first())
             }
@@ -195,8 +194,9 @@ object FastFairySoulsPathfinder {
             } ?: continue
 
 
-            if (island.isInIsland()) data?.checkHaveAll(have)
-            else {
+            if (island.isCurrent()) {
+                data?.checkHaveAll(have)
+            } else {
                 totalFound[island] = have
             }
         }
@@ -205,7 +205,7 @@ object FastFairySoulsPathfinder {
     private fun Data.checkHaveAll(have: Int): Boolean {
         val haveAll = have > 0 && have == total
         if (haveAll) {
-            allFound("already found all souls on ${LorenzUtils.skyBlockIsland} according to quests inventory")
+            allFound("already found all souls on ${SkyBlockUtils.currentIsland} according to quests inventory")
         }
         return haveAll
     }
@@ -228,7 +228,7 @@ object FastFairySoulsPathfinder {
         val missingSouls = allSouls.filter { it.position !in foundSouls }
         if (missingSouls.isEmpty()) {
 
-            val island = LorenzUtils.skyBlockIsland
+            val island = SkyBlockUtils.currentIsland
             data = if (foundSouls.isEmpty()) {
                 createEmptyData().also {
                     it.debugState = "There are no fairy souls in the graph network of $island"
@@ -329,7 +329,7 @@ object FastFairySoulsPathfinder {
     private fun onResetCommand() {
         if (isDisabledCommand()) return
         localFoundSouls().clear()
-        val island = LorenzUtils.skyBlockIsland
+        val island = SkyBlockUtils.currentIsland
         totalFound[island] = 0
         ChatUtils.chat("Reset found Fairy Souls on ${island.displayName}.")
         reload()
@@ -337,7 +337,7 @@ object FastFairySoulsPathfinder {
 
     private fun onFoundAllCommand() {
         if (isDisabledCommand()) return
-        val island = LorenzUtils.skyBlockIsland
+        val island = SkyBlockUtils.currentIsland
         ChatUtils.chat("Marked all Fairy Souls as found on ${island.displayName}.")
         data?.allFound("manually set all souls in $island as found via command")
         reload()
@@ -354,9 +354,9 @@ object FastFairySoulsPathfinder {
         return true
     }
 
-    private fun localFoundSouls(): MutableSet<LorenzVec> = foundSouls.getOrPut(LorenzUtils.skyBlockIsland) { mutableSetOf() }
+    private fun localFoundSouls(): MutableSet<LorenzVec> = foundSouls.getOrPut(SkyBlockUtils.currentIsland) { mutableSetOf() }
 
     private fun getTargetNodes(nodes: List<GraphNode>): List<GraphNode> = nodes.filter { it.hasTag(GraphNodeTag.FAIRY_SOUL) }
 
-    private fun isEnabled() = LorenzUtils.inSkyBlock && config.fastFairySouls
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.fastFairySouls
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -154,11 +154,11 @@ object FastFairySoulsPathfinder {
         }
 
         fun checkHaveAll(): Boolean {
-            val foundOnCurrentIsland = amountFoundOnCurrentIsland()
-            val haveAll = total > 0 && foundOnCurrentIsland == total
+            val amountFound = amountFoundOnCurrentIsland()
+            val haveAll = total > 0 && amountFound == total
             if (haveAll) {
                 allFound("already found all souls on ${SkyBlockUtils.currentIsland} according to hypixel data")
-                found = foundOnCurrentIsland
+                found = amountFound
             }
             return haveAll
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -150,6 +150,14 @@ object FastFairySoulsPathfinder {
             debugState = state
         }
 
+        fun checkHaveAll(): Boolean {
+            val haveAll = total > 0 && amountFoundOnCurrentIsland() == total
+            if (haveAll) {
+                allFound("already found all souls on ${SkyBlockUtils.currentIsland} according to quests inventory")
+            }
+            return haveAll
+        }
+
         private fun isDataEnabled() = data?.let { !it.disabled } ?: false
     }
 
@@ -193,21 +201,11 @@ object FastFairySoulsPathfinder {
                 }
             } ?: continue
 
-
             if (island.isCurrent()) {
-                data?.checkHaveAll(have)
-            } else {
-                totalFound[island] = have
+                data?.checkHaveAll()
             }
+            totalFound[island] = have
         }
-    }
-
-    private fun Data.checkHaveAll(have: Int): Boolean {
-        val haveAll = have > 0 && have == total
-        if (haveAll) {
-            allFound("already found all souls on ${SkyBlockUtils.currentIsland} according to quests inventory")
-        }
-        return haveAll
     }
 
     private fun createEmptyData(): Data = Data(0, 0, mutableListOf(), emptySet()).apply { disabled = true }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -301,7 +301,8 @@ object FastFairySoulsPathfinder {
                     add(it)
                     add("")
                 }
-                add("found: $found")
+                add("found with known location: $found")
+                add("actual amount of found souls: ${amountFoundOnCurrentIsland()}")
                 add("total: $total")
                 add("route: ${route.size}")
                 add("foundButNotClickedSoul: $foundButNotClickedSoul")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -84,7 +84,7 @@ object FastFairySoulsPathfinder {
         val allSouls: Set<LorenzVec>,
         var foundButNotClickedSoul: LorenzVec? = null,
     ) {
-        var disabled = false
+        var disabled = total > 0 && found == total
         var debugState: String? = null
 
         fun foundNearby() {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -224,19 +224,19 @@ object FastFairySoulsPathfinder {
         val foundSouls = foundSoulsOnCurrentIsland()
         val allSouls = getTargetNodes(graph.nodes)
         val missingSouls = allSouls.filter { it.position !in foundSouls }
-        if (missingSouls.isEmpty()) {
 
-            val island = SkyBlockUtils.currentIsland
-            data = if (foundSouls.isEmpty()) {
-                createEmptyData().also {
-                    it.debugState = "There are no fairy souls in the graph network of $island"
+        if (missingSouls.isEmpty()) {
+            data =
+                if (foundSouls.isEmpty()) {
+                    createEmptyData().also {
+                        it.debugState = "There are no fairy souls in the graph network of ${SkyBlockUtils.currentIsland}"
+                    }
+                } else {
+                    val size = foundSouls.size
+                    Data(found = size, total = size, route = emptyList<LorenzVec>().toMutableList(), allSouls = foundSouls).also {
+                        it.debugState = "found all souls on ${SkyBlockUtils.currentIsland}"
+                    }
                 }
-            } else {
-                val size = foundSouls.size
-                Data(found = size, total = size, route = emptyList<LorenzVec>().toMutableList(), allSouls = foundSouls).also {
-                    it.debugState = "found all souls on $island"
-                }
-            }
             return
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -241,6 +241,7 @@ object FastFairySoulsPathfinder {
         }
 
         data = createEmptyData()
+        if (data?.checkHaveAll() ?: false) return
         calculating = true
         calculatingStart = SimpleTimeMark.now()
         "§e[SkyHanni] Calculating Fairy Soul route §b0s".asComponent().send(calculatingMessageId)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -149,18 +149,16 @@ object FastFairySoulsPathfinder {
 
         fun allFound(state: String) {
             disabled = true
-            println("before ${foundSoulsOnCurrentIsland()}")
             foundSoulsOnCurrentIsland().addAll(route)
-            println("after ${foundSoulsOnCurrentIsland()}")
+            found = foundSoulsOnCurrentIsland().size
+            totalFound[SkyBlockUtils.currentIsland] = found
             debugState = state
         }
 
         fun checkHaveAll(): Boolean {
-            val amountFound = amountFoundOnCurrentIsland()
-            val haveAll = total > 0 && amountFound == total
+            val haveAll = total > 0 && amountFoundOnCurrentIsland() == total
             if (haveAll) {
                 allFound("already found all souls on ${SkyBlockUtils.currentIsland} according to hypixel data")
-                found = amountFound
             }
             return haveAll
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -36,6 +36,9 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.navigation.NavigationUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.iterator
 
 @SkyHanniModule
 object FastFairySoulsPathfinder {
@@ -308,6 +311,11 @@ object FastFairySoulsPathfinder {
                 add("foundButNotClickedSoul: $foundButNotClickedSoul")
             } ?: run {
                 add("data is null")
+            }
+            add("")
+            add("Amount of Souls found on Islands:")
+            for ((island, amount) in totalFound) {
+                add("  ${island.displayName}: $amount")
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -106,7 +106,7 @@ object FastFairySoulsPathfinder {
             if (route.remove(nearest)) {
                 found++
             }
-            localFoundSouls().add(nearest)
+            foundSoulsOnCurrentIsland().add(nearest)
         }
 
         fun pathToNext() {
@@ -146,7 +146,7 @@ object FastFairySoulsPathfinder {
 
         fun allFound(state: String) {
             disabled = true
-            localFoundSouls().addAll(route)
+            foundSoulsOnCurrentIsland().addAll(route)
             debugState = state
         }
 
@@ -223,7 +223,7 @@ object FastFairySoulsPathfinder {
             }
             return
         }
-        val foundSouls = localFoundSouls()
+        val foundSouls = foundSoulsOnCurrentIsland()
         val allSouls = getTargetNodes(graph.nodes)
         val missingSouls = allSouls.filter { it.position !in foundSouls }
         if (missingSouls.isEmpty()) {
@@ -328,10 +328,8 @@ object FastFairySoulsPathfinder {
 
     private fun onResetCommand() {
         if (isDisabledCommand()) return
-        localFoundSouls().clear()
-        val island = SkyBlockUtils.currentIsland
-        totalFound[island] = 0
-        ChatUtils.chat("Reset found Fairy Souls on ${island.displayName}.")
+        resetFoundOnCurrentIsland()
+        ChatUtils.chat("Reset found Fairy Souls on ${SkyBlockUtils.currentIsland.displayName}.")
         reload()
     }
 
@@ -354,7 +352,17 @@ object FastFairySoulsPathfinder {
         return true
     }
 
-    private fun localFoundSouls(): MutableSet<LorenzVec> = foundSouls.getOrPut(SkyBlockUtils.currentIsland) { mutableSetOf() }
+    fun resetFoundOnCurrentIsland() = resetFoundOnIsland(SkyBlockUtils.currentIsland)
+    fun resetFoundOnIsland(island: IslandType) {
+        totalFound[island] = 0
+        foundSouls[island]?.clear()
+    }
+
+    fun amountFoundOnCurrentIsland(): Int = amountFoundOnIsland(SkyBlockUtils.currentIsland)
+    fun amountFoundOnIsland(island: IslandType): Int = totalFound.getOrDefault(island, 0)
+
+    fun foundSoulsOnCurrentIsland(): MutableSet<LorenzVec> = foundSoulsOnIsland(SkyBlockUtils.currentIsland)
+    fun foundSoulsOnIsland(island: IslandType): MutableSet<LorenzVec> = foundSouls.getOrPut(island) { mutableSetOf() }
 
     private fun getTargetNodes(nodes: List<GraphNode>): List<GraphNode> = nodes.filter { it.hasTag(GraphNodeTag.FAIRY_SOUL) }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -244,7 +244,7 @@ object FastFairySoulsPathfinder {
             return
         }
 
-        data = createEmptyData()
+        data = Data(found = 0, total = allSouls.size, route = mutableListOf(), allSouls = emptySet())
         if (data?.checkHaveAll() ?: false) return
         calculating = true
         calculatingStart = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -38,8 +38,8 @@ import at.hannibal2.skyhanni.utils.navigation.NavigationUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.collections.component1
 import kotlin.collections.component2
-import kotlin.collections.iterator
 
+@Suppress("MemberVisibilityCanBePrivate")
 @SkyHanniModule
 object FastFairySoulsPathfinder {
     val config get() = SkyHanniMod.feature.misc
@@ -154,10 +154,11 @@ object FastFairySoulsPathfinder {
         }
 
         fun checkHaveAll(): Boolean {
-            val haveAll = total > 0 && amountFoundOnCurrentIsland() == total
+            val foundOnCurrentIsland = amountFoundOnCurrentIsland()
+            val haveAll = total > 0 && foundOnCurrentIsland == total
             if (haveAll) {
                 allFound("already found all souls on ${SkyBlockUtils.currentIsland} according to hypixel data")
-                found = amountFoundOnCurrentIsland()
+                found = foundOnCurrentIsland
             }
             return haveAll
         }
@@ -165,8 +166,8 @@ object FastFairySoulsPathfinder {
         private fun isDataEnabled() = data?.let { !it.disabled } ?: false
     }
 
-    @HandleEvent
-    fun onWorldChange(event: WorldChangeEvent) {
+    @HandleEvent(WorldChangeEvent::class)
+    fun onWorldChange() {
         data = null
     }
 
@@ -181,8 +182,8 @@ object FastFairySoulsPathfinder {
         }
     }
 
-    @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    @HandleEvent(SecondPassedEvent::class)
+    fun onSecondPassed() {
         if (!isEnabled()) return
 
         data?.let {
@@ -230,22 +231,21 @@ object FastFairySoulsPathfinder {
         val missingSouls = allSouls.filter { it.position !in foundSouls }
 
         if (missingSouls.isEmpty()) {
-            data =
-                if (foundSouls.isEmpty()) {
-                    createEmptyData().also {
-                        it.debugState = "There are no fairy souls in the graph network of ${SkyBlockUtils.currentIsland}"
-                    }
-                } else {
-                    val size = foundSouls.size
-                    Data(found = size, total = size, route = emptyList<LorenzVec>().toMutableList(), allSouls = foundSouls).also {
-                        it.debugState = "found all souls on ${SkyBlockUtils.currentIsland}"
-                    }
+            data = if (foundSouls.isEmpty()) {
+                createEmptyData().also {
+                    it.debugState = "There are no fairy souls in the graph network of ${SkyBlockUtils.currentIsland}"
                 }
+            } else {
+                val size = foundSouls.size
+                Data(found = size, total = size, route = emptyList<LorenzVec>().toMutableList(), allSouls = foundSouls).also {
+                    it.debugState = "found all souls on ${SkyBlockUtils.currentIsland}"
+                }
+            }
             return
         }
 
         data = Data(found = 0, total = allSouls.size, route = mutableListOf(), allSouls = emptySet())
-        if (data?.checkHaveAll() ?: false) return
+        if (data?.checkHaveAll() == true) return
         calculating = true
         calculatingStart = SimpleTimeMark.now()
         "§e[SkyHanni] Calculating Fairy Soul route §b0s".asComponent().send(calculatingMessageId)
@@ -281,8 +281,8 @@ object FastFairySoulsPathfinder {
         }
     }
 
-    @HandleEvent
-    fun onIslandGraphReload(event: IslandGraphReloadEvent) {
+    @HandleEvent(IslandGraphReloadEvent::class)
+    fun onIslandGraphReload() {
         if (isEnabled()) {
             reload()
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -156,7 +156,8 @@ object FastFairySoulsPathfinder {
         fun checkHaveAll(): Boolean {
             val haveAll = total > 0 && amountFoundOnCurrentIsland() == total
             if (haveAll) {
-                allFound("already found all souls on ${SkyBlockUtils.currentIsland} according to quests inventory")
+                allFound("already found all souls on ${SkyBlockUtils.currentIsland} according to hypixel data")
+                found = amountFoundOnCurrentIsland()
             }
             return haveAll
         }


### PR DESCRIPTION
## What
The Fast Fairy Soul thing ignored if you have all souls found in the totalFound profile storage, if found (the coordinates of the found souls) doesn't have all.
This case happened for all island except the current one, if you have all fairy souls and you open the quest menu. That's because it only adds the coords for the found souls if you're currently on the island.
This lead to you having to open the quest menu in new island you visited.

[https://discord.com/channels/997079228510117908/1380836500530528357](https://discord.com/channels/997079228510117908/1380836500530528357)

## Changelog Fixes
+ Fixed Fast Fairy Souls Pathfinder not detecting already found fairy souls from the quest menu. - rueblimaster