### PR TITLE
Improvement: Support new Magic Find messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -109,7 +109,7 @@ object ChatFilter {
 
     // Kill Combo
     /**
-     * REGEX-TEST: §a§l+5 Kill Combo §r§8+§r§b3% §r§b? Magic Find
+     * REGEX-TEST: §a§l+5 Kill Combo §r§8+§r§b3% §r§b✯ Magic Find
      */
     private val killComboPatterns = listOf(
         "§.§l\\+(.*) Kill Combo (.*)".toPattern(),

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -35,6 +35,7 @@ object RareDropMessages {
 
     /**
      * REGEX-TEST: §6§lPET DROP! §r§5Baby Yeti §r§b(+§r§b168% §r§b✯ Magic Find§r§b)
+     * REGEX-TEST: §6§lPET DROP! §r§5Baby Yeti §r§b(+§r§b168 §r§b✯ Magic Find§r§b)
      * REGEX-TEST: §6§lPET DROP! §r§5Slug §6(§6+1300☘)
      */
     private val petDroppedPattern by petGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
@@ -132,10 +132,11 @@ object GhostTracker {
 
     /**
      * REGEX-TEST: §6§lRARE DROP! §r§9Sorrow §r§b(+§r§b210% §r§b✯ Magic Find§r§b)
+     * REGEX-TEST: §6§lRARE DROP! §r§9Sorrow §r§b(+§r§b210 §r§b✯ Magic Find§r§b)
      */
     private val itemDropPattern by patternGroup.pattern(
         "itemdrop",
-        "§6§lRARE DROP! §r§9(?<item>[^§]*) §r§b\\([+](?:§.)*(?<mf>\\d*)% §r§b✯ Magic Find§r§b\\)",
+        "§6§lRARE DROP! §r§9(?<item>[^§]*) §r§b\\([+](?:§.)*(?<mf>\\d*)%? §r§b✯ Magic Find§r§b\\)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonChatFilter.kt
@@ -134,7 +134,7 @@ object DungeonChatFilter {
     private val pickupPatterns = listOf(
         "(.*) §r§ehas obtained §r§a§r§9Superboom TNT§r§e!".toPattern(),
         "(.*) §r§ehas obtained §r§a§r§9Superboom TNT §r§8x2§r§e!".toPattern(),
-        "§6§lRARE DROP! §r§9Hunk of Blue Ice §r§b\\(+(.*)% Magic Find!\\)".toPattern(),
+        "§6§lRARE DROP! §r§9Hunk of Blue Ice §r§b\\(+(.*)%? Magic Find!\\)".toPattern(),
         "(.*) §r§ehas obtained §r§a§r§6Revive Stone§r§e!".toPattern(),
         "(.*) §r§ffound a §r§dWither Essence§r§f! Everyone gains an extra essence!".toPattern(),
         "§d(.*) the Fairy§r§f: You killed me! Take this §r§6Revive Stone §r§fso that my death is not in vain!".toPattern(),


### PR DESCRIPTION
## What
Updated patterns to prepare for an upcoming change to Magic Find messages that is currently on alpha (`+123% ✯ Magic Find` -> `+123 ✯ Magic Find`).

This should be safe to merge already, as it supports both formats.

Didn't touch the enchanted book pattern, as those would break without #4540 anyway.

## Changelog Improvements
+ Added support for Hypixel’s new Magic Find format. - Luna