### PR TITLE
Fix: Inaccurate Contest Stats

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestStatsSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestStatsSummary.kt
@@ -42,6 +42,7 @@ object JacobContestStatsSummary {
 
         when (event.phase) {
             FarmingContestPhase.START -> {
+                blocksBroken.clear()
                 ChatUtils.chat("Started tracking your Jacob Contest Blocks Per Second!")
                 startTime = SimpleTimeMark.now()
             }
@@ -56,7 +57,6 @@ object JacobContestStatsSummary {
                 val color = getBlocksPerSecondColor(blocksPerSecond)
                 ChatUtils.chat("§7Average Blocks Per Second: $color$blocksPerSecond")
                 ChatUtils.chat("§7Participated for §b$time")
-                blocksBroken.clear()
             }
 
             FarmingContestPhase.CHANGE -> {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestStatsSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestStatsSummary.kt
@@ -56,6 +56,7 @@ object JacobContestStatsSummary {
                 val color = getBlocksPerSecondColor(blocksPerSecond)
                 ChatUtils.chat("§7Average Blocks Per Second: $color$blocksPerSecond")
                 ChatUtils.chat("§7Participated for §b$time")
+                blocksBroken.clear()
             }
 
             FarmingContestPhase.CHANGE -> {
@@ -63,7 +64,6 @@ object JacobContestStatsSummary {
                 startTime = SimpleTimeMark.now()
             }
         }
-        blocksBroken.clear()
     }
 
     private fun getBlocksPerSecondColor(blocksPerSecond: Double) = if (blocksPerSecond > 19) "§c" else "§a"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestStatsSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestStatsSummary.kt
@@ -63,6 +63,7 @@ object JacobContestStatsSummary {
                 startTime = SimpleTimeMark.now()
             }
         }
+        blocksBroken.clear()
     }
 
     private fun getBlocksPerSecondColor(blocksPerSecond: Double) = if (blocksPerSecond > 19) "§c" else "§a"


### PR DESCRIPTION
## What
Fixes an issue where contest stats reported players getting impossible block break counts, caused by stats not getting cleared after every farming contest. Untested as of making this pr but should work. 

## Changelog Fixes
+ Fixed incorrect stats summary for Jacob's Contests. - Chissl
