### PR TITLE
Fix: Item Pickup Log Caching

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -47,7 +47,9 @@ object ItemPickupLog {
         CHANGE_AMOUNT(
             "§a+256",
             { entry, prefix ->
-                val formattedAmount = if (config.shorten) entry.amount.shortFormat() else entry.amount.addSeparators()
+                val formattedAmount = entry.amount.absoluteValue.let {
+                    if (config.shorten) it.shortFormat() else it.addSeparators()
+                }
                 Renderable.text("$prefix$formattedAmount")
             },
         ),
@@ -80,6 +82,7 @@ object ItemPickupLog {
         fun updateAmount(change: Long) {
             amount += change
             timeUntilExpiry = SimpleTimeMark.now()
+            renderableCache.clear()
         }
 
         fun isExpired() = timeUntilExpiry.passedSince() > config.expireAfter.seconds


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1401709596191752312
Fixes double negative signs, and not counting correctly.

## Changelog Fixes
+ Fixed double negative signs in Item Pickup Log. - Daveed
+ Fixed Item Pickup Log not counting correctly. - Daveed