### PR TITLE
Backend: Jump to Config (from ConfigFix)

### DIFF
--- a/.live-plugins/jump-to-definition/plugin.kts
+++ b/.live-plugins/jump-to-definition/plugin.kts
@@ -14,49 +14,73 @@ import org.jetbrains.kotlin.psi.*
 
 registerIntention(NavigateToConfigIntention())
 
-val basePkg = "at.hannibal2.skyhanni.config"
-val baseClass = "at.hannibal2.skyhanni.config.Features"
+val baseConfigPkg = "at.hannibal2.skyhanni.config"
+val baseConfigClass = "at.hannibal2.skyhanni.config.Features"
+
+val baseStoragePkg = "$baseConfigPkg.storage"
+val profileStorageClass = "$baseStoragePkg.ProfileSpecificStorage"
+val playerStorageClass = "$baseStoragePkg.PlayerSpecificStorage"
 
 class NavigateToConfigIntention :
     SelfTargetingOffsetIndependentIntention<KtStringTemplateExpression>(
         KtStringTemplateExpression::class.java,
-        { "Go to config" }
+        { "Go to definition" }
     ) {
     override fun isApplicableTo(element: KtStringTemplateExpression): Boolean {
         val literal = element.text.removeSurrounding("\"")
-        if (literal.startsWith("#") || !literal.contains('.')) {
+        if (!literal.contains('.')) {
             return false
         }
 
         val call = PsiTreeUtil.getParentOfType(element, KtCallExpression::class.java) ?: return false
         val dot = call.parent as? KtDotQualifiedExpression ?: return false
-        if (dot.receiverExpression.text != "event" || call.calleeExpression?.text != "move") {
-            return false
-        }
-        return true
+        return !(dot.receiverExpression.text != "event" || call.calleeExpression?.text != "move")
     }
+
+    private fun searchProjectFor(
+        element: KtStringTemplateExpression,
+        className: String,
+    ) : KtClassOrObject? = JavaPsiFacade.getInstance(element.project).findClass(
+        className,
+        GlobalSearchScope.projectScope(element.project)
+    )?.navigationElement as? KtClassOrObject
 
     override fun applyTo(element: KtStringTemplateExpression, editor: Editor?) {
         val path = element.text.removeSurrounding("\"")
-        val segments = path.split('.')
+        val segments = path.split('.').takeIf { it.isNotEmpty() }?.toMutableList() ?: return
         val project = element.project
 
-        var current = JavaPsiFacade.getInstance(project).findClass(
-            baseClass,
-            GlobalSearchScope.projectScope(project)
-        )?.navigationElement as? KtClassOrObject ?: run {
+        val basePath = when (segments.first()) {
+            "#profile" -> {
+                segments.removeFirst()
+                profileStorageClass
+            }
+            "#player" -> {
+                segments.removeFirst()
+                playerStorageClass
+            }
+            else -> baseConfigClass
+        }
+
+        var current = searchProjectFor(element, basePath) ?: run {
             show("⚠️ Could not find root Features class for path '$path'")
             return
         }
 
         for ((i, name) in segments.withIndex()) {
-            val prop = current?.declarations.orEmpty().filterIsInstance<KtProperty>().firstOrNull { it.name == name } ?: run {
+            val prop = current.declarations.filterIsInstance<KtProperty>().firstOrNull { it.name == name } ?: run {
                 show("⚠️ Property '$name' not found in ${current.name} for path '$path'")
                 return
             }
 
             if (i == segments.lastIndex) {
-                show("Opening ${current.name} for path '$path'")
+                (prop.navigationElement as? NavigatablePsiElement)?.navigate(true)
+                return
+            }
+
+            val isPropMap = prop.typeReference?.text?.startsWith("MutableMap") == true ||
+                prop.typeReference?.text?.startsWith("Map") == true
+            if (i == segments.lastIndex - 1 && isPropMap) {
                 (prop.navigationElement as? NavigatablePsiElement)?.navigate(true)
                 return
             }
@@ -70,9 +94,9 @@ class NavigateToConfigIntention :
             val candidates = PsiShortNamesCache
                 .getInstance(project)
                 .getClassesByName(rawType, scope)
-                .filter { it.qualifiedName?.startsWith(basePkg) == true }
+                .filter { it.qualifiedName?.startsWith(baseConfigPkg) == true }
             val psiClass = candidates.firstOrNull() ?: run {
-                show("⚠️ Config class '$rawType' not found under '$basePkg' for path '$path'")
+                show("⚠️ Config class '$rawType' not found under '$baseConfigPkg' for path '$path'")
                 return
             }
 

--- a/.live-plugins/navigateconfigpath/plugin.kts
+++ b/.live-plugins/navigateconfigpath/plugin.kts
@@ -1,0 +1,85 @@
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiShortNamesCache
+import com.intellij.psi.util.PsiTreeUtil
+import liveplugin.registerIntention
+import liveplugin.PluginUtil.show
+import org.jetbrains.kotlin.idea.codeinsight.api.classic.intentions.SelfTargetingOffsetIndependentIntention
+import org.jetbrains.kotlin.psi.*
+
+// depends-on-plugin org.jetbrains.kotlin
+// depends-on-plugin com.intellij.java
+
+registerIntention(NavigateToConfigIntention())
+
+val basePkg = "at.hannibal2.skyhanni.config"
+val baseClass = "at.hannibal2.skyhanni.config.Features"
+
+class NavigateToConfigIntention :
+    SelfTargetingOffsetIndependentIntention<KtStringTemplateExpression>(
+        KtStringTemplateExpression::class.java,
+        { "Go to config" }
+    ) {
+    override fun isApplicableTo(element: KtStringTemplateExpression): Boolean {
+        val literal = element.text.removeSurrounding("\"")
+        if (literal.startsWith("#") || !literal.contains('.')) {
+            return false
+        }
+
+        val call = PsiTreeUtil.getParentOfType(element, KtCallExpression::class.java) ?: return false
+        val dot = call.parent as? KtDotQualifiedExpression ?: return false
+        if (dot.receiverExpression.text != "event" || call.calleeExpression?.text != "move") {
+            return false
+        }
+        return true
+    }
+
+    override fun applyTo(element: KtStringTemplateExpression, editor: Editor?) {
+        val path = element.text.removeSurrounding("\"")
+        val segments = path.split('.')
+        val project = element.project
+
+        var current = JavaPsiFacade.getInstance(project).findClass(
+            baseClass,
+            GlobalSearchScope.projectScope(project)
+        )?.navigationElement as? KtClassOrObject ?: run {
+            show("⚠️ Could not find root Features class for path '$path'")
+            return
+        }
+
+        for ((i, name) in segments.withIndex()) {
+            val prop = current?.declarations.orEmpty().filterIsInstance<KtProperty>().firstOrNull { it.name == name } ?: run {
+                show("⚠️ Property '$name' not found in ${current.name} for path '$path'")
+                return
+            }
+
+            if (i == segments.lastIndex) {
+                show("Opening ${current.name} for path '$path'")
+                (prop.navigationElement as? NavigatablePsiElement)?.navigate(true)
+                return
+            }
+
+            val rawType = prop.typeReference?.text?.substringBefore('<')?.substringBefore('?') ?: run {
+                show("⚠️ Could not parse type of '${prop.name}' in ${current.name} for path '$path'")
+                return
+            }
+
+            val scope = GlobalSearchScope.projectScope(project)
+            val candidates = PsiShortNamesCache
+                .getInstance(project)
+                .getClassesByName(rawType, scope)
+                .filter { it.qualifiedName?.startsWith(basePkg) == true }
+            val psiClass = candidates.firstOrNull() ?: run {
+                show("⚠️ Config class '$rawType' not found under '$basePkg' for path '$path'")
+                return
+            }
+
+            current = psiClass.navigationElement as? KtClassOrObject ?: run {
+                show("⚠️ Navigation target for class '$rawType' is not a KtClassOrObject")
+                return
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
Follow-up to #4414 - this adds the other direction. From a string inside an `event.move( )`, there is an `Open Config` option which will try to parse where the path resolves to. See images.

<details>
<summary>Images</summary>

<img width="1005" height="419" alt="image" src="https://github.com/user-attachments/assets/cdd399bf-3ddb-43c5-9a85-cead82198f1e" />
<img width="368" height="92" alt="image" src="https://github.com/user-attachments/assets/0369be59-7565-483b-ad20-7dd94fad0092" />

<img width="262" height="157" alt="image" src="https://github.com/user-attachments/assets/4e2f2a8f-4f07-48dc-86a6-0a8d14d6860f" />
<img width="357" height="84" alt="image" src="https://github.com/user-attachments/assets/b084c10f-3884-475d-8b03-31a6ad530103" />
</details>

## Changelog Technical Details
+ Added live plugin for jumping to config from migration path. - Daveed

