### PR TITLE
Improvement: Optimize clicks in Moonglade Beacon Solver

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
@@ -252,9 +252,9 @@ object MoongladeBeacon {
             )
             return event.cancel()
         }
-        if (!config.useMiddleClick) return
 
-        if (event.clickedButton != 0) return
+        if (!config.useMiddleClick) return
+        if (event.clickedButton != 10) return
         event.makePickblock()
     }
 
@@ -401,8 +401,9 @@ object MoongladeBeacon {
     }
 
     private inline fun <reified E : Enum<E>> E.internalGetOffset(other: E): Int {
-        val raw = this.ordinal - other.ordinal
-        return if (raw < 0) raw + enumValues<E>().size else raw
+        val size = enumValues<E>().size
+        val offset = ((this.ordinal - other.ordinal) + size) % size
+        return if (offset > size / 2) offset - size else offset
     }
 
     private inline fun <reified T : Enum<T>> NullableDataPair<T>.getOffset(): Int? {
@@ -523,7 +524,7 @@ object MoongladeBeacon {
 
         fun RenderInventoryItemTipEvent.tryLabelIfAble() {
             if (isEnchanted && !upgradingStrength) return
-            val offset = getOffsetBySlot(slot.index)?.takeIf { it > 0 } ?: return
+            val offset = getOffsetBySlot(slot.index)?.takeIf { it != 0 } ?: return
             stackTip = "§a$offset"
         }
 

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
@@ -525,7 +525,7 @@ object MoongladeBeacon {
         fun RenderInventoryItemTipEvent.tryLabelIfAble() {
             if (isEnchanted && !upgradingStrength) return
             val offset = getOffsetBySlot(slot.index)?.takeIf { it != 0 } ?: return
-            stackTip = if (offset > 0) "§a$offset" else "§c$offset"
+            stackTip = "§a$offset"
         }
 
         fun getOffsetBySlot(slot: Int): Int? = when (slot) {

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
@@ -525,7 +525,7 @@ object MoongladeBeacon {
         fun RenderInventoryItemTipEvent.tryLabelIfAble() {
             if (isEnchanted && !upgradingStrength) return
             val offset = getOffsetBySlot(slot.index)?.takeIf { it != 0 } ?: return
-            stackTip = "§a$offset"
+            stackTip = if (offset > 0) "§a$offset" else "§c$offset"
         }
 
         fun getOffsetBySlot(slot: Int): Int? = when (slot) {

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
@@ -254,7 +254,7 @@ object MoongladeBeacon {
         }
 
         if (!config.useMiddleClick) return
-        if (event.clickedButton != 10) return
+        if (event.clickedButton != 0) return
         event.makePickblock()
     }
 


### PR DESCRIPTION
## What
Optimized the solution provided by the Moonglade Beacon Solver so that it will show a negative number when you can get there with fewer right clicks than it would take with left clicks.

## Changelog Improvements
+ Moonglade Beacon Solver now shows negative numbers when right-clicking is faster. - Luna
