### PR TITLE
Backend: Fix pet lvl 0

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
@@ -208,8 +208,8 @@ object PetUtils {
      * @param coerceToMax Whether to floor the calculated level to the maximum level of the pet. (Default: true)
      */
     fun xpToLevel(totalXp: Double, petInternalName: NeuInternalName, coerceToMax: Boolean = true): Int = runCatching {
-        var xp = totalXp.takeIf { it > 0 } ?: return 0
-        val rarityOffset = getRarityOffset(petInternalName) ?: return 0
+        var xp = totalXp.takeIf { it > 0 } ?: return 1
+        val rarityOffset = getRarityOffset(petInternalName) ?: return 1
         val xpList = getFullLevelingTree(petInternalName)
 
         var level = 1


### PR DESCRIPTION
## What
Fixed pets lvl 0 showing as stack numbers.
not a user facing bug as we were hiding stack size on stack size 1 items until now as well.

## Changelog Technical Details
+ Fixed internal display of pets at Level 0 when they have 0 XP. - hannibal2