### PR TITLE
Fix: Small chat formatting fixes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.extraAttributes
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.PrimitiveRecipe
 import at.hannibal2.skyhanni.utils.StringUtils.cleanString
 import at.hannibal2.skyhanni.utils.StringUtils.removeUnusedDecimal
@@ -452,7 +453,7 @@ object EnoughUpdatesManager {
         neuPetsJson = event.getConstant<NeuPetsJson>("pets")
         neuPetNums = event.getConstant<JsonObject>("petnums")
         if (itemMap.isNotEmpty()) {
-            ChatUtils.chat("Reloaded ${itemMap.size} items in the NEU repo")
+            ChatUtils.chat("Reloaded ${itemMap.size.addSeparators()} items in the NEU repo")
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ColorFormattingHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ColorFormattingHelper.kt
@@ -39,13 +39,13 @@ object ColorFormattingHelper {
     }
 
     private fun printColorCodesExtra() {
-        ChatUtils.chat("§c================= Formatting Extra ==================", false)
+        ChatUtils.chat("§c================= Formatting Extra ==================", prefix = false)
         ChatUtils.clickableLinkChat(
             "§#§6§a§e§e§4§8§/[Click here to view codes on minecraft.wiki]",
             "https://minecraft.wiki/w/Formatting_codes#Color_codes",
             "§eOpen §cminecraft.wiki§e!",
-            false,
-            false,
+            autoOpen = false,
+            prefix = false,
         )
         ChatUtils.chat(
             "§eYou can also uses SkyHanni's system for any colors. " +
@@ -60,7 +60,7 @@ object ColorFormattingHelper {
             "§eOpen §ccolor-hex.com§e!",
             prefix = false,
         )
-        ChatUtils.chat("§c===================================================", false)
+        ChatUtils.chat("§c===================================================", prefix = false)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
@@ -110,9 +110,7 @@ object WikiManager {
         val wiki = if (useFandom) "SkyBlock Fandom Wiki" else "Official SkyBlock Wiki"
         val urlPrefix = if (useFandom) FANDOM_URL_PREFIX else OFFICIAL_URL_PREFIX
         if (search == "") {
-            ChatUtils.clickableLinkChat(
-                "§7Click §e§lHERE §7to visit the §6$wiki§7!", urlPrefix, "§7The $wiki!"
-            )
+            ChatUtils.clickableLinkChat("§7Click §e§lHERE §7to visit the §6$wiki§7!", urlPrefix, "§7The $wiki!")
             return
         }
 
@@ -123,7 +121,7 @@ object WikiManager {
             "§7Click §e§lHERE §7to find §a$displaySearch §7on the §6$wiki§7!",
             searchUrl,
             "§7View §a$displaySearch §7on the §6$wiki§7!",
-            autoOpen
+            autoOpen,
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -169,6 +169,7 @@ object ChatUtils {
             this.onClick(expireAt, oneTimeClick, onClick)
             this.hover = hover.asComponent()
         }
+
         if (replaceSameMessage) {
             text.send(getUniqueMessageIdForString(rawText))
         } else {
@@ -251,14 +252,19 @@ object ChatUtils {
         autoOpen: Boolean = false,
         prefix: Boolean = true,
         prefixColor: String = "§e",
+        replaceSameMessage: Boolean = false,
     ) {
         val msgPrefix = if (prefix) prefixColor + CHAT_PREFIX else ""
-        chat(
-            TextHelper.text(msgPrefix + message) {
-                this.url = url
-                this.hover = "$prefixColor$hover".asComponent()
-            },
-        )
+        val text = TextHelper.text(msgPrefix + message) {
+            this.url = url
+            this.hover = "$prefixColor$hover".asComponent()
+        }
+        if (replaceSameMessage) {
+            text.send(getUniqueMessageIdForString(message))
+        } else {
+            chat(text)
+        }
+
         if (autoOpen) OSUtils.openBrowser(url)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -139,7 +139,7 @@ object ComputerTimeOffset {
             "Your computer's clock is off by ${offsetMillis.absoluteValue.format()}.\n" +
                 "§ePlease update your time settings. Many features may not function correctly until you do.\n" +
                 "§eClick here for instructions on how to fix your clock.",
-            offsetFixLinks ?: return,
+            url = offsetFixLinks ?: return,
             prefixColor = "§c",
             replaceSameMessage = true,
         )

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -141,6 +141,7 @@ object ComputerTimeOffset {
                 "§eClick here for instructions on how to fix your clock.",
             offsetFixLinks ?: return,
             prefixColor = "§c",
+            replaceSameMessage = true,
         )
     }
 


### PR DESCRIPTION
## What
Two small fixes in chat that I noticed:
1. This "patcher for the 1.21 mod" adds numbers of repeating messages to the computer time-off messages.
<img width="612" height="78" alt="image" src="https://github.com/user-attachments/assets/d851f828-1205-4013-a1bf-1625e65598d8" />

2. The repo message in chat doesn't have a thousand-comma.

Added more support to one chat message function and generic formatting cleanup.

## Changelog Fixes
+ Fixed "Your computer's clock is off" messages sometimes spamming the chat. - hannibal2

## Changelog Technical Details
+ ChatUtils.clickableLinkChat now supports parameter replaceSameMessage. - hannibal2