### PR TITLE
Fix: Pumpkins were not carved on 1.21

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/ComponentUtils.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/ComponentUtils.kt
@@ -236,6 +236,7 @@ object ComponentUtils {
             strippedId == "fence" -> "oak_fence"
             strippedId == "fence_gate" -> "oak_fence_gate"
             strippedId == "grass" -> "grass_block"
+            strippedId == "pumpkin" -> "carved_pumpkin"
             strippedId == "lit_pumpkin" -> "jack_o_lantern"
             strippedId == "planks" -> getWood(damage) + "_planks"
             strippedId == "mob_spawner" -> "spawner"

--- a/versions/mapping-1.16.5-forge-1.8.9.txt
+++ b/versions/mapping-1.16.5-forge-1.8.9.txt
@@ -689,6 +689,7 @@ net.minecraft.world.level.block.Blocks CACTUS cactus
 net.minecraft.world.level.block.Blocks CAKE cake
 net.minecraft.world.level.block.Blocks CARPET carpet
 net.minecraft.world.level.block.Blocks CARROTS carrots
+net.minecraft.world.level.block.Blocks CARVED_PUMPKIN pumpkin
 net.minecraft.world.level.block.Blocks CAULDRON cauldron
 net.minecraft.world.level.block.Blocks CHEST chest
 net.minecraft.world.level.block.Blocks CLAY clay
@@ -797,7 +798,6 @@ net.minecraft.world.level.block.Blocks POTATOES potatoes
 net.minecraft.world.level.block.Blocks POWERED_COMPARATOR powered_comparator
 net.minecraft.world.level.block.Blocks POWERED_REPEATER powered_repeater
 net.minecraft.world.level.block.Blocks PRISMARINE prismarine
-net.minecraft.world.level.block.Blocks PUMPKIN pumpkin
 net.minecraft.world.level.block.Blocks PUMPKIN_STEM pumpkin_stem
 net.minecraft.world.level.block.Blocks QUARTZ_BLOCK quartz_block
 net.minecraft.world.level.block.Blocks QUARTZ_STAIRS quartz_stairs


### PR DESCRIPTION
## What
Minecraft added non carved pumpkins at some point, hypixel doesnt use them

## Changelog Fixes
+ Fixed SkyHanni failing to detect pumpkin farming on 1.21. - nopo
