### PR TITLE
Fix: Block Strength Guide being unopenable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -26,6 +26,10 @@ object HypixelCommands {
         send("sbmenu")
     }
 
+    fun stats() {
+        send("stats")
+    }
+
     fun skills() {
         send("skills")
     }


### PR DESCRIPTION
## What
This PR fixes several issues with the Block Strength Guide (/blockstrengthguide). These issues were:

- Fixed the Block Strength Guide not being openable due to the new /stats menu.
- Fixed /blockstrengthguide being runnable outside of SkyBlock.
- Fixed a race condition that prevented the GUI from being openable if the user reloaded it too quickly.
- Fixed some typos and capitalization in the Block Strength Guide.

## Changelog Fixes
+ Fixed Block Strength Guide not opening. - brooke