### PR TITLE
Fix: Signal Enhancer in Foraging Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
@@ -144,10 +144,11 @@ object ForagingTrackerLegacy {
      * REGEX-TEST: §aTender Wood §8x0-5
      * REGEX-TEST: §aTender Wood §8x0-9
      * REGEX-TEST: §aVinesap §8x0-3
+     * REGEX-TEST: §6Signal Enhancer §8(§a0.4%§8)
      */
     val hoverRewardPattern by patternGroup.pattern(
         "hover-reward",
-        "(?:§.)*(?<item>.*) (?:§.)*§8x(?<amount>[\\d,-]+)"
+        "(?:§.)*(?<item>.*) (?:§.)*§8x?(?:(?<amount>[\\d,-]+)|\\((?:§.)*(?<percentage>[\\d.]+)%(?:§.)*\\))"
     )
 
     /**

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
@@ -284,7 +284,8 @@ object ForagingTracker {
         ChatUtils.debug("found loot lines:\n${lootLines.joinToString("\n").replace("§", "&")}")
         lootLines.forEach { line ->
             val (item, amountString) = ForagingTrackerLegacy.hoverRewardPattern.matchMatcher(line) {
-                group("item") to group("amount")
+                val amountString = if (groupOrNull("percentage") != null) "1" else group("amount")
+                group("item") to amountString
             } ?: return@forEach
             ChatUtils.debug("found hover loot: $item x$amountString")
             if (amountString.contains("-")) {


### PR DESCRIPTION
## What
putting a percentage in the lore is pretty bad, even for hypixel

## Changelog Fixes
+ Fixed Signal Enhancer not tracking in Foraging Tracker. - Daveed
    * Blame Hypixel for including a percentage in Lore.
