### PR TITLE
Fix: TextCompat Hover NPE

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -172,7 +172,7 @@ var IChatComponent.hover: IChatComponent?
         //#if MC < 1.16
         this.chatStyle.chatHoverEvent = value?.let { HoverEvent(HoverEvent.Action.SHOW_TEXT, it) }
         //#else
-        //$$ (this as MutableText).styled {it.withHoverEvent(HoverEvent.ShowText(value))}
+        //$$ value?.let { value -> (this as MutableText).styled { it.withHoverEvent(HoverEvent.ShowText(value)) } }
         //#endif
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -214,7 +214,7 @@ var IChatComponent.url: String?
         //#if MC < 1.16
         this.chatStyle.chatClickEvent = value?.let { ClickEvent(ClickEvent.Action.OPEN_URL, it) }
         //#else
-        //$$ (this as MutableText).styled { (it.withClickEvent(ClickEvent.OpenUrl(URI.create(value)))) }
+        //$$ (this as MutableText).styled { (it.withClickEvent(ClickEvent.OpenUrl(URI.create(value.orEmpty())))) }
         //#endif
     }
 


### PR DESCRIPTION
## What
Fixed a missing null check in TextCompat.hover on modern Minecraft versions causing crashes.

## Changelog Fixes
+ Fixed rare crash when hovering over chat messages on 1.21. - Luna
    * Example: Compact Tree Gift with 0 rewards.
