### PR TITLE
Fix: Typo in changelog viewer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangeLogViewerScreen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangeLogViewerScreen.kt
@@ -136,7 +136,7 @@ class ChangeLogViewerScreen : SkyhanniBaseScreen() {
                         Renderable.text("§aNo changes found", horizontalAlign = RenderUtils.HorizontalAlignment.CENTER)
                     } else if (!ChangelogViewer.shouldShowBeta) {
                         Renderable.text(
-                            "§aOnly Full Releases were added, turn on \"Include Betas\"",
+                            "§aNo Full Releases in specified interval, modify the search or turn on \"Include Betas\"",
                             horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
                         )
                     } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangeLogViewerScreen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangeLogViewerScreen.kt
@@ -136,7 +136,7 @@ class ChangeLogViewerScreen : SkyhanniBaseScreen() {
                         Renderable.text("§aNo changes found", horizontalAlign = RenderUtils.HorizontalAlignment.CENTER)
                     } else if (!ChangelogViewer.shouldShowBeta) {
                         Renderable.text(
-                            "§aOnly Betas where added, turn on \"Include Betas\"",
+                            "§aOnly Full Releases were added, turn on \"Include Betas\"",
                             horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
                         )
                     } else {


### PR DESCRIPTION
## What
Now the text has no typo + is correct.

## Changelog Fixes
+ Fixed a typo in the Changelog Viewer. - CalMWolfs
