### PR TITLE
Fix: detecting fairy souls while falling

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -54,4 +54,6 @@ object PlayerUtils {
     fun getRawUuid(): UUID = MinecraftCompat.localPlayer.uniqueID
 
     fun getName(): String = MinecraftCompat.localPlayer.name
+
+    fun inAir(): Boolean = MinecraftCompat.localPlayer.isAirBorne
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -55,5 +55,5 @@ object PlayerUtils {
 
     fun getName(): String = MinecraftCompat.localPlayer.name
 
-    fun inAir(): Boolean = MinecraftCompat.localPlayer.isAirBorne
+    fun inAir(): Boolean = !MinecraftCompat.localPlayer.onGround
 }


### PR DESCRIPTION
## What
Fixed not detecting fairy souls when jumping and clicking on them mid air.
We now also check the nearest fairy sould 10 blocks above the player if not found around the player, only when in air.

Reported: https://discord.com/channels/997079228510117908/1383866885799415818

## Changelog Fixes
+ Fixed clicks on Fairy Souls not detected while falling. - hannibal2