### PR TITLE
Fix: Support Surrogate pairs in 1.21 Visual Words

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/compat/OrdereredTextUtils.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/compat/OrdereredTextUtils.kt
@@ -15,7 +15,6 @@ object OrderedTextUtils {
 
     @JvmStatic
     fun orderedTextToLegacyString(orderedText: OrderedText?): String {
-
         orderedText ?: return ""
 
         return textToLegacyCache.getOrPut(orderedText) {
@@ -26,7 +25,7 @@ object OrderedTextUtils {
                     builder.append(requiredStyleChangeString(lastStyle, style, true))
                     lastStyle = style
                 }
-                builder.append(codePoint.toChar())
+                builder.appendCodePoint(codePoint)
                 true
             }
 
@@ -91,7 +90,7 @@ object OrderedTextUtils {
                         if (formatting != null) {
                             lastStyle = lastStyle.withExclusiveFormatting(formatting)
                         } else if (nextChar == 'z') {
-                            lastStyle = lastStyle.withColor(CHROMA_COLOR)
+                            lastStyle = Style.EMPTY.withColor(CHROMA_COLOR)
                         }
 
                         index ++
@@ -112,7 +111,6 @@ object OrderedTextUtils {
 
     @JvmStatic
     fun legacyTextToOrderedText(legacyString: String?): OrderedText {
-
         return OrderedText { visitor ->
 
             legacyString ?: return@OrderedText true
@@ -155,6 +153,16 @@ object OrderedTextUtils {
                         }
                     }
 
+                } else if (char.isHighSurrogate() && index + 1 < legacyString.length) {
+                    val nextChar = legacyString[index + 1]
+
+                    if (nextChar.isLowSurrogate()) {
+                        visitor.accept(0, lastStyle, Character.toCodePoint(char, nextChar))
+
+                        index ++
+                    } else {
+                        visitor.accept(0, lastStyle, char.code)
+                    }
                 } else {
                     visitor.accept(0, lastStyle, char.code)
                 }


### PR DESCRIPTION
Emojis use two characters to draw correctly, and minecraft turns those two characters into one integer code point in the ordered text provider. The previous iteration did not take this into account, reducing these integers that encode 2 characters into one. This causes issues with mods that want to use emojis in their uis. 

Without this change (SkyOcean):
![image](https://github.com/user-attachments/assets/3e9d63db-dffc-4dac-bd2c-4b7f0ac9c710)

With this change (SkyOcean):
![image](https://github.com/user-attachments/assets/2198a5ed-6316-4891-9d42-4d17bb43d66c)


## Changelog Fixes
+ Fixed Visual Words removing emojis. - bloxigus

