### PR TITLE
Improvement: Give opacity to held items and block helmets

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinItemRenderer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinItemRenderer.java
@@ -27,7 +27,8 @@ public class MixinItemRenderer {
 
     @ModifyArg(method = "renderItem(Lnet/minecraft/item/ItemDisplayContext;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;II[ILjava/util/List;Lnet/minecraft/client/render/RenderLayer;Lnet/minecraft/client/render/item/ItemRenderState$Glint;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/ItemRenderer;getItemGlintConsumer(Lnet/minecraft/client/render/VertexConsumerProvider;Lnet/minecraft/client/render/RenderLayer;ZZ)Lnet/minecraft/client/render/VertexConsumer;"), index = 1)
     private static RenderLayer modifyRenderLayer(RenderLayer layer) {
-        if (EntityRenderDispatcherHookKt.getEntity() instanceof LivingEntity) {
+        if (EntityRenderDispatcherHookKt.getEntity() instanceof LivingEntity livingEntity) {
+            if (EntityOpacityManager.getEntityOpacity(livingEntity) == null) return layer;
             return TexturedRenderLayers.getItemEntityTranslucentCull();
         }
         return layer;

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinItemRenderer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinItemRenderer.java
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.mixins.transformers.renderer;
+
+import at.hannibal2.skyhanni.data.entity.EntityOpacityManager;
+import at.hannibal2.skyhanni.mixins.hooks.EntityRenderDispatcherHookKt;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.TexturedRenderLayers;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(ItemRenderer.class)
+public class MixinItemRenderer {
+
+    @ModifyArg(method = "renderBakedItemQuads", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/VertexConsumer;quad(Lnet/minecraft/client/util/math/MatrixStack$Entry;Lnet/minecraft/client/render/model/BakedQuad;FFFFII)V"), index = 5)
+    private static float modifyAlpha(float originalAlpha) {
+        if (EntityRenderDispatcherHookKt.getEntity() instanceof LivingEntity livingEntity) {
+            Integer entityAlpha = EntityOpacityManager.getEntityOpacity(livingEntity);
+            if (entityAlpha == null) return originalAlpha;
+            float alphaFloat = entityAlpha / 255.0F;
+
+            return Math.min(originalAlpha, alphaFloat);
+        }
+        return originalAlpha;
+    }
+
+    @ModifyArg(method = "renderItem(Lnet/minecraft/item/ItemDisplayContext;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;II[ILjava/util/List;Lnet/minecraft/client/render/RenderLayer;Lnet/minecraft/client/render/item/ItemRenderState$Glint;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/ItemRenderer;getItemGlintConsumer(Lnet/minecraft/client/render/VertexConsumerProvider;Lnet/minecraft/client/render/RenderLayer;ZZ)Lnet/minecraft/client/render/VertexConsumer;"), index = 1)
+    private static RenderLayer modifyRenderLayer(RenderLayer layer) {
+        if (EntityRenderDispatcherHookKt.getEntity() instanceof LivingEntity) {
+            return TexturedRenderLayers.getItemEntityTranslucentCull();
+        }
+        return layer;
+    }
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinRendererLivingEntity.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinRendererLivingEntity.java
@@ -70,7 +70,8 @@ public abstract class MixinRendererLivingEntity<T extends LivingEntity, S extend
 
     @Inject(method = "getRenderLayer", at = @At("HEAD"), cancellable = true)
     public void getRenderState(LivingEntityRenderState state, boolean showBody, boolean translucent, boolean showOutline, CallbackInfoReturnable<RenderLayer> cir) {
-        if (showBody && EntityRenderDispatcherHookKt.getEntity() instanceof LivingEntity) {
+        if (showBody && EntityRenderDispatcherHookKt.getEntity() instanceof LivingEntity livingEntity) {
+            if (EntityOpacityManager.getEntityOpacity(livingEntity) == null) return;
             cir.setReturnValue(RenderLayer.getItemEntityTranslucentCull(this.getTexture(state)));
         }
     }


### PR DESCRIPTION
made it also hide held items and blocks on the head on 1.21 like it does on 1.8

<img width="293" height="260" alt="image" src="https://github.com/user-attachments/assets/6d494e75-16a5-4c69-8c74-c3f9bac48f97" />


[excluding as related to earlier commit](https://github.com/hannibal002/SkyHanni/pull/4470)

exclude_from_changelog

