### PR TITLE
Fix + Backend: Grinch sea creature and /shtestmessage

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/SeaCreatureJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/SeaCreatureJson.kt
@@ -17,6 +17,7 @@ data class SeaCreatureJson(
 
 data class SeaCreatureInfo(
     @Expose @SerializedName("chat_message") val chatMessage: String,
+    @Expose @SerializedName("alternate_messages") val alternateMessages: List<String> = emptyList(),
     @Expose @SerializedName("fishing_experience") val fishingExperience: Int,
     @Expose val rare: Boolean = false,
     @Expose val rarity: LorenzRarity,

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -77,6 +77,9 @@ object SeaCreatureManager {
 
                 val creature = SeaCreature(name, fishingExperience, chatColor, rare, rarity)
                 seaCreatureMap[chatMessage] = creature
+                for (alternateMessage in seaCreature.alternateMessages) {
+                    seaCreatureMap[alternateMessage] = creature
+                }
                 allFishingMobs[name] = creature
                 variantFishes.add(name)
                 counter++

--- a/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
@@ -78,7 +78,7 @@ object TestChatCommand {
         val event = SkyHanniChatEvent(message, componentText)
         event.post()
 
-        if (event.blockedReason != "") {
+        if (event.blockedReason != null) {
             if (!isHidden) ChatUtils.chat("§cChat blocked: ${event.blockedReason}")
             return
         }


### PR DESCRIPTION
## What
The grinch has different message on 1.21 than on 1.8 which is partly due to our converting text to string and partially due to minecraft. But this pr also adds support for alternate messages for sea creatures which I doubt will ever really be used but you never know, hypixel might add some in the future and now we will support them.

## Changelog Fixes
+ Fixed grinch sea creature detection on 1.21. - CalMWolfs

## Changelog Technical Details
+ Fixed /shtestmessage reporting that messages were blocked when they weren't. - CalMWolfs
+ Added the ability for sea creatures to have alternate messages that they match on. - CalMWolfs
