### PR TITLE
Feature: Pest Trap Release Keybind

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTrapConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTrapConfig.kt
@@ -25,11 +25,11 @@ class PestTrapConfig {
 
     @Expose
     @ConfigOption(
-        name = "Collect All Hotkey",
-        desc = "Collect all pests in a pest trap when you press this keybind."
+        name = "Release All Hotkey",
+        desc = "Release all pests in a pest trap when you press this keybind."
     )
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
-    var collectHotkey: Int = Keyboard.KEY_NONE
+    var releaseHotkey: Int = Keyboard.KEY_NONE
 
     @Expose
     @ConfigOption(name = "Warnings", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTrapConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTrapConfig.kt
@@ -7,10 +7,12 @@ import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
+import org.lwjgl.input.Keyboard
 
 class PestTrapConfig {
 
@@ -20,6 +22,14 @@ class PestTrapConfig {
     )
     @ConfigEditorButton(buttonText = "Go")
     val displayRunnable = Runnable { SkyHanniMod.feature.gui.tabWidget::display.jumpToEditor() }
+
+    @Expose
+    @ConfigOption(
+        name = "Collect All Hotkey",
+        desc = "Collect all pests in a pest trap when you press this keybind."
+    )
+    @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
+    var collectHotkey: Int = Keyboard.KEY_NONE
 
     @Expose
     @ConfigOption(name = "Warnings", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapApi.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestTrapDataEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -41,6 +42,7 @@ object PestTrapApi {
     private var timeEnteredGarden: SimpleTimeMark? = null
     var MAX_TRAPS = 3
         private set
+    val inInventory get() = InventoryUtils.openInventoryName() == "Mouse Trap" || InventoryUtils.openInventoryName() == "Pest Trap"
 
     @HandleEvent
     fun onWidgetUpdate(event: WidgetUpdateEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapApi.kt
@@ -42,7 +42,8 @@ object PestTrapApi {
     private var timeEnteredGarden: SimpleTimeMark? = null
     var MAX_TRAPS = 3
         private set
-    val inInventory get() = InventoryUtils.openInventoryName() == "Mouse Trap" || InventoryUtils.openInventoryName() == "Pest Trap"
+    private val inventoryNames = setOf("Mouse Trap", "Pest Trap")
+    val inInventory get() = InventoryUtils.openInventoryName() in inventoryNames
 
     @HandleEvent
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
@@ -67,14 +68,17 @@ object PestTrapApi {
                 widgetEnabledAndVisible[TabWidget.PEST_TRAPS] = true
                 trapsPlaced = event.lines.firstNotNullOfOrNull { it.getTrapsPlacedOrNull() }
             }
+
             TabWidget.FULL_TRAPS -> {
                 widgetEnabledAndVisible[TabWidget.FULL_TRAPS] = true
                 fullTraps = event.lines.firstNotNullOfOrNull { it.getFullTrapsOrNull() }
             }
+
             TabWidget.NO_BAIT -> {
                 widgetEnabledAndVisible[TabWidget.NO_BAIT] = true
                 noBaitTraps = event.lines.firstNotNullOfOrNull { it.getNoBaitTrapsOrNull() }
             }
+
             else -> return
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.mixins.transformers.gui.AccessorGuiContainer
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
-import at.hannibal2.skyhanni.utils.InventoryUtils.slots
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
@@ -65,8 +64,7 @@ object PestTrapFeatures {
         if (!config.releaseHotkey.isKeyHeld()) return
         val inventory = event.guiContainer as? AccessorGuiContainer ?: return
         inventory as GuiContainer
-        val slot = inventory.slots()[16]
-        InventoryCompat.clickInventorySlot(slot.slotIndex, mouseButton = 0, mode = 0)
+        InventoryCompat.clickInventorySlot(16, mouseButton = 0, mode = 0)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
@@ -24,7 +24,6 @@ import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat
 import io.github.notenoughupdates.moulconfig.observer.Property
 import net.minecraft.client.audio.ISound
-import net.minecraft.client.gui.inventory.GuiContainer
 import kotlin.math.max
 import kotlin.time.Duration.Companion.seconds
 
@@ -62,13 +61,12 @@ object PestTrapFeatures {
     fun onKeybind(event: GuiKeyPressEvent) {
         if (!PestTrapApi.inInventory) return
         if (!config.releaseHotkey.isKeyHeld()) return
-        val inventory = event.guiContainer as? AccessorGuiContainer ?: return
-        inventory as GuiContainer
+        if (event.guiContainer !is AccessorGuiContainer) return
         InventoryCompat.clickInventorySlot(16, mouseButton = 0, mode = 0)
     }
 
-    @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    @HandleEvent(ConfigLoadEvent::class)
+    fun onConfigLoad() {
         ConditionalUtils.onToggle(config.warningConfig.warningSound) {
             warningSound = refreshSound()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
@@ -6,20 +6,26 @@ import at.hannibal2.skyhanni.config.features.garden.pests.PestTrapConfig
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
+import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestTrapDataEvent
 import at.hannibal2.skyhanni.features.garden.pests.PestTrapApi.MAX_TRAPS
 import at.hannibal2.skyhanni.features.garden.pests.PestTrapApi.fullTraps
 import at.hannibal2.skyhanni.features.garden.pests.PestTrapApi.noBaitTraps
 import at.hannibal2.skyhanni.features.garden.pests.PestTrapApi.trapsPlaced
+import at.hannibal2.skyhanni.mixins.transformers.gui.AccessorGuiContainer
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.InventoryUtils.slots
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import at.hannibal2.skyhanni.utils.StringUtils
+import at.hannibal2.skyhanni.utils.compat.InventoryCompat
 import io.github.notenoughupdates.moulconfig.observer.Property
 import net.minecraft.client.audio.ISound
+import net.minecraft.client.gui.inventory.GuiContainer
 import kotlin.math.max
 import kotlin.time.Duration.Companion.seconds
 
@@ -52,6 +58,16 @@ object PestTrapFeatures {
 
     private fun getNextWarningMark() = SimpleTimeMark.now() + virtualReminderInterval
     private fun refreshSound() = soundString.takeIf(String::isNotEmpty)?.let { SoundUtils.createSound(it, 1f) }
+
+    @HandleEvent
+    fun onKeybind(event: GuiKeyPressEvent) {
+        if (!PestTrapApi.inInventory) return
+        if (!config.collectHotkey.isKeyHeld()) return
+        val inventory = event.guiContainer as? AccessorGuiContainer ?: return
+        inventory as GuiContainer
+        val slot = inventory.slots()[16]
+        InventoryCompat.clickInventorySlot(slot.slotIndex, mouseButton = 0, mode = 0)
+    }
 
     @HandleEvent
     fun onConfigLoad(event: ConfigLoadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
@@ -62,7 +62,7 @@ object PestTrapFeatures {
     @HandleEvent
     fun onKeybind(event: GuiKeyPressEvent) {
         if (!PestTrapApi.inInventory) return
-        if (!config.collectHotkey.isKeyHeld()) return
+        if (!config.releaseHotkey.isKeyHeld()) return
         val inventory = event.guiContainer as? AccessorGuiContainer ?: return
         inventory as GuiContainer
         val slot = inventory.slots()[16]


### PR DESCRIPTION
## What
Adds a keybind that clicks the "release all pests" button when in a pest trap.

## Changelog New Features
+ Added keybind to release all pests in a Pest Trap. - Chissl


