### PR TITLE
Fix: Colorful Item Stats replacing commas

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -22,7 +22,7 @@ object ColorfulItemStats {
      * REGEX-FAIL: §7Health: §c+1000❤
      */
     private val genericStat by group.pattern(
-        "generic-new",
+        "generic-stats",
         "§7(?<stat>[a-zA-Z ]+): (?<oldColor>§[0-9a-f])(?<bonus>[-+]?[\\d.,%s]+)(?:\\s|$)",
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -40,7 +40,7 @@ object ColorfulItemStats {
                     stat.uppercase().replace(" ", "_")
                 )
 
-                val bonusGroup = group("bonus").replace(",", ".")
+                val bonusGroup = group("bonus")
                 val bonus = when {
                     config.replacePercentages && config.statIcons && bonusGroup.endsWith("%") -> bonusGroup.removeSuffix("%")
                     config.replaceRiftSeconds && config.statIcons && bonusGroup.endsWith("s") -> bonusGroup.removeSuffix("s")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -22,7 +22,7 @@ object ColorfulItemStats {
      * REGEX-FAIL: §7Health: §c+1000❤
      */
     private val genericStat by group.pattern(
-        "generic",
+        "generic-new",
         "§7(?<stat>[a-zA-Z ]+): (?<oldColor>§[0-9a-f])(?<bonus>[-+]?[\\d.,%s]+)(?:\\s|$)",
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -50,7 +50,6 @@ object ColorfulItemStats {
                 buildString {
                     append("§7$stat: ")
                     append(skyblockStat.icon.take(2))
-                    append(skyblockStat.icon.take(2))
                     append(bonus)
                     if (config.statIcons) {
                         skyblockStat.icon.lastOrNull()?.let { append(it) }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -38,7 +38,7 @@ object ColorfulItemStats {
 
                 val skyblockStat = SkyblockStat.getValueOrNull(
                     stat.uppercase().replace(" ", "_")
-                )
+                ) ?: return@replace this.group()
 
                 val bonusGroup = group("bonus")
                 val bonus = when {
@@ -49,15 +49,11 @@ object ColorfulItemStats {
 
                 buildString {
                     append("§7$stat: ")
-                    append(
-                        SkyblockStat.getValueOrNull(
-                            stat.uppercase().replace(" ", "_")
-                        )?.icon?.take(2) ?: oldColor
-                    )
-                    append(skyblockStat?.icon?.take(2) ?: oldColor)
+                    append(skyblockStat.icon.take(2))
+                    append(skyblockStat.icon.take(2))
                     append(bonus)
                     if (config.statIcons) {
-                        skyblockStat?.icon?.lastOrNull()?.let { append(it) }
+                        skyblockStat.icon.lastOrNull()?.let { append(it) }
                     }
                     append(oldColor)
                     append(" ")


### PR DESCRIPTION
idk how this happened :(
also the pattern change from earlier has backwards compatability issues, so changing key name
and fixed future issues by returning if the found sb stat was null

## Changelog Fixes
+ Fixed colorful item tooltips replacing commas with dots. - CalMWolfs