### PR TITLE
Backend: InventoryDetector Second Constructor

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryDetector.kt
@@ -5,6 +5,8 @@ import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import java.util.regex.Pattern
 
 /**
  * The InventoryDetector tracks whether an inventory is open and provides
@@ -17,6 +19,13 @@ class InventoryDetector(
     val openInventory: (String) -> Unit = {},
     val checkInventoryName: (String) -> Boolean,
 ) {
+    constructor(
+        pattern: Pattern,
+        openInventory: (String) -> Unit = {},
+    ) : this(
+        openInventory,
+        checkInventoryName = { name -> pattern.matches(name) }
+    )
 
     init {
         detectors.add(this)


### PR DESCRIPTION
## What
Figured since I've got a couple PRs that could benefit from this, now, it'd be worth separating it out so it can be merged separately. Adds a second constructor to `InventoryDetector` so that you can just pass it a pattern, and it does the name matching assignment.

## Changelog Technical Details
+ Added secondary constructor to InventoryDetector. - Daveed
    * Accepts a Pattern for name matching.

