### PR TITLE
Fix: Getting display names of common rarity items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -767,7 +767,7 @@ object ScoreboardPattern {
      */
     val riftDimensionPattern by riftSB.pattern(
         "dimension",
-        "\\s*§fRift Dimension",
+        "\\s*(?:§f)?Rift Dimension",
     )
     val riftHotdogTitlePattern by riftSB.pattern(
         "hotdogtitle",

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -204,7 +204,7 @@ object ItemUtils {
     //#else
     //$$ fun getDisplayName(compound: ComponentMap?): String? {
     //$$     compound ?: return null
-    //$$     val name = compound.get(DataComponentTypes.CUSTOM_NAME)?.formattedTextCompat()
+    //$$     val name = compound.get(DataComponentTypes.CUSTOM_NAME)?.formattedTextCompatWithStartingWhiteColorCode()
     //$$     if (name.isNullOrEmpty()) return null
     //$$     return name
     //$$ }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -58,7 +58,6 @@ fun IChatComponent.unformattedTextCompat(): String =
 
 // has to be a separate function for pattern mappings
 fun IChatComponent?.formattedTextCompatLessResets(): String = this.formattedTextCompat(noExtraResets = true)
-
 fun IChatComponent?.formattedTextCompatWithStartingWhiteColorCode(): String = this.formattedTextCompat(removeStartingWhiteColorCode = false)
 
 @JvmOverloads

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -25,11 +25,9 @@ import net.minecraft.util.ChatComponentText
 //$$ import kotlin.math.abs
 //$$ import net.minecraft.text.TranslatableTextContent
 //#endif
-
 //#if MC > 1.16
 //$$ private val unformattedTextCache = java.util.WeakHashMap<Component, String>()
 //$$ private val formattedTextCache = java.util.WeakHashMap<Component, String>()
-//$$ private val formattedTextNoResetsCache = java.util.WeakHashMap<Component, String>()
 //#endif
 
 fun IChatComponent.unformattedTextForChatCompat(): String {
@@ -59,33 +57,29 @@ fun IChatComponent.unformattedTextCompat(): String =
 //#endif
 
 // has to be a separate function for pattern mappings
-fun IChatComponent?.formattedTextCompatLessResets(): String = this.formattedTextCompat(true)
+fun IChatComponent?.formattedTextCompatLessResets(): String = this.formattedTextCompat(noExtraResets = true)
+
+fun IChatComponent?.formattedTextCompatWithStartingWhiteColorCode(): String = this.formattedTextCompat(removeStartingWhiteColorCode = false)
 
 @JvmOverloads
 @Suppress("unused")
-fun IChatComponent?.formattedTextCompat(noExtraResets: Boolean = false): String =
+fun IChatComponent?.formattedTextCompat(noExtraResets: Boolean = false, removeStartingWhiteColorCode: Boolean = true): String =
 //#if MC < 1.16
     this?.formattedText.orEmpty()
 //#else
 //$$ run {
 //$$     this ?: return@run ""
-//$$     if (noExtraResets) {
-//$$         formattedTextNoResetsCache.getOrPut(this) {
-//$$             computeFormattedTextCompat(true)
-//$$         }
-//$$     } else {
-//$$         formattedTextCache.getOrPut(this) {
-//$$             computeFormattedTextCompat(false)
-//$$         }
+//$$     formattedTextCache.getOrPut(this) {
+//$$         computeFormattedTextCompat(noExtraResets, removeStartingWhiteColorCode)
 //$$     }
 //$$ }
 //$$
-//$$ private fun Component?.computeFormattedTextCompat(noExtraResets: Boolean): String {
+//$$ private fun Component?.computeFormattedTextCompat(noExtraResets: Boolean, removeStartingWhiteColorCode: Boolean): String {
 //$$     this ?: return ""
 //$$     val sb = StringBuilder()
 //$$     for (component in iterator()) {
 //$$         val chatStyle = component.style.chatStyle()
-//$$         if ((sb.contains("§") && sb.toString() != "§r") || chatStyle != "§f") {
+//$$         if (!removeStartingWhiteColorCode || (sb.contains("§") && sb.toString() != "§r") || chatStyle != "§f") {
 //$$             sb.append(chatStyle)
 //$$         }
 //$$         sb.append(component.unformattedTextForChatCompat())

--- a/versions/pattern-mappings-1.16.5-forge-1.8.9.txt
+++ b/versions/pattern-mappings-1.16.5-forge-1.8.9.txt
@@ -15,7 +15,7 @@ net.minecraft.world.entity.Entity net.minecraft.entity.Entity name.formattedText
 
 net.minecraft.world.entity.player.Player net.minecraft.entity.player.EntityPlayer name.formattedTextCompatLessResets() getName() at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 
-net.minecraft.world.item.ItemStack net.minecraft.item.ItemStack displayName.formattedTextCompat() getDisplayName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+net.minecraft.world.item.ItemStack net.minecraft.item.ItemStack displayName.formattedTextCompatWithStartingWhiteColorCode() getDisplayName() at.hannibal2.skyhanni.utils.compat.formattedTextCompatWithStartingWhiteColorCode
 
 net.minecraft.world.scores.Objective net.minecraft.scoreboard.ScoreObjective displayName.formattedTextCompat() getDisplayName() at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 


### PR DESCRIPTION
## What
Fixed errors relating to getting the name of an item stack that starts with white text. This is due to text changing over the last 10 years of minecraft so some strings need the `§f` stripped from the start of them and others don't but stack display names seem like something that doesnt need that.
Also fixed a pattern in rift that seems to behave differently than other scoreboard lines. Doesnt feel patch notes worthy

## Changelog Fixes
+ Fixed errors in Hoppity Collection Stats and Thaumaturgy Stats. - CalMWolfs

## Changelog Technical Details
+ Made item display names always include the white color code. - CalMWolfs

