### PR TITLE
Feature: Highlight Birries

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/BirriesHighlightConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/BirriesHighlightConfig.kt
@@ -1,0 +1,31 @@
+package at.hannibal2.skyhanni.config.features.foraging
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyModern
+import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.ChromaColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
+import java.awt.Color
+
+class BirriesHighlightConfig {
+
+    @Expose
+    @ConfigOption(name = "Highlight Birries", desc = "Highlights nearby Birries.")
+    @FeatureToggle
+    @ConfigEditorBoolean
+    @OnlyModern
+    @SearchTag("tadpole tad pole poll")
+    var enabled: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Highlight Birries", desc = "Highlights nearby Birries")
+    @ConfigEditorColour
+    @OnlyModern
+    @SearchTag("tadpole tad pole poll")
+    var color: ChromaColour = Color.GREEN.toChromaColor()
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/BirriesHighlightConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/BirriesHighlightConfig.kt
@@ -22,7 +22,7 @@ class BirriesHighlightConfig {
     var enabled: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Highlight Birries", desc = "Highlights nearby Birries")
+    @ConfigOption(name = "Color", desc = "Color for the Birries highlight")
     @ConfigEditorColour
     @OnlyModern
     @SearchTag("tadpole tad pole poll")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
@@ -2,6 +2,8 @@ package at.hannibal2.skyhanni.config.features.foraging
 
 import at.hannibal2.skyhanni.config.OnlyLegacy
 import at.hannibal2.skyhanni.config.OnlyModern
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
@@ -19,5 +21,12 @@ class ForagingConfig {
     @ConfigEditorInfoText
     var notice: String = ""
 
+
+
+    @Expose
+    @ConfigOption(name = "Birries Highlight", desc = "")
+    @OnlyModern
+    @Accordion
+    var birriesHighlight = BirriesHighlightConfig()
 
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/BirriesHighlighter.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/BirriesHighlighter.kt
@@ -1,0 +1,24 @@
+package at.hannibal2.skyhanni.features.foraging
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.MobEvent
+import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ColorUtils.toColor
+import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
+
+@SkyHanniModule
+object BirriesHighlighter {
+
+    val config get() = SkyHanniMod.feature.foraging.birriesHighlight
+
+    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    fun onMob(event: MobEvent.Spawn.SkyblockMob) {
+        if (event.mob.name != "Birries") return
+        RenderLivingEntityHelper.setEntityColor(event.mob.baseEntity, config.color.toColor()) { isEnabled() && event.mob.baseEntity.distanceToPlayer() < 10 }
+    }
+
+    fun isEnabled() = config.enabled
+}


### PR DESCRIPTION
## What
Highlights Birries (tadpoles) in the galatea as they are kinda small

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/9d57e665-6df8-4986-a264-50e2b5bd4587)
![image](https://github.com/user-attachments/assets/514bf9d7-52e3-48fe-a204-bcd0c9393b15)
![image](https://github.com/user-attachments/assets/be49e30c-72d0-4d5d-beae-e77d929d56e5)

</details>

## Changelog New Features
+ Highlight the small Birries in Galatea. - nopo