### PR TITLE
Improvement: Added color options for types of Auction items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/AuctionHouseConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/AuctionHouseConfig.kt
@@ -1,9 +1,12 @@
 package at.hannibal2.skyhanni.config.features.inventory
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.utils.LorenzColor
 import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.ChromaColour
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import org.lwjgl.input.Keyboard
@@ -17,11 +20,21 @@ class AuctionHouseConfig {
     @Expose
     @ConfigOption(
         name = "Highlight Auctions",
-        desc = "Highlight own items that are sold in green and that are expired in red."
+        desc = "Highlight own items that are sold and expired."
     )
     @ConfigEditorBoolean
     @FeatureToggle
     var highlightAuctions: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Sold Color", desc = "Color of sold items.")
+    @ConfigEditorColour
+    var soldColor: ChromaColour = LorenzColor.GREEN.toChromaColor(255)
+
+    @Expose
+    @ConfigOption(name = "Expired Color", desc = "Color of expired items.")
+    @ConfigEditorColour
+    var expiredColor: ChromaColour = LorenzColor.RED.toChromaColor(255)
 
     @Expose
     @ConfigOption(
@@ -31,6 +44,11 @@ class AuctionHouseConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var highlightAuctionsUnderbid: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Underbid Color", desc = "Color of underbid BIN items.")
+    @ConfigEditorColour
+    var underbidColor: ChromaColour = LorenzColor.GOLD.toChromaColor(255)
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/AuctionsHighlighter.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
@@ -52,11 +51,11 @@ object AuctionsHighlighter {
         for ((slot, stack) in chest.getUpperItems()) {
             val lore = stack.getLore()
             if (lore.any { it == "§7Status: §aSold!" }) {
-                slot.highlight(LorenzColor.GREEN)
+                slot.highlight(config.soldColor)
                 continue
             }
             if (lore.any { it == "§7Status: §cExpired!" }) {
-                slot.highlight(LorenzColor.RED)
+                slot.highlight(config.expiredColor)
                 continue
             }
             if (config.highlightAuctionsUnderbid) {
@@ -64,7 +63,7 @@ object AuctionsHighlighter {
                     val coins = group("coins").formatLong()
                     EstimatedItemValueCalculator.getTotalPrice(stack)?.let { totalPrice ->
                         if (coins > totalPrice) {
-                            slot.highlight(LorenzColor.GOLD)
+                            slot.highlight(config.underbidColor)
                         }
                     }
                 }


### PR DESCRIPTION
## What
This PR adds color options for sold, expired, and underbid Auction items. A friend wanted to use the "Highlight Auctions" feature but had difficulty distinguishing between the green and red used for the different categories.

<details>
<summary>Images</summary>

### New settings
<img width="664" height="507" alt="The new 'Sold Color', 'Expired Color', and 'Underbid Color' settings." src="https://github.com/user-attachments/assets/9ba69ea7-1efb-46fa-b3c9-2d78ef49843a" />

### Auction item showcase

<img width="346" height="183" alt="Auction listings, using new colours for bought, underbid, and unsold items." src="https://github.com/user-attachments/assets/34624eda-9d01-4080-a501-b6aaaf344898" />

</details>

## Changelog Improvements
+ Added color options for sold, expired, and underbid Auction items. - brooke-gill