### PR TITLE
Fix: Eating wardrobe tooltips

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.DrawScreenAfterEvent;
 import at.hannibal2.skyhanni.events.GuiContainerEvent;
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent;
 import at.hannibal2.skyhanni.events.render.gui.DrawBackgroundEvent;
+import at.hannibal2.skyhanni.features.inventory.wardrobe.CustomWardrobe;
 import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeApi;
 import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests;
 import at.hannibal2.skyhanni.utils.DelayedRun;
@@ -58,7 +59,7 @@ public abstract class MixinHandledScreen {
 
     @ModifyArg(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;Ljava/util/Optional;IILnet/minecraft/util/Identifier;)V"), index = 1)
     private List<Text> renderBackground(List<Text> textTooltip, @Local ItemStack itemStack, @Local(argsOnly = true) DrawContext drawContext) {
-        if (WardrobeApi.INSTANCE.getInCustomWardrobe()) {
+        if (WardrobeApi.INSTANCE.getInCustomWardrobe() && !CustomWardrobe.INSTANCE.getEditMode()) {
             return new ArrayList<>();
         }
         return ToolTipData.processModernTooltip(drawContext, itemStack, textTooltip);


### PR DESCRIPTION
## What
Fixed eating tooltips when editing custom wardrobe.

## Changelog Fixes
+ Fixed tooltips hiding when editing wardrobe sets on 1.21. - CalMWolfs

