### PR TITLE
Improvement: Hide clickable chat hint

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -213,6 +213,5 @@ class ChatConfig {
             "The message is still clickable and shows infos on hover.",
     )
     @ConfigEditorBoolean
-    @FeatureToggle
     var hideClickableHint: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -130,7 +130,7 @@ class ChatConfig {
     @Expose
     @ConfigOption(
         name = "Compact Jacob Claim",
-        desc = "Compact the Jacob Claim message, only showing full information when hovering."
+        desc = "Compact the Jacob Claim message, only showing full information when hovering.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -205,4 +205,14 @@ class ChatConfig {
     @SearchTag("format")
     @FeatureToggle
     var shortenCoinAmounts: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Hide Clickable Hints",
+        desc = "Hides the 'Click to x' chat line from SkyHanni messages. " +
+            "The message is still clickable and shows infos on hover.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var hideClickableHint: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatConfig.kt
@@ -214,5 +214,5 @@ class ChatConfig {
     )
     @ConfigEditorBoolean
     @FeatureToggle
-    var hideClickableHint: Boolean = true
+    var hideClickableHint: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -419,8 +419,10 @@ object ChatUtils {
         action: () -> Unit,
         oneTimeClick: Boolean = false,
     ) {
+        val hint = if (SkyHanniMod.feature.chat.hideClickableHint) "" else
+            "\n§e[CLICK to $actionName or disable this feature]"
         clickableChat(
-            "$message\n§e[CLICK to $actionName or disable this feature]",
+            "$message$hint",
             onClick = {
                 if (KeyboardManager.isShiftKeyDown() || KeyboardManager.isModifierKeyDown()) {
                     option.jumpToEditor()


### PR DESCRIPTION
## Changelog Improvements
+ Added option to hide Clickable Chat Hints. - hannibal2
    * Hides the 'Click to x' chat line in SkyHanni messages. The message remains clickable and shows info on hover.