### PR TITLE
Fix: Minor performance issues

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/chroma/ChromaFontManager.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/chroma/ChromaFontManager.kt
@@ -51,7 +51,12 @@ fun forceChromaStyleIfNecessary(style: Style): Style {
 
 fun isNotActuallyEqualBecauseOfChroma(
     textColor: TextColor,
-    testObject: Any
+    testObject: Any,
 ): Boolean = testObject is TextColor &&
     (textColor.name == "chroma" || testObject.name == "chroma") &&
-    textColor.name != testObject.name
+    textColor.getTextColorName() != testObject.getTextColorName()
+
+// the get name inside of text colour does a string format and is very bad for performance
+private fun TextColor.getTextColorName(): String? {
+    return if (name != null) name else rgb.toString()
+}

--- a/versions/1.21.5/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.5/src/main/resources/skyhanni.accesswidener
@@ -32,3 +32,4 @@ accessible method net/minecraft/text/TextColor <init> (ILjava/lang/String;)V
 accessible field net/minecraft/client/gui/screen/ingame/AbstractSignEditScreen text Lnet/minecraft/block/entity/SignText;
 accessible field net/minecraft/client/gui/screen/ingame/AbstractSignEditScreen currentRow I
 accessible method net/minecraft/client/gui/screen/ingame/AbstractSignEditScreen setCurrentRowMessage (Ljava/lang/String;)V
+accessible field net/minecraft/text/TextColor name Ljava/lang/String;


### PR DESCRIPTION
## What
Every time a text object was compared to another it would call a string format which is not great for performance

<details>
<summary>Images</summary>

Before: Skyhanni is half of this skyblocker function
![image](https://github.com/user-attachments/assets/eebf4682-c83b-4987-8da7-9584bff2ca45)

After: Skyhanni is so small it doesnt even show it
![image](https://github.com/user-attachments/assets/e9e97d96-ec15-4102-8375-63e110d49870)

</details>

## Changelog Fixes
+ Fixed minor performance issues. - nopo