### PR TITLE
Improvement: Re-add Daedalus Axe as a farming tool

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -80,6 +80,8 @@ object GardenApi {
 
     // TODO USE SH-REPO
     private val otherToolsList = listOf(
+        "DAEDALUS_AXE",
+        "STARRED_DAEDALUS_AXE",
         "BASIC_GARDENING_HOE",
         "ADVANCED_GARDENING_AXE",
         "BASIC_GARDENING_AXE",


### PR DESCRIPTION
## What
Hypixel did something funny with mosquito pet and it's now feasible to (sorta) use daedalus axe as a farming tool again. 

## Changelog Improvements
+ Re-added Daedalus Axe as a farming tool. - Chissl

