### PR TITLE
Backend: Add extra details to enforced config options

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -294,8 +294,9 @@ class BlockingMoulConfigProcessor : MoulConfigProcessor<Features>(SkyHanniMod.fe
             UpdateKeybinds.keybinds.add(extraPath)
         }
         //#endif
-        if (EnforcedConfigValues.isBlockedFromEditing(extraPath)) {
-            return GuiOptionEditorBlocked(default)
+
+        EnforcedConfigValues.isBlockedFromEditing(extraPath)?.let { extraMessage ->
+            return GuiOptionEditorBlocked(default, extraMessage)
         }
 
         if (PlatformUtils.IS_LEGACY) {

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -19,19 +19,19 @@ import kotlin.time.Duration.Companion.INFINITE
 @SkyHanniModule
 object EnforcedConfigValues {
 
-    private var enforcedValues: List<EnforcedValueData> = listOf()
+    private var enforcedConfigValues: List<EnforcedValueData> = listOf()
     private var hasSentPSAsOnce = false
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         val constant = event.getConstant<EnforcedConfigValuesJson>("misc/EnforcedConfigValues").enforcedConfigValues
-        val oldEnforcedValues = enforcedValues
-        enforcedValues = constant.filter {
+        val oldEnforcedValues = enforcedConfigValues
+        enforcedConfigValues = constant.filter {
             SkyHanniMod.modVersion <= it.affectedVersion
         }.filter {
             it.affectedMinecraftVersions?.contains(PlatformUtils.MC_VERSION) ?: true
         }
-        if (oldEnforcedValues == enforcedValues) return
+        if (oldEnforcedValues == enforcedConfigValues) return
         hasSentPSAsOnce = false
         // we have to recreate the whole config when a value changes
         // so that the option is blocked off inside the config
@@ -52,13 +52,13 @@ object EnforcedConfigValues {
     }
 
     private fun sendPSAs() {
-        val notifications = enforcedValues.mapNotNull { it.notificationPSA }
+        val notifications = enforcedConfigValues.mapNotNull { it.notificationPSA }
         for (notification in notifications) {
             if (notification.isNotEmpty()) {
                 NotificationManager.queueNotification(SkyHanniNotification(notification, INFINITE, true))
             }
         }
-        val chat = enforcedValues.flatMap { it.chatPSA.orEmpty() }
+        val chat = enforcedConfigValues.flatMap { it.chatPSA.orEmpty() }
         if (chat.isNotEmpty()) {
             var shouldPrefix = true
             for (line in chat) {
@@ -69,7 +69,7 @@ object EnforcedConfigValues {
     }
 
     private fun enforceOntoConfig(config: Any) {
-        for (enforcedValue in enforcedValues.flatMap { it.enforcedValues }) {
+        for (enforcedValue in enforcedConfigValues.flatMap { it.enforcedValues }) {
             val shimmy = Shimmy.makeShimmy(config, enforcedValue.path.split("."))
             if (shimmy == null) {
                 try {
@@ -85,10 +85,11 @@ object EnforcedConfigValues {
         }
     }
 
-    fun isBlockedFromEditing(optionPath: String): Boolean {
-        return enforcedValues.flatMap { it.enforcedValues }.any {
-            it.path == optionPath
-        }
+    fun isBlockedFromEditing(optionPath: String): String? {
+        val firstEnforcedValue = enforcedConfigValues.firstOrNull { enforcedValueData ->
+            enforcedValueData.enforcedValues.any { it.path == optionPath }
+        } ?: return null
+        return firstEnforcedValue.extraMessage ?: ""
     }
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -19,19 +19,19 @@ import kotlin.time.Duration.Companion.INFINITE
 @SkyHanniModule
 object EnforcedConfigValues {
 
-    private var enforcedConfigValues: List<EnforcedValueData> = listOf()
+    private var enforcedConfigValuesData: List<EnforcedValueData> = listOf()
     private var hasSentPSAsOnce = false
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         val constant = event.getConstant<EnforcedConfigValuesJson>("misc/EnforcedConfigValues").enforcedConfigValues
-        val oldEnforcedValues = enforcedConfigValues
-        enforcedConfigValues = constant.filter {
+        val oldEnforcedValues = enforcedConfigValuesData
+        enforcedConfigValuesData = constant.filter {
             SkyHanniMod.modVersion <= it.affectedVersion
         }.filter {
             it.affectedMinecraftVersions?.contains(PlatformUtils.MC_VERSION) ?: true
         }
-        if (oldEnforcedValues == enforcedConfigValues) return
+        if (oldEnforcedValues == enforcedConfigValuesData) return
         hasSentPSAsOnce = false
         // we have to recreate the whole config when a value changes
         // so that the option is blocked off inside the config
@@ -52,13 +52,13 @@ object EnforcedConfigValues {
     }
 
     private fun sendPSAs() {
-        val notifications = enforcedConfigValues.mapNotNull { it.notificationPSA }
+        val notifications = enforcedConfigValuesData.mapNotNull { it.notificationPSA }
         for (notification in notifications) {
             if (notification.isNotEmpty()) {
                 NotificationManager.queueNotification(SkyHanniNotification(notification, INFINITE, true))
             }
         }
-        val chat = enforcedConfigValues.flatMap { it.chatPSA.orEmpty() }
+        val chat = enforcedConfigValuesData.flatMap { it.chatPSA.orEmpty() }
         if (chat.isNotEmpty()) {
             var shouldPrefix = true
             for (line in chat) {
@@ -69,7 +69,7 @@ object EnforcedConfigValues {
     }
 
     private fun enforceOntoConfig(config: Any) {
-        for (enforcedValue in enforcedConfigValues.flatMap { it.enforcedValues }) {
+        for (enforcedValue in enforcedConfigValuesData.flatMap { it.enforcedValues }) {
             val shimmy = Shimmy.makeShimmy(config, enforcedValue.path.split("."))
             if (shimmy == null) {
                 try {
@@ -86,10 +86,10 @@ object EnforcedConfigValues {
     }
 
     fun isBlockedFromEditing(optionPath: String): String? {
-        val firstEnforcedValue = enforcedConfigValues.firstOrNull { enforcedValueData ->
+        val firstEnforcedValue = enforcedConfigValuesData.firstOrNull { enforcedValueData ->
             enforcedValueData.enforcedValues.any { it.path == optionPath }
         } ?: return null
-        return firstEnforcedValue.extraMessage ?: ""
+        return firstEnforcedValue.extraMessage.orEmpty()
     }
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/GuiOptionEditorBlocked.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/GuiOptionEditorBlocked.kt
@@ -32,7 +32,6 @@ class GuiOptionEditorBlocked(private val base: GuiOptionEditor, private val extr
             (x + iconWidth).toInt(), (y + (oneThird * 2) - fontRenderer.height / 2f).toInt(),
             true, (width - iconWidth).toInt(), -0xbbbc,
         )
-
     }
 
     override fun mouseInput(x: Int, y: Int, width: Int, mouseX: Int, mouseY: Int): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/config/GuiOptionEditorBlocked.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/GuiOptionEditorBlocked.kt
@@ -4,8 +4,7 @@ import io.github.notenoughupdates.moulconfig.common.MyResourceLocation
 import io.github.notenoughupdates.moulconfig.common.RenderContext
 import io.github.notenoughupdates.moulconfig.gui.GuiOptionEditor
 
-class GuiOptionEditorBlocked(base: GuiOptionEditor) : GuiOptionEditor(base.getOption()) {
-    private val base: GuiOptionEditor = base
+class GuiOptionEditorBlocked(private val base: GuiOptionEditor, private val extraMessage: String) : GuiOptionEditor(base.getOption()) {
 
     override fun render(context: RenderContext, x: Int, y: Int, width: Int) {
         // No super. We delegate and overlay ourselves instead.
@@ -18,12 +17,22 @@ class GuiOptionEditorBlocked(base: GuiOptionEditor) : GuiOptionEditor(base.getOp
         context.drawTexturedRect(blockedTexture, x.toFloat(), y.toFloat(), iconWidth, height.toFloat())
 
         val fontRenderer = context.minecraft.defaultFontRenderer
+
+        val oneThird: Float = height / 3f
+
         context.drawStringScaledMaxWidth(
             "This option is currently not available.",
             fontRenderer,
-            (x + iconWidth).toInt(), (y + height / 2f - fontRenderer.height / 2f).toInt(),
+            (x + iconWidth).toInt(), (y + oneThird - fontRenderer.height / 2f).toInt(),
             true, (width - iconWidth).toInt(), -0xbbbc,
         )
+        context.drawStringScaledMaxWidth(
+            extraMessage,
+            fontRenderer,
+            (x + iconWidth).toInt(), (y + (oneThird * 2) - fontRenderer.height / 2f).toInt(),
+            true, (width - iconWidth).toInt(), -0xbbbc,
+        )
+
     }
 
     override fun mouseInput(x: Int, y: Int, width: Int, mouseX: Int, mouseY: Int): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/EnforcedConfigValuesJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/EnforcedConfigValuesJson.kt
@@ -15,6 +15,7 @@ data class EnforcedValueData(
     @Expose var chatPSA: List<String>? = null,
     @Expose var affectedVersion: ModVersion,
     @Expose var affectedMinecraftVersions: List<String>? = null,
+    @Expose var extraMessage: String? = null,
 )
 
 data class EnforcedValue(


### PR DESCRIPTION
## What
Added the option to attatch extra details to a disabled config option. It then renders this text on the config option so people can know why it is disabled and we can say stuff like update to new version for fix.

<details>
<summary>Images</summary>

<img width="555" height="100" alt="image" src="https://github.com/user-attachments/assets/d3f75131-7a0c-4d23-a16a-fd2e459a90ba" />

</details>

## Changelog Technical Details
+ Added the ability to give more info on why a config option is disabled when people view it. - CalMWolfs

