### PR TITLE
Improvement: micro performance boosts

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.optionalEmpty
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIfKey
 import java.lang.reflect.Method
 
@@ -93,8 +94,8 @@ object SkyHanniEvents {
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<DisabledEventsJson>("DisabledEvents")
-        disabledHandlers = data.disabledHandlers
-        disabledHandlerInvokers = data.disabledInvokers
+        disabledHandlers = data.disabledHandlers.optionalEmpty()
+        disabledHandlerInvokers = data.disabledInvokers.optionalEmpty()
     }
 
     val seconds = listOf(10, 60, 60 * 5)

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
-import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -23,7 +23,7 @@ object EntityData {
     private val maxHealthMap = mutableMapOf<Int, Int>()
     private val nametagCache = TimeLimitedCache<Entity, ChatComponentText>(50.milliseconds)
     private val healthDisplayCache = TimeLimitedCache<String, String>(50.milliseconds)
-    private val lastVisibilityCheck = TimeLimitedCache<Entity, Pair<SimpleTimeMark, Boolean>>(500.milliseconds)
+    private val lastVisibilityCheck = TimeLimitedCache<Int, Boolean>(200.milliseconds)
 
     @HandleEvent
     fun onTick() {
@@ -73,13 +73,11 @@ object EntityData {
 
     @JvmStatic
     fun onRenderCheck(entity: Entity, camX: Double, camY: Double, camZ: Double): Boolean {
-        lastVisibilityCheck[entity]?.let { (time, result) ->
-            if (time.passedSince() < 200.milliseconds) {
-                return result
-            }
+        lastVisibilityCheck[entity.entityId]?.let { result ->
+            return result
         }
         val result = CheckRenderEntityEvent(entity, camX, camY, camZ).post()
-        lastVisibilityCheck[entity] = SimpleTimeMark.now() to result
+        lastVisibilityCheck[entity.entityId] = result
         return result
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
@@ -56,7 +56,7 @@ object EntityOpacityManager {
 
     private fun opacity(entity: EntityLivingBase): Int = entities[entity] ?: error("can not read opacity bc not in map")
 
-    @HandleEvent
+    @HandleEvent//TODO keep
     fun onPreRender(event: SkyHanniRenderEntityEvent.Pre<EntityLivingBase>) {
         if (!active) return
         val canChangeOpacity = canChangeOpacity(event.entity)
@@ -71,7 +71,7 @@ object EntityOpacityManager {
         GlStateManager.color(1f, 1f, 1f, opacity / 100f)
     }
 
-    @HandleEvent
+    @HandleEvent//TODO keep
     fun onPostRender(event: SkyHanniRenderEntityEvent.Post<EntityLivingBase>) {
         if (!active) return
         if (!canChangeOpacity(event.entity)) return

--- a/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/entity/EntityOpacityManager.kt
@@ -56,7 +56,7 @@ object EntityOpacityManager {
 
     private fun opacity(entity: EntityLivingBase): Int = entities[entity] ?: error("can not read opacity bc not in map")
 
-    @HandleEvent//TODO keep
+    @HandleEvent
     fun onPreRender(event: SkyHanniRenderEntityEvent.Pre<EntityLivingBase>) {
         if (!active) return
         val canChangeOpacity = canChangeOpacity(event.entity)
@@ -71,7 +71,7 @@ object EntityOpacityManager {
         GlStateManager.color(1f, 1f, 1f, opacity / 100f)
     }
 
-    @HandleEvent//TODO keep
+    @HandleEvent
     fun onPostRender(event: SkyHanniRenderEntityEvent.Post<EntityLivingBase>) {
         if (!active) return
         if (!canChangeOpacity(event.entity)) return

--- a/src/main/java/at/hannibal2/skyhanni/events/CheckRenderEntityEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/CheckRenderEntityEvent.kt
@@ -2,8 +2,9 @@ package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import net.minecraft.entity.Entity
+import net.minecraft.entity.EntityLivingBase
 
-data class CheckRenderEntityEvent<T : Entity>(
+data class CheckRenderEntityEvent<T : EntityLivingBase>(
     val entity: T,
     val camX: Double,
     val camY: Double,

--- a/src/main/java/at/hannibal2/skyhanni/events/CheckRenderEntityEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/CheckRenderEntityEvent.kt
@@ -4,6 +4,13 @@ import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
 
+/**
+ * THis event is already cached and only fires 5 times per second per entity.
+ * This means the changed visibility state can take up to 200ms until it updates.
+ * This is a cached version similarly to [SkyHanniRenderEntityEvent].
+ * Do not use this event when you want to do further render calls!
+ * Internally we directly mixin to shouldRender.
+ */
 data class CheckRenderEntityEvent<T : EntityLivingBase>(
     val entity: T,
     val camX: Double,

--- a/src/main/java/at/hannibal2/skyhanni/events/CheckRenderEntityEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/CheckRenderEntityEvent.kt
@@ -11,7 +11,7 @@ import net.minecraft.entity.EntityLivingBase
  * Do not use this event when you want to do further render calls!
  * Internally we directly mixin to shouldRender.
  */
-data class CheckRenderEntityEvent<T : EntityLivingBase>(
+data class CheckRenderEntityEvent<T : Entity>(
     val entity: T,
     val camX: Double,
     val camY: Double,

--- a/src/main/java/at/hannibal2/skyhanni/events/CheckRenderEntityEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/CheckRenderEntityEvent.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import net.minecraft.entity.Entity
-import net.minecraft.entity.EntityLivingBase
 
 /**
  * THis event is already cached and only fires 5 times per second per entity.

--- a/src/main/java/at/hannibal2/skyhanni/events/SkyHanniRenderEntityEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/SkyHanniRenderEntityEvent.kt
@@ -4,12 +4,12 @@ import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import net.minecraft.entity.EntityLivingBase
 
 // TODO replace all "cancel only" usages of this event. the only remaining stuff should be EntityOpacityManager
-@Deprecated("use CheckRenderEntityEvent instead")
 /**
  * This event gets called multiple times per frame per entity.
  * This is super inefficient, only use it if absolutely necessary, and then also only with heavy caching added.
  * For normal cases of "hide this entity" rather use [CheckRenderEntityEvent].
  */
+@Deprecated("use CheckRenderEntityEvent instead")
 open class SkyHanniRenderEntityEvent<T : EntityLivingBase>(
     val entity: T,
     val x: Double,

--- a/src/main/java/at/hannibal2/skyhanni/events/SkyHanniRenderEntityEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/SkyHanniRenderEntityEvent.kt
@@ -5,6 +5,11 @@ import net.minecraft.entity.EntityLivingBase
 
 // TODO replace all "cancel only" usages of this event. the only remaining stuff should be EntityOpacityManager
 @Deprecated("use CheckRenderEntityEvent instead")
+/**
+ * This event gets called multiple times per frame per entity.
+ * This is super inefficient, only use it if absolutely necessary, and then also only with heavy caching added.
+ * For normal cases of "hide this entity" rather use [CheckRenderEntityEvent].
+ */
 open class SkyHanniRenderEntityEvent<T : EntityLivingBase>(
     val entity: T,
     val x: Double,

--- a/src/main/java/at/hannibal2/skyhanni/events/SkyHanniRenderEntityEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/SkyHanniRenderEntityEvent.kt
@@ -3,6 +3,8 @@ package at.hannibal2.skyhanni.events
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import net.minecraft.entity.EntityLivingBase
 
+// TODO replace all "cancel only" usages of this event. the only remaining stuff should be EntityOpacityManager
+@Deprecated("use CheckRenderEntityEvent instead")
 open class SkyHanniRenderEntityEvent<T : EntityLivingBase>(
     val entity: T,
     val x: Double,

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/HideDamageSplash.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/HideDamageSplash.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.combat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
+import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import net.minecraft.entity.item.EntityArmorStand
@@ -12,7 +12,7 @@ import net.minecraft.entity.item.EntityArmorStand
 object HideDamageSplash {
 
     @HandleEvent(priority = HandleEvent.HIGH, onlyOnSkyblock = true)
-    fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityArmorStand>) {
+    fun onCheckRender(event: CheckRenderEntityEvent<EntityArmorStand>) {
         if (!SkyHanniMod.feature.combat.hideDamageSplash) return
 
         if (DamageIndicatorManager.isDamageSplash(event.entity)) {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.config.features.combat.damageindicator.DamageIndica
 import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.data.SlayerApi
 import at.hannibal2.skyhanni.events.BossHealthChangeEvent
+import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.DamageIndicatorDeathEvent
 import at.hannibal2.skyhanni.events.DamageIndicatorDetectedEvent
 import at.hannibal2.skyhanni.events.DamageIndicatorFinalBossEvent
@@ -946,7 +947,7 @@ object DamageIndicatorManager {
     private val dummyDamageCache = mutableListOf<UUID>()
 
     @HandleEvent(priority = HandleEvent.HIGH)
-    fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<EntityArmorStand>) {
+    fun onCheckRender(event: CheckRenderEntityEvent<EntityArmorStand>) {
         if (!isEnabled()) return
         val entity = event.entity
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.events.DamageIndicatorDeathEvent
 import at.hannibal2.skyhanni.events.DamageIndicatorDetectedEvent
 import at.hannibal2.skyhanni.events.DamageIndicatorFinalBossEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
@@ -559,4 +559,6 @@ object CollectionUtils {
         retainAll(sequence.toSet())
     }
 
+    fun <T> Set<T>.optionalEmpty(): Set<T> = if (isEmpty()) emptySet() else this
+
 }


### PR DESCRIPTION
## What

<details>
<summary>1. empty set is slightly faster than a set that does not contain any elements.</summary>

<img width="800" height="344" alt="image" src="https://github.com/user-attachments/assets/ca9b83b7-0ecc-4925-8adb-a63321445e3d" />

we now have `Set.optionalEmpty()` that makes a empty set into a empty set. useful for high hitting contains checks, like `isDisabledHandler` and `isDisabledInvoker` in event manager class.

</details>


<details>
<summary>2. start replacing `SkyHanniRenderEntityEvent` with `CheckRenderEntityEvent`.</summary>

`CheckRenderEntityEvent` only fires 5 times per second per entity.
SkyHanniRenderEntityEvent should only be used if absolutely necessary. every normal case of "we want to hide this entity" should use `CheckRenderEntityEvent` instead.

</details>

## Changelog Improvements
+ Improved performance a bit. - hannibal2