### PR TITLE
Fix: Missing Trophy Fish

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.fishing.TrophyFishCaughtEvent
 import at.hannibal2.skyhanni.features.fishing.FishingApi
-import at.hannibal2.skyhanni.features.fishing.trophy.TrophyFishManager.loadMissingTrophyFish
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -95,6 +94,7 @@ object TrophyFishDisplay {
                 showCaughtHigher,
                 requireArmor,
             ) {
+                TrophyFishManager.loadMissingTrophyFish()
                 update()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.fishing.TrophyFishCaughtEvent
 import at.hannibal2.skyhanni.features.fishing.FishingApi
+import at.hannibal2.skyhanni.features.fishing.trophy.TrophyFishManager.loadMissingTrophyFish
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -55,6 +56,7 @@ object TrophyFishDisplay {
     fun onIslandChange(event: IslandChangeEvent) {
         if (event.newIsland == IslandType.CRIMSON_ISLE) {
             DelayedRun.runDelayed(200.milliseconds) {
+                TrophyFishManager.loadMissingTrophyFish()
                 update()
             }
         }
@@ -62,6 +64,7 @@ object TrophyFishDisplay {
 
     @HandleEvent
     fun onTrophyFishCaught(event: TrophyFishCaughtEvent) {
+        TrophyFishManager.loadMissingTrophyFish()
         recentlyDroppedTrophies[getInternalName(event.trophyFishName)] = event.rarity
         update()
         DelayedRun.runDelayed(5.1.seconds) {
@@ -72,6 +75,7 @@ object TrophyFishDisplay {
     @HandleEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
         display = emptyList()
+        TrophyFishManager.loadMissingTrophyFish()
         update()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishManager.kt
@@ -42,10 +42,24 @@ object TrophyFishManager {
         "§.(?<rarity>.*) §c✖",
     )
 
+    fun loadMissingTrophyFish(): Int {
+        val savedFishes = fish ?: return 0
+        var updatedFishes = 0
+        for (internalName in trophyFishInfo.keys) {
+            savedFishes.getOrPut(internalName) {
+                updatedFishes += 1
+                mutableMapOf()
+            }
+        }
+        return updatedFishes
+    }
+
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<TrophyFishJson>("TrophyFish")
         trophyFishInfo = data.trophyFish
+        loadMissingTrophyFish()
+        TrophyFishDisplay.update()
     }
 
     val fish: MutableMap<String, MutableMap<TrophyRarity, Int>>?
@@ -97,8 +111,8 @@ object TrophyFishManager {
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (event.inventoryName != "Trophy Fishing") return
 
+        var updatedFishes = loadMissingTrophyFish()
         val savedFishes = fish ?: return
-        var updatedFishes = 0
         for (stack in event.inventoryItems.values) {
             val internalName = TrophyFishApi.getInternalName(stack.displayName.replace("§k", ""))
 


### PR DESCRIPTION
## What
Fixed trophy fish the player has never caught being treated as nonexistent, causing Trophy Fish Display to sometimes incorrectly say the player has caught all of a specific tier.

## Changelog Fixes
+ Fixed Trophy Fish Display incorrectly saying you caught all trophy fish of a specific tier when you have never caught any tier of some. - Luna