### PR TITLE
Fix: Hide lottery messages not hiding

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -315,7 +315,7 @@ object ChatFilter {
 
     private val lotteryMessages = listOf(
         "§bNew day! §r§eYour §r§2Lottery §r§ebuff changed!",
-        "§8§oYou can disable this messaging by toggling Sky Mall in your /hotm!",
+        "§8§oYou can disable this messaging by toggling Lottery in your /hotf!",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -314,8 +314,8 @@ object ChatFilter {
     )
 
     private val lotteryMessages = listOf(
-        "§r§bNew day! §r§eYour §r§2Lottery §r§ebuff changed!",
-        "§r§8§oYou can disable this messaging by toggling Lottery in your /hotf!"
+        "§bNew day! §r§eYour §r§2Lottery §r§ebuff changed!",
+        "§8§oYou can disable this messaging by toggling Sky Mall in your /hotm!",
     )
 
     /**


### PR DESCRIPTION
## What
Hide lottery messages not hiding everything.

## Changelog Fixes
+ Fixed Hide lottery messages only hiding the buff message and not all lottery messages. - CalMWolfs
