### PR TITLE
Improvement: Add command to toggle sho setup mode

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OrderedWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OrderedWaypoints.kt
@@ -213,6 +213,13 @@ object OrderedWaypoints {
                     callback { erase(getArg(name)) }
                 }
             }
+            literal("setupmode") {
+                description = "Erases the route with the specified name."
+                arg("enable", BrigadierArguments.bool()) { enableSetupMode ->
+                    callback { toggleSetupMode(getArg(enableSetupMode)) }
+                }
+                simpleCallback { toggleSetupMode(!config.setupMode) }
+            }
         }
     }
 
@@ -361,6 +368,11 @@ object OrderedWaypoints {
         }
         saveConfig()
         ChatUtils.chat("Route $name successfully deleted.")
+    }
+
+    private fun toggleSetupMode(value: Boolean) {
+        config.setupMode = value
+        ChatUtils.chat("Toggled setup mode to $value")
     }
 
     private fun decideWaypoints() {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OrderedWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OrderedWaypoints.kt
@@ -214,9 +214,9 @@ object OrderedWaypoints {
                 }
             }
             literal("setupmode") {
-                description = "Erases the route with the specified name."
-                arg("enable", BrigadierArguments.bool()) { enableSetupMode ->
-                    callback { toggleSetupMode(getArg(enableSetupMode)) }
+                description = "Toggles setup mode."
+                argCallback("enable", BrigadierArguments.bool()) { enableSetupMode ->
+                    toggleSetupMode(enableSetupMode)
                 }
                 simpleCallback { toggleSetupMode(!config.setupMode) }
             }


### PR DESCRIPTION
## What
Added a command to toggle setup mode instead of having to go into the config for it.

## Changelog Improvements
+ Added /sho setupmode to easily toggle setup mode for ordered waypoints. - CalMWolfs
