### PR TITLE
Fix:  FEATURES.md formating problem

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1016,6 +1016,8 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
 
 ## Foraging
 
+</summary>
+
 + Added Foraging Quest Helper. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/4130)
     + Shows paths to useful locations for unlocking the 1.21 Foraging island.
 + Added Moonglade Beacon Ready Alert. - nopo (https://github.com/hannibal002/SkyHanni/pull/4135)
@@ -1023,6 +1025,9 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
 + Highlight the small Birries in Galatea. - nopo (https://github.com/hannibal002/SkyHanni/pull/4137)
 + Added Heart Of The Forest features. - Thunderblade73 (https://github.com/hannibal002/SkyHanni/pull/4040)
     + Show Perk Levels and Enabled Perks in the menu.
+
+</details>
+<details open><summary>
 
 ## Events
 


### PR DESCRIPTION
there is a formatting problem with the file that makes foraging title not collapse correctly like the others

exclude_from_changelog 