### PR TITLE
Improvement: Filter Swoop's Message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/HuntingFilterConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/HuntingFilterConfig.kt
@@ -13,4 +13,10 @@ class HuntingFilterConfig {
     @ConfigEditorBoolean
     var redundantComments: Boolean = false
 
+    @Expose
+    @ConfigOption(name = "Swoop Huntaxe", desc = "Hide Swoop's message about monsters only taking damage from axes.")
+    @SearchTag("swoop axe")
+    @ConfigEditorBoolean
+    var swoopAxeMessage: Boolean = false
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/HuntingFilterConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/HuntingFilterConfig.kt
@@ -15,7 +15,6 @@ class HuntingFilterConfig {
 
     @Expose
     @ConfigOption(name = "Swoop Huntaxe", desc = "Hide Swoop's message about monsters only taking damage from axes.")
-    @SearchTag("swoop axe")
     @ConfigEditorBoolean
     var swoopAxeMessage: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -489,6 +489,14 @@ object ChatFilter {
         "(?:§.)*The Frog is exhausted\\.\\.\\.",
     )
 
+    /**
+     * REGEX-TEST: §e[NPC] §bSwoop§f: §rWow! I forgot to tell you, monsters around here can only take damage from Axes!
+     */
+    private val swoopAxePattern by huntingPatternGroup.pattern(
+        "swoop-axe-message",
+        "§e\\[NPC] §bSwoop§f: §rWow! I forgot to tell you, monsters around here can only take damage from Axes!"
+    )
+
     private val patternsMap: Map<String, List<Pattern>> = mapOf(
         "lobby" to lobbyPatterns,
         "warping" to warpingPatterns,
@@ -520,6 +528,7 @@ object ChatFilter {
         "reward_bundles" to rewardBundlePatterns,
         "redundant_hunting" to redundantShardsPatterns,
         "unmineable_tree" to unmineableTreePatterns,
+        "swoop_axe" to listOf(swoopAxePattern),
     )
 
     private val messagesMap: Map<String, List<String>> = mapOf(
@@ -602,6 +611,7 @@ object ChatFilter {
         dungeonConfig.fairy && DungeonApi.inDungeon() && message.isPresent("fairy") -> "fairy"
         foragingConfig.unmineable && IslandTypeTags.FORAGING_CUSTOM_TREES.inAny() && message.isPresent("unmineable_tree") -> "unmineable_tree"
         huntingConfig.redundantComments && IslandType.GALATEA.isCurrent() && message.isPresent("redundant_hunting") -> "redundant_hunting"
+        huntingConfig.swoopAxeMessage && message.isPresent("swoop_axe") -> "swoop_axe"
         config.gardenNoPest && GardenApi.inGarden() && PestApi.noPestsChatPattern.matches(message) -> "garden_pest"
         config.legacyItemsWarning && message.isPresent("legacy_items") -> "legacy_items"
 


### PR DESCRIPTION
## What
Chat filter to remove message when hitting Galatea mobs with something that isn't an axe.

<details>
<summary>Images</summary>

<!-- drop images here -->
<img width="616" height="258" alt="SwoopConfig" src="https://github.com/user-attachments/assets/33cfe620-a531-4350-a8a7-e43b90912eab" />
<img width="991" height="45" alt="SwoopChatHistory" src="https://github.com/user-attachments/assets/e82dabf1-c152-40de-9a42-9aecf6220dbb" />

</details>

## Changelog Improvements
+ Added filter for Swoop's message. - Roboo