### PR TITLE
Improvement: Add Free Will to minion estimated item value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -45,6 +45,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getDungeonStarCount
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getEnrichment
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getExtraAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getFarmingForDummiesCount
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getFreeWill
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getGemstones
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHelmetSkin
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHotPotatoCount
@@ -103,6 +104,7 @@ object EstimatedItemValueCalculator {
         ::addEnrichment,
         ::addDivanPowderCoating,
         ::addMithrilInfusion,
+        ::addFreeWill,
 
         // counted
         ::addCrimsonPrestige,
@@ -152,6 +154,7 @@ object EstimatedItemValueCalculator {
     private val BOOKWORM_BOOK = "BOOKWORM_BOOK".toInternalName()
     private val STONK_PICKAXE = "STONK_PICKAXE".toInternalName()
     private val MITHRIL_INFUSION = "MITHRIL_INFUSION".toInternalName()
+    private val FREE_WILL = "FREE_WILL".toInternalName()
 
     fun getTotalPrice(stack: ItemStack, ignoreBasePrice: Boolean = false): Double? {
         val (totalPrice, basePrice) = calculate(stack, mutableListOf())
@@ -259,6 +262,11 @@ object EstimatedItemValueCalculator {
     private fun addMithrilInfusion(stack: ItemStack, list: MutableList<String>): Double {
         if (!stack.getMithrilInfusion()) return 0.0
         return list.formatHaving("Mithril Infusion", MITHRIL_INFUSION)
+    }
+
+    private fun addFreeWill(stack: ItemStack, list: MutableList<String>): Double {
+        if (!stack.getFreeWill()) return 0.0
+        return list.formatHaving("Free Will", FREE_WILL)
     }
 
     private fun addArtOfWar(stack: ItemStack, list: MutableList<String>): Double {

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -54,6 +54,7 @@ object SkyBlockItemModifierUtils {
     }?.takeIf { it > 0 }
 
     fun ItemStack.getMithrilInfusion(): Boolean = getAttributeByte("mithril_infusion") == 1.toByte()
+    fun ItemStack.getFreeWill(): Boolean = getAttributeByte("free_will") == 1.toByte()
 
     private fun ItemStack.getBaseSilexCount() = when (getInternalName().asString()) {
         "STONK_PICKAXE" -> 1


### PR DESCRIPTION
## What
Minions can now be free. Didn't test.

## Changelog Improvements
+ Added Free Will to minion estimated item value. - CalMWolfs

