### PR TITLE
Fix: Blaze Daggers display on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/TitleData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/TitleData.kt
@@ -5,6 +5,9 @@ import at.hannibal2.skyhanni.events.TitleReceivedEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import net.minecraft.network.play.server.S45PacketTitle
+//#if MC > 1.21
+//$$ import net.minecraft.network.packet.s2c.play.SubtitleS2CPacket
+//#endif
 
 @SkyHanniModule
 object TitleData {
@@ -13,9 +16,15 @@ object TitleData {
     fun onReceiveCurrentShield(event: PacketReceivedEvent) {
         val packet = event.packet
 
-        if (packet !is S45PacketTitle) return
-        val message = packet.message ?: return
-        val formattedText = message.formattedText
+        val text = when (packet) {
+            is S45PacketTitle -> packet.message ?: return
+            //#if MC > 1.21
+            //$$ is SubtitleS2CPacket -> packet.text
+            //#endif
+            else -> return
+        }
+
+        val formattedText = text.formattedText
         if (TitleReceivedEvent(formattedText).post()) {
             event.cancel()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerDaggerHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerDaggerHelper.kt
@@ -181,7 +181,7 @@ object BlazeSlayerDaggerHelper {
         if (!isEnabled()) return
 
         for (shield in HellionShield.entries) {
-            if (shield.formattedName + "§r" == event.title) {
+            if (shield.formattedName in event.title) {
                 for (dagger in Dagger.entries.filter { shield in it.shields }) {
                     dagger.shields.forEach { it.active = false }
                     dagger.updated = true


### PR DESCRIPTION
## What
Added SubtitleS2CPacket to TitleReceivedEvent as titles and subtitles are split into 2 different packets on 1.21 and fixed checking for attunement in title.

## Changelog Fixes
+ Fixed Blaze Daggers display on 1.21. - yhtez

## Changelog Technical Details
+ Added SubtitleS2CPacket to TitleReceivedEvent on 1.21. - yhtez
