### PR TITLE
Fix: hide not clickable items dark foreground

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -52,6 +52,12 @@ import net.minecraft.inventory.ContainerChest
 import net.minecraft.item.ItemStack
 import kotlin.time.Duration.Companion.seconds
 
+//#if MC > 1.21
+//$$ import net.minecraft.client.MinecraftClient
+//$$ import net.minecraft.client.gui.DrawContext
+//$$ import net.minecraft.client.gui.screen.ingame.GenericContainerScreen
+//#endif
+
 @SkyHanniModule
 object HideNotClickableItems {
 
@@ -107,6 +113,56 @@ object HideNotClickableItems {
         }
     }
 
+    //#if MC > 1.21
+//$$     @JvmStatic
+//$$     fun <T> test(slots: DefaultedList<Slot>, context: DrawContext, x: Int, y: Int) {
+//$$         val (background, border) = onRun(slots) ?: return
+//$$
+//$$         for ((slot, color) in border) {
+//$$             val sx: Int = x + slot.x
+//$$             val sy: Int = y + slot.y
+//$$ //             context.fill(sx, sy, sx + 16, sy + 16, -0x78000000)
+//$$             context.fill(sx, sy, sx + 16, sy + 16, color.rgb)
+//$$         }
+//$$
+//$$         // semi-transparent gray: 0x88000000
+//$$         for (slot in slots) {
+//$$             val sx: Int = x + slot.x
+//$$             val sy: Int = y + slot.y
+//$$             context.fill(sx, sy, sx + 16, sy + 16, -0x78000000)
+//$$         }
+//$$     }
+//
+//$$     @JvmStatic
+//$$     fun onRun(slots: DefaultedList<Slot>): Pair<MutableMap<Slot, Color>, MutableMap<Slot, Color>>? {
+//$$         if (!isEnabled()) return null
+//$$         if (bypassActive()) return null
+//$$ //         if (event.gui !is GenericContainerScreen) return
+//$$ //         val chest = event.container as GenericContainerScreenHandler
+//$$         val chestName = InventoryUtils.openInventoryName()
+//$$
+//$$
+//$$         val background = mutableMapOf<Slot, Color>()
+//$$         val border = mutableMapOf<Slot, Color>()
+//$$
+//$$         for (slot in slots) {
+//$$             val stack = slot.stack ?: continue
+//$$ //         }
+//$$ //         for ((slot, stack) in chest.getLowerItems()) {
+//$$             if (hide(chestName, stack)) {
+//$$                 background[slot] = LorenzColor.DARK_GRAY.addOpacity(config.opacity)
+//$$ //                 slot.highlight(LorenzColor.DARK_GRAY.addOpacity(config.opacity))
+//$$             } else if (showGreenLine && config.itemsGreenLine) {
+//$$                 border[slot] = LorenzColor.GREEN.addOpacity(200)
+//$$ //                 slot.drawBorder(LorenzColor.GREEN.addOpacity(200))
+//$$             }
+//$$         }
+//$$
+//$$         return background to border
+//$$     }
+//#else
+
+
     @HandleEvent(onlyOnSkyblock = true)
     fun onForegroundDrawn(event: GuiContainerEvent.ForegroundDrawnEvent) {
         if (!isEnabled()) return
@@ -123,6 +179,8 @@ object HideNotClickableItems {
             }
         }
     }
+
+//#endif
 
     @HandleEvent(priority = HandleEvent.LOWEST)
     fun onTooltip(event: ToolTipEvent) {

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.DrawScreenAfterEvent;
 import at.hannibal2.skyhanni.events.GuiContainerEvent;
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent;
 import at.hannibal2.skyhanni.events.render.gui.DrawBackgroundEvent;
+import at.hannibal2.skyhanni.features.inventory.HideNotClickableItems;
 import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeApi;
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests;
 import at.hannibal2.skyhanni.utils.DelayedRun;
@@ -15,6 +16,8 @@ import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.item.ItemStack;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.slot.Slot;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -27,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Mixin(HandledScreen.class)
-public abstract class MixinHandledScreen {
+public abstract class MixinHandledScreen<T extends ScreenHandler> {
 
     @Inject(method = "render", at = @At(value = "HEAD"), cancellable = true)
     private void renderHead(DrawContext context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
@@ -70,5 +73,30 @@ public abstract class MixinHandledScreen {
         if (new GuiKeyPressEvent((HandledScreen<?>) (Object) this).post()) {
             cir.setReturnValue(false);
         }
+    }
+
+    // these fields exist in HandledScreen
+    protected int x;
+    protected int y;
+    protected T handler;
+
+    @Inject(
+        method = "drawForeground(Lnet/minecraft/client/gui/DrawContext;II)V",
+        at = @At("TAIL")
+    )
+    private void onDrawForeground(DrawContext context, int mouseX, int mouseY, CallbackInfo ci) {
+//         GuiContainerEvent.ForegroundDrawnEvent(context, handler, handler., mouseX, mouseY, partialTicks).post()
+
+//         handler.slots
+
+        HideNotClickableItems.test(handler.slots, context, this.x, this.y);
+
+
+        // semi-transparent gray: 0x88000000
+//         for (Slot slot : handler.slots) {
+//             int sx = this.x + slot.x;
+//             int sy = this.y + slot.y;
+//             context.fill(sx, sy, sx + 16, sy + 16, 0x88000000);
+//         }
     }
 }


### PR DESCRIPTION
## What
my first try at bringing back the dark foreground. cant get it to work, idk why

![image](https://github.com/user-attachments/assets/90f7cdfe-9097-4ca0-beb6-7e56e36491cb)

Probably a better solution would be to wrap this into a version generic utils that then gets special implemented by 1.21

## Changelog Fixes
+ Fixed dark foreground not showing for Hide Not Clickable Entities. - hannibal2