### PR TITLE
Backend: Improve Regex101 integration

### DIFF
--- a/.live-plugins/regexr/plugin.kts
+++ b/.live-plugins/regexr/plugin.kts
@@ -82,7 +82,7 @@ inner class RenameKotlinFunctionToUseCamelCaseIntention : PsiElementBaseIntentio
 
     override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
         val info = findRegexInfo(element) ?: return
-        val regex = info.getRegexText()
+        val regex = info.getRegexText()?.replace("/", "\\/")
         if (regex == null) {
             show("Regex needs to be a bare string literal in order to open it in the browser!")
             return
@@ -92,7 +92,7 @@ inner class RenameKotlinFunctionToUseCamelCaseIntention : PsiElementBaseIntentio
                 urlEncode(
                     info.getExamples().joinToString("\n")
                 )
-            }"
+            }&flavor=java"
         )
     }
 

--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -20,10 +20,10 @@ class RepoPatternElement private constructor(
     val pattern by lazy { rawPattern.toPattern() }
 
     val regex101Url: String by lazy {
-        val encodedPattern = URLEncoder.encode(rawPattern, "UTF-8")
+        val encodedPattern = URLEncoder.encode(rawPattern.replace("/", "\\/", "UTF-8")
         val urlEncodedNewLine = URLEncoder.encode("\n", "UTF-8")
         val encodedTests = regexTests.joinToString(urlEncodedNewLine) { URLEncoder.encode(it, "UTF-8") }
-        "https://regex101.com/?regex=$encodedPattern&testString=$encodedTests"
+        "https://regex101.com/?regex=$encodedPattern&testString=$encodedTests&flavor=java"
     }
 
     companion object {

--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -20,7 +20,7 @@ class RepoPatternElement private constructor(
     val pattern by lazy { rawPattern.toPattern() }
 
     val regex101Url: String by lazy {
-        val encodedPattern = URLEncoder.encode(rawPattern.replace("/", "\\/", "UTF-8")
+        val encodedPattern = URLEncoder.encode(rawPattern.replace("/", "\\/"), "UTF-8")
         val urlEncodedNewLine = URLEncoder.encode("\n", "UTF-8")
         val encodedTests = regexTests.joinToString(urlEncodedNewLine) { URLEncoder.encode(it, "UTF-8") }
         "https://regex101.com/?regex=$encodedPattern&testString=$encodedTests&flavor=java"


### PR DESCRIPTION
## What
Improved Regex101 integration (for IntelliJ LivePlugin and Detekt) by automatically selecting the Java flavor, as well as automatically escaping any forward slashes (they are used as a delimiter on Regex101, and there is no option to use no delimiter).

exclude_from_changelog