### PR TITLE
Feature: Hide status effects from top right

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -454,5 +454,6 @@ public class MiscConfig {
     @OnlyModern
     @ConfigEditorBoolean
     @FeatureToggle
+    @SearchTag("beacon potion")
     public boolean hideStatusEffects = true;
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -399,6 +399,7 @@ public class MiscConfig {
     @ConfigOption(name = "NEU Soul Path Find", desc = "When showing §e/neusouls on§7, show a pathfind to the faily souls missing and a percentage of souls done in chat.")
     @ConfigEditorBoolean
     @FeatureToggle
+    @OnlyLegacy
     public boolean neuSoulsPathFind = true;
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.config.features.misc;
 
 import at.hannibal2.skyhanni.config.FeatureToggle;
 import at.hannibal2.skyhanni.config.OnlyLegacy;
+import at.hannibal2.skyhanni.config.OnlyModern;
 import at.hannibal2.skyhanni.config.core.config.Position;
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature;
 import at.hannibal2.skyhanni.config.features.commands.CommandsConfig;
@@ -297,6 +298,7 @@ public class MiscConfig {
     @ConfigOption(name = "NEU Heavy Pearls", desc = "Fix NEU's Heavy Pearl detection.")
     @ConfigEditorBoolean
     @FeatureToggle
+    @OnlyLegacy
     public boolean fixNeuHeavyPearls = true;
 
     @Expose
@@ -446,4 +448,11 @@ public class MiscConfig {
     )
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     public int abiphoneAcceptKey = Keyboard.KEY_NONE;
+
+    @Expose
+    @ConfigOption(name = "Hide Status Effects", desc = "Hides status effects in the top right of the screen")
+    @OnlyModern
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean hideStatusEffects = true;
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinInGameHud.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinInGameHud.java
@@ -1,0 +1,17 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.SkyHanniMod;
+import net.minecraft.client.gui.hud.InGameHud;
+    import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(InGameHud.class)
+public class MixinInGameHud {
+
+    @Inject(method = "renderStatusEffectOverlay", at = @At("HEAD"), cancellable = true)
+    public void disableEffects(CallbackInfo ci) {
+        if (SkyHanniMod.feature.misc.hideStatusEffects) ci.cancel();
+    }
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinInGameHud.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinInGameHud.java
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.SkyHanniMod;
+import at.hannibal2.skyhanni.utils.SkyBlockUtils;
 import net.minecraft.client.gui.hud.InGameHud;
     import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,6 +13,6 @@ public class MixinInGameHud {
 
     @Inject(method = "renderStatusEffectOverlay", at = @At("HEAD"), cancellable = true)
     public void disableEffects(CallbackInfo ci) {
-        if (SkyHanniMod.feature.misc.hideStatusEffects) ci.cancel();
+        if (SkyBlockUtils.INSTANCE.getInSkyBlock() && SkyHanniMod.feature.misc.hideStatusEffects) ci.cancel();
     }
 }


### PR DESCRIPTION
## What
Hides effects from top right
I also put only legacy on 2 neu config options

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/e1b2f0cf-3d82-4036-910c-d144575b3200)

</details>

## Changelog New Features
+ Added Hide Effects from top right. - nopo
