### PR TITLE
Fix: Bucketed Item Tracker displaying invalid items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
@@ -77,6 +77,8 @@ abstract class BucketedItemTrackerData<E : Enum<E>>(clazz: KClass<E>) : ItemTrac
     @Expose
     val bucketedItems: MutableMap<E, MutableMap<NeuInternalName, TrackedItem>> = mutableMapOf()
 
+    fun getBucketedItems(bucket: E) = bucketedItems[bucket] ?: flattenBucketsItems()
+
     private val E.items get() = bucketedItems[this] ?: mutableMapOf()
     val selectedBucketItems get() = selectedBucket?.items ?: flattenBucketsItems()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniBucketedItemTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniBucketedItemTracker.kt
@@ -57,10 +57,10 @@ class SkyHanniBucketedItemTracker<E : Enum<E>, BucketedData : BucketedItemTracke
             it.addItem(bucket, internalName, amount, command)
         }
         getSharedTracker()?.let {
-            val totalProp = it.get(DisplayMode.TOTAL).selectedBucketItems.getOrPut(internalName) {
+            val totalProp = it.get(DisplayMode.TOTAL).getBucketedItems(bucket).getOrPut(internalName) {
                 ItemTrackerData.TrackedItem()
             }
-            val sessionProp = it.get(DisplayMode.SESSION).selectedBucketItems.getOrPut(internalName) {
+            val sessionProp = it.get(DisplayMode.SESSION).getBucketedItems(bucket).getOrPut(internalName) {
                 ItemTrackerData.TrackedItem()
             }
             sessionProp.hidden = totalProp.hidden


### PR DESCRIPTION
## What
Fixes bucketed item tracker creating and adding invalid items to the display bucket when an item is added to another bucket. 

## Changelog Fixes
+ Fixed bucketed item trackers displaying invalid items. - Chissl