### PR TITLE
Fix: duplicate enum entries in CS

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 89
+    const val CONFIG_VERSION = 90
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardConfigFix.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardConfigFix.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
+import scala.xml.parsing.`MarkupParser$class`.element
 
 @SkyHanniModule
 object CustomScoreboardConfigFix {
@@ -98,6 +99,10 @@ object CustomScoreboardConfigFix {
         }
 
         event.addEvent(89, ScoreboardConfigEventElement.GALATEA)
+
+        event.transform(90, EVENT_ENTRIES_KEY) { element ->
+            JsonArray().apply { element.asJsonArray.toSet().forEach(::add) }
+        }
     }
 
     private fun ConfigUpdaterMigrator.ConfigFixEvent.addEvent(version: Int, vararg keys: ScoreboardConfigEventElement) {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardConfigFix.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardConfigFix.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
-import scala.xml.parsing.`MarkupParser$class`.element
 
 @SkyHanniModule
 object CustomScoreboardConfigFix {


### PR DESCRIPTION
## What
for some reason duplicate entries work just fine ??
will show twice for the people who manually enabled the galatea lines (if config ported) or used a new config

## Changelog Fixes
+ Fixed Custom Scoreboard showing Galatea lines twice. -  j10a1n15

