### PR TITLE
Improvement: Dont queued gfs on alpha

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
@@ -122,7 +122,7 @@ object GetFromSackApi {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onMessageToServer(event: MessageSendToServerEvent) {
-        if (!config.queuedGFS && !config.bazaarGFS) return
+        if ((!config.queuedGFS && !config.bazaarGFS) || SkyBlockUtils.isOnAlphaServer) return
         if (!event.isCommand(commandsWithSlash)) return
         val replacedEvent = GetFromSacksTabComplete.handleUnderlineReplace(event)
         queuedHandler(replacedEvent)
@@ -138,7 +138,7 @@ object GetFromSackApi {
     }
 
     private fun queuedHandler(event: MessageSendToServerEvent) {
-        if (!config.queuedGFS) return
+        if (!config.queuedGFS || SkyBlockUtils.isOnAlphaServer) return
         if (event.senderIsSkyhanni()) return
 
         val (result, stack) = commandValidator(event.splitMessage.drop(1))


### PR DESCRIPTION
## What
alpha often has items that arent on the non alpha, skyhanni is silly and bricks gfs for new items, but no longer, with this new revelation all these issues and more shall go 

<details>
<summary>Images</summary>

"image of gfs not working"

</details>

## Changelog Improvements
+ Improved /gfs queuing on Alpha. - nopo
