### PR TITLE
Backend: Retry Gradle Resolution Failure

### DIFF
--- a/.github/actions/gradle-retry/action.yml
+++ b/.github/actions/gradle-retry/action.yml
@@ -1,0 +1,20 @@
+name: 'Gradle with resolution-error-only retry'
+description: 'Run ./gradlew [...] and retry only on HTTP/resolution errors'
+inputs:
+    gradle-command:
+        description: 'Arguments to pass to gradlew'
+        required: false
+        default: 'build --stacktrace'
+    max-attempts:
+        description: 'How many times to retry'
+        required: false
+        default: '3'
+runs:
+    using: composite
+    steps:
+        - name: Retryable Gradle
+          shell: bash
+          run: |
+              export MAX_RETRIES=${{ inputs.max-attempts }}
+              chmod +x scripts/gradlew-retry.kts
+              scripts/gradlew-retry.kts ${{ inputs.gradle-command }}

--- a/.github/scripts/gradlew-retry.kts
+++ b/.github/scripts/gradlew-retry.kts
@@ -1,0 +1,54 @@
+#!/usr/bin/env kotlin
+
+import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.toJavaDuration
+
+// How many times to retry - override with MAX_RETRIES env var
+val maxAttempts = System.getenv("MAX_RETRIES")?.toIntOrNull() ?: 3
+
+// Grab everything after the script name as our gradlew args
+val gradleArgs = args.toList()
+if (gradleArgs.isEmpty()) {
+    println("Usage: gradlew-retry.kts <gradlew-args...>")
+    exitProcess(1)
+}
+val cmd = listOf("./gradlew") + gradleArgs
+
+/**
+ * REGEX-TEST: Could not determine the dependencies of task ':1.8.9:shadowJar'.
+ * REGEX-TEST: Could not GET 'https://repo.spongepowered.org/repository/maven-public/org/spongepowered/mixin/0.7.11-SNAPSHOT/mixin-0.7.11-20180703.121122-1.jar'
+ * REGEX-TEST: Could not GET 'https://maven.minecraftforge.net/org/apache/logging/log4j/log4j-core/'. Received status code 502 from server: Bad Gateway
+ * REGEX-TEST: Could not resolve all files for configuration ':1.16.5-forge:compileClasspath'.
+ */
+val retryableErrorRegex = Regex(
+    // language=RegExp
+    "Could not (?:GET '?(?<url>https?:\\/\\/[^']+)(?:'\\.?)?(?: (?<error>.*))?|determine|resolve)(?: (?:all files for configuration|the dependencies of task) '(?<task>:[^']+)')?",
+    RegexOption.COMMENTS
+)
+
+for (i in 1..maxAttempts) {
+    println("Gradle attempt #$i/$maxAttempts: ${cmd.joinToString(" ")}")
+
+    val proc = ProcessBuilder(cmd)
+        .redirectErrorStream(true)
+        .start()
+    val output = proc.inputStream.bufferedReader().readText()
+    proc.waitFor()
+    print(output)
+
+    if (proc.exitValue() == 0) {
+        println("✅ Build succeeded on attempt #$i")
+        exitProcess(0)
+    } else if (retryableErrorRegex.containsMatchIn(output)) {
+        val backoffTime = (i * 1000).milliseconds
+        println("   detected retryable error; retrying in ${backoffTime.inWholeSeconds} seconds...")
+        Thread.sleep(backoffTime.toJavaDuration())
+    } else {
+        println("   non-retryable failure; aborting.")
+        exitProcess(proc.exitValue())
+    }
+}
+
+println("❌ failed after $maxAttempts attempts")
+exitProcess(1)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,15 +25,19 @@ jobs:
                     repository: ${{ github.event.pull_request.head.repo.full_name }}
 
             -   uses: ./.github/actions/setup-normal-workspace
