### PR TITLE
Backend: checkPrDescription null check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,8 +144,8 @@ tasks.runClient {
 
 tasks.register("checkPrDescription", ChangelogVerification::class) {
     this.outputDirectory.set(layout.buildDirectory)
-    this.prTitle = project.findProperty("prTitle") as String
-    this.prBody = project.findProperty("prBody") as String
+    this.prTitle = project.findProperty("prTitle") as? String ?: ""
+    this.prBody = project.findProperty("prBody") as? String ?: ""
 }
 
 // Disabled because it breaks mixins with the minecraft dev plugin


### PR DESCRIPTION
## What
Added a null check to `checkPrDescription` so it doesn't error when it gets triggered outside a PR, e.g. by running `./gradlew -q :tasks --all`.

exclude_from_changelog
