### PR TITLE
Backend: Wrapped Regex Tests

### DIFF
--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -27,6 +27,8 @@ class RepoPatternElement private constructor(
     }
 
     companion object {
+        private val wrappedRegexTestPattern = "WRAPPED-REGEX-TEST: \"(?<test>.*)\"".toPattern()
+
         fun KtPropertyDelegate.asRepoPatternElement(): RepoPatternElement? {
             val expression = this.expression as? KtDotQualifiedExpression ?: return null
             val callExpression = expression.selectorExpression as? KtCallExpression ?: return null
@@ -65,6 +67,11 @@ class RepoPatternElement private constructor(
                 }
                 if (line.contains("REGEX-FAIL: ")) {
                     failingRegexTests.add(line.substringAfter("REGEX-FAIL: "))
+                }
+                wrappedRegexTestPattern.matcher(line).let { matcher ->
+                    if (!matcher.find()) return@forEach
+                    val test = matcher.group("test") ?: return@forEach
+                    regexTests.add(test)
                 }
             }
             return regexTests to failingRegexTests

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -45,10 +45,10 @@ object NeuItems {
     private val patternGroup = RepoPattern.group("data.neu.items")
 
     /**
-     * REGEX-TEST: §7[lvl 1➡100]
-     * REGEX-TEST: §f§f§7[lvl {lvl}]
-     * REGEX-TEST: §f§f§7[lvl 1➡100]
-     * REGEX-TEST: §f§f§7[Lvl {LVL}]
+     * WRAPPED-REGEX-TEST: "§7[lvl 1➡100] "
+     * WRAPPED-REGEX-TEST: "§f§f§7[lvl {lvl}] "
+     * WRAPPED-REGEX-TEST: "§f§f§7[lvl 1➡100] "
+     * WRAPPED-REGEX-TEST: "§f§f§7[Lvl {LVL}] "
      */
     private val neuPetLevelRegex by patternGroup.pattern(
         "pet-level",

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -52,7 +52,7 @@ object NeuItems {
      */
     private val neuPetLevelRegex by patternGroup.pattern(
         "pet-level",
-        "(?i)(?:§.)+\\[lvl (?:\\d+➡\\d+|\\{lvl})\\] ?"
+        "(?i)(?:§.)+\\[lvl (?:\\d+➡\\d+|\\{lvl})\\] "
     )
 
     /** Keys are internal names as String */


### PR DESCRIPTION
## What
In some cases, it would be beneficial to be able to quote escape regex tests that end with spaces, or contain other characters in which intelliJ tries to treat the string as, not a string.

<details>
<summary>Images</summary>

<img width="1470" height="332" alt="image" src="https://github.com/user-attachments/assets/185276ab-c65c-48da-bfd5-9673b96ef1af" />
</details>

## Changelog Technical Details
+ Added `WRAPPED-REGEX-TEST`. - Daveed
    * Ability to wrap regex tests in quotes.

