### PR TITLE
Improvement: Update money per hour on pet change

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/CurrentPetApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/CurrentPetApi.kt
@@ -70,6 +70,8 @@ object CurrentPetApi {
         if (petData.uuid == null) {
             ErrorManager.skyHanniError("Tried to assert a non-UUID having pet!")
         }
+
+        PetChangedEvent(petData).post()
         ProfileStorageData.profileSpecific?.currentPetUuid = petData.uuid
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/CurrentPetApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/CurrentPetApi.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.data.PetData
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.pets.PetChangedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.LorenzRarity
@@ -82,6 +83,8 @@ object CurrentPetApi {
             )?.takeIf {
                 it.uuid != null
             } ?: return
+
+            PetChangedEvent(resolvedPet).post()
 
             ProfileStorageData.profileSpecific?.currentPetUuid = resolvedPet.uuid
         }

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/CurrentPetApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/CurrentPetApi.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.data.PetData
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
-import at.hannibal2.skyhanni.events.pets.PetChangedEvent
+import at.hannibal2.skyhanni.events.pets.PetChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.LorenzRarity
@@ -71,7 +71,7 @@ object CurrentPetApi {
             ErrorManager.skyHanniError("Tried to assert a non-UUID having pet!")
         }
 
-        PetChangedEvent(petData).post()
+        PetChangeEvent(petData).post()
         ProfileStorageData.profileSpecific?.currentPetUuid = petData.uuid
     }
 
@@ -86,7 +86,7 @@ object CurrentPetApi {
                 it.uuid != null
             } ?: return
 
-            PetChangedEvent(resolvedPet).post()
+            PetChangeEvent(resolvedPet).post()
 
             ProfileStorageData.profileSpecific?.currentPetUuid = resolvedPet.uuid
         }

--- a/src/main/java/at/hannibal2/skyhanni/events/pets/PetChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/pets/PetChangeEvent.kt
@@ -3,4 +3,4 @@ package at.hannibal2.skyhanni.events.pets
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.PetData
 
-class PetChangedEvent(val pet: PetData) : SkyHanniEvent()
+class PetChangeEvent(val pet: PetData) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/pets/PetChangedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/pets/PetChangedEvent.kt
@@ -1,0 +1,6 @@
+package at.hannibal2.skyhanni.events.pets
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.data.PetData
+
+class PetChangedEvent(val pet: PetData) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -4,11 +4,13 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.garden.MoneyPerHourConfig.CustomFormatEntry
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.garden.GardenToolChangeEvent
+import at.hannibal2.skyhanni.events.pets.PetChangedEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.CropType.Companion.getByNameOrNull
 import at.hannibal2.skyhanni.features.garden.GardenApi
@@ -66,6 +68,11 @@ object CropMoneyDisplay {
     @HandleEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
         display = null
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onPetChanged(event: PetChangedEvent) {
+        update()
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.garden.GardenToolChangeEvent
-import at.hannibal2.skyhanni.events.pets.PetChangedEvent
+import at.hannibal2.skyhanni.events.pets.PetChangeEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.CropType.Companion.getByNameOrNull
 import at.hannibal2.skyhanni.features.garden.GardenApi
@@ -71,7 +71,7 @@ object CropMoneyDisplay {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onPetChanged(event: PetChangedEvent) {
+    fun onPetChange(event: PetChangeEvent) {
         update()
     }
 


### PR DESCRIPTION
## What
This PR adds in a new on pet change event that is used to trigger an update to the money per hour display whilst on the garden.

closes #133 

## Changelog Improvements
+ Updated Garden Money-Per-Hour display on pet change. - Stuflo19
