### PR TITLE
Fix: Pet Drop Rarity with no Magic Find

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -41,7 +41,7 @@ object RareDropMessages {
      */
     private val petDroppedPattern by petGroup.pattern(
         "droppedmessage",
-        "(?<start>(?:§.)*PET DROP! )(?:§.)*§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end>(?: .*))?",
+        "(?<start>(?:§.)*PET DROP! )(?:§.)*§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end>(?: .*)?)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -37,10 +37,11 @@ object RareDropMessages {
      * REGEX-TEST: §6§lPET DROP! §r§5Baby Yeti §r§b(+§r§b168% §r§b✯ Magic Find§r§b)
      * REGEX-TEST: §6§lPET DROP! §r§5Baby Yeti §r§b(+§r§b168 §r§b✯ Magic Find§r§b)
      * REGEX-TEST: §6§lPET DROP! §r§5Slug §6(§6+1300☘)
+     * REGEX-TEST: §6§lPET DROP! §r§6Rat
      */
     private val petDroppedPattern by petGroup.pattern(
         "droppedmessage",
-        "(?<start>(?:§.)*PET DROP! )(?:§.)*§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end> .*)",
+        "(?<start>(?:§.)*PET DROP! )(?:§.)*§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end>(?: .*))?",
     )
 
     /**


### PR DESCRIPTION
## What
Fixed Pet Drop Rarity not working on pet drop messages that don't show Magic Find or Farming Fortune.

Scuffed regex to avoid breaking old versions as they don't use `.groupOrNull()`.

## Changelog Fixes
+ Fixed Pet Drop Rarity on messages without Magic Find or Farming Fortune. - Luna