### PR TITLE
Fix: Crash on 1.8 when mods do weird stuff

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/DrawContextUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/DrawContextUtils.kt
@@ -30,7 +30,12 @@ object DrawContextUtils {
     val drawContext: DrawContext
         get() = _drawContext ?: run {
             ErrorManager.crashInDevEnv("drawContext is null")
-            ErrorManager.skyHanniError("drawContext is null")
+            //#if MC < 1.21
+            ErrorManager.logErrorStateWithData("drawContext is null", "drawContext is null, renderDepth: $renderDepth")
+            DrawContext()
+            //#else
+            //$$ ErrorManager.skyHanniError("drawContext is null")
+            //#endif
         }
 
     fun drawItem(item: ItemStack, x: Int, y: Int) = drawContext.drawItem(item, x, y)


### PR DESCRIPTION
## What
I'm not exactly sure how this crash was caused as it didn't seem possible but this is an un-needed exception on 1.8 as `DrawContext` is a fake concept there.

## Changelog Fixes
+ Fixed rare potential crash on 1.8. - CalMWolfs
