### PR TITLE
Fix: Prevent incorrect slayer spawn costs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -109,11 +109,16 @@ object SlayerProfitTracker {
     @HandleEvent
     fun onPurseChange(event: PurseChangeEvent) {
         if (!isEnabled()) return
-        val coins = event.coins
+        var coins = event.coins
         if (event.reason == PurseChangeCause.GAIN_MOB_KILL && SlayerApi.isInCorrectArea) {
             tryAddItem(NeuInternalName.SKYBLOCK_COIN, coins.toInt(), command = false)
         }
+        // TODO spawn costs in repo
         if (event.reason == PurseChangeCause.LOSE_SLAYER_QUEST_STARTED) {
+            if (coins < -100000 || coins > 0) {
+                ChatUtils.debug("Wrong Slayer Spawn Cost! Cost is 100k instead.")
+                coins = -100000.0
+            }
             addSlayerCosts(coins)
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -116,8 +116,8 @@ object SlayerProfitTracker {
         // TODO spawn costs in repo
         if (event.reason == PurseChangeCause.LOSE_SLAYER_QUEST_STARTED) {
             if (coins < -100000 || coins > 0) {
-                ChatUtils.debug("Wrong Slayer Spawn Cost! Cost is 100k instead.")
-                coins = -100000.0
+                ChatUtils.debug("Wrong Slayer Spawn Cost! Ignoring!")
+                return
             }
             addSlayerCosts(coins)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -109,7 +109,7 @@ object SlayerProfitTracker {
     @HandleEvent
     fun onPurseChange(event: PurseChangeEvent) {
         if (!isEnabled()) return
-        var coins = event.coins
+        val coins = event.coins
         if (event.reason == PurseChangeCause.GAIN_MOB_KILL && SlayerApi.isInCorrectArea) {
             tryAddItem(NeuInternalName.SKYBLOCK_COIN, coins.toInt(), command = false)
         }


### PR DESCRIPTION
## What
Slayer spawn costs can occasionally include bank deposits/other losses of coins. This doesn't fix the core issue, but prevents those values from getting added to tracker. Reported [here](https://discord.com/channels/997079228510117908/1000669238035497022/1405720809812656158): 

## Changelog Fixes
+ Prevented incorrect Slayer spawn costs from being added to the Profit Tracker. - Chissl