### PR TITLE
Fix: Pet Tab Pattern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -100,7 +100,7 @@ object PetStorageApi {
     @Suppress("MaxLineLength")
     private val petTabWidgetXpPattern by patternGroup.pattern(
         "tab.xp",
-        " (?:§.)+(?:(?<max>MAX LEVEL)|(?:\\+(?:§.)+)?(?<current>[\\d,.kM]+)(?:§.|\\/)*(?<next>[\\d,.kM]*) XP(?: (?:§.)+\\((?<percentage>[\\d.]+)%\\))?)",
+        " (?:§.)+(?:(?<max>MAX LEVEL)|(?:\\+(?:§.)+)?(?<current>[\\d,.kM]+)(?:(?:§.|\\/)*(?<next>[\\d,.kM]+))? XP(?: (?:§.)+\\((?<percentage>[\\d.]+)%\\))?)",
     )
 
     /**


### PR DESCRIPTION
## What
I sincerely doubt this is causing any issues, but technically the pattern was matching an empty `next` group for maxed XP pets.

<details>
<summary>Images</summary>

before
<img width="2173" height="637" alt="image" src="https://github.com/user-attachments/assets/e152dca6-00b0-42a5-b681-4709fe29d954" />

after
<img width="741" height="348" alt="image" src="https://github.com/user-attachments/assets/85fc5f84-3789-42e6-a76f-a244ceee110a" />
</details>

exclude_from_changelog

