### PR TITLE
Fix: Experiment Addons Helper misbehaving with NEU

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 93
+    const val CONFIG_VERSION = 94
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentationTableConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentationTableConfig.kt
@@ -34,7 +34,7 @@ class ExperimentationTableConfig {
     @Expose
     @ConfigOption(
         name = "Guardian Reminder",
-        desc = "Sends a warning when opening the Experimentation Table without a §9§lGuardian Pet §7equipped."
+        desc = "Sends a warning when opening the Experimentation Table without a §9§lGuardian Pet §7equipped.",
     )
     @ConfigEditorBoolean
     @SearchTag("enchant enchanting")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.features.inventory.experimentationtable
 
+import at.hannibal2.skyhanni.config.FeatureToggle
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
@@ -9,11 +10,20 @@ class ExperimentsAddonsConfig {
 
     @Expose
     @ConfigOption(
+        name = "Enabled",
+        desc = "Enable the helper for Chronomatron and Ultrasequencer."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enabled: Boolean = false
+
+    @Expose
+    @ConfigOption(
         name = "Next Click Helper",
         desc = "Highlights the next slot to click in Chronomatron, and shows all items in Ultrasequencer."
     )
     @ConfigEditorBoolean
-    var highlightNextClick: Boolean = false
+    var highlightNextClick: Boolean = true
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
@@ -11,7 +11,7 @@ class ExperimentsAddonsConfig {
     @Expose
     @ConfigOption(
         name = "Enabled",
-        desc = "Enable the helper for Chronomatron and Ultrasequencer."
+        desc = "Enable the helper for Chronomatron and Ultrasequencer.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -20,7 +20,7 @@ class ExperimentsAddonsConfig {
     @Expose
     @ConfigOption(
         name = "Next Click Helper",
-        desc = "Highlights the next slot to click in Chronomatron, and shows all items in Ultrasequencer."
+        desc = "Highlights the next slot to click in Chronomatron, and shows all items in Ultrasequencer.",
     )
     @ConfigEditorBoolean
     var highlightNextClick: Boolean = true
@@ -28,7 +28,7 @@ class ExperimentsAddonsConfig {
     @Expose
     @ConfigOption(
         name = "Prevent Misclicks",
-        desc = "Prevent clicking wrong colors in Chronomatron, and wrong slots in Ultrasequencer."
+        desc = "Prevent clicking wrong colors in Chronomatron, and wrong slots in Ultrasequencer.",
     )
     @ConfigEditorBoolean
     @SearchTag("missclick")
@@ -37,7 +37,7 @@ class ExperimentsAddonsConfig {
     @Expose
     @ConfigOption(
         name = "Max Clicks Alert",
-        desc = "Display an alert when you reach the maximum clicks gained from Chronomatron or Ultrasequencer."
+        desc = "Display an alert when you reach the maximum clicks gained from Chronomatron or Ultrasequencer.",
     )
     @ConfigEditorBoolean
     var maxSequenceAlert: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.inventory.experimentationtable
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.ExperimentationTableApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
@@ -24,6 +25,7 @@ import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addStrin
 import at.hannibal2.skyhanni.utils.compat.EnchantmentsCompat
 import at.hannibal2.skyhanni.utils.compat.getIdentifierString
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable
+import com.google.gson.JsonPrimitive
 import net.minecraft.item.ItemStack
 
 @SkyHanniModule
@@ -119,6 +121,7 @@ object ExperimentsAddonsHelper {
     // <editor-fold desc="Next click highlighting">
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+        if (!config.enabled) return
         if (!config.highlightNextClick || currentAddonPhase != HelperPhase.REPLICATE) return
 
         if (!ExperimentationTableApi.inAddon) return
@@ -154,6 +157,7 @@ object ExperimentsAddonsHelper {
     // <editor-fold desc="Slot click stuff">
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!config.enabled) return
         if (event.slot == null || event.item == null || !ExperimentationTableApi.inAddon) return
         if (!config.preventMisclicks || currentAddonPhase != HelperPhase.REPLICATE) return
         event.handleChronomatronClick()
@@ -185,6 +189,7 @@ object ExperimentsAddonsHelper {
     // <editor-fold desc="Next click highlighting">
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
     fun onReplaceItem(event: ReplaceItemEvent) {
+        if (!config.enabled) return
         if (!ExperimentationTableApi.inAddon || !config.highlightNextClick || currentAddonPhase != HelperPhase.REPLICATE) return
 
         if (ExperimentationTableApi.inChronomatron) event.replaceChronomatronItem()
@@ -347,4 +352,13 @@ object ExperimentsAddonsHelper {
         )
     }
     // </editor-fold>
+
+    @HandleEvent
+    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+        val basePath = "inventory.experimentationTable.addons"
+        event.move(94, "$basePath.highlightNextClick", "$basePath.enabled")
+        event.transform(94, "$basePath.highlightNextClick") {
+            JsonPrimitive(true)
+        }
+    }
 }


### PR DESCRIPTION
## What
Made a new enabled option along with making the other two options require this. Doesn't fully fix the problem and there is still some weird behaviour in the addons and superpairs but this fixes the neu solver from being fully broken.

## Changelog Fixes
+ Fixed Incompatibilities between Neu and SkyHanni experimentation addons helper. - CalMWolfs

