### PR TITLE
Fix: Fixed Hide Armor in 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
@@ -1,11 +1,11 @@
 package at.hannibal2.skyhanni.features.misc
 
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.misc.HideArmorConfig.ModeEntry
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
-import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.getArmorInventory

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
@@ -1,10 +1,11 @@
 package at.hannibal2.skyhanni.features.misc
 
-import at.hannibal2.skyhanni.SkyHanniMod
+
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.misc.HideArmorConfig.ModeEntry
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.getArmorInventory
@@ -14,9 +15,10 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat.Companion.hasPotionEffect
 import net.minecraft.client.entity.EntityPlayerSP
+import net.minecraft.entity.Entity
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
-import net.minecraft.entity.Entity
+
 
 @SkyHanniModule
 object HideArmor {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
@@ -16,14 +16,15 @@ import at.hannibal2.skyhanni.utils.compat.EffectsCompat.Companion.hasPotionEffec
 import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
+import net.minecraft.entity.Entity
 
 @SkyHanniModule
 object HideArmor {
 
-    private val config get() = SkyHanniMod.feature.misc.hideArmor2
+    val config get() = SkyHanniMod.feature.misc.hideArmor2
     private var armor = mapOf<Int, ItemStack>()
 
-    private fun shouldHideArmor(entity: EntityPlayer): Boolean {
+    fun shouldHideArmor(entity: EntityPlayer): Boolean {
         if (!SkyBlockUtils.inSkyBlock) return false
         if (entity is FakePlayer) return false
         if (entity.hasPotionEffect(EffectsCompat.INVISIBILITY)) return false
@@ -73,5 +74,19 @@ object HideArmor {
         event.transform(15, "misc.hideArmor2.mode") { element ->
             ConfigUtils.migrateIntToEnum(element, ModeEntry::class.java)
         }
+    }
+
+    private val CURRENT_RENDERED_ENTITY: ThreadLocal<Entity> = ThreadLocal<Entity>()
+
+    fun set(entity: Entity) {
+        CURRENT_RENDERED_ENTITY.set(entity)
+    }
+
+    fun get(): Entity {
+        return CURRENT_RENDERED_ENTITY.get()
+    }
+
+    fun clear() {
+        CURRENT_RENDERED_ENTITY.remove()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderManager.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderManager.java
@@ -1,13 +1,20 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.data.EntityData;
+import at.hannibal2.skyhanni.features.misc.HideArmor;
 import net.minecraft.client.renderer.culling.ICamera;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+//#if MC > 1.21
+//$$ import net.minecraft.client.util.math.MatrixStack;
+//$$ import net.minecraft.client.render.VertexConsumerProvider;
+//#endif
+
 
 @Mixin(RenderManager.class)
 public class MixinRenderManager {
@@ -18,4 +25,31 @@ public class MixinRenderManager {
             cir.setReturnValue(false);
         }
     }
+    //#if MC > 1.21
+    //$$ @Inject(method = "render", at = @At("HEAD"))
+    //$$ private void onRenderStart(
+    //$$     Entity entity,
+    //$$     double x, double y, double z,
+    //$$     float tickDelta,
+    //$$     MatrixStack matrices,
+    //$$     VertexConsumerProvider vertexConsumers,
+    //$$     int light,
+    //$$     CallbackInfo ci
+    //$$ ) {
+    //$$     HideArmor.INSTANCE.set(entity);
+    //$$ }
+    //$$
+    //$$ @Inject(method = "render", at = @At("RETURN"))
+    //$$ private void onRenderEnd(
+    //$$     Entity entity,
+    //$$     double x, double y, double z,
+    //$$     float tickDelta,
+    //$$     MatrixStack matrices,
+    //$$     VertexConsumerProvider vertexConsumers,
+    //$$     int light,
+    //$$     CallbackInfo ci
+    //$$ ) {
+    //$$     HideArmor.INSTANCE.clear();
+    //$$ }
+    //#endif
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinArmorFeatureRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinArmorFeatureRenderer.java
@@ -1,0 +1,39 @@
+package at.hannibal2.skyhanni.mixins.transformers.renderer;
+
+import at.hannibal2.skyhanni.features.misc.HideArmor;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+//#if MC > 1.21
+//$$ import net.minecraft.client.render.entity.feature.ArmorFeatureRenderer;
+//$$ import net.minecraft.client.util.math.MatrixStack;
+//$$ import net.minecraft.client.render.VertexConsumerProvider;
+//$$ import net.minecraft.client.render.entity.state.BipedEntityRenderState;
+//$$ import net.minecraft.entity.EquipmentSlot;
+//$$ import net.minecraft.client.render.entity.model.BipedEntityModel;
+//$$
+//$$ @Mixin(ArmorFeatureRenderer.class)
+//$$ public class MixinArmorFeatureRenderer {
+//$$     @Inject(method = "renderArmor", at = @At("HEAD"), cancellable = true)
+//$$     private void onRenderArmor(
+//$$         MatrixStack matrixStack,
+//$$         VertexConsumerProvider vertexConsumerProvider,
+//$$         ItemStack stack,
+//$$         EquipmentSlot slot,
+//$$         int light,
+//$$         BipedEntityModel armorModel,
+//$$         CallbackInfo ci
+//$$     ) {
+//$$         Entity current = HideArmor.INSTANCE.get();
+//$$         if (current instanceof PlayerEntity && HideArmor.INSTANCE.shouldHideArmor(((PlayerEntity) current))) {
+//$$             if(!HideArmor.INSTANCE.getConfig().onlyHelmet || slot == EquipmentSlot.HEAD){
+//$$                 ci.cancel();
+//$$             }
+//$$         }
+//$$     }
+//$$ }
+//#endif

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinHeadFeatureRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinHeadFeatureRenderer.java
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.mixins.transformers.renderer;
+
+import at.hannibal2.skyhanni.features.misc.HideArmor;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+//#if MC > 1.21
+//$$ import net.minecraft.client.render.entity.feature.HeadFeatureRenderer;
+//$$ import net.minecraft.client.util.math.MatrixStack;
+//$$ import net.minecraft.client.render.VertexConsumerProvider;
+//$$ import net.minecraft.client.render.entity.state.LivingEntityRenderState;
+//$$
+//$$ @Mixin(HeadFeatureRenderer.class)
+//$$ public class MixinHeadFeatureRenderer {
+//$$     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
+//$$      private void onRenderArmor(
+//$$          MatrixStack matrixStack,
+//$$          VertexConsumerProvider vertexConsumerProvider,
+//$$          int light,
+//$$          LivingEntityRenderState renderState,
+//$$          float f,
+//$$          float g,
+//$$          CallbackInfo ci
+//$$      ) {
+//$$          Entity current = HideArmor.INSTANCE.get();
+//$$          if (current instanceof PlayerEntity && HideArmor.INSTANCE.shouldHideArmor(((PlayerEntity) current))) {
+//$$              ci.cancel();
+//$$          }
+//$$      }
+//$$  }
+//#endif


### PR DESCRIPTION
## What
Fixed all Hide Armor features in 1.21.5. Now it uses mixins to stop rendering armor parts as render events do not exist in 1.21.5.

## Changelog Fixes
+ Fixed Hide Armor in 1.21. - Skw972
    

