### PR TITLE
Backend: Resettable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.api
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.pet.CurrentPetApi
+import at.hannibal2.skyhanni.config.storage.NoReset
 import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.IslandType
@@ -295,22 +296,12 @@ object ExperimentationTableApi {
     }
 
     data class ExperimentationDataSet(
-        @Transient var type: ExperimentationTaskType? = null,
-        @Transient var tier: ExperimentationTier? = null,
-        var enchantingXpGained: Long = 0L,
-        var rareFoundFired: Boolean = false,
+        var type: ExperimentationTaskType? = null,
+        var tier: ExperimentationTier? = null,
+        @NoReset var enchantingXpGained: Long = 0L,
+        @NoReset var rareFoundFired: Boolean = false,
     ) : Resettable() {
-        @Transient private val otherRewards: MutableMap<NeuInternalName, Int> = mutableMapOf()
-
-        override fun reset() {
-            super.reset()
-            // todo at some point make resettable storage set deal with this stuff
-            //  Resettable doesn't deal with nulls or clearing mutables
-            //  It does (^ that) after #4244 gets merged, so I'll do that eventually -David
-            otherRewards.clear()
-            type = null
-            tier = null
-        }
+        private val otherRewards: MutableMap<NeuInternalName, Int> = mutableMapOf()
 
         fun addReward(internalName: NeuInternalName, amount: Int = 1) {
             otherRewards.addOrPut(internalName, amount)

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.api
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.pet.CurrentPetApi
-import at.hannibal2.skyhanni.config.storage.ResettableStorageSet
+import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
@@ -299,13 +299,13 @@ object ExperimentationTableApi {
         @Transient var tier: ExperimentationTier? = null,
         var enchantingXpGained: Long = 0L,
         var rareFoundFired: Boolean = false,
-    ) : ResettableStorageSet() {
+    ) : Resettable() {
         @Transient private val otherRewards: MutableMap<NeuInternalName, Int> = mutableMapOf()
 
         override fun reset() {
             super.reset()
             // todo at some point make resettable storage set deal with this stuff
-            //  ResettableStorageSet doesn't deal with nulls or clearing mutables
+            //  Resettable doesn't deal with nulls or clearing mutables
             //  It does (^ that) after #4244 gets merged, so I'll do that eventually -David
             otherRewards.clear()
             type = null

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.api
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.pet.CurrentPetApi
-import at.hannibal2.skyhanni.config.storage.NoReset
 import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.IslandType
@@ -298,8 +297,8 @@ object ExperimentationTableApi {
     data class ExperimentationDataSet(
         var type: ExperimentationTaskType? = null,
         var tier: ExperimentationTier? = null,
-        @NoReset var enchantingXpGained: Long = 0L,
-        @NoReset var rareFoundFired: Boolean = false,
+        var enchantingXpGained: Long = 0L,
+        var rareFoundFired: Boolean = false,
     ) : Resettable() {
         private val otherRewards: MutableMap<NeuInternalName, Int> = mutableMapOf()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customwardrobe/ColorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customwardrobe/ColorConfig.kt
@@ -1,13 +1,13 @@
 package at.hannibal2.skyhanni.config.features.inventory.customwardrobe
 
-import at.hannibal2.skyhanni.config.storage.ResettableStorageSet
+import at.hannibal2.skyhanni.config.storage.Resettable
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
-class ColorConfig : ResettableStorageSet() {
+class ColorConfig : Resettable() {
 
     @ConfigOption(name = "Reset to Default", desc = "Reset all custom wardrobe color settings to the default.")
     @ConfigEditorButton(buttonText = "Reset")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customwardrobe/SpacingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customwardrobe/SpacingConfig.kt
@@ -1,13 +1,13 @@
 package at.hannibal2.skyhanni.config.features.inventory.customwardrobe
 
-import at.hannibal2.skyhanni.config.storage.ResettableStorageSet
+import at.hannibal2.skyhanni.config.storage.Resettable
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
 
-class SpacingConfig : ResettableStorageSet() {
+class SpacingConfig : Resettable() {
 
     @ConfigOption(name = "Reset to Default", desc = "Reset all custom wardrobe spacing settings to the default.")
     @ConfigEditorButton(buttonText = "Reset")

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/NoReset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/NoReset.kt
@@ -1,0 +1,8 @@
+package at.hannibal2.skyhanni.config.storage
+
+/**
+ * Used in cases where you want to exclude a field present in a [Resettable] to not be reset.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FIELD)
+annotation class NoReset

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -478,7 +478,7 @@ class ProfileSpecificStorage(
         var visitorDrops: VisitorDrops = VisitorDrops()
 
         // Todo: Move to a SkyhanniTracker (preferably bucketed by rarity)
-        class VisitorDrops {
+        class VisitorDrops : Resettable() {
             @Expose
             var acceptedVisitors: Int = 0
 

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -315,7 +315,7 @@ class ProfileSpecificStorage(
             @Expose var singleSlotCooldownMark: SimpleTimeMark? = null,
             @Expose var allSlotsCooldownMark: SimpleTimeMark? = null,
             @Expose var purchasedHitmanSlots: Int = 0,
-        ) : ResettableStorageSet()
+        ) : Resettable()
 
         @Expose
         var hitmanStats: HitmanStatsStorage = HitmanStatsStorage()

--- a/src/main/java/at/hannibal2/skyhanni/events/garden/contests/rewards/ContestRewardsClaimedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/contests/rewards/ContestRewardsClaimedEvent.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.events.garden.contests.rewards
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
-import at.hannibal2.skyhanni.config.storage.ResettableStorageSet
+import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.features.garden.AnitaMedalProfit
 import at.hannibal2.skyhanni.features.garden.CropType
 
@@ -13,4 +13,4 @@ data class ContestRewardSet(
     var books: Map<CropType, Int> = emptyMap(),
     var medals: Map<AnitaMedalProfit.MedalType, Int> = emptyMap(),
     var bits: Int = 0
-) : ResettableStorageSet()
+) : Resettable()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.event.hoppity
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
-import at.hannibal2.skyhanni.config.storage.ResettableStorageSet
+import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.HoppityEggLocationsJson
 import at.hannibal2.skyhanni.events.GuiContainerEvent
@@ -139,7 +139,7 @@ object HoppityApi {
         var lastProfit: String = "",
         var lastMeal: HoppityEggType? = null,
         var lastDuplicateAmount: Long? = null,
-    ) : ResettableStorageSet()
+    ) : Resettable()
 
     val hoppityRarities = LorenzRarity.entries.filter { it <= DIVINE }
     private val hoppityDataSet = HoppityStateDataSet()

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactSweepDetails.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactSweepDetails.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.features.foraging
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.config.storage.ResettableStorageSet
+import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.events.IslandChangeEvent
@@ -76,7 +76,7 @@ object CompactSweepDetails {
         var sweep: Double = -1.0,
         var toughness: Double = -1.0,
         var treeType: String = "",
-    ) : ResettableStorageSet()
+    ) : Resettable()
 
     private var sweepDetailsAreDirty = false
     private var isInsideSweepDetails = false

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
@@ -266,17 +266,8 @@ object GardenVisitorDropStatistics {
         val storage = GardenApi.storage?.visitorDrops ?: return
         ChatUtils.clickableChat(
             "Click here to reset Visitor Drops Statistics.",
-            // Todo: Make the storage class extend `Resettable`, so this can just be a .reset() call
-            //  This should happen at the same time as the tracker migration - see #profile.garden.visitorDrops
             onClick = {
-                storage.copper = 0
-                storage.bits = 0
-                storage.farmingExp = 0
-                storage.gardenExp = 0
-                storage.gemstonePowder = 0
-                storage.mithrilPowder = 0
-                storage.acceptedRarities = mutableMapOf()
-                storage.rewardsCount = mutableMapOf()
+                storage.reset()
                 ChatUtils.chat("Visitor Drop Statistics reset!")
                 saveAndUpdate()
             },

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
@@ -266,7 +266,7 @@ object GardenVisitorDropStatistics {
         val storage = GardenApi.storage?.visitorDrops ?: return
         ChatUtils.clickableChat(
             "Click here to reset Visitor Drops Statistics.",
-            // Todo: Make the storage class extend `ResettableStorageSet`, so this can just be a .reset() call
+            // Todo: Make the storage class extend `Resettable`, so this can just be a .reset() call
             //  This should happen at the same time as the tracker migration - see #profile.garden.visitorDrops
             onClick = {
                 storage.copper = 0

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FannCost.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FannCost.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.config.storage.ResettableStorageSet
+import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -53,7 +53,7 @@ object FannCost {
         var expEarned: Double? = null,
         var expDaily: Double? = null,
         var duration: Duration = Duration.ZERO,
-    ) : ResettableStorageSet()
+    ) : Resettable()
 
     private const val TRAINING_DURATION_SLOT_NUM = 15
     private const val BEGIN_TRAINING_SLOT_NUM = 22

--- a/src/test/java/at/hannibal2/skyhanni/test/ResettableStorageSetTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ResettableStorageSetTest.kt
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.test
 
-import at.hannibal2.skyhanni.config.storage.ResettableStorageSet
+import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityApi
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggType
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -23,7 +23,7 @@ class ResettableStorageSetTest {
         var nullInt: Int? = null,
         @Transient var transientString: String = "transient",
         val defaultBool: Boolean = false,
-    ) : ResettableStorageSet() {
+    ) : Resettable() {
         val list: MutableList<String> = mutableListOf()
         val map: MutableMap<String, Int> = mutableMapOf()
         @Transient val transientList: MutableList<String> = mutableListOf("transientListItem")

--- a/src/test/java/at/hannibal2/skyhanni/test/ResettableTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ResettableTest.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.test
 
+import at.hannibal2.skyhanni.config.storage.NoReset
 import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityApi
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggType
@@ -12,7 +13,7 @@ import io.mockk.mockkObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
-class ResettableStorageSetTest {
+class ResettableTest {
 
     data class TestStorage(
         var string: String = "default",
@@ -25,8 +26,13 @@ class ResettableStorageSetTest {
         val defaultBool: Boolean = false,
     ) : Resettable() {
         val list: MutableList<String> = mutableListOf()
+        private val privateList: MutableList<String> = mutableListOf("privateListItem")
         val map: MutableMap<String, Int> = mutableMapOf()
-        @Transient val transientList: MutableList<String> = mutableListOf("transientListItem")
+        private val privateMap: MutableMap<String, Int> = mutableMapOf("privateKey" to 1)
+        @NoReset val noResetList: MutableList<String> = mutableListOf("noResetListItem")
+
+        fun getPrivateListSize(): Int = privateList.size
+        fun getPrivateMapSize(): Int = privateMap.size
 
         val intGetter: Int get() = staticInt + 1
     }
@@ -100,12 +106,22 @@ class ResettableStorageSetTest {
         )
 
         Assertions.assertTrue(
+            storage.getPrivateListSize() == 0,
+            "Private list should be cleared"
+        )
+
+        Assertions.assertTrue(
             storage.map.isEmpty(),
             "Map property should be cleared"
         )
 
         Assertions.assertTrue(
-            storage.transientList.isNotEmpty(),
+            storage.getPrivateMapSize() == 0,
+            "Private map should be cleared"
+        )
+
+        Assertions.assertTrue(
+            storage.noResetList.isNotEmpty(),
             "Transient list should not be cleared"
         )
 

--- a/versions/1.21.5/buildpaths-excluded.txt
+++ b/versions/1.21.5/buildpaths-excluded.txt
@@ -56,7 +56,7 @@ at.hannibal2.skyhanni.test.ComponentSpanTest.kt
 at.hannibal2.skyhanni.test.RepoPatternTest.kt
 at.hannibal2.skyhanni.test.ItemModifierTest.kt
 at.hannibal2.skyhanni.test.garden.VisitorListenerTest.kt
-at.hannibal2.skyhanni.test.ResettableStorageSetTest.kt
+at.hannibal2.skyhanni.test.ResettableTest.kt
 
 at.hannibal2.skyhanni.mixins.transformers.ExtendedColorPatch.java
 at.hannibal2.skyhanni.mixins.transformers.MixinEntityFireball.java

--- a/versions/1.21.7/buildpaths-excluded.txt
+++ b/versions/1.21.7/buildpaths-excluded.txt
@@ -56,6 +56,8 @@ at.hannibal2.skyhanni.test.ComponentSpanTest.kt
 at.hannibal2.skyhanni.test.RepoPatternTest.kt
 at.hannibal2.skyhanni.test.ItemModifierTest.kt
 at.hannibal2.skyhanni.test.garden.VisitorListenerTest.kt
-at.hannibal2.skyhanni.test.ResettableTestnnibal2.skyhanni.mixins.transformers.ExtendedColorPatch.java
+at.hannibal2.skyhanni.test.ResettableTest.kt
+
+at.hannibal2.skyhanni.mixins.transformers.ExtendedColorPatch.java
 at.hannibal2.skyhanni.mixins.transformers.MixinEntityFireball.java
 at.hannibal2.skyhanni.mixins.transformers.MixinGuiPlayerTabOverlay.java

--- a/versions/1.21.7/buildpaths-excluded.txt
+++ b/versions/1.21.7/buildpaths-excluded.txt
@@ -56,8 +56,6 @@ at.hannibal2.skyhanni.test.ComponentSpanTest.kt
 at.hannibal2.skyhanni.test.RepoPatternTest.kt
 at.hannibal2.skyhanni.test.ItemModifierTest.kt
 at.hannibal2.skyhanni.test.garden.VisitorListenerTest.kt
-at.hannibal2.skyhanni.test.ResettableStorageSetTest.kt
-
-at.hannibal2.skyhanni.mixins.transformers.ExtendedColorPatch.java
+at.hannibal2.skyhanni.test.ResettableTestnnibal2.skyhanni.mixins.transformers.ExtendedColorPatch.java
 at.hannibal2.skyhanni.mixins.transformers.MixinEntityFireball.java
 at.hannibal2.skyhanni.mixins.transformers.MixinGuiPlayerTabOverlay.java


### PR DESCRIPTION
## What
I'm anticipating a potential slew of ballooning problems with #4415, so in an attempt to expedite some other things dependent on [this] - this PR changes `ResettableStorageSet` to `Resettable`, as I accidentally created a class that's also applicable in some Configs. Also added support for `Resettable`s within `Resettable`s, so they can be nested.

## Changelog Technical Details
+ Renamed ResettableStorageSet to Resettable. - Daveed
    * Added NoReset annotation.
    * Useful when you can't use Transient due to JVM implications.
