### PR TITLE
Fix: Exception in estimate item value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
@@ -28,7 +28,7 @@ data class ItemValueCalculationDataJson(
 
 data class AlwaysActiveEnchantJson(
     @Expose val level: Int,
-    @Expose val internalNames: List<NeuInternalName>,
+    @Expose @SerializedName("items") val internalNames: List<NeuInternalName>,
 )
 
 data class EndCapData(


### PR DESCRIPTION
## What
Fixed a minor error.

## Changelog Fixes
+ Fixed estimated item value error on items with replenish or scavenger 5. - CalMWolfs

