### PR TITLE
Fix: Cake Tracker cache error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
@@ -202,7 +202,8 @@ object CakeTracker {
         if (inCakeInventory) checkInventoryCakes()
         if (!inAuctionHouse) return
 
-        (event.container as ContainerChest).getUpperItems().forEach { (slot, _) ->
+        val containerChest = event.container as? ContainerChest ?: return
+        containerChest.getUpperItems().forEach { (slot, _) ->
             slotHighlightCache[slot.slotIndex]?.let { color ->
                 slot.highlight(color)
             }


### PR DESCRIPTION
## What
Fixed a cache error in CakeTracker class.
Reported: https://discord.com/channels/997079228510117908/1384482950090981437
<details>
<summary>Stack Trace</summary>

```
SkyHanni 3.7.0: Caught a ClassCastException in at.hannibal2.skyhanni.features.inventory.caketracker.CakeTracker.onBackgroundDrawn(at.hannibal2.skyhanni.events.GuiContainerEvent$BackgroundDrawnEvent) at GuiContainerEvent.BackgroundDrawnEvent: net.minecraft.inventory.ContainerPlayer cannot be cast to net.minecraft.inventory.ContainerChest
 
Caused by java.lang.ClassCastException: net.minecraft.inventory.ContainerPlayer cannot be cast to net.minecraft.inventory.ContainerChest
    at SH.features.inventory.caketracker.CakeTracker.onBackgroundDrawn(CakeTracker.kt:204)
<Skyhanni event post>
```

</details>

## Changelog Fixes
+ Fixed rare Cake Tracker error. - hannibal2