### PR TITLE
Backend: Make all text color white

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
@@ -70,7 +70,7 @@ object ItemTipHelper {
             } else 0
             val y = guiTop + yDisplayPosition + 9 + itemTipEvent.offsetY
 
-            GuiRenderUtils.drawString(stackTip, x, y, 16777215)
+            GuiRenderUtils.drawString(stackTip, x, y, -1)
         }
         DrawContextUtils.popMatrix()
         GlStateManager.enableLighting()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -119,7 +119,7 @@ object TabListRenderer {
                     line,
                     x + totalWidth / 2f - minecraft.fontRendererObj.getStringWidth(line) / 2f,
                     headerY.toFloat(),
-                    0xFFFFFF,
+                    -1,
                 )
                 headerY += 8 + 1
             }
@@ -134,7 +134,7 @@ object TabListRenderer {
                     line,
                     x + totalWidth / 2f - minecraft.fontRendererObj.getStringWidth(line) / 2f,
                     footerY.toFloat(),
-                    -0x1,
+                    -1,
                 )
                 footerY += LINE_HEIGHT
             }
@@ -199,14 +199,14 @@ object TabListRenderer {
                         text,
                         middleX + column.getMaxWidth() / 2f - tabLine.getWidth() / 2f,
                         middleY.toFloat(),
-                        0xFFFFFF,
+                        -1,
                     )
                 } else {
                     GuiRenderUtils.drawString(
                         text,
                         middleX.toFloat(),
                         middleY.toFloat(),
-                        0xFFFFFF,
+                        -1,
                     )
                 }
                 middleY += LINE_HEIGHT

--- a/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
@@ -54,7 +54,7 @@ object GuiRenderUtils {
     }
 
     fun drawStringCentered(str: String?, x: Int, y: Int) {
-        drawStringCentered(str, x.toFloat(), y.toFloat(), true, 0xffffff)
+        drawStringCentered(str, x.toFloat(), y.toFloat(), true, -1)
     }
 
     fun drawStringCenteredScaledMaxWidth(text: String, x: Float, y: Float, shadow: Boolean, length: Int, color: Int) {
@@ -67,19 +67,19 @@ object GuiRenderUtils {
         DrawContextUtils.popMatrix()
     }
 
-    fun drawString(str: String, x: Float, y: Float, color: Int = 0xffffff, shadow: Boolean = true) {
+    fun drawString(str: String, x: Float, y: Float, color: Int = -1, shadow: Boolean = true) {
         DrawContextUtils.drawContext.drawText(fr, str, x.toInt(), y.toInt(), color, shadow)
     }
 
-    fun drawString(str: String, x: Int, y: Int, color: Int = 0xffffff, shadow: Boolean = true) {
+    fun drawString(str: String, x: Int, y: Int, color: Int = -1, shadow: Boolean = true) {
         DrawContextUtils.drawContext.drawText(fr, str, x, y, color, shadow)
     }
 
-    fun drawStrings(strings: String, x: Int, y: Int, color: Int = 0xffffff, shadow: Boolean = true) {
+    fun drawStrings(strings: String, x: Int, y: Int, color: Int = -1, shadow: Boolean = true) {
         drawStrings(strings.split("\n"), x, y, color, shadow)
     }
 
-    fun drawStrings(strings: List<String>, x: Int, y: Int, color: Int = 0xffffff, shadow: Boolean = true) {
+    fun drawStrings(strings: List<String>, x: Int, y: Int, color: Int = -1, shadow: Boolean = true) {
         var newY = y
         for (string in strings) {
             DrawContextUtils.drawContext.drawText(fr, string, x, newY, color, shadow)

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -269,9 +269,9 @@ object RenderUtils {
         if (centered) {
             val strLen: Int = fr.getStringWidth(string)
             val x2 = offsetX - strLen / 2f
-            GuiRenderUtils.drawString(display, x2, 0f, 0)
+            GuiRenderUtils.drawString(display, x2, 0f, -1)
         } else {
-            GuiRenderUtils.drawString(display, 0f, 0f, 0)
+            GuiRenderUtils.drawString(display, 0f, 0f, -1)
         }
 
         DrawContextUtils.popMatrix()
@@ -585,7 +585,7 @@ object RenderUtils {
         DrawContextUtils.pushPop {
             DrawContextUtils.translate((xPos - fontRenderer.getStringWidth(text)).toFloat(), yPos.toFloat(), 200f)
             DrawContextUtils.scale(scale, scale, 1f)
-            GuiRenderUtils.drawString(text, 0f, 0f, 16777215)
+            GuiRenderUtils.drawString(text, 0f, 0f, -1)
 
             val reverseScale = 1 / scale
 


### PR DESCRIPTION
## What
Made the default color for rendering text be white. I honestly don't think the number we had did anything before as we used chat formatting to set color anyways but on 1.21.6 the color we had before makes all text fully transparent. This did not seem to visually change anything on 1.8 or 1.21.5

## Changelog Technical Details
+ Made default text color white. - CalMWolfs
