### PR TITLE
Fix: SkillApi not working when you have more than 1000% xp

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -51,7 +51,7 @@ object SkillApi {
      */
     private val skillPercentPattern by patternGroup.pattern(
         "skill.percent",
-        "\\+(?<gained>[\\d.,]+) (?<skillName>.+) \\((?<progress>[\\d.]+)%\\)",
+        "\\+(?<gained>[\\d.,]+) (?<skillName>.+) \\((?<progress>[\\d.,]+)%\\)",
     )
 
     /**


### PR DESCRIPTION
## What
Fixes 1000% overflow when you arent max in that skill

## Changelog Fixes
+ Fixed SkillApi not working with >1000% overflow. - nopo
