### PR TITLE
Improvement: Add george prices to npc prices

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/neu/NeuGeorgeJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/neu/NeuGeorgeJson.kt
@@ -1,0 +1,8 @@
+package at.hannibal2.skyhanni.data.jsonobjects.repo.neu
+
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import com.google.gson.annotations.Expose
+
+data class NeuGeorgeJson(
+    @Expose val prices: Map<NeuInternalName, Double>?
+)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/HypixelItemApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/HypixelItemApi.kt
@@ -1,9 +1,13 @@
 package at.hannibal2.skyhanni.features.inventory.bazaar
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.data.jsonobjects.other.SkyblockItemsDataJson
+import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuGeorgeJson
+import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuItems
@@ -13,11 +17,25 @@ import at.hannibal2.skyhanni.utils.json.fromJson
 
 class HypixelItemApi {
 
+    @SkyHanniModule
     companion object {
 
         private var npcPrices = mapOf<NeuInternalName, Double>()
+        private var georgePrices = mapOf<NeuInternalName, Double>()
 
         fun getNpcPrice(internalName: NeuInternalName) = npcPrices[internalName]
+
+        @HandleEvent
+        fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
+            val constant = event.getConstant<NeuGeorgeJson>("george")
+            val prices = constant.prices ?: return
+            georgePrices = prices
+            val newMap = npcPrices.toMutableMap()
+            for (price in prices) {
+                newMap[price.key] = price.value
+            }
+            npcPrices
+        }
     }
 
     private val hypixelItemStatic = ApiStaticGetPath(
@@ -45,7 +63,7 @@ class HypixelItemApi {
 
     fun start() {
         SkyHanniMod.launchIOCoroutine {
-            npcPrices = loadNpcPrices()
+            npcPrices = loadNpcPrices() + georgePrices
         }
 
         // TODO use SecondPassedEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/HypixelItemApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/HypixelItemApi.kt
@@ -34,7 +34,7 @@ class HypixelItemApi {
             for (price in prices) {
                 newMap[price.key] = price.value
             }
-            npcPrices
+            npcPrices = newMap
         }
     }
 


### PR DESCRIPTION
## Dependencies
- https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/pull/2048

## What
Hypixel decides george prices shouldnt be in the api

## Changelog Improvements
+ Trackers now show george price for pets when the tracker is set to npc. - nopo
