### PR TITLE
Fix: Invalid keybinds above 255 on 1.8

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
@@ -203,7 +203,7 @@ object UpdateKeybinds {
         if (!config.storage.hasPlayedBefore) {
             return
         }
-        if (lastMcVersion == currentMcVersion || lastMcVersion != "1.8.9" && currentMcVersion != "1.8.9") {
+        if (lastMcVersion == currentMcVersion || (lastMcVersion != "1.8.9" && currentMcVersion != "1.8.9")) {
             tryFixLegacyKeybinds()
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
@@ -154,16 +154,7 @@ object UpdateKeybinds {
         }
         var shouldNotify = false
         for (keybind in keybinds) {
-            val shimmy = Shimmy.makeShimmy(SkyHanniMod.feature, keybind.split("."))
-            if (shimmy == null) {
-                try {
-                    ErrorManager.skyHanniError("Could not create shimmy for path $keybind")
-                } catch (_: Exception) {
-                    continue
-                }
-            }
-
-            val currentValue = shimmy.getJson().asInt
+            val (shimmy, currentValue) = readKeybindConfig(keybind) ?: continue
 
             if (keybindMap.containsKey(currentValue)) {
                 val newValue = keybindMap[currentValue]
@@ -190,6 +181,17 @@ object UpdateKeybinds {
         }
     }
 
+    private fun readKeybindConfig(keybind: String): Pair<Shimmy, Int>? {
+        val shimmy = Shimmy.makeShimmy(SkyHanniMod.feature, keybind.split("."))
+            ?: try {
+                ErrorManager.skyHanniError("Could not create shimmy for path $keybind")
+            } catch (_: Exception) {
+                return null
+            }
+
+        return shimmy to shimmy.getJson().asInt
+    }
+
     private var hasUpdated = false
 
     @HandleEvent(priority = HandleEvent.HIGH)
@@ -214,16 +216,7 @@ object UpdateKeybinds {
     private fun tryFixLegacyKeybinds() {
         if (!PlatformUtils.IS_LEGACY) return
         for (keybind in keybinds) {
-            val shimmy = Shimmy.makeShimmy(SkyHanniMod.feature, keybind.split("."))
-            if (shimmy == null) {
-                try {
-                    ErrorManager.skyHanniError("Could not create shimmy for path $keybind")
-                } catch (_: Exception) {
-                    continue
-                }
-            }
-
-            val currentValue = shimmy.getJson().asInt
+            val (_, currentValue) = readKeybindConfig(keybind) ?: continue
 
             if (currentValue >= 255) {
                 SkyHanniConfigSearchResetCommand.resetCommand(arrayOf("reset", "config.$keybind"))

--- a/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
@@ -204,9 +204,36 @@ object UpdateKeybinds {
             return
         }
         if (lastMcVersion == currentMcVersion || lastMcVersion != "1.8.9" && currentMcVersion != "1.8.9") {
+            tryFixLegacyKeybinds()
             return
         }
 
         fixKeybinds(lastMcVersion != "1.8.9")
+    }
+
+    private fun tryFixLegacyKeybinds() {
+        if (!PlatformUtils.IS_LEGACY) return
+        for (keybind in keybinds) {
+            val shimmy = Shimmy.makeShimmy(SkyHanniMod.feature, keybind.split("."))
+            if (shimmy == null) {
+                try {
+                    ErrorManager.skyHanniError("Could not create shimmy for path $keybind")
+                } catch (_: Exception) {
+                    continue
+                }
+            }
+
+            val currentValue = shimmy.getJson().asInt
+
+            if (currentValue >= 255) {
+                SkyHanniConfigSearchResetCommand.resetCommand(arrayOf("reset", "config.$keybind"))
+                logger.log("$keybind old $currentValue")
+                logger.log("$keybind resetting to default because it was above 255 on 1.8")
+
+                DelayedRun.runDelayed(3.seconds) {
+                    ChatUtils.chat("Keybind $keybind was invalid and it has been reset, please set it manually in /sh")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What
1.8 only supports like 200 keys and it will crash if you try to get the name of a key above 255

## Changelog Fixes
+ Fixed crashes caused by keybind migration. - nopo
    * Invalid keybinds now reset.
