### PR TITLE
Backend: Fix intellij warnings

### DIFF
--- a/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
+++ b/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
@@ -181,13 +181,12 @@ class ModuleProcessor(
         OutputStreamWriter(file).use {
             it.write("package at.hannibal2.skyhanni.utils\n\n")
             it.write("object VersionConstants {\n")
-            it.write("    val MOD_VERSION = \"$modVersion\"\n")
-            it.write("        private set")
+            it.write("    const val MOD_VERSION = \"$modVersion\"\n")
             it.write("    // Do not use this mc version as its reflective of the compile time version\n")
             it.write("    // And might not be correct at run time\n")
             it.write("    // We use it for the auto updater only\n")
-            it.write("    val MC_VERSION = \"$mcVersion\"\n")
-            it.write("        private set")
+            it.write("    var MC_VERSION = \"$mcVersion\"\n")
+            it.write("        private set\n")
             it.write("}\n")
         }
         logger.warn("Generated VersionConstants file with mod version $modVersion and mc version $mcVersion")

--- a/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
+++ b/annotation-processors/src/main/kotlin/at/hannibal2/skyhanni/skyhannimodule/ModuleProcessor.kt
@@ -181,11 +181,13 @@ class ModuleProcessor(
         OutputStreamWriter(file).use {
             it.write("package at.hannibal2.skyhanni.utils\n\n")
             it.write("object VersionConstants {\n")
-            it.write("    const val MOD_VERSION = \"$modVersion\"\n")
+            it.write("    val MOD_VERSION = \"$modVersion\"\n")
+            it.write("        private set")
             it.write("    // Do not use this mc version as its reflective of the compile time version\n")
             it.write("    // And might not be correct at run time\n")
             it.write("    // We use it for the auto updater only\n")
-            it.write("    const val MC_VERSION = \"$mcVersion\"\n")
+            it.write("    val MC_VERSION = \"$mcVersion\"\n")
+            it.write("        private set")
             it.write("}\n")
         }
         logger.warn("Generated VersionConstants file with mod version $modVersion and mc version $mcVersion")

--- a/src/main/java/at/hannibal2/skyhanni/utils/system/PlatformUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/system/PlatformUtils.kt
@@ -24,11 +24,11 @@ import net.minecraftforge.fml.common.Loader
 object PlatformUtils {
 
     //#if MC < 1.21
-    const val MC_VERSION: String = VersionConstants.MC_VERSION
+    val MC_VERSION: String = VersionConstants.MC_VERSION
     //#else
     //$$ val MC_VERSION: String = net.minecraft.SharedConstants.getGameVersion().name
     //#endif
-    const val IS_LEGACY: Boolean = VersionConstants.MC_VERSION == "1.8.9"
+    val IS_LEGACY: Boolean = VersionConstants.MC_VERSION == "1.8.9"
 
     val isDevEnvironment: Boolean by lazy {
         //#if MC < 1.16


### PR DESCRIPTION
## What
IntelliJ likes to predict what values some members have. For the MC version string and the legacy boolean, this is confusing. IntelliJ thinks while looking at other classes that those members are constants, and will never change.

## Changelog Technical Details
+ Disabled IntelliJ’s MC Version/Legacy Prediction to avoid incorrect warnings and suggestions. - hannibal2