### PR TITLE
Improvement: Foraging Tracker now stays for a few seconds after swapping off an axe

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingTrackerConfig.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.OnlyModern
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
@@ -32,6 +33,15 @@ class ForagingTrackerConfig {
     @ConfigEditorBoolean
     @OnlyModern
     var onlyHoldingAxe: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Disappearing Delay",
+        desc = "The delay in seconds before the tracker disappears after you stop holding an axe."
+    )
+    @ConfigEditorSlider(minValue = 0f, maxValue = 60f, minStep = 1f)
+    @OnlyModern
+    var disappearingDelay: Int = 15
 
     @Expose
     @ConfigOption(name = "Show Whole Trees", desc = "Estimate how many full trees you have chopped down, using percentage summing.")

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
+import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
 import at.hannibal2.skyhanni.events.SackChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -20,6 +21,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDoubleOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.formatIntOrNull
@@ -359,15 +361,8 @@ object ForagingTracker {
     }
 
     @HandleEvent
-    fun onPacketSent(event: PacketSentEvent) {
-        val packet = event.packet
-        if (packet !is UpdateSelectedSlotC2SPacket) return
-        handleSlotChange(packet.selectedSlot)
-    }
-
-    private fun handleSlotChange(newSlot: Int) {
-        val isAxe = InventoryUtils.getItemsInOwnInventoryWithNull()?.get(newSlot)?.getItemCategoryOrNull() == ItemCategory.AXE
-        if (isAxe) {
+    fun onItemChange(event: ItemInHandChangeEvent) {
+        if (event.newItem.getItemStack().getItemCategoryOrNull() == ItemCategory.AXE) {
             if (!hasHeldAxe) {
                 hasHeldAxe = true
             }
@@ -378,5 +373,4 @@ object ForagingTracker {
             }
         }
     }
-
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
 import at.hannibal2.skyhanni.events.SackChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.minecraft.packet.PacketSentEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -37,6 +38,7 @@ import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.StringRenderable
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniBucketedItemTracker
+import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
 import net.minecraft.text.Text
 import kotlin.time.Duration.Companion.seconds
 
@@ -56,8 +58,12 @@ object ForagingTracker {
         tracker.initRenderer({ config.position }) { isInIsland() && heldItemEnabled() && config.enabled }
     }
 
-    private fun heldItemEnabled() = !config.onlyHoldingAxe || isHoldingAxe()
-    private fun isHoldingAxe() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.AXE
+    private fun heldItemEnabled() = !config.onlyHoldingAxe ||
+        (isHoldingAxe() || lastAxeHeldTime.passedSince() < config.disappearingDelay.seconds)
+    private fun isHoldingAxe() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.AXE || hasHeldAxe
+
+    private var lastAxeHeldTime: SimpleTimeMark = SimpleTimeMark.farPast()
+    private var hasHeldAxe: Boolean = false
 
     private fun drawDisplay(bucketData: ForagingTrackerLegacy.BucketData): List<Searchable> = buildList {
         addSearchString("§a§lForaging Tracker")
@@ -349,6 +355,27 @@ object ForagingTracker {
             description = "Resets the Foraging Tracker."
             category = CommandCategory.USERS_RESET
             simpleCallback { tracker.resetCommand() }
+        }
+    }
+
+    @HandleEvent
+    fun onPacketSent(event: PacketSentEvent) {
+        val packet = event.packet
+        if (packet !is UpdateSelectedSlotC2SPacket) return
+        handleSlotChange(packet.selectedSlot)
+    }
+
+    private fun handleSlotChange(newSlot: Int) {
+        val isAxe = InventoryUtils.getItemsInOwnInventoryWithNull()?.get(newSlot)?.getItemCategoryOrNull() == ItemCategory.AXE
+        if (isAxe) {
+            if (!hasHeldAxe) {
+                hasHeldAxe = true
+            }
+        } else {
+            if (hasHeldAxe) {
+                hasHeldAxe = false
+                lastAxeHeldTime = SimpleTimeMark.now()
+            }
         }
     }
 

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
@@ -40,7 +40,6 @@ import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.StringRenderable
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniBucketedItemTracker
-import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
 import net.minecraft.text.Text
 import kotlin.time.Duration.Companion.seconds
 
@@ -364,15 +363,13 @@ object ForagingTracker {
 
     @HandleEvent
     fun onItemChange(event: ItemInHandChangeEvent) {
-        if (event.newItem.getItemStack().getItemCategoryOrNull() == ItemCategory.AXE) {
-            if (!hasHeldAxe) {
-                hasHeldAxe = true
-            }
-        } else {
-            if (hasHeldAxe) {
-                hasHeldAxe = false
+        if (!isInIsland()) return
+        val isAxe = event.newItem.getItemStack().getItemCategoryOrNull() == ItemCategory.AXE
+        if (isAxe != hasHeldAxe) {
+            if (!isAxe) {
                 lastAxeHeldTime = SimpleTimeMark.now()
             }
+            hasHeldAxe = isAxe
         }
     }
 }


### PR DESCRIPTION
## What
Makes the Foraging Tracker stay on screen for a few seconds after swapping off an axe.

## Changelog Improvements
+ Improved Foraging Tracker to remain on screen for configurable seconds after swapping off an axe. - Helium9

