### PR TITLE
Backend: fixed small performance issues in dmg indicator

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -116,7 +116,7 @@ object SkyHanniMod {
     lateinit var visualWordsData: VisualWordsJson
     lateinit var petData: PetDataStorage
     lateinit var orderedWaypointsRoutesData: OrderedWaypointsRoutes
-    val renderEnabled get() = GlobalRender.enabled
+    val renderDisabled get() = !GlobalRender.enabled
 
     lateinit var configManager: ConfigManager
     val logger: Logger = LogManager.getLogger("SkyHanni")
@@ -138,7 +138,7 @@ object SkyHanniMod {
      */
     fun launchIOCoroutineWithMutex(
         mutex: Mutex,
-        block: suspend CoroutineScope.() -> Unit
+        block: suspend CoroutineScope.() -> Unit,
     ): Job = launchCoroutine {
         mutex.withLock {
             withContext(Dispatchers.IO, block)

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.config.storage.OrderedWaypointsRoutes
+import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.data.GuiEditManager
 import at.hannibal2.skyhanni.data.OtherInventoryData
 import at.hannibal2.skyhanni.data.PetDataStorage
@@ -115,6 +116,7 @@ object SkyHanniMod {
     lateinit var visualWordsData: VisualWordsJson
     lateinit var petData: PetDataStorage
     lateinit var orderedWaypointsRoutesData: OrderedWaypointsRoutes
+    val renderEnabled get() = GlobalRender.enabled
 
     lateinit var configManager: ConfigManager
     val logger: Logger = LogManager.getLogger("SkyHanni")

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -116,7 +116,6 @@ object SkyHanniMod {
     lateinit var visualWordsData: VisualWordsJson
     lateinit var petData: PetDataStorage
     lateinit var orderedWaypointsRoutesData: OrderedWaypointsRoutes
-    val renderDisabled get() = !GlobalRender.enabled
 
     lateinit var configManager: ConfigManager
     val logger: Logger = LogManager.getLogger("SkyHanni")

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -35,8 +35,8 @@ object RenderEvents {
 
     @SubscribeEvent
     fun onRenderWorld(event: RenderWorldLastEvent) {
-        if (!canRender()) return
         if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!canRender()) return
         SkyHanniRenderWorldEvent(WorldRenderContext(), event.partialTicks).post()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.api.minecraftevents
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.render.BlockOverlayRenderEvent
@@ -14,7 +15,6 @@ import at.hannibal2.skyhanni.events.render.gui.InitializeGuiEvent
 import at.hannibal2.skyhanni.events.render.gui.RenderingTickEvent
 import at.hannibal2.skyhanni.events.render.gui.ScreenDrawnEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.compat.DrawContext
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.WorldRenderContext
@@ -35,7 +35,7 @@ object RenderEvents {
 
     @SubscribeEvent
     fun onRenderWorld(event: RenderWorldLastEvent) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         if (!canRender()) return
         SkyHanniRenderWorldEvent(WorldRenderContext(), event.partialTicks).post()
     }

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.api.minecraftevents
 
-import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.render.BlockOverlayRenderEvent
@@ -35,7 +35,7 @@ object RenderEvents {
 
     @SubscribeEvent
     fun onRenderWorld(event: RenderWorldLastEvent) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         if (!canRender()) return
         SkyHanniRenderWorldEvent(WorldRenderContext(), event.partialTicks).post()
     }

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -35,7 +35,7 @@ object RenderEvents {
 
     @SubscribeEvent
     fun onRenderWorld(event: RenderWorldLastEvent) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         if (!canRender()) return
         SkyHanniRenderWorldEvent(WorldRenderContext(), event.partialTicks).post()
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.entity.EntityHealthDisplayEvent
 import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
@@ -72,6 +73,7 @@ object EntityData {
 
     @JvmStatic
     fun onRenderCheck(entity: Entity, camX: Double, camY: Double, camZ: Double): Boolean {
+        if (!SkyHanniDebugsAndTests.globalRender) return true
         lastVisibilityCheck[entity.entityId]?.let { result ->
             return result
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -25,6 +25,7 @@ object EntityData {
     private val healthDisplayCache = TimeLimitedCache<String, String>(50.milliseconds)
     private val lastVisibilityCheck = TimeLimitedCache<Int, Boolean>(200.milliseconds)
 
+    // TODO replace with packet detection
     @HandleEvent
     fun onTick() {
         for (entity in EntityUtils.getEntities<EntityLivingBase>()) { // this completely ignores the ignored entities list?

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.data
 
-import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ElectionApi.derpy
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
@@ -74,7 +73,7 @@ object EntityData {
 
     @JvmStatic
     fun onRenderCheck(entity: Entity, camX: Double, camY: Double, camZ: Double): Boolean {
-        if (SkyHanniMod.renderDisabled) return true
+        if (GlobalRender.renderDisabled) return true
         lastVisibilityCheck[entity.entityId]?.let { result ->
             return result
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.data
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ElectionApi.derpy
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
@@ -8,7 +9,6 @@ import at.hannibal2.skyhanni.events.entity.EntityHealthDisplayEvent
 import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
@@ -73,7 +73,7 @@ object EntityData {
 
     @JvmStatic
     fun onRenderCheck(entity: Entity, camX: Double, camY: Double, camZ: Double): Boolean {
-        if (!SkyHanniDebugsAndTests.globalRender) return true
+        if (!SkyHanniMod.renderEnabled) return true
         lastVisibilityCheck[entity.entityId]?.let { result ->
             return result
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -73,7 +73,7 @@ object EntityData {
 
     @JvmStatic
     fun onRenderCheck(entity: Entity, camX: Double, camY: Double, camZ: Double): Boolean {
-        if (!SkyHanniMod.renderEnabled) return true
+        if (SkyHanniMod.renderDisabled) return true
         lastVisibilityCheck[entity.entityId]?.let { result ->
             return result
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
@@ -22,6 +22,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 object GlobalRender {
 
     var enabled = true
+        private set
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
@@ -1,0 +1,39 @@
+package at.hannibal2.skyhanni.data
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+
+/**
+ * This not only toggles all mixins that render skyhanni elements in 2d or 3d,
+ * (e.g. renderables, entity highlight, inventory background, slot number)
+ * but also all render related logic of all features. (e.g. hide entites, tab list, etc)
+ * With this toggle set to false, only skyhanni features that visually work are chat messages.
+ *
+ * Note that this does not change the internal data fetching and processing for non render focused features.
+ *
+ * The debug command is useful to instantly see if a performance problem or mod conflict is due to SkyHanni or not.
+ */
+@SkyHanniModule
+object GlobalRender {
+
+    var enabled = true
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shrendertoggle") {
+            description = "Disables/enables the rendering of all skyhanni guis."
+            category = CommandCategory.USERS_BUG_FIX
+            callback {
+                enabled = !enabled
+                if (enabled) {
+                    ChatUtils.chat("§aEnabled global renderer!")
+                } else {
+                    ChatUtils.chat("§cDisabled global renderer! Run this command again to show SkyHanni rendering again.")
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
@@ -1,8 +1,10 @@
 package at.hannibal2.skyhanni.data
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 
@@ -33,6 +35,19 @@ object GlobalRender {
                 } else {
                     ChatUtils.chat("§cDisabled global renderer! Run this command again to show SkyHanni rendering again.")
                 }
+            }
+        }
+    }
+
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Global Render")
+        if (enabled) {
+            event.addIrrelevant("normal enabled")
+        } else {
+            event.addData {
+                add("Global renderer is disabled!")
+                add("No rendering-related features from SkyHanni will show up anywhere!")
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.data
 
-import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GlobalRender.kt
@@ -20,8 +20,8 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 @SkyHanniModule
 object GlobalRender {
 
-    var enabled = true
-        private set
+    val renderDisabled get() = !enabled
+    private var enabled = true
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
@@ -108,7 +108,7 @@ object GuiEditManager {
 
     @JvmStatic
     fun renderLast(context: DrawContext) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         if (!isInGui()) return
 
         DrawContextUtils.setContext(context)

--- a/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
@@ -109,8 +109,8 @@ object GuiEditManager {
 
     @JvmStatic
     fun renderLast(context: DrawContext) {
-        if (!isInGui()) return
         if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!isInGui()) return
 
         DrawContextUtils.setContext(context)
         DrawContextUtils.translate(0f, 0f, 200f)

--- a/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
@@ -108,7 +108,7 @@ object GuiEditManager {
 
     @JvmStatic
     fun renderLast(context: DrawContext) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         if (!isInGui()) return
 
         DrawContextUtils.setContext(context)

--- a/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.events.GuiPositionMovedEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.SignUtils.isGardenSign
@@ -109,7 +108,7 @@ object GuiEditManager {
 
     @JvmStatic
     fun renderLast(context: DrawContext) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         if (!isInGui()) return
 
         DrawContextUtils.setContext(context)

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -292,6 +292,8 @@ object IslandGraphs {
     fun onTick(event: SkyHanniTickEvent) {
         if (currentIslandGraph == null) return
         if (event.isMod(2)) {
+
+            // TODO add dev config toggle to disable
             update()
         }
         updateFeedback()

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.data
 
-import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.DrawScreenAfterEvent
 import at.hannibal2.skyhanni.events.GuiRenderItemEvent
@@ -39,7 +38,7 @@ object ItemTipHelper {
 
     @HandleEvent(priority = HandleEvent.HIGHEST, onlyOnSkyblock = true)
     fun onRenderInventoryItemOverlayPost(event: DrawScreenAfterEvent) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
 
         val gui = Minecraft.getMinecraft().currentScreen
         if (gui !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
@@ -39,7 +39,7 @@ object ItemTipHelper {
 
     @HandleEvent(priority = HandleEvent.HIGHEST, onlyOnSkyblock = true)
     fun onRenderInventoryItemOverlayPost(event: DrawScreenAfterEvent) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
 
         val gui = Minecraft.getMinecraft().currentScreen
         if (gui !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.data
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.DrawScreenAfterEvent
 import at.hannibal2.skyhanni.events.GuiRenderItemEvent
@@ -7,7 +8,6 @@ import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
 import at.hannibal2.skyhanni.mixins.transformers.gui.AccessorGuiContainer
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.GuiRenderUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSlotText
@@ -39,7 +39,7 @@ object ItemTipHelper {
 
     @HandleEvent(priority = HandleEvent.HIGHEST, onlyOnSkyblock = true)
     fun onRenderInventoryItemOverlayPost(event: DrawScreenAfterEvent) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
 
         val gui = Minecraft.getMinecraft().currentScreen
         if (gui !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.data
 
-import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.render.gui.DrawBackgroundEvent
@@ -19,7 +18,7 @@ object RenderData {
 
     @JvmStatic
     fun postRenderOverlay(context: DrawContext) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
         val screen = Minecraft.getMinecraft().currentScreen
 
@@ -32,7 +31,7 @@ object RenderData {
 
     @HandleEvent
     fun onBackgroundDraw(event: DrawBackgroundEvent) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
         val currentScreen = Minecraft.getMinecraft().currentScreen ?: return
         if (currentScreen !is GuiInventory && currentScreen !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
@@ -19,7 +19,7 @@ object RenderData {
 
     @JvmStatic
     fun postRenderOverlay(context: DrawContext) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
         val screen = Minecraft.getMinecraft().currentScreen
 
@@ -32,7 +32,7 @@ object RenderData {
 
     @HandleEvent
     fun onBackgroundDraw(event: DrawBackgroundEvent) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
         val currentScreen = Minecraft.getMinecraft().currentScreen ?: return
         if (currentScreen !is GuiInventory && currentScreen !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
@@ -1,11 +1,11 @@
 package at.hannibal2.skyhanni.data
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.render.gui.DrawBackgroundEvent
 import at.hannibal2.skyhanni.features.misc.visualwords.VisualWordGui
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.compat.DrawContext
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
 import net.minecraft.client.Minecraft
@@ -19,7 +19,7 @@ object RenderData {
 
     @JvmStatic
     fun postRenderOverlay(context: DrawContext) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
         val screen = Minecraft.getMinecraft().currentScreen
 
@@ -32,7 +32,7 @@ object RenderData {
 
     @HandleEvent
     fun onBackgroundDraw(event: DrawBackgroundEvent) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
         val currentScreen = Minecraft.getMinecraft().currentScreen ?: return
         if (currentScreen !is GuiInventory && currentScreen !is GuiChest) return

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
@@ -428,26 +428,27 @@ class MobFinder {
     } else null
 
     private fun tryAddEntitySpider(entity: EntityLivingBase): EntityResult? {
-        if (entity.hasNameTagWith(1, "§5☠ §4Tarantula Broodfather ")) {
-            when {
-                entity.hasMaxHealth(740, true) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_1)
-                entity.hasMaxHealth(30_000, true) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_2)
-                entity.hasMaxHealth(900_000, true) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_3)
-                entity.hasMaxHealth(2_400_000, true) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_4)
-                entity.hasMaxHealth(10_000_000, true) -> return EntityResult(bossType = BossType.SLAYER_SPIDER_5_1)
+        when {
+            entity.hasMaxHealth(740, true) -> EntityResult(bossType = BossType.SLAYER_SPIDER_1)
+            entity.hasMaxHealth(30_000, true) -> EntityResult(bossType = BossType.SLAYER_SPIDER_2)
+            entity.hasMaxHealth(900_000, true) -> EntityResult(bossType = BossType.SLAYER_SPIDER_3)
+            entity.hasMaxHealth(2_400_000, true) -> EntityResult(bossType = BossType.SLAYER_SPIDER_4)
+            entity.hasMaxHealth(10_000_000, true) -> EntityResult(bossType = BossType.SLAYER_SPIDER_5_1)
+            else -> null
+        }?.let {
+            if (entity.hasNameTagWith(1, "§5☠ §4Tarantula Broodfather ")) {
+                return it
             }
         }
-        if (entity.hasNameTagWith(1, "§5☠ §4Conjoined Brood ")) {
-            if (entity.hasMaxHealth(20_000_000, true)) {
-                return EntityResult(bossType = BossType.SLAYER_SPIDER_5_2)
-            }
+        if (entity.hasMaxHealth(20_000_000, true) && entity.hasNameTagWith(1, "§5☠ §4Conjoined Brood ")) {
+            return EntityResult(bossType = BossType.SLAYER_SPIDER_5_2)
         }
-        if (entity.hasNameTagWith(1, "[§7Lv12§8] §4Broodmother")) {
-            if (entity.hasMaxHealth(6000)) {
+        if (IslandType.SPIDER_DEN.isCurrent()) {
+            if (entity.hasMaxHealth(6000) && entity.hasNameTagWith(1, "[§7Lv12§8] §4Broodmother")) {
                 return EntityResult(bossType = BossType.BROODMOTHER)
             }
+            checkArachne(entity as EntitySpider)?.let { return it }
         }
-        checkArachne(entity as EntitySpider)?.let { return it }
         return null
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -453,6 +453,7 @@ object ItemAbilityCooldown {
         event.move(31, "itemAbilities", "inventory.itemAbilities")
     }
 
+    // TODO add item caching
     private fun hasAbility(stack: ItemStack): MutableList<ItemAbility> {
         val itemName: String = stack.cleanName()
         val internalName = stack.getInternalName()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.dungeon.DungeonMobManager
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -35,7 +34,7 @@ object HideFarEntities {
 
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         if (!isEnabled()) return
         if (event.isMod(20)) {
             updateNeverHide()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.dungeon.DungeonMobManager
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
@@ -34,6 +35,7 @@ object HideFarEntities {
 
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {
+        if (!SkyHanniDebugsAndTests.globalRender) return
         if (!isEnabled()) return
         if (event.isMod(20)) {
             updateNeverHide()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -34,7 +34,7 @@ object HideFarEntities {
 
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         if (!isEnabled()) return
         if (event.isMod(20)) {
             updateNeverHide()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideFarEntities.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.PartyApi
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
@@ -34,7 +35,7 @@ object HideFarEntities {
 
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         if (!isEnabled()) return
         if (event.isMod(20)) {
             updateNeverHide()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -179,7 +179,7 @@ object AdvancedPlayerList {
 
     fun ignoreCustomTabList(): Boolean {
         val denyKeyPressed = SkyHanniMod.feature.dev.debug.bypassAdvancedPlayerTabList.isKeyHeld()
-        return !SkyHanniMod.renderEnabled || denyKeyPressed
+        return SkyHanniMod.renderDisabled || denyKeyPressed
     }
 
     private fun createCustomName(data: PlayerData): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.misc.compacttablist
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.features.misc.compacttablist.AdvancedPlayerListConfig.PlayerSortEntry
 import at.hannibal2.skyhanni.data.FriendApi
+import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.data.GuildApi
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.PartyApi
@@ -179,7 +180,7 @@ object AdvancedPlayerList {
 
     fun ignoreCustomTabList(): Boolean {
         val denyKeyPressed = SkyHanniMod.feature.dev.debug.bypassAdvancedPlayerTabList.isKeyHeld()
-        return SkyHanniMod.renderDisabled || denyKeyPressed
+        return GlobalRender.renderDisabled || denyKeyPressed
     }
 
     private fun createCustomName(data: PlayerData): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -180,7 +180,7 @@ object AdvancedPlayerList {
 
     fun ignoreCustomTabList(): Boolean {
         val denyKeyPressed = SkyHanniMod.feature.dev.debug.bypassAdvancedPlayerTabList.isKeyHeld()
-        return denyKeyPressed || !SkyHanniDebugsAndTests.globalRender
+        return !SkyHanniDebugsAndTests.globalRender || denyKeyPressed
     }
 
     private fun createCustomName(data: PlayerData): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.features.misc.ContributorManager
 import at.hannibal2.skyhanni.features.misc.MarkedPlayerManager
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.PlayerUtils
@@ -180,7 +179,7 @@ object AdvancedPlayerList {
 
     fun ignoreCustomTabList(): Boolean {
         val denyKeyPressed = SkyHanniMod.feature.dev.debug.bypassAdvancedPlayerTabList.isKeyHeld()
-        return !SkyHanniDebugsAndTests.globalRender || denyKeyPressed
+        return !SkyHanniMod.renderEnabled || denyKeyPressed
     }
 
     private fun createCustomName(data: PlayerData): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -32,7 +32,7 @@ object TabListRenderer {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlayPre(event: GameOverlayRenderPreEvent) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         if (event.type != RenderLayer.PLAYER_LIST) return
         if (!config.enabled.get()) return
         event.cancel()
@@ -47,7 +47,7 @@ object TabListRenderer {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         if (!config.enabled.get()) return
         if (!config.toggleTab) return
         if (Minecraft.getMinecraft().currentScreen != null) return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SkipTabListLineEvent
 import at.hannibal2.skyhanni.events.render.gui.GameOverlayRenderPreEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.GuiRenderUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isActive
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -33,7 +32,7 @@ object TabListRenderer {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlayPre(event: GameOverlayRenderPreEvent) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         if (event.type != RenderLayer.PLAYER_LIST) return
         if (!config.enabled.get()) return
         event.cancel()
@@ -48,7 +47,7 @@ object TabListRenderer {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         if (!config.enabled.get()) return
         if (!config.toggleTab) return
         if (Minecraft.getMinecraft().currentScreen != null) return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.minecraftevents.RenderLayer
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SkipTabListLineEvent
 import at.hannibal2.skyhanni.events.render.gui.GameOverlayRenderPreEvent
@@ -32,7 +33,7 @@ object TabListRenderer {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlayPre(event: GameOverlayRenderPreEvent) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         if (event.type != RenderLayer.PLAYER_LIST) return
         if (!config.enabled.get()) return
         event.cancel()
@@ -47,7 +48,7 @@ object TabListRenderer {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         if (!config.enabled.get()) return
         if (!config.toggleTab) return
         if (Minecraft.getMinecraft().currentScreen != null) return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SkipTabListLineEvent
 import at.hannibal2.skyhanni.events.render.gui.GameOverlayRenderPreEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.GuiRenderUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isActive
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -32,6 +33,7 @@ object TabListRenderer {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlayPre(event: GameOverlayRenderPreEvent) {
+        if (!SkyHanniDebugsAndTests.globalRender) return
         if (event.type != RenderLayer.PLAYER_LIST) return
         if (!config.enabled.get()) return
         event.cancel()
@@ -46,6 +48,7 @@ object TabListRenderer {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (!SkyHanniDebugsAndTests.globalRender) return
         if (!config.enabled.get()) return
         if (!config.toggleTab) return
         if (Minecraft.getMinecraft().currentScreen != null) return

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
-import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.data.GuiData
 import at.hannibal2.skyhanni.events.DrawScreenAfterEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
@@ -37,7 +37,7 @@ class GuiContainerHook(guiAny: Any) {
     }
 
     fun backgroundDrawn(context: DrawContext, mouseX: Int, mouseY: Int, partialTicks: Float) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         GuiContainerEvent.BackgroundDrawnEvent(context, gui, container, mouseX, mouseY, partialTicks).post()
     }
 
@@ -48,7 +48,7 @@ class GuiContainerHook(guiAny: Any) {
         partialTicks: Float,
         ci: CallbackInfo,
     ) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         if (GuiContainerEvent.PreDraw(context, gui, container, mouseX, mouseY, partialTicks).post()) {
             if (PlatformUtils.isNeuLoaded()) NEUApi.setInventoryButtonsToDisabled()
             GuiData.preDrawEventCancelled = true
@@ -61,7 +61,7 @@ class GuiContainerHook(guiAny: Any) {
     }
 
     fun postDraw(context: DrawContext, mouseX: Int, mouseY: Int, partialTicks: Float) {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         GuiContainerEvent.PostDraw(context, gui, container, mouseX, mouseY, partialTicks).post()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
@@ -1,12 +1,12 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.GuiData
 import at.hannibal2.skyhanni.events.DrawScreenAfterEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent.ClickType
 import at.hannibal2.skyhanni.events.GuiContainerEvent.CloseWindowEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent.SlotClickEvent
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.compat.DrawContext
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
@@ -37,7 +37,7 @@ class GuiContainerHook(guiAny: Any) {
     }
 
     fun backgroundDrawn(context: DrawContext, mouseX: Int, mouseY: Int, partialTicks: Float) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         GuiContainerEvent.BackgroundDrawnEvent(context, gui, container, mouseX, mouseY, partialTicks).post()
     }
 
@@ -48,7 +48,7 @@ class GuiContainerHook(guiAny: Any) {
         partialTicks: Float,
         ci: CallbackInfo,
     ) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         if (GuiContainerEvent.PreDraw(context, gui, container, mouseX, mouseY, partialTicks).post()) {
             if (PlatformUtils.isNeuLoaded()) NEUApi.setInventoryButtonsToDisabled()
             GuiData.preDrawEventCancelled = true
@@ -61,7 +61,7 @@ class GuiContainerHook(guiAny: Any) {
     }
 
     fun postDraw(context: DrawContext, mouseX: Int, mouseY: Int, partialTicks: Float) {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         GuiContainerEvent.PostDraw(context, gui, container, mouseX, mouseY, partialTicks).post()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
@@ -37,7 +37,7 @@ class GuiContainerHook(guiAny: Any) {
     }
 
     fun backgroundDrawn(context: DrawContext, mouseX: Int, mouseY: Int, partialTicks: Float) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         GuiContainerEvent.BackgroundDrawnEvent(context, gui, container, mouseX, mouseY, partialTicks).post()
     }
 
@@ -48,7 +48,7 @@ class GuiContainerHook(guiAny: Any) {
         partialTicks: Float,
         ci: CallbackInfo,
     ) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         if (GuiContainerEvent.PreDraw(context, gui, container, mouseX, mouseY, partialTicks).post()) {
             if (PlatformUtils.isNeuLoaded()) NEUApi.setInventoryButtonsToDisabled()
             GuiData.preDrawEventCancelled = true
@@ -61,7 +61,7 @@ class GuiContainerHook(guiAny: Any) {
     }
 
     fun postDraw(context: DrawContext, mouseX: Int, mouseY: Int, partialTicks: Float) {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         GuiContainerEvent.PostDraw(context, gui, container, mouseX, mouseY, partialTicks).post()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderItemHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderItemHook.kt
@@ -13,7 +13,7 @@ fun renderItemOverlayPost(
     yPosition: Int,
     text: String?,
 ) {
-    if (!SkyHanniMod.renderEnabled) return
+    if (SkyHanniMod.renderDisabled) return
     GuiRenderItemEvent.RenderOverlayEvent.GuiRenderItemPost(
         context,
         stack,
@@ -24,6 +24,6 @@ fun renderItemOverlayPost(
 }
 
 fun renderItemReturn(context: DrawContext, stack: ItemStack, x: Int, y: Int) {
-    if (!SkyHanniMod.renderEnabled) return
+    if (SkyHanniMod.renderDisabled) return
     RenderGuiItemOverlayEvent(context, stack, x, y).post()
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderItemHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderItemHook.kt
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
-import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.events.GuiRenderItemEvent
 import at.hannibal2.skyhanni.events.RenderGuiItemOverlayEvent
 import at.hannibal2.skyhanni.utils.compat.DrawContext
@@ -13,7 +13,7 @@ fun renderItemOverlayPost(
     yPosition: Int,
     text: String?,
 ) {
-    if (SkyHanniMod.renderDisabled) return
+    if (GlobalRender.renderDisabled) return
     GuiRenderItemEvent.RenderOverlayEvent.GuiRenderItemPost(
         context,
         stack,
@@ -24,6 +24,6 @@ fun renderItemOverlayPost(
 }
 
 fun renderItemReturn(context: DrawContext, stack: ItemStack, x: Int, y: Int) {
-    if (SkyHanniMod.renderDisabled) return
+    if (GlobalRender.renderDisabled) return
     RenderGuiItemOverlayEvent(context, stack, x, y).post()
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderItemHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderItemHook.kt
@@ -1,8 +1,8 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.events.GuiRenderItemEvent
 import at.hannibal2.skyhanni.events.RenderGuiItemOverlayEvent
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.compat.DrawContext
 import net.minecraft.item.ItemStack
 
@@ -13,7 +13,7 @@ fun renderItemOverlayPost(
     yPosition: Int,
     text: String?,
 ) {
-    if (!SkyHanniDebugsAndTests.globalRender) return
+    if (!SkyHanniMod.renderEnabled) return
     GuiRenderItemEvent.RenderOverlayEvent.GuiRenderItemPost(
         context,
         stack,
@@ -24,6 +24,6 @@ fun renderItemOverlayPost(
 }
 
 fun renderItemReturn(context: DrawContext, stack: ItemStack, x: Int, y: Int) {
-    if (!SkyHanniDebugsAndTests.globalRender) return
+    if (!SkyHanniMod.renderEnabled) return
     RenderGuiItemOverlayEvent(context, stack, x, y).post()
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -1,10 +1,10 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIfKey
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
@@ -94,7 +94,7 @@ object RenderLivingEntityHelper {
 
     @JvmStatic
     fun <T : EntityLivingBase> internalSetColorMultiplier(entity: T, default: Int): Int {
-        if (!SkyHanniDebugsAndTests.globalRender) return default
+        if (!SkyHanniMod.renderEnabled) return default
         if (entityColorMap.containsKey(entity)) {
             val condition = entityColorCondition[entity] ?: return default
             if (condition.invoke()) {
@@ -106,7 +106,7 @@ object RenderLivingEntityHelper {
 
     @JvmStatic
     fun <T : EntityLivingBase> internalChangeHurtTime(entity: T): Int {
-        if (!SkyHanniDebugsAndTests.globalRender) return entity.hurtTime
+        if (!SkyHanniMod.renderEnabled) return entity.hurtTime
         run {
             val condition = entityNoHurtTimeCondition[entity] ?: return@run
             if (condition.invoke()) {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -94,7 +94,7 @@ object RenderLivingEntityHelper {
 
     @JvmStatic
     fun <T : EntityLivingBase> internalSetColorMultiplier(entity: T, default: Int): Int {
-        if (!SkyHanniMod.renderEnabled) return default
+        if (SkyHanniMod.renderDisabled) return default
         if (entityColorMap.containsKey(entity)) {
             val condition = entityColorCondition[entity] ?: return default
             if (condition.invoke()) {
@@ -106,7 +106,7 @@ object RenderLivingEntityHelper {
 
     @JvmStatic
     fun <T : EntityLivingBase> internalChangeHurtTime(entity: T): Int {
-        if (!SkyHanniMod.renderEnabled) return entity.hurtTime
+        if (SkyHanniMod.renderDisabled) return entity.hurtTime
         run {
             val condition = entityNoHurtTimeCondition[entity] ?: return@run
             if (condition.invoke()) {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
-import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -94,7 +94,7 @@ object RenderLivingEntityHelper {
 
     @JvmStatic
     fun <T : EntityLivingBase> internalSetColorMultiplier(entity: T, default: Int): Int {
-        if (SkyHanniMod.renderDisabled) return default
+        if (GlobalRender.renderDisabled) return default
         if (entityColorMap.containsKey(entity)) {
             val condition = entityColorCondition[entity] ?: return default
             if (condition.invoke()) {
@@ -106,7 +106,7 @@ object RenderLivingEntityHelper {
 
     @JvmStatic
     fun <T : EntityLivingBase> internalChangeHurtTime(entity: T): Int {
-        if (SkyHanniMod.renderDisabled) return entity.hurtTime
+        if (GlobalRender.renderDisabled) return entity.hurtTime
         run {
             val condition = entityNoHurtTimeCondition[entity] ?: return@run
             if (condition.invoke()) {

--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -157,7 +157,7 @@ object DebugCommand {
 
     private fun globalRender(event: DebugDataCollectEvent) {
         event.title("Global Render")
-        if (SkyHanniDebugsAndTests.globalRender) {
+        if (SkyHanniMod.renderEnabled) {
             event.addIrrelevant("normal enabled")
         } else {
             event.addData {

--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -52,7 +52,6 @@ object DebugCommand {
         // calling default debug stuff
         player(event)
         repoData(event)
-        globalRender(event)
         skyblockStatus(event)
         networkInfo(event)
         profileName(event)
@@ -152,18 +151,6 @@ object DebugCommand {
                 add(" /shtestwaypoint $x $y $z pathfind")
             }
             add("isOnAlphaServer: '${SkyBlockUtils.isOnAlphaServer}'")
-        }
-    }
-
-    private fun globalRender(event: DebugDataCollectEvent) {
-        event.title("Global Render")
-        if (SkyHanniMod.renderEnabled) {
-            event.addIrrelevant("normal enabled")
-        } else {
-            event.addData {
-                add("Global renderer is disabled!")
-                add("No renderable elements from SkyHanni will show up anywhere!")
-            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -83,8 +83,6 @@ object SkyHanniDebugsAndTests {
     @Suppress("MemberVisibilityCanBePrivate")
     var displayList = emptyList<Renderable>()
 
-    var globalRender = true
-
     var a = 1.0
     var b = 60.0
     var c = 0.0
@@ -617,18 +615,6 @@ object SkyHanniDebugsAndTests {
                     ChatUtils.chat("§eYou are currently in ${SkyBlockUtils.currentIsland}.")
                 } else {
                     ChatUtils.chat("§eYou are not in Skyblock.")
-                }
-            }
-        }
-        event.registerBrigadier("shrendertoggle") {
-            description = "Disables/enables the rendering of all skyhanni guis."
-            category = CommandCategory.USERS_BUG_FIX
-            callback {
-                globalRender = !globalRender
-                if (globalRender) {
-                    ChatUtils.chat("§aEnabled global renderer!")
-                } else {
-                    ChatUtils.chat("§cDisabled global renderer! Run this command again to show SkyHanni rendering again.")
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
 import at.hannibal2.skyhanni.mixins.transformers.CustomRenderGlobal
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.getFirstPassenger
@@ -366,6 +367,7 @@ object EntityOutlineRenderer {
      */
     @HandleEvent
     fun onTick() {
+        if (!SkyHanniDebugsAndTests.globalRender) return
         if (!isEnabled()) return
 
         val renderGlobal = try {

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
+import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
 import at.hannibal2.skyhanni.mixins.transformers.CustomRenderGlobal
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -366,7 +367,7 @@ object EntityOutlineRenderer {
      */
     @HandleEvent
     fun onTick() {
-        if (SkyHanniMod.renderDisabled) return
+        if (GlobalRender.renderDisabled) return
         if (!isEnabled()) return
 
         val renderGlobal = try {

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
 import at.hannibal2.skyhanni.mixins.transformers.CustomRenderGlobal
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.getFirstPassenger
@@ -367,7 +366,7 @@ object EntityOutlineRenderer {
      */
     @HandleEvent
     fun onTick() {
-        if (!SkyHanniDebugsAndTests.globalRender) return
+        if (!SkyHanniMod.renderEnabled) return
         if (!isEnabled()) return
 
         val renderGlobal = try {

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityOutlineRenderer.kt
@@ -366,7 +366,7 @@ object EntityOutlineRenderer {
      */
     @HandleEvent
     fun onTick() {
-        if (!SkyHanniMod.renderEnabled) return
+        if (SkyHanniMod.renderDisabled) return
         if (!isEnabled()) return
 
         val renderGlobal = try {

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -41,6 +41,7 @@ import net.minecraft.entity.SharedMonsterAttributes
 @SkyHanniModule
 object EntityUtils {
 
+    // TODO remove this relatively heavy call everywhere
     @Deprecated("Use Mob Detection Instead")
     fun EntityLivingBase.hasNameTagWith(
         y: Int,

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
+import at.hannibal2.skyhanni.data.GlobalRender;
 import at.hannibal2.skyhanni.data.GuiData;
 import at.hannibal2.skyhanni.data.ToolTipData;
 import at.hannibal2.skyhanni.data.model.TextInput;
@@ -10,7 +11,6 @@ import at.hannibal2.skyhanni.events.render.gui.DrawBackgroundEvent;
 import at.hannibal2.skyhanni.events.render.gui.GuiMouseInputEvent;
 import at.hannibal2.skyhanni.features.inventory.BetterContainers;
 import at.hannibal2.skyhanni.features.inventory.wardrobe.CustomWardrobe;
-import at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests;
 import at.hannibal2.skyhanni.utils.DelayedRun;
 import at.hannibal2.skyhanni.utils.KeyboardManager;
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat;
@@ -36,7 +36,7 @@ public abstract class MixinHandledScreen {
 
     @Inject(method = "render", at = @At(value = "HEAD"), cancellable = true)
     private void renderHead(DrawContext context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
-        if (!SkyHanniDebugsAndTests.INSTANCE.getGlobalRender()) return;
+        if (GlobalRender.INSTANCE.getRenderDisabled()) return;
         HandledScreen<?> gui = (HandledScreen<?>) (Object) this;
         if (new GuiContainerEvent.PreDraw(context, gui, gui.getScreenHandler(), mouseX, mouseY, deltaTicks).post()) {
             GuiData.INSTANCE.setPreDrawEventCancelled(true);


### PR DESCRIPTION
## What
using spark's "flat view" mode is op:


the long deprecated (and hopefully some day fully replaced by mob detection) function `hasNameTagWith` is a heavy hitter:

this gets currently called for each entity each tick once. when standing in crimson isle tara area, spark showed me this: (was with `/shrendertoggle`)
<img width="1123" height="656" alt="image" src="https://github.com/user-attachments/assets/84579532-3fb2-4aba-9e20-0c654c34de89" />

## Changelog Technical Details
+ Improved performance of Damage Indicator slightly. - hannibal2
+ Fixed `EntityOutlineRenderer` ignoring `/shrendertoggle`. - hannibal2
+ Moved Global Render from SkyHanniDebugsAndTests to GlobalRender, accessed via SkyHanniMod. - hannibal2