### PR TITLE
Backend: Pest profit tacker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -11,7 +11,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 104
+    const val CONFIG_VERSION = 105
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -11,7 +11,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 105
+    const val CONFIG_VERSION = 106
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestsConfig.kt
@@ -38,7 +38,7 @@ class PestsConfig {
     @Expose
     @ConfigOption(name = "Pest Profit Tracker", desc = "")
     @Accordion
-    val pestProfitTacker: PestProfitTrackerConfig = PestProfitTrackerConfig()
+    val pestProfitTracker: PestProfitTrackerConfig = PestProfitTrackerConfig()
 
     @Expose
     @ConfigOption(name = "Spray", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -49,7 +49,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object PestProfitTracker {
-    val config: PestProfitTrackerConfig get() = SkyHanniMod.feature.garden.pests.pestProfitTacker
+    val config: PestProfitTrackerConfig get() = SkyHanniMod.feature.garden.pests.pestProfitTracker
 
     private val patternGroup = RepoPattern.group("garden.pests.tracker")
 
@@ -359,5 +359,6 @@ object PestProfitTracker {
                 }.sumOf { it.value },
             )
         }
+        event.move(105, "garden.pests.pestProfitTacker", "garden.pests.pestProfitTracker")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -359,7 +359,7 @@ object PestProfitTracker {
                 }.sumOf { it.value },
             )
         }
-        event.move(105, "garden.pests.pestProfitTacker", "garden.pests.pestProfitTracker") { entry ->
+        event.move(106, "garden.pests.pestProfitTacker", "garden.pests.pestProfitTracker") { entry ->
             entry
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -359,6 +359,8 @@ object PestProfitTracker {
                 }.sumOf { it.value },
             )
         }
-        event.move(105, "garden.pests.pestProfitTacker", "garden.pests.pestProfitTracker")
+        event.move(105, "garden.pests.pestProfitTacker", "garden.pests.pestProfitTracker") { entry ->
+            entry
+        }
     }
 }


### PR DESCRIPTION
## What
Rename pestProfitTacker value to PestProfitT**r**acker in garden config because it was annoying me

exclude_from_changelog



