### PR TITLE
Fix: #4628

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
@@ -88,7 +88,7 @@ class DevConfig {
     val debugItemPos: Position = Position(90, 70)
 
     @Expose
-    @ConfigLink(owner = DebugConfig::class, field = "raytracedOreblock")
+    @ConfigLink(owner = DebugConfig::class, field = "rayTracedOreBlock")
     val debugOrePos: Position = Position(1, 200)
 
     // TODO move [these] to a ContributorAppearanceConfig, or something similar


### PR DESCRIPTION
## Dependencies
- #4628

## What
because the pr #4628 didn't also rename inside the config link, it caused minecraft to crash in the dev env, this did not happen when starting it with mc normally.

exclude_from_changelog