### PR TITLE
Fix: BZ best sell method 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.java
@@ -27,6 +27,7 @@ public class BazaarConfig {
     @FeatureToggle
     public boolean bestSellMethod = false;
 
+    // TODO rename to bestSellMethodPosition
     @Expose
     @ConfigLink(owner = BazaarConfig.class, field = "bestSellMethod")
     public Position bestSellMethodPos = new Position(394, 142);

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarBestSellMethod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarBestSellMethod.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.bazaar.BazaarOpenedProductEvent
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.getBazaarDataOrError
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils.getAmountInInventory
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
@@ -15,7 +16,9 @@ import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import net.minecraft.item.ItemStack
+import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
 object BazaarBestSellMethod {
@@ -43,6 +46,15 @@ object BazaarBestSellMethod {
     fun onBazaarOpenedProduct(event: BazaarOpenedProductEvent) {
         if (!isEnabled()) return
         display = updateDisplay(event.openedProduct)
+
+        // on 1.21 NeuInternalName.getAmountInInventory() does not include the item currently clicked at
+        if (!PlatformUtils.IS_LEGACY) {
+            DelayedRun.runDelayed(300.milliseconds) {
+                if (display.isEmpty()) {
+                    display = updateDisplay(event.openedProduct)
+                }
+            }
+        }
     }
 
     private fun updateDisplay(internalName: NeuInternalName?): String {


### PR DESCRIPTION
## What
On 1.21 NeuInternalName.getAmountInInventory() does not include the item currently clicked/hovering at the cursor
in 1.8.9 the same functions work correctly though.

the proper fix would be to investigate why 1.8 contains the item hovered over and include that to this utils function in 1.21 as well.

for now, this is a sloppy but perfectly fine working workaround

## Changelog Fixes
+ Fixed Bazaar Best Sell Method often not showing up on 1.21. - hannibal2