### PR TITLE
Fix: Tree progress display showing on other islands

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
@@ -24,7 +24,7 @@ object TreeProgressDisplay {
     private val config get() = SkyHanniMod.feature.foraging.trees.progress
     private var display: Renderable? = null
 
-    @HandleEvent(onlyOnSkyblock = true)
+    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.enabled) return
         if (display == null) return


### PR DESCRIPTION
## What
Describe what this pull request does, including technical details, screenshots, links to discord, etc.

## Changelog Fixes
+ Fixed Tree Progress displaying on other islands. - nopo