### PR TITLE
Feature: Status effect hider

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.features.gui
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyModern
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.features.chroma.ChromaConfig
 import at.hannibal2.skyhanni.config.features.gui.customscoreboard.CustomScoreboardConfig
@@ -170,6 +171,13 @@ class GuiConfig {
     @ConfigOption(name = "Widen Config", desc = "Make SkyHanni's config window wider. (~1.5x)")
     @ConfigEditorBoolean
     val widenConfig: Property<Boolean> = Property.of(false)
+
+    @Expose
+    @ConfigOption(name = "Hide Status Effects", desc = "Hide the status effect displays at top right of the screen and in inventory.")
+    @OnlyModern
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var hideStatusEffects: Boolean = true
 
     @Expose
     val titlePosition: Position = Position(0, 160)

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/gui/StatusEffectHider.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/gui/StatusEffectHider.kt
@@ -1,0 +1,12 @@
+package at.hannibal2.skyhanni.features.gui
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+
+object StatusEffectHider {
+
+    private val config get() = SkyHanniMod.feature.gui
+
+    @JvmStatic
+    fun shouldHide(): Boolean = SkyBlockUtils.inSkyBlock && config.hideStatusEffects
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/render/MixinInGameHud.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/render/MixinInGameHud.java
@@ -1,0 +1,20 @@
+package at.hannibal2.skyhanni.mixins.transformers.render;
+
+import at.hannibal2.skyhanni.features.gui.StatusEffectHider;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.render.RenderTickCounter;
+import net.minecraft.client.gui.hud.InGameHud;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(InGameHud.class)
+public class MixinInGameHud {
+
+    // The status effect in the inventory.
+    @Inject(method = "renderStatusEffectOverlay", at = @At("HEAD"), cancellable = true)
+    private void hideStatusEffects(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) {
+        if (StatusEffectHider.shouldHide()) ci.cancel();
+    }
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/render/MixinStatusEffectsDisplay.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/render/MixinStatusEffectsDisplay.java
@@ -1,0 +1,19 @@
+package at.hannibal2.skyhanni.mixins.transformers.render;
+
+import at.hannibal2.skyhanni.features.gui.StatusEffectHider;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.StatusEffectsDisplay;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(StatusEffectsDisplay.class)
+public class MixinStatusEffectsDisplay {
+
+    // The status effect in the top right corner of the screen
+    @Inject(method = "drawStatusEffects(Lnet/minecraft/client/gui/DrawContext;IIF)V", at = @At("HEAD"), cancellable = true)
+    private void hideInventoryStatusEffects(DrawContext context, int mouseX, int mouseY, float tickDelta, CallbackInfo ci) {
+        if (StatusEffectHider.shouldHide()) ci.cancel();
+    }
+}


### PR DESCRIPTION
## What
saw #4156 too late. anyway, this PR adds both status effect hiders in one.

## Changelog New Features
+ Added Hide Status Effects. - hannibal2
    * Hide the status effect displays at top right of the screen and in inventory.
    * Only in 1.21, as 1.8 doesn't have those status effect displays.