### PR TITLE
Backend: Brigadier Arguments

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierArguments.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierArguments.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.SimpleStringArgumentType
 import com.mojang.brigadier.arguments.BoolArgumentType
 import com.mojang.brigadier.arguments.DoubleArgumentType
 import com.mojang.brigadier.arguments.FloatArgumentType
@@ -26,4 +27,8 @@ object BrigadierArguments {
     fun string(): StringArgumentType = StringArgumentType.string()
     fun greedyString(): StringArgumentType = StringArgumentType.greedyString()
     fun word(): StringArgumentType = StringArgumentType.word()
+
+    fun <T : Any> simpleMap(map: Map<String, T>): SimpleStringArgumentType<T> {
+        return SimpleStringArgumentType(map)
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierBuilder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierBuilder.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
 import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.isGreedy
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.toSuggestionProvider
 import at.hannibal2.skyhanni.utils.StringUtils.hasWhitespace
 import at.hannibal2.skyhanni.utils.StringUtils.splitLastWhitespace
@@ -37,7 +38,11 @@ class BaseBrigadierBuilder(override val name: String) : CommandData, BrigadierBu
 
 open class BrigadierBuilder<B : ArgumentBuilder<Any?, B>>(
     val builder: ArgumentBuilder<Any?, B>,
+    private val hasGreedyArg: Boolean = false,
 ) {
+    private fun checkGreedy() =
+        require(!hasGreedyArg) { "Cannot add an argument/literal to a builder that has a greedy argument." }
+
     /** Executes the code block when the command is executed. */
     fun callback(block: ArgContext.() -> Unit) {
         this.builder.executes {
@@ -89,6 +94,7 @@ open class BrigadierBuilder<B : ArgumentBuilder<Any?, B>>(
      * ```
      */
     fun literal(vararg names: String, action: LiteralCommandBuilder.() -> Unit) {
+        checkGreedy()
         for (name in names) {
             if (name.hasWhitespace()) {
                 val (prevLiteral, nextLiteral) = name.splitLastWhitespace()
@@ -160,6 +166,7 @@ open class BrigadierBuilder<B : ArgumentBuilder<Any?, B>>(
         suggestions: SuggestionProvider<Any?>? = null,
         action: ArgumentCommandBuilder<T>.() -> Unit,
     ) {
+        checkGreedy()
         if (name.hasWhitespace()) {
             val (prevLiteral, nextLiteral) = name.splitLastWhitespace()
             literal(prevLiteral) {
@@ -167,10 +174,11 @@ open class BrigadierBuilder<B : ArgumentBuilder<Any?, B>>(
             }
             return
         }
+        val isGreedy = argument.isGreedy()
         val builder = BrigadierBuilder(
             RequiredArgumentBuilder.argument<Any?, T>(name, argument).apply {
                 if (suggestions != null) suggests(suggestions)
-            },
+            }, isGreedy
         )
         builder.action()
         this.builder.then(builder.builder)

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierBuilder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierBuilder.kt
@@ -178,7 +178,8 @@ open class BrigadierBuilder<B : ArgumentBuilder<Any?, B>>(
         val builder = BrigadierBuilder(
             RequiredArgumentBuilder.argument<Any?, T>(name, argument).apply {
                 if (suggestions != null) suggests(suggestions)
-            }, isGreedy
+            },
+            isGreedy,
         )
         builder.action()
         this.builder.then(builder.builder)

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
@@ -98,7 +98,6 @@ object BrigadierUtils {
             ?: NeuInternalName.fromItemNameOrInternalName(withSpaces).handleItem()
     }
 
-    // TODO: add support for 1.21
     fun SuggestionsBuilder.addOptionalEscaped(
         collection: Collection<String>,
     ): SuggestionsBuilder {
@@ -127,7 +126,6 @@ object BrigadierUtils {
         return this
     }
 
-    // TODO: add support for 1.21
     fun SuggestionsBuilder.addEscaped(
         collection: Collection<String>,
     ): SuggestionsBuilder {

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
@@ -1,15 +1,198 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.InternalNameArgumentType
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuItems
+import at.hannibal2.skyhanni.utils.StringUtils.hasWhitespace
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.arguments.StringArgumentType
+import com.mojang.brigadier.exceptions.CommandSyntaxException
 import com.mojang.brigadier.suggestion.SuggestionProvider
+import com.mojang.brigadier.suggestion.Suggestions
+import com.mojang.brigadier.suggestion.SuggestionsBuilder
+import java.util.concurrent.CompletableFuture
 
 object BrigadierUtils {
 
-    fun Collection<String>.toSuggestionProvider() = SuggestionProvider<Any?> { _, builder ->
-        for (s in this) {
-            if (s.startsWith(builder.remainingLowerCase)) {
-                builder.suggest(s)
+    const val DOUBLE_QUOTE = '"'
+    private const val SINGLE_QUOTE = '\''
+
+    // Add greedy arguments here
+    fun <T> ArgumentType<T>.isGreedy(): Boolean {
+        return when (this) {
+            is StringArgumentType -> this.type == StringArgumentType.StringType.GREEDY_PHRASE
+            is InternalNameArgumentType -> this.isGreedy
+            else -> false
+        }
+    }
+
+    fun Collection<String>.toSuggestionProvider(shouldEscape: Boolean = true) = SuggestionProvider<Any?> { _, builder ->
+        if (shouldEscape) builder.addOptionalEscaped(this)
+        else builder.addUnescaped(this)
+        builder.buildFuture()
+    }
+
+    private fun isCharAllowed(c: Char): Boolean = StringReader.isAllowedInUnquotedString(c) || c == SINGLE_QUOTE
+
+    /** The same as [StringReader.readString], except it doesn't accept escaping with `'`. */
+    fun StringReader.readOptionalDoubleQuotedString(): String {
+        if (!canRead()) return ""
+        return if (peek() == DOUBLE_QUOTE) {
+            skip()
+            readStringUntil(DOUBLE_QUOTE)
+        } else {
+            val start = cursor
+            while (canRead() && isCharAllowed(peek())) {
+                skip()
+            }
+            return string.substring(start, cursor)
+        }
+    }
+
+    /** Returns the remaining text in the [StringReader] and sets the cursor at the end */
+    fun StringReader.readGreedyString(): String {
+        val text = remaining
+        cursor = totalLength
+        return text
+    }
+
+    /** The same as [StringReader.readQuotedString], except it doesn't accept escaping with `'`. */
+    fun StringReader.readDoubleQuotedString(): String {
+        if (!canRead()) return ""
+        if (peek() != DOUBLE_QUOTE) throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.readerExpectedStartOfQuote().createWithContext(this)
+        skip()
+        return readStringUntil(DOUBLE_QUOTE)
+    }
+
+    fun String.escapeDoubleQuote(): String {
+        if (firstOrNull() != DOUBLE_QUOTE) return this
+        return substring(1, lastIndex - 1)
+    }
+
+    enum class ItemParsingFail {
+        UNKNOWN_ITEM,
+        DISALLOWED_ITEM,
+        EMPTY,
+    }
+
+    /** Parses an item (both internal name and item name) into an NeuInternalName. If it fails, it returns an ItemParsingFail instead */
+    fun parseItem(
+        input: String,
+        aliases: Map<String, NeuInternalName> = NeuItems.commonItemAliases.global,
+        isValidItem: (NeuInternalName) -> Boolean = { true },
+    ): Any {
+        if (input.isBlank()) return ItemParsingFail.EMPTY
+        val withSpaces = input.replace("_", " ")
+
+        fun NeuInternalName.handleItem(): Any = when {
+            !isKnownItem() -> ItemParsingFail.UNKNOWN_ITEM
+            !isValidItem(this) -> ItemParsingFail.DISALLOWED_ITEM
+            else -> this
+        }
+
+        return aliases[withSpaces]?.handleItem()
+            ?: NeuInternalName.fromItemNameOrInternalName(withSpaces).handleItem()
+    }
+
+    // TODO: add support for 1.21
+    fun SuggestionsBuilder.addOptionalEscaped(
+        collection: Collection<String>,
+    ): SuggestionsBuilder {
+        if (collection.isEmpty()) return this
+        val input = remainingLowerCase
+        val isEscaped = input.firstOrNull() == DOUBLE_QUOTE
+        val escaped = if (isEscaped) input.drop(1) else input
+        val lastWhitespace = escaped.lastIndexOf(' ')
+        for (string in collection) {
+            if (lastWhitespace == -1) {
+                if (isEscaped || string.hasWhitespace()) suggest("$DOUBLE_QUOTE$string$DOUBLE_QUOTE")
+                else suggest(string)
+            } else {
+                val suggestion = string.substring(lastWhitespace + 1)
+                if (suggestion.isBlank()) suggest("$DOUBLE_QUOTE")
+                else suggest("$suggestion$DOUBLE_QUOTE")
             }
         }
-        builder.buildFuture()
+        return this
+    }
+
+    // TODO: add support for 1.21
+    fun SuggestionsBuilder.addEscaped(
+        collection: Collection<String>,
+    ): SuggestionsBuilder {
+        if (collection.isEmpty()) return this
+        val input = remainingLowerCase
+        val escaped = input.drop(1)
+        val lastWhitespace = escaped.lastIndexOf(' ')
+        for (string in collection) {
+            if (lastWhitespace == -1) {
+                suggest("$DOUBLE_QUOTE$string$DOUBLE_QUOTE")
+            } else {
+                val suggestion = string.substring(lastWhitespace + 1)
+                if (suggestion.isBlank()) suggest("$DOUBLE_QUOTE")
+                else suggest("$suggestion$DOUBLE_QUOTE")
+            }
+        }
+        return this
+    }
+
+    // TODO: add support for 1.21
+    fun SuggestionsBuilder.addUnescaped(
+        collection: Collection<String>,
+    ): SuggestionsBuilder {
+        if (collection.isEmpty()) return this
+        val input = remainingLowerCase
+        val isEscaped = input.firstOrNull() == DOUBLE_QUOTE
+        val escaped = if (isEscaped) input.drop(1) else input
+        val lastWhitespace = escaped.lastIndexOf(' ')
+        for (string in collection) {
+            if (lastWhitespace == -1) {
+                if (input == string) continue
+                suggest(string)
+            } else {
+                val suggestion = string.substring(lastWhitespace + 1) + if (isEscaped) DOUBLE_QUOTE else ""
+                if (suggestion.isNotBlank()) suggest(suggestion)
+            }
+        }
+        return this
+    }
+
+    fun parseItemNameTabComplete(
+        input: String,
+        builder: SuggestionsBuilder,
+        limit: Int = 200,
+        showWhenEmpty: Boolean = false,
+        isGreedy: Boolean = false,
+        isValidItem: (NeuInternalName) -> Boolean,
+    ): CompletableFuture<Suggestions> {
+        if (input.isEmpty() && !showWhenEmpty) return builder.buildFuture()
+        val unEscaped = if (input.firstOrNull() == DOUBLE_QUOTE) input.drop(1) else input
+        if (unEscaped.isBlank() && !showWhenEmpty) return builder.buildFuture()
+
+        val lowercaseStart = unEscaped.replace("_", " ")
+        val items = NeuItems.findItemNameStartingWithWithoutNPCs(lowercaseStart, isValidItem).take(limit)
+
+        if (isGreedy) builder.addUnescaped(items) else builder.addOptionalEscaped(items)
+        return builder.buildFuture()
+    }
+
+    fun parseInternalNameTabComplete(
+        input: String,
+        builder: SuggestionsBuilder,
+        limit: Int = 200,
+        showWhenEmpty: Boolean = false,
+        isGreedy: Boolean = false,
+        isValidItem: (NeuInternalName) -> Boolean,
+    ): CompletableFuture<Suggestions> {
+        if (input.isEmpty() && !showWhenEmpty) return builder.buildFuture()
+        val unEscaped = if (input.firstOrNull() == DOUBLE_QUOTE) input.drop(1) else input
+        if (unEscaped.isBlank() && !showWhenEmpty) return builder.buildFuture()
+
+        val start = unEscaped.replace(" ", "_").uppercase()
+        val items = NeuItems.findInternalNameStartingWithWithoutNPCs(start, isValidItem).take(limit)
+
+        if (isGreedy) builder.addUnescaped(items) else builder.addOptionalEscaped(items)
+        return builder.buildFuture()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
@@ -27,9 +27,12 @@ object BrigadierUtils {
         }
     }
 
-    fun Collection<String>.toSuggestionProvider(shouldEscape: Boolean = true) = SuggestionProvider<Any?> { _, builder ->
-        if (shouldEscape) builder.addOptionalEscaped(this)
-        else builder.addUnescaped(this)
+    fun Collection<String>.toSuggestionProvider() = SuggestionProvider<Any?> { _, builder ->
+        for (s in this) {
+            if (s.startsWith(builder.remainingLowerCase)) {
+                builder.suggest(s)
+            }
+        }
         builder.buildFuture()
     }
 
@@ -102,6 +105,7 @@ object BrigadierUtils {
         if (collection.isEmpty()) return this
         val input = remainingLowerCase
         val isEscaped = input.firstOrNull() == DOUBLE_QUOTE
+        //#if MC < 1.21
         val escaped = if (isEscaped) input.drop(1) else input
         val lastWhitespace = escaped.lastIndexOf(' ')
         for (string in collection) {
@@ -114,6 +118,12 @@ object BrigadierUtils {
                 else suggest("$suggestion$DOUBLE_QUOTE")
             }
         }
+        //#else
+        //$$ for (string in collection) {
+        //$$     if (isEscaped || string.hasWhitespace()) suggest("$DOUBLE_QUOTE$string$DOUBLE_QUOTE")
+        //$$     else suggest(string)
+        //$$ }
+        //#endif
         return this
     }
 
@@ -123,6 +133,7 @@ object BrigadierUtils {
     ): SuggestionsBuilder {
         if (collection.isEmpty()) return this
         val input = remainingLowerCase
+        //#if MC < 1.21
         val escaped = input.drop(1)
         val lastWhitespace = escaped.lastIndexOf(' ')
         for (string in collection) {
@@ -134,6 +145,9 @@ object BrigadierUtils {
                 else suggest("$suggestion$DOUBLE_QUOTE")
             }
         }
+        //#else
+        //$$ for (string in collection) suggest("$DOUBLE_QUOTE$string$DOUBLE_QUOTE")
+        //#endif
         return this
     }
 
@@ -143,6 +157,7 @@ object BrigadierUtils {
     ): SuggestionsBuilder {
         if (collection.isEmpty()) return this
         val input = remainingLowerCase
+        //#if MC < 1.21
         val isEscaped = input.firstOrNull() == DOUBLE_QUOTE
         val escaped = if (isEscaped) input.drop(1) else input
         val lastWhitespace = escaped.lastIndexOf(' ')
@@ -155,6 +170,9 @@ object BrigadierUtils {
                 if (suggestion.isNotBlank()) suggest(suggestion)
             }
         }
+        //#else
+        //$$ for (string in collection) suggest(string)
+        //#endif
         return this
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/EnumArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/EnumArgumentType.kt
@@ -1,0 +1,62 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import com.mojang.brigadier.LiteralMessage
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
+import com.mojang.brigadier.suggestion.Suggestions
+import com.mojang.brigadier.suggestion.SuggestionsBuilder
+import java.util.concurrent.CompletableFuture
+
+class EnumArgumentType<E : Enum<E>> private constructor(
+    clazz: Class<E>,
+    toString: (E) -> String,
+) : ArgumentType<E> {
+
+    private val mapping: Map<String, E> = clazz.enumConstants.associateBy { constant ->
+        val string = toString(constant)
+        require(string.none { it.isWhitespace() }) {
+            "String representation of constant ${constant.name} of enum ${clazz.simpleName} contains whitespace: '$string'"
+        }
+        string
+    }
+
+    private val invalidValueException = DynamicCommandExceptionType { input ->
+        LiteralMessage("Invalid value '$input'.")
+    }
+
+    override fun parse(reader: StringReader): E {
+        val input = reader.readUnquotedString()
+        val entry = mapping.entries.find { (string, _) -> string.equals(input, true) }
+        return entry?.value ?: throw invalidValueException.createWithContext(reader, input)
+    }
+
+    override fun <S : Any?> listSuggestions(context: CommandContext<S>, builder: SuggestionsBuilder): CompletableFuture<Suggestions> {
+        val string = builder.remainingLowerCase
+        for (enum in mapping.keys) {
+            if (enum.startsWith(string, true)) builder.suggest(enum)
+        }
+        return builder.buildFuture()
+    }
+
+    override fun getExamples(): Collection<String> = mapping.keys
+
+    companion object {
+        fun <E : Enum<E>> create(clazz: Class<E>, toString: (E) -> String): EnumArgumentType<E> {
+            return EnumArgumentType(clazz, toString)
+        }
+        inline fun <reified E : Enum<E>> name(): EnumArgumentType<E> {
+            return create(E::class.java) { it.name }
+        }
+
+        inline fun <reified E : Enum<E>> lowercase(): EnumArgumentType<E> {
+            return create(E::class.java) { it.name.lowercase() }
+        }
+
+        /** The string representation of the enum should not change during runtime. */
+        inline fun <reified E : Enum<E>> custom(noinline toString: (E) -> String): EnumArgumentType<E> {
+            return create(E::class.java, toString)
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/InternalNameArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/InternalNameArgumentType.kt
@@ -1,0 +1,122 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.escapeDoubleQuote
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.readGreedyString
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.readOptionalDoubleQuotedString
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import com.mojang.brigadier.LiteralMessage
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import com.mojang.brigadier.suggestion.Suggestions
+import com.mojang.brigadier.suggestion.SuggestionsBuilder
+import java.util.concurrent.CompletableFuture
+
+private typealias ParsingFail = BrigadierUtils.ItemParsingFail
+
+sealed class InternalNameArgumentType(
+    val isGreedy: Boolean = false,
+) : ArgumentType<NeuInternalName> {
+
+    protected open val showWhenEmpty: Boolean = false
+
+    private val unknownValueException = DynamicCommandExceptionType { input ->
+        LiteralMessage("Unknown item '$input'.")
+    }
+
+    private val disallowedValueException = DynamicCommandExceptionType { input ->
+        LiteralMessage("Disallowed item '$input'.")
+    }
+
+    private val emptyValueException = SimpleCommandExceptionType { "Empty item name provided." }
+
+    override fun parse(reader: StringReader): NeuInternalName {
+        val input = if (isGreedy) reader.readGreedyString().escapeDoubleQuote()
+        else reader.readOptionalDoubleQuotedString()
+
+        val result = BrigadierUtils.parseItem(input, isValidItem = ::isValidItem)
+        return when (result) {
+            is NeuInternalName -> result
+            ParsingFail.DISALLOWED_ITEM -> throw disallowedValueException.createWithContext(reader, input)
+            ParsingFail.UNKNOWN_ITEM -> throw unknownValueException.createWithContext(reader, input)
+            ParsingFail.EMPTY -> throw emptyValueException.createWithContext(reader)
+            else -> throw IllegalArgumentException("Unexpected item parsing result: $result")
+        }
+    }
+
+    protected open fun isValidItem(item: NeuInternalName): Boolean = true
+
+    private open class ItemName(isGreedy: Boolean) : InternalNameArgumentType(isGreedy) {
+        override fun <S : Any?> listSuggestions(context: CommandContext<S>, builder: SuggestionsBuilder): CompletableFuture<Suggestions> {
+            return BrigadierUtils.parseItemNameTabComplete(
+                builder.remainingLowerCase,
+                builder,
+                showWhenEmpty = showWhenEmpty,
+                isGreedy = isGreedy,
+                isValidItem = ::isValidItem,
+            )
+        }
+    }
+
+    private open class InternalName(isGreedy: Boolean) : InternalNameArgumentType(isGreedy) {
+        override fun <S : Any?> listSuggestions(context: CommandContext<S>, builder: SuggestionsBuilder): CompletableFuture<Suggestions> {
+            return BrigadierUtils.parseInternalNameTabComplete(
+                builder.remaining,
+                builder,
+                showWhenEmpty = showWhenEmpty,
+                isGreedy = isGreedy,
+                isValidItem = ::isValidItem,
+            )
+        }
+    }
+
+    @Suppress("unused")
+    companion object {
+        fun itemName(isGreedy: Boolean = false): InternalNameArgumentType = ItemName(isGreedy)
+
+        fun itemName(
+            showWhenEmpty: Boolean = false,
+            isGreedy: Boolean = false,
+            isValid: (NeuInternalName) -> Boolean,
+        ): InternalNameArgumentType {
+            return object : ItemName(isGreedy) {
+                override val showWhenEmpty: Boolean = showWhenEmpty
+                override fun isValidItem(item: NeuInternalName): Boolean = isValid(item)
+            }
+        }
+
+        fun itemName(
+            allowed: Collection<NeuInternalName>,
+            showWhenEmpty: Boolean = false,
+            isGreedy: Boolean = false,
+        ): InternalNameArgumentType {
+            val set = allowed.toSet()
+            return itemName(showWhenEmpty, isGreedy) { it in set }
+        }
+
+        fun internalName(isGreedy: Boolean = false): InternalNameArgumentType = InternalName(isGreedy)
+
+        fun internalName(
+            showWhenEmpty: Boolean = false,
+            isGreedy: Boolean = false,
+            isValid: (NeuInternalName) -> Boolean,
+        ): InternalNameArgumentType {
+            return object : InternalName(isGreedy) {
+                override val showWhenEmpty: Boolean = showWhenEmpty
+                override fun isValidItem(item: NeuInternalName): Boolean = isValid(item)
+            }
+        }
+
+        fun internalName(
+            allowed: Collection<NeuInternalName>,
+            showWhenEmpty: Boolean = false,
+            isGreedy: Boolean = false,
+        ): InternalNameArgumentType {
+            val set = allowed.toSet()
+            return internalName(showWhenEmpty, isGreedy) { it in set }
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/LorenzVecArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/LorenzVecArgumentType.kt
@@ -1,0 +1,40 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import at.hannibal2.skyhanni.utils.LorenzVec
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+
+sealed class LorenzVecArgumentType : ArgumentType<LorenzVec> {
+    data object Int : LorenzVecArgumentType() {
+        override fun parse(reader: StringReader): LorenzVec {
+            val x = reader.readInt()
+            reader.skipWhitespace()
+            val y = reader.readInt()
+            reader.skipWhitespace()
+            val z = reader.readInt()
+            return LorenzVec(x, y, z)
+        }
+
+        override fun getExamples(): Collection<String> = listOf("1 2 3", "-4 0 5")
+    }
+    data object Double : LorenzVecArgumentType() {
+        override fun parse(reader: StringReader): LorenzVec {
+            val x = reader.readDouble()
+            reader.skipWhitespace()
+            val y = reader.readDouble()
+            reader.skipWhitespace()
+            val z = reader.readDouble()
+            return LorenzVec(x, y, z)
+        }
+
+        override fun getExamples(): Collection<String> = listOf("1.0 2.5 -3", "0.0 0.0 0.0")
+    }
+
+    companion object {
+        /** Only accepts integers as input */
+        fun int(): LorenzVecArgumentType = Int
+
+        /** Accepts any number as input */
+        fun double(): LorenzVecArgumentType = Double
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/SimpleStringArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/SimpleStringArgumentType.kt
@@ -1,0 +1,33 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.addOptionalEscaped
+import com.mojang.brigadier.LiteralMessage
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
+import com.mojang.brigadier.suggestion.Suggestions
+import com.mojang.brigadier.suggestion.SuggestionsBuilder
+import java.util.concurrent.CompletableFuture
+
+class SimpleStringArgumentType<T : Any>(
+    map: Map<String, T>,
+) : ArgumentType<T> {
+
+    private val map: Map<String, T> = map.mapKeys { it.key.lowercase() }
+
+    private val invalidValueException = DynamicCommandExceptionType { input ->
+        LiteralMessage("Invalid value '$input'.")
+    }
+
+    override fun parse(reader: StringReader): T {
+        val input = reader.readString().lowercase()
+        return map[input] ?: throw invalidValueException.createWithContext(reader, input)
+    }
+
+    override fun <S : Any> listSuggestions(context: CommandContext<S>, builder: SuggestionsBuilder): CompletableFuture<Suggestions> {
+        return builder.addOptionalEscaped(map.keys).buildFuture()
+    }
+
+    override fun getExamples(): Collection<String> = map.keys
+}

--- a/versions/1.21.5/buildpaths.txt
+++ b/versions/1.21.5/buildpaths.txt
@@ -685,6 +685,10 @@ at.hannibal2.skyhanni.config.commands.brigadier.CommandData.kt
 at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent.kt
 at.hannibal2.skyhanni.features.commands.HelpCommand.kt
 at/hannibal2/skyhanni/config/commands/brigadier/BrigadierBuilder.kt
+at/hannibal2/skyhanni/config/commands/brigadier/arguments/EnumArgumentType.kt
+at/hannibal2/skyhanni/config/commands/brigadier/arguments/InternalNameArgumentType.kt
+at/hannibal2/skyhanni/config/commands/brigadier/arguments/LorenzVecArgumentType.kt
+at/hannibal2/skyhanni/config/commands/brigadier/arguments/SimpleStringArgumentType.kt
 at.hannibal2.skyhanni.config.commands.CommandBuilder.kt
 at.hannibal2.skyhanni.config.commands.CommandsRegistry.kt
 at/hannibal2/skyhanni/utils/CommandUtils.kt


### PR DESCRIPTION
## What
This PR adds more brigadier arguments, such as EnumArgumentType, LorenzVecArgument, SimpleStringArgumentType, and InternalNameArgumentType. The InternalNameArgumentType has many options, and can be used so that the tab completion suggests either raw internal names or item names, with optional greedy support so quotes arent needed.

It also adds various brigadier util functions to deal with adding suggestions, and a check to make sure literals or other arguments arent used after a greedy argument.

## Changelog Technical Details
+ Added more Brigadier Argument Types. - Empa