### PR TITLE
Improvement: Disable soul sand speed logic on modern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/FarmingLaneConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/laneswitch/FarmingLaneConfig.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.features.garden.laneswitch
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyLegacy
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.features.garden.CropType
 import com.google.gson.annotations.Expose
@@ -39,6 +40,7 @@ class FarmingLaneConfig {
         desc = "Show an informational note on distance display while on soul sand, that speed calculations are inaccurate"
     )
     @ConfigEditorBoolean
+    @OnlyLegacy
     var distanceSoulSandWarning: Boolean = true
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -84,7 +84,7 @@ object FarmingLaneFeatures {
                     " §7(${movementState.label}§7)"
                 } else ""
                 add("§7Time remaining: $color$format$suffix")
-                if (MovementSpeedDisplay.usingSoulsandSpeed && config.distanceSoulSandWarning) {
+                if (MovementSpeedDisplay.usingLegacySoulSandSpeed && config.distanceSoulSandWarning) {
                     add("§7Using inaccurate soul sand speed!")
                 }
             }
@@ -187,7 +187,7 @@ object FarmingLaneFeatures {
             return MovementState.TOO_SLOW
         }
         // only calculate the time if the speed has not changed
-        if (!MovementSpeedDisplay.usingSoulsandSpeed) {
+        if (!MovementSpeedDisplay.usingLegacySoulSandSpeed) {
             if (sameSpeedCounter < 6) {
                 return MovementState.CALCULATING
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MovementSpeedDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MovementSpeedDisplay.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import net.minecraft.init.Blocks
 import kotlin.concurrent.fixedRateTimer
 
@@ -21,14 +22,14 @@ object MovementSpeedDisplay {
     private val config get() = SkyHanniMod.feature.misc
 
     private var display = ""
-    private val soulsandSpeeds = mutableListOf<Double>()
+    private val soulSandSpeeds = mutableListOf<Double>()
 
     /**
      * This speed value represents the movement speed in blocks per second.
      * This has nothing to do with the speed stat.
      */
     var speed = 0.0
-    var usingSoulsandSpeed = false
+    var usingLegacySoulSandSpeed = false
 
     init {
         // TODO use LorenzTickEvent
@@ -47,17 +48,20 @@ object MovementSpeedDisplay {
             // Distance from previous tick, multiplied by TPS
             oldPos.distance(newPos) * 20
         }
-        val movingOnSoulsand = LocationUtils.playerLocation().getBlockAt() == Blocks.soul_sand && speed > 0.0
-        if (movingOnSoulsand) {
-            soulsandSpeeds.add(speed)
-            if (soulsandSpeeds.size > 6) {
-                speed = soulsandSpeeds.average()
-                soulsandSpeeds.removeAt(0)
+
+        // 1.15+ has consistent soul sand speed
+        val movingOnSoulSand = PlatformUtils.IS_LEGACY && LocationUtils.playerLocation().getBlockAt() == Blocks.soul_sand && speed > 0.0
+        if (movingOnSoulSand) {
+            soulSandSpeeds.add(speed)
+            if (soulSandSpeeds.size > 6) {
+                speed = soulSandSpeeds.average()
+                soulSandSpeeds.removeAt(0)
             }
         } else {
-            soulsandSpeeds.clear()
+            soulSandSpeeds.clear()
         }
-        usingSoulsandSpeed = movingOnSoulsand && soulsandSpeeds.size == 6
+        usingLegacySoulSandSpeed = movingOnSoulSand && soulSandSpeeds.size == 6
+
         if (isEnabled()) {
             display = "Movement Speed: ${speed.roundTo(2)}"
         }


### PR DESCRIPTION
## What
Disabled the inaccurate soul sand speed check on modern, since it is no longer relevant.

## Changelog Improvements
+ Disabled "Inaccurate Soul Sand Speed" warning in Minecraft 1.21. - Luna
    * Soul Sand Speed is consistent on modern Minecraft versions.
