### PR TITLE
Fix: Reliable Time-Based Dwarven King Prediction

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -24,7 +25,10 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sorted
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import java.util.Collections
+import kotlin.collections.buildList
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 
 @SkyHanniModule
 object KingTalismanHelper {
@@ -125,11 +129,11 @@ object KingTalismanHelper {
                 val current = king == currentKing
 
                 val missingTimeFormat = if (current) {
-                    val changedTime = timeUntil - 1000 * 60 * 20 * (kingCircles.size - 1)
+                    val changedTime = timeUntil.inWholeMilliseconds - 1000 * 60 * 20 * (kingCircles.size - 1)
                     val time = changedTime.milliseconds.format(maxUnits = 2)
                     "§7(§b$time remaining§7)"
                 } else {
-                    val time = timeUntil.milliseconds.format(maxUnits = 2)
+                    val time = timeUntil.format(maxUnits = 2)
                     "§7(§bin $time§7)"
                 }
 
@@ -150,30 +154,28 @@ object KingTalismanHelper {
         val storage = storage ?: error("profileSpecific is null")
         val kingsTalkedTo = storage.kingsTalkedTo
         val (nextKing, until) = getKingTimes().filter { it.key !in kingsTalkedTo }.sorted().firstNotNullOf { it }
-        val time = until.milliseconds.format(maxUnits = 2)
+        val time = until.format(maxUnits = 2)
 
         return "§cNext missing king: §7$nextKing §7(§bin $time§7)"
     }
 
-    private fun getKingTimes(): MutableMap<String, Long> {
+    private fun getKingTimes(): Map<String, Duration> {
+        // TODO: Needs more data - Currently believe king index to be only year based and resets at start of year
         val sbTime = SkyBlockTime.now()
-        val absDay = (sbTime.year - 1) * 372 + (sbTime.month - 1) * 31 + (sbTime.day - 1)
-        val kingIndex = (absDay + 4) % kingCircles.size
-        val circleStart = absDay - kingIndex
-        val oneSBDay = 1000 * 60 * 20
+        val yearDay = (sbTime.month - 1) * 31 + sbTime.day
+        val kingIndex = (yearDay + 5) % kingCircles.size
+        val absDay = (sbTime.year - 1) * 372 + (sbTime.month - 1) * 31 + sbTime.day
+        val startTime = SkyBlockTime.fromAbsoluteDay(absDay - kingIndex)
+        val oneSBDay = 20.minutes
         val oneCircleTime = oneSBDay * kingCircles.size
-        val kingTime = mutableMapOf<String, Long>()
-        for ((index, king) in kingCircles.withIndex()) {
-            val startTime = SkyBlockTime.fromAbsoluteDay(index + circleStart)
 
-            var timeNext = startTime.toMillis()
-            while (timeNext < SimpleTimeMark.now().toMillis()) {
+        return kingCircles.mapIndexed{ index, king ->
+            var timeNext = (startTime + oneSBDay * index).toTimeMark().timeUntil()
+            while (timeNext.isNegative()){
                 timeNext += oneCircleTime
             }
-            val timeUntil = timeNext - SimpleTimeMark.now().toMillis()
-            kingTime[king] = timeUntil
-        }
-        return kingTime
+            king to timeNext
+        }.toMap()
     }
 
     private fun getCurrentKing() = getKingTimes().sortedDesc().firstNotNullOf { it.key }
@@ -198,6 +200,24 @@ object KingTalismanHelper {
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.register("shprintking"){
+            description = "Prints out king related debug stuff"
+            category = CommandCategory.DEVELOPER_DEBUG
+            callback {
+                for ((king, time) in getKingTimes()) {
+                    ChatUtils.chat(king + ": " + time.inWholeSeconds.toString())
+                }
+                val sbTime = SkyBlockTime.now()
+                val yearDay = (sbTime.month - 1) * 31 + sbTime.day
+                val kingIndex = (yearDay + 5) % kingCircles.size
+                val absDay = (sbTime.year - 1) * 372 + (sbTime.month - 1) * 31 + sbTime.day
+                val startTime = SkyBlockTime.fromAbsoluteDay(absDay - kingIndex)
+                ChatUtils.chat("SB Time: ${sbTime.year} - ${sbTime.month} - ${sbTime.day}")
+                ChatUtils.chat("Absolute day: $absDay")
+                ChatUtils.chat("King index: $kingIndex")
+                ChatUtils.chat("Start time: ${startTime.toMillis()/1000}")
+            }
+        }
         event.register("shresetkinghelper") {
             description = "Resets the King Talisman Helper"
             category = CommandCategory.USERS_RESET

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
@@ -12,11 +12,8 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -26,7 +23,6 @@ import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sorted
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.entity.item.EntityArmorStand
 import java.util.Collections
 import kotlin.time.Duration.Companion.milliseconds
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
-import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -37,17 +36,6 @@ object KingTalismanHelper {
     private val storage get() = ProfileStorageData.profileSpecific?.mining
 
     private val patternGroup = RepoPattern.group("mining.kingtalisman")
-
-    /**
-     * REGEX-TEST: §6§lKing Brammor
-     * REGEX-TEST: §6§lKing Emkam
-     * REGEX-TEST: §6§lKing Kevin
-     * REGEX-TEST: §6§lKing Redros
-     */
-//     private val kingPattern by patternGroup.pattern(
-//         "king",
-//         "§6§lKing (?<name>.*)",
-//     )
 
     /**
      * REGEX-TEST: §7You have received a §r§fKing Talisman§r§7!
@@ -169,9 +157,9 @@ object KingTalismanHelper {
         val oneSBDay = 20.minutes
         val oneCircleTime = oneSBDay * kingCircles.size
 
-        return kingCircles.mapIndexed{ index, king ->
+        return kingCircles.mapIndexed { index, king ->
             var timeNext = (startTime + oneSBDay * index).toTimeMark().timeUntil()
-            while (timeNext.isNegative()){
+            while (timeNext.isNegative()) {
                 timeNext += oneCircleTime
             }
             king to timeNext
@@ -200,7 +188,7 @@ object KingTalismanHelper {
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
-        event.register("shprintking"){
+        event.register("shprintking") {
             description = "Prints out king related debug stuff"
             category = CommandCategory.DEVELOPER_DEBUG
             callback {
@@ -215,7 +203,7 @@ object KingTalismanHelper {
                 ChatUtils.chat("SB Time: ${sbTime.year} - ${sbTime.month} - ${sbTime.day}")
                 ChatUtils.chat("Absolute day: $absDay")
                 ChatUtils.chat("King index: $kingIndex")
-                ChatUtils.chat("Start time: ${startTime.toMillis()/1000}")
+                ChatUtils.chat("Start time: ${startTime.toMillis() / 1000}")
             }
         }
         event.register("shresetkinghelper") {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -43,10 +44,10 @@ object KingTalismanHelper {
      * REGEX-TEST: §6§lKing Kevin
      * REGEX-TEST: §6§lKing Redros
      */
-    private val kingPattern by patternGroup.pattern(
-        "king",
-        "§6§lKing (?<name>.*)",
-    )
+//     private val kingPattern by patternGroup.pattern(
+//         "king",
+//         "§6§lKing (?<name>.*)",
+//     )
 
     /**
      * REGEX-TEST: §7You have received a §r§fKing Talisman§r§7!
@@ -55,21 +56,6 @@ object KingTalismanHelper {
         "talisman",
         "§7You have received a §r§fKing Talisman§r§7!",
     )
-
-    private var currentOffset: Int? = null
-    private var skyblockYear = 0
-
-    private fun getCurrentOffset(): Int? {
-        if (SkyBlockTime.now().year != skyblockYear) {
-            return null
-        }
-        return currentOffset
-    }
-
-    private fun kingFix() {
-        currentOffset = null
-        ChatUtils.chat("Reset internal offset of King Talisman Helper.")
-    }
 
     private fun resetKings() {
         storage?.kingsTalkedTo = mutableListOf<String>()
@@ -98,36 +84,11 @@ object KingTalismanHelper {
     @HandleEvent
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
-        val storage = storage ?: return
-
-        val nearby = isNearby()
-        if (nearby && getCurrentOffset() == null) {
-            checkOffset()
-        }
-
-        val kingsTalkedTo = storage.kingsTalkedTo
-        if (getCurrentOffset() == null) {
-            val allKings = kingsTalkedTo.size == kingCircles.size
-            display = if (allKings) emptyList() else listOf("§cVisit the king to sync up.")
-            return
-        }
 
         update()
-        display = if (nearby) allKingsDisplay else Collections.singletonList(farDisplay)
+        display = if (isNearby()) allKingsDisplay else Collections.singletonList(farDisplay)
     }
 
-    private fun checkOffset() {
-        val king = EntityUtils.getEntitiesNearby<EntityArmorStand>(LorenzVec(129.6, 196.0, 196.7), 2.0)
-            .firstOrNull { it.name.startsWith("§6§lKing ") } ?: return
-        val foundKing = kingPattern.matchMatcher(king.name) {
-            group("name")
-        } ?: return
-
-        val currentId = kingCircles.indexOf(getCurrentKing())
-        val foundId = kingCircles.indexOf(foundKing)
-        currentOffset = currentId - foundId
-        skyblockYear = SkyBlockTime.now().year
-    }
 
     fun isEnabled() = config.enabled &&
         SkyBlockUtils.inSkyBlock &&
@@ -137,7 +98,6 @@ object KingTalismanHelper {
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (event.inventoryName != "Commissions") return
         if (!isEnabled()) return
-        if (getCurrentOffset() == null) return
         if (!isNearby()) return
         val storage = storage ?: return
 
@@ -200,19 +160,21 @@ object KingTalismanHelper {
     }
 
     private fun getKingTimes(): MutableMap<String, Long> {
-        val currentOffset = getCurrentOffset() ?: 0
+        val sbTime = SkyBlockTime.now()
+        val absDay = (sbTime.year - 1) * 372 + (sbTime.month - 1) * 31 + (sbTime.day - 1)
+        val kingIndex = (absDay + 4) % kingCircles.size
+        val circleStart = absDay - kingIndex
         val oneSBDay = 1000 * 60 * 20
         val oneCircleTime = oneSBDay * kingCircles.size
         val kingTime = mutableMapOf<String, Long>()
         for ((index, king) in kingCircles.withIndex()) {
-//             val startTime = SkyBlockTime(day = index + 2 - kingCircles.size)
-//             val startTime = SkyBlockTime(day = index - kingCircles.size)
-            val startTime = SkyBlockTime(day = index + currentOffset - kingCircles.size)
+            val startTime = SkyBlockTime.fromAbsoluteDay(index + circleStart)
+
             var timeNext = startTime.toMillis()
-            while (timeNext < System.currentTimeMillis()) {
+            while (timeNext < SimpleTimeMark.now().toMillis()) {
                 timeNext += oneCircleTime
             }
-            val timeUntil = timeNext - System.currentTimeMillis()
+            val timeUntil = timeNext - SimpleTimeMark.now().toMillis()
             kingTime[king] = timeUntil
         }
         return kingTime
@@ -240,11 +202,6 @@ object KingTalismanHelper {
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
-        event.register("shkingfix") {
-            description = "Resets the local King Talisman Helper offset."
-            category = CommandCategory.USERS_BUG_FIX
-            callback { kingFix() }
-        }
         event.register("shresetkinghelper") {
             description = "Resets the King Talisman Helper"
             category = CommandCategory.USERS_RESET

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
@@ -148,10 +148,8 @@ object KingTalismanHelper {
     }
 
     private fun getKingTimes(): Map<String, Duration> {
-        // TODO: Needs more data - Currently believe king index to be only year based and resets at start of year
         val sbTime = SkyBlockTime.now()
-        val yearDay = (sbTime.month - 1) * 31 + sbTime.day
-        val kingIndex = (yearDay + 5) % kingCircles.size
+        val kingIndex = (sbTime.day + 5) % kingCircles.size
         val absDay = (sbTime.year - 1) * 372 + (sbTime.month - 1) * 31 + sbTime.day
         val startTime = SkyBlockTime.fromAbsoluteDay(absDay - kingIndex)
         val oneSBDay = 20.minutes
@@ -188,24 +186,6 @@ object KingTalismanHelper {
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
-        event.register("shprintking") {
-            description = "Prints out king related debug stuff"
-            category = CommandCategory.DEVELOPER_DEBUG
-            callback {
-                for ((king, time) in getKingTimes()) {
-                    ChatUtils.chat(king + ": " + time.inWholeSeconds.toString())
-                }
-                val sbTime = SkyBlockTime.now()
-                val yearDay = (sbTime.month - 1) * 31 + sbTime.day
-                val kingIndex = (yearDay + 5) % kingCircles.size
-                val absDay = (sbTime.year - 1) * 372 + (sbTime.month - 1) * 31 + sbTime.day
-                val startTime = SkyBlockTime.fromAbsoluteDay(absDay - kingIndex)
-                ChatUtils.chat("SB Time: ${sbTime.year} - ${sbTime.month} - ${sbTime.day}")
-                ChatUtils.chat("Absolute day: $absDay")
-                ChatUtils.chat("King index: $kingIndex")
-                ChatUtils.chat("Start time: ${startTime.toMillis() / 1000}")
-            }
-        }
         event.register("shresetkinghelper") {
             description = "Resets the King Talisman Helper"
             category = CommandCategory.USERS_RESET

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockTime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockTime.kt
@@ -57,6 +57,11 @@ data class SkyBlockTime(
         fun fromSBYear(year: Int): SkyBlockTime =
             fromTimeMark(SimpleTimeMark(SKYBLOCK_EPOCH_START_MILLIS + (SKYBLOCK_YEAR_MILLIS * year)))
 
+        fun fromAbsoluteDay(absDay: Int): SkyBlockTime {
+            val millis = SKYBLOCK_EPOCH_START_MILLIS + absDay * SKYBLOCK_DAY_MILLIS
+            return fromTimeMark(SimpleTimeMark(millis))
+        }
+
         fun fromSeason(year: Int, season: SkyblockSeason, modifier: SkyblockSeasonModifier? = null): SkyBlockTime {
             return fromTimeMark(
                 SimpleTimeMark(


### PR DESCRIPTION
## What
**King Talisman feature** uses proximity nametags to keep track of Dwarven King offsets. 
Instead of using Armor Stand detection which bugs out sometimes, I used exact time-based calculation based on **absolute day** (total days since Year 0)
Additionally, I changed a few `System.currentTimeMillis()` to `SimpleTimeMark.now().toMillis()`

## Changelog Fixes
+ Changed King Talisman Helper to use the absolute day to calculate the current Dwarven King. - penguin

## Changelog Technical Details
+ Added function `fromAbsoluteDay()` in `SkyBlockTime.kt`. - penguin
+ Removed command `/shkingfix`. - penguin