### PR TITLE
Backend: Detekt Fixes

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -47,13 +47,13 @@ jobs:
                     fi
 
             -   name: Add label if detekt fails
-                if: ${{ failure() && steps.check_sarif.outputs.exists == 'true' }}
+                if: ${{ steps.run_detekt.outcome == 'failure' && steps.check_sarif.outputs.exists == 'true' }}
                 uses: actions-ecosystem/action-add-labels@v1
                 with:
                     github_token: ${{ secrets.GITHUB_TOKEN }}
                     labels: 'Detekt'
             -   name: Remove label if detekt passes
-                if: success()
+                if: ${{ steps.run_detekt.outcome != 'failure' }}
                 uses: actions-ecosystem/action-remove-labels@v1
                 with:
                     github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -104,7 +104,7 @@ jobs:
                     kotlinc -script .github/scripts/process-detekt-output.kts
             -   name: Check for duplicate comment
                 id: check_duplicate
-                uses: actions/github-script@v6
+                uses: actions/github-script@v7
                 with:
                     script: |
                         const fs = require('fs');
@@ -123,7 +123,7 @@ jobs:
                 run: echo "Duplicate comment found, skipping..."
 
             -   name: Add comment to PR
-                uses: actions/github-script@v6
+                uses: actions/github-script@v7
                 if: steps.check_duplicate.outputs.result != 'true'
                 with:
                     github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -47,7 +47,7 @@ jobs:
 
             -   name: Add comment to PR if changelog verification fails
                 if: failure()
-                uses: actions/github-script@v6
+                uses: actions/github-script@v7
                 with:
                     github-token: ${{ secrets.GITHUB_TOKEN }}
                     script: |


### PR DESCRIPTION
## What
We were using github-script 6, which, unsurprisingly, was bugged as fuck still ( see [this issue](https://github.com/actions/github-script/issues/256) ) - bumped to v7, which fixes [this](https://github.com/hannibal002/SkyHanni/actions/runs/16319274842/job/46093197807?pr=4393), and fixed the conditions for adding/removing the Detekt tag.

## Changelog Technical Details
+ Fixed Detekt workflows again. - Daveed

