### PR TITLE
Fix: Wrongly named option in AttributeShardOverlay

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/bazaar/HypixelBazaarFetcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/bazaar/HypixelBazaarFetcher.kt
@@ -83,8 +83,8 @@ object HypixelBazaarFetcher {
 
     private fun process(products: Map<String, BazaarProduct>) = products.mapNotNull { (key, product) ->
         val internalName = NeuItems.transHypixelNameToInternalName(key)
-        val sellOfferPrice = product.buySummary.minOfOrNull { it.pricePerUnit } ?: 0.0
-        val instantBuyPrice = product.sellSummary.maxOfOrNull { it.pricePerUnit } ?: 0.0
+        val instantBuyPrice = product.buySummary.minOfOrNull { it.pricePerUnit } ?: 0.0
+        val instantSellPrice = product.sellSummary.maxOfOrNull { it.pricePerUnit } ?: 0.0
 
         if (product.quickStatus.isEmpty()) {
             return@mapNotNull null
@@ -96,7 +96,7 @@ object HypixelBazaarFetcher {
             if (!isUnobtainableBazaarProduct(key) && SkyHanniDebugsAndTests.enabled) println("Unknown bazaar product: $key/$internalName")
             return@mapNotNull null
         }
-        internalName to BazaarData(internalName.repoItemName, sellOfferPrice, instantBuyPrice, product)
+        internalName to BazaarData(internalName.repoItemName, instantBuyPrice, instantSellPrice, product)
     }.toMap()
 
     private fun isUnobtainableBazaarProduct(key: String): Boolean = when (key) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -178,7 +178,7 @@ object CropMoneyDisplay {
                 val bazaarData = internalName.getBazaarData()
                 val price =
                     if (SkyBlockUtils.noTradeMode || bazaarData == null) internalName.getNpcPrice() / 160
-                    else (bazaarData.instantBuyPrice + bazaarData.sellOfferPrice) / 320
+                    else (bazaarData.instantSellPrice + bazaarData.instantBuyPrice) / 320
                 extraMoneyPerHour.dicerCoins = 60 * 60 * GardenCropSpeed.getRecentBPS() * dicerDrops * price
             }
 
@@ -319,8 +319,8 @@ object CropMoneyDisplay {
         val bazaarData = internalName.getBazaarData() ?: return null
 
         val npcCoins = internalName.getNpcPrice() * cropsPerHour
-        val sellOfferCoins = bazaarData.sellOfferPrice * cropsPerHour
-        val instantSellCoins = bazaarData.instantBuyPrice * cropsPerHour
+        val sellOfferCoins = bazaarData.instantBuyPrice * cropsPerHour
+        val instantSellCoins = bazaarData.instantSellPrice * cropsPerHour
         val bountifulCoins = if (toolHasBountiful?.get(crop) == true && config.bountiful) speedPerHour * 0.2 else 0.0
 
         return CropMoneyData(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardOverlay.kt
@@ -63,7 +63,7 @@ object AttributeShardOverlay {
 
     enum class AttributeShardPriceSource(val displayName: String, val priceSource: ItemPriceSource) {
         INSTANT_BUY("BZ Instant Buy", ItemPriceSource.BAZAAR_INSTANT_BUY),
-        SELL_ORDER("BZ Sell Order", ItemPriceSource.BAZAAR_INSTANT_SELL),
+        SELL_ORDER("BZ Buy Order", ItemPriceSource.BAZAAR_INSTANT_SELL),
         ;
 
         override fun toString(): String = displayName

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarBestSellMethod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarBestSellMethod.kt
@@ -58,7 +58,7 @@ object BazaarBestSellMethod {
         if (having <= 0) return ""
 
         val data = internalName.getBazaarDataOrError()
-        val totalDiff = (data.sellOfferPrice - data.instantBuyPrice) * having
+        val totalDiff = (data.instantBuyPrice - data.instantSellPrice) * having
         val result = totalDiff.toInt().shortFormat()
 
         val name = internalName.repoItemName

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarData.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.data.bazaar.BazaarProduct
 
 data class BazaarData(
     val displayName: String,
-    val sellOfferPrice: Double,
     val instantBuyPrice: Double,
+    val instantSellPrice: Double,
     val product: BazaarProduct,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderHelper.kt
@@ -104,7 +104,7 @@ object BazaarOrderHelper {
 
             pricePattern.matchMatcher(line) {
                 val price = group("number").formatDouble()
-                if (buyOrSell.first && price < data.instantBuyPrice || buyOrSell.second && price > data.sellOfferPrice) {
+                if (buyOrSell.first && price < data.instantSellPrice || buyOrSell.second && price > data.instantBuyPrice) {
                     map[slot] = LorenzColor.GOLD
                     return
                 }

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -427,11 +427,11 @@ object SkyHanniDebugsAndTests {
         val internalName = event.itemStack.getInternalNameOrNull() ?: return
 
         val data = internalName.getBazaarData() ?: return
+        val instantSellPrice = data.instantSellPrice
         val instantBuyPrice = data.instantBuyPrice
-        val sellOfferPrice = data.sellOfferPrice
 
+        event.toolTip.add("§7BZ instantSellPrice: ${instantSellPrice.addSeparators()}")
         event.toolTip.add("§7BZ instantBuyPrice: ${instantBuyPrice.addSeparators()}")
-        event.toolTip.add("§7BZ sellOfferPrice: ${sellOfferPrice.addSeparators()}")
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemPriceUtils.kt
@@ -50,7 +50,7 @@ object ItemPriceUtils {
 
         if (priceSource != ItemPriceSource.NPC_SELL) {
             getBazaarData()?.let {
-                return if (priceSource == ItemPriceSource.BAZAAR_INSTANT_BUY) it.sellOfferPrice else it.instantBuyPrice
+                return if (priceSource == ItemPriceSource.BAZAAR_INSTANT_BUY) it.instantBuyPrice else it.instantSellPrice
             }
 
             getLowestBinOrNull()?.let {
@@ -127,8 +127,8 @@ object ItemPriceUtils {
             add("getLowestBinOrNull: §6${internalName.getLowestBinOrNull()?.addSeparators()}")
 
             internalName.getBazaarData().let {
-                add("getBazaarData sellOfferPrice: §6${it?.sellOfferPrice?.addSeparators()}")
                 add("getBazaarData instantBuyPrice: §6${it?.instantBuyPrice?.addSeparators()}")
+                add("getBazaarData instantSellPrice: §6${it?.instantSellPrice?.addSeparators()}")
             }
 
             add("getNpcPriceOrNull: §6${internalName.getNpcPriceOrNull()?.addSeparators()}")


### PR DESCRIPTION
## What
So basically the bazaar stuff was all wrong as instant buy price is the same as sell order price. Below should be the only user facing change I think as the rest is debug or internal code.

## Changelog Fixes
+ Fixed wrongly named option in Attribute Shard Overlay. - CalMWolfs

