### PR TITLE
Fix: Pet XP Level as Stack Size

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/PetData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PetData.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.PetUtils
 import at.hannibal2.skyhanni.utils.PetUtils.hasValidHigherTier
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils
 import com.google.gson.annotations.Expose
 import java.util.UUID
 
@@ -44,6 +45,15 @@ data class PetData(
     @Expose var exp: Double? = null, // The total XP of the pet as a double, e.g., `0.0`
     @Expose val uuid: UUID? = null, // If this data is for a 'real' pet, this is the UUID of it
 ) {
+    constructor(petInfo: SkyBlockItemModifierUtils.PetInfo) : this(
+        petInfo._internalName,
+        petInfo.properSkinItem,
+        petInfo.getSkinVariantIndex(),
+        petInfo.heldItem,
+        petInfo.exp,
+        petInfo.uniqueId
+    )
+
     private val tierBoosted get() = heldItemInternalName == TIER_BOOST && petInternalName.hasValidHigherTier()
     private val properPetName = PetUtils.getPetProperName(petInternalName)
     private val specifiedRarity = PetUtils.getPetRarity(petInternalName) ?: LorenzRarity.COMMON

--- a/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.pet.CurrentPetApi
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.PetData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.AnimatedSkinJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuAnimatedSkullsJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuItemJson
@@ -132,10 +133,18 @@ object PetUtils {
             .sumOf { it.toDouble() }
     }
 
-    fun xpToLevel(totalXp: Double, petInternalName: NeuInternalName): Int {
+    fun xpToLevel(petInfo: SkyBlockItemModifierUtils.PetInfo): Int = PetData(petInfo).level
+
+    /**
+     * DO NOT USE THIS METHOD UNLESS YOU ARE SURE YOU HAVE A FAUX INTERNAL NAME!
+     * Converts total XP to a pet level.
+     * @param totalXp The total XP of the pet.
+     * @param petFauxInternalName The internal name of the pet, reflecting tier boost properly.
+     */
+    fun xpToLevel(totalXp: Double, petFauxInternalName: NeuInternalName): Int {
         var xp = totalXp.takeIf { it > 0 } ?: return 1
-        val rarityOffset = getRarityOffset(petInternalName) ?: return 1
-        val xpList = getFullLevelingTree(petInternalName)
+        val rarityOffset = getRarityOffset(petFauxInternalName) ?: return 1
+        val xpList = getFullLevelingTree(petFauxInternalName)
 
         var level = 1
         for (i in 0 + rarityOffset until xpList.size) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -71,8 +71,6 @@ object SkyBlockItemModifierUtils {
 
     private fun ItemStack.isDungeonItem() = getLore().any { it.contains("DUNGEON ") }
 
-    private val TIER_BOOST = "PET_ITEM_TIER_BOOST".toInternalName()
-
     data class PetInfo(
         @Expose val type: String,
         @Expose val active: Boolean,
@@ -89,6 +87,7 @@ object SkyBlockItemModifierUtils {
         @Expose val noMove: Boolean,
         @Expose val extraData: JsonObject? = null,
     ) {
+        @Suppress("PropertyName")
         @Deprecated("Do not use, does not reflect Tier Boost, use PetData(petInfo).fauxInternalName instead")
         val _internalName = "$type;${tier.id}".toInternalName()
         val properSkinItem get() = skin?.let { "PET_SKIN_$skin".toInternalName() }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getStringList
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.isPositive
+import at.hannibal2.skyhanni.utils.PetUtils.hasValidHigherTier
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import com.google.gson.JsonObject
@@ -70,6 +71,8 @@ object SkyBlockItemModifierUtils {
 
     private fun ItemStack.isDungeonItem() = getLore().any { it.contains("DUNGEON ") }
 
+    private val TIER_BOOST = "PET_ITEM_TIER_BOOST".toInternalName()
+
     data class PetInfo(
         @Expose val type: String,
         @Expose val active: Boolean,
@@ -86,6 +89,8 @@ object SkyBlockItemModifierUtils {
         @Expose val noMove: Boolean,
         @Expose val extraData: JsonObject? = null,
     ) {
+        @Deprecated("Do not use, does not reflect Tier Boost, use PetData(petInfo).fauxInternalName instead")
+        val _internalName = "$type;${tier.id}".toInternalName()
         val properSkinItem get() = skin?.let { "PET_SKIN_$skin".toInternalName() }
         fun getSkinVariantIndex() = skin?.let {
             extraData?.entrySet()?.firstOrNull { json ->
@@ -134,7 +139,7 @@ object SkyBlockItemModifierUtils {
     fun ItemStack.getPetInfo(): PetInfo? =
         ConfigManager.gson.fromJson(getExtraAttributes()?.getString("petInfo"), PetInfo::class.java)
 
-    fun ItemStack.getPetLevel(): Int = PetUtils.xpToLevel(getPetInfo()?.exp ?: 0.0, getInternalName())
+    fun ItemStack.getPetLevel(): Int = getPetInfo()?.let(PetUtils::xpToLevel) ?: 1
 
     fun ItemStack.getMaxPetLevel(): Int = PetUtils.getMaxLevel(getInternalName())
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getStringList
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.isPositive
-import at.hannibal2.skyhanni.utils.PetUtils.hasValidHigherTier
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import com.google.gson.JsonObject


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1385879246630817813
Made it so pets with less than 10.0 xp no longer display their stack size, as it was showing everywhere, including in the repo item list.

## Changelog Fixes
+ Fixed Pet-Level stack size display. - Daveed

