### PR TITLE
Fix: Not posting the glow event on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -1,10 +1,12 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIfKey
+import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
 import java.awt.Color
 
@@ -17,6 +19,11 @@ object RenderLivingEntityHelper {
     private val entityNoHurtTimeCondition = mutableMapOf<EntityLivingBase, () -> Boolean>()
     var areMobsHighlighted = false
     var renderingRealGlow = false
+    var currentGlowEvent: RenderEntityOutlineEvent? = null
+
+    fun isEntityInGlowEvent(entity: Entity): Int {
+        return currentGlowEvent?.entitiesToOutline?.get(entity) ?: 0
+    }
 
     @HandleEvent
     fun onWorldChange() {
@@ -41,6 +48,7 @@ object RenderLivingEntityHelper {
                 return
             }
         }
+        if (currentGlowEvent?.entitiesToOutline?.isNotEmpty() == true) areMobsHighlighted = true
     }
 
     fun <T : EntityLivingBase> removeEntityColor(entity: T) {


### PR DESCRIPTION
## What
The glow event is used for party highlight and sea creature highlight
we only post the non xray version because the xray one was only used to backport features

## Changelog Fixes
+ Fixed Sea Creature Highlight. - nopo
+ Fixed Party Highlight. - nopo

