### PR TITLE
Backend: Stop Including Kotlin on Modern

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,7 +182,10 @@ dependencies {
     }
 
     // Discord RPC client
-    shadowImpl("com.github.caoimhebyrne:KDiscordIPC:0.2.3")
+    shadowImpl("com.github.caoimhebyrne:KDiscordIPC:0.2.3") {
+        exclude("org.jetbrains.kotlin")
+        exclude("org.jetbrains.kotlinx")
+    }
     compileOnly(libs.jbAnnotations)
 
     headlessLwjgl(libs.headlessLwjgl)


### PR DESCRIPTION
## What
KDiscordIPC implemented kotlin which made it transitive.
Decreased filesize by only 3mb for me..?

## Changelog Technical Details
+ Stop including Kotlin on modern. - meowora, j10a1n15
