### PR TITLE
Fix: Changelog Viewer wrong format for last entry

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangelogViewer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangelogViewer.kt
@@ -132,7 +132,7 @@ object ChangelogViewer {
         .replace("#+\\s*".toRegex(), "§l§9") // Formatting for headings
         .replace("(\n[ \t]+)[+\\-*][^+\\-*]".toRegex(), "$1§7") // Formatting for sub points
         .replace("\n[+\\-*][^+\\-*]".toRegex(), "\n§a") // Formatting for points
-        .replace("(- [^-\r\n]*\r\n)".toRegex(), "§b§l$1") // Color contributors
+        .replace("(- [^-\r\n]*(\r\n|$))".toRegex(), "§b§l$1") // Color contributors
         .replace("\\[(.+?)\\]\\(.+?\\)".toRegex(), "$1") // Random Links
         .replace("`", "\"") // Fix Code Blocks to look better
         .replace("§l§9(?:Version|SkyHanni)[^\r\n]*\r\n".toRegex(), "") // Remove Version from Body

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangelogViewer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangelogViewer.kt
@@ -132,7 +132,7 @@ object ChangelogViewer {
         .replace("#+\\s*".toRegex(), "§l§9") // Formatting for headings
         .replace("(\n[ \t]+)[+\\-*][^+\\-*]".toRegex(), "$1§7") // Formatting for sub points
         .replace("\n[+\\-*][^+\\-*]".toRegex(), "\n§a") // Formatting for points
-        .replace("(- [^-\r\n]*(\r\n|$))".toRegex(), "§b§l$1") // Color contributors
+        .replace("(- [^-\r\n]*(?:\r\n|$))".toRegex(), "§b§l$1") // Color contributors
         .replace("\\[(.+?)\\]\\(.+?\\)".toRegex(), "$1") // Random Links
         .replace("`", "\"") // Fix Code Blocks to look better
         .replace("§l§9(?:Version|SkyHanni)[^\r\n]*\r\n".toRegex(), "") // Remove Version from Body


### PR DESCRIPTION
## What
I use \r\n to detect the end of the contributer name, but the last line of the changelog has no \r\n at the end therefore matching the end should also be valid.

<details>
<summary>Images</summary>

The issue:
![image](https://github.com/user-attachments/assets/4e88acbd-f16c-49b2-bc57-cf5b53424648)

</details>

## Changelog Fixes
+ Fixed format for last entry of the ChangelogViewer. - Thunderblade73

