### PR TITLE
Fix: Typo in block strength guide

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/BlockStrengthGuide.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/BlockStrengthGuide.kt
@@ -222,7 +222,7 @@ object BlockStrengthGuide {
                     add(Renderable.placeholder(0, 5))
 
                     addString("§3Block Strength: §f${ore.strength.addSeparators()}")
-                    addExtraInfo("This defines the \"thoughness\" of a block.")
+                    addExtraInfo("This defines the \"toughness\" of a block.")
                     addExtraInfo("A higher number means it takes longer")
                     addExtraInfo("to break $blockName.")
 


### PR DESCRIPTION
## What
I've seen at least 2 people point this out and just thought of it.

## Changelog Fixes
+ Fixed a typo in the block strength guide. - CalMWolfs

