### PR TITLE
Fix: Melons showing as melon bloc

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/ComponentUtils.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/ComponentUtils.kt
@@ -192,6 +192,7 @@ object ComponentUtils {
             strippedId == "wool" -> getColor(damage) + "_wool"
             strippedId == "trapdoor" -> "oak_trapdoor"
             strippedId == "speckled_melon" -> "glistering_melon_slice"
+            strippedId == "melon" -> "melon_slice"
             strippedId == "melon_block" -> "melon"
             strippedId == "fish" -> when (damage) {
                 0 -> "cod"

--- a/versions/mapping-1.16.5-forge-1.8.9.txt
+++ b/versions/mapping-1.16.5-forge-1.8.9.txt
@@ -577,7 +577,7 @@ net.minecraft.world.item.Items LEATHER_HELMET leather_helmet
 net.minecraft.world.item.Items LEATHER_LEGGINGS leather_leggings
 net.minecraft.world.item.Items MAGMA_CREAM magma_cream
 net.minecraft.world.item.Items MAP map
-net.minecraft.world.item.Items MELON melon
+net.minecraft.world.item.Items MELON_SLICE melon
 net.minecraft.world.item.Items MELON_SEEDS melon_seeds
 net.minecraft.world.item.Items MILK_BUCKET milk_bucket
 net.minecraft.world.item.Items MINECART minecart


### PR DESCRIPTION
## What
melon became melon slice and melon block became melon

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/055c1fde-d505-4cc2-8a0e-06cf69be647b)

</details>

## Changelog Fixes
+ Fixed Melons showing as melon blocks. - nopo

