### PR TITLE
Fix: Shorten Coin Amount on < 1 values

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -202,6 +202,7 @@ class ChatConfig {
             "e.g. §65,100,000 Coins §7-> §65.1M Coins",
     )
     @ConfigEditorBoolean
+    @SearchTag("format")
     @FeatureToggle
     var shortenCoinAmounts: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ShortenCoins.kt
@@ -39,9 +39,10 @@ object ShortenCoins {
 
         val originalComponent = event.chatComponent.siblings.firstOrNull() ?: event.chatComponent
 
-        event.chatComponent = modifiedMessage.asComponent {
+        val newComponent = modifiedMessage.asComponent {
             chatStyle = originalComponent.chatStyle
         }
+        event.replaceComponent(newComponent, "shortened_coins")
     }
 
     fun Number.formatChatCoins(): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarCancelledBuyOrderClipboard.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
@@ -73,7 +74,7 @@ object BazaarCancelledBuyOrderClipboard {
     fun onChat(event: SkyHanniChatEvent) {
         if (!isEnabled()) return
         val coins = cancelledMessagePattern.matchMatcher(event.message) {
-            group("coins").formatInt()
+            group("coins").formatDouble()
         } ?: return
 
         val latestAmount = latestAmount ?: return

--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -7,6 +7,7 @@ import java.text.DecimalFormat
 import java.text.NumberFormat
 import java.util.Locale
 import java.util.TreeMap
+import kotlin.math.absoluteValue
 import kotlin.math.pow
 
 object NumberUtil {
@@ -51,8 +52,8 @@ object NumberUtil {
      * @author assylias
      */
     private fun compactFormat(input: Number, preciseBillions: Boolean = false): String {
-        val doubleValue = input.toDouble()
-        if (doubleValue < 1) return input.toString()
+        val absDoubleValue = input.toDouble().absoluteValue
+        if (absDoubleValue < 1) return input.toString()
 
         val value = input.toLong()
         // Long.MIN_VALUE == -Long.MIN_VALUE, so we need an adjustment here

--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -50,9 +50,11 @@ object NumberUtil {
      * @link https://stackoverflow.com/a/30661479
      * @author assylias
      */
-    private fun compactFormat(value: Number, preciseBillions: Boolean = false): String {
-        @Suppress("NAME_SHADOWING")
-        val value = value.toLong()
+    private fun compactFormat(input: Number, preciseBillions: Boolean = false): String {
+        val doubleValue = input.toDouble()
+        if (doubleValue < 1) return input.toString()
+
+        val value = input.toLong()
         // Long.MIN_VALUE == -Long.MIN_VALUE, so we need an adjustment here
         if (value == Long.MIN_VALUE) return compactFormat(Long.MIN_VALUE + 1, preciseBillions)
         if (value < 0) return "-" + compactFormat(-value, preciseBillions)


### PR DESCRIPTION
## What
If its less than 1 I just show the original number. Also added a search tag and message replace reason

## Changelog Fixes
+ Fixed shorten coin amount behaving incorrectly on values < 1. - CalMWolfs
