### PR TITLE
Fix: Slayer menu NPE

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
+import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -30,7 +31,7 @@ object BlockNotSpawnable {
         val slot = event.slot ?: return
         if (InventoryUtils.openInventoryName() != "Slayer") return
 
-        val stack = slot.stack ?: return
+        val stack = slot.stack?.orNull() ?: return
         if (notSpawnablePattern.anyMatches(stack.getLore())) {
             event.cancel()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
@@ -30,7 +30,8 @@ object BlockNotSpawnable {
         val slot = event.slot ?: return
         if (InventoryUtils.openInventoryName() != "Slayer") return
 
-        if (notSpawnablePattern.anyMatches(slot.stack.getLore())) {
+        val stack = slot.stack ?: return
+        if (notSpawnablePattern.anyMatches(stack.getLore())) {
             event.cancel()
         }
     }


### PR DESCRIPTION
## What
removed one npe. idk where it comes, but i know where it goes -> away

<details>
<summary>stack trace</summary>

```
SkyHanni 3.7.0: Caught a NullPointerException in at.hannibal2.skyhanni.features.slayer.BlockNotSpawnable.onSlotClick(at.hannibal2.skyhanni.events.GuiContainerEvent$SlotClickEvent) at GuiContainerEvent.SlotClickEvent: getStack(...) must not be null
 
Caused by java.lang.NullPointerException: getStack(...) must not be null
    at SH.features.slayer.BlockNotSpawnable.onSlotClick(BlockNotSpawnable.kt:33)
<Skyhanni event post>
```

</details>

reported: https://discord.com/channels/997079228510117908/1385244798755274872

## Changelog Fixes
+ Fixed rare error opening Slayer Menu. - hannibal2