### PR TITLE
Fix: Two custom wardrobe issues on modern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -1659,8 +1659,8 @@ interface Renderable {
                 //$$     playerY + height,
                 //$$     entityScale,
                 //$$     0.0625f,
-                //$$     -mouseXRelativeToPlayer,
-                //$$     -mouseYRelativeToPlayer,
+                //$$     -mouseXRelativeToPlayer + if (followMouse) 70f else 0f,
+                //$$     -mouseYRelativeToPlayer + if (followMouse) 195f else 0f,
                 //$$     player
                 //$$ )
                 //$$ DrawContextUtils.translate(35f, 125f, 0f)

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.DrawScreenAfterEvent;
 import at.hannibal2.skyhanni.events.GuiContainerEvent;
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent;
 import at.hannibal2.skyhanni.events.render.gui.DrawBackgroundEvent;
+import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeApi;
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests;
 import at.hannibal2.skyhanni.utils.DelayedRun;
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat;
@@ -56,6 +57,10 @@ public abstract class MixinHandledScreen {
 
     @ModifyArg(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;Ljava/util/Optional;IILnet/minecraft/util/Identifier;)V"), index = 1)
     private List<Text> renderBackground(List<Text> textTooltip, @Local ItemStack itemStack, @Local(argsOnly = true) DrawContext drawContext) {
+        if (WardrobeApi.INSTANCE.getInCustomWardrobe()) {
+            textTooltip.clear();
+            return textTooltip;
+        }
         return ToolTipData.processModernTooltip(drawContext, itemStack, textTooltip);
     }
 


### PR DESCRIPTION
## What
Fixed 2 custom wardrobe bugs, I couldn't reproduce the weird offset that some people have and I also didnt look into the players not rendering over the rounded rectangles.

## Changelog Fixes
+ Fixed fake player in custom wardrobe not looking towards your mouse. - CalMWolfs
+ Fixed extra tooltip rendering in custom wardrobe GUI. - CalMWolfs

