### PR TITLE
Fix + Improvement: Squeaky Reforge

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FarmingReforge.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FarmingReforge.kt
@@ -14,6 +14,7 @@ enum class FarmingReforge(
     BLESSED("Blessed", "BLESSED_FRUIT", 5, 7, 9, 13, 16, 20),
     BOUNTIFUL("Bountiful", "GOLDEN_BALL", 1, 2, 3, 5, 7, 10),
     BLOOMING("Blooming", "FLOWERING_BOUQUET", 1, 2, 3, 4, 5, 6),
+    SQUEAKY("Squeaky", "SQUEAKY_TOY", 2, 4, 6, 8, 10, 12),
     ROOTED("Rooted", "BURROWING_SPORES", 6, 9, 12, 15, 18, 21),
     BUSTLING("Bustling", "SKYMART_BROCHURE", 1, 2, 4, 6, 8, 10),
     MOSSY("Mossy", "OVERGROWN_GRASS", 5, 10, 15, 20, 25, 30),

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FortuneUpgrades.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/fortuneguide/FortuneUpgrades.kt
@@ -106,8 +106,11 @@ object FortuneUpgrades {
             recombobulateItem(item, genericUpgrades)
             when (item.getReforgeName()) {
                 "rooted" -> {}
-                "blooming" -> {
+                "squeaky" -> {
                     reforgeItem(item, FarmingReforge.ROOTED, genericUpgrades)
+                }
+                "blooming" -> {
+                    reforgeItem(item, FarmingReforge.SQUEAKY, genericUpgrades)
                 }
 
                 else -> {


### PR DESCRIPTION
## What
Made the Farming Fortune guide aware of the Squeaky reforge.

Didn't add #4524 as a dependency—hopefully it won't conflict, but it should be fairly trivial to resolve if it does.

## Changelog Improvements
+ Farming Fortune Guide now suggests the Squeaky reforge between Blooming and Rooted. - Luna
    * While mainly intended for Pest Farming, it also serves as a mid-point in Farming Fortune.

## Changelog Fixes
+ Fixed Farming Fortune Guide suggesting Blooming instead of Squeaky reforge. - Luna