### PR TITLE
Fix + Improvement: Crown of Avarice Tracker & Stereo Pants

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -31,12 +31,11 @@ import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 import net.minecraft.tileentity.TileEntity
 //#if MC > 1.21
-//$$ import net.minecraft.entity.attribute.EntityAttributes
-//$$ import net.minecraft.entity.player.PlayerInventory
 //$$ import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
+//$$ import net.minecraft.entity.attribute.EntityAttributes
+//$$ import net.minecraft.entity.EquipmentSlot
 //#else
 import net.minecraft.entity.SharedMonsterAttributes
-
 //#endif
 
 @SkyHanniModule
@@ -171,11 +170,12 @@ object EntityUtils {
     //#else
     //$$ fun LivingEntity.getArmorInventory(): Array<ItemStack?>? {
     //$$     if (this !is PlayerEntity) return null
-    //$$     val list = mutableListOf<ItemStack?>()
-    //$$     for (equipmentSlot in PlayerInventory.EQUIPMENT_SLOTS.values) {
-    //$$         list.add(inventory.equipment.get(equipmentSlot).orNull())
-    //$$     }
-    //$$     return list.normalizeAsArray()
+    //$$     return buildList {
+    //$$         add(inventory.equipment.get(EquipmentSlot.FEET).orNull())
+    //$$         add(inventory.equipment.get(EquipmentSlot.LEGS).orNull())
+    //$$         add(inventory.equipment.get(EquipmentSlot.CHEST).orNull())
+    //$$         add(inventory.equipment.get(EquipmentSlot.HEAD).orNull())
+    //$$     }.normalizeAsArray()
     //$$ }
     //#endif
 

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
@@ -3,6 +3,8 @@ package at.hannibal2.skyhanni.features.foraging
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.NotificationManager
+import at.hannibal2.skyhanni.data.SkyHanniNotification
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
@@ -13,10 +15,11 @@ import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.events.minecraft.ServerTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.ItemUtils.isEnchanted
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.ModernPatterns
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatIntOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
@@ -26,6 +29,7 @@ import at.hannibal2.skyhanni.utils.renderables.StringRenderable
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 import kotlin.math.abs
+import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object MoongladeBeacon {
@@ -111,6 +115,15 @@ object MoongladeBeacon {
             upgradingStrength = true
         }
         currentServerTicks = 0
+        checkPants()
+    }
+
+    private val STEREO_PANTS = "MUSIC_PANTS".toInternalName()
+
+    private fun checkPants() {
+        if (InventoryUtils.getLeggings()?.getInternalName() != STEREO_PANTS) return
+        val text = "The solver may not work properly if you are wearing Stereo Pants!"
+        NotificationManager.queueNotification(SkyHanniNotification(text, length = 5.seconds, showOverInventory = true))
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
Stereo pants are loud, inventory compat was wrong.

<details>
<summary>Images</summary>

<img width="751" height="72" alt="image" src="https://github.com/user-attachments/assets/1e469d22-1374-462a-94d2-423c75701701" />

</details>

## Changelog Improvements
+ Made Moonglade beacon solver notify you if you are wearing stereo pants. - CalMWolfs

## Changelog Fixes
+ Fixed Crown of Avarice tracker sometimes not working on 1.21. - CalMWolfs
