### PR TITLE
Backend: Fix NoSuchFieldException in PacketTest (for real this time)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
@@ -137,7 +137,9 @@ object PacketTest {
             }
         } else {
             val id = try {
-                packet.getEntityId()
+                val field = packet.javaClass.getDeclaredField("entityId")
+                field.makeAccessible()
+                field.get(packet)
             } catch (e: NoSuchFieldException) {
                 null
             } ?: return


### PR DESCRIPTION
## What
#4410 didn't actually fix it.

exclude_from_changelog

