### PR TITLE
Backend: Allow changing neu repo location

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
@@ -24,7 +24,7 @@ class DevConfig {
     @Expose
     @ConfigOption(name = "Neu Repository", desc = "")
     @Accordion
-    var neuRepo: NeuRepositoryConfig = NeuRepositoryConfig()
+    val neuRepo: NeuRepositoryConfig = NeuRepositoryConfig()
 
     @Expose
     @ConfigOption(name = "Debug", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
@@ -15,10 +15,16 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import org.lwjgl.input.Keyboard
 
 class DevConfig {
+
     @Expose
     @ConfigOption(name = "Repository", desc = "")
     @Accordion
     val repo: RepositoryConfig = RepositoryConfig()
+
+    @Expose
+    @ConfigOption(name = "Neu Repository", desc = "")
+    @Accordion
+    var neuRepo: NeuRepositoryConfig = NeuRepositoryConfig()
 
     @Expose
     @ConfigOption(name = "Debug", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
@@ -1,0 +1,52 @@
+package at.hannibal2.skyhanni.config.features.dev
+
+import at.hannibal2.skyhanni.api.enoughupdates.EnoughUpdatesRepo
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class NeuRepositoryConfig {
+
+    @Expose
+    @ConfigOption(
+        name = "NEU Repo Auto Update",
+        desc = "Update the NEU repository on every startup.\n" +
+            "§cOnly disable this if you know what you are doing!\n " +
+            "§eThis only works if NEU is not installed, if it is use their settings.",
+    )
+    @ConfigEditorBoolean
+    var repoAutoUpdate: Boolean = true
+
+    @ConfigOption(name = "Update NEU Repo Now", desc = "Update your NEU repository to the latest version")
+    @ConfigEditorButton(buttonText = "Update")
+    var updateRepo: Runnable = Runnable(EnoughUpdatesRepo::downloadRepo)
+
+    @Expose
+    @ConfigOption(name = "NEU Repository Location", desc = "")
+    @Accordion
+    var location: RepositoryLocation = RepositoryLocation()
+
+    class RepositoryLocation {
+        @ConfigOption(name = "Reset Repository Location", desc = "Reset your NEU repository location to the default.")
+        @ConfigEditorButton(buttonText = "Reset")
+        var resetRepoLocation: Runnable = Runnable { EnoughUpdatesRepo.resetRepoLocation() }
+
+        @Expose
+        @ConfigOption(name = "Repository User", desc = "The Repository Branch, default: NotEnoughUpdates")
+        @ConfigEditorText
+        var user: String = "NotEnoughUpdates"
+
+        @Expose
+        @ConfigOption(name = "Repository Name", desc = "The Repository Name, default: NotEnoughUpdates-REPO")
+        @ConfigEditorText
+        var name: String = "NotEnoughUpdates-REPO"
+
+        @Expose
+        @ConfigOption(name = "Repository Branch", desc = "The Repository Branch, default: master")
+        @ConfigEditorText
+        var branch: String = "master"
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
@@ -22,17 +22,17 @@ class NeuRepositoryConfig {
 
     @ConfigOption(name = "Update NEU Repo Now", desc = "Update your NEU repository to the latest version")
     @ConfigEditorButton(buttonText = "Update")
-    var updateRepo: Runnable = Runnable(EnoughUpdatesRepo::downloadRepo)
+    val updateRepo: Runnable = Runnable(EnoughUpdatesRepo::downloadRepo)
 
     @Expose
     @ConfigOption(name = "NEU Repository Location", desc = "")
     @Accordion
-    var location: RepositoryLocation = RepositoryLocation()
+    val location: RepositoryLocation = RepositoryLocation()
 
     class RepositoryLocation {
         @ConfigOption(name = "Reset Repository Location", desc = "Reset your NEU repository location to the default.")
         @ConfigEditorButton(buttonText = "Reset")
-        var resetRepoLocation: Runnable = Runnable { EnoughUpdatesRepo.resetRepoLocation() }
+        val resetRepoLocation: Runnable = Runnable { EnoughUpdatesRepo.resetRepoLocation() }
 
         @Expose
         @ConfigOption(name = "Repository User", desc = "The Repository Branch, default: NotEnoughUpdates")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.kt
@@ -14,7 +14,7 @@ class RepositoryConfig {
     @ConfigOption(
         name = "Repo Auto Update",
         desc = "Update the repository on every startup.\n" +
-            "§cOnly disable this if you know what you are doing!"
+            "§cOnly disable this if you know what you are doing!",
     )
     @ConfigEditorBoolean
     var repoAutoUpdate: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.test
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.enoughupdates.EnoughUpdatesRepo
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
@@ -186,6 +187,15 @@ object DebugCommand {
                 for (constant in RepoManager.unsuccessfulConstants) {
                     add("  - $constant")
                 }
+            }
+
+            val neuRepoConfig = SkyHanniMod.feature.dev.neuRepo
+            add(" neuRepoAutoUpdate: ${neuRepoConfig.repoAutoUpdate}")
+
+            if (!EnoughUpdatesRepo.hasDefaultRepositoryLocation()) {
+                add(" neu repo location: '${EnoughUpdatesRepo.getRepoLocation()}'")
+            } else {
+                add(" neu repo location: default")
             }
 
             add(" loaded neu items: ${NeuItems.allNeuRepoItems().size}")


### PR DESCRIPTION
## What
I've made a few things on 1.21 that would've benefitted from being able to change the repo location so I just copied the existing logic over to the neu repo. On 1.8 you would still use the neu settings unless you for some reason dont have that installed there.

## Changelog Technical Details
+ Allowed changing NEU item repo download location. - CalMWolfs
    * Works only when NEU isn't installed.
