### PR TITLE
Improvement: item pickup log shows total coin value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogCoinValueConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogCoinValueConfig.kt
@@ -12,7 +12,7 @@ class ItemPickupLogCoinValueConfig {
     @Expose
     @ConfigOption(name = "Total Coin Value", desc = "Show total coin value of the items in your pickup log.")
     @ConfigEditorBoolean
-    var totalCoinValue: Boolean = false
+    var enabled: Boolean = false
 
     @Expose
     @ConfigOption(name = "Price Source", desc = "What price source to use for total coin value.")
@@ -22,5 +22,5 @@ class ItemPickupLogCoinValueConfig {
     @Expose
     @ConfigOption(name = "Total Coin Value Threshold", desc = "Only show total coin value when above this threshold.")
     @ConfigEditorSlider(minValue = 0f, maxValue = 1_000_000f, minStep = 1000f)
-    var totalCoinValueThreshold: Float = 10_000f
+    var threshold: Float = 10_000f
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogCoinValueConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogCoinValueConfig.kt
@@ -1,0 +1,26 @@
+package at.hannibal2.skyhanni.config.features.inventory
+
+import at.hannibal2.skyhanni.utils.ItemPriceSource
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class ItemPickupLogCoinValueConfig {
+
+    @Expose
+    @ConfigOption(name = "Total Coin Value", desc = "Show total coin value of the items in your pickup log.")
+    @ConfigEditorBoolean
+    var totalCoinValue: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Price Source", desc = "What price source to use for total coin value.")
+    @ConfigEditorDropdown
+    var priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_SELL
+
+    @Expose
+    @ConfigOption(name = "Total Coin Value Threshold", desc = "Only show total coin value when above this threshold.")
+    @ConfigEditorSlider(minValue = 0f, maxValue = 1_000_000f, minStep = 1000f)
+    var totalCoinValueThreshold: Float = 10_000f
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogConfig.kt
@@ -3,9 +3,9 @@ package at.hannibal2.skyhanni.config.features.inventory
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.features.inventory.ItemPickupLog
-import at.hannibal2.skyhanni.utils.ItemPriceSource
 import at.hannibal2.skyhanni.utils.RenderUtils
 import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
@@ -46,19 +46,9 @@ class ItemPickupLogConfig {
     var coins: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Total Coin Value", desc = "Show total coin value of the items in your pickup log.")
-    @ConfigEditorBoolean
-    var totalCoinValue: Boolean = false
-
-    @Expose
-    @ConfigOption(name = "Price Source", desc = "What price source to use for total coin value.")
-    @ConfigEditorDropdown
-    var priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_SELL
-
-    @Expose
-    @ConfigOption(name = "Total Coin Value Threshold", desc = "Only show total coin value when above this threshold.")
-    @ConfigEditorSlider(minValue = 0f, maxValue = 1_000_000f, minStep = 1000f)
-    var totalCoinValueThreshold: Float = 10_000f
+    @ConfigOption(name = "Pickup Coin Value", desc = "")
+    @Accordion
+    val coinValue: ItemPickupLogCoinValueConfig = ItemPickupLogCoinValueConfig()
 
     @Expose
     @ConfigOption(name = "Alignment", desc = "How the item pickup log should be aligned.")
@@ -83,5 +73,3 @@ class ItemPickupLogConfig {
     @ConfigLink(owner = ItemPickupLogConfig::class, field = "enabled")
     val position: Position = Position(-256, 140)
 }
-
-

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ItemPickupLogConfig.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features.inventory
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.features.inventory.ItemPickupLog
+import at.hannibal2.skyhanni.utils.ItemPriceSource
 import at.hannibal2.skyhanni.utils.RenderUtils
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
@@ -43,6 +44,21 @@ class ItemPickupLogConfig {
     @ConfigOption(name = "Coins", desc = "Show coins added and removed from purse.")
     @ConfigEditorBoolean
     var coins: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Total Coin Value", desc = "Show total coin value of the items in your pickup log.")
+    @ConfigEditorBoolean
+    var totalCoinValue: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Price Source", desc = "What price source to use for total coin value.")
+    @ConfigEditorDropdown
+    var priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_SELL
+
+    @Expose
+    @ConfigOption(name = "Total Coin Value Threshold", desc = "Only show total coin value when above this threshold.")
+    @ConfigEditorSlider(minValue = 0f, maxValue = 1_000_000f, minStep = 1000f)
+    var totalCoinValueThreshold: Float = 10_000f
 
     @Expose
     @ConfigOption(name = "Alignment", desc = "How the item pickup log should be aligned.")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -29,7 +29,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
 import at.hannibal2.skyhanni.utils.renderables.Renderable

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -290,11 +290,11 @@ object ItemPickupLog {
     }
 
     private fun computeTotalCoinValue(display: MutableList<Renderable>) {
-        if (!coinConfig.totalCoinValue || !(itemsAddedToInventory.isNotEmpty() || itemsRemovedFromInventory.isNotEmpty())) return
+        if (!coinConfig.enabled || !(itemsAddedToInventory.isNotEmpty() || itemsRemovedFromInventory.isNotEmpty())) return
         val valueAdded = itemsAddedToInventory.values.sumOf { it.coinValue() }
         val valueRemoved = itemsRemovedFromInventory.values.sumOf { it.coinValue() }
         val total = valueAdded - valueRemoved
-        if (total >= coinConfig.totalCoinValueThreshold || coinConfig.totalCoinValueThreshold == 0f) {
+        if (total >= coinConfig.threshold || coinConfig.threshold == 0f) {
             display.addString("Value: ${total.formatCoin()} Coins")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -12,6 +12,8 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemNameResolver
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.formatCoin
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
@@ -279,8 +281,29 @@ object ItemPickupLog {
         if (display.isEmpty()) {
             this.display = null
         } else {
+            if (config.totalCoinValue && (itemsAddedToInventory.isNotEmpty() || itemsRemovedFromInventory.isNotEmpty())) {
+                computeTotalCoinValue(display)
+            }
             val renderable = Renderable.vertical(display, verticalAlign = config.alignment)
             this.display = Renderable.fixedSizeColumn(renderable, 30)
+        }
+    }
+
+    private fun computeTotalCoinValue(display: MutableList<Renderable>) {
+        val valueAdded = itemsAddedToInventory.values.sumOf { entry ->
+            // Handle purse coins as a special case
+            if (entry.name == "§6Coins") entry.amount.toDouble()
+            else (entry.neuInternalName?.getPriceOrNull(config.priceSource) ?: 0.0) * entry.amount
+        }
+        val valueRemoved = itemsRemovedFromInventory.values.sumOf { entry ->
+            // Handle purse coins as a special case
+            if (entry.name == "§6Coins") entry.amount.toDouble()
+            else (entry.neuInternalName?.getPriceOrNull(config.priceSource) ?: 0.0) * entry.amount
+        }
+        val total = valueAdded - valueRemoved
+        if (total >= config.totalCoinValueThreshold || config.totalCoinValueThreshold == 0f) {
+            val displayValue = "Value: ${total.formatCoin()} Coins"
+            display.add(Renderable.text(displayValue))
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -281,30 +282,28 @@ object ItemPickupLog {
         if (display.isEmpty()) {
             this.display = null
         } else {
-            if (config.totalCoinValue && (itemsAddedToInventory.isNotEmpty() || itemsRemovedFromInventory.isNotEmpty())) {
-                computeTotalCoinValue(display)
-            }
+            computeTotalCoinValue(display)
             val renderable = Renderable.vertical(display, verticalAlign = config.alignment)
             this.display = Renderable.fixedSizeColumn(renderable, 30)
         }
     }
 
     private fun computeTotalCoinValue(display: MutableList<Renderable>) {
-        val valueAdded = itemsAddedToInventory.values.sumOf { entry ->
-            // Handle purse coins as a special case
-            if (entry.name == "§6Coins") entry.amount.toDouble()
-            else (entry.neuInternalName?.getPriceOrNull(config.priceSource) ?: 0.0) * entry.amount
-        }
-        val valueRemoved = itemsRemovedFromInventory.values.sumOf { entry ->
-            // Handle purse coins as a special case
-            if (entry.name == "§6Coins") entry.amount.toDouble()
-            else (entry.neuInternalName?.getPriceOrNull(config.priceSource) ?: 0.0) * entry.amount
-        }
+        if (!config.totalCoinValue || !(itemsAddedToInventory.isNotEmpty() || itemsRemovedFromInventory.isNotEmpty())) return
+        val valueAdded = itemsAddedToInventory.values.sumOf { it.coinValue() }
+        val valueRemoved = itemsRemovedFromInventory.values.sumOf { it.coinValue() }
         val total = valueAdded - valueRemoved
         if (total >= config.totalCoinValueThreshold || config.totalCoinValueThreshold == 0f) {
-            val displayValue = "Value: ${total.formatCoin()} Coins"
-            display.add(Renderable.text(displayValue))
+            display.addString("Value: ${total.formatCoin()} Coins")
         }
+    }
+
+    private fun PickupEntry.coinValue() = if (name == "§6Coins") {
+        // Handle purse coins as a special case
+        amount.toDouble()
+    } else {
+        val pricePer = neuInternalName?.getPriceOrNull(config.priceSource) ?: 0.0
+        pricePer * amount
     }
 
     private fun handleCompactLines(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -88,6 +88,7 @@ object ItemPickupLog {
     }
 
     private val config get() = SkyHanniMod.feature.inventory.itemPickupLog
+    private val coinConfig = config.coinValue
     private val coinIcon = "COIN_TALISMAN".toInternalName()
 
     private val itemList = mutableMapOf<Int, Pair<ItemStack, Int>>()
@@ -289,11 +290,11 @@ object ItemPickupLog {
     }
 
     private fun computeTotalCoinValue(display: MutableList<Renderable>) {
-        if (!config.totalCoinValue || !(itemsAddedToInventory.isNotEmpty() || itemsRemovedFromInventory.isNotEmpty())) return
+        if (!coinConfig.totalCoinValue || !(itemsAddedToInventory.isNotEmpty() || itemsRemovedFromInventory.isNotEmpty())) return
         val valueAdded = itemsAddedToInventory.values.sumOf { it.coinValue() }
         val valueRemoved = itemsRemovedFromInventory.values.sumOf { it.coinValue() }
         val total = valueAdded - valueRemoved
-        if (total >= config.totalCoinValueThreshold || config.totalCoinValueThreshold == 0f) {
+        if (total >= coinConfig.totalCoinValueThreshold || coinConfig.totalCoinValueThreshold == 0f) {
             display.addString("Value: ${total.formatCoin()} Coins")
         }
     }
@@ -302,7 +303,7 @@ object ItemPickupLog {
         // Handle purse coins as a special case
         amount.toDouble()
     } else {
-        val pricePer = neuInternalName?.getPriceOrNull(config.priceSource) ?: 0.0
+        val pricePer = neuInternalName?.getPriceOrNull(coinConfig.priceSource) ?: 0.0
         pricePer * amount
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -88,7 +88,7 @@ object ItemPickupLog {
     }
 
     private val config get() = SkyHanniMod.feature.inventory.itemPickupLog
-    private val coinConfig = config.coinValue
+    private val coinConfig get() = config.coinValue
     private val coinIcon = "COIN_TALISMAN".toInternalName()
 
     private val itemList = mutableMapOf<Int, Pair<ItemStack, Int>>()
@@ -295,7 +295,7 @@ object ItemPickupLog {
         val valueRemoved = itemsRemovedFromInventory.values.sumOf { it.coinValue() }
         val total = valueAdded - valueRemoved
         if (total >= coinConfig.threshold || coinConfig.threshold == 0f) {
-            display.addString("Value: ${total.formatCoin()} Coins")
+            display.add(0, Renderable.text("§eValue: ${total.formatCoin()} coins"))
         }
     }
 


### PR DESCRIPTION
## What
Add an option for users to see the total coin value of items picked up in the log. Would be neat to look at while grinding items to see short term coin gains. Can choose bz instant buy/sell and npc price, other items show LBIN.

example image shows coins from sack change event while mining
<details>
<summary>Images</summary>
<img width="190" height="123" alt="image" src="https://github.com/user-attachments/assets/58d975bd-64ca-4e9a-9afe-3e73e7c4abdf" />


<!-- drop images here -->

</details>

## Changelog Improvements
+ Added option to show total coin value of items in the Item Pickup Log. - pretzoot

