### PR TITLE
Fix: Hide vanilla enchants applying outside of SkyBlock

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
@@ -36,7 +36,7 @@ public class MixinItemStack implements ItemStackCachedData {
     //#else
     //$$ @Inject(method = "appendComponentTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/tooltip/TooltipAppender;appendTooltip(Lnet/minecraft/item/Item$TooltipContext;Ljava/util/function/Consumer;Lnet/minecraft/item/tooltip/TooltipType;Lnet/minecraft/component/ComponentsAccess;)V"), cancellable = true)
     //$$ public <T extends net.minecraft.item.tooltip.TooltipAppender> void blockVanillaEnchants(net.minecraft.component.ComponentType<T> componentType, net.minecraft.item.Item.TooltipContext context, net.minecraft.component.type.TooltipDisplayComponent displayComponent, java.util.function.Consumer<net.minecraft.text.Text> textConsumer, net.minecraft.item.tooltip.TooltipType type, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
-    //$$     if (at.hannibal2.skyhanni.SkyHanniMod.feature.getInventory().enchantParsing.hideVanillaEnchants.get() && componentType == net.minecraft.component.DataComponentTypes.ENCHANTMENTS) {
+    //$$     if (at.hannibal2.skyhanni.utils.SkyBlockUtils.INSTANCE.getInSkyBlock() && at.hannibal2.skyhanni.SkyHanniMod.feature.getInventory().enchantParsing.hideVanillaEnchants.get() && componentType == net.minecraft.component.DataComponentTypes.ENCHANTMENTS) {
     //$$         ci.cancel();
     //$$     }
     //$$ }


### PR DESCRIPTION
## What
Fixed hide vanilla enchants applying outside of SkyBlock on 1.21

## Changelog Fixes
+ Fixed hide vanilla enchants applying outside SkyBlock on 1.21. - CalMWolfs

