### PR TITLE
Fix + Backend: Edge case with shiny orb tracker and EntityClickEvent remove null

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityClickEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityClickEvent.kt
@@ -6,5 +6,5 @@ import net.minecraft.entity.Entity
 import net.minecraft.item.ItemStack
 import net.minecraft.network.play.client.C02PacketUseEntity
 
-class EntityClickEvent(clickType: ClickType, val action: C02PacketUseEntity.Action, val clickedEntity: Entity?, itemInHand: ItemStack?) :
+class EntityClickEvent(clickType: ClickType, val action: C02PacketUseEntity.Action, val clickedEntity: Entity, itemInHand: ItemStack?) :
     WorldClickEvent(itemInHand, clickType)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
@@ -15,12 +15,15 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.MobUtils.mob
 import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatIntOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -43,6 +46,8 @@ object PigFeaturesApi {
     )
 
     private val patternGroup = RepoPattern.group("event.year-of-the-pig")
+
+    private val SHINY_ORB_ITEM = "SHINY_ORB".toInternalName()
 
     private val data: MutableList<ShinyOrbData> = mutableListOf()
     val dataSetList get() = data
@@ -173,8 +178,10 @@ object PigFeaturesApi {
     @HandleEvent(onlyOnIsland = IslandType.HUB)
     fun onEntityClick(event: EntityClickEvent) {
         if (!isYearOfThePig()) return
-        val entity = event.clickedEntity ?: return
 
+        if (InventoryUtils.getItemInHand()?.getInternalNameOrNull() != SHINY_ORB_ITEM) return
+
+        val entity = event.clickedEntity ?: return
         if (entity is EntityPig && entity.mob?.name == "SHINY PIG") entity.handlePigClick()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
@@ -181,7 +181,7 @@ object PigFeaturesApi {
 
         if (InventoryUtils.getItemInHand()?.getInternalNameOrNull() != SHINY_ORB_ITEM) return
 
-        val entity = event.clickedEntity ?: return
+        val entity = event.clickedEntity
         if (entity is EntityPig && entity.mob?.name == "SHINY PIG") entity.handlePigClick()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/HighlightVisitorsOutsideOfGarden.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/HighlightVisitorsOutsideOfGarden.kt
@@ -79,7 +79,6 @@ object HighlightVisitorsOutsideOfGarden {
             VisitorBlockBehaviour.DONT -> false
             VisitorBlockBehaviour.ALWAYS -> true
             VisitorBlockBehaviour.ONLY_ON_BINGO -> SkyBlockUtils.isBingoProfile
-            null -> false
         }
 
     private fun isVisitorNearby(location: LorenzVec) =
@@ -89,7 +88,7 @@ object HighlightVisitorsOutsideOfGarden {
     fun onClickEntity(event: EntityClickEvent) {
         if (!shouldBlock) return
         if (MinecraftCompat.localPlayer.isSneaking) return
-        val entity = event.clickedEntity ?: return
+        val entity = event.clickedEntity
         if (isVisitor(entity) || (entity is EntityArmorStand && isVisitorNearby(entity.getLorenzVec()))) {
             if (event.action != Action.INTERACT_AT) {
                 ChatUtils.chatAndOpenConfig(

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -141,7 +141,7 @@ object MinionFeatures {
         if (!enableWithHub()) return
         if (event.clickType != ClickType.RIGHT_CLICK) return
 
-        lastClickedEntity = event.clickedEntity?.getLorenzVec() ?: return
+        lastClickedEntity = event.clickedEntity.getLorenzVec()
     }
 
     @HandleEvent(onlyOnSkyblock = true)


### PR DESCRIPTION
## What
Fixed the tracker showing up if you accidentally clicked a pig and there was an orb nearby. This also is prob a tiny performance boost as well.
Made entity in EntityClickEvent no longer nullable because how do you click on an entity but not click on an entity at the same time.

## Changelog Fixes
+ Fixed an edge case where shiny orb tracker would show up when it isn't meant to. - CalMWolfs

## Changelog Technical Details
+ Made entity in EntityClickEvent no longer nullable . - CalMWolfs