### PR TITLE
Improvement: Add option to only show shard data for ones in current inventory

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/AttributeShardsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/AttributeShardsConfig.kt
@@ -33,6 +33,11 @@ class AttributeShardsConfig {
     var includeHuntingBox: Boolean = true
 
     @Expose
+    @ConfigOption(name = "Only Current Inventory", desc = "Only show the shards that are in the current inventory you have open.")
+    @ConfigEditorBoolean
+    var onlyCurrentInventory: Boolean = false
+
+    @Expose
     @ConfigOption(name = "Display Sorting Method", desc = "The method used to sort the attribute shards in the overlay.")
     @ConfigEditorDropdown
     var displaySortingMethod: AttributeShardOverlay.AttributeShardSorting = AttributeShardOverlay.AttributeShardSorting.PRICE_TO_NEXT_TIER

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -49,11 +49,9 @@ object InventoryUtils {
             .filter { it.inventory !is InventoryPlayer }
     }
 
-//     fun getItemsInLowerChestWithNull(): List<Slot> {
-//         val guiChest = Minecraft.getMinecraft().currentScreen as? GuiChest ?: return emptyList()
-//         return guiChest.inventorySlots.inventorySlots
-//             .filter { it.inventory is InventoryPlayer }
-//     }
+    fun getItemIdsInOpenChest(): Set<NeuInternalName> {
+        return getItemsInOpenChest().mapNotNull { it.stack?.getInternalNameOrNull() }.toSet()
+    }
 
     // only works while not in an inventory
     fun getSlotsInOwnInventory(): List<Slot> {


### PR DESCRIPTION
## What
Added an option to only show attribute shard data for the shards visible in your current inventory.
Also replaced an unused function with `getItemIdsInOpenChest` which can be used for inventory comparisons or other sorting purposes like this pr has

## Changelog Improvements
+ Added option to only show Attribute Shard data for shards visible in your current inventory. - CalMWolfs
