### PR TITLE
Backend: `onAnyToggled`

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ConditionalUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConditionalUtils.kt
@@ -2,6 +2,10 @@ package at.hannibal2.skyhanni.utils
 
 import io.github.notenoughupdates.moulconfig.observer.Observer
 import io.github.notenoughupdates.moulconfig.observer.Property
+import java.lang.reflect.Modifier
+import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
 
 object ConditionalUtils {
 
@@ -70,6 +74,36 @@ object ConditionalUtils {
 
         // Compare the non-null second values
         return second1.compareTo(second2)
+    }
+
+    /**
+     * Recursively scans each given 'root' for any fields of type Property<*>,
+     * then calls the existing onToggle(...) overload with all discovered properties.
+     */
+    fun onToggleAll(vararg roots: Any, observer: Runnable) = roots.forEach { root ->
+        collectProperties(root, mutableSetOf()).forEach {
+            onToggle(it, observer = observer)
+        }
+    }
+
+    private fun collectProperties(
+        current: Any,
+        visited: MutableSet<Any>
+    ): List<Property<*>> = buildList {
+        if (!visited.add(current)) return@buildList
+
+        for (prop in current::class.memberProperties) {
+            // Intentionally ignore transients and static properties
+            if (prop.hasAnnotation<Transient>()) return@buildList
+            prop.isAccessible = true
+            val value = runCatching { prop.getter.call(current) }.getOrNull() ?: continue
+            when (value) {
+                is Property<*> -> add(value)
+                else -> addAll(
+                    collectProperties(value, visited)
+                )
+            }
+        }
     }
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConditionalUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConditionalUtils.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.utils
 
 import io.github.notenoughupdates.moulconfig.observer.Observer
 import io.github.notenoughupdates.moulconfig.observer.Property
-import java.lang.reflect.Modifier
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
@@ -80,7 +79,7 @@ object ConditionalUtils {
      * Recursively scans each given 'root' for any fields of type Property<*>,
      * then calls the existing onToggle(...) overload with all discovered properties.
      */
-    fun onToggleAll(vararg roots: Any, observer: Runnable) = roots.forEach { root ->
+    fun onAnyToggled(vararg roots: Any, observer: Runnable) = roots.forEach { root ->
         collectProperties(root, mutableSetOf()).forEach {
             onToggle(it, observer = observer)
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConditionalUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConditionalUtils.kt
@@ -5,6 +5,8 @@ import io.github.notenoughupdates.moulconfig.observer.Property
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.javaGetter
 
 object ConditionalUtils {
 
@@ -92,9 +94,8 @@ object ConditionalUtils {
         if (!visited.add(current)) return@buildList
 
         for (prop in current::class.memberProperties) {
-            // Intentionally ignore transients and static properties
-            if (prop.hasAnnotation<Transient>()) return@buildList
-            prop.isAccessible = true
+            if (prop.javaField == null && prop.javaGetter == null || prop.hasAnnotation<Transient>()) continue
+            if (runCatching { prop.isAccessible = true }.isFailure) continue
             val value = runCatching { prop.getter.call(current) }.getOrNull() ?: continue
             when (value) {
                 is Property<*> -> add(value)


### PR DESCRIPTION
## What
This PR adds a method to ConditionalUtils that can be used to `onToggle()` every property in a config at once, and it will also iterate down to sub-configs as well. First implemented in Pet Display V2, but I've been finding use cases for it elsewhere.

## Changelog Technical Details
+ Added `onAnyToggled` to ConditionalUtils. - Daveed
    * Allows you to `onToggle()` an entire config file at once.

