### PR TITLE
Fix: Use vanilla nametag format outside skyblock

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinPlayerEntityRenderer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinPlayerEntityRenderer.java
@@ -20,6 +20,10 @@ public class MixinPlayerEntityRenderer {
         index = 1
     )
     private Text modifyRenderLabelIfPresentArgs(Text text) {
-        return Text.of(EntityData.getHealthDisplay(TextCompatKt.formattedTextCompatLessResets(text)));
+        if (at.hannibal2.skyhanni.utils.SkyBlockUtils.INSTANCE.getInSkyBlock()) {
+            return Text.of(EntityData.getHealthDisplay(TextCompatKt.formattedTextCompatLessResets(text)));
+        }
+
+        return text;
     }
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinPlayerEntityRenderer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinPlayerEntityRenderer.java
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.data.EntityData;
+import at.hannibal2.skyhanni.utils.SkyBlockUtils;
 import at.hannibal2.skyhanni.utils.compat.TextCompatKt;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
 import net.minecraft.text.Text;
@@ -20,10 +21,9 @@ public class MixinPlayerEntityRenderer {
         index = 1
     )
     private Text modifyRenderLabelIfPresentArgs(Text text) {
-        if (at.hannibal2.skyhanni.utils.SkyBlockUtils.INSTANCE.getInSkyBlock()) {
+        if (SkyBlockUtils.INSTANCE.getInSkyBlock()) {
             return Text.of(EntityData.getHealthDisplay(TextCompatKt.formattedTextCompatLessResets(text)));
         }
-
         return text;
     }
 }


### PR DESCRIPTION
## What
Fixes an issue where SkyHanni nametag rendering is overridden resulting in non-colored team name tags.

When playing on a server that uses vanilla teams with assigned colors any user on a team will have their above head name shown in white text rather than the expected team color text.

Image of colored name in chat due to above team, white nametag, and fixed colored nametag:

<img width="703" height="173" alt="image" src="https://github.com/user-attachments/assets/aa76760c-9d99-4db1-b45e-f839b1a37669" />

**Steps to replicate:**
```
/team add blue
/team join blue @a
/team modify blue color aqua
```


Reported on Discord and making PR based on response to ticket.

Fixed by changing the player entity render mixin to only format and apply when on a server that isn't Hypixel Skyblock.


## Changelog Fixes
+ Fixed Vanilla Nametag Colors. - Pugzy
