### PR TITLE
Backend: Fix NoSuchFieldException in PacketTest

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
@@ -136,7 +136,11 @@ object PacketTest {
                 entityMap.getOrDefault(it, mutableListOf()).add(packet)
             }
         } else {
-            val id = packet.getEntityId() ?: return
+            val id = try {
+                packet.getEntityId()
+            } catch (e: NoSuchFieldException) {
+                null
+            } ?: return
             entityMap.getOrDefault(id, mutableListOf()).add(packet)
         }
     }


### PR DESCRIPTION
## What
Added a try/catch to PacketTest to not error if the packet doesn't have an `entityId` field.

## Changelog Technical Details
+ Fixed occasional NoSuchFieldException in `/shtestpacket`. - Luna
