### PR TITLE
Fix: Rare crash with highlighted entities

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -92,9 +92,9 @@ object RenderLivingEntityHelper {
     fun <T : EntityLivingBase> internalSetColorMultiplier(entity: T, default: Int): Int {
         if (!SkyHanniDebugsAndTests.globalRender) return default
         if (entityColorMap.containsKey(entity)) {
-            val condition = entityColorCondition[entity]!!
+            val condition = entityColorCondition[entity] ?: return default
             if (condition.invoke()) {
-                return entityColorMap[entity]!!
+                return entityColorMap[entity] ?: return default
             }
         }
         return default

--- a/versions/1.8.9/detekt/baseline.xml
+++ b/versions/1.8.9/detekt/baseline.xml
@@ -308,8 +308,6 @@
     <ID>UnsafeCallOnNullableType:RenderEntityOutlineEvent.kt$RenderEntityOutlineEvent$entitiesToChooseFrom!!</ID>
     <ID>UnsafeCallOnNullableType:RenderEntityOutlineEvent.kt$RenderEntityOutlineEvent$entitiesToOutline!!</ID>
     <ID>UnsafeCallOnNullableType:RenderGlobalHook.kt$RenderGlobalHook$camera!!</ID>
-    <ID>UnsafeCallOnNullableType:RenderLivingEntityHelper.kt$RenderLivingEntityHelper$entityColorCondition[entity]!!</ID>
-    <ID>UnsafeCallOnNullableType:RenderLivingEntityHelper.kt$RenderLivingEntityHelper$entityColorMap[entity]!!</ID>
     <ID>UnsafeCallOnNullableType:RepoUtils.kt$RepoUtils$file!!</ID>
     <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$match.groups[1]!!</ID>
     <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$match.groups[2]!!</ID>


### PR DESCRIPTION
## What
Dead entities are removed on tick so there is a very small chance it could of crashed between those 3 lines

## Changelog Fixes
+ Fixed rare crash with highlighted entities. - nopo
