### PR TITLE
Backend: Performance update for bazaar order helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationTableApi.kt
@@ -29,8 +29,8 @@ object ExperimentationTableApi {
     private val inTable get() = inventoriesPattern.matches(openInventoryName())
     var currentExperiment: Experiment? = null
     val superpairInventory = InventoryDetector(
-        openInventory = { name ->
-            currentExperiment = superpairsPattern.matchMatcher(name) {
+        openInventory = { event ->
+            currentExperiment = superpairsPattern.matchMatcher(event.inventoryName) {
                 Experiment.entries.find { it.nameString == group("experiment") }
             }
         },


### PR DESCRIPTION
## What
instead of checking all items in the bz order menu every frame against multiple mixins, we now only do so once on inventory open.
Also using inventory detector to cache the inventory name.
Also changed the backend of inventory detector to pass the inventory open event over to the parameter.

## Changelog Technical Details
+ Added caching to BZ Order Helper. - hannibal2