### PR TITLE
Backend: Bumped loom version

### DIFF
--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -3,7 +3,7 @@ import com.replaymod.gradle.preprocess.Node
 
 plugins {
     id("com.github.SkyHanniStudios.SkyHanni-Preprocessor") version "1.0.3"
-    id("gg.essential.loom") version "1.9.29" apply false
+    id("gg.essential.loom") version "1.10.34" apply false
     kotlin("jvm") version "2.0.0" apply false
     kotlin("plugin.power-assert") version "2.0.0" apply false
     id("com.google.devtools.ksp") version "2.0.0-1.0.24" apply false


### PR DESCRIPTION
## What
Bumps the essential-loom version to 1.10.34 (which is compatible with gradle configuration-cache for our tasks).

I had no issue with it, but I already know that does mean literally nothing.
I pulled that out of #4461 to reduce unforeseen issues.

## Changelog Technical Details
+ Bumped Loom to 1.10.34. - Thunderblade73
