### PR TITLE
Backend: Add `synchronize` to Dep Workflow

### DIFF
--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -2,7 +2,7 @@ name: Check PR Dependencies
 
 on:
     pull_request_target:
-        types: [ opened, edited, closed ]
+        types: [ opened, edited, synchronize, closed ]
 
 permissions:
     contents: read


### PR DESCRIPTION
## What
This is 1/2 from git docs, and 1/2 a shot in the dark - but I _believe_ this should fix the "Waiting on Dependency PR" tag not being removed when it should.

exclude_from_changelog
