### PR TITLE
Fix: Add back message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -456,7 +456,8 @@ object GardenNextJacobContest {
         isFetchingContests = true
         SkyHanniMod.launchIOCoroutine {
             knownContests = EliteDevApi.fetchUpcomingContests().orEmpty()
-            if (knownContests.isNotEmpty()) {
+            if (haveAllContests) {
+                ChatUtils.chat("Successfully loaded this year's contests from elitebot.dev automatically!")
                 fetchedFromElite = true
                 nextContestsAvailableAt = SkyBlockTime(SkyBlockTime.now().year + 1, 1, 2).toTimeMark()
                 loadedContestsYear = SkyBlockTime.now().year


### PR DESCRIPTION
## What
In #4110, the message when contests load successfully was accidentally removed, this adds it back.

## Changelog Fixes
+ Fixed missing message when fetching contests from EliteDev. - Daveed
