### PR TITLE
Fix: Hide "Config Button" option on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
@@ -164,6 +164,7 @@ class GuiConfig {
     @ConfigOption(name = "Config Button", desc = "Add a button to the pause menu to configure SkyHanni.")
     @ConfigEditorBoolean
     @FeatureToggle
+    @OnlyLegacy
     var configButtonOnPause: Boolean = true
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.features.gui
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyLegacy
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.features.chroma.ChromaConfig
 import at.hannibal2.skyhanni.config.features.gui.customscoreboard.CustomScoreboardConfig


### PR DESCRIPTION
## What
Made the "Config Button" option hidden on modern Minecraft versions. It already doesn't work and I do not think we should be implementing this, as we already have Mod Menu integration. Let's leave mods putting config buttons in the pause menu in the past.

## Changelog Fixes
+ Removed non-functional "Config Button" option on Minecraft 1.21. - Luna
    * Use Mod Menu instead.