### PR TITLE
Fix: Cleanup Hide Armor

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 90
+    const val CONFIG_VERSION = 91
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.java
@@ -58,8 +58,7 @@ public class MiscConfig {
     @ConfigOption(name = "Hide Armor", desc = "")
     @Accordion
     @Expose
-    // TODO maybe we can migrate this already
-    public HideArmorConfig hideArmor2 = new HideArmorConfig();
+    public HideArmorConfig hideArmor = new HideArmorConfig();
 
     @Expose
     @ConfigOption(name = "Non-God Pot Effects", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
@@ -4,6 +4,7 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.features.misc.HideArmorConfig
 import at.hannibal2.skyhanni.config.features.misc.HideArmorConfig.ModeEntry
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -23,7 +24,7 @@ import net.minecraft.item.ItemStack
 @SkyHanniModule
 object HideArmor {
 
-    val config get() = SkyHanniMod.feature.misc.hideArmor2
+    val config: HideArmorConfig get() = SkyHanniMod.feature.misc.hideArmor
     private var armor = mapOf<Int, ItemStack>()
 
     fun shouldHideArmor(entity: EntityPlayer): Boolean {
@@ -76,19 +77,23 @@ object HideArmor {
         event.transform(15, "misc.hideArmor2.mode") { element ->
             ConfigUtils.migrateIntToEnum(element, ModeEntry::class.java)
         }
+        event.move(91, "misc.hideArmor2", "misc.hideArmor")
     }
 
     private val CURRENT_RENDERED_ENTITY: ThreadLocal<Entity> = ThreadLocal<Entity>()
 
-    fun set(entity: Entity) {
+    @JvmStatic
+    fun setCurrentEntity(entity: Entity) {
         CURRENT_RENDERED_ENTITY.set(entity)
     }
 
-    fun get(): Entity {
+    @JvmStatic
+    fun getCurrentEntity(): Entity? {
         return CURRENT_RENDERED_ENTITY.get()
     }
 
-    fun clear() {
+    @JvmStatic
+    fun clearCurrentEntity() {
         CURRENT_RENDERED_ENTITY.remove()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderManager.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderManager.java
@@ -28,12 +28,12 @@ public class MixinRenderManager {
     //#if MC > 1.21
     //$$ @Inject(method = "render(Lnet/minecraft/entity/Entity;DDDFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At("HEAD"))
     //$$ private void onRenderStart(Entity entity, double x, double y, double z, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-    //$$     HideArmor.INSTANCE.set(entity);
+    //$$     HideArmor.setCurrentEntity(entity);
     //$$ }
     //$$
     //$$ @Inject(method = "render(Lnet/minecraft/entity/Entity;DDDFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At("RETURN"))
     //$$ private void onRenderEnd(Entity entity, double x, double y, double z, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-    //$$     HideArmor.INSTANCE.clear();
+    //$$     HideArmor.clearCurrentEntity();
     //$$ }
     //#endif
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinArmorFeatureRenderer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinArmorFeatureRenderer.java
@@ -26,7 +26,10 @@ public class MixinArmorFeatureRenderer {
         BipedEntityModel armorModel,
         CallbackInfo ci
     ) {
-        Entity current = HideArmor.INSTANCE.get();
+        Entity current = HideArmor.getCurrentEntity();
+        if (current == null) {
+            return;
+        }
         if (current instanceof PlayerEntity && HideArmor.INSTANCE.shouldHideArmor(((PlayerEntity) current))) {
             if (!HideArmor.INSTANCE.getConfig().onlyHelmet || slot == EquipmentSlot.HEAD) {
                 ci.cancel();

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinHeadFeatureRenderer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinHeadFeatureRenderer.java
@@ -25,7 +25,10 @@ public class MixinHeadFeatureRenderer {
         float g,
         CallbackInfo ci
     ) {
-        Entity current = HideArmor.INSTANCE.get();
+        Entity current = HideArmor.getCurrentEntity();
+        if (current == null) {
+            return;
+        }
         if (current instanceof PlayerEntity && HideArmor.INSTANCE.shouldHideArmor(((PlayerEntity) current))) {
             ci.cancel();
         }


### PR DESCRIPTION
## What
While the entity should never be null it can potentially be and we dont do a null check and as we are in a mixin then 💥 
I don't think this can crash on 1.8 or 1.21.5 but it definitely does on 1.21.6. Also did a long awaited config fix and improved method names slightly.

## Changelog Fixes
+ Fixed potential Hide Armour crash. - CalMWolfs
