### PR TITLE
Backend: Fix Living Snake debug logging

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveSnakeFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveSnakeFeatures.kt
@@ -133,8 +133,8 @@ object LivingCaveSnakeFeatures {
         snakes.removeIf {
             val invalidShape = it.invalidShape()
             val invalidHead = it.invalidHead()
-            if (invalidShape && SkyHanniDebugsAndTests.enabled) ChatUtils.chat("LivingCaveSnake remove because of invalid shape")
-            if (invalidHead && SkyHanniDebugsAndTests.enabled) ChatUtils.chat("LivingCaveSnake remove because of invalid head")
+            if (invalidShape) ChatUtils.debug("LivingCaveSnake removed because of invalid shape")
+            if (invalidHead) ChatUtils.debug("LivingCaveSnake removed because of invalid head")
             invalidShape || invalidHead
         }
         snakes.forEach { it.tick() }


### PR DESCRIPTION
## What
Fixed Living Snake debug messages using `ChatUtils.chat()` instead of `ChatUtils.debug()`. Also fixed the grammar.

## Changelog Technical Details
+ Fixed Living Snake debug messages not using the correct debug method. - Luna