### PR TITLE
Improvement: Update Blaze Daggers display instantly on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerDaggerHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerDaggerHelper.kt
@@ -7,8 +7,8 @@ import at.hannibal2.skyhanni.config.core.config.gui.GuiPositionEditor
 import at.hannibal2.skyhanni.config.features.slayer.blaze.BlazeHellionConfig.FirstDaggerEntry
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.SlayerApi
-import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.TitleReceivedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -199,7 +199,7 @@ object BlazeSlayerDaggerHelper {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onBlockClick(event: BlockClickEvent) {
+    fun onItemClick(event: ItemClickEvent) {
         if (!isEnabled()) return
         if (clientSideClicked) return
         if (event.clickType != ClickType.RIGHT_CLICK) return


### PR DESCRIPTION
## What
Fix Blaze Daggers display not updating instantly on 1.21 ([as mentioned in previous PR](https://github.com/hannibal002/SkyHanni/pull/4278#pullrequestreview-2993460340)) by switching to using `ItemClickEvent` rather than `BlockClickEvent`.

## Changelog Improvements
+ Updated Blaze Daggers display instantly on 1.21. - yhtez

## Changelog Technical Details
+ Changed Blaze Dagger helper to use `ItemClickEvent`. - yhtez

