### PR TITLE
Fix: PetInfo Serialization + Harp Feature RenderSystem thread

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -136,7 +136,6 @@ object HarpFeatures {
     fun onDisconnect(event: ClientDisconnectEvent) {
         if (!config.guiScale) return
         unSetGuiScale()
-
     }
 
     @HandleEvent
@@ -149,16 +148,28 @@ object HarpFeatures {
     private var isGuiScaled = false
 
     private fun setGuiScale() {
+        //#if MC > 1.21
+        //$$ MinecraftClient.getInstance().execute {
+        //#endif
         guiSetting = getMinecraftGuiScale()
         setMinecraftGuiScale(0)
         isGuiScaled = true
         updateScale()
+        //#if MC > 1.21
+        //$$ }
+        //#endif
     }
 
     private fun unSetGuiScale() {
         if (!isGuiScaled) return
+        //#if MC > 1.21
+        //$$ MinecraftClient.getInstance().execute {
+        //#endif
         setMinecraftGuiScale(guiSetting)
         isGuiScaled = false
+        //#if MC > 1.21
+        //$$ }
+        //#endif
     }
 
     private fun getMinecraftGuiScale(): Int {
@@ -166,6 +177,7 @@ object HarpFeatures {
         //#if MC < 1.21
         return gameSettings.guiScale
         //#else
+        //$$ RenderSystem.assertOnRenderThread()
         //$$ return gameSettings.guiScale.value
         //#endif
     }
@@ -175,6 +187,7 @@ object HarpFeatures {
         //#if MC < 1.21
         gameSettings.guiScale = scale
         //#else
+        //$$ RenderSystem.assertOnRenderThread()
         //$$ gameSettings.guiScale.value = scale
         //#endif
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -28,6 +28,9 @@ import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.player.inventory.ContainerLocalMenu
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+//#if MC > 1.21
+//$$ import com.mojang.blaze3d.systems.RenderSystem
+//#endif
 
 // Delaying key presses by 300ms comes from NotEnoughUpdates
 @SkyHanniModule
@@ -118,6 +121,7 @@ object HarpFeatures {
         val height = GuiScreenUtils.scaledWindowHeight
         minecraft.currentScreen?.setWorldAndResolution(minecraft, width, height)
         //#else
+        //$$ RenderSystem.assertOnRenderThread()
         //$$ minecraft.window.calculateScaleFactor(minecraft.options.guiScale.value, minecraft.forcesUnicodeFont())
         //#endif
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -71,6 +71,7 @@ object SkyBlockItemModifierUtils {
 
     private fun ItemStack.isDungeonItem() = getLore().any { it.contains("DUNGEON ") }
 
+    @KSerializable
     data class PetInfo(
         @Expose val type: String,
         @Expose val active: Boolean,

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -84,8 +84,8 @@ object SkyBlockItemModifierUtils {
         @Deprecated("Some pets do not have uuids, use uniqueId instead", replaceWith = ReplaceWith("uniqueId"))
         @Expose val uuid: UUID? = null,
         @Expose val uniqueId: UUID? = null, // Only null when pet is read from a shop, or another non-"owned" source
-        @Expose val hideRightClick: Boolean,
-        @Expose val noMove: Boolean,
+        @Expose val hideRightClick: Boolean? = null,
+        @Expose val noMove: Boolean? = null,
         @Expose val extraData: JsonObject? = null,
     ) {
         @Suppress("PropertyName")


### PR DESCRIPTION
## What
Both incredibly small fixes for modern. PetInfo needed `@KSerializable` to properly calculate its internalname, and the Harp Feature for setting GUI scale needed to be on a render thread, which was harder than expected.

https://discord.com/channels/997079228510117908/1386424951162277930
https://discord.com/channels/997079228510117908/1386429336978194493

## Changelog Fixes
+ Fixed Harp GUI scale option error in 1.21. - Daveed
+ Fixed pet candy display error. - Daveed
