### PR TITLE
Fix: NoSuchElementException in PowderChestTimer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
@@ -108,7 +108,7 @@ object PowderChestTimer {
     }
 
     private fun drawDisplay(): String? {
-        if (chests.isEmpty()) return null
+        val chests = chests.takeIf { it.isNotEmpty() } ?: return null
 
         val count = chests.size
         val name = StringUtils.pluralize(count, "chest")
@@ -123,11 +123,11 @@ object PowderChestTimer {
     @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
-        if (chests.isEmpty()) return
+        val chests = chests.takeIf { it.isNotEmpty() } ?: return
 
-        event.renderChests()
+        event.renderChests(chests)
 
-        val chestToConnect = sortChests()
+        val chestToConnect = sortChests(chests)
         if (chestToConnect.isEmpty()) return
 
         event.drawFirstLine(chestToConnect)
@@ -155,7 +155,7 @@ object PowderChestTimer {
         }
     }
 
-    private fun sortChests(): List<Map.Entry<LorenzVec, SimpleTimeMark>> {
+    private fun sortChests(chests: TimeLimitedCache<LorenzVec, SimpleTimeMark>): List<Map.Entry<LorenzVec, SimpleTimeMark>> {
         val sortedChests = when (config.lineMode) {
             PowderChestTimerConfig.LineMode.OLDEST -> chests.entries.sortedBy { it.value.timeUntil() }
             PowderChestTimerConfig.LineMode.NEAREST -> chests.entries.sortedBy { it.key.distanceToPlayer() }
@@ -165,7 +165,7 @@ object PowderChestTimer {
         return sortedChests.take(config.drawLineToChestAmount)
     }
 
-    private fun SkyHanniRenderWorldEvent.renderChests() {
+    private fun SkyHanniRenderWorldEvent.renderChests(chests: TimeLimitedCache<LorenzVec, SimpleTimeMark>) {
         val playerY = LocationUtils.playerLocation().y
         for ((loc, time) in chests) {
             val timeLeft = time.timeUntil()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
@@ -108,7 +108,7 @@ object PowderChestTimer {
     }
 
     private fun drawDisplay(): String? {
-        val chests = chests.takeIf { it.isNotEmpty() } ?: return null
+        val chests = chests.takeIf { it.isNotEmpty() }?.toMap() ?: return null
 
         val count = chests.size
         val name = StringUtils.pluralize(count, "chest")
@@ -123,7 +123,7 @@ object PowderChestTimer {
     @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
-        val chests = chests.takeIf { it.isNotEmpty() } ?: return
+        val chests = chests.takeIf { it.isNotEmpty() }?.toMap() ?: return
 
         event.renderChests(chests)
 
@@ -155,7 +155,7 @@ object PowderChestTimer {
         }
     }
 
-    private fun sortChests(chests: TimeLimitedCache<LorenzVec, SimpleTimeMark>): List<Map.Entry<LorenzVec, SimpleTimeMark>> {
+    private fun sortChests(chests: Map<LorenzVec, SimpleTimeMark>): List<Map.Entry<LorenzVec, SimpleTimeMark>> {
         val sortedChests = when (config.lineMode) {
             PowderChestTimerConfig.LineMode.OLDEST -> chests.entries.sortedBy { it.value.timeUntil() }
             PowderChestTimerConfig.LineMode.NEAREST -> chests.entries.sortedBy { it.key.distanceToPlayer() }
@@ -165,7 +165,7 @@ object PowderChestTimer {
         return sortedChests.take(config.drawLineToChestAmount)
     }
 
-    private fun SkyHanniRenderWorldEvent.renderChests(chests: TimeLimitedCache<LorenzVec, SimpleTimeMark>) {
+    private fun SkyHanniRenderWorldEvent.renderChests(chests: Map<LorenzVec, SimpleTimeMark>) {
         val playerY = LocationUtils.playerLocation().y
         for ((loc, time) in chests) {
             val timeLeft = time.timeUntil()


### PR DESCRIPTION
## What
Fixed a very frequent bug:
![image](https://github.com/user-attachments/assets/d99ea4c9-fbf5-4021-b34d-dee6a99befdf)

fixed NoSuchElementException in PowderChestTimer by listening to the whole map so that no entries can change while rendering

<details>
<summary>Stack Trace</summary>

```
SkyHanni 3.9.0: Caught a NoSuchElementException in at.hannibal2.skyhanni.features.mining.powdertracker.PowderChestTimer.onRenderWorld(at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent) at SkyHanniRenderWorldEvent: null
 
Caused by java.util.NoSuchElementException: null
    at com.google.common.cache.LocalCache$HashIterator.nextEntry(LocalCache.java:4343)
    at com.google.common.cache.LocalCache$EntryIterator.next(LocalCache.java:4430)
    at com.google.common.cache.LocalCache$EntryIterator.next(LocalCache.java:4426)
    at kotlin.collections.CollectionsKt___CollectionsKt.toList(_Collections.kt:1315)
    at kotlin.collections.CollectionsKt___CollectionsKt.sortedWith(_Collections.kt:1073)
    at SH.features.mining.powdertracker.PowderChestTimer.sortChests(PowderChestTimer.kt:227)
    at SH.features.mining.powdertracker.PowderChestTimer.onRenderWorld(PowderChestTimer.kt:130)
<Skyhanni event post>
```

</details>

## Changelog Fixes
+ Fixed Powder Chest Timer error. - hannibal2