### PR TITLE
Fix: Harp gui scale applying when not in harp

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -47,10 +47,11 @@ object HarpFeatures {
 
     /**
      * REGEX-TEST: Harp - Amazing Grace
+     * REGEX-FAIL: Harpy ➜ Instant Buy
      */
     private val inventoryTitlePattern by patternGroup.pattern(
         "inventory",
-        "Harp.*",
+        "Harp -.*",
     )
     private val menuTitlePattern by patternGroup.pattern(
         "menu",


### PR DESCRIPTION
## What
Fix harp bug.

## Changelog Fixes
+ Fixed Harp GUI scale affecting other inventories (e.g., Harpy on Bazaar). - CalMWolfs
