### PR TITLE
Fix: Added missing carolyn items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CarrolynTable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/CarrolynTable.kt
@@ -30,6 +30,18 @@ enum class CarrolynTable(val crop: CropType, val label: String, completeMessage:
         "FINE FLOURS EXPORTATION COMPLETE!",
         "[NPC] Carrolyn: Thank you for the flour.",
     ),
+    WARTY(
+        CropType.NETHER_WART,
+        "Warty",
+        "WARTYS EXPORTATION COMPLETE!",
+        "[NPC] Carrolyn: Thank you for the warts.",
+    ),
+    HALF_EATEN_MUSHROOM(
+        CropType.MUSHROOM,
+        "Half Eaten Mushroom",
+        "MUSHROOMS EXPORTATION COMPLETE!",
+        "[NPC] Carrolyn: Thank you for the mushrooms.",
+    )
     ;
 
     /** Pattern without color codes */


### PR DESCRIPTION
## What
Half eaten mushrooms and warty where added some time ago, but we didn't add those. Will show inside /ff.

Mushroom messages are checked but the wart ones are just guesses

## Changelog Fixes
+ Added warty and half eaten mushrooms to /ff. - Thunderblade73
