### PR TITLE
Backend: copy item format change

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
@@ -28,7 +28,7 @@ object CopyItemCommand {
 
     fun copyItemToClipboard(itemStack: ItemStack) {
         val resultList = mutableListOf<String>()
-        resultList.add(itemStack.getInternalName().toString())
+        resultList.add("internal name: " + itemStack.getInternalName().asString())
         resultList.add("display name: '" + itemStack.displayName.toString() + "'")
         resultList.add("minecraft id: '" + itemStack.getMinecraftId() + "'")
         resultList.add("lore:")


### PR DESCRIPTION
## What
made a totally useless format change in the /sh copy item logic:

<details>
<summary>the change</summary>

old:
```
internalName:SKYBLOCK_MENU
display name: '§aSkyBlock Menu §7(Click)'
```

new:
```
internal name: SKYBLOCK_MENU
display name: '§aSkyBlock Menu §7(Click)'
```

</details>

## Changelog Technical Details
+ Refined /shcopyitem format. - hannibal2