### PR TITLE
Fix: Wilted Berberis Helper ghost waypoints

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/RiftWiltedBerberisHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/RiftWiltedBerberisHelper.kt
@@ -33,7 +33,9 @@ object RiftWiltedBerberisHelper {
     private val config get() = RiftApi.config.area.dreadfarm.wiltedBerberis
 
     private val berberisSounds = setOf("mob.horse.donkey.death", "mob.horse.donkey.hit")
-    private val list = mutableSetOf<WiltedBerberis>()
+
+    // NOTE: Do not make this a set, it breaks identity checks
+    private val list = mutableListOf<WiltedBerberis>()
 
     private var isOnFarmland = false
     private var hasFarmingToolInHand = false


### PR DESCRIPTION
## What
Reverted a premature optimization in #4373 that changed a list to a set, breaking identity checks due to the items being data classes with mutable properties, often causing a ghost waypoint to stick around after the last Wilted Berberis in a plot is harvested.

## Changelog Fixes
+ Fixed Wilted Berberis Helper occasionally not removing old waypoints. - Luna