### PR TITLE
Fix: Pest spawn timer showing when disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -211,6 +211,7 @@ object PestSpawnTimer {
     }
 
     private fun shouldRender(): Boolean = when {
+        !config.enabled -> false
         config.onlyWithFarmingTool && config.onlyWithVacuum -> hasFarmingToolInHand() || hasVacuumInHand()
         config.onlyWithFarmingTool -> hasFarmingToolInHand()
         config.onlyWithVacuum -> hasVacuumInHand()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -211,7 +211,7 @@ object PestSpawnTimer {
     }
 
     private fun shouldRender(): Boolean = when {
-        !config.enabled -> false
+        !isEnabled() -> false
         config.onlyWithFarmingTool && config.onlyWithVacuum -> hasFarmingToolInHand() || hasVacuumInHand()
         config.onlyWithFarmingTool -> hasFarmingToolInHand()
         config.onlyWithVacuum -> hasVacuumInHand()


### PR DESCRIPTION
## What
Fixes pest spawn timer showing when disabled in config. 

## Changelog Fixes
+ Fixed Pest Spawn Timer displaying incorrectly. - Chissl


