### PR TITLE
Improvement: Limit the amount of visual words stored in the visual word caches

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/collection/TimeAndSizeLimitedCache.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/collection/TimeAndSizeLimitedCache.kt
@@ -2,8 +2,8 @@ package at.hannibal2.skyhanni.utils.collection
 
 import com.google.common.cache.Cache
 import com.google.common.cache.RemovalCause
-import kotlin.time.Duration
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 
 @Suppress("unused")
 class TimeAndSizeLimitedCache<K : Any, V : Any>(

--- a/src/main/java/at/hannibal2/skyhanni/utils/collection/TimeAndSizeLimitedCache.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/collection/TimeAndSizeLimitedCache.kt
@@ -1,0 +1,20 @@
+package at.hannibal2.skyhanni.utils.collection
+
+import com.google.common.cache.Cache
+import com.google.common.cache.RemovalCause
+import kotlin.time.Duration
+import java.util.concurrent.TimeUnit
+
+@Suppress("unused")
+class TimeAndSizeLimitedCache<K : Any, V : Any>(
+    maxSize: Long,
+    expireAfterWrite: Duration,
+    removalListener: ((K?, V?, RemovalCause) -> Unit)? = null,
+) : CacheMap<K, V>() {
+
+    override val cache: Cache<K, V> = buildCache {
+        maximumSize(maxSize)
+        expireAfterWrite(expireAfterWrite.inWholeNanoseconds, TimeUnit.NANOSECONDS)
+        setRemovalListener(removalListener)
+    }
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.features.misc.visualwords
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
+import at.hannibal2.skyhanni.utils.collection.TimeAndSizeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.OrderedTextUtils.requiredStyleChangeString
 import net.minecraft.client.MinecraftClient
 import net.minecraft.text.OrderedText
@@ -16,8 +16,8 @@ import kotlin.time.Duration.Companion.minutes
 object ModifyVisualWords {
     private val config get() = SkyHanniMod.feature.gui.modifyWords
 
-    val textCache = TimeLimitedCache<OrderedText, OrderedText>(5.minutes)
-    val stringVisitableCache = TimeLimitedCache<StringVisitable, StringVisitable>(5.minutes)
+    val textCache = TimeAndSizeLimitedCache<OrderedText, OrderedText>(262144, 5.minutes)
+    val stringVisitableCache = TimeAndSizeLimitedCache<StringVisitable, StringVisitable>(262144, 5.minutes)
 
     // Replacements the user added manually via /shwords
     var userModifiedWords = mutableListOf<VisualWordText>()

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -42,6 +42,13 @@ object ModifyVisualWords {
         if (!config.enabled) return orderedText
         if (!changeWords) return orderedText
 
+        if (userModifiedWords.isEmpty() && SkyHanniMod.visualWordsData.modifiedWords.isNotEmpty()) {
+            userModifiedWords.addAll(SkyHanniMod.visualWordsData.modifiedWords.map { VisualWordText.fromVisualWord(it) })
+            update()
+        }
+
+        if (userModifiedWords.isEmpty()) return orderedText
+
         return textCache.getOrPut(orderedText) {
 
             var characters = mutableListOf<StyledCharacter>()
@@ -88,6 +95,13 @@ object ModifyVisualWords {
         if (!config.enabled) return stringVisitable
         if (!changeWords) return stringVisitable
 
+        if (userModifiedWords.isEmpty() && SkyHanniMod.visualWordsData.modifiedWords.isNotEmpty()) {
+            userModifiedWords.addAll(SkyHanniMod.visualWordsData.modifiedWords.map { VisualWordText.fromVisualWord(it) })
+            update()
+        }
+
+        if (userModifiedWords.isEmpty()) return stringVisitable
+
         return stringVisitableCache.getOrPut(stringVisitable) {
             var characters = mutableListOf<StyledCharacter>()
             stringVisitable.visit(
@@ -125,11 +139,6 @@ object ModifyVisualWords {
     }
 
     private fun doReplacements(characters: MutableList<StyledCharacter>): MutableList<StyledCharacter> {
-
-        if (userModifiedWords.isEmpty() && SkyHanniMod.visualWordsData.modifiedWords.isNotEmpty()) {
-            userModifiedWords.addAll(SkyHanniMod.visualWordsData.modifiedWords.map { VisualWordText.fromVisualWord(it) })
-            update()
-        }
 
         var workingCharacters = characters
 

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -16,8 +16,8 @@ import kotlin.time.Duration.Companion.minutes
 object ModifyVisualWords {
     private val config get() = SkyHanniMod.feature.gui.modifyWords
 
-    val textCache = TimeAndSizeLimitedCache<OrderedText, OrderedText>(262144, 5.minutes)
-    val stringVisitableCache = TimeAndSizeLimitedCache<StringVisitable, StringVisitable>(262144, 5.minutes)
+    val textCache = TimeAndSizeLimitedCache<OrderedText, OrderedText>(131072, 5.minutes)
+    val stringVisitableCache = TimeAndSizeLimitedCache<StringVisitable, StringVisitable>(65565, 5.minutes)
 
     // Replacements the user added manually via /shwords
     var userModifiedWords = mutableListOf<VisualWordText>()


### PR DESCRIPTION
## What
Uses a size limited cache to only store a maximum of 200k visual words in memory (probably can be lowered)
https://spark.lucko.me/Tn1H9fqSLV <- shows 4.3m cache entries (a lot)

Also prevents visual words from visual wordsing if there are no visual words to visualually word.

## Changelog Improvements
+ Reduced memory usage with a large amount of text rendering. - bloxigus

