### PR TITLE
Feature: Fix a Hypixel bug causing double clicks with certain items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -502,4 +502,14 @@ class MiscConfig {
     @ConfigOption(name = "Abiphone Hotkey", desc = "Answer incoming abiphone calls with a hotkey.")
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     var abiphoneAcceptKey: Int = Keyboard.KEY_NONE
+
+    @Expose
+    @ConfigOption(
+        name = "Fix item double clicks",
+        desc = "Fixes a Hypixel bug causing double clicks on blocks with blaze daggers or a fishing rod with autopet.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    @OnlyModern
+    var fixDoubleClicks: Boolean = true
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/FixDoubleClicks.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/FixDoubleClicks.kt
@@ -1,0 +1,30 @@
+package at.hannibal2.skyhanni.features.misc
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.ClickType
+import at.hannibal2.skyhanni.events.BlockClickEvent
+import at.hannibal2.skyhanni.features.fishing.FishingApi
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalNames
+
+@SkyHanniModule
+object FixDoubleClicks {
+    private val itemIds = setOf(
+        // Blaze daggers
+        "FIREDUST_DAGGER", "BURSTFIRE_DAGGER", "HEARTFIRE_DAGGER",
+        "MAWDUST_DAGGER", "BURSTMAW_DAGGER", "HEARTMAW_DAGGER",
+    ).toInternalNames()
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onBlockClick(event: BlockClickEvent) {
+        if (!SkyHanniMod.feature.misc.fixDoubleClicks) return
+        if (event.clickType != ClickType.RIGHT_CLICK) return
+
+        val itemInHand = event.itemInHand ?: return
+        val shouldPrevent = FishingApi.holdingRod || itemIds.contains(itemInHand.getInternalName())
+
+        if (shouldPrevent) event.cancel()
+    }
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/FixDoubleClicks.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/misc/FixDoubleClicks.kt
@@ -11,8 +11,7 @@ import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalNames
 
 @SkyHanniModule
 object FixDoubleClicks {
-    private val itemIds = setOf(
-        // Blaze daggers
+    private val blazeDaggers = setOf(
         "FIREDUST_DAGGER", "BURSTFIRE_DAGGER", "HEARTFIRE_DAGGER",
         "MAWDUST_DAGGER", "BURSTMAW_DAGGER", "HEARTMAW_DAGGER",
     ).toInternalNames()
@@ -23,7 +22,7 @@ object FixDoubleClicks {
         if (event.clickType != ClickType.RIGHT_CLICK) return
 
         val itemInHand = event.itemInHand ?: return
-        val shouldPrevent = FishingApi.holdingRod || itemIds.contains(itemInHand.getInternalName())
+        val shouldPrevent = FishingApi.holdingRod || blazeDaggers.contains(itemInHand.getInternalName())
 
         if (shouldPrevent) event.cancel()
     }


### PR DESCRIPTION
## What
Cancel BlockClick event if right clicking with blaze daggers or fishing rods (with on rod cast autopet rules) to fix a server side bug that only affects newer version clients effectively causing 2 clicks to be registered.
Similar to [this feature](https://github.com/Skytils/SkytilsMod/blob/132ae674382d7b14d2c4202df5da6d75a1598174/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt#L555-L578) in Skytils, and is acknowledged by admins as an unintended bug: https://hypixel.net/threads/hypixel-skyblock-0-23-2-the-primordial-broodfather.5956502/post-41123094

## Changelog New Features
+ Fixed Hypixel 1.21 double-click bug when right-clicking a block with Blaze Daggers or Fishing Rods. - yhtez

