### PR TITLE
Feature: Fix Hypixel Killer Spring Sound Spam on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/vampire/KillerSpringConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/vampire/KillerSpringConfig.kt
@@ -37,7 +37,7 @@ class KillerSpringConfig {
     @Expose
     @ConfigOption(
         name = "Fix Sound Spam",
-        desc = "Fix Hypixel spamming sounds during Killer Spring and overloading the Minecraft sound engine.",
+        desc = "Fixes a Hypixel bug that overloads Minecraft's sound engine with Killer Spring sounds and results in no sounds for a few seconds.",
     )
     @SearchTag("mute wither")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/vampire/KillerSpringConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/vampire/KillerSpringConfig.kt
@@ -1,10 +1,12 @@
 package at.hannibal2.skyhanni.config.features.slayer.vampire
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyModern
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class KillerSpringConfig {
     @Expose
@@ -31,4 +33,15 @@ class KillerSpringConfig {
     @ConfigOption(name = "Lines Start Color", desc = "Starting color of the lines.")
     @ConfigEditorColour
     var linesColor: String = "0:255:255:13:0"
+
+    @Expose
+    @ConfigOption(
+        name = "Fix Sound Spam",
+        desc = "Fix Hypixel spamming sounds during Killer Spring and overloading the Minecraft sound engine.",
+    )
+    @SearchTag("mute wither")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    @OnlyModern
+    var fixSoundSpam: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/vampire/KillerSpringConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/vampire/KillerSpringConfig.kt
@@ -37,7 +37,8 @@ class KillerSpringConfig {
     @Expose
     @ConfigOption(
         name = "Fix Sound Spam",
-        desc = "Fixes a Hypixel bug that overloads Minecraft's sound engine with Killer Spring sounds and results in no sounds for a few seconds.",
+        desc = "Fixes a Hypixel bug that overloads Minecraft's sound engine with Killer Spring sounds " +
+            "and results in no sounds for a few seconds.",
     )
     @SearchTag("mute wither")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/SoundCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/SoundCompat.kt
@@ -32,6 +32,7 @@ object SoundCompat {
         "mob.pig.say" to "entity.pig.ambient",
         "mob.sheep.say" to "entity.sheep.ambient",
         "mob.wither.shoot" to "entity.wither.shoot",
+        "mob.wither.spawn" to "entity.wither.spawn",
         "mob.wolf.bark" to "entity.wolf.ambient",
         "mob.wolf.death" to "entity.wolf.death",
         "mob.wolf.growl" to "entity.wolf.growl",


### PR DESCRIPTION
## What
Cancels multiple `mob.wither.spawn` sounds sent within the same tick by Hypixel while in the Stillgore Chateau to prevent Minecraft's sound engine from becoming overloaded and causing all sounds to be muted for a few seconds after a Killer Spring spawns.

Marked as `@OnlyModern` because while Hypixel's behavior appears similar on 1.8, it does not cause any noticeable issues there.

## Changelog New Features
+ Added a workaround for a Hypixel bug that results in no sounds for a few seconds after the Vampire Slayer's Killer Spring spawns on 1.21. - Luna