### PR TITLE
Backend: Remove unnecessary `.intern()` in ItemResolutionQuery

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
@@ -190,7 +190,7 @@ class ItemResolutionQuery {
         resolvedName = if (resolvedName == null) {
             resolveContextualName()
         } else {
-            when (resolvedName.intern()) {
+            when (resolvedName) {
                 "PET" -> resolvePetName()
                 "RUNE", "UNIQUE_RUNE" -> resolveRuneName()
                 "ENCHANTED_BOOK" -> resolveEnchantedBookNameFromNBT()


### PR DESCRIPTION
## What
Removed an unnecessary `.intern()` call in ItemResolutionQuery that may lead to a performance hit.

TL;DR: Kotlin's `when` checks compile down to `Intrinsics.areEqual()`, which are basically equivalent to `.equals()`, not an identity check, therefore `.intern()` is unnecessary.

https://discord.com/channels/997079228510117908/1088575698605711420/1397657511615791307

## Changelog Technical Details
+ Removed an unnecessary `.intern()` call in ItemResolutionQuery that may lead to a performance hit. - Luna