### PR TITLE
Fix: Actual self boss check in SlayerTimeMessages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
@@ -29,14 +29,14 @@ object SlayerTimeMessages {
     @HandleEvent
     fun onSlayerQuestCompleteEvent(event: SlayerQuestCompleteEvent) {
         val startTime = SlayerApi.questStartTime
-        if (config.timeToKillMessage) {
+        if (config.timeToKillMessage)
             ChatUtils.chat(
                 if (config.compactTimeMessage)
                     "${bossName}§e took §b$killTime§e."
                 else
                     "It took §b$killTime§e to kill ${bossName}.",
             )
-        }
+
         if (!config.questCompleteMessage || startTime.isFarPast()) return
 
         val duration = startTime.passedSince().format()

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
@@ -12,14 +12,14 @@ import at.hannibal2.skyhanni.utils.TimeUtils.format
 object SlayerTimeMessages {
 
     private val config get() = SlayerApi.config
-    private var killTime = 0
+    private var killTime = ""
     private var bossName = ""
 
     @HandleEvent
     fun onDamageIndicatorDeathEvent(event: DamageIndicatorDeathEvent) {
         val (bossType, timeToKill) = with(event.data) { bossType to timeToKill }
         if (!config.timeToKillMessage || !bossType.isSlayer) return
-        killTime = timeToKill.toInt()
+        killTime = timeToKill
         bossName = if (config.compactTimeMessage) {
             bossType.shortName
         } else

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.slayer
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SlayerApi
-import at.hannibal2.skyhanni.data.mob.Mob.Companion.belongsToPlayer
 import at.hannibal2.skyhanni.events.DamageIndicatorDeathEvent
 import at.hannibal2.skyhanni.events.SlayerQuestCompleteEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -13,23 +12,31 @@ import at.hannibal2.skyhanni.utils.TimeUtils.format
 object SlayerTimeMessages {
 
     private val config get() = SlayerApi.config
+    private var killTime = 0
+    private var bossName = ""
 
     @HandleEvent
     fun onDamageIndicatorDeathEvent(event: DamageIndicatorDeathEvent) {
         val (bossType, timeToKill) = with(event.data) { bossType to timeToKill }
-        if (!config.timeToKillMessage || !bossType.isSlayer || !event.data.entity.belongsToPlayer()) return
-
-        ChatUtils.chat(
-            if (config.compactTimeMessage)
-                "${bossType.shortName}§e took §b$timeToKill§e."
-            else
-                "It took §b$timeToKill§e to kill ${bossType.fullName}.",
-        )
+        if (!config.timeToKillMessage || !bossType.isSlayer) return
+        killTime = timeToKill.toInt()
+        bossName = if (config.compactTimeMessage) {
+            bossType.shortName
+        } else
+            bossType.fullName
     }
 
     @HandleEvent
     fun onSlayerQuestCompleteEvent(event: SlayerQuestCompleteEvent) {
         val startTime = SlayerApi.questStartTime
+        if (config.timeToKillMessage) {
+            ChatUtils.chat(
+                if (config.compactTimeMessage)
+                    "${bossName}§e took §b$killTime§e."
+                else
+                    "It took §b$killTime§e to kill ${bossName}.",
+            )
+        }
         if (!config.questCompleteMessage || startTime.isFarPast()) return
 
         val duration = startTime.passedSince().format()


### PR DESCRIPTION
## What
Last check fully just always returned null, this is much more definitive
(Excluded from changelog since there's already a changelog about this being fixed from an older broken PR in this beta)

exclude_from_changelog
