### PR TITLE
Fix: Crash in Changelog Viewer and all other gui screens

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -198,7 +198,7 @@ object KeyboardManager {
 
         else -> Keyboard.isKeyDown(this)
         //#else
-        //$$ this < -1 -> ErrorManager.skyHanniError("Error while checking if a key is pressed. Keycode is invalid", "keycode" to this)
+        //$$ this < -1 -> ErrorManager.skyHanniError("Error while checking if a key is pressed. Keycode is invalid: $this")
         //$$ this == -1 -> false
         //$$ this in 0..5 -> MouseCompat.isButtonDown(this)
         //$$ else -> InputUtil.isKeyPressed(MinecraftClient.getInstance().window.handle, this)

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils.compat
 
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiScreen
 //#if MC > 1.21
@@ -20,135 +21,189 @@ abstract class SkyhanniBaseScreen : GuiScreen(
     //#if MC < 1.21
     final override fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
         super.drawScreen(mouseX, mouseY, partialTicks)
-        DrawContextUtils.setContext(DrawContext())
-        onDrawScreen(mouseX, mouseY, partialTicks)
-        DrawContextUtils.clearContext()
+        postDrawScreen(DrawContext(), mouseX, mouseY, partialTicks)
     }
     //#else
     //$$ override fun render(context: DrawContext, mouseX: Int, mouseY: Int, delta: Float) {
     //$$    super.render(context, mouseX, mouseY, delta)
-    //$$    DrawContextUtils.setContext(context)
-    //$$    onDrawScreen(mouseX, mouseY, delta)
-    //$$    DrawContextUtils.clearContext()
+    //$$    postDrawScreen(context, mouseX, mouseY, delta)
     //$$ }
     //$$
     //$$ override fun renderBackground(context: DrawContext, mouseX: Int, mouseY: Int, deltaTicks: Float) {
-    //$$         this.renderDarkening(context)
-    //$$     }
+    //$$     this.renderDarkening(context)
+    //$$ }
     //#endif
 
+    private fun postDrawScreen(context: DrawContext, mouseX: Int, mouseY: Int, partialTicks: Float) {
+        DrawContextUtils.setContext(context)
+        try {
+            onDrawScreen(mouseX, mouseY, partialTicks)
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Error while drawing screen", "screen" to this)
+        }
+        DrawContextUtils.clearContext()
+    }
     open fun onDrawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {}
 
     //#if MC < 1.21
     final override fun mouseClicked(mouseX: Int, mouseY: Int, mouseButton: Int) {
         super.mouseClicked(mouseX, mouseY, mouseButton)
-        onMouseClicked(mouseX, mouseY, mouseButton)
+        postMouseClicked(mouseX, mouseY, mouseButton)
     }
     //#else
     //$$ override fun mouseClicked(mouseX: Double, mouseY: Double, mouseButton: Int): Boolean {
-    //$$     onMouseClicked(mouseX.toInt(), mouseY.toInt(), mouseButton)
-    //$$     onHandleMouseInput()
+    //$$     postMouseClicked(mouseX.toInt(), mouseY.toInt(), mouseButton)
+    //$$     postHandleMouseInput()
     //$$     return super.mouseClicked(mouseX, mouseY, mouseButton)
     //$$ }
     //#endif
 
+    private fun postMouseClicked(originalMouseX: Int, originalMouseY: Int, mouseButton: Int) {
+        try {
+            onMouseClicked(originalMouseX, originalMouseY, mouseButton)
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Error while clicking mouse", "screen" to this)
+        }
+    }
     open fun onMouseClicked(originalMouseX: Int, originalMouseY: Int, mouseButton: Int) {}
 
     //#if MC < 1.21
     final override fun keyTyped(typedChar: Char, keyCode: Int) {
         super.keyTyped(typedChar, keyCode)
-        onKeyTyped(typedChar, keyCode)
+        postKeyTyped(typedChar, keyCode)
     }
     //#else
     //$$ override fun keyPressed(keyCode: Int, scanCode: Int, modifiers: Int): Boolean {
-    //$$     onKeyTyped(null, keyCode)
+    //$$     postKeyTyped(null, keyCode)
     //$$     return super.keyPressed(keyCode, scanCode, modifiers)
     //$$ }
     //$$
     //$$ override fun charTyped(chr: Char, modifiers: Int): Boolean {
-    //$$     onKeyTyped(chr, null)
+    //$$     postKeyTyped(chr, null)
     //$$     return super.charTyped(chr, modifiers)
     //$$ }
     //#endif
 
+    private fun postKeyTyped(typedChar: Char?, keyCode: Int?) {
+        try {
+            onKeyTyped(typedChar, keyCode)
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Error while typing key", "screen" to this)
+        }
+    }
     open fun onKeyTyped(typedChar: Char?, keyCode: Int?) {}
 
     //#if MC < 1.21
     final override fun mouseReleased(mouseX: Int, mouseY: Int, state: Int) {
         super.mouseReleased(mouseX, mouseY, state)
-        onMouseReleased(mouseX, mouseY, state)
+        postMouseReleased(mouseX, mouseY, state)
     }
     //#else
     //$$ override fun mouseReleased(mouseX: Double, mouseY: Double, button: Int): Boolean {
-    //$$     onMouseReleased(mouseX.toInt(), mouseY.toInt(), button)
-    //$$     onHandleMouseInput()
+    //$$     postMouseReleased(mouseX.toInt(), mouseY.toInt(), button)
+    //$$     postHandleMouseInput()
     //$$     return super.mouseReleased(mouseX, mouseY, button)
     //$$ }
     //#endif
 
+    private fun postMouseReleased(originalMouseX: Int, originalMouseY: Int, state: Int) {
+        try {
+            onMouseReleased(originalMouseX, originalMouseY, state)
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Error while releasing mouse", "screen" to this)
+        }
+    }
     open fun onMouseReleased(originalMouseX: Int, originalMouseY: Int, state: Int) {}
 
     //#if MC < 1.21
     final override fun mouseClickMove(mouseX: Int, mouseY: Int, clickedMouseButton: Int, timeSinceLastClick: Long) {
         super.mouseClickMove(mouseX, mouseY, clickedMouseButton, timeSinceLastClick)
-        onMouseClickMove(mouseX, mouseY, clickedMouseButton, timeSinceLastClick)
+        postMouseClickMove(mouseX, mouseY, clickedMouseButton, timeSinceLastClick)
     }
     //#else
     //$$ override fun mouseDragged(mouseX: Double, mouseY: Double, button: Int, deltaX: Double, deltaY: Double): Boolean {
     //$$     // TODO there is no timeSince last click in modern
-    //$$     onMouseClickMove(mouseX.toInt(), mouseY.toInt(), button, 0L)
-    //$$     onHandleMouseInput()
+    //$$     postMouseClickMove(mouseX.toInt(), mouseY.toInt(), button, 0L)
+    //$$     postHandleMouseInput()
     //$$     return super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY)
     //$$ }
     //#endif
 
+    private fun postMouseClickMove(originalMouseX: Int, originalMouseY: Int, clickedMouseButton: Int, timeSinceLastClick: Long) {
+        try {
+            onMouseClickMove(originalMouseX, originalMouseY, clickedMouseButton, timeSinceLastClick)
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Error while clicking and moving mouse", "screen" to this)
+        }
+    }
     open fun onMouseClickMove(originalMouseX: Int, originalMouseY: Int, clickedMouseButton: Int, timeSinceLastClick: Long) {}
 
     //#if MC < 1.21
     final override fun handleMouseInput() {
         super.handleMouseInput()
-        onHandleMouseInput()
+        postHandleMouseInput()
     }
     //#else
     //$$ override fun mouseMoved(mouseX: Double, mouseY: Double) {
-    //$$     onHandleMouseInput()
+    //$$     postHandleMouseInput()
     //$$     super.mouseMoved(mouseX, mouseY)
     //$$ }
     //$$
     //$$ override fun mouseScrolled(mouseX: Double, mouseY: Double, horizontalAmount: Double, verticalAmount: Double): Boolean {
-    //$$     onHandleMouseInput()
+    //$$     postHandleMouseInput()
     //$$     return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount)
     //$$ }
     //#endif
 
+    private fun postHandleMouseInput() {
+        try {
+            onHandleMouseInput()
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Error while handling mouse input", "screen" to this)
+        }
+    }
     open fun onHandleMouseInput() {}
 
     //#if MC < 1.21
     final override fun onGuiClosed() {
         super.onGuiClosed()
-        guiClosed()
+        postGuiClosed()
     }
     //#else
     //$$ override fun close() {
     //$$     super.close()
-    //$$     guiClosed()
+    //$$     postGuiClosed()
     //$$ }
     //#endif
 
+    private fun postGuiClosed() {
+        try {
+            guiClosed()
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Error while closing GUI", "screen" to this)
+        }
+    }
     open fun guiClosed() {}
 
     //#if MC < 1.21
     final override fun initGui() {
         super.initGui()
-        onInitGui()
+        postInitGui()
     }
     //#else
     //$$ override fun init() {
     //$$     super.init()
-    //$$     onInitGui()
+    //$$     postInitGui()
     //$$ }
     //#endif
 
+    private fun postInitGui() {
+        try {
+            onInitGui()
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Error while initializing GUI", "screen" to this)
+        }
+    }
     open fun onInitGui() {}
 
     fun drawDefaultBackground(mouseX: Int, mouseY: Int, partialTicks: Float) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
@@ -7,7 +7,7 @@ import net.minecraft.client.gui.GuiScreen
 //$$ import net.minecraft.client.gui.DrawContext
 //#endif
 
-@Suppress("UnusedParameter")
+@Suppress("UnusedParameter", "LargeClass")
 abstract class SkyhanniBaseScreen : GuiScreen(
     //#if MC > 1.20
     //$$ net.minecraft.text.Text.empty()

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/SkyhanniBaseScreen.kt
@@ -7,7 +7,7 @@ import net.minecraft.client.gui.GuiScreen
 //$$ import net.minecraft.client.gui.DrawContext
 //#endif
 
-@Suppress("UnusedParameter", "LargeClass")
+@Suppress("UnusedParameter")
 abstract class SkyhanniBaseScreen : GuiScreen(
     //#if MC > 1.20
     //$$ net.minecraft.text.Text.empty()

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.darker
 import at.hannibal2.skyhanni.utils.GuiRenderUtils
 import at.hannibal2.skyhanni.utils.GuiRenderUtils.renderOnScreen
+import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.LEFT_MOUSE
 import at.hannibal2.skyhanni.utils.KeyboardManager.RIGHT_MOUSE
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
@@ -863,7 +864,7 @@ interface Renderable {
             hoveredColor: (Color) -> Color = { it.darker(0.5) },
             onClick: (Boolean) -> Unit,
             onHover: (Boolean) -> Unit = {},
-            button: Int = 0,
+            button: Int = KeyboardManager.LEFT_MOUSE,
             bypassChecks: Boolean = false,
             condition: (Boolean) -> Boolean = { true },
             startState: Boolean = false,
@@ -886,7 +887,7 @@ interface Renderable {
             override fun render(posX: Int, posY: Int) {
                 val realColor: Color
                 if (isHovered(posX, posY) && condition(state) && shouldAllowLink(true, bypassChecks)) {
-                    if ((button - 100).isKeyClicked()) {
+                    if (button.isKeyClicked()) {
                         state = !state
                         onClick(state)
                     }

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -27,7 +27,6 @@
     <ID>CyclomaticComplexMethod:VisualWordGui.kt$VisualWordGui$override fun onDrawScreen(originalMouseX: Int, originalMouseY: Int, partialTicks: Float)</ID>
     <ID>EmptyClassBlock:ModernPatterns.kt$ModernPatterns${ }</ID>
     <ID>InjectDispatcher:ChangelogViewer.kt$ChangelogViewer$IO</ID>
-    <ID>InjectDispatcher:ChangelogViewer.kt$ChangelogViewer$IO</ID>
     <ID>InjectDispatcher:ClipboardUtils.kt$ClipboardUtils$IO</ID>
     <ID>InjectDispatcher:SkyHanniMod.kt$SkyHanniMod$IO</ID>
     <ID>LargeClass:WorldRenderUtils.kt$WorldRenderUtils</ID>
@@ -246,7 +245,6 @@
     <ID>SpreadOperator:ItemUtils.kt$ItemUtils$(tag, displayName, *lore.toTypedArray())</ID>
     <ID>SpreadOperator:LimboPlaytime.kt$LimboPlaytime$( itemID.getItemStack().item, ITEM_NAME, *createItemLore() )</ID>
     <ID>SpreadOperator:TextHelper.kt$TextHelper$(*component.toTypedArray(), separator = separator)</ID>
-    <ID>TooManyFunctions:CollectionUtils.kt$CollectionUtils</ID>
     <ID>TooManyFunctions:EstimatedItemValueCalculator.kt$EstimatedItemValueCalculator</ID>
     <ID>TooManyFunctions:GuiRenderUtils.kt$GuiRenderUtils</ID>
     <ID>TooManyFunctions:ItemResolutionQuery.kt$ItemResolutionQuery</ID>
@@ -254,6 +252,7 @@
     <ID>TooManyFunctions:NumberUtil.kt$NumberUtil</ID>
     <ID>TooManyFunctions:OreBlock.kt$at.hannibal2.skyhanni.features.mining.OreBlock.kt</ID>
     <ID>TooManyFunctions:RegexUtils.kt$RegexUtils</ID>
+    <ID>TooManyFunctions:SkyhanniBaseScreen.kt$SkyhanniBaseScreen : GuiScreen</ID>
     <ID>TooManyFunctions:TextCompat.kt$at.hannibal2.skyhanni.utils.compat.TextCompat.kt</ID>
     <ID>TooManyFunctions:WorldRenderUtils.kt$WorldRenderUtils</ID>
     <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Double::plus)!!</ID>


### PR DESCRIPTION
## What
Fixed crash in changelog viewer on modern versions as `Renderable.rectButton` had logic that didn't properly work with multiversion.
Added try catches to every function in SkyHanniBaseScreen so that other crashes in guis dont happen in the future

## Changelog Fixes
+ Fixed changelog viewer crash on 1.21. - CalMWolfs

## Changelog Technical Details
+ Made all `SkyhanniBaseScreen`s crash-proof. - CalMWolfs

