### PR TITLE
Backend: Separate glow depth vertex consumers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -17,12 +17,41 @@ object RenderLivingEntityHelper {
     private val entityColorCondition = mutableMapOf<EntityLivingBase, () -> Boolean>()
 
     private val entityNoHurtTimeCondition = mutableMapOf<EntityLivingBase, () -> Boolean>()
+
+    @JvmStatic
     var areMobsHighlighted = false
-    var renderingRealGlow = false
+    @JvmStatic
     var currentGlowEvent: RenderEntityOutlineEvent? = null
 
-    fun isEntityInGlowEvent(entity: Entity): Int {
+    private fun isEntityInGlowEvent(entity: Entity): Int {
         return currentGlowEvent?.entitiesToOutline?.get(entity)?.rgb ?: 0
+    }
+
+    @JvmStatic
+    fun check() {
+        areMobsHighlighted = false
+        val conditions = entityColorCondition.values
+        for (entry in conditions) {
+            if (entry.invoke()) {
+                areMobsHighlighted = true
+                return
+            }
+        }
+        if (currentGlowEvent?.entitiesToOutline?.isNotEmpty() == true) areMobsHighlighted = true
+    }
+
+    @JvmStatic
+    fun getEntityGlowColor(entity: Entity): Int? {
+        val livingEntity = entity as? EntityLivingBase ?: return null
+        val color = internalSetColorMultiplier(livingEntity, 0)
+        if (color == 0) {
+            val eventColor = isEntityInGlowEvent(entity)
+            if (eventColor == 0) {
+                return null
+            }
+            return eventColor
+        }
+        return color
     }
 
     @HandleEvent
@@ -38,18 +67,6 @@ object RenderLivingEntityHelper {
         entityColorMap.removeIfKey { it.isDead }
         entityColorCondition.removeIfKey { it.isDead }
         entityNoHurtTimeCondition.removeIfKey { it.isDead }
-    }
-
-    fun check() {
-        areMobsHighlighted = false
-        val conditions = entityColorCondition.values
-        for (entry in conditions) {
-            if (entry.invoke()) {
-                areMobsHighlighted = true
-                return
-            }
-        }
-        if (currentGlowEvent?.entitiesToOutline?.isNotEmpty() == true) areMobsHighlighted = true
     }
 
     fun <T : EntityLivingBase> removeEntityColor(entity: T) {

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinWorldRenderer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinWorldRenderer.java
@@ -2,19 +2,18 @@ package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent;
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper;
-import at.hannibal2.skyhanni.utils.EntityUtils;
+import at.hannibal2.skyhanni.utils.render.SkyHanniOutlineVertexConsumerProvider;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.Share;
-import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.Framebuffer;
+import net.minecraft.client.render.BufferBuilderStorage;
 import net.minecraft.client.render.DefaultFramebufferSet;
+import net.minecraft.client.render.OutlineVertexConsumerProvider;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.Handle;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -28,72 +27,54 @@ public class MixinWorldRenderer {
 
     @Shadow
     @Final
-    private MinecraftClient client;
-
-    @Shadow
-    @Final
     private DefaultFramebufferSet framebufferSet;
 
     @Inject(method = "getEntitiesToRender", at = @At(value = "HEAD"))
     public void resetRealGlowing(CallbackInfoReturnable<Boolean> cir) {
-        RenderLivingEntityHelper.INSTANCE.setRenderingRealGlow(false);
-        RenderLivingEntityHelper.INSTANCE.check();
+        RenderLivingEntityHelper.check();
         RenderEntityOutlineEvent noXrayOutlineEvent = new RenderEntityOutlineEvent(RenderEntityOutlineEvent.Type.NO_XRAY, null);
-        RenderLivingEntityHelper.INSTANCE.setCurrentGlowEvent(noXrayOutlineEvent);
+        RenderLivingEntityHelper.setCurrentGlowEvent(noXrayOutlineEvent);
         noXrayOutlineEvent.post();
-    }
-
-    @Inject(method = "getEntitiesToRender", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;hasOutline(Lnet/minecraft/entity/Entity;)Z"))
-    public void getIfRealGlowing(CallbackInfoReturnable<Boolean> cir, @Local Entity entity) {
-        if (entity.isGlowing()) RenderLivingEntityHelper.INSTANCE.setRenderingRealGlow(true);
     }
 
     @WrapOperation(method = {"renderEntities", "getEntitiesToRender"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;hasOutline(Lnet/minecraft/entity/Entity;)Z"))
     public boolean shouldAlsoGlow(MinecraftClient instance, Entity entity, Operation<Boolean> original) {
-        if (entity instanceof LivingEntity livingEntity) {
-            int i = RenderLivingEntityHelper.internalSetColorMultiplier(livingEntity, 0);
-            if (i == 0) {
-                if (RenderLivingEntityHelper.INSTANCE.isEntityInGlowEvent(entity) == 0) {
-                    return original.call(instance, entity);
-                }
-            }
-            boolean returnValue;
-            if (RenderLivingEntityHelper.INSTANCE.getRenderingRealGlow()) {
-                returnValue = EntityUtils.INSTANCE.canBeSeen(entity, 150, .5);
-            } else {
-                returnValue = true;
-            }
-            return returnValue;
+        Integer glowColor = RenderLivingEntityHelper.getEntityGlowColor(entity);
+        if (glowColor == null) {
+            return original.call(instance, entity);
         }
-        return original.call(instance, entity);
+        return true;
     }
 
     @WrapOperation(method = "renderEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getTeamColorValue()I"))
     public int changeGlowColour(Entity entity, Operation<Integer> original) {
-        if (entity instanceof LivingEntity livingEntity) {
-            int i = RenderLivingEntityHelper.internalSetColorMultiplier(livingEntity, 0);
-            if (i == 0) {
-                int otherColor = RenderLivingEntityHelper.INSTANCE.isEntityInGlowEvent(entity);
-                if (otherColor != 0) {
-                    i = otherColor;
-                } else {
-                    return original.call(entity);
-                }
-            }
-            return i;
+        Integer glowColor = RenderLivingEntityHelper.getEntityGlowColor(entity);
+        if (glowColor == null) {
+            return original.call(entity);
         }
-        return original.call(entity);
+        return glowColor;
+    }
+
+    @WrapOperation(method = "renderEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/BufferBuilderStorage;getOutlineVertexConsumers()Lnet/minecraft/client/render/OutlineVertexConsumerProvider;"))
+    private OutlineVertexConsumerProvider modifyVertexConsumerProvider(BufferBuilderStorage storage, Operation<OutlineVertexConsumerProvider> original, @Local Entity entity) {
+        Integer glowColor = RenderLivingEntityHelper.getEntityGlowColor(entity);
+        if (glowColor == null) {
+            return original.call(storage);
+        }
+        return SkyHanniOutlineVertexConsumerProvider.getVertexConsumers();
     }
 
     @Inject(method = "method_62214", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/CommandEncoder;clearColorAndDepthTextures(Lcom/mojang/blaze3d/textures/GpuTexture;ILcom/mojang/blaze3d/textures/GpuTexture;D)V", ordinal = 0, shift = At.Shift.AFTER))
-    private void setGlowDepth(CallbackInfo ci, @Share(namespace = "c", value = "copiedOutlineDepth") LocalBooleanRef copiedOutlineDepth) {
-        if (RenderLivingEntityHelper.INSTANCE.getAreMobsHighlighted() && !copiedOutlineDepth.get()) {
-            Handle<Framebuffer> glowFramebuffer = framebufferSet.entityOutlineFramebuffer;
-            if (glowFramebuffer == null) return;
-            glowFramebuffer.get().copyDepthFrom(client.getFramebuffer());
-            // copiedOutlineDepth is for performance compat with skyblocker
-            copiedOutlineDepth.set(true);
-        }
+    private void setGlowDepth(CallbackInfo ci) {
+        Handle<Framebuffer> glowFramebuffer = framebufferSet.entityOutlineFramebuffer;
+        if (glowFramebuffer == null) return;
+        SkyHanniOutlineVertexConsumerProvider.storeVanillaDepthAttachment();
+    }
+
+    @Inject(method = "method_62214", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/OutlineVertexConsumerProvider;draw()V"))
+    private void renderSkyhanniGlow(CallbackInfo ci) {
+        if (!RenderLivingEntityHelper.getAreMobsHighlighted()) return;
+        SkyHanniOutlineVertexConsumerProvider.getVertexConsumers().draw();
     }
 
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/RenderPipelineMixin.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/RenderPipelineMixin.java
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
-import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper;
+import at.hannibal2.skyhanni.utils.render.SkyHanniOutlineVertexConsumerProvider;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.platform.DepthTestFunction;
@@ -13,6 +13,8 @@ public class RenderPipelineMixin {
 
     @ModifyReturnValue(method = "getDepthTestFunction", at = @At("RETURN"))
     private DepthTestFunction setGlowDepth(DepthTestFunction original) {
-        return ((Object) this == RenderPipelines.OUTLINE_CULL || (Object) this == RenderPipelines.OUTLINE_NO_CULL) && (RenderLivingEntityHelper.INSTANCE.getAreMobsHighlighted() && !RenderLivingEntityHelper.INSTANCE.getRenderingRealGlow()) ? DepthTestFunction.LEQUAL_DEPTH_TEST : original;
+        RenderPipeline thisPipeline = (RenderPipeline) (Object) this;
+        if (thisPipeline != RenderPipelines.OUTLINE_CULL && thisPipeline != RenderPipelines.OUTLINE_NO_CULL) return original;
+        return SkyHanniOutlineVertexConsumerProvider.getCurrentlyActive() ? DepthTestFunction.LEQUAL_DEPTH_TEST : original;
     }
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinFramebuffer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinFramebuffer.java
@@ -1,0 +1,22 @@
+package at.hannibal2.skyhanni.mixins.transformers.renderer;
+
+import at.hannibal2.skyhanni.utils.render.SkyHanniOutlineVertexConsumerProvider;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.mojang.blaze3d.textures.GpuTexture;
+import net.minecraft.client.gl.Framebuffer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Framebuffer.class)
+public class MixinFramebuffer {
+
+    @ModifyReturnValue(method = "getDepthAttachment", at = @At("RETURN"))
+    private GpuTexture modifyDepthAttachment(GpuTexture original) {
+        GpuTexture overrideTexture = SkyHanniOutlineVertexConsumerProvider.getOverrideDepthAttachment();
+        if (overrideTexture != null) {
+            return overrideTexture;
+        }
+        return original;
+    }
+
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/render/SkyHanniOutlineVertexConsumerProvider.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/render/SkyHanniOutlineVertexConsumerProvider.kt
@@ -1,0 +1,72 @@
+package at.hannibal2.skyhanni.utils.render
+
+import com.mojang.blaze3d.textures.GpuTexture
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.render.OutlineVertexConsumerProvider
+import net.minecraft.client.render.RenderLayer
+import net.minecraft.client.render.VertexConsumer
+import net.minecraft.client.render.VertexConsumerProvider
+//#if MC > 1.21.6
+//$$ import com.mojang.blaze3d.systems.RenderSystem
+//$$ import com.mojang.blaze3d.textures.GpuTextureView
+//#endif
+
+class SkyHanniOutlineVertexConsumerProvider(parent: VertexConsumerProvider.Immediate) : OutlineVertexConsumerProvider(parent) {
+
+    override fun draw() {
+        beginRendering()
+        super.draw()
+        finishRendering()
+    }
+
+    override fun getBuffer(renderLayer: RenderLayer): VertexConsumer {
+        beginRendering()
+        val returnVal = super.getBuffer(renderLayer)
+        finishRendering()
+        return returnVal
+    }
+
+    companion object {
+
+        @JvmStatic
+        val vertexConsumers by lazy { SkyHanniOutlineVertexConsumerProvider(MinecraftClient.getInstance().bufferBuilders.entityVertexConsumers) }
+
+        //#if MC < 1.21.6
+        private var vanillaDepthAttachment: GpuTexture? = null
+
+        @JvmStatic
+        fun getOverrideDepthAttachment(): GpuTexture? {
+            if (!currentlyActive) return null
+            return vanillaDepthAttachment
+        }
+        //#else
+        //$$ private var vanillaDepthAttachmentView: GpuTextureView? = null
+        //#endif
+
+        @JvmStatic
+        var currentlyActive = false
+
+        private fun beginRendering() {
+            currentlyActive = true
+            //#if MC > 1.21.6
+            //$$ RenderSystem.outputDepthTextureOverride = vanillaDepthAttachmentView
+            //#endif
+        }
+
+        private fun finishRendering() {
+            currentlyActive = false
+            //#if MC > 1.21.6
+            //$$ RenderSystem.outputDepthTextureOverride = null
+            //#endif
+        }
+
+        @JvmStatic
+        fun storeVanillaDepthAttachment() {
+            //#if MC < 1.21.6
+            vanillaDepthAttachment = MinecraftClient.getInstance().framebuffer.depthAttachment
+            //#else
+            //$$ vanillaDepthAttachmentView = MinecraftClient.getInstance().framebuffer.depthAttachmentView
+            //#endif
+        }
+    }
+}


### PR DESCRIPTION
## What
Now our glow doesn't mess with Minecraft's at all or have weird behaviour when minecraft is rendering glow.

## Changelog Improvements
+ Improved compatability between SkyHanni's glow and Minecraft's glow on 1.21. - CalMWolfs

## Changelog Technical Details
+ Split our entity outlines vertex consumer from the normal Minecraft one so that we can modify depth test per entity. - CalMWolfs
