### PR TITLE
Improvement: Warp directly to Elizabeth in Account Upgrade Reminder

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
@@ -195,16 +195,9 @@ object UpgradeReminder {
             ChatUtils.clickToActionOrDisable(
                 "The §a$name §eupgrade has completed!",
                 config::accountUpgradeReminder,
-                actionName = "warp to Hub",
+                actionName = "warp to Elizabeth",
                 action = {
-                    HypixelCommands.warp("hub")
-                    EntityMovementData.onNextTeleport(IslandType.HUB) {
-                        IslandGraphs.pathFind(
-                            LorenzVec(-2.6, 73.0, -101.6),
-                            "§eCommunity Shop",
-                            condition = { config.accountUpgradeReminder },
-                        )
-                    }
+                    HypixelCommands.warp("elizabeth")
                 },
             )
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
@@ -3,9 +3,6 @@ package at.hannibal2.skyhanni.features.fame
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.EntityMovementData
-import at.hannibal2.skyhanni.data.IslandGraphs
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
@@ -16,7 +13,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher


### PR DESCRIPTION
## What
Improved the the prompt for Account Upgrade Reminder to use `/warp elizabeth` instead of `/warp hub`.

## Changelog Improvements
+ Changed Account Upgrade Reminder to warp directly to Elizabeth. - Luna