### PR TITLE
Fix: Enchanted Book Drop Message Changer (On Alpha)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/RareDropMessagesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/RareDropMessagesConfig.kt
@@ -19,7 +19,7 @@ class RareDropMessagesConfig {
     @Expose
     @ConfigOption(
         name = "Enchanted Book Name",
-        desc = "Shows what enchantment the dropped enchanted book is."
+        desc = "Modifies Book messages to show only book name and colour relative to rarity."
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/RareDropMessagesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/RareDropMessagesConfig.kt
@@ -19,7 +19,7 @@ class RareDropMessagesConfig {
     @Expose
     @ConfigOption(
         name = "Enchanted Book Name",
-        desc = "Modifies Book messages to show only book name and colour relative to rarity."
+        desc = "Modifies Book messages to show only book name and color relative to rarity."
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -76,7 +76,7 @@ object RareDropMessages {
         "(?<start>§e\\[NPC] Oringo§f: §b✆ §f§r§8• )§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end> Pet)",
     )
 
-    @Suppress("maxlinelength")
+
     /**
      * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book §r§b(+§r§b208% §r§b✯ Magic Find§r§b)
      * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book
@@ -84,6 +84,7 @@ object RareDropMessages {
      */
     private val enchantedBookPattern by repoGroup.pattern(
         "enchantedbook",
+        @Suppress("MaxLineLength")
         "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book(?<bookname> \\(.*\\))?(?<end> §r§b\\(\\+(?:§.)*(?<mf>\\d*)%? §r§b✯ Magic Find§r§b\\))?.*",
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -80,11 +80,11 @@ object RareDropMessages {
     /**
      * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book §r§b(+§r§b208% §r§b✯ Magic Find§r§b)
      * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book
-     * §r§6§lRARE DROP! §r§fEnchanted Book (Corruption I§r§f) §r§b(+§r§b314 §r§b✯ Magic Find§r§b)§r
+     * REGEX-TEST: §r§6§lRARE DROP! §r§fEnchanted Book (Corruption I§r§f) §r§b(+§r§b314 §r§b✯ Magic Find§r§b)§r
      */
+    @Suppress("MaxLineLength")
     private val enchantedBookPattern by repoGroup.pattern(
         "enchantedbook",
-        @Suppress("MaxLineLength")
         "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book(?<bookname> \\(.*\\))?(?<end> §r§b\\(\\+(?:§.)*(?<mf>\\d*)%? §r§b✯ Magic Find§r§b\\))?.*",
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -79,10 +79,11 @@ object RareDropMessages {
     /**
      * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book §r§b(+§r§b208% §r§b✯ Magic Find§r§b)
      * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book
+     * §r§6§lRARE DROP! §r§fEnchanted Book (Corruption I§r§f) §r§b(+§r§b314 §r§b✯ Magic Find§r§b)§r
      */
     private val enchantedBookPattern by repoGroup.pattern(
         "enchantedbook",
-        "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book \\((?<bookName>.*)\\) (?<end>§r§b\\(\\+(?:§.)*(?<mf>\\d*) §r§b✯ Magic Find§r§b\\))?.*",
+        "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book(?<bookname> \\(.*\\))? (?<end>§r§b\\(\\+(?:§.)*(?<mf>\\d*)%? §r§b✯ Magic Find§r§b\\))?.*",
     )
 
     private val petPatterns = listOf(
@@ -128,15 +129,13 @@ object RareDropMessages {
         if (SkyBlockUtils.inAnyIsland(ignoredBookIslands)) return
         var bookItemName = ""
 
-        val itemName = internalName.repoItemName
         var anyRecentMessage = false
         for (line in ChatUtils.chatLines) {
             if (line.passedSinceSent() > 1.seconds) break
             val message = line.chatMessage
-            if (itemName in message) return // the message already has the enchant name
             if (enchantedBookPattern.matches(message)) {
                 enchantedBookPattern.matchMatcher(message) {
-                    bookItemName = group("bookName")
+                    bookItemName = group("bookname")
                 }
                 anyRecentMessage = true
                 break
@@ -145,7 +144,7 @@ object RareDropMessages {
 
         if (anyRecentMessage && config.enchantedBook) {
             ChatUtils.editFirstMessage(
-                component = { it.formattedText.replace("Enchanted Book $bookItemName", internalName.repoItemName).asComponent() },
+                component = { it.formattedText.replace("Enchanted Book$bookItemName", internalName.repoItemName).asComponent() },
                 "enchanted book",
                 predicate = { it.passedSinceSent() < 1.seconds && enchantedBookPattern.matches(it.chatMessage) },
             )

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
@@ -81,7 +82,7 @@ object RareDropMessages {
      */
     private val enchantedBookPattern by repoGroup.pattern(
         "enchantedbook",
-        "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book(?<end> §r§b\\([+](?:§.)*(?<mf>\\d*)% §r§b✯ Magic Find§r§b\\))?.*",
+        "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book \\((?<bookName>.*)\\) (?<end>§r§b\\(\\+(?:§.)*(?<mf>\\d*) §r§b✯ Magic Find§r§b\\))?.*",
     )
 
     private val petPatterns = listOf(
@@ -125,6 +126,7 @@ object RareDropMessages {
         val category = internalName.getItemStackOrNull()?.getItemCategoryOrNull() ?: return
         if (category != ItemCategory.ENCHANTED_BOOK) return
         if (SkyBlockUtils.inAnyIsland(ignoredBookIslands)) return
+        var bookItemName = ""
 
         val itemName = internalName.repoItemName
         var anyRecentMessage = false
@@ -133,6 +135,9 @@ object RareDropMessages {
             val message = line.chatMessage
             if (itemName in message) return // the message already has the enchant name
             if (enchantedBookPattern.matches(message)) {
+                enchantedBookPattern.matchMatcher(message) {
+                    bookItemName = group("bookName")
+                }
                 anyRecentMessage = true
                 break
             }
@@ -140,7 +145,7 @@ object RareDropMessages {
 
         if (anyRecentMessage && config.enchantedBook) {
             ChatUtils.editFirstMessage(
-                component = { it.formattedText.replace("Enchanted Book", internalName.repoItemName).asComponent() },
+                component = { it.formattedText.replace("Enchanted Book $bookItemName", internalName.repoItemName).asComponent() },
                 "enchanted book",
                 predicate = { it.passedSinceSent() < 1.seconds && enchantedBookPattern.matches(it.chatMessage) },
             )

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -76,6 +76,7 @@ object RareDropMessages {
         "(?<start>§e\\[NPC] Oringo§f: §b✆ §f§r§8• )§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end> Pet)",
     )
 
+    @Suppress("maxlinelength")
     /**
      * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book §r§b(+§r§b208% §r§b✯ Magic Find§r§b)
      * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book
@@ -83,7 +84,7 @@ object RareDropMessages {
      */
     private val enchantedBookPattern by repoGroup.pattern(
         "enchantedbook",
-        "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book(?<bookname> \\(.*\\))? (?<end>§r§b\\(\\+(?:§.)*(?<mf>\\d*)%? §r§b✯ Magic Find§r§b\\))?.*",
+        "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book(?<bookname> \\(.*\\))?(?<end> §r§b\\(\\+(?:§.)*(?<mf>\\d*)%? §r§b✯ Magic Find§r§b\\))?.*",
     )
 
     private val petPatterns = listOf(


### PR DESCRIPTION
reverted via https://github.com/hannibal002/SkyHanni/commit/a127e50829a1d0c2953043f0d26483daac7b19e0
ignore_from_changelog

## What
Hypixel Changed the Message for Book Drops to include name, this just changes the current option into a "prettierfier" than a fixer

(I haven't tested on main atm but, *technically* it might work?)

<details>
<summary>Images</summary>
<img width="987" height="72" alt="image" src="https://github.com/user-attachments/assets/67f3d985-4d8a-499d-8621-5e26e147a584" />
(was tested on a broken version so the item add event was being, questionable, at the time in what was added)
<!-- drop images here -->

</details>

## Changelog Fixes
+ Fixed Enchanted Book Drop Message Changer for new format. - fazfoxy
