### PR TITLE
Backend: Kserializable + `@SerializedName`

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/KSerializable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KSerializable.kt
@@ -18,6 +18,7 @@ import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.javaType
 import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 import com.google.gson.internal.`$Gson$Types` as InternalGsonTypes
@@ -60,7 +61,10 @@ class KotlinTypeAdapterFactory : TypeAdapterFactory {
                 field.isAccessible = true
             }.getOrNull() ?: return@mapNotNull null
             val kType = field.returnType
-            val name = param.findAnnotation<SerializedName>()?.value ?: param.name!!
+            val name = param.findAnnotation<SerializedName>()?.value
+                ?: field.findAnnotation<SerializedName>()?.value
+                ?: field.javaField?.getAnnotation(SerializedName::class.java)?.value
+                ?: param.name!!
 
             val javaTypeForAdapter = if (kType.jvmErasure.java.isAnnotationPresent(JvmInline::class.java)) kType.jvmErasure.java
             else InternalGsonTypes.resolve(type.type, type.rawType, kType.javaType)


### PR DESCRIPTION
## What
Too many PRs have needed this. I'm getting sick of it. This makes the name resolution of `@KSerializable` classes actually able to handle `@SerializedName` annotations on the backing java fields.

## Changelog Technical Details
+ Addressed more loading issues using KSerializable and GSON annotations. - Daveed
