### PR TITLE
Fix: ConcurrentModificationException

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -42,8 +42,9 @@ object RenderLivingEntityHelper {
 
     fun check() {
         areMobsHighlighted = false
-        for (entry in entityColorCondition) {
-            if (entry.value.invoke()) {
+        val conditions = entityColorCondition.values
+        for (entry in conditions) {
+            if (entry.invoke()) {
                 areMobsHighlighted = true
                 return
             }


### PR DESCRIPTION
## What
Fixes:

```
java.util.ConcurrentModificationException
	at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:1023)
	at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1058)
	at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1055)
	at knot//at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper.check(RenderLivingEntityHelper.kt:45)
	at knot//net.minecraft.client.renderer.LevelRenderer.handler$eic000$skyhanni$resetRealGlowing(LevelRenderer.java:16555)
	at knot//net.minecraft.client.renderer.LevelRenderer.collectVisibleEntities(LevelRenderer.java)
	at knot//net.minecraft.client.renderer.LevelRenderer.renderLevel(LevelRenderer.java:473)
	at knot//net.minecraft.client.renderer.GameRenderer.renderLevel(GameRenderer.java:756)
	at knot//net.minecraft.client.renderer.GameRenderer.render(GameRenderer.java:517)
	at knot//net.minecraft.client.Minecraft.runTick(Minecraft.java:1353)
	at knot//net.minecraft.client.Minecraft.run(Minecraft.java:936)
	at knot//net.minecraft.client.main.Main.main(Main.java:265)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
```

## Changelog Fixes
+ Fixed rare crash when rendering entities on 1.21. - CalMWolfs

