### PR TITLE
Fix: Estimated chest value displaying books at half their value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -34,7 +34,6 @@ import at.hannibal2.skyhanni.utils.renderables.addLine
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiInventory
-import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
 
 @SkyHanniModule
@@ -201,11 +200,9 @@ object ChestValue {
             val internalName = stack.getInternalNameOrNull() ?: continue
             if (internalName.getItemStackOrNull() == null) continue
             val list = mutableListOf<String>()
-            var total = EstimatedItemValueCalculator.calculate(stack, list).first
-
+            val total = EstimatedItemValueCalculator.calculate(stack, list).first
             val key = "$internalName+$total"
-            if (stack.item == Items.enchanted_book)
-                total /= 2
+
             list.add("§aTotal: §6§l${total.formatPrice()} coins")
             if (total == 0.0) continue
             val item = getOrPut(key) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -49,7 +49,6 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getGemstones
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHelmetSkin
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHotPotatoCount
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHypixelEnchantments
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getItemId
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getManaDisintegrators
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getMithrilInfusion
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPolarvoidBookCount
@@ -76,6 +75,7 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumByKey
 import at.hannibal2.skyhanni.utils.compat.NbtCompat
 import io.github.notenoughupdates.moulconfig.observer.Property
+import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
 import java.util.Locale
 
@@ -164,7 +164,7 @@ object EstimatedItemValueCalculator {
     fun calculate(stack: ItemStack, list: MutableList<String>): Pair<Double, Double> {
         val basePrice = addBaseItem(stack, list)
         // The value of enchantments will already be added in ::addEnchantments, so set to 0 to avoid double counting
-        val foldValue = if (stack.getItemId() == "ENCHANTED_BOOK") 0.0
+        val foldValue = if (stack.item == Items.enchanted_book) 0.0
         else basePrice
         val totalPrice = additionalCostFunctions.fold(foldValue) { total, function -> total + function(stack, list) }
         return totalPrice to basePrice


### PR DESCRIPTION
## What
The logic to correct books being valued at twice their price introduced in #4247 was already present in ChestValue. Now that this correction is present in EstimatedItemValueCalculator, it should be removed.

## Changelog Fixes
+ Fixed estimated chest value displaying books at half their value. - SuperClash

