### PR TITLE
add the other deleted options to frog mask display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/frogmask/FrogMaskFeaturesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/frogmask/FrogMaskFeaturesConfig.kt
@@ -12,7 +12,7 @@ class FrogMaskFeaturesConfig {
     @Expose
     @ConfigOption(
         name = "Frog Mask Display",
-        desc = "Displays information about the active §2Frog Mask§7 region. §eRequires a Frog Mask to be worn.",
+        desc = "Displays information about the active §2Frog Mask§7 region. §eRequires a Frog Mask in your inventory.",
     )
     @ConfigEditorDropdown
     var display: FrogMaskCondition = FrogMaskCondition.DISABLED
@@ -20,7 +20,9 @@ class FrogMaskFeaturesConfig {
     enum class FrogMaskCondition(private val displayName: String) {
         DISABLED("Off"),
         ALWAYS("Always"),
-        PARK("In The Park")
+        PARK("In The Park"),
+        WORN("While Worn"),
+        WORN_IN_PARK("While Worn in The Park"),
         ;
 
         override fun toString() = displayName


### PR DESCRIPTION
adds the other options that got eaten in the merge of #3522 

exclude_from_changelog