### PR TITLE
Fix: Pet Display Names

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -686,8 +686,8 @@ object ItemUtils {
 
     @Suppress("ReturnCount")
     private fun NeuInternalName.grabItemName(): String {
-        if (this.getItemStackOrNull()?.getPetInfo() != null) {
-            return PetUtils.getCleanPetName(this@grabItemName, colored = true) + " Pet"
+        if (this.isPet) {
+            return PetUtils.getCleanPetName(this, colored = true) + " Pet"
         }
         if (this == NeuInternalName.WISP_POTION) {
             return "§fWisp's Ice-Flavored Water"

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetInfo
 import net.minecraft.init.Items
@@ -96,7 +97,7 @@ class NeuInternalName private constructor(private val internalName: String) {
         }
 
     val isPet: Boolean
-        get() = this in PetUtils.petInternalNames || this.getItemStackOrNull()?.getPetInfo() != null
+        get() = this in PetUtils.petInternalNames || this.getItemStackOrNull()?.getItemCategoryOrNull() == ItemCategory.PET
 
     private val isEnchantedBook: Boolean
         get() = getItemStackOrNull()?.item == Items.enchanted_book

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetInfo
 import net.minecraft.init.Items
 
 class NeuInternalName private constructor(private val internalName: String) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetInfo
 import net.minecraft.init.Items
 
 class NeuInternalName private constructor(private val internalName: String) {
@@ -95,7 +96,7 @@ class NeuInternalName private constructor(private val internalName: String) {
         }
 
     val isPet: Boolean
-        get() = this in PetUtils.petInternalNames
+        get() = this in PetUtils.petInternalNames || this.getItemStackOrNull()?.getPetInfo() != null
 
     private val isEnchantedBook: Boolean
         get() = getItemStackOrNull()?.item == Items.enchanted_book


### PR DESCRIPTION
## What
Fixed display names of pets -- see changelog/images.

<details>
<summary>Images</summary>

Before:
![image](https://github.com/user-attachments/assets/f6806acd-cdc9-4f01-b1df-47859da4002f)
![image](https://github.com/user-attachments/assets/2e8482fb-2b75-4355-9ab1-cde018774c91)

After:
![image](https://github.com/user-attachments/assets/0a482436-3a1e-4b51-a99d-a2003e2068f0)
![image](https://github.com/user-attachments/assets/c5fc00f8-76ed-4478-acfd-61787862ddac)
</details>

## Changelog Fixes
+ Fixed pets showing "[Lvl {LVL}]" in names in displays/trackers. - Daveed
