### PR TITLE
Fix: Typo in Moonglade Beacon Solver

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
@@ -245,7 +245,7 @@ object MoongladeBeacon {
             SoundUtils.playErrorSound()
             TitleManager.sendTitle(
                 "§cOver-click Prevented",
-                subtitleText = "§7Hold §eContol §7to bypass",
+                subtitleText = "§7Hold §eControl §7to bypass",
                 duration = 1.seconds,
                 location = TitleManager.TitleLocation.INVENTORY,
             )


### PR DESCRIPTION
## What
Fixed a small typo in the Moonglade Beacon Solver.

## Changelog Fixes
+ Fixed typo 'Contol' → 'Control' in Moonglade Beacon Solver. - Luna

