### PR TITLE
Fix: Incorrect highlight for locked HOTM perks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -451,7 +451,7 @@ enum class HotmData(
 
         override val notUnlockedPattern by patternGroup.pattern(
             "perk.notunlocked",
-            "(?:§.)*Requires.*|.*Mountain!|(?:§.)*Click to unlock!|",
+            "(?:§.)*Requires.*|.*Mountain(?:§.)*!|(?:§.)*Click to unlock!",
         )
 
         /**

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -449,6 +449,12 @@ enum class HotmData(
             "(?:§.)*§(?<color>.)Level (?<level>\\d+).*",
         )
 
+        /**
+          * REGEX-TEST: §7§cRequires Mining Speed
+          * REGEX-TEST: §7§cRequires Tier 10
+          * REGEX-TEST: §5Mountain§c!
+          * REGEX-TEST: §7§eClick to unlock!
+          */
         override val notUnlockedPattern by patternGroup.pattern(
             "perk.notunlocked",
             "(?:§.)*Requires.*|.*Mountain(?:§.)*!|(?:§.)*Click to unlock!",

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -450,11 +450,11 @@ enum class HotmData(
         )
 
         /**
-          * REGEX-TEST: §7§cRequires Mining Speed
-          * REGEX-TEST: §7§cRequires Tier 10
-          * REGEX-TEST: §5Mountain§c!
-          * REGEX-TEST: §7§eClick to unlock!
-          */
+         * REGEX-TEST: §7§cRequires Mining Speed
+         * REGEX-TEST: §7§cRequires Tier 10
+         * REGEX-TEST: §5Mountain§c!
+         * REGEX-TEST: §7§eClick to unlock!
+         */
         override val notUnlockedPattern by patternGroup.pattern(
             "perk.notunlocked",
             "(?:§.)*Requires.*|.*Mountain(?:§.)*!|(?:§.)*Click to unlock!",


### PR DESCRIPTION
## What
Thank you Hypixel... (also removed a stray `|` at the end)

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/e6001e73-ef6f-49c2-8cde-aea508899abd)
</details>

## Changelog Fixes
+ Fixed some HOTM perks you haven't unlocked being incorrectly highlighted. - Luna
