### PR TITLE
Fix: Keybind migration causing crashes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
@@ -168,7 +168,7 @@ object UpdateKeybinds {
 
             if (keybindMap.containsKey(currentValue)) {
                 val newValue = keybindMap[currentValue]
-                shimmy.setJson(JsonPrimitive(newValue))
+                shimmy.set(newValue)
 
                 logger.log("$keybind old $currentValue")
                 logger.log("$keybind new $newValue")

--- a/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.json.Shimmy
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
-import com.google.gson.JsonPrimitive
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 


### PR DESCRIPTION
## What
Fixes keybinds crashing due to them saving as a double instead of int

## Changelog Fixes
+ Fixed config crashes from invalid keybinds. - nopo
    * his won’t fix existing migrated configs; only applies to new ones.
    * Convert config to 1.8 and back to 1.21 to resolve issues.
