### PR TITLE
Fix: Powder Chest Timer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -275,8 +275,10 @@ object MiningApi {
         pickobulusEndPattern.matchMatcher(event.message) {
             val amount = group("amount").formatInt()
             resetPickobulusEvent()
-            val blocks = pickobulusMinedBlocks.take(amount).countBy { it.second }
-            if (blocks.isNotEmpty()) OreMinedEvent(null, blocks).post()
+            val limited = pickobulusMinedBlocks.take(amount)
+            val blocks = limited.countBy { it.second }
+            val positions = limited.mapTo(mutableSetOf()) { it.first }
+            if (blocks.isNotEmpty()) OreMinedEvent(null, blocks, positions).post()
             pickobulusMinedBlocks.clear()
             return
         }
@@ -425,15 +427,18 @@ object MiningApi {
             return
         }
 
-        val extraBlocks = surroundingMinedBlocks.filter {
+        val minedBlocks = surroundingMinedBlocks.filter {
             // We can do this because all blocks that don't have an init sound also cannot be mined by
             // efficient miner when other blocks are mined.
             // The more correct way of doing this would be making sure the oretype of the originally mined
             // block matches
             if (ignoreFilter) it.first.ore == originalBlock.ore else it.first.confirmed
-        }.countBy { it.first.ore }
+        }
 
-        OreMinedEvent(originalBlock.ore, extraBlocks).post()
+        val extraBlocks = minedBlocks.countBy { it.first.ore }
+        val positions = minedBlocks.mapTo(mutableSetOf()) { it.second }
+
+        OreMinedEvent(originalBlock.ore, extraBlocks, positions).post()
         lastOreMinedTime = SimpleTimeMark.now()
 
         surroundingMinedBlocks.clear()

--- a/src/main/java/at/hannibal2/skyhanni/events/mining/OreMinedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/mining/OreMinedEvent.kt
@@ -2,5 +2,10 @@ package at.hannibal2.skyhanni.events.mining
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.features.mining.OreBlock
+import at.hannibal2.skyhanni.utils.LorenzVec
 
-class OreMinedEvent(val originalOre: OreBlock?, val extraBlocks: Map<OreBlock, Int>) : SkyHanniEvent()
+class OreMinedEvent(
+    val originalOre: OreBlock?,
+    val extraBlocks: Map<OreBlock, Int>,
+    val positions: Set<LorenzVec>,
+) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreType.kt
@@ -1,191 +1,161 @@
 package at.hannibal2.skyhanni.features.mining
 
 import at.hannibal2.skyhanni.data.MiningApi
+import at.hannibal2.skyhanni.utils.EnumUtils.toFormattedName
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import net.minecraft.block.state.IBlockState
 
 enum class OreType(
-    val oreName: String,
     internalName: String,
     vararg oreBlocks: OreBlock,
+    oreName: String? = null
 ) {
     MITHRIL(
-        "Mithril",
         "MITHRIL_ORE",
         OreBlock.LOW_TIER_MITHRIL, OreBlock.MID_TIER_MITHRIL, OreBlock.HIGH_TIER_MITHRIL,
     ),
     TITANIUM(
-        "Titanium",
         "TITANIUM_ORE",
         OreBlock.TITANIUM,
     ),
     COBBLESTONE(
-        "Cobblestone",
         "COBBLESTONE",
         OreBlock.STONE, OreBlock.COBBLESTONE,
     ),
     COAL(
-        "Coal",
         "COAL",
         OreBlock.COAL_ORE, OreBlock.PURE_COAL,
     ),
     IRON(
-        "Iron",
         "IRON_INGOT",
         OreBlock.IRON_ORE, OreBlock.PURE_IRON,
     ),
     GOLD(
-        "Gold",
         "GOLD_INGOT",
         OreBlock.GOLD_ORE, OreBlock.PURE_GOLD,
     ),
     LAPIS(
-        "Lapis Lazuli",
         "INK_SACK-4",
         OreBlock.LAPIS_ORE, OreBlock.PURE_LAPIS,
+        oreName = "Lapis Lazuli"
     ),
     REDSTONE(
-        "Redstone",
         "REDSTONE",
         OreBlock.REDSTONE_ORE, OreBlock.PURE_REDSTONE,
     ),
     EMERALD(
-        "Emerald",
         "EMERALD",
         OreBlock.EMERALD_ORE, OreBlock.PURE_EMERALD,
     ),
     DIAMOND(
-        "Diamond",
         "DIAMOND",
         OreBlock.DIAMOND_ORE, OreBlock.PURE_DIAMOND,
     ),
     NETHERRACK(
-        "Netherrack",
         "NETHERRACK",
         OreBlock.NETHERRACK,
     ),
     QUARTZ(
-        "Nether Quartz",
         "QUARTZ",
         OreBlock.QUARTZ_ORE,
+        oreName = "Nether Quartz"
     ),
     GLOWSTONE(
-        "Glowstone",
         "GLOWSTONE_DUST",
         OreBlock.GLOWSTONE,
     ),
     MYCELIUM(
-        "Mycelium",
         "MYCEL",
         OreBlock.MYCELIUM,
     ),
     RED_SAND(
-        "Red Sand",
         "SAND-1",
         OreBlock.RED_SAND,
     ),
     SULPHUR(
-        "Sulphur",
         "SULPHUR_ORE",
         OreBlock.SULPHUR,
     ),
     GRAVEL(
-        "Gravel",
         "GRAVEL",
         OreBlock.GRAVEL,
     ),
     END_STONE(
-        "End Stone",
         "ENDER_STONE",
         OreBlock.END_STONE,
     ),
     OBSIDIAN(
-        "Obsidian",
         "OBSIDIAN",
         OreBlock.OBSIDIAN,
     ),
     HARD_STONE(
-        "Hard Stone",
         "HARD_STONE",
         OreBlock.HARD_STONE_HOLLOWS, OreBlock.HARD_STONE_TUNNELS, OreBlock.HARD_STONE_MINESHAFT,
     ),
     RUBY(
-        "Ruby",
         "ROUGH_RUBY_GEM",
         OreBlock.RUBY,
     ),
     AMBER(
-        "Amber",
         "ROUGH_AMBER_GEM",
         OreBlock.AMBER,
     ),
     AMETHYST(
-        "Amethyst",
         "ROUGH_AMETHYST_GEM",
         OreBlock.AMETHYST,
     ),
     JADE(
-        "Jade",
         "ROUGH_JADE_GEM",
         OreBlock.JADE,
     ),
     SAPPHIRE(
-        "Sapphire",
         "ROUGH_SAPPHIRE_GEM",
         OreBlock.SAPPHIRE,
     ),
     TOPAZ(
-        "Topaz",
         "ROUGH_TOPAZ_GEM",
         OreBlock.TOPAZ,
     ),
     JASPER(
-        "Jasper",
         "ROUGH_JASPER_GEM",
         OreBlock.JASPER,
     ),
     OPAL(
-        "Opal",
         "ROUGH_OPAL_GEM",
         OreBlock.OPAL,
     ),
     AQUAMARINE(
-        "Aquamarine",
         "ROUGH_AQUAMARINE_GEM",
         OreBlock.AQUAMARINE,
     ),
     CITRINE(
-        "Citrine",
         "ROUGH_CITRINE_GEM",
         OreBlock.CITRINE,
     ),
     ONYX(
-        "Onyx",
         "ROUGH_ONYX_GEM",
         OreBlock.ONYX,
     ),
     PERIDOT(
-        "Peridot",
         "ROUGH_PERIDOT_GEM",
         OreBlock.PERIDOT,
     ),
     UMBER(
-        "Umber",
         "UMBER",
         OreBlock.LOW_TIER_UMBER, OreBlock.MID_TIER_UMBER, OreBlock.HIGH_TIER_UMBER,
     ),
     TUNGSTEN(
-        "Tungsten",
         "TUNGSTEN",
         OreBlock.LOW_TIER_TUNGSTEN_TUNNELS, OreBlock.LOW_TIER_TUNGSTEN_MINESHAFT, OreBlock.HIGH_TIER_TUNGSTEN,
     ),
     GLACITE(
-        "Glacite",
         "GLACITE",
         OreBlock.GLACITE,
     ),
     ;
+
+    val oreName = oreName ?: toFormattedName()
 
     val oreBlocks = oreBlocks.toSet()
 
@@ -214,7 +184,7 @@ enum class OreType(
         }
 
         fun OreBlock.getOreType(): OreType? {
-            return OreType.entries.firstOrNull { this in it.oreBlocks }
+            return OreType.entries.firstOrNull { it.isType(this) }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OreType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OreType.kt
@@ -191,6 +191,8 @@ enum class OreType(
 
     val internalName: NeuInternalName = internalName.toInternalName()
 
+    fun isType(oreBlock: OreBlock): Boolean = oreBlock in oreBlocks
+
     fun isGemstone(): Boolean = this in gemstones
 
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
@@ -11,6 +11,9 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.events.mining.OreMinedEvent
+import at.hannibal2.skyhanni.features.mining.OreCategory
+import at.hannibal2.skyhanni.features.mining.OreType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
@@ -27,15 +30,22 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.StringUtils
-import at.hannibal2.skyhanni.utils.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfLimit
+import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
+import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
+import at.hannibal2.skyhanni.utils.render.FrustumUtils
 import net.minecraft.block.BlockChest
 import net.minecraft.block.state.IBlockState
 import java.awt.Color
+import java.util.Comparator
+import kotlin.comparisons.compareBy
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+
+private typealias LineMode = PowderChestTimerConfig.LineMode
 
 @SkyHanniModule
 object PowderChestTimer {
@@ -43,7 +53,12 @@ object PowderChestTimer {
     private val config get() = SkyHanniMod.feature.mining.powderChestTimer
 
     private var display: String? = null
-    private val chests = TimeLimitedCache<LorenzVec, SimpleTimeMark>(61.seconds)
+    private val chests = TimeLimitedCache<LorenzVec, ChestData>(61.seconds)
+    private var orderedChests = emptyList<ChestData>()
+
+    private val recentlyMinedHardstone = TimeLimitedSet<LorenzVec>(5.seconds)
+    private val recentlyChangedBlocks = TimeLimitedSet<LorenzVec>(5.seconds)
+
     private val maxDuration = 60.seconds
     private const val MAX_CHEST_DISTANCE = 15
     private const val NEAR_PLAYER_DISTANCE = 25
@@ -53,22 +68,57 @@ object PowderChestTimer {
         EntityUtils.getPlayerEntities().any { it.distanceToPlayer() < NEAR_PLAYER_DISTANCE }
     }
 
+    private data class ChestData(
+        val location: LorenzVec,
+        val despawnTime: SimpleTimeMark = maxDuration.fromNow(),
+        var hasSeen: Boolean = false,
+    ) {
+        fun updateHasSeen() {
+            if (hasSeen) return
+            if (!FrustumUtils.isVisible(location.getBlockAABB())) return
+            hasSeen = true
+        }
+    }
+
     @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
     fun onPlaySound(event: PlaySoundEvent) {
-        if (event.soundName == "random.levelup" && event.pitch == 1f && event.volume == 1.0f) {
-            lastSound = SimpleTimeMark.now()
-        }
+        if (event.soundName != "random.levelup" || event.pitch != 1f || event.volume != 1.0f) return
+        lastSound = SimpleTimeMark.now()
     }
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
     fun onRenderOverlay() {
-        if (isEnabled()) {
-            config.position.renderString(display, posLabel = "Powder Chest Timer")
-        }
+        if (!isEnabled()) return
+        config.position.renderString(display, posLabel = "Powder Chest Timer")
     }
 
     @HandleEvent
-    fun onWorldChange() = chests.clear()
+    fun onWorldChange() {
+        chests.clear()
+        orderedChests = emptyList()
+        recentlyMinedHardstone.clear()
+        recentlyChangedBlocks.clear()
+    }
+
+    private fun OreMinedEvent.isHardstone(): Boolean {
+        if (originalOre != null && OreType.HARD_STONE.isType(originalOre)) return true
+        return extraBlocks.keys.firstOrNull()?.let { OreType.HARD_STONE.isType(it) } ?: false
+    }
+
+    private fun handleChest() {
+        val intersect = recentlyMinedHardstone.intersect(recentlyChangedBlocks)
+        if (intersect.isEmpty()) return
+        recentlyMinedHardstone.removeAll(intersect)
+        recentlyChangedBlocks.removeAll(intersect)
+        for (location in intersect) chests[location] = ChestData(location)
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
+    fun onOreMine(event: OreMinedEvent) {
+        if (!event.isHardstone()) return
+        recentlyMinedHardstone.addAll(event.positions)
+        handleChest()
+    }
 
     @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
     fun onServerBlockChange(event: ServerBlockChangeEvent) {
@@ -79,7 +129,8 @@ object PowderChestTimer {
 
         if (isNewChest && !isOldChest) {
             if (arePlayersNearby && lastSound.passedSince() > 200.milliseconds) return
-            chests[location] = maxDuration.fromNow()
+            recentlyChangedBlocks.add(location)
+            handleChest()
         } else if (isOldChest && !isNewChest) {
             chests.remove(location)
         }
@@ -102,19 +153,24 @@ object PowderChestTimer {
 
     @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
     fun onTick() {
-        if (isEnabled()) {
-            display = drawDisplay()
+        if (!isEnabled()) return
+
+        val sort: Comparator<ChestData> = when (config.lineMode) {
+            LineMode.OLDEST -> compareBy { it.despawnTime.timeUntil() }
+            LineMode.NEAREST -> compareBy { it.location.distanceToPlayer() }
+            else -> return
         }
+        orderedChests = chests.values.sortedWith(sort).onEach(ChestData::updateHasSeen)
+        display = drawDisplay()
     }
 
     private fun drawDisplay(): String? {
-        if (chests.isEmpty()) return null
+        if (orderedChests.isEmpty()) return null
 
-        val count = chests.size
+        val count = orderedChests.size
         val name = StringUtils.pluralize(count, "chest")
-        val first = chests.values.minByOrNull { it.timeUntil() } ?: return null
+        val timeUntil = orderedChests.minOfOrNull { it.despawnTime.timeUntil() } ?: return null
 
-        val timeUntil = first.timeUntil()
         val color = timeUntil.getColorBasedOnTime().toChatColor()
 
         return "$color${timeUntil.format(TimeUnit.SECOND)} §8(§e$count §b$name§8)"
@@ -123,11 +179,12 @@ object PowderChestTimer {
     @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
-        if (chests.isEmpty()) return
+        if (orderedChests.isEmpty()) return
 
         val playerY = LocationUtils.playerLocation().y
 
-        for ((loc, time) in chests) {
+        for ((loc, time, hasSeen) in orderedChests) {
+            if (!hasSeen) continue
             val timeLeft = time.timeUntil()
 
             if (config.highlightChests) {
@@ -143,13 +200,7 @@ object PowderChestTimer {
             }
         }
 
-        val sortedChests = when (config.lineMode) {
-            PowderChestTimerConfig.LineMode.OLDEST -> chests.entries.sortedBy { it.value.timeUntil() }
-            PowderChestTimerConfig.LineMode.NEAREST -> chests.entries.sortedBy { it.key.distanceToPlayer() }
-            else -> return
-        }
-
-        val chestToConnect = sortedChests.take(config.drawLineToChestAmount)
+        val chestToConnect = orderedChests.takeIfLimit(config.drawLineToChestAmount, ChestData::hasSeen)
         val (firstPos, firstTime) = chestToConnect.firstOrNull() ?: return
 
         event.drawLineToEye(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.mining.OreMinedEvent
-import at.hannibal2.skyhanni.features.mining.OreCategory
 import at.hannibal2.skyhanni.features.mining.OreType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
@@ -174,6 +174,8 @@ data class LorenzVec(
     fun boundingToOffset(offX: Double, offY: Double, offZ: Double) =
         AxisAlignedBB(x, y, z, x + offX, y + offY, z + offZ)
 
+    fun getBlockAABB(): AxisAlignedBB = boundingToOffset(1.0, 1.0, 1.0)
+
     fun scale(scalar: Double): LorenzVec = LorenzVec(scalar * x, scalar * y, scalar * z)
 
     fun axisAlignedTo(other: LorenzVec) = AxisAlignedBB(x, y, z, other.x, other.y, other.z)

--- a/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
@@ -228,6 +228,18 @@ object CollectionUtils {
         return collection
     }
 
+    fun <T> Iterable<T>.takeIfLimit(limit: Int, predicate: (T) -> Boolean): List<T> {
+        val result = mutableListOf<T>()
+        for (element in this) {
+            if (predicate(element)) {
+                result.add(element)
+                if (result.size == limit) break
+            }
+        }
+        return result
+    }
+
+
     /** Updates a value if it is present in the set (equals), useful if the newValue is not reference equal with the value in the set */
     inline fun <reified T> MutableSet<T>.refreshReference(newValue: T) = if (this.contains(newValue)) {
         this.remove(newValue)


### PR DESCRIPTION
## What
Fixes a NoSuchElementException in PowderChestTimer, and makes it so that other chests dont get detected as powder chests. To do this, it adds a set of lorenzvec in OreMineEvent for the blocks that got mined. It also makes it so that powder chests dont get highlighted/drawn a line to if the player hasnt seen them.

## Changelog Fixes
+ Fixed Powder Chest Timer detecting other chests as powder chests. - Empa
+ Fixed Powder Chest Timer sometimes throwing errors in chat. - Empa

## Changelog Technical Details
+ Added `positions` set to OreMineEvent. - Empa