### PR TITLE
Fix: Add Unpack Check to Repos

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoFileSystem.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoFileSystem.kt
@@ -39,25 +39,34 @@ sealed interface RepoFileSystem {
 
     fun loadFromZip(
         zipFile: File,
-    ) = ZipFile(zipFile.absolutePath).use { zip ->
-        zip.entries().asSequence().filter { !it.isDirectory }.forEach { entry ->
-            val relative = entry.name
-                .substringAfter('/', "")
-                .takeIf { it.isNotBlank() }
-                ?: return@forEach
+        logger: RepoLogger,
+    ): Boolean = runCatching {
+        ZipFile(zipFile.absolutePath).use { zip ->
+            zip.entries().asSequence().filter { !it.isDirectory }.forEach { entry ->
+                val relative = entry.name
+                    .substringAfter('/', "")
+                    .takeIf { it.isNotBlank() }
+                    ?: return@forEach
 
-            if (this is DiskRepoFileSystem) {
-                // Security: ensure the file is within the root directory
-                val outPath = root.toPath().resolve(relative).normalize()
-                if (!outPath.startsWith(root.toPath())) throw RuntimeException(
-                    "SkyHanni detected an invalid zip file. This is a potential security risk, " +
-                        "please report this on the SkyHanni discord."
-                )
+                if (this@RepoFileSystem is DiskRepoFileSystem) {
+                    // Security: ensure the file is within the root directory
+                    val outPath = root.toPath().resolve(relative).normalize()
+                    if (!outPath.startsWith(root.toPath())) throw RuntimeException(
+                        "SkyHanni detected an invalid zip file. This is a potential security risk, " +
+                            "please report this on the SkyHanni discord."
+                    )
+                }
+
+                val data = zip.getInputStream(entry).readBytes()
+                write(relative, data)
             }
-
-            val data = zip.getInputStream(entry).readBytes()
-            write(relative, data)
         }
+        true
+    }.getOrElse {
+        logger.throwErrorWithCause(
+            "Failed to load repo from zip file: ${zipFile.absolutePath}",
+            it,
+        )
     }
 
     companion object {
@@ -102,12 +111,13 @@ class MemoryRepoFileSystem(private val diskRoot: File) : RepoFileSystem, Disposa
         it.startsWith("$path/") && it.removePrefix("$path/").endsWith(".json")
     }.map { it.removePrefix("$path/") }
 
-    override fun loadFromZip(zipFile: File) {
-        super.loadFromZip(zipFile)
-        if (flushJob != null) return
+    override fun loadFromZip(zipFile: File, logger: RepoLogger): Boolean {
+        val success = super.loadFromZip(zipFile, logger)
+        if (flushJob != null) return success
         flushJob = SkyHanniMod.launchIOCoroutine {
             saveToDisk(diskRoot)
         }
+        return success
     }
 
     override fun dispose() = storage.clear()

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoFileSystem.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoFileSystem.kt
@@ -113,10 +113,7 @@ class MemoryRepoFileSystem(private val diskRoot: File) : RepoFileSystem, Disposa
 
     override fun loadFromZip(zipFile: File, logger: RepoLogger): Boolean {
         val success = super.loadFromZip(zipFile, logger)
-        if (flushJob != null) return success
-        flushJob = SkyHanniMod.launchIOCoroutine {
-            saveToDisk(diskRoot)
-        }
+        if (flushJob == null) flushJob = SkyHanniMod.launchIOCoroutine { saveToDisk(diskRoot) }
         return success
     }
 


### PR DESCRIPTION
## What
Adds detection for the unpack failing, which will then prevent the current commit from being written to file, which is (probably???) how people were ending up with permanently borked repos - also added more logging so it should be easier to debug why this is happening, when it does.

Some portion of these failures are probably unavoidable HTTP bullshit things, but 🤷

## Changelog Fixes
+ Fixed deadlock issue with repo management. - Daveed
