### PR TITLE
Fix: Another lot of 1.21 stuff

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
@@ -69,7 +69,7 @@ class ItemResolutionQuery {
 
         @HandleEvent
         fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
-            val typeToken = object  : TypeToken<List<BazaarOverride>>() {}.type
+            val typeToken = object : TypeToken<List<BazaarOverride>>() {}.type
             val overrides = event.getConstant<List<BazaarOverride>>("bazaarstocks", typeToken)
             bazaarOverrides = overrides.associate { it.bazaarInternalName to it.neuInternalName }
         }

--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.api.enoughupdates
 
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigManager
+import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -16,6 +18,9 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.UtilsPatterns
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonObject
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiScreen
 import net.minecraft.client.gui.inventory.GuiChest
@@ -60,6 +65,20 @@ class ItemResolutionQuery {
             "§6(?<name>.+?) ?(?<tier>[IVXL]+)?$",
         )
 
+        private var bazaarOverrides = mapOf<String, String>()
+
+        @HandleEvent
+        fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
+            val typeToken = object  : TypeToken<List<BazaarOverride>>() {}.type
+            val overrides = event.getConstant<List<BazaarOverride>>("bazaarstocks", typeToken)
+            bazaarOverrides = overrides.associate { it.bazaarInternalName to it.neuInternalName }
+        }
+
+        private data class BazaarOverride(
+            @Expose @SerializedName("stock") val bazaarInternalName: String,
+            @Expose @SerializedName("id") val neuInternalName: String,
+        )
+
         private val petPattern = ".*(\\[Lvl .*] )§(.).*".toPattern()
 
         val petRarities = listOf("COMMON", "UNCOMMON", "RARE", "EPIC", "LEGENDARY", "MYTHIC")
