### PR TITLE
Backend: KuudraTier Enum Class

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraTier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraTier.kt
@@ -15,7 +15,7 @@ enum class KuudraTier(val displayName: String) {
     var doneToday: Boolean = false
 
     private var intLocation: LorenzVec? = null
-    private var intTierNumber: Int = 0
+    private var intTierNumber: Int = ordinal + 1
     private var intDisplayItem: NeuInternalName = "KUUDRA_${name}_TIER_KEY".toInternalName()
 
     val location: LorenzVec? get() = intLocation
@@ -29,10 +29,6 @@ enum class KuudraTier(val displayName: String) {
     fun getTieredDisplayName() = "Tier $intTierNumber ($displayName)"
 
     companion object {
-        init {
-            KuudraTier.entries.forEach { it.setTierNumber(it.ordinal + 1) }
-        }
-
         fun addRepoData(
             displayName: String,
             displayItem: NeuInternalName,

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraTier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraTier.kt
@@ -2,13 +2,47 @@ package at.hannibal2.skyhanni.features.nether.kuudra
 
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 
-class KuudraTier(
-    val name: String,
-    val displayItem: NeuInternalName,
-    val location: LorenzVec?,
-    val tierNumber: Int,
-    var doneToday: Boolean = false,
-) {
-    fun getDisplayName() = "Tier $tierNumber ($name)"
+enum class KuudraTier(val displayName: String) {
+    BASIC("Basic"),
+    HOT("Hot"),
+    BURNING("Burning"),
+    FIERY("Fiery"),
+    INFERNAL("Infernal"),
+    ;
+
+    var doneToday: Boolean = false
+
+    private var intLocation: LorenzVec? = null
+    private var intTierNumber: Int = 0
+    private var intDisplayItem: NeuInternalName = "KUUDRA_${name}_TIER_KEY".toInternalName()
+
+    val location: LorenzVec? get() = intLocation
+    val tierNumber: Int get() = intTierNumber
+    val displayItem: NeuInternalName get() = intDisplayItem
+
+    private fun setTierNumber(tierNumber: Int) { this.intTierNumber = tierNumber }
+    private fun setLocation(location: LorenzVec?) { this.intLocation = location }
+    private fun setDisplayItem(displayItem: NeuInternalName) { this.intDisplayItem = displayItem }
+
+    fun getTieredDisplayName() = "Tier $intTierNumber ($displayName)"
+
+    companion object {
+        init {
+            KuudraTier.entries.forEach { it.setTierNumber(it.ordinal + 1) }
+        }
+
+        fun addRepoData(
+            displayName: String,
+            displayItem: NeuInternalName,
+            location: LorenzVec?,
+            tier: Int,
+        ) {
+            val target = entries.firstOrNull { it.displayName == displayName } ?: return
+            target.setLocation(location)
+            target.setDisplayItem(displayItem)
+            target.setTierNumber(tier)
+        }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/quest/KuudraQuest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/quest/KuudraQuest.kt
@@ -9,5 +9,5 @@ class KuudraQuest(val kuudraTier: KuudraTier, state: QuestState) :
         QuestCategory.KUUDRA,
         "Kill Kuudra ${kuudraTier.name} Tier",
         state,
-        displayName = kuudraTier.getDisplayName()
+        displayName = kuudraTier.getTieredDisplayName()
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/kuudra/DailyKuudraBossHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/kuudra/DailyKuudraBossHelper.kt
@@ -15,17 +15,17 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
-import at.hannibal2.skyhanni.utils.RenderUtils.drawDynamicText
-import at.hannibal2.skyhanni.utils.RenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.addLine
 
 @SkyHanniModule
 object DailyKuudraBossHelper {
 
-    val kuudraTiers = mutableListOf<KuudraTier>()
+    val kuudraTiers get() = KuudraTier.entries
 
     private var kuudraLocation: LorenzVec? = null
     private var allKuudraDone = true
@@ -48,7 +48,7 @@ object DailyKuudraBossHelper {
     fun onKuudraDone(event: KuudraCompleteEvent) {
         val tier = event.kuudraTier
         val kuudraTier = getByTier(tier) ?: return
-        ChatUtils.debug("Detected kuudra tier done: ${kuudraTier.getDisplayName()}")
+        ChatUtils.debug("Detected kuudra tier done: ${kuudraTier.getTieredDisplayName()}")
         DailyQuestHelper.finishKuudra(kuudraTier)
         kuudraTier.doneToday = true
         updateAllKuudraDone()
@@ -63,7 +63,7 @@ object DailyKuudraBossHelper {
             for (tier in kuudraTiers) {
                 if (config.hideComplete.get() && tier.doneToday) continue
                 val result = if (tier.doneToday) "§aDone" else "§bTodo"
-                val displayName = tier.getDisplayName()
+                val displayName = tier.getTieredDisplayName()
                 val displayItem = tier.displayItem
 
                 addLine {
@@ -90,7 +90,6 @@ object DailyKuudraBossHelper {
     }
 
     fun onRepoReload(data: Map<String, ReputationQuest>) {
-        kuudraTiers.clear()
         var tier = 1
         for ((displayName, kuudraTier) in data) {
             val displayItem = kuudraTier.item
@@ -98,7 +97,7 @@ object DailyKuudraBossHelper {
             if (location != null) {
                 kuudraLocation = location
             }
-            kuudraTiers.add(KuudraTier(displayName, displayItem, location, tier))
+            KuudraTier.addRepoData(displayName, displayItem, location, tier)
 
             tier++
         }


### PR DESCRIPTION
## What
Fully qualifies the KuudraTier class as an enum class, and implements late-repo-loading into said class, rather than it just being a class - this is 'necessary' to unfurl a kuudra tier from GSON.

## Changelog Technical Details
+ Refactored `KuudraTier` to an enum class. - Daveed
