### PR TITLE
fix: two farming leaderboard things

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -124,10 +124,9 @@ object FarmingWeightDisplay {
 
     private val config get() = GardenApi.config.eliteFarmingWeights
     private val storage get() = GardenApi.storage?.farmingWeight
-    private val lbName get() = when (config.eliteLBType.get().leaderboardName) {
-        "" -> "Farming Weight"
-        else -> "$config.eliteLBType.get().leaderboardName Farming Weight"
-    }
+    private val lbName get() = config.eliteLBType.get().leaderboardName.let {
+        if (it.isEmpty()) "" else "$it "
+    } + "Farming Weight"
     private val localCounter = mutableMapOf<CropType, Long>()
 
     private var display = emptyList<Renderable>()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -124,7 +124,10 @@ object FarmingWeightDisplay {
 
     private val config get() = GardenApi.config.eliteFarmingWeights
     private val storage get() = GardenApi.storage?.farmingWeight
-    private val lbName get() = "${config.eliteLBType.get().leaderboardName} Farming Weight"
+    private val lbName get() = when (config.eliteLBType.get().leaderboardName) {
+        "" -> "Farming Weight"
+        else -> "$config.eliteLBType.get().leaderboardName Farming Weight"
+    }
     private val localCounter = mutableMapOf<CropType, Long>()
 
     private var display = emptyList<Renderable>()
@@ -293,7 +296,7 @@ object FarmingWeightDisplay {
             storage?.lastLeaderboard = leaderboardPosition
 
             // Remove passed player to present the next one
-            nextPlayers.removeFirst()
+            nextPlayers.removeFirstOrNull()
 
             // Display waiting message if nextPlayers list is empty
             // Update values to next player


### PR DESCRIPTION
## What
Fixes two incredibly small things in farming weight leaderboard, neither of which are worth a changelog entry.

exclude_from_changelog
