### PR TITLE
Fix: Incorrect Sun Gecko Highlight

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
@@ -140,8 +140,10 @@ object SunGeckoHelper {
         val mob = event.mob
         val name = mob.name
         if (!name.contains("Sun Gecko")) return
-        if (name.contains("?") && config.highlightFakeBoss) {
-            mob.highlight(Color.RED.addAlpha(80))
+        if (name.contains("?")) {
+            if (config.highlightFakeBoss) {
+                mob.highlight(Color.RED.addAlpha(80))
+            }
         } else {
             if (config.highlightRealBoss) {
                 mob.highlight(Color.GREEN.addAlpha(80))


### PR DESCRIPTION
## What
Fixed incorrect condition logic in Sun Gecko Helper leading to the clones being incorrectly  highlighted as the real boss sometimes.

## Changelog Fixes
+ Fixed Sun Gecko Helper's "Highlight Real Boss" incorrectly highlighting the clones in green if "Highlight Clones" is disabled. - Luna