### PR TITLE
Fix: Tier 5 slayer detection errors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteItemResourceJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteItemResourceJson.kt
@@ -114,7 +114,7 @@ data class EliteItemRequirement(
         ageUnit.asDuration(rawInt)
     }
     val slayerBossType: SlayerType? = slayerBossTypeStr?.let {
-        SlayerType.getByClazzName(it)
+        SlayerType.getByClassName(it)
     }
     val targetPracticeMode: Int? = eliteMode?.romanToDecimalIfNecessary()
     val ciFaction: FactionType? = ciFactionStr?.let {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerType.kt
@@ -11,18 +11,21 @@ enum class SlayerType(
     val rngName: String,
     val clazz: Class<*>,
     val miniBossType: SlayerMiniBossType? = null,
+    val otherNames: List<String> = listOf(),
 ) {
     REVENANT(
         "Revenant Horror",
         "revenant",
         EntityZombie::class.java,
         SlayerMiniBossType.REVENANT,
+        listOf("Atoned Horror"),
     ),
     TARANTULA(
         "Tarantula Broodfather",
         "tarantula",
         EntitySpider::class.java,
         SlayerMiniBossType.TARANTULA,
+        listOf("Conjoined Brood"),
     ),
     SVEN(
         "Sven Packmaster",
@@ -50,8 +53,11 @@ enum class SlayerType(
     ;
 
     companion object {
-        fun getByName(name: String): SlayerType? = entries.firstOrNull { name.contains(it.displayName) }
-        fun getByClazzName(name: String): SlayerType? = entries.firstOrNull {
+        fun getByName(name: String): SlayerType? = entries.firstOrNull { slayer ->
+            name.contains(slayer.displayName) || slayer.otherNames.any { name.contains(it) }
+        }
+
+        fun getByClassName(name: String): SlayerType? = entries.firstOrNull {
             it.clazz.simpleName.removePrefix("Entity").equals(name, ignoreCase = true)
         }
     }


### PR DESCRIPTION
## What
Fixed issues detecting Atoned Horror and Conjoined Brood, and renamed a method in SlayerType that was unnecessarily "clazz"-ified.

## Changelog Fixes
+ Fixed errors with Atoned Horror (Revenant) and Conjoined Brood (Tarantula) Slayer bosses. - Luna

## Changelog Technical Details
+ Renamed `SlayerType.getByClazzName()` to `SlayerType.getByClassName()`. - Luna
