### PR TITLE
Fix: Pet experience tooltip on Jade Dragons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/pets/PetExperienceToolTipConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/pets/PetExperienceToolTipConfig.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.config.FeatureToggle
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class PetExperienceToolTipConfig {
     @Expose
@@ -21,7 +22,8 @@ class PetExperienceToolTipConfig {
     var showAlways: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Dragon Egg", desc = "For a Golden Dragon Egg, show progress to level 100 instead of 200.")
+    @ConfigOption(name = "Dragon Egg", desc = "For a Dragon pets that start as an egg, show progress to level 100 instead of 200.")
+    @SearchTag("golden jade")
     @ConfigEditorBoolean
-    var showGoldenDragonEgg: Boolean = true
+    var showDragonEgg: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
@@ -16,6 +16,7 @@ data class ItemsJson(
     @Expose @SerializedName("book_bundle_amount") val bookBundleAmount: Map<String, Int>,
     @Expose @SerializedName("value_calculation_data") val valueCalculationData: ItemValueCalculationDataJson,
     @Expose @SerializedName("compact_names") val compactNames: Map<String, String>,
+    @Expose @SerializedName("level_200_pet_names") val level200PetNames: Set<String>,
 )
 
 data class ItemValueCalculationDataJson(

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
@@ -16,7 +16,6 @@ data class ItemsJson(
     @Expose @SerializedName("book_bundle_amount") val bookBundleAmount: Map<String, Int>,
     @Expose @SerializedName("value_calculation_data") val valueCalculationData: ItemValueCalculationDataJson,
     @Expose @SerializedName("compact_names") val compactNames: Map<String, String>,
-    @Expose @SerializedName("level_200_pet_names") val level200PetNames: Set<String>,
 )
 
 data class ItemValueCalculationDataJson(

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/PetExpTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/PetExpTooltip.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.KeyboardManager
@@ -110,13 +111,13 @@ object PetExpTooltip {
     }
 
     private fun getMaxValues(petName: String, petExperience: Double): Pair<Int, Int> {
-        val useGoldenDragonLevels =
-            petName.contains("Golden Dragon") && (!config.showGoldenDragonEgg || petExperience >= LEVEL_100_LEGENDARY)
+        val isLevel200Pet = ItemUtils.maxPetLevel(petName) == 200
+        val useLevel200PetLevelling = isLevel200Pet && (!config.showDragonEgg || petExperience >= LEVEL_100_LEGENDARY)
 
-        val maxLevel = if (useGoldenDragonLevels) 200 else 100
+        val maxLevel = if (useLevel200PetLevelling) 200 else 100
 
         val maxXP = when {
-            useGoldenDragonLevels -> LEVEL_200_LEGENDARY
+            useLevel200PetLevelling -> LEVEL_200_LEGENDARY
             petName.contains("Bingo") -> LEVEL_100_COMMON
 
             else -> LEVEL_100_LEGENDARY
@@ -129,10 +130,7 @@ object PetExpTooltip {
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "misc.petExperienceToolTip.petDisplay", "misc.pets.petExperienceToolTip.petDisplay")
         event.move(3, "misc.petExperienceToolTip.showAlways", "misc.pets.petExperienceToolTip.showAlways")
-        event.move(
-            3,
-            "misc.petExperienceToolTip.showGoldenDragonEgg",
-            "misc.pets.petExperienceToolTip.showGoldenDragonEgg",
-        )
+        event.move(3, "misc.petExperienceToolTip.showGoldenDragonEgg", "misc.pets.petExperienceToolTip.showGoldenDragonEgg")
+        event.move(96, "misc.pets.petExperienceToolTip.showGoldenDragonEgg", "misc.pets.petExperienceToolTip.showDragonEgg")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/PetExpTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/PetExpTooltip.kt
@@ -6,15 +6,17 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.LorenzRarity
+import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.PetUtils
 import at.hannibal2.skyhanni.utils.ReflectionUtils.makeAccessible
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetInfo
 import at.hannibal2.skyhanni.utils.StringUtils
@@ -54,7 +56,8 @@ object PetExpTooltip {
                 index
             }
 
-            val (maxLevel, maxXP) = getMaxValues(name, petExperience)
+            val internalName = itemStack.getInternalNameOrNull() ?: return
+            val (maxLevel, maxXP) = getMaxValues(name, petExperience, internalName)
 
             val percentage = petExperience / maxXP
             val percentageFormat = percentage.formatPercentage()
@@ -110,8 +113,8 @@ object PetExpTooltip {
         objectNeuTooltipTweaks.javaClass.getDeclaredField("petExtendExp").makeAccessible()
     }
 
-    private fun getMaxValues(petName: String, petExperience: Double): Pair<Int, Int> {
-        val isLevel200Pet = ItemUtils.maxPetLevel(petName) == 200
+    private fun getMaxValues(petName: String, petExperience: Double, internalName: NeuInternalName): Pair<Int, Int> {
+        val isLevel200Pet = PetUtils.getMaxLevel(internalName) == 200
         val useLevel200PetLevelling = isLevel200Pet && (!config.showDragonEgg || petExperience >= LEVEL_100_LEGENDARY)
 
         val maxLevel = if (useLevel200PetLevelling) 200 else 100

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -672,12 +672,10 @@ object ItemUtils {
     )
 
     @HandleEvent
-    @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
     fun onRepoReload(event: RepositoryReloadEvent) {
         compactItemNameCache.clear()
         // if compactNames is null, we want the npe to happen in onRepoReload(), not in getRepoCompactName()
-        val repoData = event.getConstant<ItemsJson>("Items")
-        compactNameReplace = repoData.compactNames!!
+        compactNameReplace = event.getConstant<ItemsJson>("Items").compactNames!!
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -262,8 +262,6 @@ object ItemUtils {
 
     fun isRecombobulated(stack: ItemStack) = stack.isRecombobulated()
 
-    fun maxPetLevel(name: String) = if (level200PetNames.any { it.contains(name) }) 200 else 100
-
     fun getItemsInInventory(withCursorItem: Boolean = false): List<ItemStack> {
         val list: LinkedList<ItemStack> = LinkedList()
         val player = MinecraftCompat.localPlayer
@@ -665,7 +663,6 @@ object ItemUtils {
     }
 
     private var compactNameReplace = mapOf<String, String>()
-    private var level200PetNames = setOf<String>()
     var bazaarOverrides = mapOf<String, String>()
         private set
 
@@ -681,7 +678,6 @@ object ItemUtils {
         // if compactNames is null, we want the npe to happen in onRepoReload(), not in getRepoCompactName()
         val repoData = event.getConstant<ItemsJson>("Items")
         compactNameReplace = repoData.compactNames!!
-        level200PetNames = repoData.level200PetNames
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -262,7 +262,7 @@ object ItemUtils {
 
     fun isRecombobulated(stack: ItemStack) = stack.isRecombobulated()
 
-    fun maxPetLevel(name: String) = if (name.contains("Golden Dragon")) 200 else 100
+    fun maxPetLevel(name: String) = if (level200PetNames.any { it.contains(name) }) 200 else 100
 
     fun getItemsInInventory(withCursorItem: Boolean = false): List<ItemStack> {
         val list: LinkedList<ItemStack> = LinkedList()
@@ -665,6 +665,7 @@ object ItemUtils {
     }
 
     private var compactNameReplace = mapOf<String, String>()
+    private var level200PetNames = setOf<String>()
     var bazaarOverrides = mapOf<String, String>()
         private set
 
@@ -674,11 +675,13 @@ object ItemUtils {
     )
 
     @HandleEvent
+    @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
     fun onRepoReload(event: RepositoryReloadEvent) {
         compactItemNameCache.clear()
         // if compactNames is null, we want the npe to happen in onRepoReload(), not in getRepoCompactName()
-        @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-        compactNameReplace = event.getConstant<ItemsJson>("Items").compactNames!!
+        val repoData = event.getConstant<ItemsJson>("Items")
+        compactNameReplace = repoData.compactNames!!
+        level200PetNames = repoData.level200PetNames
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -675,6 +675,7 @@ object ItemUtils {
     fun onRepoReload(event: RepositoryReloadEvent) {
         compactItemNameCache.clear()
         // if compactNames is null, we want the npe to happen in onRepoReload(), not in getRepoCompactName()
+        @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
         compactNameReplace = event.getConstant<ItemsJson>("Items").compactNames!!
     }
 


### PR DESCRIPTION
## What
Used level 200 pets from the repo and renamed the option.

## Changelog Fixes
+ Fixed Pet experience tooltip on Jade Dragons. - CalMWolfs

