### PR TITLE
Fix: Foraging tracker not hiding when the config is off

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
@@ -105,7 +105,7 @@ object ForagingTracker {
         tracker.addPriceFromButton(this)
     }
 
-    private fun isEnabled() = IslandTypeTags.FORAGING_CUSTOM_TREES.inAny() && heldItemEnabled()
+    private fun isEnabled() = config.enabled && IslandTypeTags.FORAGING_CUSTOM_TREES.inAny() && heldItemEnabled()
     private fun heldItemEnabled() = !config.onlyHoldingAxe || isHoldingAxe()
     private fun isHoldingAxe() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.AXE
 


### PR DESCRIPTION
## What
Foraging tracker not hiding when the config is off

## Changelog Fixes
+ Fixed Foraging tracker not hiding when the config is off. - nopo
