### PR TITLE
Backend: Fix Newlines in Regex Tests

### DIFF
--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -21,7 +21,8 @@ class RepoPatternElement private constructor(
 
     val regex101Url: String by lazy {
         val encodedPattern = URLEncoder.encode(rawPattern, "UTF-8")
-        val encodedTests = regexTests.joinToString("\n") { URLEncoder.encode(it, "UTF-8") }
+        val urlEncodedNewLine = URLEncoder.encode("\n", "UTF-8")
+        val encodedTests = regexTests.joinToString(urlEncodedNewLine) { URLEncoder.encode(it, "UTF-8") }
         "https://regex101.com/?regex=$encodedPattern&testString=$encodedTests"
     }
 

--- a/detekt/src/main/kotlin/style/InSkyBlockEarlyReturn.kt
+++ b/detekt/src/main/kotlin/style/InSkyBlockEarlyReturn.kt
@@ -20,7 +20,7 @@ class InSkyBlockEarlyReturn(config: Config) : SkyHanniRule(config) {
         Debt.FIVE_MINS
     )
 
-    private fun KtExpression.containsInSkyBlockCheck(): Boolean = text.contains("LorenzUtils.inSkyBlock")
+    private fun KtExpression.containsInSkyBlockCheck(): Boolean = text.contains("SkyBlockUtils.inSkyBlock")
     private fun KtExpression.isEarlyReturn(): Boolean = this is KtIfExpression && then is KtReturnExpression
 
     override fun visitNamedFunction(function: KtNamedFunction) {


### PR DESCRIPTION
## What
It was url-encoding the regex tests, but not the newlines, so they were actually ending up on a new line in the detekt comment file (see images)

<details>
<summary>Images</summary>

![image](https://github.com/user-attachments/assets/abc4b582-438d-4b4d-a01b-d741fb5bd5dd)
</details>

## Changelog Technical Details
+ Fixed links given by Detekt when regex tests fail. - Daveed
+ Fixed checking for `LorenzUtils.inSkyBlock` in Detekt rule. - Daveed

