### PR TITLE
Fix: Incompatibilities with some other mods rendering

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
@@ -1,10 +1,8 @@
 package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.api.minecraftevents.RenderLayer
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.render.gui.DrawBackgroundEvent
-import at.hannibal2.skyhanni.events.render.gui.GameOverlayRenderPreEvent
 import at.hannibal2.skyhanni.features.misc.visualwords.VisualWordGui
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
@@ -18,15 +16,15 @@ import net.minecraft.client.renderer.GlStateManager
 @SkyHanniModule
 object RenderData {
 
-    @HandleEvent
-    fun onRenderOverlayPre(event: GameOverlayRenderPreEvent) {
-        if (event.type != RenderLayer.HOTBAR) return
+    @JvmStatic
+    fun postRenderOverlay(context: DrawContext) {
         if (!SkyHanniDebugsAndTests.globalRender) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
-
+        DrawContextUtils.setContext(context)
         DrawContextUtils.translated(z = -3) {
             renderOverlay(DrawContextUtils.drawContext)
         }
+        DrawContextUtils.clearContext()
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiIngameForge.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiIngameForge.java
@@ -1,0 +1,19 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.data.RenderData;
+import at.hannibal2.skyhanni.utils.compat.DrawContext;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraftforge.client.GuiIngameForge;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiIngameForge.class)
+public class MixinGuiIngameForge {
+
+    @Inject(method = "renderTooltip", at = @At(value = "HEAD"))
+    private void onRenderTooltip(ScaledResolution sr, float partialTicks, CallbackInfo ci) {
+        RenderData.postRenderOverlay(new DrawContext());
+    }
+}

--- a/versions/1.21.5/buildpaths-excluded.txt
+++ b/versions/1.21.5/buildpaths-excluded.txt
@@ -32,6 +32,7 @@ at.hannibal2.skyhanni.mixins.transformers.MixinEntityFireball.java
 at.hannibal2.skyhanni.mixins.transformers.MixinEntityHorse.java
 at.hannibal2.skyhanni.mixins.transformers.MixinFontRenderer.java
 at.hannibal2.skyhanni.mixins.transformers.MixinGuiChat.java
+at.hannibal2.skyhanni.mixins.transformers.MixinGuiIngameForge.java
 at.hannibal2.skyhanni.mixins.transformers.MixinGuiPlayerTabOverlay.java
 at.hannibal2.skyhanni.mixins.transformers.MixinNetHandlerPlayClient.java
 at.hannibal2.skyhanni.mixins.transformers.MixinNetworkManager.java

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -1,13 +1,19 @@
 package at.hannibal2.skyhanni.api.minecraftevents
 
+import at.hannibal2.skyhanni.data.RenderData
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.render.gui.GameOverlayRenderPostEvent
 import at.hannibal2.skyhanni.events.render.gui.GameOverlayRenderPreEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import net.fabricmc.fabric.api.client.rendering.v1.HudLayerRegistrationCallback
+import net.fabricmc.fabric.api.client.rendering.v1.IdentifiedLayer
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents
+import net.minecraft.client.MinecraftClient
 import net.minecraft.client.gui.DrawContext
+import net.minecraft.client.render.RenderTickCounter
 import net.minecraft.client.render.VertexConsumerProvider
 import net.minecraft.client.util.math.MatrixStack
+import net.minecraft.util.Identifier
 
 @SkyHanniModule
 object RenderEvents {
@@ -33,6 +39,14 @@ object RenderEvents {
 
         // InitializeGuiEvent
 
+        HudLayerRegistrationCallback.EVENT.register { context ->
+            context.attachLayerAfter(IdentifiedLayer.SLEEP, Identifier.of("skyhanni", "hotbar_layer"), RenderEvents::postGui)
+        }
+    }
+
+    private fun postGui(context: DrawContext, tick: RenderTickCounter) {
+        if (MinecraftClient.getInstance().options.hudHidden) return
+        RenderData.postRenderOverlay(context)
     }
 
     // GameOverlayRenderPreEvent


### PR DESCRIPTION
## What
Made rendering not be tied to forge/fabric's hotbar layer. On 1.8 we mixin just before the forge event is posted and on 1.21 we move the location of our rendering to be later. This solves conflicts with apec, skycubed and autohud.

## Changelog Fixes
+ Fixed SkyHanni GUIs rendering incorrectly when other mods moved the hotbar on 1.21. - CalMWolfs

## Changelog Technical Details
+ Removed direct use of hotbar layer for GUI rendering. - CalMWolfs
