### PR TITLE
Fix: Custom Scoreboard Party Display not disappearing when a party of 2 players is disbanded due to the leader disconnecting for 5 mins.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/PartyApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PartyApi.kt
@@ -242,7 +242,8 @@ object PartyApi {
         if (message == "§eYou left the party." ||
             message == "§cThe party was disbanded because all invites expired and the party was empty." ||
             message == "§cYou are not currently in a party." ||
-            message == "§cYou are not in a party."
+            message == "§cYou are not in a party." ||
+            message == "§cThe party was disbanded because the party leader disconnected."
         ) {
             partyLeft()
         }


### PR DESCRIPTION
## What
Adds the string `§cThe party was disbanded because the party leader disconnected.` to the PartyApi, fixing the Custom Scoreboard not removing the party element when a party of 2 players is disbanded due to the leader disconnecting and not returning within 5 minutes.

## Changelog Fixes
+ Fixed Custom Scoreboard Party Display persisting for 5 minutes after the leader disconnects from a two-player party. - NeoNyaa