### PR TITLE
Fix: wither skeleton mob detection on 1.21+

### DIFF
--- a/versions/mapping-1.16.5-forge-1.8.9.txt
+++ b/versions/mapping-1.16.5-forge-1.8.9.txt
@@ -412,7 +412,7 @@ net.minecraft.world.entity.monster.Guardian net.minecraft.entity.monster.EntityG
 net.minecraft.world.entity.monster.MagmaCube net.minecraft.entity.monster.EntityMagmaCube
 net.minecraft.world.entity.monster.Monster net.minecraft.entity.monster.EntityMob
 net.minecraft.world.entity.monster.Silverfish net.minecraft.entity.monster.EntitySilverfish
-net.minecraft.world.entity.monster.Skeleton net.minecraft.entity.monster.EntitySkeleton
+net.minecraft.world.entity.monster.AbstractSkeleton net.minecraft.entity.monster.EntitySkeleton
 net.minecraft.world.entity.monster.Slime net.minecraft.entity.monster.EntitySlime
 net.minecraft.world.entity.monster.Spider net.minecraft.entity.monster.EntitySpider
 net.minecraft.world.entity.monster.Witch net.minecraft.entity.monster.EntityWitch


### PR DESCRIPTION
## What
Changed mapping from Skeleton to AbstractSkeleton which Skeletons and Wither Skeletons both inherit from. Could add a specific case for Wither Skeletons on newer versions in MobFinder instead if that is preferred.

## Changelog Fixes
+ Fixed Wither Skeleton Mob Detection on 1.21+. - yhtez
    * Fixed Mob HP for Bladesoul and Quazzi.

