### PR TITLE
Improvement + Fix: Add config option for self-trigger party commands and fix self-trigger interaction with trust level

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/PartyCommandsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/PartyCommandsConfig.java
@@ -18,7 +18,7 @@ public class PartyCommandsConfig {
     @Expose
     @ConfigEditorBoolean
     @ConfigOption(name = "Self-Trigger Commands", desc = "Allow party chat commands to trigger on your own messages.")
-    public boolean selfTriggerCommands = true;
+    public boolean selfTriggerCommands = false;
 
     @Expose
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/PartyCommandsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/PartyCommandsConfig.java
@@ -14,6 +14,12 @@ public class PartyCommandsConfig {
     @ConfigOption(name = "Trust Level", desc = "Choose who can run party chat commands.")
     public @NotNull TrustedUser defaultRequiredTrustLevel = TrustedUser.FRIENDS;
 
+    // TODO should this be customizable per-command
+    @Expose
+    @ConfigEditorBoolean
+    @ConfigOption(name = "Self-Trigger Commands", desc = "Allow party chat commands to trigger on your own messages.")
+    public boolean selfTriggerCommands = true;
+
     @Expose
     @ConfigEditorBoolean
     @ConfigOption(name = "Party Transfer", desc = "Automatically transfer the party to people who type §b!ptme§7.")

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
@@ -108,6 +108,7 @@ object PartyChatCommands {
     }
 
     private fun isTrustedUser(name: String): Boolean {
+        if (name == PlayerUtils.getName()) return true
         val friend = FriendApi.getAllFriends().find { it.name == name }
         return when (config.defaultRequiredTrustLevel) {
             PartyCommandsConfig.TrustedUser.FRIENDS -> friend != null

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
@@ -130,7 +130,7 @@ object PartyChatCommands {
         val commandLabel = event.message.substring(1).substringBefore(' ')
         val command = indexedPartyChatCommands[commandLabel.lowercase()] ?: return
         val name = event.cleanedAuthor
-        if (name == PlayerUtils.getName() && !command.triggerableBySelf) return
+        if (name == PlayerUtils.getName() && (!command.triggerableBySelf || !config.selfTriggerCommands)) return
         if (!command.isEnabled()) return
         if (command.requiresPartyLead && PartyApi.partyLeader != PlayerUtils.getName()) return
         if (isBlockedUser(name)) {


### PR DESCRIPTION
## What
Add a config option for whether party commands should be triggered by yourself and fix self-triggered party commands not working if a trust level was set.

## Changelog Improvements
+ Added config option for self-triggered party commands. - yhtez

## Changelog Fixes
+ Fixed self-triggered party commands incorrectly checking friendship status when trust level was set. - yhtez

