### PR TITLE
Fix: Enchanted Book Detection for Corpses and Excavator

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
@@ -11,10 +11,8 @@ import at.hannibal2.skyhanni.events.mining.CrystalNucleusLootEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.NONE
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.fromItemNameOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHypixelEnchantments
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.events.mining.CrystalNucleusLootEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.NONE
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.fromItemNameOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -39,13 +40,6 @@ object CrystalNucleusApi {
     private val endPattern by patternGroup.pattern(
         "loot.end",
         "§3§l▬{64}",
-    )
-    /**
-     * REGEX-TEST: §fEnchanted Book (Lapidary I)
-     */
-    private val bookTypePattern by RepoPattern.pattern(
-        "filter.crystalnucleus.run.enchantedbook",
-        "§fEnchanted Book \\((?<type>\\S*).*\\)"
     )
 
     private var inLootLoop = false
@@ -137,12 +131,10 @@ object CrystalNucleusApi {
         if (itemName.contains(" Powder")) return null
         // Books are not directly added to the loot map, but are checked for later.
         if (itemName.startsWith("§fEnchanted")) {
-            val bookType = bookTypePattern.matchMatcher(itemName) {
-                group("type").lowercase()
-            }
+            val bookType = ItemUtils.readBookType(itemName)
             return when (bookType) {
-                "lapidary" -> LAPIDARY_I_BOOK_ITEM to 1
-                "fortune" -> FORTUNE_IV_BOOK_ITEM to 1
+                "Lapidary I" -> LAPIDARY_I_BOOK_ITEM to 1
+                "Fortune IV" -> FORTUNE_IV_BOOK_ITEM to 1
                 // Fallback to inventory based system
                 else -> {
                     unCheckedBooks += amount

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorApi.kt
@@ -110,9 +110,8 @@ object FossilExcavatorApi {
             ItemUtils.readItemAmount(group("item"))
         } ?: return
 
-        if (pair.first.startsWith("§fEnchanted Book (")) {
-            val book = ItemUtils.readBookType(pair.first) ?: return
-            pair = book to pair.second
+        ItemUtils.readBookType(pair.first)?.let {
+            pair = it to pair.second
         }
         loot.add(pair)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorApi.kt
@@ -109,9 +109,10 @@ object FossilExcavatorApi {
              */
             ItemUtils.readItemAmount(group("item"))
         } ?: return
-        // Workaround: If it is an enchanted book, we assume it is a paleontologist I book
-        if (pair.first.let { it == "§fEnchanted" || it == "§fEnchanted Book" }) {
-            pair = "§9Paleontologist I" to pair.second
+
+        if (pair.first.startsWith("§fEnchanted Book (")) {
+            val book = ItemUtils.readBookType(pair.first) ?: return
+            pair = book to pair.second
         }
         loot.add(pair)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.mining.CorpseLootedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils
-import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.mining.CorpseLootedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -34,16 +35,9 @@ object CorpseApi {
 
     /**
      * REGEX-TEST:     §r§9☠ Fine Onyx Gemstone §r§8x2
-     */
-    private val itemPattern by chatPatternGroup.pattern("item", " {4}§r(?<item>.+)")
-
-    /**
      * REGEX-TEST:     §r§fEnchanted Book (Ice Cold I§r§f)
      */
-    private val enchantedBookPattern by chatPatternGroup.pattern(
-        "enchantedBook",
-        " {4}§r§fEnchanted Book \\((?<item>.+)§r§f\\)"
-    )
+    private val itemPattern by chatPatternGroup.pattern("item", " {4}§r(?<item>.+)")
 
     private var inLoot = false
     private val loot = mutableListOf<Pair<String, Int>>()
@@ -84,9 +78,7 @@ object CorpseApi {
         } ?: return
 
         if (pair.first.startsWith("§fEnchanted Book (")) {
-            val book = enchantedBookPattern.matchMatcher(message) {
-                group("item") ?: "Ice Cold I"
-            } ?: return
+            val book = ItemUtils.readBookType(pair.first) ?: return
             pair = book to pair.second
         }
         loot.add(pair)

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
@@ -37,6 +37,14 @@ object CorpseApi {
      */
     private val itemPattern by chatPatternGroup.pattern("item", " {4}§r(?<item>.+)")
 
+    /**
+     * REGEX-TEST:     §r§fEnchanted Book (Ice Cold I§r§f)
+     */
+    private val enchantedBookPattern by chatPatternGroup.pattern(
+        "enchantedBook",
+        " {4}§r§fEnchanted Book \\((?<item>.+)§r§f\\)"
+    )
+
     private var inLoot = false
     private val loot = mutableListOf<Pair<String, Int>>()
 
@@ -74,10 +82,12 @@ object CorpseApi {
              */
             ItemUtils.readItemAmount(group("item"))
         } ?: return
-        // Workaround: If it is an enchanted book, we assume it is a paleontologist I book
-        if (pair.first.let { it == "§fEnchanted" || it == "§fEnchanted Book" }) {
-//             pair = "Paleontologist I" to pair.second
-            pair = "§9Ice Cold I" to pair.second
+
+        if (pair.first.startsWith("§fEnchanted Book (")) {
+            val book = enchantedBookPattern.matchMatcher(message) {
+                group("item") ?: "Ice Cold I"
+            } ?: return
+            pair = book to pair.second
         }
         loot.add(pair)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -589,6 +589,20 @@ object ItemUtils {
         return makePair(input, itemName, matcher)
     }
 
+    /**
+     * REGEX-TEST: §fEnchanted Book (Lapidary I)
+     * REGEX-TEST: §fEnchanted Book (Ice Cold I§r§f)
+     */
+    private val enchantedBookPattern by RepoPattern.pattern(
+        "enchantedBook",
+        "§fEnchanted Book \\((?<item>.+)\\)"
+    )
+    fun readBookType(input: String): String? {
+        return enchantedBookPattern.matchMatcher(input) {
+            group("item").removeColor()
+        }
+    }
+
     private fun makePair(input: String, itemName: String, matcher: Matcher): Pair<String, Int> {
         val matcherAmount = matcher.group("amount")
         val amount = matcherAmount?.formatInt() ?: 1

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -594,7 +594,7 @@ object ItemUtils {
      * REGEX-TEST: §fEnchanted Book (Ice Cold I§r§f)
      */
     private val enchantedBookPattern by RepoPattern.pattern(
-        "enchantedBook",
+        "item.enchantedbook",
         "§fEnchanted Book \\((?<item>.+)\\)"
     )
     fun readBookType(input: String): String? {


### PR DESCRIPTION
## What
Fixes Enchanted Books not getting detected correctly for Corpses and the Fossil Excavator

## Changelog Fixes
+ Fixed Enchanted Books detection for Corpses and Fossil Excavator. - Siv
