### PR TITLE
Backend: cleanup BucketedItemTrackerData

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
@@ -44,7 +44,7 @@ object DragonProfitTracker {
         { drawDisplay(it) },
     )
 
-    class BucketData : BucketedItemTrackerData<DragonType>(DragonType::class) {
+    class BucketData : BucketedItemTrackerData<DragonType>() {
         override fun getCoinName(bucket: DragonType?, item: TrackedItem) = "<no coins>"
         override fun getCoinDescription(bucket: DragonType?, item: TrackedItem): List<String> = listOf("<no coins>")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -87,7 +87,7 @@ object PestProfitTracker {
     )
     private var adjustmentMap: Map<PestType, Map<NeuInternalName, Int>> = mapOf()
 
-    class BucketData : BucketedItemTrackerData<PestType>(PestType::class) {
+    class BucketData : BucketedItemTrackerData<PestType>() {
         override fun resetItems() {
             @Suppress("DEPRECATION")
             totalPestsKills = 0L

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseTracker.kt
@@ -42,7 +42,7 @@ object CorpseTracker {
         { drawDisplay(it) },
     )
 
-    class BucketData : BucketedItemTrackerData<CorpseType>(CorpseType::class) {
+    class BucketData : BucketedItemTrackerData<CorpseType>() {
         override fun resetItems() {
             corpsesLooted = enumMapOf()
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
@@ -3,9 +3,9 @@ package at.hannibal2.skyhanni.utils.tracker
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.renderables.ScrollValue
 import com.google.gson.annotations.Expose
-import kotlin.reflect.KClass
+import java.lang.reflect.ParameterizedType
 
-abstract class BucketedItemTrackerData<E : Enum<E>>(clazz: KClass<E>) : ItemTrackerData() {
+abstract class BucketedItemTrackerData<E : Enum<E>> : ItemTrackerData() {
 
     @Deprecated(
         "Use getDescription(bucket, timesGained) instead",
@@ -87,7 +87,13 @@ abstract class BucketedItemTrackerData<E : Enum<E>>(clazz: KClass<E>) : ItemTrac
 
     abstract fun E.isBucketSelectable(): Boolean
 
-    private val buckets: Array<E> = clazz.java.enumConstants
+    @Suppress("UNCHECKED_CAST")
+    private val enumClass: Class<E> by lazy {
+        val superType = (javaClass.genericSuperclass as ParameterizedType)
+        superType.actualTypeArguments[0] as Class<E>
+    }
+
+    private val buckets: Array<E> = enumClass.enumConstants
     val selectableBuckets: List<E> = buckets.filter { it.isBucketSelectable() }
 
     private val scrollValues: Map<E?, ScrollValue> = buckets.associateWith { ScrollValue() } + (null to ScrollValue())


### PR DESCRIPTION
## Dependencies
- #4072

## What
using a reflection hack to avoid the parameter of type class.
This could blow up if we were to use another layer of abstraction, but for now it works fine.

## Changelog Technical Details
+ Removed parameters for isntances of BucketedItemTrackerData. - hannibal2