### PR TITLE
Fix: Fix Ghost Entities behaving incorrectly

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
@@ -8,7 +8,10 @@ import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.MobUtils.isDefaultValue
 import at.hannibal2.skyhanni.utils.compat.getAllEquipment
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import net.minecraft.entity.item.EntityArmorStand
+import net.minecraft.entity.monster.EntityMob
+import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.network.play.server.S0CPacketSpawnPlayer
 //#if MC < 1.21
 import net.minecraft.network.play.server.S0FPacketSpawnMob
@@ -26,33 +29,37 @@ object FixGhostEntities {
 
     private var recentlyRemovedEntities = ArrayDeque<Int>()
     private var recentlySpawnedEntities = ArrayDeque<Int>()
+    private val hiddenEntityIds = mutableListOf<Int>()
 
     @HandleEvent
     fun onWorldChange() {
         recentlyRemovedEntities = ArrayDeque()
         recentlySpawnedEntities = ArrayDeque()
+        hiddenEntityIds.clear()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onReceiveCurrentShield(event: PacketReceivedEvent) {
-        if (!isEnabled()) return
+    fun onPacketReceive(event: PacketReceivedEvent) {
+        if (!config.fixGhostEntities) return
         // Disable in Kuudra for now - causes players to randomly disappear in supply phase
         // TODO: Remove once fixed
-        if (KuudraApi.inKuudra()) return
 
-        val packet = event.packet
+        // Disabled on modern versions as the detection is not fully correct leading to incorrect hiding of entities
+        // TODO fix this
+        if (KuudraApi.inKuudra || !PlatformUtils.IS_LEGACY) return
 
-        when (packet) {
+        when (val packet = event.packet) {
             is S0CPacketSpawnPlayer -> {
                 if (packet.entityID in recentlyRemovedEntities) {
-                    event.cancel()
+                    hiddenEntityIds.add(packet.entityID)
+                    println("entityIds size: ${hiddenEntityIds.size}")
                 }
                 recentlySpawnedEntities.addLast(packet.entityID)
             }
             //#if MC < 1.21
             is S0FPacketSpawnMob -> {
                 if (packet.entityID in recentlyRemovedEntities) {
-                    event.cancel()
+                    hiddenEntityIds.add(packet.entityID)
                 }
                 recentlySpawnedEntities.addLast(packet.entityID)
             }
@@ -66,18 +73,27 @@ object FixGhostEntities {
                             recentlyRemovedEntities.removeFirst()
                         }
                     }
+                    hiddenEntityIds.remove(entityID)
                 }
             }
         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onCheckRender(event: CheckRenderEntityEvent<EntityArmorStand>) {
-        if (!config.hideTemporaryArmorstands) return
-        with(event.entity) {
-            if (ticksExisted < 10 && isDefaultValue() && getAllEquipment().all { it == null }) event.cancel()
+    fun onCheckRender(event: CheckRenderEntityEvent<*>) {
+        if (config.hideTemporaryArmorstands && event.entity is EntityArmorStand) {
+            with(event.entity) {
+                if (ticksExisted < 10 && isDefaultValue() && getAllEquipment().all { it == null }) {
+                    event.cancel()
+                }
+            }
+        }
+        if (config.fixGhostEntities && (event.entity is EntityMob || event.entity is EntityPlayer)) {
+            with(event.entity) {
+                if (hiddenEntityIds.contains(entityId)) {
+                    event.cancel()
+                }
+            }
         }
     }
-
-    fun isEnabled() = config.fixGhostEntities
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
@@ -52,7 +52,6 @@ object FixGhostEntities {
             is S0CPacketSpawnPlayer -> {
                 if (packet.entityID in recentlyRemovedEntities) {
                     hiddenEntityIds.add(packet.entityID)
-                    println("entityIds size: ${hiddenEntityIds.size}")
                 }
                 recentlySpawnedEntities.addLast(packet.entityID)
             }


### PR DESCRIPTION
## What
Fix Ghost Entities was behaving incorrectly in that it was fully cancelling the entity from being registered to the client which would make this a cheat as you could click through these invisible entities which is not allowed even if they are bugged and not meant to be there. Now we just cancel the rendering event instead which is what the correct behaviour should be.

I've also made some changes to the file to make it work on 1.21 more in line as 1.8 as on 1.8 there is spawnPlayer, spawnMob and spawnObjects so ive added the filter to check for player and mobs. Unfortunately this still doesnt fix all issues with fix ghost entities on 1.21 as players still sometimes randomly are hidden so I've disabled the feature on modern for the time being until its fully fixed.

## Changelog Fixes
+ Fixed Fix ghost entities behaving incorrectly. - CalMWolfs
    * This fixes corpses sometimes being hidden on 1.21.

