### PR TITLE
Fix: Jacob Contest saying it took 55 years

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestStatsSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestStatsSummary.kt
@@ -38,7 +38,7 @@ object JacobContestStatsSummary {
     fun onFarmingContest(event: FarmingContestEvent) {
         if (!config.enabled) return
         val cropsBroken = blocksBroken[event.crop] ?: 0
-        if (config.hideZeroCropStats && cropsBroken == 0) return
+        if (event.phase == FarmingContestPhase.STOP && config.hideZeroCropStats && cropsBroken == 0) return
 
         when (event.phase) {
             FarmingContestPhase.START -> {


### PR DESCRIPTION
## What
crops broken is often 0 when the contest starts

<details>
<summary>Images</summary>

<img width="597" height="67" alt="image" src="https://github.com/user-attachments/assets/c3388571-6d36-4379-882a-a50e1109d9c1" />

</details>

## Changelog Fixes
+ Fixed Jacob Contests Saying they went for 55 years. - nopo
