### PR TITLE
Backend: Re-Ramp NTP Check when Stable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.EnumUtils.next
+import at.hannibal2.skyhanni.utils.EnumUtils.previous
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import kotlinx.coroutines.delay
@@ -39,6 +40,7 @@ object ComputerTimeOffset {
         }
     }
 
+    private var stableRuns: Int = 0
     private var state = State.NORMAL
     private var offsetDuration: Duration? = null
     private var lastSystemTime = System.currentTimeMillis()
@@ -70,7 +72,13 @@ object ComputerTimeOffset {
                 "Computer Time Offset calculation took longer than normal. Checking less often now.",
             )
             return
-        } else timeCheckMutex.unlock() // Immediate release, we only want to check if it's already running
+        } else {
+            if (stableRuns++ > 10) {
+                stableRuns = 0
+                state = state.previous() ?: state
+            }
+            timeCheckMutex.unlock()
+        } // Immediate release, we only want to check if it's already running
 
         val wasOffsetBefore = (offsetDuration?.absoluteValue ?: 0.seconds) > 5.seconds
         SkyHanniMod.launchIOCoroutineWithMutex(timeCheckMutex) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -64,6 +64,7 @@ object ComputerTimeOffset {
     private fun tryCheckOffset() {
         // probably a problem when the response somehow took longer than 1s?
         if (!timeCheckMutex.tryLock()) {
+            stableRuns = 0
             state = state.next() ?: error("state is already TOTALLY_OFF")
             if (state == State.TOTALLY_OFF) ErrorManager.logErrorStateWithData(
                 "Error when checking Computer Time Offset",

--- a/src/main/java/at/hannibal2/skyhanni/utils/EnumUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EnumUtils.kt
@@ -18,6 +18,16 @@ object EnumUtils {
     fun <T : Enum<T>> Enum<T>.toFormattedName(): String =
         name.split("_").joinToString(" ") { it.lowercase().replaceFirstChar(Char::uppercase) }
 
+    inline fun <reified T : Enum<T>> T.previous(wrap: Boolean = false): T? {
+        val values = enumValues<T>()
+        val previousIndex = ordinal - 1
+        return when {
+            previousIndex >= 0 -> values[previousIndex]
+            wrap -> values.lastOrNull()
+            else -> null
+        }
+    }
+
     inline fun <reified T : Enum<T>> T.next(wrap: Boolean = false): T? {
         val values = enumValues<T>()
         val nextIndex = ordinal + 1


### PR DESCRIPTION
## What
At 'present,' the ComputerTimeOffset has unidirectional state control, and once it's in a SLOW state, will never go back to normal, despite the fact that in most cases, it can, after whatever lag caused it to fail, has finished.

## Changelog Technical Details
+ Added 'ramp-up' for Computer Time Offset if in SLOW state, and performing stably. - Daveed

