### PR TITLE
Fix: Cleanup with item stack nullables

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/CropAccessoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/CropAccessoryData.kt
@@ -37,7 +37,7 @@ object CropAccessoryData {
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!accessoryBagNamePattern.matches(event.inventoryName)) return
 
-        val items = event.inventoryItems.mapNotNull { it.value }
+        val items = event.inventoryItems.values
         val bestInPage = bestCropAccessory(items)
         if (bestInPage > accessoryInBag) {
             accessoryInBag = bestInPage
@@ -56,7 +56,7 @@ object CropAccessoryData {
         }
     }
 
-    private fun bestCropAccessory(items: List<ItemStack>) =
+    private fun bestCropAccessory(items: Collection<ItemStack>) =
         items.mapNotNull { item -> CropAccessory.getByName(item.getInternalName()) }
             .maxOrNull() ?: CropAccessory.NONE
 

--- a/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
@@ -19,6 +19,7 @@ open class InventoryOpenEvent(private val inventory: OtherInventoryData.Inventor
         items.entries.removeIf { !it.value.isNotEmpty() }
         return items
     }
+    // TODO might remove: the value is never null
     val inventoryItemsWithNull: Map<Int, ItemStack?> by lazy {
         (0 until inventorySize).associateWith { inventoryItems[it].orNull() }
     }

--- a/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
@@ -19,9 +19,8 @@ open class InventoryOpenEvent(private val inventory: OtherInventoryData.Inventor
         items.entries.removeIf { !it.value.isNotEmpty() }
         return items
     }
-    // TODO might remove: the value is never null
     val inventoryItemsWithNull: Map<Int, ItemStack?> by lazy {
-        (0 until inventorySize).associateWith { inventoryItems[it].orNull() }
+        (0 until inventorySize).associateWith { inventoryItems[it] }
     }
     val inventoryItemsPrimitive: Map<Int, PrimitiveItemStack> by lazy {
         val map = mutableMapOf<Int, PrimitiveItemStack>()

--- a/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.toPrimitiveStackOrNull
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
-import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import net.minecraft.item.ItemStack
 
 open class InventoryOpenEvent(private val inventory: OtherInventoryData.Inventory) : SkyHanniEvent() {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
@@ -421,8 +421,7 @@ object BestiaryData {
         return true
     }
 
-    private fun isBestiaryGui(stack: ItemStack?, name: String): Boolean {
-        if (!stack.isNotEmpty()) return false
+    private fun isBestiaryGui(stack: ItemStack, name: String): Boolean {
         val bestiaryGuiTitleMatcher = titlePattern.matcher(name)
         if (bestiaryGuiTitleMatcher.matches()) {
             if ("Bestiary" != bestiaryGuiTitleMatcher.group("title")) {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
@@ -28,7 +28,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.addRenderableButton
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -103,7 +103,6 @@ object CroesusChestTracker {
                 return
             }
 
-            // TODO current impl of inventoryItemsWithNull hides all null fields already - this might cause bugs
             // With null, since if an item is missing the chest will be set null
             checkChests(event.inventoryItemsWithNull)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -103,6 +103,7 @@ object CroesusChestTracker {
                 return
             }
 
+            // TODO current impl of inventoryItemsWithNull hides all null fields already - this might cause bugs
             // With null, since if an item is missing the chest will be set null
             checkChests(event.inventoryItemsWithNull)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/EquipmentApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/EquipmentApi.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedGlassPane
-import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.item.ItemStack
 import kotlin.time.Duration.Companion.seconds

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/EquipmentApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/EquipmentApi.kt
@@ -107,7 +107,7 @@ object EquipmentApi {
     }
 
     private fun handleInventoryItem(slot: EquipmentSlot, itemStack: ItemStack?) {
-        val item = if (itemStack.isNotEmpty() && !itemStack.isStainedGlassPane()) itemStack else null
+        val item = if (itemStack != null && !itemStack.isStainedGlassPane()) itemStack else null
         setEquipment(slot, item)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -166,7 +166,7 @@ object HideNotClickableItems {
         val slot = event.slot ?: return
 
         if (slot.slotNumber == slot.slotIndex) return
-        val stack = slot.stack?.orNull() ?: return
+        val stack = slot.stack.orNull() ?: return
 
         if (hide(chestName, stack)) {
             event.cancel()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -45,7 +45,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRiftTransferable
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
-import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
+import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
@@ -120,9 +120,7 @@ object HideNotClickableItems {
             if (hide(chestName, stack)) {
                 slot.highlight(LorenzColor.DARK_GRAY.addOpacity(config.opacity))
             } else if (showGreenLine && config.itemsGreenLine) {
-                if (stack.isNotEmpty()) {
-                    slot.drawBorder(LorenzColor.GREEN.addOpacity(200))
-                }
+                slot.drawBorder(LorenzColor.GREEN.addOpacity(200))
             }
         }
     }
@@ -168,9 +166,7 @@ object HideNotClickableItems {
         val slot = event.slot ?: return
 
         if (slot.slotNumber == slot.slotIndex) return
-        if (slot.stack == null) return
-
-        val stack = slot.stack
+        val stack = slot.stack?.orNull() ?: return
 
         if (hide(chestName, stack)) {
             event.cancel()

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/BlockNotSpawnable.kt
@@ -31,7 +31,7 @@ object BlockNotSpawnable {
         val slot = event.slot ?: return
         if (InventoryUtils.openInventoryName() != "Slayer") return
 
-        val stack = slot.stack?.orNull() ?: return
+        val stack = slot.stack.orNull() ?: return
         if (notSpawnablePattern.anyMatches(stack.getLore())) {
             event.cancel()
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.utils.compat.InventoryCompat
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.convertEmptyToNull
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.filterNotNullOrEmpty
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
+import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.normalizeAsArray
 import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
@@ -151,7 +152,7 @@ object InventoryUtils {
     fun ContainerChest.getAllItems(): Map<Slot, ItemStack> = buildMap {
         for (slot in inventorySlots) {
             if (slot == null) continue
-            val stack = slot.stack ?: continue
+            val stack = slot.stack?.orNull() ?: continue
             this[slot] = stack
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -152,7 +152,7 @@ object InventoryUtils {
     fun ContainerChest.getAllItems(): Map<Slot, ItemStack> = buildMap {
         for (slot in inventorySlots) {
             if (slot == null) continue
-            val stack = slot.stack?.orNull() ?: continue
+            val stack = slot.stack.orNull() ?: continue
             this[slot] = stack
         }
     }


### PR DESCRIPTION
## What
`slot.item` and many other instances of item stacks in code are currently in 1.8 nullable or not nullable, and in 1.21 either non-nullable and real items or non-nullable but empty. To differentiate between those states, we already have `ItemStack?.orNull()` and `ItemStack?.isNotNull()`. Using those two functions in feature classes is not ideal. This PR tries to avoid some of those design problems by implementing the logic deeper in the utils classes if possible, and removes redundant code in the process. Also fixed a bug.

## Changelog Fixes
+ Fixed empty inventory slots graying and unclickable in Sacks menu when Hide Non-Clickable Items enabled. - hannibal2

## Changelog Technical Details
+ Cleaned up ItemStack nullability. - hannibal2