### PR TITLE
Backend: Skip Detekt on GH Build Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
             -   uses: ./.github/actions/setup-normal-workspace
             -   name: Build with Gradle
-                run: ./gradlew assemble -x test --stacktrace
+                run: ./gradlew assemble -x test --stacktrace -PskipDetekt=true
             -   uses: actions/upload-artifact@v4
                 name: Upload development build
                 with:


### PR DESCRIPTION
## What
We have a separate workflow to run `detektMain` anyways, so there's no reason to have the build run it as well.

## Changelog Technical Details
+ Disabled Detekt on legacy build GitHub workflow. - Daveed

