### PR TITLE
Backend: Fix fabric.mod.json warning

### DIFF
--- a/versions/1.21.5/src/main/resources/fabric.mod.json
+++ b/versions/1.21.5/src/main/resources/fabric.mod.json
@@ -1,5 +1,17 @@
 {
-    "_note": "If you make changes here you must also make changes to all other fabric.mod.json files in other versions.",
+    "custom": {
+        "_note": "If you make changes here you must also make changes to all other fabric.mod.json files in other versions.",
+        "modmenu": {
+            "update_checker": true,
+            "links": {
+                "Discord Link": "https://discord.gg/skyhanni-997079228510117908",
+                "Modrinth Page": "https://modrinth.com/mod/skyhanni",
+                "List of all Features": "https://github.com/hannibal002/SkyHanni/blob/beta/docs/FEATURES.md",
+                "Source Code on Github": "https://github.com/hannibal002/SkyHanni",
+                "Contributing Guide Docs": "https://github.com/hannibal002/SkyHanni/blob/beta/CONTRIBUTING.md"
+            }
+        }
+    },
     "schemaVersion": 1,
     "version": "${version}",
     "id": "skyhanni",
@@ -37,17 +49,5 @@
     "contact": {
         "homepage": "https://modrinth.com/mod/skyhanni",
         "issues": "https://discord.gg/skyhanni-997079228510117908"
-    },
-    "custom": {
-        "modmenu": {
-            "update_checker": true,
-            "links": {
-                "Discord Link": "https://discord.gg/skyhanni-997079228510117908",
-                "Modrinth Page": "https://modrinth.com/mod/skyhanni",
-                "List of all Features": "https://github.com/hannibal002/SkyHanni/blob/beta/docs/FEATURES.md",
-                "Source Code on Github": "https://github.com/hannibal002/SkyHanni",
-                "Contributing Guide Docs": "https://github.com/hannibal002/SkyHanni/blob/beta/CONTRIBUTING.md"
-            }
-        }
     }
 }

--- a/versions/1.21.7/src/main/resources/fabric.mod.json
+++ b/versions/1.21.7/src/main/resources/fabric.mod.json
@@ -1,5 +1,17 @@
 {
-    "_note": "If you make changes here you must also make changes to all other fabric.mod.json files in other versions.",
+    "custom": {
+        "_note": "If you make changes here you must also make changes to all other fabric.mod.json files in other versions.",
+        "modmenu": {
+            "update_checker": true,
+            "links": {
+                "Discord Link": "https://discord.gg/skyhanni-997079228510117908",
+                "Modrinth Page": "https://modrinth.com/mod/skyhanni",
+                "List of all Features": "https://github.com/hannibal002/SkyHanni/blob/beta/docs/FEATURES.md",
+                "Source Code on Github": "https://github.com/hannibal002/SkyHanni",
+                "Contributing Guide Docs": "https://github.com/hannibal002/SkyHanni/blob/beta/CONTRIBUTING.md"
+            }
+        }
+    },
     "schemaVersion": 1,
     "version": "${version}",
     "id": "skyhanni",
@@ -37,17 +49,5 @@
     "contact": {
         "homepage": "https://modrinth.com/mod/skyhanni",
         "issues": "https://discord.gg/skyhanni-997079228510117908"
-    },
-    "custom": {
-        "modmenu": {
-            "update_checker": true,
-            "links": {
-                "Discord Link": "https://discord.gg/skyhanni-997079228510117908",
-                "Modrinth Page": "https://modrinth.com/mod/skyhanni",
-                "List of all Features": "https://github.com/hannibal002/SkyHanni/blob/beta/docs/FEATURES.md",
-                "Source Code on Github": "https://github.com/hannibal002/SkyHanni",
-                "Contributing Guide Docs": "https://github.com/hannibal002/SkyHanni/blob/beta/CONTRIBUTING.md"
-            }
-        }
     }
 }


### PR DESCRIPTION
## What
Fixed Fabric Loader warning about an invalid field in `fabric.mod.json`. 

Per https://wiki.fabricmc.net/documentation:fabric_mod_json: 
> You can add any field you want to add inside `custom` field. Loader would ignore them.

exclude_from_changelog

