### PR TITLE
Fix: Some of Custom Wardrobe on 1.21.7

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGenericContainerScreen.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGenericContainerScreen.java
@@ -7,6 +7,12 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+//#if MC > 1.21.6
+//$$ import at.hannibal2.skyhanni.data.GuiData;
+//$$ import net.minecraft.client.gui.DrawContext;
+//$$ import org.spongepowered.asm.mixin.injection.Inject;
+//$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+//#endif
 
 @Mixin(GenericContainerScreen.class)
 abstract class MixinGenericContainerScreen {
@@ -28,4 +34,13 @@ abstract class MixinGenericContainerScreen {
     private Identifier getCustomTexture(Identifier sprite) {
         return skyhanni$hook.getTexture(sprite);
     }
+
+    //#if MC > 1.21.6
+    //$$ @Inject(method = "drawBackground", at = @At(value = "HEAD"), cancellable = true)
+    //$$ private void cancelWardrobeBackground(DrawContext context, float deltaTicks, int mouseX, int mouseY, CallbackInfo ci) {
+    //$$     if (GuiData.INSTANCE.getPreDrawEventCancelled()) {
+    //$$         ci.cancel();
+    //$$     }
+    //$$ }
+    //#endif
 }


### PR DESCRIPTION
## What
No longer displays the inventory over the custom wardrobe, doesn't fix fake players not rendering.

## Changelog Fixes
+ Fixed Custom Wardrobe not hiding the inventory screen on 1.21.7. - CalMWolfs

