### PR TITLE
Fix: Scoreboard Element Patterns

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -218,7 +218,7 @@ object CustomScoreboard {
         currentIslandEntries = config.scoreboardEntries.get().map { it.element }
         currentIslandEvents = eventsConfig.eventEntries.get().map { it.event }
 
-        activePatterns = (ScoreboardConfigElement.getElements() + ScoreboardConfigEventElement.getEvents())
+        activePatterns = ScoreboardConfigElement.getElements()
             .flatMap { it.elementPatterns }
             .distinct()
         activePatterns += ScoreboardPattern.brokenPatterns

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementEvents.kt
@@ -19,7 +19,7 @@ object ScoreboardElementEvents : ScoreboardElement() {
 
     override val configLine = "§7Wide Range of Events\n§7(too much to show all)"
 
-    override val elementPatterns =
+    override val elementPatterns get() =
         ScoreboardConfigEventElement.entries.filter { it.event.showIsland() }.flatMap { it.event.elementPatterns }
 
     override fun getLines(): List<ScoreboardLine> = if (showWhen()) getElementsFromAny(getDisplay()) else listOf()


### PR DESCRIPTION
## What
This PR fixes ScoreboardElementEvents initializing the elementPatterns val incorrectly, making it so that it always gets initialized as empty (and island checks get called on init, which fucked over #3974 for me)

This technically doesn't affect users, since it would still get patterns from the events themselves, but still should be fixed nonetheless.

exclude_from_changelog