### PR TITLE
Fix + Backend + Feature: Genericize `RotatingPerk` (HotX)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
@@ -1,0 +1,32 @@
+package at.hannibal2.skyhanni.api
+
+import at.hannibal2.skyhanni.data.hotx.ChatRepoPatternEnum
+import at.hannibal2.skyhanni.data.hotx.ItemRepoPatternEnum
+import org.intellij.lang.annotations.Language
+
+object HotfApi {
+
+    var lottery: LotteryPerk? = null
+
+    enum class LotteryPerk(
+        @Language("RegExp") override val chatPatternRaw: String,
+        @Language("RegExp") override val itemPatternRaw: String,
+    ) : ChatRepoPatternEnum, ItemRepoPatternEnum {
+        SWEEP(
+            chatPatternRaw = "§r§fGain §r§a\\+5% §r§2∮ Sweep§r§f\\.",
+            itemPatternRaw = "Gain §a\\+5% §2∮ Sweep§7\\."
+        ),
+        MANGROVE_FORTUNE(
+            chatPatternRaw = "§r§fGain §r§a\\+50 §r§6☘ Mangrove Fortune§r§f\\.",
+            itemPatternRaw = "Gain §a\\+50 §6☘ Mangrove Fortune§7\\."
+        ),
+        FIG_FORTUNE(
+            chatPatternRaw = "§r§fGain §r§a\\+50 §r§6☘ Fig Fortune§r§f\\.",
+            itemPatternRaw = "Gain §a\\+50 §6☘ Fig Fortune§7\\."
+        ),
+        ;
+
+        override val basePath = "foraging.hotf.lottery"
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/api/HotmApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotmApi.kt
@@ -3,7 +3,9 @@ package at.hannibal2.skyhanni.api
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage
 import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.hotx.ChatRepoPatternEnum
 import at.hannibal2.skyhanni.data.hotx.HotmData
+import at.hannibal2.skyhanni.data.hotx.ItemRepoPatternEnum
 import at.hannibal2.skyhanni.events.mining.PowderEvent
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -12,9 +14,10 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getDrillUpgrades
-import at.hannibal2.skyhanni.utils.TimeLimitedCache
+import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.item.ItemStack
+import org.intellij.lang.annotations.Language
 import kotlin.time.Duration.Companion.seconds
 
 object HotmApi {
@@ -102,30 +105,31 @@ object HotmApi {
 
     var mineshaftMayhem: MayhemPerk? = null
 
-    enum class SkymallPerk(chat: String, itemString: String) {
+    enum class SkymallPerk(
+        @Language("RegExp") override val chatPatternRaw: String,
+        @Language("RegExp") override val itemPatternRaw: String,
+    ) : ChatRepoPatternEnum, ItemRepoPatternEnum {
         MINING_SPEED("Gain §r§6\\+100⸕ Mining Speed§r§f\\.", "Gain §6\\+100⸕ Mining Speed§7\\."),
         MINING_FORTUNE("Gain §r§6\\+50☘ Mining Fortune§r§f\\.", "Gain §6\\+50☘ Mining Fortune§7\\."),
         EXTRA_POWDER("Gain §r§a\\+15% §r§fmore Powder while mining\\.", "Gain §a\\+15% §7more Powder while mining\\."),
         ABILITY_COOLDOWN("§r§a-20%§r§f Pickaxe Ability cooldowns\\.", "§a-20%§7 Pickaxe Ability cooldowns\\."),
         GOBLIN_CHANCE("§r§a10x §r§fchance to find Golden and Diamond Goblins\\.", "§a10x §7chance to find Golden and"),
-        TITANIUM("Gain §r§a5x §r§9Titanium §r§fdrops", "Gain §a5x §9Titanium §7drops\\.")
+        TITANIUM("Gain §r§a5x §r§9Titanium §r§fdrops", "Gain §a5x §9Titanium §7drops\\."),
         ;
 
-        private val patternName = name.lowercase().replace("_", ".")
-
-        val chatPattern by RepoPattern.pattern("mining.hotm.skymall.chat.$patternName", chat)
-        val itemPattern by RepoPattern.pattern("mining.hotm.skymall.item.$patternName", itemString)
+        override val basePath = "mining.hotm.skymall"
     }
 
-    enum class MayhemPerk(chat: String) {
+    enum class MayhemPerk(
+        @Language("RegExp") override val chatPatternRaw: String,
+    ) : ChatRepoPatternEnum {
         SCRAP_CHANCE("Your §r§9Suspicious Scrap §r§7chance was buffed by your §r§aMineshaft Mayhem §r§7perk!"),
         MINING_FORTUNE("You received a §r§a§r§6☘ Mining Fortune §r§7buff from your §r§aMineshaft Mayhem §r§7perk!"),
         MINING_SPEED("You received a §r§a§r§6⸕ Mining Speed §r§7buff from your §r§aMineshaft Mayhem §r§7perk!"),
         COLD_RESISTANCE("You received a §r§a§r§b❄ Cold Resistance §r§7buff from your §r§aMineshaft Mayhem §r§7perk!"),
-        ABILITY_COOLDOWN("Your Pickaxe Ability cooldown was reduced §r§7from your §r§aMineshaft Mayhem §r§7perk!");
+        ABILITY_COOLDOWN("Your Pickaxe Ability cooldown was reduced §r§7from your §r§aMineshaft Mayhem §r§7perk!"),
+        ;
 
-        private val patternName = name.lowercase().replace("_", ".")
-
-        val chatPattern by RepoPattern.pattern("mining.hotm.mayhem.chat.$patternName", chat)
+        override val basePath = "mining.hotm.mayhem"
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -188,7 +188,7 @@ class ChatConfig {
     var hideSkyMall: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Hide Lottery Messages", desc = "Hide the Lottery messages from Hotf in the chat.")
+    @ConfigOption(name = "Hide Lottery Messages", desc = "Hide the Lottery messages outside of Foraging Islands.")
     @ConfigEditorBoolean
     @FeatureToggle
     var hideLottery: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -188,6 +188,12 @@ class ChatConfig {
     var hideSkyMall: Boolean = true
 
     @Expose
+    @ConfigOption(name = "Hide Lottery Messages", desc = "Hide the Lottery messages from Hotf in the chat.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var hideLottery: Boolean = true
+
+    @Expose
     @ConfigOption(
         name = "Shorten Coin Amounts",
         desc = "Replace coin amounts in chat messages with their shortened version.\n" +

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
@@ -106,6 +106,11 @@ object IslandTypeTags {
     )
 
     // Foraging
+    val FORAGING = IslandTypeTag(
+        "foraging",
+        IslandType.THE_PARK,
+        IslandType.GALATEA,
+    )
     val FORAGING_CUSTOM_TREES = IslandTypeTag(
         "foraging_custom_trees",
         IslandType.GALATEA,

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -462,8 +462,6 @@ enum class HotfData(
             }
         }
 
-        override fun inPerkArea(): Boolean = IslandTypeTags.FORAGING.inAny()
-
         @HandleEvent
         override fun onInventoryClose(event: InventoryCloseEvent) = super.onInventoryClose(event)
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -441,7 +441,7 @@ enum class HotfData(
         }
 
         override fun tryBlock(event: SkyHanniChatEvent) {
-            if (!chatConfig.hideSkyMall) return
+            if (!chatConfig.hideLottery) return
             event.blockedReason = "lottery"
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.data.hotx
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.HotfApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ProfileStorageData
@@ -436,7 +437,7 @@ enum class HotfData(
         }
 
         override fun extraChatHandling(event: SkyHanniChatEvent) {
-            // Hi I'm not empty
+            if (chatConfig.hideSkyMall) event.blockedReason = "LOTTERY"
         }
 
         override fun readFromHeartOrReset(line: String, isHeartItem: Boolean) {
@@ -489,6 +490,8 @@ enum class HotfData(
 
     }
 }
+
+private val chatConfig get() = SkyHanniMod.feature.chat
 
 private val patternGroup = RepoPattern.group("foraging.hotf")
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.data.hotx
 
 import at.hannibal2.skyhanni.api.HotfApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -446,14 +446,13 @@ enum class HotfData(
         }
 
         override fun readFromHeartOrReset(line: String, isHeartItem: Boolean) {
-            (if (isHeartItem) whisperHeartPattern else whisperResetPattern).matchMatcher(line) {
-                val whisper = group("whisper").formatLong()
-                if (isHeartItem) {
-                    whispersCurrent = whisper
-                    whispersTotal = whisper
-                } else {
-                    whispersTotal += whisper
-                }
+            val pattern = if (isHeartItem) whisperHeartPattern else whisperResetPattern
+            val whisper = pattern.matchMatcher(line) { group("whisper").formatLong() } ?: return
+            if (isHeartItem) {
+                whispersCurrent = whisper
+                whispersTotal = whisper
+            } else {
+                whispersTotal += whisper
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.data.hotx
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.HotfApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
@@ -441,7 +442,7 @@ enum class HotfData(
         }
 
         override fun tryBlock(event: SkyHanniChatEvent) {
-            if (!chatConfig.hideLottery) return
+            if (!chatConfig.hideLottery || IslandTypeTags.FORAGING.inAny()) return
             event.blockedReason = "lottery"
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -437,7 +437,7 @@ enum class HotfData(
         }
 
         override fun extraChatHandling(event: SkyHanniChatEvent) {
-            if (chatConfig.hideSkyMall) event.blockedReason = "LOTTERY"
+            if (chatConfig.hideSkyMall) event.blockedReason = "lottery"
         }
 
         override fun readFromHeartOrReset(line: String, isHeartItem: Boolean) {

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.data.hotx
 
+import at.hannibal2.skyhanni.api.HotfApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
@@ -8,9 +10,9 @@ import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.allLettersFirstUppercase
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.inventory.Slot
@@ -300,9 +302,10 @@ enum class HotfData(
     override fun getStorage(): HotxTree? = ProfileStorageData.profileSpecific?.foraging?.hotFTree
 
     @SkyHanniModule
-    companion object : HotxHandler<HotfData, HotfReward>(entries) {
+    companion object : HotxHandler<HotfData, HotfReward, HotfApi.LotteryPerk>(entries) {
         override val name: String = "HotF"
         override val core: HotfData = CENTER_OF_THE_FOREST
+        override val rotatingPerkClazz = HotfApi.LotteryPerk::class
         override var tokens: Int
             get() = ProfileStorageData.profileSpecific?.foraging?.tokens ?: 0
             set(value) {
@@ -326,6 +329,7 @@ enum class HotfData(
                 ProfileStorageData.profileSpecific?.foraging?.whispers?.total = value
             }
 
+        // <editor-fold desc="Patterns">
         /**
          * REGEX-TEST: §7§a§lSELECTED
          * REGEX-TEST: §a§lENABLED
@@ -398,7 +402,7 @@ enum class HotfData(
         /**
          * REGEX-TEST:  §7You have reset your §r§aHeart of the Forest§r§7! Your §r§aPerks §r§7and §r§aAbilities §r§7have been reset.
          */
-        private val resetChatPattern by patternGroup.pattern(
+        override val resetChatPattern by patternGroup.pattern(
             "reset.chat",
             "\\s*§7You have reset your §r§aHeart of the Forest§r§7! Your §r§aPerks §r§7and §r§aAbilities §r§7have been reset\\.",
         )
@@ -418,6 +422,7 @@ enum class HotfData(
             "whisper.reset",
             "\\s+§8- §.(?<whisper>[\\d,]*) Forest Whispers",
         )
+        // </editor-fold>
 
         override val readingLevelTransform: Matcher.() -> Int = {
             group("level").toInt()
@@ -428,6 +433,10 @@ enum class HotfData(
         }
 
         override fun Slot.extraHandling(entry: HotfData, lore: List<String>) {
+            // Hi I'm not empty
+        }
+
+        override fun extraChatHandling(event: SkyHanniChatEvent) {
             // Hi I'm not empty
         }
 
@@ -453,19 +462,23 @@ enum class HotfData(
             }
         }
 
+        override fun inPerkArea(): Boolean = IslandTypeTags.FORAGING.inAny()
+
         @HandleEvent
         override fun onInventoryClose(event: InventoryCloseEvent) = super.onInventoryClose(event)
 
         @HandleEvent(onlyOnSkyblock = true)
         override fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) = super.onInventoryFullyOpened(event)
 
-        @HandleEvent(onlyOnSkyblock = true)
-        fun onChat(event: SkyHanniChatEvent) {
-            if (resetChatPattern.matches(event.message)) {
-                resetTree()
-                return
-            }
+        override fun setRotatingPerk(newRotatingPerk: HotfApi.LotteryPerk?) {
+            HotfApi.lottery = newRotatingPerk
+            ChatUtils.debug("setting lottery to ${HotfApi.lottery}")
         }
+
+        @HandleEvent(onlyOnSkyblock = true)
+        override fun onChat(event: SkyHanniChatEvent) = super.onChat(event)
+
+        override val rotatingPerkEntry = LOTTERY
 
         @HandleEvent
         fun onDebug(event: DebugDataCollectEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -437,7 +437,12 @@ enum class HotfData(
         }
 
         override fun extraChatHandling(event: SkyHanniChatEvent) {
-            if (chatConfig.hideSkyMall) event.blockedReason = "lottery"
+            // Hi I'm not empty
+        }
+
+        override fun tryBlock(event: SkyHanniChatEvent) {
+            if (!chatConfig.hideSkyMall) return
+            event.blockedReason = "lottery"
         }
 
         override fun readFromHeartOrReset(line: String, isHeartItem: Boolean) {

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.api.HotmApi
 import at.hannibal2.skyhanni.api.HotmApi.MayhemPerk
 import at.hannibal2.skyhanni.api.HotmApi.SkymallPerk
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
 import at.hannibal2.skyhanni.data.model.TabWidget

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -637,8 +637,12 @@ enum class HotmData(
         @HandleEvent(onlyOnSkyblock = true)
         override fun onChat(event: SkyHanniChatEvent) = super.onChat(event)
 
+        override fun tryBlock(event: SkyHanniChatEvent) {
+            if (!chatConfig.hideSkyMall || IslandTypeTags.MINING.inAny()) return
+            event.blockedReason = "skymall"
+        }
+
         override fun extraChatHandling(event: SkyHanniChatEvent) {
-            if (chatConfig.hideSkyMall && !IslandTypeTags.MINING.inAny()) event.blockedReason = "skymall"
             DelayedRun.runNextTick {
                 mayhemChatPattern.matchMatcher(event.message) {
                     val perk = group("perk")

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -604,8 +604,6 @@ enum class HotmData(
             }
         }
 
-        override fun inPerkArea(): Boolean = IslandTypeTags.MINING.inAny()
-
         @HandleEvent
         override fun onInventoryClose(event: InventoryCloseEvent) = super.onInventoryClose(event)
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.HotmApi
 import at.hannibal2.skyhanni.api.HotmApi.MayhemPerk
 import at.hannibal2.skyhanni.api.HotmApi.SkymallPerk
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
 import at.hannibal2.skyhanni.data.model.TabWidget
@@ -22,7 +23,6 @@ import at.hannibal2.skyhanni.utils.ConditionalUtils.transformIf
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.indexOfFirstMatch
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.allLettersFirstUppercase
@@ -421,9 +421,10 @@ enum class HotmData(
 
     // TODO move all object functions into hotm api?
     @SkyHanniModule
-    companion object : HotxHandler<HotmData, HotmReward>(entries) {
+    companion object : HotxHandler<HotmData, HotmReward, SkymallPerk>(entries) {
 
         override val name: String = "HotM"
+        override val rotatingPerkClazz = SkymallPerk::class
 
         val storage get() = ProfileStorageData.profileSpecific?.mining?.hotmTree
 
@@ -435,6 +436,7 @@ enum class HotmData(
             "Heart of the Mountain",
         )
 
+        // <editor-fold desc="Patterns">
         /**
          * REGEX-TEST: §5§o§7Level 1§8/50 §7(§b0 §l0%§7):skull:
          * REGEX-TEST: §7Level 1§8/50
@@ -477,7 +479,7 @@ enum class HotmData(
             "(?:§.)*§7Cost",
         )
 
-        private val resetChatPattern by patternGroup.pattern(
+        override val resetChatPattern by patternGroup.pattern(
             "reset.chat",
             "§aReset your §r§5Heart of the Mountain§r§a! Your Perks and Abilities have been reset\\.",
         )
@@ -507,11 +509,6 @@ enum class HotmData(
             "\\s+§8- §5(?<token>\\d+) Token of the Mountain",
         )
 
-        private val skymallPattern by patternGroup.pattern(
-            "skymall",
-            "(?:§eNew buff§r§r§r: §r§f|§8 ■ §7)(?<perk>.*)",
-        )
-
         private val mayhemChatPattern by patternGroup.pattern(
             "mayhem",
             "§b§lMAYHEM! §r§7(?<perk>.*)",
@@ -525,6 +522,7 @@ enum class HotmData(
             "widget.powder",
             "\\s*(?<type>\\w+): (?:§.)+(?<amount>[\\d,.]+)",
         )
+        // </editor-fold>
 
         override var tokens: Int
             get() = ProfileStorageData.profileSpecific?.mining?.tokens ?: 0
@@ -581,7 +579,7 @@ enum class HotmData(
         }
 
         override fun Slot.extraHandling(entry: HotmData, lore: List<String>) {
-            if (entry == SKY_MALL) handleSkyMall(lore)
+            // Hi I'm not empty
         }
 
         override val core = CORE_OF_THE_MOUNTAIN
@@ -597,37 +595,6 @@ enum class HotmData(
             }
         }
 
-        private val skyMallCurrentEffect by patternGroup.pattern(
-            "skymall.current",
-            "§aYour Current Effect",
-        )
-
-        private fun handleSkyMall(lore: List<String>) {
-            if (!SKY_MALL.enabled || !SKY_MALL.isUnlocked) HotmApi.skymall = null
-            else {
-                val index = skyMallCurrentEffect.indexOfFirstMatch(lore) ?: run {
-                    ErrorManager.logErrorStateWithData(
-                        "Could not read the skymall effect from the hotm tree",
-                        "skyMallCurrentEffect didn't match",
-                        "lore" to lore,
-                    )
-                    return
-                }
-                skymallPattern.matchMatcher(lore[index + 1]) {
-                    val perk = group("perk")
-                    HotmApi.skymall = SkymallPerk.entries.firstOrNull { it.itemPattern.matches(perk) } ?: run {
-                        ErrorManager.logErrorStateWithData(
-                            "Could not read the skymall effect from the hotm tree",
-                            "no itemPattern matched",
-                            "lore" to lore,
-                            "perk" to perk,
-                        )
-                        null
-                    }
-                }
-            }
-        }
-
         @HandleEvent(onlyOnSkyblock = true)
         fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
             ScoreboardPattern.powderPattern.firstMatcher(event.added) {
@@ -636,6 +603,8 @@ enum class HotmData(
                 type.setAmount(amount, postEvent = true)
             }
         }
+
+        override fun inPerkArea(): Boolean = IslandTypeTags.MINING.inAny()
 
         @HandleEvent
         override fun onInventoryClose(event: InventoryCloseEvent) = super.onInventoryClose(event)
@@ -661,26 +630,15 @@ enum class HotmData(
             }
         }
 
+        override fun setRotatingPerk(newRotatingPerk: SkymallPerk?) {
+            HotmApi.skymall = newRotatingPerk
+            ChatUtils.debug("setting skymall to ${HotmApi.skymall}")
+        }
+
         @HandleEvent(onlyOnSkyblock = true)
-        fun onChat(event: SkyHanniChatEvent) {
-            if (resetChatPattern.matches(event.message)) {
-                resetTree()
-                return
-            }
-            skymallPattern.matchMatcher(event.message) {
-                val perk = group("perk")
-                HotmApi.skymall = SkymallPerk.entries.firstOrNull { it.chatPattern.matches(perk) } ?: run {
-                    ErrorManager.logErrorStateWithData(
-                        "Could not read the skymall effect from chat",
-                        "no chatPattern matched",
-                        "chat" to event.message,
-                        "perk" to perk,
-                    )
-                    null
-                }
-                ChatUtils.debug("setting skymall to ${HotmApi.skymall}")
-                return
-            }
+        override fun onChat(event: SkyHanniChatEvent) = super.onChat(event)
+
+        override fun extraChatHandling(event: SkyHanniChatEvent) {
             DelayedRun.runNextTick {
                 mayhemChatPattern.matchMatcher(event.message) {
                     val perk = group("perk")
@@ -697,6 +655,8 @@ enum class HotmData(
                 }
             }
         }
+
+        override val rotatingPerkEntry: HotmData = SKY_MALL
 
         @HandleEvent
         fun onIslandChange(event: IslandChangeEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -1,9 +1,11 @@
 package at.hannibal2.skyhanni.data.hotx
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.HotmApi
 import at.hannibal2.skyhanni.api.HotmApi.MayhemPerk
 import at.hannibal2.skyhanni.api.HotmApi.SkymallPerk
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
 import at.hannibal2.skyhanni.data.model.TabWidget
@@ -636,6 +638,7 @@ enum class HotmData(
         override fun onChat(event: SkyHanniChatEvent) = super.onChat(event)
 
         override fun extraChatHandling(event: SkyHanniChatEvent) {
+            if (chatConfig.hideSkyMall && !IslandTypeTags.MINING.inAny()) event.blockedReason = "skymall"
             DelayedRun.runNextTick {
                 mayhemChatPattern.matchMatcher(event.message) {
                     val perk = group("perk")
@@ -679,6 +682,8 @@ enum class HotmData(
         }
     }
 }
+
+private val chatConfig get() = SkyHanniMod.feature.chat
 
 private val coreOfTheMountainPerks = mutableMapOf<Int, Map<HotmReward, Double>>()
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -3,17 +3,22 @@ package at.hannibal2.skyhanni.data.hotx
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.RegexUtils.indexOfFirstMatch
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import net.minecraft.inventory.Slot
 import java.util.regex.Matcher
 import java.util.regex.Pattern
+import kotlin.reflect.KClass
 
-abstract class HotxHandler<Data : HotxData<Reward>, Reward>(val data: Collection<Data>) {
+abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: Collection<Data>)
+    where RotPerkE : Enum<*>,
+          RotPerkE : RepoPatternEnum {
 
     /**
      * Name of the Tree Eg: HotM, HotF
@@ -106,6 +111,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward>(val data: Collection
         }
         entry.enabled = lore.any { enabledPattern.matches(it) }
 
+        handleRotatingPerk(entry, lore)
         extraHandling(entry, lore)
     }
 
@@ -176,5 +182,97 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward>(val data: Collection
             InventoryUtils.getItemsInOpenChest().forEach { it.parse() }
             extraInventoryHandling()
         }
+    }
+
+    abstract val rotatingPerkClazz: KClass<RotPerkE>
+    private val rotatingPerkClassName by lazy { rotatingPerkClazz.java.simpleName.removeSuffix("Perk") }
+    private val allRotatingPerks = rotatingPerkClazz.java.enumConstants
+
+    abstract val resetChatPattern: Pattern
+    open val rotatingPerkPattern: Pattern by lazy { HotxPatterns.rotatingPerkPattern }
+
+    abstract fun inPerkArea(): Boolean
+    abstract fun extraChatHandling(event: SkyHanniChatEvent)
+    abstract fun setRotatingPerk(newRotatingPerk: RotPerkE?)
+
+    open fun onChat(event: SkyHanniChatEvent) {
+        if (resetChatPattern.matches(event.message)) {
+            resetTree()
+            return
+        }
+        tryReadRotatingPerkChat(event)
+        extraChatHandling(event)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private inline fun <reified PType : RepoPatternEnum> getPatternedPerks(): Map<RotPerkE, Pattern> =
+        allRotatingPerks.filterIsInstance<PType>().map {
+            it as RotPerkE to when (PType::class) {
+                ChatRepoPatternEnum::class -> (it as ChatRepoPatternEnum).chatPattern
+                ItemRepoPatternEnum::class -> (it as ItemRepoPatternEnum).itemPattern
+                else -> error("Unsupported pattern type: ${PType::class.java}")
+            }
+        }.associate { it }
+
+    private val chatPatternedCache: Map<RotPerkE, Pattern> by lazy {
+        getPatternedPerks<ChatRepoPatternEnum>()
+    }
+
+    private fun tryReadRotatingPerkChat(event: SkyHanniChatEvent) {
+        if (!inPerkArea()) return
+
+        rotatingPerkPattern.matchMatcher(event.message) {
+            val perk = group("perk")
+            val foundPerk = chatPatternedCache.firstNotNullOfOrNull { (enum, pattern) ->
+                if (!pattern.matches(perk)) return@firstNotNullOfOrNull null
+                enum
+            } ?: run {
+                ErrorManager.logErrorStateWithData(
+                    "Could not read the $rotatingPerkClassName effect from chat",
+                    "no chatPattern matched",
+                    "chat" to event.message,
+                    "perk" to perk,
+                )
+                return
+            }
+            setRotatingPerk(foundPerk)
+        }
+    }
+
+    abstract val rotatingPerkEntry: Data
+
+    private val itemPatternedCache: Map<RotPerkE, Pattern> by lazy {
+        getPatternedPerks<ItemRepoPatternEnum>()
+    }
+
+    fun Slot.handleRotatingPerk(entry: Data, lore: List<String>) {
+        if (entry != rotatingPerkEntry) return
+        val foundPerk = if (!entry.enabled || !entry.isUnlocked) null
+        else {
+            val index = HotxPatterns.itemPreEffectPattern.indexOfFirstMatch(lore) ?: run {
+                ErrorManager.logErrorStateWithData(
+                    "Could not read the $rotatingPerkClassName effect from the $name tree",
+                    "itemPreEffectPattern didn't match",
+                    "lore" to lore,
+                )
+                null
+            }
+            if (index == null) null
+            else {
+                val nextLine = lore[index + 1]
+                itemPatternedCache.firstNotNullOfOrNull { (enum, pattern) ->
+                    if (!pattern.matches(nextLine)) return@firstNotNullOfOrNull null
+                    enum
+                } ?: run {
+                    ErrorManager.logErrorStateWithData(
+                        "Could not read the $rotatingPerkClassName effect from the $name tree",
+                        "no itemPattern matched",
+                        "nextLine" to nextLine,
+                    )
+                    null
+                }
+            }
+        }
+        setRotatingPerk(foundPerk)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -222,15 +222,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
             val foundPerk = chatPatternedCache.firstNotNullOfOrNull { (enum, pattern) ->
                 if (!pattern.matches(perk)) return@firstNotNullOfOrNull null
                 enum
-            } ?: run {
-                ErrorManager.logErrorStateWithData(
-                    "Could not read the $rotatingPerkClassName effect from chat",
-                    "no chatPattern matched",
-                    "chat" to event.message,
-                    "perk" to perk,
-                )
-                return false
-            }
+            } ?: return false
             setRotatingPerk(foundPerk)
             return true
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.RegexUtils.indexOfFirstMatch
+import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import net.minecraft.inventory.Slot
@@ -253,8 +254,9 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
             if (index == null) null
             else {
                 val nextLine = lore[index + 1]
-                itemPatternedCache.firstNotNullOfOrNull { (enum, pattern) ->
-                    if (!pattern.matches(nextLine)) return@firstNotNullOfOrNull null
+                val perkLore = HotxPatterns.rotatingPerkPattern.matchGroup(nextLine, "perk") ?: return
+                itemPatternedCache.firstNotNullOfOrNull { (enum, itemPattern) ->
+                    if (!itemPattern.matches(perkLore)) return@firstNotNullOfOrNull null
                     enum
                 } ?: run {
                     ErrorManager.logErrorStateWithData(

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -112,7 +112,9 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
         }
         entry.enabled = lore.any { enabledPattern.matches(it) }
 
-        handleRotatingPerk(entry, lore)
+        fetchRotatingPerk(entry, lore)?.let {
+            setRotatingPerk(it)
+        }
         extraHandling(entry, lore)
     }
 
@@ -239,13 +241,8 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
         getPatternedPerks<ItemRepoPatternEnum>()
     }
 
-    private fun handleRotatingPerk(entry: Data, lore: List<String>) {
-        if (entry != rotatingPerkEntry) return
-        val perk = getPerk(entry, lore) ?: return
-        setRotatingPerk(perk)
-    }
-
-    private fun getPerk(entry: Data, lore: List<String>): RotPerkE? {
+    private fun fetchRotatingPerk(entry: Data, lore: List<String>): RotPerkE? {
+        if (entry != rotatingPerkEntry) return null
         if (!entry.enabled || !entry.isUnlocked) return null
 
         val index = HotxPatterns.itemPreEffectPattern.indexOfFirstMatch(lore) ?: run {

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -191,7 +191,6 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
     abstract val resetChatPattern: Pattern
     open val rotatingPerkPattern: Pattern by lazy { HotxPatterns.rotatingPerkPattern }
 
-    abstract fun inPerkArea(): Boolean
     abstract fun extraChatHandling(event: SkyHanniChatEvent)
     abstract fun setRotatingPerk(newRotatingPerk: RotPerkE?)
 
@@ -200,7 +199,6 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
             resetTree()
             return
         }
-        tryReadRotatingPerkChat(event)
         extraChatHandling(event)
     }
 
@@ -218,9 +216,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
         getPatternedPerks<ChatRepoPatternEnum>()
     }
 
-    private fun tryReadRotatingPerkChat(event: SkyHanniChatEvent) {
-        if (!inPerkArea()) return
-
+    fun tryReadRotatingPerkChat(event: SkyHanniChatEvent): Boolean? {
         rotatingPerkPattern.matchMatcher(event.message) {
             val perk = group("perk")
             val foundPerk = chatPatternedCache.firstNotNullOfOrNull { (enum, pattern) ->
@@ -233,10 +229,12 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
                     "chat" to event.message,
                     "perk" to perk,
                 )
-                return
+                return false
             }
             setRotatingPerk(foundPerk)
+            return true
         }
+        return null
     }
 
     abstract val rotatingPerkEntry: Data

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -264,7 +264,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
                 "no itemPattern matched",
                 "nextLine" to nextLine,
             )
-            return null
         }
+        return null
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -239,35 +239,35 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
         getPatternedPerks<ItemRepoPatternEnum>()
     }
 
-    fun Slot.handleRotatingPerk(entry: Data, lore: List<String>) {
+    private fun handleRotatingPerk(entry: Data, lore: List<String>) {
         if (entry != rotatingPerkEntry) return
-        val foundPerk = if (!entry.enabled || !entry.isUnlocked) null
-        else {
-            val index = HotxPatterns.itemPreEffectPattern.indexOfFirstMatch(lore) ?: run {
-                ErrorManager.logErrorStateWithData(
-                    "Could not read the $rotatingPerkClassName effect from the $name tree",
-                    "itemPreEffectPattern didn't match",
-                    "lore" to lore,
-                )
-                null
-            }
-            if (index == null) null
-            else {
-                val nextLine = lore[index + 1]
-                val perkLore = HotxPatterns.rotatingPerkPattern.matchGroup(nextLine, "perk") ?: return
-                itemPatternedCache.firstNotNullOfOrNull { (enum, itemPattern) ->
-                    if (!itemPattern.matches(perkLore)) return@firstNotNullOfOrNull null
-                    enum
-                } ?: run {
-                    ErrorManager.logErrorStateWithData(
-                        "Could not read the $rotatingPerkClassName effect from the $name tree",
-                        "no itemPattern matched",
-                        "nextLine" to nextLine,
-                    )
-                    null
-                }
-            }
+        val perk = getPerk(entry, lore) ?: return
+        setRotatingPerk(perk)
+    }
+
+    private fun getPerk(entry: Data, lore: List<String>): RotPerkE? {
+        if (!entry.enabled || !entry.isUnlocked) return null
+
+        val index = HotxPatterns.itemPreEffectPattern.indexOfFirstMatch(lore) ?: run {
+            ErrorManager.logErrorStateWithData(
+                "Could not read the $rotatingPerkClassName effect from the $name tree",
+                "itemPreEffectPattern didn't match",
+                "lore" to lore,
+            )
+            return null
         }
-        setRotatingPerk(foundPerk)
+        val nextLine = lore[index + 1]
+        val perkLore = HotxPatterns.rotatingPerkPattern.matchGroup(nextLine, "perk") ?: return null
+        itemPatternedCache.firstNotNullOfOrNull { (enum, itemPattern) ->
+            if (itemPattern.matches(perkLore)) return enum
+            return@firstNotNullOfOrNull null
+        } ?: run {
+            ErrorManager.logErrorStateWithData(
+                "Could not read the $rotatingPerkClassName effect from the $name tree",
+                "no itemPattern matched",
+                "nextLine" to nextLine,
+            )
+            return null
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -216,6 +216,8 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
         getPatternedPerks<ChatRepoPatternEnum>()
     }
 
+    abstract fun tryBlock(event: SkyHanniChatEvent)
+
     fun tryReadRotatingPerkChat(event: SkyHanniChatEvent): Boolean? {
         rotatingPerkPattern.matchMatcher(event.message) {
             val perk = group("perk")
@@ -223,6 +225,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
                 if (!pattern.matches(perk)) return@firstNotNullOfOrNull null
                 enum
             } ?: return false
+            tryBlock(event)
             setRotatingPerk(foundPerk)
             return true
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -186,7 +186,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
 
     abstract val rotatingPerkClazz: KClass<RotPerkE>
     private val rotatingPerkClassName by lazy { rotatingPerkClazz.java.simpleName.removeSuffix("Perk") }
-    private val allRotatingPerks = rotatingPerkClazz.java.enumConstants
+    private val allRotatingPerks by lazy { rotatingPerkClazz.java.enumConstants }
 
     abstract val resetChatPattern: Pattern
     open val rotatingPerkPattern: Pattern by lazy { HotxPatterns.rotatingPerkPattern }

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxPatterns.kt
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.data.hotx
+
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+object HotxPatterns {
+
+    private val patternGroup = RepoPattern.group("misc.hotx")
+
+    /**
+     * REGEX-TEST: §eNew buff§r§r§r: §r§fGain §r§a+5% §r§2∮ Sweep§r§f.
+     * REGEX-TEST: §eNew buff§r§r§r: §r§fGain §r§a+50 §r§6☘ Mangrove Fortune§r§f.
+     * REGEX-TEST: §eNew buff§r§r§r: §r§fGain §r§a+50 §r§6☘ Fig Fortune§r§f.
+     * REGEX-TEST: §8 ■ §7Gain §a+5% §2∮ Sweep§7.
+     * REGEX-TEST: §8 ■ §7Gain §a+50 §6☘ Mangrove Fortune§7.
+     * REGEX-TEST: §8 ■ §7Gain §a+50 §6☘ Fig Fortune§7
+     *
+     * REGEX-TEST: §eNew buff§r§r§r: §r§fGain §r§6+50☘ Mining Fortune§r§f.
+     * REGEX-TEST: §8 ■ §7Gain §6+100⸕ Mining Speed§7.
+     * REGEX-TEST: §8 ■ §7Gain §6+50☘ Mining Fortune§7.
+     * REGEX-TEST: §8 ■ §7Gain §a+15% §7more Powder while mining.
+     * REGEX-TEST: §8 ■ §7§a-20%§7 Pickaxe Ability cooldowns.
+     * REGEX-TEST: §8 ■ §7§a10x §7chance to find Golden and
+     * REGEX-TEST: §8 ■ §7Gain §a5x §9Titanium §7drops.
+     */
+    val rotatingPerkPattern by patternGroup.pattern(
+        "perk.generic",
+        "(?:§eNew buff§r§r§r: §r§f|§8 ■ §7)(?<perk>.*)"
+    )
+
+    // The line that appears before the "current" perk effect in the item tooltip.
+    val itemPreEffectPattern by patternGroup.pattern(
+        "perk.item.before",
+        "§aYour Current Effect"
+    )
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/RepoPatternEnum.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/RepoPatternEnum.kt
@@ -1,0 +1,33 @@
+package at.hannibal2.skyhanni.data.hotx
+
+import at.hannibal2.skyhanni.data.hotx.RepoEnumHelper.toPatternName
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import java.util.regex.Pattern
+
+interface RepoPatternEnum {
+    val basePath: String
+    val patternName: String
+        get() = (this as Enum<*>).toPatternName()
+}
+
+interface ChatRepoPatternEnum : RepoPatternEnum {
+    val chatPatternRaw: String
+    val chatPattern: Pattern get() =
+        RepoPattern.pattern(
+            "$basePath.chat.$patternName",
+            chatPatternRaw
+        ).value
+}
+
+interface ItemRepoPatternEnum : RepoPatternEnum {
+    val itemPatternRaw: String
+    val itemPattern: Pattern get() =
+        RepoPattern.pattern(
+            "$basePath.item.$patternName",
+            itemPatternRaw
+        ).value
+}
+
+private object RepoEnumHelper {
+    fun Enum<*>.toPatternName() = name.lowercase().replace("_", ".")
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -305,6 +305,10 @@ object ChatFilter {
         "§8§oYou can disable this messaging by toggling Sky Mall in your /hotm!",
     )
 
+    private val lotteryMessages = listOf(
+
+    )
+
     /**
      * REGEX-TEST: §e[NPC] Jacob§f: §rYour §9Anita's Talisman §fis giving you §6+25☘ Carrot Fortune §fduring the contest!
      */
@@ -548,7 +552,8 @@ object ChatFilter {
         config.factoryUpgrade && message.isPresent("factory_upgrade") -> "factory_upgrade"
         config.sacrifice && message.isPresent("sacrifice") -> "sacrifice"
         generalConfig.hideJacob && !GardenApi.inGarden() && anitaFortunePattern.matches(message) -> "jacob_event"
-        generalConfig.hideSkyMall && !IslandTypeTags.MINING.inAny() && (skymallPerkPattern.matches(message) || message.isPresent("skymall")) -> "skymall"
+        generalConfig.hideSkyMall && !IslandTypeTags.MINING.inAny() && message.isPresent("skymall") -> "skymall"
+        generalConfig.hideLottery && message.isPresent("lottery") -> "lottery"
         dungeonConfig.rareDrops && message.isPresent("rare_drops") -> "rare_drops"
         dungeonConfig.soloClass && DungeonApi.inDungeon() && message.isPresent("solo_class") -> "solo_class"
         dungeonConfig.soloStats && DungeonApi.inDungeon() && message.isPresent("solo_stats") -> "solo_stats"

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -306,7 +306,8 @@ object ChatFilter {
     )
 
     private val lotteryMessages = listOf(
-
+        "§r§bNew day! §r§eYour §r§2Lottery §r§ebuff changed!",
+        "§r§8§oYou can disable this messaging by toggling Lottery in your /hotf!"
     )
 
     /**
@@ -499,6 +500,7 @@ object ChatFilter {
         "fire_sale" to fireSaleMessages,
         "event" to eventMessage,
         "skymall" to skymallMessages,
+        "lottery" to lotteryMessages,
         "parkour" to parkourCancelMessages,
         "teleport_pads" to teleportPadMessages,
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -318,14 +318,6 @@ object ChatFilter {
         "§e\\[NPC] Jacob§f: §rYour §9Anita's \\w+ §fis giving you §6\\+\\d{1,2}☘ .+ Fortune §fduring the contest!",
     )
 
-    /**
-     * REGEX-TEST: §eNew buff§r§r§r: §r§fGain §r§6+50☘ Mining Fortune§r§f.
-     */
-    private val skymallPerkPattern by RepoPattern.pattern(
-        "chat.skymall.perk",
-        "§eNew buff§r§r§r:.*",
-    )
-
     // Winter Gift
     private val winterGiftPatterns = buildList {
         GiftProfitTracker.run {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -547,7 +547,7 @@ object ChatFilter {
         config.sacrifice && message.isPresent("sacrifice") -> "sacrifice"
         generalConfig.hideJacob && !GardenApi.inGarden() && anitaFortunePattern.matches(message) -> "jacob_event"
         generalConfig.hideSkyMall && !IslandTypeTags.MINING.inAny() && message.isPresent("skymall") -> "skymall"
-        generalConfig.hideLottery && message.isPresent("lottery") -> "lottery"
+        generalConfig.hideLottery && !IslandTypeTags.FORAGING.inAny() && message.isPresent("lottery") -> "lottery"
         dungeonConfig.rareDrops && message.isPresent("rare_drops") -> "rare_drops"
         dungeonConfig.soloClass && DungeonApi.inDungeon() && message.isPresent("solo_class") -> "solo_class"
         dungeonConfig.soloStats && DungeonApi.inDungeon() && message.isPresent("solo_stats") -> "solo_stats"

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.hotx.HotfData
 import at.hannibal2.skyhanni.data.hotx.HotmData
-import at.hannibal2.skyhanni.data.hotx.HotxData
 import at.hannibal2.skyhanni.data.hotx.HotxHandler
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -4,10 +4,13 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.hotx.HotfData
 import at.hannibal2.skyhanni.data.hotx.HotmData
+import at.hannibal2.skyhanni.data.hotx.HotxData
 import at.hannibal2.skyhanni.data.hotx.HotxHandler
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 
@@ -16,6 +19,26 @@ object HotxFeatures {
 
     private val configHotm get() = SkyHanniMod.feature.mining.hotm
     private val configHotf get() = SkyHanniMod.feature.foraging.hotf
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onChat(event: SkyHanniChatEvent) {
+        val claimMap: Map<HotxHandler<*, *, *>, Boolean?> = listOf(
+            HotmData, HotfData,
+        ).associateWith { data ->
+            data.tryReadRotatingPerkChat(event)
+        }
+
+        val claimResults = claimMap.values
+        val wasClaimed = claimResults.any { it == true }
+        val noMatches = claimResults.all { it == null }
+        if (wasClaimed || noMatches) return
+
+        ErrorManager.logErrorStateWithData(
+            "Could not read the rotating effect from chat",
+            "no hotxhandler claimed the event",
+            "chat" to event.message,
+        )
+    }
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -19,7 +19,7 @@ object HotxFeatures {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        val handler: HotxHandler<*, *> = when {
+        val handler: HotxHandler<*, *, *> = when {
             HotmData.inInventory && configHotm.highlightEnabledPerks -> HotmData
             HotfData.inInventory && configHotf.highlightEnabledPerks -> HotfData
             else -> return
@@ -38,7 +38,7 @@ object HotxFeatures {
     }
 
     private fun handleLevelStackSize(event: RenderItemTipEvent) {
-        val handler: HotxHandler<*, *> = when {
+        val handler: HotxHandler<*, *, *> = when {
             HotmData.inInventory && configHotm.levelStackSize -> HotmData
             HotfData.inInventory && configHotf.levelStackSize -> HotfData
             else -> return
@@ -52,7 +52,7 @@ object HotxFeatures {
     }
 
     private fun handleTokenStackSize(event: RenderItemTipEvent) {
-        val handler: HotxHandler<*, *> = when {
+        val handler: HotxHandler<*, *, *> = when {
             HotmData.inInventory && configHotm.tokenStackSize -> HotmData
             HotfData.inInventory && configHotf.tokenStackSize -> HotfData
             else -> return

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -54,30 +54,6 @@ object LocationUtils {
 
     fun AxisAlignedBB.isPlayerInside() = isInside(playerLocation())
 
-    /**
-     * When passed a corner pair of vectors, checks if the player can see the center point of, or optionally
-     * a number of other points on the box, defined by the [step] parameter.
-     *
-     * A note about the [step] parameter - it is linear, but at a rate of increasing by [stepDensity], per face, per step.
-     * So, use both sparingly, as it can lead to a lot of rays being cast.
-     *
-     * @param viewDistance The maximum distance at which the player can see the box.
-     * @param offset An optional vertical offset to apply to the box corners.
-     * @param step The number of "middle points" between faces to check. Default is 0, meaning only the center point is checked.
-     * @param stepDensity The number of rays to cast from the center of each face towards the nearest corner.
-     * @return True if the player can see any face of the box, false otherwise.
-     */
-    fun Pair<LorenzVec, LorenzVec>.anyFaceCanBeSeen(
-        viewDistance: Number = 150.0,
-        step: Int = 0,
-        stepDensity: Int = 4,
-        offset: Double? = null
-    ): Boolean {
-        val player = MinecraftCompat.localPlayer
-        val eyeLocation = playerEyeLocation()
-        return canSee(eyeLocation, this, offset) && eyeLocation.distance(this) < viewDistance.toDouble()
-    }
-
     fun LorenzVec.canBeSeen(viewDistance: Number = 150.0, offset: Double? = null): Boolean {
         val a = playerEyeLocation()
         val b = this

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -54,6 +54,30 @@ object LocationUtils {
 
     fun AxisAlignedBB.isPlayerInside() = isInside(playerLocation())
 
+    /**
+     * When passed a corner pair of vectors, checks if the player can see the center point of, or optionally
+     * a number of other points on the box, defined by the [step] parameter.
+     *
+     * A note about the [step] parameter - it is linear, but at a rate of increasing by [stepDensity], per face, per step.
+     * So, use both sparingly, as it can lead to a lot of rays being cast.
+     *
+     * @param viewDistance The maximum distance at which the player can see the box.
+     * @param offset An optional vertical offset to apply to the box corners.
+     * @param step The number of "middle points" between faces to check. Default is 0, meaning only the center point is checked.
+     * @param stepDensity The number of rays to cast from the center of each face towards the nearest corner.
+     * @return True if the player can see any face of the box, false otherwise.
+     */
+    fun Pair<LorenzVec, LorenzVec>.anyFaceCanBeSeen(
+        viewDistance: Number = 150.0,
+        step: Int = 0,
+        stepDensity: Int = 4,
+        offset: Double? = null
+    ): Boolean {
+        val player = MinecraftCompat.localPlayer
+        val eyeLocation = playerEyeLocation()
+        return canSee(eyeLocation, this, offset) && eyeLocation.distance(this) < viewDistance.toDouble()
+    }
+
     fun LorenzVec.canBeSeen(viewDistance: Number = 150.0, offset: Double? = null): Boolean {
         val a = playerEyeLocation()
         val b = this


### PR DESCRIPTION
## What
Set up generics for handling the rotating perks (SkyMall for HOTM + Lottery for HOTF). Added checks for being on the right Island Type(s), so this will fix the incessant issues with SkyMall trying to read the Lottery perks, and vice versa.

## Changelog New Features
+ Added Hide Lottery Messages. - Daveed
    * Lottery messages from HOTF hidden outside Foraging Islands.

## Changelog Fixes
+ Fixed errors with SkyMall and HOTF perk. - Daveed

## Changelog Technical Details
+ Refactored HotX classes around Rotating Perk enum. - Daveed

