### PR TITLE
Fix: Unneeded memory use when a OrderedText object was kept in use

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -45,39 +45,39 @@ object ModifyVisualWords {
         return textCache.getOrPut(orderedText) {
 
             var characters = mutableListOf<StyledCharacter>()
-            var hasCachedCharacters = false
-            var lastDiff = 1
             var replace = true
 
-            OrderedText { visitor ->
-                if (!hasCachedCharacters) {
-
-                    var lastIndex = 0
-                    orderedText.accept { index, style, codePoint ->
-                        if (codePoint == -1) {
-                            replace = false
-                            return@accept true
-                        }
-                        lastDiff = index - lastIndex
-                        lastIndex = index
-                        characters.add(StyledCharacter(codePoint, style, index == 0))
-                        true
-                    }
-
-                    if (replace) characters = doReplacements(characters)
-
-                    hasCachedCharacters = true
+            orderedText.accept { index, style, codePoint ->
+                if (codePoint == -1) {
+                    replace = false
+                    return@accept true
                 }
-
-                var index = 0
-                for (character in characters) {
-                    if (!visitor.accept(index, character.style, character.codePoint)) {
-                        return@OrderedText false
-                    }
-                    index += lastDiff
-                }
+                characters.add(StyledCharacter(codePoint, style, index == 0))
                 true
             }
+
+            if (replace) characters = doReplacements(characters)
+
+            val outputTexts = mutableListOf<OrderedText>()
+            var lastStyle: Style? = null
+            val textStringBuilder = StringBuilder()
+
+            for (character in characters) {
+                if (character.style != lastStyle) {
+                    outputTexts.add(OrderedText.styledForwardsVisitedString(textStringBuilder.toString(), lastStyle))
+
+                    lastStyle = character.style
+
+                    outputTexts.clear()
+                }
+                textStringBuilder.appendCodePoint(character.codePoint)
+            }
+
+            if (textStringBuilder.isNotEmpty()) {
+                outputTexts.add(OrderedText.styledForwardsVisitedString(textStringBuilder.toString(), lastStyle))
+            }
+
+            OrderedText.concat(outputTexts)
         }
     }
 

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -64,11 +64,12 @@ object ModifyVisualWords {
 
             for (character in characters) {
                 if (character.style != lastStyle) {
-                    outputTexts.add(OrderedText.styledForwardsVisitedString(textStringBuilder.toString(), lastStyle))
+                    if (textStringBuilder.isNotEmpty())
+                        outputTexts.add(OrderedText.styledForwardsVisitedString(textStringBuilder.toString(), lastStyle))
 
                     lastStyle = character.style
 
-                    outputTexts.clear()
+                    textStringBuilder.clear()
                 }
                 textStringBuilder.appendCodePoint(character.codePoint)
             }


### PR DESCRIPTION
~~This is such a minor change that I don't think it deserves a changelog entry~~

im gonna cry if you ask me to reformat this again

## Changelog Fixes
+ Fixed memory leak in Visual Words feature. - bloxigus