### PR TITLE
Fix; AnimatedItemStackRenderable Out of Frame

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/item/AnimatedItemStackRenderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/item/AnimatedItemStackRenderable.kt
@@ -1,10 +1,13 @@
 package at.hannibal2.skyhanni.utils.renderables.item
 
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.GuiRenderUtils.renderOnScreen
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
+import at.hannibal2.skyhanni.utils.compat.EnchantmentsCompat
 import at.hannibal2.skyhanni.utils.inPartialSeconds
 import net.minecraft.item.ItemStack
 import net.minecraft.util.EnumFacing.Axis
@@ -24,7 +27,10 @@ data class ItemStackBounceDefinition(
     val upwardBounce: Int = 0,
     val downwardBounce: Int = 0,
     val bounceSpeed: Double = 0.0,
-)
+) {
+    fun isEnabled() = (upwardBounce > 0 || downwardBounce > 0) && bounceSpeed > 0.0
+    fun getTotalBounceHeight(): Int = upwardBounce + downwardBounce
+}
 
 /**
  * A data class that defines the rotation behavior of an item stack.
@@ -41,8 +47,21 @@ data class ItemStackRotationDefinition(
     val rotationSpeed: Double = 0.0,
 )
 
+/**
+ * A data class that defines behavior for a 'frame' of an ItemStack animation.
+ *
+ * A ticks parameter of 0 will make the frame last permanently.
+ *
+ * @param stack The ItemStack that should render during this frame.
+ * @param ticks How long this frame should last, in ticks (assuming a nominal 20/s)
+ */
+data class ItemStackAnimationFrame(
+    val stack: ItemStack,
+    val ticks: Int = 0,
+)
+
 class AnimatedItemStackRenderable(
-    item: ItemStack,
+    frames: Collection<ItemStackAnimationFrame>,
     private val rotation: ItemStackRotationDefinition = ItemStackRotationDefinition(),
     private val bounce: ItemStackBounceDefinition = ItemStackBounceDefinition(),
     scale: Double = NeuItems.ITEM_FONT_SIZE,
@@ -53,7 +72,9 @@ class AnimatedItemStackRenderable(
     override val verticalAlign: VerticalAlignment = VerticalAlignment.CENTER,
     override val highlight: Boolean = false,
 ) : ItemStackRenderable(
-    item,
+    frames.firstOrNull()?.stack ?: ErrorManager.skyHanniError(
+        "Cannot initialize AnimatedItemStackRenderable with an empty animation context.",
+    ),
     scale,
     xSpacing,
     ySpacing,
@@ -62,10 +83,42 @@ class AnimatedItemStackRenderable(
     verticalAlign,
     highlight,
 ) {
-    override val height = (15.5 * scale + 0.5).toInt() + ySpacing + bounce.upwardBounce + bounce.downwardBounce
-    private val startTime = SimpleTimeMark.now()
+    constructor(
+        item: ItemStack,
+        rotation: ItemStackRotationDefinition = ItemStackRotationDefinition(),
+        bounce: ItemStackBounceDefinition = ItemStackBounceDefinition(),
+        scale: Double = NeuItems.ITEM_FONT_SIZE,
+        xSpacing: Int = 2,
+        ySpacing: Int = 1,
+        rescaleSkulls: Boolean = true,
+        horizontalAlign: HorizontalAlignment = HorizontalAlignment.LEFT,
+        verticalAlign: VerticalAlignment = VerticalAlignment.CENTER,
+        highlight: Boolean = false,
+    ) : this(
+        listOf(ItemStackAnimationFrame(item, 0)), rotation, bounce, scale, xSpacing,
+        ySpacing, rescaleSkulls, horizontalAlign, verticalAlign, highlight,
+    )
 
-    private var currentRotation: Vec3 = Vec3(0.0, 0.0, 0.0)
+    private var frameIndex = 0
+    private var ticksInFrame = 0.0
+    private val frameDefs = frames.map { (itemStack, ticks) ->
+        val newStack = itemStack.copy().apply {
+            if (highlight) addEnchantment(EnchantmentsCompat.PROTECTION.enchantment, 1)
+        }
+        ItemStackAnimationFrame(newStack, ticks)
+    }.takeIfNotEmpty() ?: ErrorManager.skyHanniError(
+        "Cannot initialize AnimatedItemStackRenderable with an empty animation context.",
+    )
+
+    private val startTime = SimpleTimeMark.now()
+    private val baseItemHeight = (15.5 * scale + 0.5).toInt() + ySpacing
+    private val fullBounceHeight = if (bounce.isEnabled()) bounce.getTotalBounceHeight() else 0
+    private val bounceOffset = fullBounceHeight / 2.0
+
+    override val height = baseItemHeight + fullBounceHeight
+    override val stack: ItemStack get() = frameDefs[frameIndex].stack
+
+    var currentRotation: Vec3 = Vec3(0.0, 0.0, 0.0)
     private fun generateNextRotation(deltaTime: Double): Vec3 = Vec3(
         currentRotation.xCoord + when (rotation.axis) {
             Axis.X -> rotation.rotationSpeed * deltaTime
@@ -82,22 +135,34 @@ class AnimatedItemStackRenderable(
     )
 
     private fun ItemStackBounceDefinition.calculateBounce(): Double {
-        if (bounceSpeed == 0.0 || (upwardBounce == 0 && downwardBounce == 0)) return 0.0
+       if (!bounce.isEnabled()) return 0.0
 
         val t = startTime.passedSince().inPartialSeconds
-        val period = (upwardBounce + downwardBounce) * 2.0 / bounceSpeed
+        val period = fullBounceHeight * 2.0 / bounceSpeed
         val theta = (t % period) / period * (2 * Math.PI)
         val sinTheta = sin(theta)
-        return sinTheta * (if (sinTheta >= 0) upwardBounce else downwardBounce)
+        val pureBounce = sinTheta * (if (sinTheta >= 0) upwardBounce else downwardBounce)
+        return pureBounce + bounceOffset
+    }
+
+    private fun tryMoveNextFrame(dt: Double) {
+        val transitionTicks = frameDefs[frameIndex].ticks.takeIf { it > 0 } ?: return
+
+        ticksInFrame += dt * 20.0
+        if (ticksInFrame <= transitionTicks) return
+
+        frameIndex = (frameIndex + 1) % frameDefs.size
+        ticksInFrame = 0.0
     }
 
     override fun renderWithDelta(posX: Int, posY: Int, deltaTime: Duration) {
         currentRotation = generateNextRotation(deltaTime.inPartialSeconds)
         val currentOffsetY = bounce.calculateBounce()
+        tryMoveNextFrame(deltaTime.inPartialSeconds)
 
         stack.renderOnScreen(
-            x = (posX + (xSpacing / 2f)),
-            y = (posY + currentOffsetY).toFloat(),
+            x = (xSpacing / 2f),
+            y = currentOffsetY.toFloat(),
             scaleMultiplier = scale,
             rescaleSkulls = rescaleSkulls,
             rotationDegrees = currentRotation,

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/item/AnimatedItemStackRenderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/item/AnimatedItemStackRenderable.kt
@@ -135,7 +135,7 @@ class AnimatedItemStackRenderable(
     )
 
     private fun ItemStackBounceDefinition.calculateBounce(): Double {
-       if (!bounce.isEnabled()) return 0.0
+        if (!bounce.isEnabled()) return 0.0
 
         val t = startTime.passedSince().inPartialSeconds
         val period = fullBounceHeight * 2.0 / bounceSpeed

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/item/ItemStackRenderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/item/ItemStackRenderable.kt
@@ -21,7 +21,7 @@ open class ItemStackRenderable(
     override val verticalAlign: VerticalAlignment = VerticalAlignment.CENTER,
     open val highlight: Boolean = false,
 ) : TimeDependentRenderable() {
-    val stack: ItemStack = item.copy().apply {
+    open val stack: ItemStack = item.copy().apply {
         if (highlight) addEnchantment(EnchantmentsCompat.PROTECTION.enchantment, 1)
     }
 
@@ -30,12 +30,16 @@ open class ItemStackRenderable(
 
     override fun renderWithDelta(posX: Int, posY: Int, deltaTime: Duration) {
         stack.renderOnScreen(
-            xSpacing / 2.0f,
-            0F,
+            xSpacing / 2f,
+            0f,
             scaleMultiplier = scale,
             rescaleSkulls,
         )
     }
 
-    fun withTip() = Renderable.hoverTips(stack, stack.getTooltipCompat(false), stack = stack)
+    fun withTip() = Renderable.hoverTips(
+        stack,
+        stack.getTooltipCompat(false),
+        stack = stack
+    )
 }


### PR DESCRIPTION
## What
Fixed issues with the animated item stack renderable that were causing bounces to go out of the top of the frame. Also pulled the animation stuff out of #4083 while I was here.

exclude_from_changelog
