### PR TITLE
Fix: add back decimals to kill time and check for own boss

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -14,12 +14,14 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LocationUtils.getBoxCenter
 import at.hannibal2.skyhanni.utils.LocationUtils.union
 import at.hannibal2.skyhanni.utils.MobUtils
+import at.hannibal2.skyhanni.utils.MobUtils.mob
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.toSingletonListOrEmpty
 import at.hannibal2.skyhanni.utils.compat.getAllEquipment
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import io.github.notenoughupdates.moulconfig.observer.Property
+import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.item.EntityArmorStand
 import net.minecraft.entity.monster.EntityZombie
@@ -83,7 +85,11 @@ class Mob(
 
     val owner: MobUtils.OwnerShip?
 
-    fun belongsToPlayer(): Boolean = owner?.equals(PlayerUtils.getName()) ?: false
+    companion object {
+
+        fun Entity?.belongsToPlayer(): Boolean = this?.mob.belongsToPlayer()
+        fun Mob?.belongsToPlayer(): Boolean = this?.owner?.equals(PlayerUtils.getName()) ?: false
+    }
 
     val hologram1Delegate = lazy { MobUtils.getArmorStand(armorStand ?: baseEntity, 1) }
     val hologram2Delegate = lazy { MobUtils.getArmorStand(armorStand ?: baseEntity, 2) }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorEntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorEntityData.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.combat.damageindicator
 
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import net.minecraft.entity.EntityLivingBase
 
@@ -27,5 +28,5 @@ class DamageIndicatorEntityData(
     var serverTicksAlive: Long = 0L,
 ) {
 
-    val timeToKill by lazy { "§e" + foundTime.passedSince().format() }
+    val timeToKill by lazy { "§e" + foundTime.passedSince().format(TimeUnit.SECOND, showMilliSeconds = true) }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/jerry/HighlightJerries.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.event.jerry
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.mob.Mob
+import at.hannibal2.skyhanni.data.mob.Mob.Companion.belongsToPlayer
 import at.hannibal2.skyhanni.data.mob.MobData
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.MobEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
@@ -6,6 +6,8 @@ import at.hannibal2.skyhanni.events.DamageIndicatorDeathEvent
 import at.hannibal2.skyhanni.events.SlayerQuestCompleteEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.MobUtils.mob
+import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 
 @SkyHanniModule
@@ -16,7 +18,7 @@ object SlayerTimeMessages {
     @HandleEvent
     fun onDamageIndicatorDeathEvent(event: DamageIndicatorDeathEvent) {
         val (bossType, timeToKill) = with(event.data) { bossType to timeToKill }
-        if (!config.timeToKillMessage || !bossType.isSlayer) return
+        if (!config.timeToKillMessage || !bossType.isSlayer || (event.data.entity.mob?.owner?.ownerName != PlayerUtils.getName())) return
 
         ChatUtils.chat(
             if (config.compactTimeMessage)

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
@@ -2,12 +2,11 @@ package at.hannibal2.skyhanni.features.slayer
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SlayerApi
+import at.hannibal2.skyhanni.data.mob.Mob.Companion.belongsToPlayer
 import at.hannibal2.skyhanni.events.DamageIndicatorDeathEvent
 import at.hannibal2.skyhanni.events.SlayerQuestCompleteEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.MobUtils.mob
-import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 
 @SkyHanniModule
@@ -18,7 +17,7 @@ object SlayerTimeMessages {
     @HandleEvent
     fun onDamageIndicatorDeathEvent(event: DamageIndicatorDeathEvent) {
         val (bossType, timeToKill) = with(event.data) { bossType to timeToKill }
-        if (!config.timeToKillMessage || !bossType.isSlayer || (event.data.entity.mob?.owner?.ownerName != PlayerUtils.getName())) return
+        if (!config.timeToKillMessage || !bossType.isSlayer || !event.data.entity.belongsToPlayer()) return
 
         ChatUtils.chat(
             if (config.compactTimeMessage)

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.mob.Mob
+import at.hannibal2.skyhanni.data.mob.Mob.Companion.belongsToPlayer
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent


### PR DESCRIPTION
## What
Adds back the decimals (Yes, I did fuckup the first one and then do this)

## Changelog Fixes
+ Fixed missing decimals in Slayer Time to Kill chat message. - fazfoxy
+ Fixed Slayer Kill Timer showing for other players’ bosses. - fazfoxy

