### PR TITLE
Improvement: Make /shedittracker say the name of the bucket

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonProfitTracker.kt
@@ -62,6 +62,10 @@ object DragonProfitTracker {
             )
         }
 
+        override fun bucketName(): String {
+            return "Dragon"
+        }
+
         fun getTotalDragonCount(): Long {
             return if (selectedBucket == null || selectedBucket !in DragonType.values()) {
                 dragonKills.values.sum()

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
@@ -62,6 +62,10 @@ object ForagingTrackerLegacy {
 
         override fun TreeType.isBucketSelectable() = true
 
+        override fun bucketName(): String {
+            return "tree"
+        }
+
         @Expose
         var treesCut: MutableMap<TreeType, Long> = enumMapOf()
         fun getTreeCount(): Long = selectedBucket?.let { treesCut[it] } ?: treesCut.values.sum()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -116,6 +116,10 @@ object PestProfitTracker {
 
         override fun PestType.isBucketSelectable() = this in PestType.filterableEntries
 
+        override fun bucketName(): String {
+            return "Pest"
+        }
+
         @Suppress("DEPRECATION")
         fun getTotalPestCount(): Long =
             if (selectedBucket != null) pestKills[selectedBucket] ?: 0L

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseTracker.kt
@@ -66,6 +66,10 @@ object CorpseTracker {
 
         override fun CorpseType.isBucketSelectable() = true
 
+        override fun bucketName(): String {
+            return "Corpse"
+        }
+
         @Expose
         var corpsesLooted: MutableMap<CorpseType, Long> = enumMapOf()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
@@ -87,6 +87,8 @@ abstract class BucketedItemTrackerData<E : Enum<E>>(clazz: KClass<E>) : ItemTrac
 
     abstract fun E.isBucketSelectable(): Boolean
 
+    abstract fun bucketName(): String
+
     private val buckets: Array<E> = clazz.java.enumConstants
     val selectableBuckets: List<E> = buckets.filter { it.isBucketSelectable() }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniBucketedItemTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniBucketedItemTracker.kt
@@ -35,7 +35,7 @@ class SkyHanniBucketedItemTracker<E : Enum<E>, BucketedData : BucketedItemTracke
         modify { data ->
             bucket = data.selectedBucket ?: run {
                 ChatUtils.userError(
-                    "No ${data.bucketName()} selected for §b$name§c.\n§cSelect one in the §b$name §cGUI, then try again.",
+                    "No §b${data.bucketName()} §cselected for §b$name§c.\n§cSelect one in the §b$name §cGUI, then try again.",
                 )
                 cancel()
                 return@modify

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniBucketedItemTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniBucketedItemTracker.kt
@@ -35,7 +35,7 @@ class SkyHanniBucketedItemTracker<E : Enum<E>, BucketedData : BucketedItemTracke
         modify { data ->
             bucket = data.selectedBucket ?: run {
                 ChatUtils.userError(
-                    "No bucket selected for §b$name§c.\n§cSelect one in the §b$name §cGUI, then try again.",
+                    "No ${data.bucketName()} selected for §b$name§c.\n§cSelect one in the §b$name §cGUI, then try again.",
                 )
                 cancel()
                 return@modify


### PR DESCRIPTION
## What
It now says no tree selected for foragting tracker instead of bucket
<img width="830" height="132" alt="image" src="https://github.com/user-attachments/assets/3dc6b522-5424-4d73-b201-542576fa8aac" />


## Changelog Improvements
+ Made /shedittracker more clear for bucketed trackers. - nopo