### PR TITLE
Backend: Remove old weird config migrations

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.config
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
-import at.hannibal2.skyhanni.features.misc.limbo.LimboTimeTracker
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.json.asIntOrNull
 import at.hannibal2.skyhanni.utils.json.shDeepCopy
@@ -71,7 +70,7 @@ object ConfigUpdaterMigrator {
             val newParentElement = new.at(np.dropLast(1), true)
             if (newParentElement !is JsonObject) {
                 logger.log(
-                    "Skipping add of $value to $path, since another element already inhabits that path"
+                    "Skipping add of $value to $path, since another element already inhabits that path",
                 )
                 return
             }
@@ -124,7 +123,6 @@ object ConfigUpdaterMigrator {
                 return
             }
             movesPerformed++
-            if (np == listOf("#player", "personalBest")) LimboTimeTracker.workaroundMigration(oldElem.asInt)
             newParentElement.add(np.last(), transform(oldElem.shDeepCopy()))
             logger.log("Moved element from $oldPath to $newPath")
         }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/Storage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/Storage.kt
@@ -11,12 +11,6 @@ class Storage {
     var hasPlayedBefore: Boolean = false
 
     @Expose
-    var savedMouselockedSensitivity: Float = .5f
-
-    @Expose
-    var savedMouseloweredSensitivity: Float = .5f
-
-    @Expose
     var visualWordsImported: Boolean = false
 
     @Expose
@@ -30,10 +24,6 @@ class Storage {
 
     @Expose
     var players: MutableMap<UUID, PlayerSpecificStorage> = mutableMapOf()
-
-    // TODO this should get moved into player specific
-    @Expose
-    var currentFameRank: String = "New player"
 
     @Expose
     var blacklistedUsers: MutableList<String> = mutableListOf()

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/Storage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/Storage.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.config.storage
 
 import at.hannibal2.skyhanni.features.misc.reminders.Reminder
-import at.hannibal2.skyhanni.features.misc.visualwords.VisualWord
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import com.google.gson.annotations.Expose
@@ -16,17 +15,6 @@ class Storage {
 
     @Expose
     var savedMouseloweredSensitivity: Float = .5f
-
-    @Deprecated("Moved into separate file")
-    @Expose
-    var knownFeatureToggles: Map<String, List<String>> = emptyMap()
-
-    @Deprecated(
-        message = "Use SkyHanniMod.visualWordsData.modifiedWords instead.",
-        replaceWith = ReplaceWith("SkyHanniMod.visualWordsData.modifiedWords")
-    )
-    @Expose
-    var modifiedWords: List<VisualWord> = listOf()
 
     @Expose
     var visualWordsImported: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
-import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.isPlayerInside
@@ -42,9 +41,6 @@ object LimboTimeTracker {
     private var onFire = false
 
     private val bedWarsLobbyLimbo = AxisAlignedBB(-662.0, 43.0, -76.0, -619.0, 86.0, -27.0)
-
-    private var doMigrate = false
-    private var notMigratedPB = 0
 
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent) {
@@ -181,27 +177,6 @@ object LimboTimeTracker {
             add("isLimboFake: $inFakeLimbo")
             add("since: ${limboJoinTime.passedSince()}")
         }
-    }
-
-    fun workaroundMigration(personalBest: Int) {
-        doMigrate = true
-        notMigratedPB = personalBest
-    }
-
-    @HandleEvent
-    fun onHypixelJoin(event: HypixelJoinEvent) {
-        if (!doMigrate) return
-        if (notMigratedPB != 0) {
-            ChatUtils.debug("Migrating limbo personalBest")
-            storage?.personalBest = notMigratedPB
-            storage?.userLuck = notMigratedPB * USER_LUCK_MULTIPLIER
-        }
-        if ((storage?.personalBest ?: 0) > (storage?.playtime ?: 0)) {
-            ChatUtils.debug("Migrating limbo playtime")
-            storage?.playtime = (storage?.personalBest ?: 0)
-        }
-        doMigrate = false
-        notMigratedPB = 0
     }
 
     fun isEnabled() = config.showTimeInLimbo

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigFeatures.kt
@@ -21,12 +21,6 @@ object DefaultConfigFeatures {
         if (didNotifyOnce) return
         didNotifyOnce = true
 
-        val oldToggles = SkyHanniMod.feature.storage.knownFeatureToggles
-        if (oldToggles.isNotEmpty()) {
-            SkyHanniMod.knownFeaturesData.knownFeatures = oldToggles
-            SkyHanniMod.feature.storage.knownFeatureToggles = emptyMap()
-        }
-
         val knownToggles = SkyHanniMod.knownFeaturesData.knownFeatures
         val updated = SkyHanniMod.VERSION !in knownToggles
         val processor = FeatureToggleProcessor()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -2,10 +2,8 @@ package at.hannibal2.skyhanni.features.misc.visualwords
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
-import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.mixins.transformers.AccessorMixinGuiNewChat
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -87,17 +85,6 @@ object ModifyVisualWords {
             }
 
             modifiedText
-        }
-    }
-
-    @HandleEvent
-    @Suppress("DEPRECATION")
-    fun onHypixelJoin(event: HypixelJoinEvent) {
-        val oldModifiedWords = SkyHanniMod.feature.storage.modifiedWords
-        if (oldModifiedWords.isNotEmpty()) {
-            SkyHanniMod.visualWordsData.modifiedWords = oldModifiedWords.toMutableList()
-            SkyHanniMod.feature.storage.modifiedWords = emptyList()
-            SkyHanniMod.configManager.saveConfig(ConfigFileType.VISUAL_WORDS, "Migrate visual words")
         }
     }
 }


### PR DESCRIPTION
## What
Remove specific case migrations for limbo pb, visual words and known config options. All of these were changed over a year ago and its not the end of the world if they dont get migrated as if you havent updated for that long you have other problems

## Changelog Technical Details
+ Removed unnecessary config migrations. - CalMWolfs

