### PR TITLE
Fix: Cancel Vacuum uses when particles are still being received

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -50,6 +50,10 @@ object PestParticleWaypoint {
         if (!isEnabled() || !PestApi.hasVacuumInHand()) return
         if (event.clickType != ClickType.LEFT_CLICK) return
         if (MinecraftCompat.localPlayer.isSneaking) return
+        if (lastParticle.passedSince() < 0.2.seconds) {
+            event.cancel()
+            return
+        }
         reset()
         lastPestTrackerUse = SimpleTimeMark.now()
     }


### PR DESCRIPTION
## What
Describe what this pull request does, including technical details, screenshots, links to discord, etc.

## Changelog Fixes
+ Prevented use of vacuums when a previous vacuum line is still being traced out. - bloxigus