### PR TITLE
Improvement + Backend: auto send TPS after /shtps cooldown

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -69,7 +69,7 @@ object TpsCounter {
     private fun updateDisplay() {
         val timeUntil = minimumSecondsDisplayDelay - timeSinceWorldSwitch
         val text = if (timeUntil.isPositive()) {
-            "§f${timeUntil.inWholeSeconds}s"
+            "§f(${timeUntil.inWholeSeconds}s)"
         } else {
             // when in limbo we don't receive any packets
             if (tpsList.isEmpty()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -69,7 +69,7 @@ object TpsCounter {
     private fun updateDisplay() {
         val timeUntil = minimumSecondsDisplayDelay - timeSinceWorldSwitch
         val text = if (timeUntil.isPositive()) {
-            "§f(${timeUntil.inWholeSeconds}s)"
+            "§f${timeUntil.inWholeSeconds}s"
         } else {
             // when in limbo we don't receive any packets
             if (tpsList.isEmpty()) {


### PR DESCRIPTION
## What

Makes `/shtps` send TPS after the "Calculating..." cooldown is up.
(Suggestion: https://discord.com/channels/997079228510117908/1383434040304210000)
Also fixes the command showing real TPS during April Fools (cause why not)
(Bug report: https://discord.com/channels/997079228510117908/1356653038651314267)

## Changelog Improvements
+ Made `/shtps` automatically send the TPS after its "calculating" cooldown. - MTOnline

## Changelog Technical Details
+ Fixed `/shtps` showing your real TPS during April Fools. - MTOnline

