### PR TITLE
Fix: Skymall Search Tag

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -10,6 +10,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableLi
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 import org.lwjgl.input.Keyboard
 
 class ChatConfig {
@@ -184,6 +185,7 @@ class ChatConfig {
     @Expose
     @ConfigOption(name = "Sky Mall Messages", desc = "Hide the Sky Mall messages outside of Mining Islands.")
     @ConfigEditorBoolean
+    @SearchTag("Skymall")
     @FeatureToggle
     var hideSkyMall: Boolean = true
 


### PR DESCRIPTION
## What
adds "skymall" as a search tag for Sky Mall Messages because I genuinely did not know that Sky Mall wasn't called "SkyMall" until I encountered this

exclude_from_changelog

