### PR TITLE
Fix: TimiteHelper always showing soon

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
@@ -118,7 +117,7 @@ object DungeonLividFinder {
     fun onBlockChange(event: ServerBlockChangeEvent) {
         if (!inLividBossRoom()) return
         if (event.location != blockLocation) return
-        if (!event.location.getBlockAt().isWool()) return
+        if (!event.newState.isWool()) return
 
         val newColor = event.newState.getBlockColor()
         color = newColor

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/TimiteHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/TimiteHelper.kt
@@ -58,8 +58,8 @@ object TimiteHelper {
         currentPos = event.position
         currentBlockState = event.getBlockState
 
-        val block = event.getBlockState.block
-        if (!block.isStainedGlassPane(ColoredBlockCompat.BLUE) && !block.isStainedGlassPane(ColoredBlockCompat.LIGHT_BLUE)) return
+        val blockState = event.getBlockState
+        if (!blockState.isStainedGlassPane(ColoredBlockCompat.BLUE) && !blockState.isStainedGlassPane(ColoredBlockCompat.LIGHT_BLUE)) return
 
         if (lastClick + 300.milliseconds > SimpleTimeMark.now()) {
             lastClick = SimpleTimeMark.now()
@@ -79,7 +79,7 @@ object TimiteHelper {
         }
         if (holdingClick.isFarPast()) return
 
-        if (currentBlockState?.block?.isStainedGlassPane() != true) return
+        if (currentBlockState?.isStainedGlassPane() != true) return
 
         val time = if (doubleTimeShooting) 1800 else 2000
         val timeLeft = holdingClick + time.milliseconds
@@ -98,7 +98,7 @@ object TimiteHelper {
         val map = BlockUtils.nearbyBlocks(
             LocationUtils.playerLocation(),
             distance = 15,
-            condition = { it.block.isStainedGlassPane() },
+            condition = { it.isStainedGlassPane() },
         )
 
         for ((loc, state) in map) {
@@ -112,7 +112,7 @@ object TimiteHelper {
             val state = iterator.next().key.getBlockStateAt()
             if (state.block == Blocks.air) {
                 iterator.remove()
-            } else if (state.block.isStainedGlassPane(ColoredBlockCompat.LIGHT_BLUE)) {
+            } else if (state.isStainedGlassPane(ColoredBlockCompat.LIGHT_BLUE)) {
                 iterator.remove()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/ColoredBlockCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/ColoredBlockCompat.kt
@@ -2,11 +2,16 @@ package at.hannibal2.skyhanni.utils.compat
 
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
-import net.minecraft.block.Block
 import net.minecraft.block.BlockStainedGlass
 import net.minecraft.block.state.IBlockState
 import net.minecraft.init.Blocks
+import net.minecraft.item.EnumDyeColor
 import net.minecraft.item.ItemStack
+//#if MC < 1.21
+import net.minecraft.block.BlockCarpet
+//#else
+//$$ import net.minecraft.block.Block
+//#endif
 
 /**
  * Enum class that represents colored blocks in Minecraft, stained clay, wool, stained-glass, and stained-glass panes.
@@ -210,12 +215,38 @@ enum class ColoredBlockCompat(
         //$$ return ItemStack(woolBlock, amount)
         //#endif
     }
+
+    fun createWoolBlockState(): IBlockState {
+        //#if MC < 1.16
+        val wool = Blocks.wool.defaultState
+        return wool.withProperty(BlockCarpet.COLOR, getDyeColor())
+        //#else
+        //$$ return this.woolBlock.defaultState
+        //#endif
+    }
+
+    fun createGlassBlockState(state: IBlockState? = null): IBlockState {
+        //#if MC < 1.16
+        val newState = state ?: Blocks.stained_glass.defaultState
+        return newState.withProperty(BlockCarpet.COLOR, getDyeColor())
+        //#else
+        //$$ return this.glassBlock.defaultState
+        //#endif
+    }
+
     fun createStainedClay(amount: Int = 1): ItemStack {
         //#if MC < 1.16
         return ItemStack(Blocks.stained_hardened_clay, amount, metaColor)
         //#else
         //$$ return ItemStack(clayBlock, amount)
         //#endif
+    }
+
+    fun getDyeColor(): EnumDyeColor {
+        for (entry in EnumDyeColor.entries) {
+            if (entry.metadata == this.metaColor) return entry
+        }
+        return EnumDyeColor.WHITE
     }
 
     companion object {
@@ -276,60 +307,60 @@ enum class ColoredBlockCompat(
             //#endif
         }
 
-        fun Block.isStainedGlass(color: ColoredBlockCompat): Boolean = isStainedGlass(color.metaColor)
-        fun Block.isStainedGlassPane(color: ColoredBlockCompat): Boolean = isStainedGlassPane(color.metaColor)
-        fun Block.isWool(color: ColoredBlockCompat): Boolean = isWool(color.metaColor)
-        fun Block.isStainedClay(color: ColoredBlockCompat): Boolean = isStainedClay(color.metaColor)
+        fun IBlockState.isStainedGlass(color: ColoredBlockCompat): Boolean = isStainedGlass(color.metaColor)
+        fun IBlockState.isStainedGlassPane(color: ColoredBlockCompat): Boolean = isStainedGlassPane(color.metaColor)
+        fun IBlockState.isWool(color: ColoredBlockCompat): Boolean = isWool(color.metaColor)
+        fun IBlockState.isStainedClay(color: ColoredBlockCompat): Boolean = isStainedClay(color.metaColor)
 
         /**
          * No metadata means any stained-glass
          */
-        fun Block.isStainedGlass(meta: Int? = null): Boolean {
+        fun IBlockState.isStainedGlass(meta: Int? = null): Boolean {
             //#if MC < 1.16
-            if (this != Blocks.stained_glass) return false
+            if (this.block != Blocks.stained_glass) return false
             meta ?: return true
-            return defaultState.getValue(BlockStainedGlass.COLOR).metadata == meta
+            return getValue(BlockStainedGlass.COLOR).metadata == meta
             //#else
-            //$$ return entries.any { (meta == null || it.metaColor == meta) && this == it.glassBlock }
+            //$$ return ColoredBlockCompat.entries.any { (meta == null || it.metaColor == meta) && this == it.glassBlock }
             //#endif
         }
 
         /**
          * No metadata means any stained-glass pane
          */
-        fun Block.isStainedGlassPane(meta: Int? = null): Boolean {
+        fun IBlockState.isStainedGlassPane(meta: Int? = null): Boolean {
             //#if MC < 1.16
-            if (this != Blocks.stained_glass_pane) return false
+            if (this.block != Blocks.stained_glass_pane) return false
             meta ?: return true
-            return defaultState.getValue(BlockStainedGlass.COLOR).metadata == meta
+            return getValue(BlockStainedGlass.COLOR).metadata == meta
             //#else
-            //$$ return entries.any { (meta == null || it.metaColor == meta) && this == it.glassPaneBlock }
+            //$$ return ColoredBlockCompat.entries.any { (meta == null || it.metaColor == meta) && this == it.glassPaneBlock }
             //#endif
         }
 
         /**
          * No metadata means any wool
          */
-        fun Block.isWool(meta: Int? = null): Boolean {
+        fun IBlockState.isWool(meta: Int? = null): Boolean {
             //#if MC < 1.16
-            if (this != Blocks.wool) return false
+            if (this.block != Blocks.wool) return false
             meta ?: return true
-            return defaultState.getValue(BlockStainedGlass.COLOR).metadata == meta
+            return getValue(BlockStainedGlass.COLOR).metadata == meta
             //#else
-            //$$ return entries.any { (meta == null || it.metaColor == meta) && this == it.woolBlock }
+            //$$ return ColoredBlockCompat.entries.any { (meta == null || it.metaColor == meta) && this == it.woolBlock }
             //#endif
         }
 
         /**
          * No metadata means any stained clay
          */
-        fun Block.isStainedClay(meta: Int? = null): Boolean {
+        fun IBlockState.isStainedClay(meta: Int? = null): Boolean {
             //#if MC < 1.16
-            if (this != Blocks.stained_hardened_clay) return false
+            if (this.block != Blocks.stained_hardened_clay) return false
             meta ?: return true
-            return defaultState.getValue(BlockStainedGlass.COLOR).metadata == meta
+            return getValue(BlockStainedGlass.COLOR).metadata == meta
             //#else
-            //$$ return entries.any { (meta == null || it.metaColor == meta) && this == it.clayBlock }
+            //$$ return ColoredBlockCompat.entries.any { (meta == null || it.metaColor == meta) && this == it.clayBlock }
             //#endif
         }
 
@@ -341,6 +372,13 @@ enum class ColoredBlockCompat(
             //$$     block.glassBlock == this.block || block.glassPaneBlock == this.block || block.woolBlock == this.block || block.clayBlock == this.block
             //$$ }?.color ?: LorenzColor.WHITE
             //#endif
+        }
+
+        fun fromMeta(meta: Int): ColoredBlockCompat {
+            for (entry in entries) {
+                if (entry.metaColor == meta) return entry
+            }
+            return WHITE
         }
     }
 }

--- a/versions/mapping-1.16.5-forge-1.8.9.txt
+++ b/versions/mapping-1.16.5-forge-1.8.9.txt
@@ -442,6 +442,7 @@ net.minecraft.world.item.ItemStack net.minecraft.item.ItemStack
 net.minecraft.world.item.Items net.minecraft.init.Items
 
 net.minecraft.world.item.DyeColor LIGHT_GRAY SILVER
+net.minecraft.world.item.DyeColor getId() getMetadata()
 
 net.minecraft.world.item.Item byBlock() getItemFromBlock()
 


### PR DESCRIPTION
## What
I can't actually test this as i dont have the area unlocked but this should fix it I think.
Umm i guess i added some extra function that are used in 1-3 prs down the 1.21 chain but whatever


## Changelog Fixes
+ Fixed Timite Helper showing incorrect info on all blocks. - CalMWolfs
