### PR TITLE
Fix: Modrinth action breaking intellij

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -61,7 +61,4 @@ jobs:
                 run: ./gradlew :sharedVariables:build
 
             -   name: Publish to Modrinth
-                run: ./gradlew publishToModrinth \
-                    -Pchangelog="${{ steps.get_changelog.outputs.changelog }}" \
-                    -PmodVersion="${UPDATE_VERSION}" \
-                    -PmodrinthToken="${MODRINTH_TOKEN}"
+                run: ./gradlew publishToModrinth -Pchangelog="${{ steps.get_changelog.outputs.changelog }}" -PmodVersion="${UPDATE_VERSION}" -PmodrinthToken="${MODRINTH_TOKEN}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import skyhannibuildsystem.ChangelogVerification
 import skyhannibuildsystem.CleanupMappingFiles
 import skyhannibuildsystem.DownloadBackupRepo
-// import skyhannibuildsystem.PublishToModrinth
+import skyhannibuildsystem.PublishToModrinth
 import java.io.Serializable
 import java.nio.file.Path
 import java.util.zip.ZipFile
@@ -132,13 +132,7 @@ val cleanupMappingFiles by tasks.registering(CleanupMappingFiles::class) {
     this.mappingsDirectory.set(layout.projectDirectory.asFile.parentFile)
 }
 
-// val publishToModrinth by tasks.registering(PublishToModrinth::class) {
-//     this.jarDirectory.set(rootProject.layout.buildDirectory.dir("downloadedJars"))
-//     this.changelog = project.findProperty("changelog") as String
-//     this.versionNumber = project.findProperty("modVersion") as String
-//     this.modrinthToken = project.findProperty("modrinthToken") as String
-// }
-
+val publishToModrinth by tasks.registering(PublishToModrinth::class)
 
 tasks.runClient {
     this.javaLauncher.set(

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/PublishToModrinth.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/PublishToModrinth.kt
@@ -33,9 +33,7 @@ abstract class PublishToModrinth : DefaultTask() {
 
     @TaskAction
     fun publishToModrinth() {
-
-        initStuff()
-
+        initVariables()
         val jars = jarDirectory?.get()?.asFile?.listFiles()?.filter { it.extension == "jar" }.orEmpty()
 
         for (jar in jars) {
@@ -43,7 +41,7 @@ abstract class PublishToModrinth : DefaultTask() {
         }
     }
 
-    private fun initStuff() {
+    private fun initVariables() {
         changelog = project.findProperty("changelog") as String
         versionNumber = project.findProperty("modVersion") as String
         modrinthToken = project.findProperty("modrinthToken") as String

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/PublishToModrinth.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/PublishToModrinth.kt
@@ -11,8 +11,6 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.net.http.HttpClient
@@ -21,28 +19,31 @@ import java.time.Duration
 
 abstract class PublishToModrinth : DefaultTask() {
 
-    @get:InputDirectory
-    abstract val jarDirectory: DirectoryProperty
-
-    @get:Input
-    abstract var changelog: String
-
-    @get:Input
-    abstract var versionNumber: String
-
-    @get:Input
-    abstract var modrinthToken: String
+    lateinit var jarDirectory: DirectoryProperty
+    lateinit var changelog: String
+    lateinit var versionNumber: String
+    lateinit var modrinthToken: String
 
     private val userAgent: String
         get() = "SkyHanni-$versionNumber"
 
     @TaskAction
     fun publishToModrinth() {
+
+        initStuff()
+
         val jars = jarDirectory.get().asFile.listFiles()?.filter { it.extension == "jar" }.orEmpty()
 
         for (jar in jars) {
             processJar(jar)
         }
+    }
+
+    private fun initStuff() {
+        jarDirectory.set(project.rootProject.layout.buildDirectory.dir("downloadedJars"))
+        changelog = project.findProperty("changelog") as String
+        versionNumber = project.findProperty("modVersion") as String
+        modrinthToken = project.findProperty("modrinthToken") as String
     }
 
     private val jarNamePattern = "SkyHanni-(?<modVersion>[\\d.]+)-mc(?<mcVersion>[\\d.]+)\\.jar".toPattern()

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/PublishToModrinth.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/PublishToModrinth.kt
@@ -10,7 +10,9 @@ import com.github.mizosoft.methanol.MutableRequest
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.net.http.HttpClient
@@ -19,7 +21,9 @@ import java.time.Duration
 
 abstract class PublishToModrinth : DefaultTask() {
 
-    private lateinit var jarDirectory: DirectoryProperty
+    @get:Internal
+    val jarDirectory: Provider<Directory>? = project.rootProject.layout.buildDirectory.dir("downloadedJars")
+
     private lateinit var changelog: String
     private lateinit var versionNumber: String
     private lateinit var modrinthToken: String
@@ -32,7 +36,7 @@ abstract class PublishToModrinth : DefaultTask() {
 
         initStuff()
 
-        val jars = jarDirectory.get().asFile.listFiles()?.filter { it.extension == "jar" }.orEmpty()
+        val jars = jarDirectory?.get()?.asFile?.listFiles()?.filter { it.extension == "jar" }.orEmpty()
 
         for (jar in jars) {
             processJar(jar)
@@ -40,7 +44,6 @@ abstract class PublishToModrinth : DefaultTask() {
     }
 
     private fun initStuff() {
-        jarDirectory.set(project.rootProject.layout.buildDirectory.dir("downloadedJars"))
         changelog = project.findProperty("changelog") as String
         versionNumber = project.findProperty("modVersion") as String
         modrinthToken = project.findProperty("modrinthToken") as String

--- a/buildSrc/src/main/kotlin/skyhannibuildsystem/PublishToModrinth.kt
+++ b/buildSrc/src/main/kotlin/skyhannibuildsystem/PublishToModrinth.kt
@@ -19,10 +19,10 @@ import java.time.Duration
 
 abstract class PublishToModrinth : DefaultTask() {
 
-    lateinit var jarDirectory: DirectoryProperty
-    lateinit var changelog: String
-    lateinit var versionNumber: String
-    lateinit var modrinthToken: String
+    private lateinit var jarDirectory: DirectoryProperty
+    private lateinit var changelog: String
+    private lateinit var versionNumber: String
+    private lateinit var modrinthToken: String
 
     private val userAgent: String
         get() = "SkyHanni-$versionNumber"


### PR DESCRIPTION
## What
I still have no idea how the old code cooked intellij but it did. So after way too much testing stuff I've come up with a solution that no longer breaks intellij on my laptop and therefore should also not break intellij on other people's devices.
Also did a bit of code cleanup in the action.

Reminder for hannibal,I'm not sure if you ended up adding the modrinth token to the repo so make sure you do that, #4266 has the guide. If this doesnt work I will cry, but obviously dont merge if it breaks your intellij

exclude_from_changelog

