### PR TITLE
Backend: Add Fabric Fails to Gradle Retry

### DIFF
--- a/.github/scripts/gradlew-retry.kts
+++ b/.github/scripts/gradlew-retry.kts
@@ -22,10 +22,11 @@ val cmd = listOf("./gradlew") + gradleArgs
  * REGEX-TEST: Could not resolve all files for configuration ':1.16.5-forge:compileClasspath'.
  * REGEX-TEST: > Could not resolve all files for configuration ':1.8.9:compileClasspath'.
  * REGEX-TEST:          > Could not GET 'https://maven.shedaniel.me/dev/architectury/architectury-naming-service/2.0.9/architectury-naming-service-2.0.9.jar'.
+ * REGEX-TEST: Caused by: net.fabricmc.loom.util.download.DownloadException: Failed to download file
  */
 val retryableErrorRegex = Regex(
     // language=RegExp
-    "(?:(?: +)?\\> +)?Could not (?:GET '?(?<url>https?:\\/\\/[^']+)(?:'\\.?)?(?: (?<error>.*))?|determine|resolve)(?: (?:all files for configuration|the dependencies of task) '(?<task>:[^']+)')?",
+    "(?:(?: +)?\\> +)?(?:Could not |Caused by: )(?:GET '?(?<url>https?:\\/\\/[^']+)(?:'\\.?)?(?: (?<error>.*))?|determine|resolve|net\\.fabricmc.*DownloadException:.*)(?: (?:all files for configuration|the dependencies of task) '(?<task>:[^']+)')?",
 )
 
 for (i in 1..maxAttempts) {


### PR DESCRIPTION
## What
https://github.com/hannibal002/SkyHanni/actions/runs/16783331236/job/47527548812?pr=4482

Fabric failed to download something, and gradle retry should've caught it, but regex did not match.

## Changelog Technical Details
+ Added retry in GH workflows when Fabric download(s) fail. - Daveed

