### PR TITLE
Improvement: Dmg Indicator separation

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/DamageIndicatorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/DamageIndicatorConfig.kt
@@ -10,15 +10,10 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class DamageIndicatorConfig {
     @Expose
-    @ConfigOption(name = "Damage Indicator Enabled", desc = "Show the boss' remaining health.")
+    @ConfigOption(name = "Damage Indicator Enabled", desc = "Show name and health of selected mobs big.")
     @ConfigEditorBoolean
     @FeatureToggle
     var enabled: Boolean = false
-
-    @Expose
-    @ConfigOption(name = "Healing Chat Message", desc = "Send a chat message when a boss heals themself.")
-    @ConfigEditorBoolean
-    var healingMessage: Boolean = false
 
     @Expose
     @ConfigOption(name = "Boss Name", desc = "Change how boss names are displayed.")
@@ -88,28 +83,31 @@ class DamageIndicatorConfig {
     }
 
     @Expose
-    @ConfigOption(name = "Hide Damage Splash", desc = "Hide damage splashes near the damage indicator.")
+    @ConfigOption(name = "Hide Damage Splash", desc = "Hide damage splashes near selected mobs.")
     @ConfigEditorBoolean
+    @FeatureToggle
     var hideDamageSplash: Boolean = false
 
     @Expose
     @ConfigOption(name = "Damage Over Time", desc = "Show damage and health over time below the damage indicator.")
     @ConfigEditorBoolean
-    var showDamageOverTime: Boolean = false
+    var showDamageOverTime: Boolean = false // remain dependent on dmg indicator
 
     @Expose
     @ConfigOption(name = "Hide Nametag", desc = "Hide the vanilla nametag of bosses with damage indicator enabled.")
     @ConfigEditorBoolean
-    var hideVanillaNametag: Boolean = false
+    var hideVanillaNametag: Boolean = false // remain dependent on dmg indicator
 
     @Expose
     @ConfigOption(name = "Shuriken Indicator", desc = "Indicate if an Extremely Real Shuriken has been used.")
     @ConfigEditorBoolean
+    @FeatureToggle
     var shurikenIndicator: Boolean = true
 
     @Expose
     @ConfigOption(name = "Twilight Indicator", desc = "Indicate if Twilight Arrow Poison has been used.")
     @ConfigEditorBoolean
+    @FeatureToggle
     var twilightIndicator: Boolean = true
 
     @Expose
@@ -128,11 +126,13 @@ class DamageIndicatorConfig {
             "§eRequires Damage Indicator to be active.",
     )
     @ConfigEditorBoolean
+    @FeatureToggle
     var timeToKillSlayer: Boolean = true
 
     @Expose
     @ConfigOption(name = "Show Bacte Phase", desc = "Show the current phase of Bacte in the Rift.")
     @ConfigEditorBoolean
+    @FeatureToggle
     var showBactePhase: Boolean = true
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/DamageIndicatorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/DamageIndicatorConfig.kt
@@ -9,11 +9,12 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class DamageIndicatorConfig {
+
+    // TODO rename to showNameAndHealth
     @Expose
     @ConfigOption(name = "Damage Indicator Enabled", desc = "Show name and health of selected mobs big.")
     @ConfigEditorBoolean
     @FeatureToggle
-    // TODO rename to showNameAndHealth
     var enabled: Boolean = false
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/DamageIndicatorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/DamageIndicatorConfig.kt
@@ -13,6 +13,7 @@ class DamageIndicatorConfig {
     @ConfigOption(name = "Damage Indicator Enabled", desc = "Show name and health of selected mobs big.")
     @ConfigEditorBoolean
     @FeatureToggle
+    // TODO rename to showNameAndHealth
     var enabled: Boolean = false
 
     @Expose
@@ -85,8 +86,7 @@ class DamageIndicatorConfig {
     @Expose
     @ConfigOption(name = "Hide Damage Splash", desc = "Hide damage splashes near selected mobs.")
     @ConfigEditorBoolean
-    @FeatureToggle
-    var hideDamageSplash: Boolean = false
+    var hideDamageSplash: Boolean = false // remain dependent on dmg indicator
 
     @Expose
     @ConfigOption(name = "Damage Over Time", desc = "Show damage and health over time below the damage indicator.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/DamageIndicatorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/DamageIndicatorConfig.kt
@@ -122,8 +122,7 @@ class DamageIndicatorConfig {
     @Expose
     @ConfigOption(
         name = "Time to Kill",
-        desc = "Show the time it takes to kill the slayer boss.\n" +
-            "§eRequires Damage Indicator to be active.",
+        desc = "Show the time it takes to kill the slayer boss.",
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/EnderSlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/EnderSlayerConfig.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.features.combat.damageindicator
 
+import at.hannibal2.skyhanni.config.FeatureToggle
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
@@ -8,10 +9,11 @@ class EnderSlayerConfig {
     @Expose
     @ConfigOption(name = "Laser Phase Timer", desc = "Show a timer for when the laser phase will end.")
     @ConfigEditorBoolean
+    @FeatureToggle
     var laserPhaseTimer: Boolean = false
 
-    @Expose
-    @ConfigOption(name = "Health During Laser", desc = "Show the health of Voidgloom Seraph 4 during the laser phase.")
+    @Expose // TODO test what this does exactly
+    @ConfigOption(name = "Health During Laser", desc = "Show the health of Voidgloom Seraph 4 in Damage Indicator during the laser phase .")
     @ConfigEditorBoolean
     var showHealthDuringLaser: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/EnderSlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/EnderSlayerConfig.kt
@@ -12,7 +12,8 @@ class EnderSlayerConfig {
     @FeatureToggle
     var laserPhaseTimer: Boolean = false
 
-    @Expose // TODO test what this does exactly
+    // TODO test what this does exactly
+    @Expose
     @ConfigOption(name = "Health During Laser", desc = "Show the health of Voidgloom Seraph 4 in Damage Indicator during the laser phase .")
     @ConfigEditorBoolean
     var showHealthDuringLaser: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/VampireSlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/damageindicator/VampireSlayerConfig.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.features.combat.damageindicator
 
+import at.hannibal2.skyhanni.config.FeatureToggle
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
@@ -11,6 +12,7 @@ class VampireSlayerConfig {
         desc = "Show the amount of HP left until the Steak can be used on the Vampire Slayer on top of the boss."
     )
     @ConfigEditorBoolean
+    @FeatureToggle
     var hpTillSteak: Boolean = false
 
     @Expose
@@ -19,10 +21,12 @@ class VampireSlayerConfig {
         desc = "Show a timer until the boss leaves the invincible Mania Circles state."
     )
     @ConfigEditorBoolean
+    @FeatureToggle
     var maniaCircles: Boolean = false
 
     @Expose
     @ConfigOption(name = "Percentage HP", desc = "Show a percentage next to the HP.")
     @ConfigEditorBoolean
+    @FeatureToggle
     var percentage: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/endermen/EndermanConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/endermen/EndermanConfig.kt
@@ -25,7 +25,7 @@ class EndermanConfig {
     var drawLineToNukekebi: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Phase Display", desc = "Show the current phase of the Enderman Slayer in damage indicator.")
+    @ConfigOption(name = "Phase Display", desc = "Show the current phase of the Enderman Slayer.")
     @ConfigEditorBoolean
     var phaseDisplay: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -317,6 +317,8 @@ object DamageIndicatorManager {
         BossType.SLAYER_BLAZE_QUAZII_3,
         BossType.SLAYER_BLAZE_QUAZII_4,
 
+        BossType.SLAYER_SPIDER_5_1,
+
             // TODO f3/m3 4 guardians, f2/m2 4 boss room fighters
         -> true
 
@@ -374,9 +376,10 @@ object DamageIndicatorManager {
     fun onSkyHanniTick(event: SkyHanniTickEvent) {
         data.values.forEach(::update)
         // TODO config to define between 100ms and 5 sec
-        data.removeIf {
-            val waitForRemoval = if (it.value.dead && !noDeathDisplay(it.value.bossType)) 4.seconds else 100.milliseconds
-            (SimpleTimeMark.now() > it.value.timeLastTick + waitForRemoval) || (it.value.dead && noDeathDisplay(it.value.bossType))
+        data.removeIf { (_, value) ->
+            val noDeathDisplay = noDeathDisplay(value.bossType)
+            val waitForRemoval = if (value.dead && !noDeathDisplay) 4.seconds else 100.milliseconds
+            (SimpleTimeMark.now() > value.timeLastTick + waitForRemoval) || (value.dead && noDeathDisplay)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -376,6 +376,7 @@ object DamageIndicatorManager {
     fun onSkyHanniTick(event: SkyHanniTickEvent) {
         data.values.forEach(::update)
         // TODO config to define between 100ms and 5 sec
+        // TODO fix bug that the time is always 100 ms, even when the config is enabled?
         data.removeIf { (_, value) ->
             val noDeathDisplay = noDeathDisplay(value.bossType)
             val waitForRemoval = if (value.dead && !noDeathDisplay) 4.seconds else 100.milliseconds

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -141,9 +141,6 @@ object DamageIndicatorManager {
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
 
-        // only render when actually enabled
-        if (!config.enabled) return
-
         GlStateManager.disableDepth()
         GlStateManager.disableCull()
 
@@ -169,7 +166,6 @@ object DamageIndicatorManager {
         }
 
         for (data in data.values) {
-
             val vecYOffset = when (data.bossType) {
                 BossType.END_ENDSTONE_PROTECTOR -> 3.0
                 BossType.SLAYER_SPIDER_5_1 -> 2.0
@@ -178,7 +174,7 @@ object DamageIndicatorManager {
             }
 
             if (!data.ignoreBlocks && !data.entity.canBeSeen(70.0, vecYOffset = vecYOffset)) continue
-            if (!data.isConfigEnabled()) continue
+            val showNameAndHealth = data.shouldShowNameAndHealth()
 
             val entity = data.entity
 
@@ -199,8 +195,9 @@ object DamageIndicatorManager {
                 loc
             }.add(-0.5, 0.0, -0.5)
 
-
-            event.drawDynamicText(location, healthText, sizeHealth, smallestDistanceVew = smallestDistanceVew)
+            if (showNameAndHealth) {
+                event.drawDynamicText(location, healthText, sizeHealth, smallestDistanceVew = smallestDistanceVew)
+            }
 
             if (data.nameAbove.isNotEmpty()) {
                 event.drawDynamicText(
@@ -212,11 +209,13 @@ object DamageIndicatorManager {
                 )
             }
 
-            var bossName = when (config.bossName) {
-                NameVisibility.HIDDEN -> ""
-                NameVisibility.FULL_NAME -> data.bossType.fullName
-                NameVisibility.SHORT_NAME -> data.bossType.shortName
-            }
+            var bossName = if (showNameAndHealth) {
+                when (config.bossName) {
+                    NameVisibility.HIDDEN -> ""
+                    NameVisibility.FULL_NAME -> data.bossType.fullName
+                    NameVisibility.SHORT_NAME -> data.bossType.shortName
+                }
+            } else ""
 
             if (data.namePrefix.isNotEmpty()) {
                 bossName = data.namePrefix + bossName
@@ -224,7 +223,9 @@ object DamageIndicatorManager {
             if (data.nameSuffix.isNotEmpty()) {
                 bossName += data.nameSuffix
             }
-            event.drawDynamicText(location, bossName, sizeBossName, -9f, smallestDistanceVew = smallestDistanceVew)
+            if (bossName.isNotEmpty()) {
+                event.drawDynamicText(location, bossName, sizeBossName, -9f, smallestDistanceVew = smallestDistanceVew)
+            }
 
             val icons = iconCache.getOrPut(data) {
                 buildList {
@@ -256,7 +257,7 @@ object DamageIndicatorManager {
                 diff += 22f
             } else diff += 4f
 
-            if (config.showDamageOverTime) {
+            if (showNameAndHealth && config.showDamageOverTime) {
                 val currentDamage = data.damageCounter.currentDamage
                 val currentHealing = data.damageCounter.currentHealing
                 if (currentDamage != 0L || currentHealing != 0L) {
@@ -303,7 +304,7 @@ object DamageIndicatorManager {
         GlStateManager.enableCull()
     }
 
-    private fun EntityData.isConfigEnabled() = bossType.bossTypeToggle in config.bossesToShow
+    private fun EntityData.shouldShowNameAndHealth() = config.enabled && bossType.bossTypeToggle in config.bossesToShow
 
     @Suppress("Indentation")
     private fun noDeathDisplay(bossType: BossType): Boolean = when (bossType) {
@@ -954,25 +955,24 @@ object DamageIndicatorManager {
         val entityData = data.values.find {
             val distance = it.entity.getLorenzVec().distance(entity.getLorenzVec())
             distance < 4.5
-        }
+        } ?: return
 
+        val showNameAndHealth = entityData.shouldShowNameAndHealth()
         if (isDamageSplash(entity)) {
             val name = entity.customNameTag.removeColor().replace(",", "")
 
-            if (entityData != null) {
-                if (config.hideDamageSplash) {
-                    event.cancel()
-                }
-                if (entityData.bossType == BossType.DUMMY) {
-                    val uuid = entity.uniqueID
-                    if (dummyDamageCache.contains(uuid)) return
-                    dummyDamageCache.add(uuid)
-                    val dmg = name.toCharArray().filter { Character.isDigit(it) }.joinToString("").toLong()
-                    entityData.damageCounter.currentDamage += dmg
-                }
+            if (showNameAndHealth && config.hideDamageSplash) {
+                event.cancel()
+            }
+            if (entityData.bossType == BossType.DUMMY) {
+                val uuid = entity.uniqueID
+                if (dummyDamageCache.contains(uuid)) return
+                dummyDamageCache.add(uuid)
+                val dmg = name.toCharArray().filter { Character.isDigit(it) }.joinToString("").toLong()
+                entityData.damageCounter.currentDamage += dmg
             }
         } else {
-            if (entityData != null && config.hideVanillaNametag && entityData.isConfigEnabled()) {
+            if (config.hideVanillaNametag && showNameAndHealth) {
                 val name = entity.name
                 if (name.contains("Plasmaflux")) return
                 if (name.contains("Overflux")) return

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -972,7 +972,7 @@ object DamageIndicatorManager {
                 entityData.damageCounter.currentDamage += dmg
             }
         } else {
-            if (config.hideVanillaNametag && showNameAndHealth) {
+            if (showNameAndHealth && config.hideVanillaNametag) {
                 val name = entity.name
                 if (name.contains("Plasmaflux")) return
                 if (name.contains("Overflux")) return

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -374,6 +374,7 @@ object DamageIndicatorManager {
 
     @HandleEvent
     fun onSkyHanniTick(event: SkyHanniTickEvent) {
+        if (!isEnabled()) return
         data.values.forEach(::update)
         // TODO config to define between 100ms and 5 sec
         // TODO fix bug that the time is always 100 ms, even when the config is enabled?

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerTimeMessages.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.data.SlayerApi
 import at.hannibal2.skyhanni.data.mob.Mob.Companion.belongsToPlayer
 import at.hannibal2.skyhanni.events.DamageIndicatorDeathEvent
 import at.hannibal2.skyhanni.events.SlayerQuestCompleteEvent
+import at.hannibal2.skyhanni.features.combat.damageindicator.BossType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -19,6 +20,8 @@ object SlayerTimeMessages {
         val (bossType, timeToKill) = with(event.data) { bossType to timeToKill }
         if (!config.timeToKillMessage || !bossType.isSlayer || !event.data.entity.belongsToPlayer()) return
 
+        // TODO fix tara 5 part 2 times by adding part 1 times to it
+        if (event.data.bossType == BossType.SLAYER_SPIDER_5_1) return
         ChatUtils.chat(
             if (config.compactTimeMessage)
                 "${bossType.shortName}§e took §b$timeToKill§e."


### PR DESCRIPTION
## What
started moving all sub options of dmg indicator (except hide nametag + dmg over time) out of dmg indicator dependency config wise. this allows leaving the dmg indicator visuals disabled and just enable single config options, like slayer or bacte, that will show at the mob position without showing health + name of dmg indicator.

the next steps are to move the config options into their correct config area (slayer config or rift, etc)
also the long `getCustomHealth` function and all its sub functions should be translated into an event that then gets listened in on their respective classes, making the `DamageIndicatorManager` file way shorter.
Technically, those features will still be using the backend of the dmg indicator to work, but they will finally be independent of the dmg indicator visual toggle, as recently suggested here https://discord.com/channels/997079228510117908/1406721645540016148

<details>
<summary>Images</summary>

<img width="492" height="466" alt="image" src="https://github.com/user-attachments/assets/bf9ff889-36c6-47bc-aaab-05c3666b411f" />
<img width="461" height="382" alt="image" src="https://github.com/user-attachments/assets/3008a62f-5144-4753-913a-98ec9d102ae9" />

<img width="466" height="286" alt="image" src="https://github.com/user-attachments/assets/d3ca6828-d5dc-4b7b-9adb-debe0851bab8" />


</details>


## Changelog Improvements
+ Made many Slayer features, Shuriken/Twilight indicators, and Bacte phase display independent of Damage Indicator. - hannibal2
    * Allows Bacte phase, Eman Slayer blaze timer, Slayer time-to-kill, and Vampire Slayer steak display to show without boss name/health visible.