### PR TITLE
Fix: Chat error on park & galatea

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxPatterns.kt
@@ -1,7 +1,9 @@
 package at.hannibal2.skyhanni.data.hotx
 
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
+@SkyHanniModule
 object HotxPatterns {
 
     private val patternGroup = RepoPattern.group("misc.hotx")


### PR DESCRIPTION
## What
The repo patterns were late initialized because no skyhanni module

## Changelog Fixes
+ Fixed Park and Galatea chat errors. - CalMWolfs

