### PR TITLE
Fix: ColorfulItemStats

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/ColorfulItemTooltips.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/ColorfulItemTooltips.kt
@@ -33,4 +33,13 @@ class ColorfulItemTooltips {
     @ConfigEditorBoolean
     var replacePercentages: Boolean = false
 
+    @Expose
+    @ConfigOption(
+        name = "Replace rift seconds",
+        desc = "Replaces the 's' after the rift time stat.\n" +
+            "§eRequires add stat icons to be enabled.",
+    )
+    @ConfigEditorBoolean
+    var replaceRiftSeconds: Boolean = true
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -77,7 +77,7 @@ enum class SkyblockStat(
     MAGIC_FIND("§b✯", " *Magic Find: §r§b✯$VALUE_PATTERN", " *§b✯ Magic Find §f$VALUE_PATTERN"),
     PET_LUCK("§d♣", " *Pet Luck: §r§d♣$VALUE_PATTERN", " *§d♣ Pet Luck §f$VALUE_PATTERN"),
     FISHING_SPEED("§b☂", " *Fishing Speed: §r§b☂$VALUE_PATTERN", " *§b☂ Fishing Speed §f$VALUE_PATTERN"),
-    TROPHY_FISH_CHANCE("§b☂", "Trophy Fish Chance: §r§6♔$VALUE_PATTERN", " *§6♔ Trophy Fish Chance §f(?<value>\\d+)%"),
+    TROPHY_FISH_CHANCE("§b♔", "Trophy Fish Chance: §r§6♔$VALUE_PATTERN", " *§6♔ Trophy Fish Chance §f(?<value>\\d+)%"),
     DOUBLE_HOOK_CHANCE(
         "§9⚓",
         " *Double Hook Chance: §r§9⚓$VALUE_PATTERN",
@@ -152,6 +152,11 @@ enum class SkyblockStat(
     HUNTER_FORTUNE("§d☘", " *Hunter Fortune: §r§d☘$VALUE_PATTERN", " *§d☘ Hunter Fortune §f$VALUE_PATTERN"),
     FIG_FORTUNE("§6☘", " *Fig Fortune: §r§6☘$VALUE_PATTERN", " *§6☘ Fig Fortune §f$VALUE_PATTERN"),
     MANGROVE_FORTUNE("§6☘", " *Mangrove Fortune: §r§6☘$VALUE_PATTERN", " *§6☘ Mangrove Fortune §f$VALUE_PATTERN"),
+
+    RIFT_TIME("§aф", " *Rift Time: §r§aф$VALUE_PATTERN", " *§aф Rift Time §f$VALUE_PATTERN"),
+    RIFT_DAMAGE("§5❁", " *Rift Damage: §r§5❁$VALUE_PATTERN", " *§5❁ Rift Damage §f$VALUE_PATTERN"),
+    MANA_REGEN("§b⚡", " *Mana Regen: §r§b⚡$VALUE_PATTERN", " *§b⚡ Mana Regen §f$VALUE_PATTERN"),
+    HEARTS("§c♥", " *Hearts: §r§c♥$VALUE_PATTERN", " *§c♥ Hearts §f$VALUE_PATTERN"),
 
     UNKNOWN("§c?", "", "")
     ;

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -17,10 +17,13 @@ object ColorfulItemStats {
     /**
      * REGEX-TEST: §7Crit Chance: §c+30%
      * REGEX-TEST: §7Magic Find: §a+54.52
+     * REGEX-TEST: §7Rift Time: §a+60s
+     * REGEX-TEST: §7Strength: §c+60 §e(+20) §9(+40) §8(+199.2)
+     * REGEX-FAIL: §7Health: §c+1000❤
      */
     private val genericStat by group.pattern(
         "generic",
-        "§7(?<stat>[a-zA-Z ]+): (?<oldColor>§[0-9a-f])(?<bonus>[-+]?[\\d.,%]+)",
+        "§7(?<stat>[a-zA-Z ]+): (?<oldColor>§[0-9a-f])(?<bonus>[-+]?[\\d.,%s]+)(?:\\s|$)",
     )
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -37,8 +40,12 @@ object ColorfulItemStats {
                     stat.uppercase().replace(" ", "_")
                 )
 
-                val bonusGroup = group("bonus")
-                val bonus = if (config.replacePercentages && config.statIcons) bonusGroup.removeSuffix("%") else bonusGroup
+                val bonusGroup = group("bonus").replace(",", ".")
+                val bonus = when {
+                    config.replacePercentages && config.statIcons && bonusGroup.endsWith("%") -> bonusGroup.removeSuffix("%")
+                    config.replaceRiftSeconds && config.statIcons && bonusGroup.endsWith("s") -> bonusGroup.removeSuffix("s")
+                    else -> bonusGroup
+                }
 
                 buildString {
                     append("§7$stat: ")
@@ -53,6 +60,7 @@ object ColorfulItemStats {
                         skyblockStat?.icon?.lastOrNull()?.let { append(it) }
                     }
                     append(oldColor)
+                    append(" ")
                 }
             }
         }


### PR DESCRIPTION
## What
- Fixed trophy fish chance icon
- Added rift stats to SkyblockStat enum
- Made it not replace existing symbols from hypixel

## Changelog Fixes
+ Fixed a few minor issues with colorful item stats. - CalMWolfs