@@ -67,6 +86,9 @@ class ItemResolutionQuery {
         private val BAZAAR_ENCHANTMENT_PATTERN = "ENCHANTMENT_(\\D*)_(\\d+)".toPattern()
 
         fun transformHypixelBazaarToNeuItemId(hypixelId: String): String {
+            bazaarOverrides[hypixelId]?.let {
+                return it
+            }
             val matcher = BAZAAR_ENCHANTMENT_PATTERN.matcher(hypixelId)
             if (matcher.matches()) {
                 return matcher.group(1) + ";" + matcher.group(2)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/EstimatedItemValueConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/EstimatedItemValueConfig.java
@@ -102,15 +102,6 @@ public class EstimatedItemValueConfig {
     }
 
     @Expose
-    @ConfigOption(
-        name = "Use Attribute Price",
-        desc = "Show composite price for attributes instead of lowest bin. " +
-            "This will drastically decrease the estimated value but might be correct when buying multiple low tier items and combining them."
-    )
-    @ConfigEditorBoolean
-    public Property<Boolean> useAttributeComposite = Property.of(false);
-
-    @Expose
     @ConfigLink(owner = EstimatedItemValueConfig.class, field = "enabled")
     // TODO rename "position"
     public Position itemPriceDataPos = new Position(140, 90);

--- a/src/main/java/at/hannibal2/skyhanni/data/title/TitleContext.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/title/TitleContext.kt
@@ -151,14 +151,12 @@ open class TitleContext(
 
         DrawContextUtils.pushPop {
             DrawContextUtils.translate(0f, -translation, 500f)
-            //#if TODO
             Renderable.drawInsideRoundedRect(
                 stringRenderable,
                 ColorUtils.TRANSPARENT_COLOR,
                 horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
                 verticalAlign = RenderUtils.VerticalAlignment.CENTER,
             ).renderXYAligned(0, 125, gui.width, gui.height)
-            //#endif
 
             DrawContextUtils.translate(0f, translation, -500f)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -189,7 +189,6 @@ object EstimatedItemValue {
                 ignoreArmorDyes,
                 ignoreRunes,
                 priceSource,
-                useAttributeComposite,
             ) {
                 cache.clear()
             }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
@@ -65,7 +65,13 @@ class GuiContainerHook(guiAny: Any) {
     }
 
     fun foregroundDrawn(context: DrawContext, mouseX: Int, mouseY: Int, partialTicks: Float) {
+        if (!PlatformUtils.IS_LEGACY) {
+            context.matrices.translate(0.0, 0.0, 200.0)
+        }
         GuiContainerEvent.ForegroundDrawnEvent(context, gui, container, mouseX, mouseY, partialTicks).post()
+        if (!PlatformUtils.IS_LEGACY) {
+            context.matrices.translate(0.0, 0.0, -200.0)
+        }
     }
 
     fun onDrawSlot(slot: Slot, ci: CallbackInfo) {

--- a/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
@@ -24,8 +24,10 @@ import net.minecraft.network.play.client.C03PacketPlayer
 import net.minecraft.network.play.server.S04PacketEntityEquipment
 import net.minecraft.network.play.server.S0BPacketAnimation
 import net.minecraft.network.play.server.S0CPacketSpawnPlayer
+//#if MC < 1.21
 import net.minecraft.network.play.server.S0EPacketSpawnObject
 import net.minecraft.network.play.server.S0FPacketSpawnMob
+//#endif
 import net.minecraft.network.play.server.S12PacketEntityVelocity
 import net.minecraft.network.play.server.S13PacketDestroyEntities
 import net.minecraft.network.play.server.S14PacketEntity

--- a/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
@@ -2,9 +2,9 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.mixins.transformers.AccessorRendererLivingEntity
-import at.hannibal2.skyhanni.utils.RenderUtils.getViewerPos
 import at.hannibal2.skyhanni.utils.TimeUtils.inWholeTicks
 import at.hannibal2.skyhanni.utils.compat.createWitherSkeleton
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils
 import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.client.renderer.entity.RendererLivingEntity
@@ -168,7 +168,7 @@ object HolographicEntities {
         if (!renderer.bindEntityTexture_skyhanni(entity)) return
 
         GlStateManager.pushMatrix()
-        val viewerPosition = getViewerPos(partialTicks)
+        val viewerPosition = WorldRenderUtils.getViewerPos(partialTicks)
         val mobPosition = holographicEntity.interpolatedPosition(partialTicks)
         val renderingOffset = mobPosition - viewerPosition
         GlStateManager.translate(renderingOffset.x.toFloat(), renderingOffset.y.toFloat(), renderingOffset.z.toFloat())

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -38,9 +38,6 @@ import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderXAligned
 import at.hannibal2.skyhanni.utils.shader.ShaderManager
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import net.minecraft.client.Minecraft
-//#if MC < 1.21
-import net.minecraft.client.renderer.GLAllocation
-//#endif
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.entity.Entity
 import net.minecraft.inventory.Slot
@@ -50,7 +47,9 @@ import java.awt.Color
 import java.nio.FloatBuffer
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
-//#if MC > 1.21
+//#if MC < 1.21
+import net.minecraft.client.renderer.GLAllocation
+//#else
 //$$ import com.mojang.blaze3d.systems.RenderSystem
 //$$ import org.lwjgl.BufferUtils
 //#endif
@@ -134,7 +133,7 @@ object RenderUtils {
         GlStateManager.disableDepth()
         DrawContextUtils.pushMatrix()
         // TODO don't use z
-        //#if TODO
+        //#if MC < 1.21
         val zLevel = Minecraft.getMinecraft().renderItem.zLevel
         //#else
         //$$ val zLevel = 50f
@@ -202,12 +201,6 @@ object RenderUtils {
     ) {
         _drawColor(location, color, beacon, alpha, seeThroughBlocks)
     }
-
-    //#if TODO
-    @Deprecated("Use WorldRenderUtils' getViewerPos instead", ReplaceWith("WorldRenderUtils.getViewerPos(partialTicks)"))
-    fun getViewerPos(partialTicks: Float) =
-        Minecraft.getMinecraft().renderViewEntity?.let { exactLocation(it, partialTicks) } ?: LorenzVec()
-    //#endif
 
     @Deprecated("Use WorldRenderUtils' expandBlock instead")
     fun AxisAlignedBB.expandBlock(n: Int = 1) = expand(LorenzVec.expandVector * n)

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/LineDrawer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/LineDrawer.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.utils.render
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.utils.LocationUtils.calculateEdges
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.zipWithNext3
 import net.minecraft.client.renderer.GLAllocation
 import net.minecraft.client.renderer.GlStateManager
@@ -128,7 +127,7 @@ class LineDrawer @PublishedApi internal constructor(val tessellator: Tessellator
             GlStateManager.disableAlpha()
 
             GlStateManager.pushMatrix()
-            val inverseView = RenderUtils.getViewerPos(event.partialTicks)
+            val inverseView = WorldRenderUtils.getViewerPos(event.partialTicks)
             WorldRenderUtils.translate(inverseView.negated())
 
             draws.invoke(LineDrawer(Tessellator.getInstance(), lineWidth, depth))

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/QuadDrawer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/QuadDrawer.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.utils.render
 
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.pos
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.client.renderer.Tessellator
@@ -41,8 +40,7 @@ class QuadDrawer @PublishedApi internal constructor(val tessellator: Tessellator
             GlStateManager.disableCull()
 
             GlStateManager.pushMatrix()
-            WorldRenderUtils.translate(RenderUtils.getViewerPos(event.partialTicks).negated())
-            RenderUtils.getViewerPos(event.partialTicks)
+            WorldRenderUtils.translate(WorldRenderUtils.getViewerPos(event.partialTicks).negated())
 
             quads.invoke(QuadDrawer(Tessellator.getInstance()))
 

--- a/versions/1.21.5/buildpaths-excluded.txt
+++ b/versions/1.21.5/buildpaths-excluded.txt
@@ -14,6 +14,7 @@ at.hannibal2.skyhanni.tweaker.SkyHanniTweaker.java
 at.hannibal2.skyhanni.tweaker.ModLoadingTweaker.java
 at.hannibal2.skyhanni.tweaker.TweakerUtils.java
 
+at.hannibal2.skyhanni.mixins.hooks.BlockRendererDispatcherHook.kt
 at.hannibal2.skyhanni.mixins.transformers.AccessorChatComponentText.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorFontRenderer.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorGuiEditSign.java
@@ -54,8 +55,6 @@ at.hannibal2.skyhanni.mixins.transformers.renderer.MixinContributorRendererEntit
 at.hannibal2.skyhanni.mixins.transformers.renderer.MixinRendererLivingEntity.java
 
 # these files do not work yet but should be made to work in the future
-at/hannibal2/skyhanni/mixins/hooks/BlockRendererDispatcherHook.kt
-at.hannibal2.skyhanni.test.PacketTest.kt
 at.hannibal2.skyhanni.utils.HolographicEntities.kt
 at.hannibal2.skyhanni.utils.json.NBTTypeAdapter.kt
 at.hannibal2.skyhanni.utils.json.ItemStackTypeAdapterFactory.kt

--- a/versions/mapping-1.16.5-forge-1.8.9.txt
+++ b/versions/mapping-1.16.5-forge-1.8.9.txt
@@ -199,6 +199,7 @@ net.minecraft.network.protocol.game.ClientboundMoveEntityPacket net.minecraft.ne
 net.minecraft.network.protocol.game.ClientboundOpenScreenPacket net.minecraft.network.play.server.S2DPacketOpenWindow
 net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket net.minecraft.network.play.server.S38PacketPlayerListItem
 net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket net.minecraft.network.play.server.S13PacketDestroyEntities
+net.minecraft.network.protocol.game.ClientboundRotateHeadPacket net.minecraft.network.play.server.S19PacketEntityHeadLook
 net.minecraft.network.protocol.game.ClientboundSectionBlocksUpdatePacket net.minecraft.network.play.server.S22PacketMultiBlockChange
 net.minecraft.network.protocol.game.ClientboundSetBorderPacket net.minecraft.network.play.server.S44PacketWorldBorder
 net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket net.minecraft.network.play.server.S1CPacketEntityMetadata


### PR DESCRIPTION
## What
Fixed ForegroundDrawnEvent and removed some some `//#if TODO`s and made packet test work on 1.21.

## Changelog Improvements
+ Added Bazaar price support for new Attribute Shards. - CalMWolfs

## Changelog Fixes
+ Fixed Hide Non Clickable Items and inventory highlighting not rendering properly in 1.21. - CalMWolfs

## Changelog Technical Details
+ Made ForegroundDrawnEvent render in the foreground on 1.21. - CalMWolfs

## Changelog Removed Features
+ Removed legacy Attribute Shards from Estimated Item Value. - CalMWolfs
    * Attribute Overlay remains available.