### PR TITLE
Feature: Add option to mute final Tree Breaking Sound

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
@@ -75,7 +75,6 @@ class ForagingConfig {
     @Expose
     @ConfigOption(name = "Also on Galatea", desc = "Also mutes tree breaking sounds on Galatea.")
     @ConfigEditorBoolean
-    @FeatureToggle
     @OnlyModern
     var muteTreeBreakingOnGalatea = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
@@ -64,4 +64,18 @@ class ForagingConfig {
     @FeatureToggle
     @OnlyModern
     var mutePhantoms = true
+
+    @Expose
+    @ConfigOption(name = "Mute Tree Breaking", desc = "Mutes the sound of the tree fully breaking.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    @OnlyModern
+    var muteTreeBreaking = true
+
+    @Expose
+    @ConfigOption(name = "Also on Galatea", desc = "Also mutes tree breaking sounds on Galatea.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    @OnlyModern
+    var muteTreeBreakingOnGalatea = true
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MuteTreeSounds.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MuteTreeSounds.kt
@@ -1,0 +1,20 @@
+package at.hannibal2.skyhanni.features.foraging
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.PlaySoundEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+
+@SkyHanniModule
+object MuteTreeSounds {
+    val config get() = SkyHanniMod.feature.foraging
+
+    @HandleEvent
+    fun onPlaySound(event: PlaySoundEvent) {
+        if (event.soundName == "entity.creaking.death" && config.muteTreeBreaking) {
+            if (IslandType.GALATEA.isCurrent() && !config.muteTreeBreakingOnGalatea) return
+            event.cancel()
+        }
+    }
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MuteTreeSounds.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MuteTreeSounds.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 object MuteTreeSounds {
     val config get() = SkyHanniMod.feature.foraging
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onPlaySound(event: PlaySoundEvent) {
         if (event.soundName == "entity.creaking.death" && config.muteTreeBreaking) {
             if (IslandType.GALATEA.isCurrent() && !config.muteTreeBreakingOnGalatea) return


### PR DESCRIPTION
## What
Adds option to mute the final Tree Breaking Sound when a tree is destroyed fully.

## Changelog New Features
+ Added option to mute final Tree Breaking Sound. - Helium9
