### PR TITLE
Fix: Pet Data (For real real real real real real real this time)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -75,8 +75,8 @@ object SkyBlockItemModifierUtils {
     @KSerializable
     data class PetInfo(
         @Expose val type: String,
-        @Expose val active: Boolean? = null,
-        @Expose val exp: Double,
+        @Expose val active: Boolean = false,
+        @Expose val exp: Double = 0.0,
         @Expose val tier: LorenzRarity,
         @Expose val hideInfo: Boolean = false,
         @Expose val heldItem: NeuInternalName? = null,
@@ -138,21 +138,18 @@ object SkyBlockItemModifierUtils {
     inline val ItemStack.cachedData: CachedItemData get() = (this as ItemStackCachedData).skyhanni_cachedData
 
     fun ItemStack.getPetInfo(): PetInfo? {
+        // Repo pets will always return null for PetInfo, don't even attempt to parse it
+        if (displayName.contains("→")) return null
         val petInfoJson = getExtraAttributes()?.takeIf {
             it.hasKey("petInfo")
         }?.getString("petInfo")?.takeIf {
             it.isNotEmpty()
         } ?: return null
 
-        try {
-            return ConfigManager.gson.fromJson(petInfoJson, PetInfo::class.java)
+        return try {
+            ConfigManager.gson.fromJson(petInfoJson, PetInfo::class.java)
         } catch (e: Exception) {
-            ErrorManager.skyHanniError(
-                "Failed to parse pet info for item: ${displayName.removeColor()}",
-                "exception" to e.message,
-                "extraAttributes" to extraAttributes.toString(),
-                "petInfoJson" to petInfoJson,
-            )
+            null
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -144,7 +144,7 @@ object SkyBlockItemModifierUtils {
     fun ItemStack.getPetInfo(): PetInfo? {
         val colorlessName = displayName.removeColor()
         // Repo pets will always return null for PetInfo, don't even attempt to parse it
-        if (colorlessName.contains("→")) return null
+        if (colorlessName.contains("→") || colorlessName.contains("{LVL}")) return null
         val petInfoJson = getExtraAttributes()?.takeIf {
             it.hasKey("petInfo")
         }?.getString("petInfo")?.takeIf {

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -20,6 +20,7 @@ import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.ResourceLocation
 import java.util.Locale
 import java.util.UUID
+import kotlin.time.Duration.Companion.minutes
 
 //#if MC > 1.21
 //$$ import net.minecraft.component.DataComponentTypes
@@ -137,9 +138,13 @@ object SkyBlockItemModifierUtils {
     @Suppress("CAST_NEVER_SUCCEEDS")
     inline val ItemStack.cachedData: CachedItemData get() = (this as ItemStackCachedData).skyhanni_cachedData
 
+    val warnedAboutPetParseFailure: MutableSet<String> = mutableSetOf()
+    var lastWarnedParseFailure: SimpleTimeMark = SimpleTimeMark.farPast()
+
     fun ItemStack.getPetInfo(): PetInfo? {
+        val colorlessName = displayName.removeColor()
         // Repo pets will always return null for PetInfo, don't even attempt to parse it
-        if (displayName.contains("→")) return null
+        if (colorlessName.contains("→")) return null
         val petInfoJson = getExtraAttributes()?.takeIf {
             it.hasKey("petInfo")
         }?.getString("petInfo")?.takeIf {
@@ -149,7 +154,15 @@ object SkyBlockItemModifierUtils {
         return try {
             ConfigManager.gson.fromJson(petInfoJson, PetInfo::class.java)
         } catch (e: Exception) {
-            null
+            val added = warnedAboutPetParseFailure.add(colorlessName)
+            if (!added || lastWarnedParseFailure.passedSince() <= 1.minutes) return null
+            lastWarnedParseFailure = SimpleTimeMark.now()
+            ErrorManager.skyHanniError(
+                "Failed to parse pet info for item: $colorlessName",
+                "exception" to e.message,
+                "extraAttributes" to extraAttributes.toString(),
+                "petInfoJson" to petInfoJson,
+            )
         }
     }
 


### PR DESCRIPTION
## What
Trying to do things the right way always bites me in the ass.
Repo pets continue to have either missing fields, or straight up no pet info, so even more default values and parse attempts.

Also redid the logging so that:
- It does not repeat for the same item more than once a session
- The error will not show more than once a minute totally

## Changelog Fixes
+ Fixed additional pet errors in REI search. - Daveed