-            -   name: Build with Gradle
-                run: ./gradlew assemble -x test --stacktrace -PskipDetekt=true
+            -   name: Build with Gradle w/retry
+                uses: ./.github/actions/gradle-retry
+                with:
+                    gradle-command: assemble -x test --stacktrace -PskipDetekt=true
             -   uses: actions/upload-artifact@v4
                 name: Upload development build
                 with:
                     name: "Development Build"
                     path: build/libs/*.jar
-            -   name: Test with Gradle
-                run: ./gradlew test
+            -   name: Test with Gradle w/retry
+                uses: ./.github/actions/gradle-retry
+                with:
+                    gradle-command: test
             -   uses: actions/upload-artifact@v4
                 name: "Upload test report"
                 if: ${{ !cancelled() }}
@@ -56,8 +60,10 @@ jobs:
                 run: |
                     mkdir -p .gradle
                     echo skyhanni.multi-version=compile > .gradle/private.properties
-            -   name: Build with Gradle
-                run: ./gradlew build --stacktrace -PskipDetekt=true
+            -   name: Build with Gradle w/retry
+                uses: ./.github/actions/gradle-retry
+                with:
+                    gradle-command: build --stacktrace -PskipDetekt=true
 
             -   name: Add label if build fails
                 if: ${{ failure() && github.event_name == 'pull_request_target' && github.event.pull_request.state == 'open' }}

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -29,9 +29,10 @@ jobs:
                   ref: ${{ github.event.pull_request.head.ref }}
                   repository: ${{ github.event.pull_request.head.repo.full_name }}
             -   uses: ./.github/actions/setup-normal-workspace
-            -   name: Run detekt main (w/ typing analysis)
-                run: |
-                  ./gradlew detektMain --stacktrace
+            -   name: Run detekt main (w/ typing analysis) w/gradle retry
+                uses: ./.github/actions/gradle-retry
+                with:
+                    gradle-command: detektMain --stacktrace
             -   name: Check if SARIF file exists
                 if: always()
                 id: check_sarif

--- a/.github/workflows/detekt_beta.yml
+++ b/.github/workflows/detekt_beta.yml
@@ -16,9 +16,10 @@ jobs:
             -   name: Checkout PR code
                 uses: actions/checkout@v4
             -   uses: ./.github/actions/setup-normal-workspace
-            -   name: Run detekt main (w/ typing analysis)
-                run: |
-                  ./gradlew detektMain --stacktrace
+            -   name: Run detekt main (w/ typing analysis) w/gradle retry
+                uses: ./.github/actions/gradle-retry
+                with:
+                    gradle-command: detektMain --stacktrace
             -   name: Check if SARIF file exists
                 id: check_sarif
                 run: |

--- a/.github/workflows/generate-constants.yaml
+++ b/.github/workflows/generate-constants.yaml
@@ -26,9 +26,10 @@ jobs:
                     cache: gradle
             -   name: Setup gradle
                 uses: gradle/gradle-build-action@v2
-            -   name: Generate Repo Patterns using Gradle
-                run: |
-                    ./gradlew generateRepoPatterns --stacktrace
+            -   name: Generate Repo Patterns using Gradle w/retry
+                uses: ./.github/actions/gradle-retry
+                with:
+                    gradle-command: generateRepoPatterns --stacktrace
             -   uses: actions/upload-artifact@v4
                 name: Upload generated repo regexes
                 with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,12 +23,13 @@ jobs:
             -   name: Grant execute permission for gradlew
                 run: chmod +x gradlew
 
-            -   name: Run ChangeLog verification
+            -   name: Run ChangeLog verification w/retry
                 env:
                     PR_TITLE: ${{ github.event.pull_request.title }}
                     PR_BODY: ${{ github.event.pull_request.body }}
-                run: |
-                    ./gradlew checkPrDescription -PprTitle="${PR_TITLE}" -PprBody="${PR_BODY}"
+                uses: ./.github/actions/gradle-retry
+                with:
+                    gradle-command: checkPrDescription -PprTitle="${PR_TITLE}" -PprBody="${PR_BODY}"
 
             -   name: Add label if changelog verification fails
                 if: failure()


### PR DESCRIPTION
## What
Even with the changes to repos and resolution strategy, it's still pretty commonplace for PRs to fail their workflows because of an HTTP timeout, or other resolution error.

Unfortunately, without write-access to the repo, and without force-pushing to a branch, there isn't a way for [a user] to re-run their own workflows, so this can lead to PRs being falsely flagged as being in a failing state, when they aren't.

This PR wraps all gradle calls in github workflows in a retry-wrapper, that will look for these errors, and then retry the workflow up to (at default) 3 times, before giving up entirely.

## Changelog Technical Details
+ Added Retry Mechanism for Gradle tasks in GitHub workflows. - Daveed