### PR TITLE
Fix: Sticky keybinds being reset while hovering a tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
@@ -8,21 +8,40 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+//#if MC > 1.21
+//$$ import net.minecraft.client.option.StickyKeyBinding;
+//#endif
 
 @Mixin(KeyBinding.class)
 public class MixinKeyBinding {
 
     @Inject(method = "isKeyDown", at = @At("HEAD"), cancellable = true)
     public void noIsKeyDown(CallbackInfoReturnable<Boolean> cir) {
-        GardenCustomKeybinds.isKeyDown((KeyBinding) (Object) this, cir);
-        TextInput.Companion.onMinecraftInput((KeyBinding) (Object) this, cir);
-        GraphEditor.INSTANCE.onMinecraftInput((KeyBinding) (Object) this, cir);
+        KeyBinding keyBinding = (KeyBinding) (Object) this;
+        GardenCustomKeybinds.isKeyDown(keyBinding, cir);
+        //#if MC > 1.21
+        //$$ if (keyBinding instanceof StickyKeyBinding stickyKeyBinding) {
+        //$$     if (stickyKeyBinding.toggleGetter.getAsBoolean()) {
+        //$$         return;
+        //$$     }
+        //$$ }
+        //#endif
+        TextInput.Companion.onMinecraftInput(keyBinding, cir);
+        GraphEditor.INSTANCE.onMinecraftInput(keyBinding, cir);
     }
 
     @Inject(method = "isPressed", at = @At("HEAD"), cancellable = true)
     public void noIsPressed(CallbackInfoReturnable<Boolean> cir) {
-        GardenCustomKeybinds.isKeyPressed((KeyBinding) (Object) this, cir);
-        TextInput.Companion.onMinecraftInput((KeyBinding) (Object) this, cir);
-        GraphEditor.INSTANCE.onMinecraftInput((KeyBinding) (Object) this, cir);
+        KeyBinding keyBinding = (KeyBinding) (Object) this;
+        GardenCustomKeybinds.isKeyPressed(keyBinding, cir);
+        //#if MC > 1.21
+        //$$ if (keyBinding instanceof StickyKeyBinding stickyKeyBinding) {
+        //$$     if (stickyKeyBinding.toggleGetter.getAsBoolean()) {
+        //$$         return;
+        //$$     }
+        //$$ }
+        //#endif
+        TextInput.Companion.onMinecraftInput(keyBinding, cir);
+        GraphEditor.INSTANCE.onMinecraftInput(keyBinding, cir);
     }
 }

--- a/versions/1.21.5/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.5/src/main/resources/skyhanni.accesswidener
@@ -39,3 +39,4 @@ accessible field net/minecraft/entity/LivingEntity HEALTH Lnet/minecraft/entity/
 accessible field net/minecraft/client/gui/hud/ChatHud scrolledLines I
 accessible method net/minecraft/client/gui/hud/ChatHud toChatLineX (D)D
 accessible method net/minecraft/client/gui/hud/ChatHud toChatLineY (D)D
+accessible field net/minecraft/client/option/StickyKeyBinding toggleGetter Ljava/util/function/BooleanSupplier;

--- a/versions/1.21.7/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.7/src/main/resources/skyhanni.accesswidener
@@ -39,6 +39,7 @@ accessible field net/minecraft/entity/LivingEntity HEALTH Lnet/minecraft/entity/
 accessible field net/minecraft/client/gui/hud/ChatHud scrolledLines I
 accessible method net/minecraft/client/gui/hud/ChatHud toChatLineX (D)D
 accessible method net/minecraft/client/gui/hud/ChatHud toChatLineY (D)D
+accessible field net/minecraft/client/option/StickyKeyBinding toggleGetter Ljava/util/function/BooleanSupplier;
 
 # 1.21.7 stuff
 accessible field net/minecraft/client/render/RenderLayer$MultiPhase pipeline Lcom/mojang/blaze3d/pipeline/RenderPipeline;


### PR DESCRIPTION
## What
We dont cancel a sticky keybind anymore in text editor or graph editor, i dont think this is a issue at all because its just sneak and sprint

## Changelog Fixes
+ Fixed Toggle Sneak unsneaking when hovering over a SkyHanni Tracker. - nopo

