### PR TITLE
Fix: Packet Received Event not being able to be cancelled

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinClientConnection.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinClientConnection.java
@@ -14,9 +14,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ClientConnection.class)
 public class MixinClientConnection {
 
-    @Inject(method = "handlePacket", at = @At(value = "HEAD"))
+    @Inject(method = "handlePacket", at = @At(value = "HEAD"), cancellable = true)
     private static void handlePacket$Inject$HEAD(Packet<?> packet, PacketListener listener, CallbackInfo ci) {
-        new PacketReceivedEvent(packet).post();
+        if (new PacketReceivedEvent(packet).post()) {
+            ci.cancel();
+        }
     }
 
     @Inject(method = "send(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;Z)V", at = @At(value = "HEAD"), cancellable = true)


### PR DESCRIPTION
## What
We werent cancelling packets, this fixes explosion hider and im sure a few other things that i dont exactly know 

## Changelog Fixes
+ Fixed Explosion Hider. - nopo