### PR TITLE
Improvement: Copy chat on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
@@ -37,6 +37,7 @@ object CopyChat {
     }
 
     private fun processCopyChat(mouseX: Int, mouseY: Int) {
+        // On 1.8 we use our own code to find the chat lines which uses our mouse methods, on 1.21 we use the vanilla methods
         val chatLine = if (PlatformUtils.IS_LEGACY) {
             getChatLine(MouseCompat.getX(), MouseCompat.getY()) ?: return
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
@@ -1,11 +1,8 @@
 package at.hannibal2.skyhanni.features.chat
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.render.gui.GuiMouseInputEvent
 import at.hannibal2.skyhanni.features.misc.visualwords.ModifyVisualWords
-import at.hannibal2.skyhanni.mixins.transformers.AccessorMixinGuiNewChat
-import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ChatUtils.chatMessage
 import at.hannibal2.skyhanni.utils.ChatUtils.fullComponent
@@ -16,24 +13,35 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
 import at.hannibal2.skyhanni.utils.compat.MouseCompat
-//#if MC > 1.21
-//$$ import at.hannibal2.skyhanni.utils.compat.OrderedTextUtils
-//#endif
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.ChatLine
-import net.minecraft.client.gui.GuiChat
 import net.minecraft.util.MathHelper
+//#if MC < 1.21
+import at.hannibal2.skyhanni.mixins.transformers.AccessorMixinGuiNewChat
+//#else
+//$$ import at.hannibal2.skyhanni.utils.compat.OrderedTextUtils
+//#endif
 
-@SkyHanniModule
 object CopyChat {
     private val config get() = SkyHanniMod.feature.chat.copyChat
 
-    @HandleEvent
-    fun onMouseInput(event: GuiMouseInputEvent) {
-        if (event.gui !is GuiChat) return
-        if (!config || !KeyboardManager.isRightMouseClicked()) return
-        val chatLine = getChatLine(MouseCompat.getX(), MouseCompat.getY()) ?: return
+    @JvmStatic
+    fun handleCopyChat(mouseX: Int, mouseY: Int) {
+        try {
+            if (!config) return
+            processCopyChat(mouseX, mouseY)
+        } catch (e: Exception) {
+            ErrorManager.logErrorWithData(e, "Error while copying chat line")
+        }
+    }
+
+    private fun processCopyChat(mouseX: Int, mouseY: Int) {
+        val chatLine = if (PlatformUtils.IS_LEGACY) {
+            getChatLine(MouseCompat.getX(), MouseCompat.getY()) ?: return
+        } else {
+            getChatLine(mouseX, mouseY) ?: return
+        }
         val formatted = chatLine.fullComponent.formattedText
 
         val (clipboard, infoMessage) = when {
@@ -44,7 +52,7 @@ object CopyChat {
                 //#if MC < 1.21
                 ModifyVisualWords.modifyText(formatted)?.removeColor()
                     //#else
-                    //$$ OrderedTextUtils.orderedTextToLegacyString(ModifyVisualWords.transformText(chatLine.fullComponent.asOrderedText()))
+                    //$$ OrderedTextUtils.orderedTextToLegacyString(ModifyVisualWords.transformText(chatLine.fullComponent.asOrderedText())).removeColor()
                     //#endif
                     ?: formatted
                 ) to "modified message"
@@ -61,6 +69,7 @@ object CopyChat {
     private fun getChatLine(mouseX: Int, mouseY: Int): ChatLine? {
         val mc = Minecraft.getMinecraft() ?: return null
         val chatGui = mc.ingameGUI.chatGUI ?: return null
+        //#if MC < 1.21
         val access = chatGui as AccessorMixinGuiNewChat
         val chatScale = chatGui.chatScale
         val scaleFactor = GuiScreenUtils.scaleFactor
@@ -80,6 +89,29 @@ object CopyChat {
             }
         }
         return null
+        //#else
+        //$$ val chatLineY = chatGui.toChatLineY(mouseY.toDouble())
+        //$$ val lineIndex = (chatGui.scrolledLines + chatLineY).toInt()
+        //$$ if (lineIndex < 0) return null
+        //$$ val visibleLines = chatGui.visibleMessages
+        //$$ if (lineIndex > visibleLines.size) return null
+        //$$ val visibleLine = visibleLines[lineIndex]
+        //$$
+        //$$ val matchingLines = chatGui.messages.filter {
+        //$$     it.creationTick == visibleLine.addedTime && it.content.formattedTextCompat().isNotBlank()
+        //$$ }
+        //$$
+        //$$ return when {
+        //$$     matchingLines.isEmpty() -> null
+        //$$     matchingLines.size == 1 -> matchingLines.first()
+        //$$     else -> {
+        //$$         matchingLines.firstOrNull {
+        //$$             it.content.formattedTextCompat().stripHypixelMessage().removeColor()
+        //$$                 .contains(OrderedTextUtils.orderedTextToLegacyString(visibleLine.content).removeColor())
+        //$$         } ?: matchingLines.first()
+        //$$     }
+        //$$ }
+        //#endif
     }
 
     private val isPatcherLoaded by lazy { PlatformUtils.isModInstalled("patcher") }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
@@ -91,7 +91,11 @@ object CopyChat {
         return null
         //#else
         //$$ val chatLineY = chatGui.toChatLineY(mouseY.toDouble())
+        //$$ val chatLineX = chatGui.toChatLineX(mouseX.toDouble())
         //$$ val lineIndex = (chatGui.scrolledLines + chatLineY).toInt()
+        //$$
+        //$$ if (chatLineX < -4.0 || chatLineX > MathHelper.floor(chatGui.width.toDouble() / chatGui.chatScale).toDouble()) return null
+        //$$
         //$$ if (lineIndex < 0) return null
         //$$ val visibleLines = chatGui.visibleMessages
         //$$ if (lineIndex > visibleLines.size) return null

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiChat.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiChat.java
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.events.ChatHoverEvent;
 import at.hannibal2.skyhanni.events.chat.TabCompletionEvent;
+import at.hannibal2.skyhanni.features.chat.CopyChat;
 import at.hannibal2.skyhanni.features.chat.CurrentChatDisplay;
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook;
 import net.minecraft.client.gui.GuiChat;
@@ -66,4 +67,11 @@ public class MixinGuiChat {
     public void onGuiClosed(CallbackInfo ci) {
         CurrentChatDisplay.onCloseChat();
     }
+
+    @Inject(method = "mouseClicked", at = @At("HEAD"))
+    public void mouseClicked(int mouseX, int mouseY, int mouseButton, CallbackInfo ci) {
+        if (mouseButton != 1) return;
+        CopyChat.handleCopyChat(mouseX, mouseY);
+    }
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -60,8 +60,6 @@ object KeyboardManager {
 
     fun isModifierKeyDown() = if (SystemUtils.IS_OS_MAC) isCommandKeyDown() else isControlKeyDown()
 
-    fun isRightMouseClicked() = RIGHT_MOUSE.isKeyClicked()
-
     @JvmStatic
     fun checkIsInventoryClosure(keycode: Int): Boolean {
         // Holding shift bypasses closure checks

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -56,7 +56,7 @@ object StringUtils {
     }
 
     private val formattingChars = "kmolnrKMOLNR".toSet()
-    private val colorChars = "abcdefABCDEF0123456789".toSet()
+    private val colorChars = "abcdefABCDEF0123456789z".toSet()
 
     /**
      * Removes color and optionally formatting codes from the given string, leaving plain text.

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -56,7 +56,7 @@ object StringUtils {
     }
 
     private val formattingChars = "kmolnrKMOLNR".toSet()
-    private val colorChars = "abcdefABCDEF0123456789z".toSet()
+    private val colorChars = "abcdefABCDEF0123456789zZ".toSet()
 
     /**
      * Removes color and optionally formatting codes from the given string, leaving plain text.

--- a/versions/1.21.5/buildpaths-excluded.txt
+++ b/versions/1.21.5/buildpaths-excluded.txt
@@ -17,6 +17,7 @@ at.hannibal2.skyhanni.tweaker.TweakerUtils.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorChatComponentText.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorFontRenderer.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorGuiEditSign.java
+at.hannibal2.skyhanni.mixins.transformers.AccessorMixinGuiNewChat.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorRender.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorRendererLivingEntity.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorWorldBorderPacket.java
@@ -25,7 +26,6 @@ at.hannibal2.skyhanni.mixins.transformers.MixinBlockLiquid.java
 at.hannibal2.skyhanni.mixins.transformers.MixinEntityAgeable.java
 at.hannibal2.skyhanni.mixins.transformers.MixinEntityHorse.java
 at.hannibal2.skyhanni.mixins.transformers.MixinFontRenderer.java
-at.hannibal2.skyhanni.mixins.transformers.MixinGuiChat.java
 at.hannibal2.skyhanni.mixins.transformers.MixinGuiIngameForge.java
 at.hannibal2.skyhanni.mixins.transformers.MixinNetHandlerPlayClient.java
 at.hannibal2.skyhanni.mixins.transformers.MixinNetworkManager.java

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiChat.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiChat.java
@@ -1,0 +1,19 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.features.chat.CopyChat;
+import net.minecraft.client.gui.screen.ChatScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ChatScreen.class)
+public class MixinGuiChat {
+
+    @Inject(method = "mouseClicked", at = @At("HEAD"))
+    public void mouseClicked(double mouseX, double mouseY, int mouseButton, CallbackInfoReturnable<Boolean> cir) {
+        if (mouseButton != 1) return;
+        CopyChat.handleCopyChat((int) mouseX, (int) mouseY);
+    }
+
+}

--- a/versions/1.21.5/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.5/src/main/resources/skyhanni.accesswidener
@@ -36,3 +36,5 @@ accessible method net/minecraft/client/gui/screen/ingame/AbstractSignEditScreen 
 accessible field net/minecraft/text/TextColor name Ljava/lang/String;
 accessible field net/minecraft/entity/Entity CUSTOM_NAME Lnet/minecraft/entity/data/TrackedData;
 accessible field net/minecraft/entity/LivingEntity HEALTH Lnet/minecraft/entity/data/TrackedData;
+accessible field net/minecraft/client/gui/hud/ChatHud scrolledLines I
+accessible method net/minecraft/client/gui/hud/ChatHud toChatLineY (D)D

--- a/versions/1.21.5/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.5/src/main/resources/skyhanni.accesswidener
@@ -37,4 +37,5 @@ accessible field net/minecraft/text/TextColor name Ljava/lang/String;
 accessible field net/minecraft/entity/Entity CUSTOM_NAME Lnet/minecraft/entity/data/TrackedData;
 accessible field net/minecraft/entity/LivingEntity HEALTH Lnet/minecraft/entity/data/TrackedData;
 accessible field net/minecraft/client/gui/hud/ChatHud scrolledLines I
+accessible method net/minecraft/client/gui/hud/ChatHud toChatLineX (D)D
 accessible method net/minecraft/client/gui/hud/ChatHud toChatLineY (D)D

--- a/versions/1.21.7/buildpaths-excluded.txt
+++ b/versions/1.21.7/buildpaths-excluded.txt
@@ -17,6 +17,7 @@ at.hannibal2.skyhanni.tweaker.TweakerUtils.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorChatComponentText.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorFontRenderer.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorGuiEditSign.java
+at.hannibal2.skyhanni.mixins.transformers.AccessorMixinGuiNewChat.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorRender.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorRendererLivingEntity.java
 at.hannibal2.skyhanni.mixins.transformers.AccessorWorldBorderPacket.java
@@ -25,7 +26,6 @@ at.hannibal2.skyhanni.mixins.transformers.MixinBlockLiquid.java
 at.hannibal2.skyhanni.mixins.transformers.MixinEntityAgeable.java
 at.hannibal2.skyhanni.mixins.transformers.MixinEntityHorse.java
 at.hannibal2.skyhanni.mixins.transformers.MixinFontRenderer.java
-at.hannibal2.skyhanni.mixins.transformers.MixinGuiChat.java
 at.hannibal2.skyhanni.mixins.transformers.MixinGuiIngameForge.java
 at.hannibal2.skyhanni.mixins.transformers.MixinNetHandlerPlayClient.java
 at.hannibal2.skyhanni.mixins.transformers.MixinNetworkManager.java

--- a/versions/1.21.7/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.7/src/main/resources/skyhanni.accesswidener
@@ -36,6 +36,8 @@ accessible method net/minecraft/client/gui/screen/ingame/AbstractSignEditScreen 
 accessible field net/minecraft/text/TextColor name Ljava/lang/String;
 accessible field net/minecraft/entity/Entity CUSTOM_NAME Lnet/minecraft/entity/data/TrackedData;
 accessible field net/minecraft/entity/LivingEntity HEALTH Lnet/minecraft/entity/data/TrackedData;
+accessible field net/minecraft/client/gui/hud/ChatHud scrolledLines I
+accessible method net/minecraft/client/gui/hud/ChatHud toChatLineY (D)D
 
 # 1.21.7 stuff
 accessible field net/minecraft/client/render/RenderLayer$MultiPhase pipeline Lcom/mojang/blaze3d/pipeline/RenderPipeline;

--- a/versions/1.21.7/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.7/src/main/resources/skyhanni.accesswidener
@@ -37,6 +37,7 @@ accessible field net/minecraft/text/TextColor name Ljava/lang/String;
 accessible field net/minecraft/entity/Entity CUSTOM_NAME Lnet/minecraft/entity/data/TrackedData;
 accessible field net/minecraft/entity/LivingEntity HEALTH Lnet/minecraft/entity/data/TrackedData;
 accessible field net/minecraft/client/gui/hud/ChatHud scrolledLines I
+accessible method net/minecraft/client/gui/hud/ChatHud toChatLineX (D)D
 accessible method net/minecraft/client/gui/hud/ChatHud toChatLineY (D)D
 
 # 1.21.7 stuff


### PR DESCRIPTION
## What
Made copy chat work on 1.21, also make remove color actually remove chroma color.

## Changelog Improvements
+ Made copy chat work on 1.21. - CalMWolfs

## Changelog Technical Details
+ String.removeColor now removes the chroma color code. - CalMWolfs