### PR TITLE
Fix: Voodoo Doll Detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -64,6 +64,7 @@ object ItemAbilityCooldown {
     private var abilityItems = mapOf<ItemStack, MutableList<ItemAbility>>()
     private val WEIRD_TUBA = "WEIRD_TUBA".toInternalName()
     private val WEIRDER_TUBA = "WEIRDER_TUBA".toInternalName()
+    private val VOODOO_DOLL = "VOODOO_DOLL".toInternalName()
     private val VOODOO_DOLL_WILTED = "VOODOO_DOLL_WILTED".toInternalName()
     private val WARNING_FLARE = "WARNING_FLARE".toInternalName()
     private val ALERT_FLARE = "ALERT_FLARE".toInternalName()
@@ -135,16 +136,10 @@ object ItemAbilityCooldown {
                 ItemAbility.STARLIGHT_WAND.sound()
             }
             // Voodoo Doll
-            event.soundName == "mob.guardian.curse" && event.volume == 0.2f -> {
-                ItemAbility.VOODOO_DOLL.sound()
-            }
-            // Jinxed Voodoo Doll Hit
-            event.soundName == "random.successful_hit" && event.volume == 1f && event.pitch == 0.7936508f -> {
-                ItemAbility.VOODOO_DOLL_WILTED.sound()
-            }
-            // Jinxed Voodoo Doll Miss
             event.soundName == "mob.ghast.scream" && event.volume == 1f && event.pitch >= 1.6 && event.pitch <= 1.7 -> {
-                if (VOODOO_DOLL_WILTED.recentlyHeld()) {
+                if (VOODOO_DOLL.recentlyHeld()) {
+                    ItemAbility.VOODOO_DOLL.sound()
+                } else if (VOODOO_DOLL_WILTED.recentlyHeld()) {
                     ItemAbility.VOODOO_DOLL_WILTED.sound()
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/SoundCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/SoundCompat.kt
@@ -24,7 +24,7 @@ object SoundCompat {
         "mob.endermen.portal" to "entity.enderman.teleport",
         "mob.ghast.affectionate_scream" to "entity.ghast.ambient",
         "mob.ghast.fireball" to "entity.ghast.shoot",
-        "mob.ghast.scream" to "entity.ghast.scream",
+        "mob.ghast.scream" to "entity.ghast.hurt",
         "mob.guardian.curse" to "entity.elder_guardian.curse",
         "mob.guardian.elder.idle" to "entity.elder_guardian.ambient",
         "mob.horse.donkey.death" to "entity.donkey.death",


### PR DESCRIPTION
## What
Don't know when this code was last touched, maybe it used to be correct, but it was very wrong.
- The claimed `mob.guardian.curse` sound isn't fired for Voodoo Doll. It just uses the Jinxed Voodoo Doll sound effect.
- The "hit" sound is also fired with the exact same pitch on a generic bow hit, I don't think it's reliable. I can't get the "miss" sound to not trigger, so I am assuming it triggers every time.
- The modern sound name for the ghast sound was wrong (I've confirmed what Hypixel uses).

## Changelog Fixes
+ Fixed Voodoo Doll/Jinxed Voodoo Doll ability detection. - Luna