### PR TITLE
Fix: Slayer dropped books having both a Hypixel and SH message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -68,7 +68,11 @@ object RareDropMessages {
 
     /**
      * REGEX-TEST Smite VI
-     *
+     * REGEX-TEST Ender Slayer VII
+     * Bane of Arthropods VI
+     * Critical VI
+     * Fire Aspect III
+     * Duplex I
      */
     private val slayerBookPattern by repoGroup.pattern(
         "slayerbook",

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -67,6 +67,15 @@ object RareDropMessages {
     )
 
     /**
+     * REGEX-TEST Smite VI
+     *
+     */
+    private val slayerBookPattern by repoGroup.pattern(
+        "slayerbook",
+        "(Smite VII?)|(Ender Slayer VII?)|(Bane of Arthropods VI)|(Critical VI)|(Fire Aspect III)|(Duplex I)",
+    )
+
+    /**
      * REGEX-TEST: §e[NPC] Oringo§f: §b✆ §f§r§8• §fBlue Whale Pet
      * REGEX-TEST: §e[NPC] Oringo§f: §b✆ §f§r§8• §5Giraffe Pet
      */
@@ -146,7 +155,7 @@ object RareDropMessages {
             )
         }
 
-        if (!anyRecentMessage && config.enchantedBookMissingMessage) {
+        if (!anyRecentMessage && config.enchantedBookMissingMessage && !slayerBookPattern.matches(internalName.repoItemName)) {
             var message = "§r§6§lRARE DROP! ${internalName.repoItemName}"
             if (SkyHanniMod.feature.misc.userLuck) {
                 userLuck.takeIf { it != 0f }?.let { luck ->

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -74,9 +74,9 @@ object RareDropMessages {
      * REGEX-TEST: Fire Aspect III
      * REGEX-TEST: Duplex I
      */
-    private val slayerBookPattern by repoGroup.pattern(
+    private val slayerBookIDPattern by repoGroup.pattern(
         "slayerbook",
-        "Smite VII?|Ender Slayer VII?|Bane of Arthropods VI|Critical VI|Fire Aspect III|Duplex I",
+        "SMITE;(?:6|7)|ENDER_SLAYER;(?:6|7)|MANA_STEAL;1|SMARTY_PANTS;1|BANE_OF_ARTHROPODS;6|CRITIAL;6|FIRE_ASPECT;3|ULTIMATE_REITERATE;1",
     )
 
     /**
@@ -159,7 +159,8 @@ object RareDropMessages {
             )
         }
 
-        if (!anyRecentMessage && config.enchantedBookMissingMessage && !slayerBookPattern.matches(internalName.repoItemName)) {
+        // Hypixel send Slayer Book messages late, so we do a manual internalName Regex Match
+        if (!anyRecentMessage && config.enchantedBookMissingMessage && !slayerBookIDPattern.matches(internalName.asString())) {
             var message = "§r§6§lRARE DROP! ${internalName.repoItemName}"
             if (SkyHanniMod.feature.misc.userLuck) {
                 userLuck.takeIf { it != 0f }?.let { luck ->

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -67,12 +67,9 @@ object RareDropMessages {
     )
 
     /**
-     * REGEX-TEST: Smite VI
-     * REGEX-TEST: Ender Slayer VII
-     * REGEX-TEST: Bane of Arthropods VI
-     * REGEX-TEST: Critical VI
-     * REGEX-TEST: Fire Aspect III
-     * REGEX-TEST: Duplex I
+     * REGEX-TEST: SMITE;6
+     * REGEX-TEST: ENDER_SLAYER;7
+     * REGEX-TEST: ULTIMATE_REITERATE;1
      */
     private val slayerBookIDPattern by repoGroup.pattern(
         "slayerbook",

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -69,14 +69,14 @@ object RareDropMessages {
     /**
      * REGEX-TEST Smite VI
      * REGEX-TEST Ender Slayer VII
-     * Bane of Arthropods VI
-     * Critical VI
-     * Fire Aspect III
-     * Duplex I
+     * REGEX-TEST Bane of Arthropods VI
+     * REGEX-TEST Critical VI
+     * REGEX-TEST Fire Aspect III
+     * REGEX-TEST Duplex I
      */
     private val slayerBookPattern by repoGroup.pattern(
         "slayerbook",
-        "(Smite VII?)|(Ender Slayer VII?)|(Bane of Arthropods VI)|(Critical VI)|(Fire Aspect III)|(Duplex I)",
+        "Smite VII?|Ender Slayer VII?|Bane of Arthropods VI|Critical VI|Fire Aspect III|Duplex I",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -67,12 +67,12 @@ object RareDropMessages {
     )
 
     /**
-     * REGEX-TEST Smite VI
-     * REGEX-TEST Ender Slayer VII
-     * REGEX-TEST Bane of Arthropods VI
-     * REGEX-TEST Critical VI
-     * REGEX-TEST Fire Aspect III
-     * REGEX-TEST Duplex I
+     * REGEX-TEST: Smite VI
+     * REGEX-TEST: Ender Slayer VII
+     * REGEX-TEST: Bane of Arthropods VI
+     * REGEX-TEST: Critical VI
+     * REGEX-TEST: Fire Aspect III
+     * REGEX-TEST: Duplex I
      */
     private val slayerBookPattern by repoGroup.pattern(
         "slayerbook",


### PR DESCRIPTION
## What
Adds a repo pattern for the names of Slayer books to avoid their delayed sending triggering the custom book message

## Changelog Fixes
+ Fixed Slayer books showing both Hypixel and SkyHanni messages. - fazfoxy