### PR TITLE
Fix + Backend: Agaricus Timer on 1.21 etc.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -31,8 +31,8 @@ import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzRarity
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
@@ -328,7 +328,7 @@ object ExperimentationTableApi {
     }
 
     fun inDistanceToTable(max: Double): Boolean {
-        val vec = LorenzVec.getBlockBelowPlayer()
+        val vec = LocationUtils.getBlockBelowPlayer()
         return storage?.tablePos?.let { it.distance(vec) <= max } ?: false
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -320,11 +320,11 @@ object MiningApi {
         if (waitingForInitSound) {
             if (event.soundName != "random.orb") {
                 if (event.pitch != 0.7936508f) return
-                val pos = event.location.roundLocationToBlock()
+                val pos = event.location.roundToBlock()
                 if (recentClickedBlocks.none { it.first == pos }) return
                 waitingForInitSound = false
                 waitingForEffMinerBlock = true
-                initBlockPos = event.location.roundLocationToBlock()
+                initBlockPos = event.location.roundToBlock()
                 lastInitSound = SimpleTimeMark.now()
             } else {
                 if (lastClicked.passedSince() > 1.seconds) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -45,7 +45,6 @@ import at.hannibal2.skyhanni.utils.compat.addTallGrass
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
-import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.init.Blocks
 import org.lwjgl.input.Keyboard
@@ -122,7 +121,7 @@ object GriffinBurrowHelper {
 
     private fun loadTestGriffinSpots() {
         if (!testGriffinSpots) return
-        val center = LocationUtils.playerLocation().toBlockPos().toLorenzVec()
+        val center = LocationUtils.playerLocation().roundLocationToBlock()
         val list = mutableListOf<LorenzVec>()
         for (x in -5 until 5) {
             for (z in -5 until 5) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -121,7 +121,7 @@ object GriffinBurrowHelper {
 
     private fun loadTestGriffinSpots() {
         if (!testGriffinSpots) return
-        val center = LocationUtils.playerLocation().roundLocationToBlock()
+        val center = LocationUtils.playerLocation().roundToBlock()
         val list = mutableListOf<LorenzVec>()
         for (x in -5 until 5) {
             for (z in -5 until 5) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -67,7 +67,7 @@ object GriffinBurrowParticleFinder {
         val type = ParticleType.entries.firstOrNull { it.check(event) } ?: return
 
         // TODO the rounding is a workaround, may need to be removed once we know what is going on exactly and can fix this properly
-        val location = event.location.roundLocationToBlock().down()
+        val location = event.location.roundToBlock().down()
 
         val burrow = burrows.getOrPut(location) { Burrow(location) }
         val oldBurrowType = burrow.type

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.TimeUtils.inWholeTicks
-import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.init.Blocks
 import net.minecraft.util.EnumParticleTypes
 import kotlin.time.Duration.Companion.minutes
@@ -67,8 +66,9 @@ object GriffinBurrowParticleFinder {
 
         val type = ParticleType.entries.firstOrNull { it.check(event) } ?: return
 
-        // TODO remove the workaround once we know what is going on exactly and can fix this properly
-        val location = workaround(event.location)
+        // TODO the rounding is a workaround, may need to be removed once we know what is going on exactly and can fix this properly
+        val location = event.location.roundLocationToBlock().down()
+
         val burrow = burrows.getOrPut(location) { Burrow(location) }
         val oldBurrowType = burrow.type
 
@@ -92,10 +92,10 @@ object GriffinBurrowParticleFinder {
         }
     }
 
-    private fun workaround(location: LorenzVec) = location.toBlockPos().down().toLorenzVec()
+    private fun workaround(location: LorenzVec) = location.roundLocationToBlock().down()
 
-    // TODO this funciton needs upgrades: currently only counts down the tile alive for burrows while holding a spade,
-    //  and instead of ticks alive, should use found time stamp and use passed since > 1.min
+    // TODO this function needs upgrades: currently only counts down the tile alive for burrows while holding a spade,
+    // and instead of ticks alive, should use found timestamp and use passed since > 1.min
     @HandleEvent(onlyOnIsland = IslandType.HUB)
     fun onTick() {
         val isSpade = InventoryUtils.getItemInHand()?.isDianaSpade ?: false
@@ -113,7 +113,7 @@ object GriffinBurrowParticleFinder {
         }
     }
 
-    // todo move to ParticleUtils or similar
+    // TODO move to ParticleUtils or similar
     // TODO remove the roundTo calls as they are only workarounds
     private enum class ParticleType(val check: ReceiveParticleEvent.() -> Boolean) {
         EMPTY(

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowParticleFinder.kt
@@ -92,8 +92,6 @@ object GriffinBurrowParticleFinder {
         }
     }
 
-    private fun workaround(location: LorenzVec) = location.roundLocationToBlock().down()
-
     // TODO this function needs upgrades: currently only counts down the tile alive for burrows while holding a spade,
     // and instead of ticks alive, should use found timestamp and use passed since > 1.min
     @HandleEvent(onlyOnIsland = IslandType.HUB)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/PreciseGuessBurrow.kt
@@ -53,7 +53,7 @@ object PreciseGuessBurrow {
 
         val guessPosition = guessBurrowLocation() ?: return
 
-        BurrowGuessEvent(guessPosition.down(0.5).roundLocationToBlock(), precise = bezierFitter.count() > 5, new = newBurrow).post()
+        BurrowGuessEvent(guessPosition.down(0.5).roundToBlock(), precise = bezierFitter.count() > 5, new = newBurrow).post()
         newBurrow = false
     }
 
@@ -89,7 +89,7 @@ object PreciseGuessBurrow {
         val guess = guessBurrowLocation()
         event.addIrrelevant {
             add("Burrow Guess: " + (guess?.toCleanString() ?: "No Guess"))
-            add("Rounded Guess: " + (guess?.down(0.5)?.roundLocationToBlock()?.toCleanString() ?: "No Guess"))
+            add("Rounded Guess: " + (guess?.down(0.5)?.roundToBlock()?.toCleanString() ?: "No Guess"))
             add("Particle Locations:")
             addAll(
                 bezierFitter.points.mapIndexed { index, lorenzVec ->

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenStartLocation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenStartLocation.kt
@@ -65,7 +65,7 @@ object GardenStartLocation {
             ChatUtils.chat("Auto updated your Crop Start Location for ${crop.cropName}")
         }
 
-        lastFarmedLocations[crop] = LocationUtils.playerLocation().roundLocationToBlock()
+        lastFarmedLocations[crop] = LocationUtils.playerLocation().roundToBlock()
         shouldShowLastFarmedWaypoint = false
     }
 
@@ -76,7 +76,7 @@ object GardenStartLocation {
 
         if (showStartWaypoint()) {
             GardenApi.storage?.cropStartLocations?.get(crop)
-                ?.roundLocationToBlock()
+                ?.roundToBlock()
                 ?.also {
                     event.drawWaypointFilled(it, LorenzColor.WHITE.toColor())
                     event.drawDynamicText(it, "§b${crop.cropName}", 1.5)

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/PrecisionMiningHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/PrecisionMiningHighlight.kt
@@ -35,7 +35,7 @@ object PrecisionMiningHighlight {
         val particleBoundingBox = event.location.add(-0.12, -0.12, -0.12)
             .axisAlignedTo(event.location.clone().add(0.12, 0.12, 0.12))
 
-        val blockBoundingBox = BlockUtils.getBlockLookingAt()?.let {
+        val blockBoundingBox = BlockUtils.getTargetedBlock()?.let {
             it.axisAlignedTo(it.add(1.0, 1.0, 1.0))
         } ?: return
         if (!blockBoundingBox.intersectsWith(particleBoundingBox)) return

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/PrecisionMiningHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/PrecisionMiningHighlight.kt
@@ -6,15 +6,14 @@ import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
-import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.Minecraft
 import net.minecraft.util.AxisAlignedBB
 import net.minecraft.util.EnumParticleTypes
-import net.minecraft.util.MovingObjectPosition
 import java.awt.Color
 
 @SkyHanniModule
@@ -33,14 +32,12 @@ object PrecisionMiningHighlight {
             !Minecraft.getMinecraft().gameSettings.keyBindAttack.isKeyDown
         ) return
 
-        val mouseOverObject = Minecraft.getMinecraft().objectMouseOver ?: return
-        if (mouseOverObject.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return
-
         val particleBoundingBox = event.location.add(-0.12, -0.12, -0.12)
             .axisAlignedTo(event.location.clone().add(0.12, 0.12, 0.12))
 
-        val blockBoundingBox = mouseOverObject.blockPos.toLorenzVec()
-            .axisAlignedTo(mouseOverObject.blockPos.add(1.0, 1.0, 1.0).toLorenzVec())
+        val blockBoundingBox = BlockUtils.getBlockLookingAt()?.let {
+            it.axisAlignedTo(it.add(1.0, 1.0, 1.0))
+        } ?: return
         if (!blockBoundingBox.intersectsWith(particleBoundingBox)) return
 
         lookingAtParticle = event.type == EnumParticleTypes.VILLAGER_HAPPY

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/MetalDetectorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/MetalDetectorSolver.kt
@@ -189,12 +189,12 @@ object MetalDetectorSolver {
     private fun findBaseCoordinates() {
         if (lastSearchedForBase.passedSince() < 15.seconds) return
         lastSearchedForBase = SimpleTimeMark.now()
-        val player = LocationUtils.playerLocation().roundLocationToBlock()
+        val player = LocationUtils.playerLocation().roundToBlock()
 
         for (i in -50 until 50) {
             for (j in 30 downTo -30) {
                 for (k in -50 until 50) {
-                    val blockPosition = player.add(i, j, k).roundLocationToBlock()
+                    val blockPosition = player.add(i, j, k).roundToBlock()
                     val nextBlockPosition = blockPosition.add(0, 13, 0)
                     if (blockPosition.getBlockAt() == Blocks.quartz_stairs && nextBlockPosition.getBlockAt() == Blocks.barrier) {
                         baseCoordinates = getBaseCoordinates(nextBlockPosition)

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/MineshaftWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/MineshaftWaypoints.kt
@@ -9,8 +9,8 @@ import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
@@ -37,7 +37,7 @@ object MineshaftWaypoints {
     fun onIslandChange(event: IslandChangeEvent) {
         if (event.newIsland != IslandType.MINESHAFT) return
 
-        val playerLocation = LorenzVec.getBlockBelowPlayer()
+        val playerLocation = LocationUtils.getBlockBelowPlayer()
 
         if (config.mineshaftWaypoints.entranceLocation) {
             waypoints.add(MineshaftWaypoint(waypointType = MineshaftWaypointType.ENTRANCE, location = playerLocation))

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/RiftAgaricusCap.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/RiftAgaricusCap.kt
@@ -39,7 +39,7 @@ object RiftAgaricusCap {
 
     private fun updateLocation(): LorenzVec? {
         if (InventoryUtils.getItemInHand()?.getInternalName() != RiftApi.farmingTool) return null
-        val currentLocation = BlockUtils.getBlockLookingAt() ?: return null
+        val currentLocation = BlockUtils.getTargetedBlock() ?: return null
 
         when (currentLocation.getBlockAt()) {
             Blocks.brown_mushroom -> {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/RiftWiltedBerberisHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/RiftWiltedBerberisHelper.kt
@@ -54,8 +54,7 @@ object RiftWiltedBerberisHelper {
         hasFarmingToolInHand = InventoryUtils.getItemInHand()?.getInternalName() == RiftApi.farmingTool
 
         if (MinecraftCompat.localPlayer.onGround) {
-            // We check 0.1 blocks below the player's feet because farmland is not a full block on modern versions
-            isOnFarmland = LocationUtils.playerLocation().add(0.0, -0.1, 0.0).getBlockAt() == Blocks.farmland
+            isOnFarmland = LocationUtils.getBlockBelowPlayer().getBlockAt() == Blocks.farmland
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/ParkourWaypointSaver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/ParkourWaypointSaver.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.LorenzVec.Companion.toLorenzVec
@@ -51,7 +52,7 @@ object ParkourWaypointSaver {
             }
 
             config.saveKey -> {
-                val newLocation = LorenzVec.getBlockBelowPlayer()
+                val newLocation = LocationUtils.getBlockBelowPlayer()
                 if (locations.isNotEmpty() && newLocation == locations.last()) return
                 locations.add(newLocation)
                 update()

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -463,7 +463,7 @@ object SkyHanniDebugsAndTests {
             }
 
             if (debugConfig.raytracedOreblock) {
-                BlockUtils.getBlockLookingAt(50.0)?.let { pos ->
+                BlockUtils.getTargetedBlockAtDistance(50.0)?.let { pos ->
                     OreBlock.getByStateOrNull(pos.getBlockStateAt())?.let { ore ->
                         config.debugOrePos.renderString(
                             "Looking at: ${ore.name} (${pos.toCleanString()})",

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -463,7 +463,7 @@ object SkyHanniDebugsAndTests {
             }
 
             if (debugConfig.raytracedOreblock) {
-                BlockUtils.getBlockLookingAt()?.let { pos ->
+                BlockUtils.getBlockLookingAt(50.0)?.let { pos ->
                     OreBlock.getByStateOrNull(pos.getBlockStateAt())?.let { ore ->
                         config.debugOrePos.renderString(
                             "Looking at: ${ore.name} (${pos.toCleanString()})",

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -463,7 +463,7 @@ object SkyHanniDebugsAndTests {
             }
 
             if (debugConfig.raytracedOreblock) {
-                BlockUtils.getBlockLookingAt(50.0)?.let { pos ->
+                BlockUtils.getBlockLookingAt()?.let { pos ->
                     OreBlock.getByStateOrNull(pos.getBlockStateAt())?.let { ore ->
                         config.debugOrePos.renderString(
                             "Looking at: ${ore.name} (${pos.toCleanString()})",

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
@@ -560,7 +560,7 @@ object GraphEditor {
         if (selectedEdge != null) {
             if (config.splitKey.isKeyClicked()) {
                 feedBackInTutorial("Split Edge into a Node and two edges.")
-                val middle = selectedEdge.node1.position.middle(selectedEdge.node2.position).roundLocationToBlock()
+                val middle = selectedEdge.node1.position.middle(selectedEdge.node2.position).roundToBlock()
                 val node = GraphingNode(id++, middle)
                 nodes.add(node)
                 edges.remove(selectedEdge)
@@ -686,7 +686,7 @@ object GraphEditor {
             }
         }
 
-        val position = ghostPosition ?: LocationUtils.playerEyeLocation().roundLocationToBlock()
+        val position = ghostPosition ?: LocationUtils.playerEyeLocation().roundToBlock()
         if (nodes.any { it.position == position }) {
             feedBackInTutorial("Can't create node, here is already another one.")
             return
@@ -703,7 +703,7 @@ object GraphEditor {
             ghostPosition = null
             feedBackInTutorial("Disabled Ghost Position.")
         } else {
-            ghostPosition = LocationUtils.playerEyeLocation().roundLocationToBlock()
+            ghostPosition = LocationUtils.playerEyeLocation().roundToBlock()
             feedBackInTutorial("Enabled Ghost Position.")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
@@ -76,14 +76,14 @@ object BlockUtils {
     fun getTargetedBlock(): LorenzVec? {
         val mouseOverObject = Minecraft.getMinecraft().objectMouseOver ?: return null
         if (mouseOverObject.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return null
-        return mouseOverObject.blockPos.toLorenzVec().roundLocationToBlock()
+        return mouseOverObject.blockPos.toLorenzVec().roundToBlock()
     }
 
     fun getTargetedBlockAtDistance(distance: Double) = rayTrace(
         LocationUtils.playerEyeLocation(),
         MinecraftCompat.localPlayer.lookVec.toLorenzVec(),
         distance,
-    )?.roundLocationToBlock()
+    )?.roundToBlock()
 
     private fun nearbyBlocks(center: LorenzVec, distance: Int): MutableIterable<BlockPos> {
         val from = center.add(-distance, -distance, -distance).toBlockPos()

--- a/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
@@ -86,7 +86,7 @@ object BlockUtils {
                 MinecraftCompat.localPlayer.lookVec.toLorenzVec(),
                 distance,
             )
-        }.roundLocationToBlock()
+        }?.roundLocationToBlock()
     }
 
     private fun nearbyBlocks(center: LorenzVec, distance: Int): MutableIterable<BlockPos> {

--- a/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
@@ -73,21 +73,17 @@ object BlockUtils {
     //$$ }
     //#endif
 
-    fun getBlockLookingAt(distance: Double? = null): LorenzVec? {
-        return if (distance == null) {
-            // Default reach distance - just ask Minecraft
-            val mouseOverObject = Minecraft.getMinecraft().objectMouseOver ?: return null
-            if (mouseOverObject.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return null
-            mouseOverObject.blockPos.toLorenzVec()
-        } else {
-            // Custom reach distance, so we need to ray trace manually
-            rayTrace(
-                LocationUtils.playerEyeLocation(),
-                MinecraftCompat.localPlayer.lookVec.toLorenzVec(),
-                distance,
-            )
-        }?.roundLocationToBlock()
+    fun getTargetedBlock(): LorenzVec? {
+        val mouseOverObject = Minecraft.getMinecraft().objectMouseOver ?: return null
+        if (mouseOverObject.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return null
+        return mouseOverObject.blockPos.toLorenzVec().roundLocationToBlock()
     }
+
+    fun getTargetedBlockAtDistance(distance: Double) = rayTrace(
+        LocationUtils.playerEyeLocation(),
+        MinecraftCompat.localPlayer.lookVec.toLorenzVec(),
+        distance,
+    )?.roundLocationToBlock()
 
     private fun nearbyBlocks(center: LorenzVec, distance: Int): MutableIterable<BlockPos> {
         val from = center.add(-distance, -distance, -distance).toBlockPos()

--- a/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.utils.compat.addRedstoneOres
 import net.minecraft.block.Block
 import net.minecraft.block.properties.PropertyInteger
 import net.minecraft.block.state.IBlockState
+import net.minecraft.client.Minecraft
 import net.minecraft.tileentity.TileEntitySkull
 import net.minecraft.util.BlockPos
 import net.minecraft.util.MovingObjectPosition
@@ -72,11 +73,11 @@ object BlockUtils {
     //$$ }
     //#endif
 
-    fun getBlockLookingAt(distance: Double = 10.0) = rayTrace(
-        LocationUtils.playerEyeLocation(),
-        MinecraftCompat.localPlayer.lookVec.toLorenzVec(),
-        distance,
-    )
+    fun getBlockLookingAt(): LorenzVec? {
+        val mouseOverObject = Minecraft.getMinecraft().objectMouseOver ?: return null
+        if (mouseOverObject.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return null
+        return mouseOverObject.blockPos.toLorenzVec().roundLocationToBlock()
+    }
 
     private fun nearbyBlocks(center: LorenzVec, distance: Int): MutableIterable<BlockPos> {
         val from = center.add(-distance, -distance, -distance).toBlockPos()

--- a/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
@@ -73,10 +73,20 @@ object BlockUtils {
     //$$ }
     //#endif
 
-    fun getBlockLookingAt(): LorenzVec? {
-        val mouseOverObject = Minecraft.getMinecraft().objectMouseOver ?: return null
-        if (mouseOverObject.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return null
-        return mouseOverObject.blockPos.toLorenzVec().roundLocationToBlock()
+    fun getBlockLookingAt(distance: Double? = null): LorenzVec? {
+        return if (distance == null) {
+            // Default reach distance - just ask Minecraft
+            val mouseOverObject = Minecraft.getMinecraft().objectMouseOver ?: return null
+            if (mouseOverObject.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return null
+            mouseOverObject.blockPos.toLorenzVec()
+        } else {
+            // Custom reach distance, so we need to ray trace manually
+            rayTrace(
+                LocationUtils.playerEyeLocation(),
+                MinecraftCompat.localPlayer.lookVec.toLorenzVec(),
+                distance,
+            )
+        }.roundLocationToBlock()
     }
 
     private fun nearbyBlocks(center: LorenzVec, distance: Int): MutableIterable<BlockPos> {

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -29,6 +29,9 @@ object LocationUtils {
 
     fun playerLocation() = MinecraftCompat.localPlayer.getLorenzVec()
 
+    // Block heights are are multiples of 1/16, so we subtract 1/16 to find the right block
+    fun getBlockBelowPlayer() = playerLocation().add(0.0, -1.0 / 16.0, 0.0).roundLocationToBlock()
+
     fun LorenzVec.distanceToPlayer() = distance(playerLocation())
 
     fun LorenzVec.distanceToPlayerIgnoreY() = distanceIgnoreY(playerLocation())

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -30,7 +30,7 @@ object LocationUtils {
     fun playerLocation() = MinecraftCompat.localPlayer.getLorenzVec()
 
     // Block heights are multiples of 1/16, so we subtract 1/16 to find the right block
-    fun getBlockBelowPlayer() = playerLocation().add(0.0, -1.0 / 16.0, 0.0).roundLocationToBlock()
+    fun getBlockBelowPlayer() = playerLocation().add(0.0, -1.0 / 16.0, 0.0).roundToBlock()
 
     fun LorenzVec.distanceToPlayer() = distance(playerLocation())
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -29,7 +29,7 @@ object LocationUtils {
 
     fun playerLocation() = MinecraftCompat.localPlayer.getLorenzVec()
 
-    // Block heights are are multiples of 1/16, so we subtract 1/16 to find the right block
+    // Block heights are multiples of 1/16, so we subtract 1/16 to find the right block
     fun getBlockBelowPlayer() = playerLocation().add(0.0, -1.0 / 16.0, 0.0).roundLocationToBlock()
 
     fun LorenzVec.distanceToPlayer() = distance(playerLocation())

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
@@ -139,12 +139,7 @@ data class LorenzVec(
 
     fun roundTo(precision: Int) = LorenzVec(x.roundTo(precision), y.roundTo(precision), z.roundTo(precision))
 
-    fun roundLocationToBlock(): LorenzVec {
-        val x = (x - .499999).roundTo(0)
-        val y = (y - .499999).roundTo(0)
-        val z = (z - .499999).roundTo(0)
-        return LorenzVec(x, y, z)
-    }
+    fun roundLocationToBlock() = LorenzVec(floor(x), floor(y), floor(z))
 
     fun blockCenter() = roundLocationToBlock().add(0.5, 0.5, 0.5)
 
@@ -269,8 +264,6 @@ data class LorenzVec(
 
             return LorenzVec(this[0], this[1], this[2])
         }
-
-        fun getBlockBelowPlayer() = LocationUtils.playerLocation().roundLocationToBlock().down()
 
         val expandVector = LorenzVec(0.0020000000949949026, 0.0020000000949949026, 0.0020000000949949026)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
@@ -139,9 +139,9 @@ data class LorenzVec(
 
     fun roundTo(precision: Int) = LorenzVec(x.roundTo(precision), y.roundTo(precision), z.roundTo(precision))
 
-    fun roundLocationToBlock() = LorenzVec(floor(x), floor(y), floor(z))
+    fun roundToBlock() = LorenzVec(floor(x), floor(y), floor(z))
 
-    fun blockCenter() = roundLocationToBlock().add(0.5, 0.5, 0.5)
+    fun blockCenter() = roundToBlock().add(0.5, 0.5, 0.5)
 
     fun slope(other: LorenzVec, factor: Double) = this + (other - this).scale(factor)
 


### PR DESCRIPTION
## What
Fixed Agaricus Cap timer resetting on 1.21 if you move your camera while still targeting the mushroom, because the ray trace result is no longer a full block coordinate but precise position. Also done some cleanup to nearby code and fixed incorrect logic. Hopefully this doesn't break anything else.

## Changelog Fixes
+ Fixed Agaricus Cap timer incorrectly resetting whenever you move your camera on 1.21. - Luna

## Changelog Technical Details
+ Improved `BlockUtils.getBlockLookingAt()` and split it up into `getTargetedBlock()` and `getTargetedBlockAtDistance()`. - Luna
    * Coordinates are now explicitly rounded to a full block to match 1.8 behavior.
    * The former gets the targeted block directly from Minecraft using the default reach distance instead of 10, while the latter can still be used for custom distances.
+ Moved `LorenzVec.getBlockBelowPlayer()` to `LocationUtils` and fixed incorrect behavior when the player is standing on a non-full block. - Luna
+ Renamed `LorenzVec.roundLocationToBlock()` to `roundToBlock()` and fixed incorrect rounding. - Luna