### PR TITLE
Fix: Negative shards being added to profit trackers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ItemAddManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemAddManager.kt
@@ -93,6 +93,7 @@ object ItemAddManager {
 
     @HandleEvent
     fun onShardGain(event: ShardGainEvent) {
+        if (event.amount < 0) return
         Source.SHARD.addItem(event.shardInternalName, event.amount)
     }
 


### PR DESCRIPTION
## What
Adds a check if its a negative amount like is done for sacks.

## Changelog Fixes
+ Fixed negative shards being added to profit trackers. - CalMWolfs
