### PR TITLE
Fix: Enderman Beacon highlight not working

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -56,7 +56,11 @@ object EndermanSlayerFeatures {
         val entity = event.entity
         if (entity in endermenWithBeacons || entity in flyingBeacons) return
 
-        if (entity is EntityEnderman && showBeacon() && hasBeaconInHand(entity) && entity.canBeSeen(15.0)) {
+        if (entity is EntityEnderman && showBeacon() && hasBeaconInHand(entity) && entity.canBeSeen(
+                viewDistance = 15.0,
+                ignoreFrustum = true
+            )
+        ) {
             endermenWithBeacons.add(entity)
             logger.log("Added enderman with beacon at ${entity.getLorenzVec()}")
         }
@@ -64,7 +68,7 @@ object EndermanSlayerFeatures {
         if (entity is EntityArmorStand) {
             if (showBeacon()) {
                 val stack = entity.getStandHelmet() ?: return
-                if (stack.displayName == "Beacon" && entity.canBeSeen(15.0)) {
+                if (stack.displayName == "Beacon" && entity.canBeSeen(viewDistance = 15.0, ignoreFrustum = true)) {
                     flyingBeacons.add(entity)
                     RenderLivingEntityHelper.setEntityColor(
                         entity,
@@ -137,7 +141,7 @@ object EndermanSlayerFeatures {
 
     private fun drawFlyingBeacon(event: SkyHanniRenderWorldEvent) {
         for (beacon in flyingBeacons) {
-            if (!beacon.canBeSeen()) continue
+            if (!beacon.canBeSeen(ignoreFrustum = true)) continue
             if (beaconConfig.highlightBeacon) {
                 val beaconLocation = event.exactLocation(beacon)
                 event.drawDynamicText(beaconLocation.add(y = 1), "§4Beacon", 1.8)

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -216,10 +216,10 @@ object EntityUtils {
         list.keepOnlyIn(getEntities<T>())
     }
 
-    fun Entity.canBeSeen(viewDistance: Number = 150.0, vecYOffset: Double = 0.5): Boolean {
+    fun Entity.canBeSeen(viewDistance: Number = 150.0, vecYOffset: Double = 0.5, ignoreFrustum: Boolean = false): Boolean {
         if (isDead) return false
         // TODO add cache that only updates e.g. 10 times a second
-        if (!FrustumUtils.isVisible(entityBoundingBox)) return false
+        if (!ignoreFrustum && !FrustumUtils.isVisible(entityBoundingBox)) return false
         return getLorenzVec().up(vecYOffset).canBeSeen(viewDistance)
     }
 


### PR DESCRIPTION
## What
Added an option to EntityUtils.canbeseen to ignore frustum, as for some things like this it doesnt make much sense

## Changelog Fixes
+ Fixed Enderman Beacon highlight not working. - nopo

