### PR TITLE
Fix: Pet names being wrong in trackers and such

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
@@ -111,7 +111,7 @@ object PetUtils {
      */
     private val neuPetLorePattern by CurrentPetApi.patternGroup.pattern(
         "neu.pet.lore",
-        "§7§eRight-click to add this pet to(?: your)?",
+        "(?:§7)?§eRight-click to add this pet to(?: your)?",
     )
     // </editor-fold>
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
@@ -108,6 +108,7 @@ object PetUtils {
     /**
      * REGEX-TEST: §7§eRight-click to add this pet to
      * REGEX-TEST: §7§eRight-click to add this pet to your
+     * REGEX-TEST: §eRight-click to add this pet to your
      */
     private val neuPetLorePattern by CurrentPetApi.patternGroup.pattern(
         "neu.pet.lore",


### PR DESCRIPTION
## What
no more useless colour codes on 1.21??? who could have done this

<details>
<summary>Images</summary>

<img width="1935" height="1091" alt="image" src="https://github.com/user-attachments/assets/f9cef490-45ee-462b-8984-95f7c6aeef62" />

</details>

## Changelog Fixes
+ Fixed trackers showing incorrect pet names. - nopo
