### PR TITLE
Fix: Not knowing walk speed

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -45,7 +45,7 @@ object PlayerUtils {
         //#if MC < 1.21
         return (MinecraftCompat.localPlayer.capabilities.walkSpeed * 1000).toInt()
         //#else
-        //$$ return MinecraftCompat.localPlayer.getAttributeValue(EntityAttributes.MOVEMENT_SPEED).toInt()
+        //$$ return (MinecraftCompat.localPlayer.getAttributeValue(EntityAttributes.MOVEMENT_SPEED) * 1000).toInt()
         //#endif
     }
 


### PR DESCRIPTION
## What
Also have to times by 1000 on 1.21.

## Changelog Fixes
+ Fixed incorrect speed warning when farming on 1.21. - CalMWolfs
