### PR TITLE
Fix: 1.21 NPE in entity utils

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -203,12 +203,12 @@ object EntityUtils {
     }?.asSequence()?.filterNotNull().orEmpty()
     //#else
     //$$ fun getAllTileEntities(): Sequence<BlockEntity> {
-    //$$     if (!MinecraftCompat.localWorldExists) return emptySequence()
-    //$$     val blockEntityTickers = MinecraftCompat.localWorld.blockEntityTickers.let {
+    //$$     val world = MinecraftCompat.localWorldOrNull ?: return emptySequence()
+    //$$     val blockEntityTickers = world.blockEntityTickers.let {
     //$$         if (MinecraftClient.getInstance().isOnThread) it else it.toMutableList()
     //$$     }.asSequence().filterNotNull()
     //$$
-    //$$     return blockEntityTickers.map { MinecraftCompat.localWorld.getBlockEntity(it.pos) }.filterNotNull()
+    //$$     return blockEntityTickers.mapNotNull { invoker -> invoker.pos?.let { world.getBlockEntity(it) } }
     //$$ }
     //#endif
 


### PR DESCRIPTION
## What
my first 1.21 code (that i can think of)
hopefully fixed this error here:
https://discord.com/channels/997079228510117908/1396563663908896940

looks like `it.pos` can be null. then `.getBlockEntity()` gets called with null as parameter. Also did some cleanup in the function.

## Changelog Fixes
+ Fixed rare error in Crimson Miniboss Respawn Timer on 1.21. - hannibal2