### PR TITLE
Improvement: Add Bal Shard to Crystal Nucleus Profit Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
@@ -147,7 +147,7 @@ object AttributeShardsData {
      * REGEX-TEST: §aYou caught §7x2 §fHideonleaf §aShards§a!
      * REGEX-TEST: §aYou caught §7x2 §fVoracious Spider §aShards§a!
      */
-    val caughtShardsPattern by patternGroup.pattern(
+    private val caughtShardsPattern by patternGroup.pattern(
         "caught.shards",
         "§aYou caught(?: [an]+)?(?: §7x(?<amount>\\d+))? §.(?<shardName>.+) §aShard(?:s§a)?!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
@@ -147,7 +147,7 @@ object AttributeShardsData {
      * REGEX-TEST: §aYou caught §7x2 §fHideonleaf §aShards§a!
      * REGEX-TEST: §aYou caught §7x2 §fVoracious Spider §aShards§a!
      */
-    private val caughtShardsPattern by patternGroup.pattern(
+    val caughtShardsPattern by patternGroup.pattern(
         "caught.shards",
         "§aYou caught(?: [an]+)?(?: §7x(?<amount>\\d+))? §.(?<shardName>.+) §aShard(?:s§a)?!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
@@ -48,6 +48,7 @@ object CrystalNucleusApi {
     private val FORTUNE_IV_BOOK_ITEM = "FORTUNE;4".toInternalName()
     val EPIC_BAL_ITEM = "BAL;3".toInternalName()
     val LEGENDARY_BAL_ITEM = "BAL;4".toInternalName()
+    val BAL_SHARD_ITEM = "ATTRIBUTE_SHARD_DEEP_TECHNIQUE;1".toInternalName()
     private val PRECURSOR_APPARATUS_ITEM = "PRECURSOR_APPARATUS".toInternalName()
     val JUNGLE_KEY_ITEM = "JUNGLE_KEY".toInternalName()
     private val ROBOT_PARTS_ITEMS = listOf(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -12,6 +12,8 @@ import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.mining.CrystalNucleusLootEvent
+import at.hannibal2.skyhanni.features.inventory.attribute.AttributeShardsData
+import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.BAL_SHARD_ITEM
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.EPIC_BAL_ITEM
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.JUNGLE_KEY_ITEM
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.LEGENDARY_BAL_ITEM
@@ -93,6 +95,15 @@ object CrystalNucleusTracker {
             }
             tracker.modify {
                 it.addItem(item, amount = 1, false)
+            }
+        }
+
+        AttributeShardsData.caughtShardsPattern.matchMatcher(event.message) {
+            if (group("shardName") != "Bal") return@matchMatcher
+
+            val amount = group("amount")?.toInt() ?: 1
+            tracker.modify {
+                it.addItem(BAL_SHARD_ITEM, 1, false)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -94,7 +94,7 @@ object CrystalNucleusTracker {
                 else -> return@matchMatcher
             }
             tracker.modify {
-                it.addItem(item, 1, false)
+                it.addItem(item, 1, command = false)
             }
         }
 
@@ -103,7 +103,7 @@ object CrystalNucleusTracker {
 
             val amount = group("amount")?.toInt() ?: 1
             tracker.modify {
-                it.addItem(BAL_SHARD_ITEM, amount, false)
+                it.addItem(BAL_SHARD_ITEM, amount, command = false)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -11,8 +11,8 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.item.ShardGainEvent
 import at.hannibal2.skyhanni.events.mining.CrystalNucleusLootEvent
-import at.hannibal2.skyhanni.features.inventory.attribute.AttributeShardsData
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.BAL_SHARD_ITEM
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.EPIC_BAL_ITEM
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.JUNGLE_KEY_ITEM
@@ -83,7 +83,7 @@ object CrystalNucleusTracker {
         var runsCompleted = 0L
     }
 
-    @HandleEvent(onlyOnSkyblock = true)
+    @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
     fun onChat(event: SkyHanniChatEvent) {
         balObtainedPattern.matchMatcher(event.message) {
             if (!group("player").equals(PlayerUtils.getName(), ignoreCase = true)) return@matchMatcher
@@ -94,17 +94,17 @@ object CrystalNucleusTracker {
                 else -> return@matchMatcher
             }
             tracker.modify {
-                it.addItem(item, 1, command = false)
+                it.addItem(item, amount = 1, command = false)
             }
         }
+    }
 
-        AttributeShardsData.caughtShardsPattern.matchMatcher(event.message) {
-            if (group("shardName") != "Bal") return@matchMatcher
+    @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
+    fun onShardGain(event: ShardGainEvent) {
+        if (event.shardInternalName != BAL_SHARD_ITEM) return
 
-            val amount = group("amount")?.toInt() ?: 1
-            tracker.modify {
-                it.addItem(BAL_SHARD_ITEM, amount, command = false)
-            }
+        tracker.modify {
+            it.addItem(BAL_SHARD_ITEM, event.amount, command = false)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -94,7 +94,7 @@ object CrystalNucleusTracker {
                 else -> return@matchMatcher
             }
             tracker.modify {
-                it.addItem(item, amount = 1, false)
+                it.addItem(item, 1, false)
             }
         }
 
@@ -103,7 +103,7 @@ object CrystalNucleusTracker {
 
             val amount = group("amount")?.toInt() ?: 1
             tracker.modify {
-                it.addItem(BAL_SHARD_ITEM, 1, false)
+                it.addItem(BAL_SHARD_ITEM, amount, false)
             }
         }
     }


### PR DESCRIPTION
## What
Added Bal Shard to Crystal Nucleus Profit Tracker, which has a chance to drop from the Bal boss on each hit while having a salt active (not tested).

## Changelog Improvements
+ Added Bal Shard to Crystal Nucleus Profit Tracker. - Luna