### PR TITLE
Fix: Slayer Mob Kill Coin Gain

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -111,7 +111,7 @@ object SlayerProfitTracker {
         if (!isEnabled()) return
         val coins = event.coins
         if (event.reason == PurseChangeCause.GAIN_MOB_KILL && SlayerApi.isInCorrectArea) {
-            if (coins >= 100000 || coins < 0) {
+            if (coins >= 100000) {
                 ChatUtils.debug("Mob kill coin gain too high! Ignoring!")
                 return
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerProfitTracker.kt
@@ -111,6 +111,10 @@ object SlayerProfitTracker {
         if (!isEnabled()) return
         val coins = event.coins
         if (event.reason == PurseChangeCause.GAIN_MOB_KILL && SlayerApi.isInCorrectArea) {
+            if (coins >= 100000 || coins < 0) {
+                ChatUtils.debug("Mob kill coin gain too high! Ignoring!")
+                return
+            }
             tryAddItem(NeuInternalName.SKYBLOCK_COIN, coins.toInt(), command = false)
         }
         // TODO spawn costs in repo


### PR DESCRIPTION
## What
Bandage fix to prevent impossible mob kill coin gains from being added to tracker. Reported [here](https://discord.com/channels/997079228510117908/1406987796014567457). 

## Changelog Fixes
+ Prevented incorrect mob-kill coin gains from being added to the Slayer Profit Tracker. - Chissl

