### PR TITLE
Fix: Movable xp bar not moving the experience number

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -123,13 +123,16 @@ enum class RenderLayer {
     FOOD,
     AIR,
     HOTBAR,
-    EXPERIENCE,
+    EXPERIENCE_BAR,
     TEXT,
     HEALTHMOUNT,
     JUMPBAR,
     CHAT,
     PLAYER_LIST,
-    DEBUG;
+    DEBUG,
+    // Not a real forge layer but is used on modern Minecraft versions
+    EXPERIENCE_NUMBER,
+    ;
 
     companion object {
         fun fromForge(element: RenderGameOverlayEvent.ElementType): RenderLayer {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/MovableXPBar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/MovableXPBar.kt
@@ -22,7 +22,7 @@ object MovableXPBar {
 
     @HandleEvent(priority = HandleEvent.LOWEST)
     fun onRenderOverlayPre(event: GameOverlayRenderPreEvent) {
-        if (event.type != RenderLayer.EXPERIENCE || !isEnabled()) return
+        if ((event.type != RenderLayer.EXPERIENCE_BAR && event.type != RenderLayer.EXPERIENCE_NUMBER) || !isEnabled()) return
         post = true
         DrawContextUtils.pushMatrix()
         val x = GuiScreenUtils.scaledWindowWidth / 2 - 91
@@ -34,7 +34,7 @@ object MovableXPBar {
 
     @HandleEvent(priority = HandleEvent.HIGHEST)
     fun onRenderOverlayPost(event: GameOverlayRenderPostEvent) {
-        if (event.type != RenderLayer.EXPERIENCE || !post) return
+        if ((event.type != RenderLayer.EXPERIENCE_BAR && event.type != RenderLayer.EXPERIENCE_NUMBER) || !post) return
         DrawContextUtils.popMatrix()
         post = false
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyBlockXPBar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyBlockXPBar.kt
@@ -21,7 +21,7 @@ object SkyBlockXPBar {
     @HandleEvent
     fun onRenderOverlayPre(event: GameOverlayRenderPreEvent) {
         if (!isEnabled()) return
-        if (event.type != RenderLayer.EXPERIENCE) return
+        if (event.type != RenderLayer.EXPERIENCE_BAR) return
         val (level, xp) = SkyBlockXPApi.levelXPPair ?: return
 
         with(MinecraftCompat.localPlayer) {
@@ -32,7 +32,7 @@ object SkyBlockXPBar {
 
     @HandleEvent
     fun onRenderOverlayPost(event: GameOverlayRenderPostEvent) {
-        if (event.type != RenderLayer.EXPERIENCE) return
+        if (event.type != RenderLayer.EXPERIENCE_BAR) return
         with(cache ?: return) {
             MinecraftCompat.localPlayer.setXPStats(currentXP, maxXP, level)
             cache = null

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -57,8 +57,13 @@ object RenderEvents {
     }
 
     @JvmStatic
-    fun postExperienceLayerEventPre(context: DrawContext): Boolean {
-        return GameOverlayRenderPreEvent(context, RenderLayer.EXPERIENCE).post()
+    fun postExperienceBarLayerEventPre(context: DrawContext): Boolean {
+        return GameOverlayRenderPreEvent(context, RenderLayer.EXPERIENCE_BAR).post()
+    }
+
+    @JvmStatic
+    fun postExperienceNumberLayerEventPre(context: DrawContext): Boolean {
+        return GameOverlayRenderPreEvent(context, RenderLayer.EXPERIENCE_NUMBER).post()
     }
 
     @JvmStatic
@@ -74,8 +79,13 @@ object RenderEvents {
     }
 
     @JvmStatic
-    fun postExperienceLayerEventPost(context: DrawContext) {
-        GameOverlayRenderPostEvent(context, RenderLayer.EXPERIENCE).post()
+    fun postExperienceBarLayerEventPost(context: DrawContext) {
+        GameOverlayRenderPostEvent(context, RenderLayer.EXPERIENCE_BAR).post()
+    }
+
+    @JvmStatic
+    fun postExperienceNumberLayerEventPost(context: DrawContext) {
+        GameOverlayRenderPostEvent(context, RenderLayer.EXPERIENCE_NUMBER).post()
     }
 }
 
@@ -90,11 +100,13 @@ enum class RenderLayer {
     FOOD,
     AIR,
     HOTBAR,
-    EXPERIENCE,
+    EXPERIENCE_BAR,
     TEXT,
     HEALTHMOUNT,
     JUMPBAR,
     CHAT,
     PLAYER_LIST,
-    DEBUG;
+    DEBUG,
+    // Not a real forge layer but is used on modern Minecraft versions
+    EXPERIENCE_NUMBER,
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiIngame.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiIngame.java
@@ -35,14 +35,26 @@ public class MixinGuiIngame {
 
     @Inject(method = "renderExperienceBar", at = @At("HEAD"), cancellable = true)
     public void renderExperienceBar(DrawContext context, int x, CallbackInfo ci) {
-        if (RenderEvents.postExperienceLayerEventPre(context)) {
+        if (RenderEvents.postExperienceBarLayerEventPre(context)) {
             ci.cancel();
         }
     }
 
     @Inject(method = "renderExperienceBar", at = @At("TAIL"))
     public void renderExperienceBarTail(DrawContext context, int x, CallbackInfo ci) {
-        RenderEvents.postExperienceLayerEventPost(context);
+        RenderEvents.postExperienceBarLayerEventPost(context);
+    }
+
+    @Inject(method = "renderExperienceLevel", at = @At("HEAD"), cancellable = true)
+    public void renderExperienceLevel(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) {
+        if (RenderEvents.postExperienceNumberLayerEventPre(context)) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "renderExperienceLevel", at = @At("TAIL"))
+    public void renderExperienceLevelTail(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) {
+        RenderEvents.postExperienceNumberLayerEventPost(context);
     }
 
     @Inject(method = "renderPlayerList", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/PlayerListHud;render(Lnet/minecraft/client/gui/DrawContext;ILnet/minecraft/scoreboard/Scoreboard;Lnet/minecraft/scoreboard/ScoreboardObjective;)V", shift = At.Shift.BEFORE), cancellable = true)


### PR DESCRIPTION
## What
Minecraft split up the rendering in the last 10 years, this fixes that we only moved the xp bar.

## Changelog Fixes
+ Fixed movable XP bar not moving XP number on 1.21. - CalMWolfs
