### PR TITLE
Improvement: item performance boosts

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/ItemStackCachedData.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/ItemStackCachedData.java
@@ -1,8 +1,0 @@
-package at.hannibal2.skyhanni.mixins.hooks;
-
-import at.hannibal2.skyhanni.utils.CachedItemData;
-
-public interface ItemStackCachedData {
-
-    CachedItemData getSkyhanni_cachedData();
-}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinItemStack.java
@@ -3,13 +3,10 @@ package at.hannibal2.skyhanni.mixins.transformers;
 //#if MC < 1.21
 import at.hannibal2.skyhanni.data.ToolTipData;
 //#endif
-import at.hannibal2.skyhanni.mixins.hooks.ItemStackCachedData;
-import at.hannibal2.skyhanni.utils.CachedItemData;
 import at.hannibal2.skyhanni.utils.compat.DrawContext;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -18,14 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import java.util.List;
 
 @Mixin(ItemStack.class)
-public class MixinItemStack implements ItemStackCachedData {
-
-    @Unique
-    public CachedItemData skyhanni_cachedData = new CachedItemData((Void) null);
-
-    public CachedItemData getSkyhanni_cachedData() {
-        return skyhanni_cachedData;
-    }
+public class MixinItemStack {
 
     //#if MC < 1.21
     @Inject(method = "getTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/event/ForgeEventFactory;onItemTooltip(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/player/EntityPlayer;Ljava/util/List;Z)Lnet/minecraftforge/event/entity/player/ItemTooltipEvent;", shift = At.Shift.BEFORE, remap = false), locals = LocalCapture.CAPTURE_FAILHARD)

--- a/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/CachedItemData.kt
@@ -1,6 +1,10 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
+import net.minecraft.item.Item
+import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
+import kotlin.time.Duration.Companion.minutes
 
 data class CachedItemData(
     // -1 = not loaded
@@ -37,11 +41,8 @@ data class CachedItemData(
 
     var lastExtraAttributesFetchTime: SimpleTimeMark = SimpleTimeMark.farPast(),
 ) {
-    /**
-     * Delegate constructor to avoid calling a function with default arguments from java.
-     * We can't call the generated no args constructors (or rather we cannot generate that constructor), because inline
-     * classes are not part of the java-kotlin ABI that is super well supported (especially with default arguments).
-     */
-    @Suppress("ForbiddenVoid", "UnusedPrivateProperty")
-    constructor(void: Void?) : this()
+    companion object {
+        private val cache = TimeLimitedCache<IdentityCharacteristics<Item>, CachedItemData>(expireAfterWrite = 5.minutes)
+        val ItemStack.cachedData: CachedItemData get() = cache.getOrPut(IdentityCharacteristics(item)) { CachedItemData() }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.features.misc.ReplaceRomanNumerals
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator.getAttributeName
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.CachedItemData.Companion.cachedData
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.formatCoin
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
@@ -29,7 +30,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PrimitiveIngredient.Companion.toPrimitiveItemStacks
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.cachedData
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getExtraAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHypixelEnchantments

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -66,6 +66,7 @@ import java.util.regex.Matcher
 import kotlin.time.Duration.Companion.INFINITE
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+
 //#if MC > 1.21
 //$$ import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 //$$ import net.minecraft.component.DataComponentTypes
@@ -516,35 +517,31 @@ object ItemUtils {
 
     private fun ItemStack.updateCategoryAndRarity() {
         val data = cachedData
+        if (data.itemRarityLastCheck.passedSince() < 1.seconds) return
         data.itemRarityLastCheck = SimpleTimeMark.now()
-        val internalName = getInternalName()
-        if (internalName == NeuInternalName.NONE) {
-            data.itemRarity = null
-            data.itemCategory = null
-            return
-        }
-        val pair = this.readItemCategoryAndRarity()
-        data.itemRarity = pair.first
-        data.itemCategory = pair.second
+
+        val currentLore = getLore()
+        if (data.lastLore == currentLore) return
+        data.lastLore = currentLore
+
+        val (rarity, category) = if (getInternalName() != NeuInternalName.NONE) {
+            this.readItemCategoryAndRarity()
+        } else null to null
+        data.itemRarity = rarity
+        data.itemCategory = category
     }
 
     fun ItemStack.getItemCategoryOrNull(): ItemCategory? {
         val data = cachedData
-        if (itemRarityLastCheck(data)) {
-            this.updateCategoryAndRarity()
-        }
+        this.updateCategoryAndRarity()
         return data.itemCategory
     }
 
     fun ItemStack.getItemRarityOrNull(): LorenzRarity? {
         val data = cachedData
-        if (itemRarityLastCheck(data)) {
-            this.updateCategoryAndRarity()
-        }
+        this.updateCategoryAndRarity()
         return data.itemRarity
     }
-
-    private fun itemRarityLastCheck(data: CachedItemData) = data.itemRarityLastCheck.passedSince() > 10.seconds
 
     // Taken from NEU
     fun ItemStack.editItemInfo(displayName: String, disableNeuTooltips: Boolean, lore: List<String>): ItemStack {
@@ -898,7 +895,7 @@ object ItemUtils {
         if (EnoughUpdatesManager.inLoadingState()) {
             return ChatUtils.debug(
                 "Ignoring missing repo item warning, repo is currently loading or fetching",
-                replaceSameMessage = true
+                replaceSameMessage = true,
             )
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -3,8 +3,8 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.features.fishing.FishingApi
 import at.hannibal2.skyhanni.features.fishing.FishingApi.getFishingRodPart
-import at.hannibal2.skyhanni.mixins.hooks.ItemStackCachedData
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.CachedItemData.Companion.cachedData
 import at.hannibal2.skyhanni.utils.ItemUtils.containsCompound
 import at.hannibal2.skyhanni.utils.ItemUtils.extraAttributes
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
@@ -130,9 +130,6 @@ object SkyBlockItemModifierUtils {
     }
 
     fun ItemStack.wasRiftTransferred(): Boolean = getAttributeBoolean("rift_transferred")
-
-    @Suppress("CAST_NEVER_SUCCEEDS")
-    inline val ItemStack.cachedData: CachedItemData get() = (this as ItemStackCachedData).skyhanni_cachedData
 
     val warnedAboutPetParseFailure: MutableSet<String> = mutableSetOf()
     var lastWarnedParseFailure: SimpleTimeMark = SimpleTimeMark.farPast()


### PR DESCRIPTION
## What
made the game a bit less laggy overall.

one of the heavier hitters according to spark logs are `updateCategoryAndRarity` calls. we check each line of the item lore against item categories and rarities.
this process is necessary, and in and of itself not problematic.
it becomes problematic if this happens consistently every 2-5 seconds for every item in the inventory.

originally, we had a 10s cache for the data in CachedItemData. This did not always work fine though.
We were caching `CachedItemData` via a mixin into item stack. this mixin did not provide one static instance though, especially since minecraft created copies of the item stack instance. 
the only way to store data to a item stack i could find that actually is consistent and doesnt RESET EVERY 10-15 SECONDS, was using the `ItemStack.item` field. this is now in use via `IdentityCharacteristics` and caches with a `TimeLimitedCache` for 5 minutes.
in my testing, this now properly caches every item stack in the inventory only once.

addtionally, we only run the `updateCategoryAndRarity` call now if the lore actually had changed, and we only check the lore every second.

these two changed together should save a lot of regex calls.

and the `CachedItemData` fix should reduce overall lags for all other objects we cached via it (pet data, etc)

## Changelog Improvements
+ Improved mod performance when reading item stack data. - hannibal2