### PR TITLE
Feature + Backend: hide mobs nearby Slayers, entity opacity

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
@@ -108,7 +108,7 @@ class SlayerConfig {
         desc = "Makes mobs partially transparent so that they dont annoy while having an active slayer quest. " +
             "Useful for e.g. Magma Cubes in Burning Desert for Tara Slayer.",
     )
-    @SearchTag("tarantula, spider")
+    @SearchTag("tarantula, spider opacity")
     @ConfigEditorBoolean
     @FeatureToggle
     var hideIrrelevantMobs: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
@@ -108,7 +108,7 @@ class SlayerConfig {
         desc = "Makes mobs partially transparent so that they dont annoy while having an active slayer quest. " +
             "Useful for e.g. Magma Cubes in Burning Desert for Tara Slayer.",
     )
-    @SearchTag("tarantula, spider opacity")
+    @SearchTag("tarantula spider opacity")
     @ConfigEditorBoolean
     @FeatureToggle
     var hideIrrelevantMobs: Boolean = false
@@ -118,7 +118,7 @@ class SlayerConfig {
         name = "Adjust Irrelevant Opacity",
         desc = "Adjust the opacity of irrelevant mobs. (in %)",
     )
-    @SearchTag("magma cube, tarantula, tara, spider, slayer, quest")
+    @SearchTag("magma cube tarantula tara spider slayer quest")
     @ConfigEditorSlider(minValue = 0f, maxValue = 100f, minStep = 1f)
     var hideIrrelevantMobsOpacity: Int = 40
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
@@ -10,6 +10,7 @@ import io.github.notenoughupdates.moulconfig.annotations.Category
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class SlayerConfig {
     // TODO rename to "enderman"
@@ -80,7 +81,7 @@ class SlayerConfig {
     @ConfigOption(
         name = "Hide Mob Names",
         desc = "Hide the name of the mobs you need to kill in order for the Slayer boss to spawn. " +
-                "Exclude mobs that are damaged, corrupted, runic or semi rare.",
+            "Exclude mobs that are damaged, corrupted, runic or semi rare.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -104,17 +105,20 @@ class SlayerConfig {
     @Expose
     @ConfigOption(
         name = "Hide Irrelevant Mobs",
-        desc = "Makes mobs in or near slayer areas partially transparent so that they dont annoy while having an active slayer quest. E.g. Magma Cube in Burning Desert for Tara Slayer.",
+        desc = "Makes mobs partially transparent so that they dont annoy while having an active slayer quest. " +
+            "Useful for e.g. Magma Cubes in Burning Desert for Tara Slayer.",
     )
+    @SearchTag("tarantula, spider")
     @ConfigEditorBoolean
     @FeatureToggle
     var hideIrrelevantMobs: Boolean = false
 
     @Expose
     @ConfigOption(
-        name = "Adjust irrelevant opacity",
+        name = "Adjust Irrelevant Opacity",
         desc = "Adjust the opacity of irrelevant mobs. (in %)",
     )
+    @SearchTag("magma cube, tarantula, tara, spider, slayer, quest")
     @ConfigEditorSlider(minValue = 0f, maxValue = 100f, minStep = 1f)
     var hideIrrelevantMobsOpacity: Int = 40
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
@@ -71,7 +71,7 @@ class SlayerConfig {
     @Expose
     @ConfigOption(
         name = "Line to Miniboss Width",
-        desc = "The width of the line pointing to every Slayer Mini-Boss around you."
+        desc = "The width of the line pointing to every Slayer Mini-Boss around you.",
     )
     @ConfigEditorSlider(minStep = 1f, minValue = 1f, maxValue = 10f)
     var slayerMinibossLineWidth: Int = 3
@@ -80,7 +80,7 @@ class SlayerConfig {
     @ConfigOption(
         name = "Hide Mob Names",
         desc = "Hide the name of the mobs you need to kill in order for the Slayer boss to spawn. " +
-            "Exclude mobs that are damaged, corrupted, runic or semi rare."
+                "Exclude mobs that are damaged, corrupted, runic or semi rare.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -89,7 +89,7 @@ class SlayerConfig {
     @Expose
     @ConfigOption(
         name = "Quest Warning",
-        desc = "Warn when wrong Slayer quest is selected, or killing mobs for the wrong Slayer."
+        desc = "Warn when wrong Slayer quest is selected, or killing mobs for the wrong Slayer.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -100,4 +100,21 @@ class SlayerConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var questWarningTitle: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Hide Irrelevant Mobs",
+        desc = "Makes mobs in or near slayer areas partially transparent so that they dont annoy while having an active slayer quest. E.g. Magma Cube in Burning Desert for Tara Slayer.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var hideIrrelevantMobs: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Adjust irrelevant opacity",
+        desc = "Adjust the opacity of irrelevant mobs. (in %)",
+    )
+    @ConfigEditorSlider(minValue = 0f, maxValue = 100f, minStep = 1f)
+    var hideIrrelevantMobsOpacity: Int = 40
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
@@ -1,0 +1,81 @@
+package at.hannibal2.skyhanni.data.entity
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
+import at.hannibal2.skyhanni.events.entity.EntityOpacityActiveEvent
+import at.hannibal2.skyhanni.events.entity.EntityOpacityEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
+import at.hannibal2.skyhanni.events.render.EntityRenderLayersEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.containsKeys
+import net.minecraft.client.renderer.GlStateManager
+import net.minecraft.entity.EntityLivingBase
+import org.lwjgl.opengl.GL11
+
+@SkyHanniModule
+object EntityOpacityManager {
+
+    private var shouldHide: Boolean = false
+
+    private var entities = emptyMap<EntityLivingBase, Int>()
+    private var active = false
+
+    @HandleEvent(SecondPassedEvent::class)
+    fun onSecondPassed() {
+        val event = EntityOpacityActiveEvent()
+        event.post()
+        active = event.isActive()
+    }
+
+    @HandleEvent(SkyHanniTickEvent::class, onlyOnSkyblock = true)
+    fun onTick() {
+        if (!active) return
+        val entities = mutableMapOf<EntityLivingBase, Int>()
+        for (entity in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(50.0)) {
+            val event = EntityOpacityEvent(entity)
+            event.post()
+            event.opacity?.let {
+                entities[entity] = it
+            }
+        }
+        this.entities = entities
+    }
+
+    private fun canChangeOpacity(entity: EntityLivingBase) = entities.containsKeys(entity) && opacity(entity) < 100
+
+    private fun opacity(entity: EntityLivingBase): Int = entities[entity] ?: error("can not read opacity bc not in map")
+
+    @HandleEvent
+    fun onPreRender(event: SkyHanniRenderEntityEvent.Pre<EntityLivingBase>) {
+        if (!active) return
+        val canChangeOpacity = canChangeOpacity(event.entity)
+        shouldHide = canChangeOpacity
+        if (!canChangeOpacity) return
+
+        val opacity = opacity(event.entity)
+        if (opacity <= 0) return event.cancel()
+
+        GlStateManager.enableBlend()
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA)
+        GlStateManager.color(1f, 1f, 1f, opacity / 100f)
+    }
+
+    @HandleEvent
+    fun onPostRender(event: SkyHanniRenderEntityEvent.Post<EntityLivingBase>) {
+        if (!active) return
+        if (!canChangeOpacity(event.entity)) return
+
+        GlStateManager.color(1f, 1f, 1f, 1f)
+        GlStateManager.disableBlend()
+    }
+
+    @HandleEvent
+    fun onRenderPlayer(event: EntityRenderLayersEvent.Pre<EntityLivingBase>) {
+        if (!active) return
+        if (!canChangeOpacity(event.entity)) return
+        if (!shouldHide) return
+        event.cancel()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
@@ -14,6 +14,7 @@ import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.entity.EntityLivingBase
 import org.lwjgl.opengl.GL11
 
+// TODO add 1.21.x support
 @SkyHanniModule
 object EntityOpacityManager {
 

--- a/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
@@ -34,7 +34,7 @@ object EntityOpacityManager {
     fun onTick() {
         if (!active) return
         val entities = mutableMapOf<EntityLivingBase, Int>()
-        for (entity in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(50.0)) {
+        for (entity in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(80.0)) {
             val event = EntityOpacityEvent(entity)
             event.post()
             event.opacity?.let {

--- a/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
@@ -73,7 +73,7 @@ object EntityOpacityManager {
     }
 
     @HandleEvent
-    fun onRenderPlayer(event: EntityRenderLayersEvent.Pre<EntityLivingBase>) {
+    fun onRender(event: EntityRenderLayersEvent.Pre<EntityLivingBase>) {
         if (!active) return
         if (!canChangeOpacity(event.entity)) return
         if (!shouldHide) return

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityOpacityActiveEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityOpacityActiveEvent.kt
@@ -1,0 +1,18 @@
+package at.hannibal2.skyhanni.events.entity
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+/**
+ * Fires once per second, to enable the [EntityOpacityEvent].
+ */
+class EntityOpacityActiveEvent : SkyHanniEvent() {
+    private var status = false
+
+    fun setActive(status: Boolean = true) {
+        if (status) {
+            this.status = true
+        }
+    }
+
+    fun isActive() = status
+}

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityOpacityEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityOpacityEvent.kt
@@ -1,0 +1,13 @@
+package at.hannibal2.skyhanni.events.entity
+
+import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
+import net.minecraft.entity.EntityLivingBase
+
+/**
+ * Fires once per tick per entity, to check what opacity we should hide the entity with.
+ * Requires [EntityOpacityActiveEvent] set to active.
+ */
+class EntityOpacityEvent<T : EntityLivingBase>(val entity: T) : GenericSkyHanniEvent<T>(entity.javaClass) {
+
+    var opacity: Int? = null
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/HideIrrelevantMobsInSlayer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/HideIrrelevantMobsInSlayer.kt
@@ -1,0 +1,47 @@
+package at.hannibal2.skyhanni.features.slayer
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.SlayerApi
+import at.hannibal2.skyhanni.events.entity.EntityOpacityActiveEvent
+import at.hannibal2.skyhanni.events.entity.EntityOpacityEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.MobUtils.mob
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import net.minecraft.entity.EntityLivingBase
+
+@SkyHanniModule
+object HideIrrelevantMobsInSlayer {
+
+    private val config get() = SlayerApi.config
+
+    private var irrelevantMob: IrrelevantMob? = null
+
+    @HandleEvent
+    fun onEntityOpacityActive(event: EntityOpacityActiveEvent) {
+        irrelevantMob = if (isActive() && config.hideIrrelevantMobsOpacity < 100) {
+            IrrelevantMob.entries.find { it.isInArea() }
+        } else null
+        irrelevantMob?.let {
+            event.setActive()
+        }
+    }
+
+    @HandleEvent
+    fun onEntityOpacity(event: EntityOpacityEvent<EntityLivingBase>) {
+        val irrelevantMob = irrelevantMob ?: return
+        if (event.entity.mob?.name in irrelevantMob.mobNames) {
+            event.opacity = config.hideIrrelevantMobsOpacity
+        }
+    }
+
+    enum class IrrelevantMob(val mobNames: Set<String>, val isInArea: () -> Boolean) {
+        CRIMSON_MAGMA_CUBE(
+            mobNames = setOf("Magma Cube", "Magma Cube Rider"),
+            isInArea = { IslandType.CRIMSON_ISLE.isCurrent() && SkyBlockUtils.graphArea == "Burning Desert" },
+        )
+        ;
+    }
+
+    private fun isActive() = SlayerApi.isInCorrectArea && config.hideIrrelevantMobs
+}


### PR DESCRIPTION
## What
Reused the existing "hoppity egg hide nearby player" code for mobs that are annoying while doing slayers (see screenshot)
instead of code duplication, i have abstracted the "entity opacity render" logic into two new events.

Since the hoppity egg hide nearby" feature doesnt work in 1.21.x, this new feature also only works in 1.8.

<details>
<summary>Images</summary>

<img width="794" height="524" alt="image" src="https://github.com/user-attachments/assets/d7752c8e-2552-4283-8ab8-c543bb2dd066" />
<img width="691" height="204" alt="image" src="https://github.com/user-attachments/assets/f880ea7d-62b0-4701-a1a8-29fb9d08faec" />


</details>

## Changelog New Features
+ Added Hide Irrelevant Mobs for Slayers. - hannibal2
    * Makes mobs partially transparent so that they don't annoy while having an active slayer quest.
    * Useful for e.g. Magma Cubes in Burning Desert for Tara Slayer.

## Changelog Technical Details
+ Added abstract logic for changing the opacity of entites with EntityOpacityManager. - hannibal2
    * This also includes the two new events EntityOpacityActiveEvent and EntityOpacityEvent.