### PR TITLE
Fix: garden vistior rainbow rune

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -418,7 +418,7 @@ object GardenVisitorFeatures {
             }
 
             val (itemName, amount) = ItemUtils.readItemAmount(formattedLine) ?: continue
-            val internalName = NeuInternalName.fromItemNameOrNull(itemName)?.replace("◆_", "") ?: continue
+            val internalName = NeuInternalName.fromItemNameOrNull(itemName.removeColor())?.replace("◆_", "") ?: continue
 
             // Ignoring custom NEU items like copper
             if (internalName.startsWith("SKYBLOCK_")) continue


### PR DESCRIPTION
## What
fixed the rainbow rune from not getting detected.
The `itemName` at this context is `§d◆ §cR§6a§ei§an§bb§9o§dw§9 Rune I` for the rainbow rune, and without the color codes this detection works fine.
Tested in 1.8.9

## Changelog Fixes
+ Fixed Garden Visitor detection not working with Rainbow Rune. - hannibal2