### PR TITLE
Backend: hypixel no sound sound info

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/FlowstateHelperConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/FlowstateHelperConfig.kt
@@ -16,7 +16,7 @@ class FlowstateHelperConfig {
     @ConfigOption(
         name = "Enabled",
         desc = "Shows stats for the Flowstate enchantment on Mining Tools." +
-                "§eMight not work at all due to Hypixel not sending sound data anymore.",
+            "§eMight not work at all due to Hypixel not sending sound data anymore.",
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/FlowstateHelperConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/FlowstateHelperConfig.kt
@@ -13,7 +13,11 @@ import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class FlowstateHelperConfig {
     @Expose
-    @ConfigOption(name = "Enabled", desc = "Shows stats for the Flowstate enchantment on Mining Tools.")
+    @ConfigOption(
+        name = "Enabled",
+        desc = "Shows stats for the Flowstate enchantment on Mining Tools." +
+                "§eMight not work at all due to Hypixel not sending sound data anymore.",
+    )
     @ConfigEditorBoolean
     @FeatureToggle
     var enabled: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/MineshaftPityDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/MineshaftPityDisplayConfig.kt
@@ -11,7 +11,11 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class MineshaftPityDisplayConfig {
     @Expose
-    @ConfigOption(name = "Enable Display", desc = "Enable the Mineshaft Pity Display.")
+    @ConfigOption(
+        name = "Enable Display",
+        desc = "Enable the Mineshaft Pity Display. " +
+            "§eMight not work at all due to Hypixel not sending sound data anymore.",
+    )
     @ConfigEditorBoolean
     @FeatureToggle
     var enabled: Boolean = true
@@ -24,7 +28,7 @@ class MineshaftPityDisplayConfig {
         MineshaftPityLine.COUNTER,
         MineshaftPityLine.CHANCE,
         MineshaftPityLine.NEEDED_TO_PITY,
-        MineshaftPityLine.TIME_SINCE_MINESHAFT
+        MineshaftPityLine.TIME_SINCE_MINESHAFT,
     )
 
     @Expose


### PR DESCRIPTION
## Changelog Technical Details
+ Added info to Pity Display and Flowsoul Helper configs indicating they don’t work due to missing Hypixel sound info. - hannibal2