### PR TITLE
Backend: Graph usage cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/lobby/waypoints/halloween/HalloweenBasketWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/lobby/waypoints/halloween/HalloweenBasketWaypoints.kt
@@ -139,7 +139,7 @@ object HalloweenBasketWaypoints {
         if (isActive != newIsActive && newIsActive) {
             IslandGraphs.loadLobby("MAIN_LOBBY")
 
-            val nodeList = IslandGraphs.currentIslandGraph?.nodes?.filter { it.hasTag(GraphNodeTag.HALLOWEEN_BASKET) }.orEmpty()
+            val nodeList = IslandGraphs.currentIslandGraph?.getTags(GraphNodeTag.HALLOWEEN_BASKET).orEmpty()
             basketList.clear()
             nodeList.forEach { node ->
                 basketList.add(EventWaypoint(position = node.position, isFound = false))
@@ -169,9 +169,7 @@ object HalloweenBasketWaypoints {
     }
 
     private fun getClosest(nodeList: List<GraphNode>? = null): EventWaypoint? {
-        val nodes = nodeList ?: IslandGraphs.currentIslandGraph?.nodes?.filter {
-            it.hasTag(GraphNodeTag.HALLOWEEN_BASKET)
-        }.orEmpty()
+        val nodes = nodeList ?: IslandGraphs.currentIslandGraph?.getTags(GraphNodeTag.HALLOWEEN_BASKET).orEmpty()
 
         val unFoundBaskets = basketList.filter { !it.isFound }.map { it.position }
         val unFoundNodes = nodes.filter { it.position in unFoundBaskets }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -67,7 +67,7 @@ object TunnelsMaps {
 
     private val config get() = SkyHanniMod.feature.mining.tunnelMaps
 
-    private var graph: Graph = Graph(emptyList())
+    private var graph: Graph = Graph()
     private lateinit var campfire: GraphNode
 
     private var goalReached = false
@@ -399,7 +399,7 @@ object TunnelsMaps {
         if (!isEnabled()) return
         if (checkGoalReached()) return
         val prevClosest = closestNode
-        closestNode = graph.minBy { it.position.distanceSqToPlayer() }
+        closestNode = graph.getNearest()
         val closest = closestNode ?: return
         val goal = goal ?: return
         if (closest == prevClosest && goal == prevGoal) return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -240,7 +240,7 @@ object FastFairySoulsPathfinder {
             return
         }
         val foundSouls = foundSoulsOnCurrentIsland()
-        val allSouls = getTargetNodes(graph.nodes)
+        val allSouls = getTargetNodes(graph)
         val missingSouls = allSouls.filter { it.position !in foundSouls }
 
         if (missingSouls.isEmpty()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/IslandAreas.kt
@@ -153,7 +153,7 @@ object IslandAreas {
 
             var suffix = ""
             paths[node]?.let { path ->
-                val passedAreas = path.nodes.filter { it.getAreaTag() != null }.map { it.name }.distinct().toMutableList()
+                val passedAreas = path.filter { it.getAreaTag() != null }.map { it.name }.distinct().toMutableList()
                 passedAreas.remove(name)
                 passedAreas.remove(null)
                 passedAreas.remove("null")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -113,9 +113,8 @@ object NavigationHelper {
         val graph = IslandGraphs.currentIslandGraph ?: return emptyMap()
         val closestNode = IslandGraphs.closestNode ?: return emptyMap()
 
-        val nodes = graph.nodes
         val distances = mutableMapOf<GraphNode, Double>()
-        for (node in nodes) {
+        for (node in graph) {
             val name = node.name ?: continue
             val remainingTags = node.tags.filter { it in allowedTags }
             if (remainingTags.isEmpty()) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
@@ -81,9 +81,9 @@ object WoodenButtonsHelper {
         if (!showButtons()) return
         val graph = IslandGraphs.currentIslandGraph ?: return
 
-        val closestNode = graph.getNearest {
-            it.hasTag(GraphNodeTag.RIFT_BUTTONS_QUEST) &&
-                buttonLocations["${it.name}:${it.position}"]?.any { !hitButtons.contains(it) } == true
+        val closestNode = graph.getNearest {node ->
+            node.hasTag(GraphNodeTag.RIFT_BUTTONS_QUEST) &&
+                buttonLocations["${node.name}:${node.position}"]?.any { !hitButtons.contains(it) } == true
         }
 
         if (closestNode != currentSpot) {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
@@ -81,7 +81,7 @@ object WoodenButtonsHelper {
         if (!showButtons()) return
         val graph = IslandGraphs.currentIslandGraph ?: return
 
-        val closestNode = graph.getNearest {node ->
+        val closestNode = graph.getNearest { node ->
             node.hasTag(GraphNodeTag.RIFT_BUTTONS_QUEST) &&
                 buttonLocations["${node.name}:${node.position}"]?.any { !hitButtons.contains(it) } == true
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
@@ -81,14 +81,10 @@ object WoodenButtonsHelper {
         if (!showButtons()) return
         val graph = IslandGraphs.currentIslandGraph ?: return
 
-        val closestNode = graph.nodes
-            .filter { it.hasTag(GraphNodeTag.RIFT_BUTTONS_QUEST) }
-            .filter { node ->
-                val spotName = "${node.name}:${node.position}"
-                val buttonsAtSpot = buttonLocations[spotName] ?: return@filter false
-                buttonsAtSpot.any { !hitButtons.contains(it) }
-            }
-            .minByOrNull { it.position.distanceToPlayer() }
+        val closestNode = graph.getNearest {
+            it.hasTag(GraphNodeTag.RIFT_BUTTONS_QUEST) &&
+                buttonLocations["${it.name}:${it.position}"]?.any { !hitButtons.contains(it) } == true
+        }
 
         if (closestNode != currentSpot) {
             currentSpot = closestNode

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
@@ -108,7 +108,7 @@ object GraphEditor {
 
     private val nodesAlreadyFound = mutableListOf<LorenzVec>()
     private val nodesToFind: List<LorenzVec>
-        get() = IslandGraphs.currentIslandGraph?.nodes?.map { it.position }?.filter { it !in nodesAlreadyFound }.orEmpty()
+        get() = IslandGraphs.currentIslandGraph?.map { it.position }?.filter { it !in nodesAlreadyFound }.orEmpty()
     private var currentNodeToFind: LorenzVec? = null
     private var active = false
 
@@ -244,11 +244,9 @@ object GraphEditor {
     }
 
     private fun calculateNewAllNodeFind(): LorenzVec {
-        val next = GraphUtils.findAllShortestDistancesOnCurrentIsland(
-            LocationUtils.playerLocation(),
-        ).distances.keys.first { it.position in nodesToFind }.position
+        val next = GraphUtils.findShortestDistancesOnCurrentIsland(nodesToFind).lastVisitedNode.position
 
-        val max = IslandGraphs.currentIslandGraph?.nodes?.size ?: -1
+        val max = IslandGraphs.currentIslandGraph?.size ?: -1
         val todo = nodesToFind.size
         val done = max - todo
         val percentage = (done.toDouble() / max.toDouble()) * 100
@@ -833,7 +831,7 @@ object GraphEditor {
     }
 
     fun distanceToPlayer(location: LorenzVec): Double {
-        val playerPosition = ghostPosition ?: LocationUtils.playerLocation()
+        val playerPosition = ghostPosition ?: LocationUtils.playerEyeLocation().roundToBlock()
         return location.distanceSq(playerPosition)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -28,9 +28,8 @@ object GraphEditorBugFinder {
     private fun asyncTest() {
         val graph = IslandGraphs.currentIslandGraph ?: return
         val errorsInWorld: MutableMap<GraphNode, String> = mutableMapOf()
-        val nodes = graph.nodes
 
-        for (node in nodes) {
+        for (node in graph) {
             if (node.tags.any { it in NavigationHelper.allowedTags }) {
                 val remainingTags = node.tags.filter { it in NavigationHelper.allowedTags }
                 if (remainingTags.size != 1) {
@@ -39,9 +38,8 @@ object GraphEditorBugFinder {
             }
         }
 
-
         val nearestArea = mutableMapOf<GraphNode, GraphNode>()
-        for (node in nodes) {
+        for (node in graph) {
             val pathToNearestArea = GraphUtils.findFastestPath(node) { it.getAreaTag() != null }?.first
             if (pathToNearestArea == null) {
                 continue
@@ -49,7 +47,7 @@ object GraphEditorBugFinder {
             val areaNode = pathToNearestArea.lastOrNull() ?: error("Empty path to nearest area")
             nearestArea[node] = areaNode
         }
-        for (node in nodes) {
+        for (node in graph) {
             val areaNode = nearestArea[node]?.name ?: continue
             for (neighbour in node.neighbours.keys) {
                 val neighbouringAreaNode = nearestArea[neighbour]?.name ?: continue
@@ -59,7 +57,7 @@ object GraphEditorBugFinder {
                 }
             }
         }
-        for (node in nodes) {
+        for (node in graph) {
             val nameNull = node.name.isNullOrBlank()
             val tagsEmpty = node.tags.isEmpty()
             if (nameNull > tagsEmpty) {

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphParkour.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphParkour.kt
@@ -53,7 +53,7 @@ object GraphParkour {
     }
 
     private fun graphToList(graph: Graph): List<LorenzVec>? {
-        val starts = graph.nodes.filter { it.name == "start" }
+        val starts = graph.getName("start")
         if (starts.isEmpty()) {
             ChatUtils.userError("No start node found!")
             return null
@@ -62,7 +62,7 @@ object GraphParkour {
             ChatUtils.userError("More than one start node found!")
             return null
         }
-        val ends = graph.nodes.filter { it.name == "end" }
+        val ends = graph.getName("end")
         if (ends.isEmpty()) {
             ChatUtils.userError("No end node found!")
             return null
@@ -88,7 +88,7 @@ object GraphParkour {
 
         var current = startN.first().key
 
-        while (list.size != graph.nodes.size - 1) {
+        while (list.size != graph.size - 1) {
             val neighbours = current.neighbours.filter { it.key !in list }.keys
             if (neighbours.size > 1) {
                 ChatUtils.userError("One node has more than two neighbours!")

--- a/src/main/java/at/hannibal2/skyhanni/utils/GraphUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GraphUtils.kt
@@ -35,7 +35,7 @@ object GraphUtils {
 
         val map = mutableMapOf<GraphNode, Double>()
         val distances = findAllShortestDistances(closestNode)
-        for (graphNode in graph.nodes) {
+        for (graphNode in graph) {
             if (!condition(graphNode)) continue
             val (path, distance) = distances.findPathToDestination(graphNode)
             paths[graphNode] = path
@@ -119,14 +119,28 @@ object GraphUtils {
         )
     }
 
+    fun findShortestDistancesOnCurrentIsland(
+        target: Collection<GraphNode>,
+    ): DijkstraTree = findDijkstraDistances(nearestNodeOnCurrentIsland(), target::contains)
+
+    fun findShortestDistancesOnCurrentIsland(
+        target: Collection<LorenzVec>,
+    ): DijkstraTree = findDijkstraDistances(nearestNodeOnCurrentIsland()) { target.contains(it.position) }
+
+    fun findAllShortestDistancesOnCurrentIsland(
+        bailout: (GraphNode) -> Boolean = { false },
+    ): DijkstraTree = findDijkstraDistances(nearestNodeOnCurrentIsland(), bailout)
+
     fun findAllShortestDistancesOnCurrentIsland(
         start: LorenzVec,
         bailout: (GraphNode) -> Boolean = { false },
     ): DijkstraTree = findDijkstraDistances(nearestNodeOnCurrentIsland(start), bailout)
 
+    fun nearestNodeOnCurrentIsland() = nearestNodeOnCurrentIsland(LocationUtils.playerGraphGridLocation())
+
     fun nearestNodeOnCurrentIsland(location: LorenzVec): GraphNode {
         val graph = IslandGraphs.currentIslandGraph ?: error("no island found")
-        return graph.nodes.minBy { it.position.distanceSq(location) }
+        return graph.getNearest(location)
     }
 
     fun findAllShortestDistances(

--- a/src/main/java/at/hannibal2/skyhanni/utils/GraphUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GraphUtils.kt
@@ -119,6 +119,7 @@ object GraphUtils {
         )
     }
 
+    @JvmName("findShortestDistancesOnCurrentIslandWithTargets")
     fun findShortestDistancesOnCurrentIsland(
         target: Collection<GraphNode>,
     ): DijkstraTree = findDijkstraDistances(nearestNodeOnCurrentIsland(), target::contains)

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -29,6 +29,8 @@ object LocationUtils {
 
     fun playerLocation() = MinecraftCompat.localPlayer.getLorenzVec()
 
+    fun playerGraphGridLocation() = playerEyeLocation().roundToBlock()
+
     // Block heights are multiples of 1/16, so we subtract 1/16 to find the right block
     fun getBlockBelowPlayer() = playerLocation().add(0.0, -1.0 / 16.0, 0.0).roundToBlock()
 


### PR DESCRIPTION
## What
General cleanup on every use of ``Graph``. First of all privated ``nodes``, since it is already inlined cause it is a value type. Also added consistent ``getNearest`` (previously closesed, idk about the rename but it sounds better). Also some wrong uses of Dijkstra.

## Changelog Technical Details
+ Cleaned up Graph usage. - Thunderblade73


