### PR TITLE
Fix: Text in inventories not showing on 1.21.7

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
@@ -85,9 +85,9 @@ object BetterContainers {
     private var textColor: Int = 4210752
 
     @JvmStatic
-    fun getTextColor(): Int {
-        return if (!isOverriding) 4210752
-        else textColor
+    fun getTextColor(original: Int): Int {
+        return if (!isOverriding) original
+        else textColor or 0xFF000000.toInt()
     }
 
     @JvmStatic
@@ -178,11 +178,11 @@ object BetterContainers {
         val backgroundStyle = config.menuBackgroundStyle
         val buttonStyle = config.buttonBackgroundStyle
 
-        textColor = readJsonResource(backgroundStyle.configId)?.use { reader ->
+        textColor = (readJsonResource(backgroundStyle.configId)?.use { reader ->
             val newJson = ConfigManager.gson.fromJson(reader, JsonObject::class.java)
             val textColourS = newJson.get("text-colour").asString
             textColourS.toLong(16).toInt()
-        } ?: 4210752
+        } ?: 4210752) or 0xFF000000.toInt()
 
         bufferedImageOn = readImageResource(toggleOn)
         bufferedImageOff = readImageResource(toggleOff)

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
@@ -97,8 +97,8 @@ public abstract class MixinHandledScreen {
     //#else
     //$$ @ModifyArg(method = "drawForeground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawText(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/text/Text;IIIZ)V"), index = 4)
     //#endif
-    private int customForegroundTextColor(int x) {
-        return BetterContainers.getTextColor();
+    private int customForegroundTextColor(int colour) {
+        return BetterContainers.getTextColor(colour);
     }
 
     @Redirect(method = "drawSlotHighlightBack", at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/slot/Slot;canBeHighlighted()Z"))


### PR DESCRIPTION
## What
they add alpha, we made them bald

<details>
<summary>Images</summary>

<img width="1911" height="1072" alt="image" src="https://github.com/user-attachments/assets/fc16e5fb-e22f-435b-bcdd-45b058b62a4e" />

</details>

## Changelog Fixes
+ Fixed inventory names not showing on 1.21.7 when Improved SB Menus was off. - nopo
