### PR TITLE
Fix: Melon

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -118,7 +118,7 @@ enum class SkyblockStat(
     CARROT_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Carrot Fortune $VALUE_PATTERN"),
     POTATO_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Potato Fortune $VALUE_PATTERN"),
     PUMPKIN_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Pumpkin Fortune $VALUE_PATTERN"),
-    MELON_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Melon Fortune $VALUE_PATTERN"),
+    MELON_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Melon Slice Fortune $VALUE_PATTERN"),
     MUSHROOM_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Mushroom Fortune $VALUE_PATTERN"),
     CACTUS_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Cactus Fortune $VALUE_PATTERN"),
     NETHER_WART_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Nether Wart Fortune $VALUE_PATTERN"),

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
@@ -78,6 +78,7 @@ enum class CropType(
         fun getByNameOrNull(itemName: String): CropType? {
             if (itemName == "Red Mushroom" || itemName == "Brown Mushroom") return MUSHROOM
             if (itemName == "Seeds") return WHEAT
+            if (itemName == "Melon Slice") return MELON
             return entries.firstOrNull {
                 it.cropName.equals(itemName, ignoreCase = true) ||
                     it.simpleName.equals(itemName, ignoreCase = true) ||

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -54,7 +54,7 @@ object FarmingFortuneDisplay {
     )
     private val cropSpecificTabFortunePattern by patternGroup.pattern(
         "tablist.cropspecific",
-        " (?<crop>Wheat|Carrot|Potato|Pumpkin|Sugar Cane|Melon|Cactus|Cocoa Beans|Mushroom|Nether Wart) Fortune: §r§6☘(?<fortune>\\d+)",
+        " (?<crop>Wheat|Carrot|Potato|Pumpkin|Sugar Cane|Melon Slice|Cactus|Cocoa Beans|Mushroom|Nether Wart) Fortune: §r§6☘(?<fortune>\\d+)",
     )
     private val collectionPattern by patternGroup.pattern(
         "collection",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -52,6 +52,7 @@ object FarmingFortuneDisplay {
         "tablist.universal",
         " Farming Fortune: §r§6☘(?<fortune>\\d+)",
     )
+    @Suppress("MaxLineLength", "RepoPatternRegexTestMissing")
     private val cropSpecificTabFortunePattern by patternGroup.pattern(
         "tablist.cropspecific",
         " (?<crop>Wheat|Carrot|Potato|Pumpkin|Sugar Cane|Melon Slice|Cactus|Cocoa Beans|Mushroom|Nether Wart) Fortune: §r§6☘(?<fortune>\\d+)",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/DicerRngDropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/DicerRngDropTracker.kt
@@ -49,18 +49,22 @@ object DicerRngDropTracker {
     }
 
     private val melonPatternGroup = RepoPattern.group("garden.dicer.melon")
+    @Suppress("RepoPatternRegexTestMissing")
     private val melonUncommonDropPattern by melonPatternGroup.pattern(
         "uncommon",
         "§a§lUNCOMMON DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Melon Slice§r§e!",
     )
+    @Suppress("RepoPatternRegexTestMissing")
     private val melonRareDropPattern by melonPatternGroup.pattern(
         "rare",
         "§9§lRARE DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Melon Slice§r§e!",
     )
+    @Suppress("RepoPatternRegexTestMissing")
     private val melonCrazyRareDropPattern by melonPatternGroup.pattern(
         "crazyrare",
-        "§d§lCRAZY RARE DROP! §r§eDicer dropped §r§[a|9]\\d+x §r§[a|9]Enchanted Melon(?: Block)?§r§e!",
+        "§d§lCRAZY RARE DROP! §r§eDicer dropped §r§[a|9]\\d+x §r§[a|9]Enchanted Melon(?: Block| Slice)?§r§e!",
     )
+    @Suppress("RepoPatternRegexTestMissing")
     private val melonRngesusDropPattern by melonPatternGroup.pattern(
         "rngesus",
         "§5§lPRAY TO RNGESUS DROP! §r§eDicer dropped §r§9\\d+x §r§9Enchanted Melon§r§e!",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/DicerRngDropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/DicerRngDropTracker.kt
@@ -51,11 +51,11 @@ object DicerRngDropTracker {
     private val melonPatternGroup = RepoPattern.group("garden.dicer.melon")
     private val melonUncommonDropPattern by melonPatternGroup.pattern(
         "uncommon",
-        "§a§lUNCOMMON DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Melon§r§e!",
+        "§a§lUNCOMMON DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Melon Slice§r§e!",
     )
     private val melonRareDropPattern by melonPatternGroup.pattern(
         "rare",
-        "§9§lRARE DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Melon§r§e!",
+        "§9§lRARE DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Melon Slice§r§e!",
     )
     private val melonCrazyRareDropPattern by melonPatternGroup.pattern(
         "crazyrare",
@@ -63,7 +63,7 @@ object DicerRngDropTracker {
     )
     private val melonRngesusDropPattern by melonPatternGroup.pattern(
         "rngesus",
-        "§5§lPRAY TO RNGESUS DROP! §r§eDicer dropped §r§9\\d+x §r§9Enchanted Melon Block§r§e!",
+        "§5§lPRAY TO RNGESUS DROP! §r§eDicer dropped §r§9\\d+x §r§9Enchanted Melon§r§e!",
     )
 
     private val pumpkinPatternGroup = RepoPattern.group("garden.dicer.pumpkin")


### PR DESCRIPTION
## What
Fixes "no fortune found" tablist warnings, dicer drops (maybe), and CropType lookup caused by hypixel melon name change. Former 2 are regexes and can be updated via repo, while latter requires a beta release. Haven't tested if this actually fixes dicer drops but it works in #4590 so you should definitely merge that right now :)


## Changelog Fixes
+ Fixed fortune display not detecting melon fortune from tablist. - Chissl
+ Fixed dicer drops not being added to tracker/hidden. - Chissl
+ Fixed multiple menus and features throwing an error when encountering melons. - Chissl
