### PR TITLE
Backend: Tablist End Time

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
@@ -23,6 +23,8 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.TimeUtils.getTablistEndTime
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.annotations.Expose
@@ -106,7 +108,7 @@ object GardenPlotApi {
      */
     private val plotSprayedTablistPattern by patternGroup.pattern(
         "tablist.spray",
-        "Spray: §r§[7a](?<spray>[\\w\\s]+)(?:§r§7\\((?:(?<minutes>\\d+)m)? ?(?:(?<seconds>\\d+)s)?\\))?",
+        "Spray: §r§[7a](?<spray>[\\w\\s]+)(?:§r§7\\((?<time>.*)\\))?",
     )
     var plots = listOf<Plot>()
 
@@ -254,14 +256,6 @@ object GardenPlotApi {
         ChatUtils.chat("§r§7This will expire in §r§a$time§r§7!§r")
     }
 
-    private fun isSprayAccurate(
-        sprayExpiryTime: SimpleTimeMark, expectedExpireTime: SimpleTimeMark, currentSpray: SprayType, newSpray: SprayType,
-    ): Boolean {
-        return sprayExpiryTime >= expectedExpireTime + 6.seconds ||
-            sprayExpiryTime <= expectedExpireTime - 1.minutes ||
-            currentSpray != newSpray
-    }
-
     private fun sprayMessageEligible(
         sprayExpiryTime: SimpleTimeMark, expectedExpireTime: SimpleTimeMark, currentSpray: SprayType, newSpray: SprayType,
     ): Boolean {
@@ -320,6 +314,7 @@ object GardenPlotApi {
             val spray = SprayType.getByNameOrNull(sprayName) ?: return
 
             plot?.setSpray(spray, 30.minutes)
+
         }
         cleanPlotChatPattern.matchMatcher(event.message) {
             val plotId = group("plot").toInt()
@@ -377,24 +372,16 @@ object GardenPlotApi {
         if (plot.isBarn()) return
 
         plotSprayedTablistPattern.firstMatcher(event.lines.map { it.trim() }) {
-
             val sprayName = group("spray").trim()
-            val minutes = group("minutes")?.toInt() ?: 0
-            val seconds = group("seconds")?.toInt() ?: 0
-
-            val time = if (seconds == 0) (minutes + 1).minutes
-            else minutes.minutes + seconds.seconds
-
-            val timeString = when {
-                minutes != 0 && seconds != 0 -> "${minutes}m ${seconds}s"
-                minutes != 0 -> "${minutes + 1}m"
-                else -> "${seconds}s"
+            val time = group("time")?.getTablistEndTime(plot.getData()?.sprayExpiryTime)
+            if (time == null) {
+                plot.removeSpray()
+                return
             }
 
             val newSpray: SprayType? = SprayType.getByNameOrNull(sprayName)
 
             if (plot.currentSpray != null) {
-                val expectedExpireTime = SimpleTimeMark.now() + time
                 val data = plot.getData() ?: return
 
                 val sprayExpiryTime = data.sprayExpiryTime ?: return
@@ -404,19 +391,17 @@ object GardenPlotApi {
                     plot.removeSpray()
                     return
                 } else {
-                    if (isSprayAccurate(sprayExpiryTime, expectedExpireTime, currentSpray, newSpray)) {
-                        if (sprayMessageEligible(sprayExpiryTime, expectedExpireTime, currentSpray, newSpray)) {
-                            sendSprayMessage(plot.name, sprayName, timeString)
-                        }
-                        plot.setSpray(newSpray, time)
+                    if (sprayMessageEligible(sprayExpiryTime, time, currentSpray, newSpray)) {
+                        sendSprayMessage(plot.name, sprayName, time.timeUntil().format())
                     }
+                    plot.setSpray(newSpray, time.timeUntil())
                 }
             } else {
                 if (newSpray == null) return
                 if (config.newSprayNotification) {
-                    sendSprayMessage(plot.name, sprayName, timeString)
+                    sendSprayMessage(plot.name, sprayName, time.timeUntil().format())
                 }
-                plot.setSpray(newSpray, time)
+                plot.setSpray(newSpray, time.timeUntil())
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
@@ -374,7 +374,7 @@ object GardenPlotApi {
 
         plotSprayedTablistPattern.firstMatcher(event.lines.map { it.trim() }) {
             val sprayName = group("spray").trim()
-            val time = groupOrNull("time")?.let{ getTablistEndTime(it, plot.getData()?.sprayExpiryTime) }
+            val time = groupOrNull("time")?.let { getTablistEndTime(it, plot.getData()?.sprayExpiryTime) }
             if (time == null) {
                 plot.removeSpray()
                 return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
@@ -373,7 +373,7 @@ object GardenPlotApi {
 
         plotSprayedTablistPattern.firstMatcher(event.lines.map { it.trim() }) {
             val sprayName = group("spray").trim()
-            val time = group("time")?.getTablistEndTime(plot.getData()?.sprayExpiryTime)
+            val time = getTablistEndTime(group("time"), plot.getData()?.sprayExpiryTime)
             if (time == null) {
                 plot.removeSpray()
                 return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.isInside
 import at.hannibal2.skyhanni.utils.LocationUtils.isPlayerInside
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -373,7 +374,7 @@ object GardenPlotApi {
 
         plotSprayedTablistPattern.firstMatcher(event.lines.map { it.trim() }) {
             val sprayName = group("spray").trim()
-            val time = getTablistEndTime(group("time"), plot.getData()?.sprayExpiryTime)
+            val time = groupOrNull("time")?.let{ getTablistEndTime(it, plot.getData()?.sprayExpiryTime) }
             if (time == null) {
                 plot.removeSpray()
                 return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -27,7 +27,6 @@ import at.hannibal2.skyhanni.features.garden.pests.PestApi.lastPestSpawnTime
 import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.hasGroup
@@ -37,12 +36,12 @@ import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import at.hannibal2.skyhanni.utils.TimeUtils.average
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.TimeUtils.getTablistEndTime
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -61,7 +60,7 @@ object PestSpawnTimer {
 
     private val pestCooldownPattern by patternGroup.pattern(
         "cooldown",
-        "\\sCooldown: §r§.(?:§.)?(?:(?<minutes>\\d+)m)? ?(?:(?<seconds>\\d+)s)?(?<ready>READY)?(?<maxPests>MAX PESTS)?.*",
+        "\\sCooldown: §r§.(?:§.)?(?<time>(\\d{1,2}[?:ms](?: \\d{1,2}s?)?))?(?<ready>READY)?(?<maxPests>MAX PESTS)?.*",
     )
 
     private val pestSpawnTimes: MutableList<Duration> = mutableListOf()
@@ -82,30 +81,21 @@ object PestSpawnTimer {
         if (!event.isWidget(TabWidget.PESTS)) return
 
         pestCooldownPattern.firstMatcher(event.widget.lines) {
-            val minutes = groupOrNull("minutes")?.formatInt()
-            val seconds = groupOrNull("seconds")?.formatInt()
+            val time = groupOrNull("time")?.getTablistEndTime(pestCooldownEndTime)
             ready = hasGroup("ready")
             maxPests = hasGroup("maxPests")
 
             if (ready || maxPests) {
+                pestCooldownEndTime = SimpleTimeMark.farPast()
                 shouldRepeatWarning = false
                 return
             }
-            if (minutes == null && seconds == null) return
+            if (time == null) return
+            pestCooldownEndTime = time
 
-            val tablistCooldownEnd = SimpleTimeMark.now() + (minutes?.minutes ?: 0.seconds) + (seconds?.seconds ?: 0.seconds)
-
-            if (shouldSetCooldown(tablistCooldownEnd, seconds)) {
-                // hypixel sometimes rounds time down, we'll assume times are rounded down if seconds are null and add a minute
-                pestCooldownEndTime = if (seconds == null) {
-                    tablistCooldownEnd + 1.minutes
-                } else {
-                    tablistCooldownEnd
-                }
-                if (pestSpawned) {
-                    hasWarned = false
-                    pestSpawned = false
-                }
+            if (pestSpawned) {
+                hasWarned = false
+                pestSpawned = false
             }
         }
     }
@@ -188,16 +178,6 @@ object PestSpawnTimer {
     fun onIslandChange(event: IslandChangeEvent) {
         shouldRepeatWarning = false
         longestCropBrokenTime = lastCropBrokenTime.passedSince()
-    }
-
-    private fun shouldSetCooldown(tabCooldownEnd: SimpleTimeMark, seconds: Int?): Boolean {
-        // tablist can have up to 6 seconds of delay, besides this, there is no scenario where tablist will overestimate cooldown
-        if (tabCooldownEnd > ((pestCooldownEndTime) + 6.seconds)) return true
-        // tablist sometimes rounds down to nearest min
-        if ((tabCooldownEnd + 1.minutes) < (pestCooldownEndTime) && seconds == null) return true
-        // tablist shouldn't underestimate if it is displaying seconds
-        if ((tabCooldownEnd + 1.seconds) < (pestCooldownEndTime) && seconds != null) return true
-        return false
     }
 
     private fun drawDisplay(): List<Renderable> {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -81,7 +81,7 @@ object PestSpawnTimer {
         if (!event.isWidget(TabWidget.PESTS)) return
 
         pestCooldownPattern.firstMatcher(event.widget.lines) {
-            val time = groupOrNull("time")?.getTablistEndTime(pestCooldownEndTime)
+            val time = groupOrNull("time")?.let { getTablistEndTime(it, pestCooldownEndTime) }
             ready = hasGroup("ready")
             maxPests = hasGroup("maxPests")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -60,7 +60,7 @@ object PestSpawnTimer {
 
     private val pestCooldownPattern by patternGroup.pattern(
         "cooldown",
-        "\\sCooldown: §r§.(?:§.)?(?<time>(\\d{1,2}[?:ms](?: \\d{1,2}s?)?))?(?<ready>READY)?(?<maxPests>MAX PESTS)?.*",
+        "\\sCooldown: §r§.(?:§.)?(?<time>\\d{1,2}[ms](?: \\d{1,2}s?)?)?(?<ready>READY)?(?<maxPests>MAX PESTS)?.*",
     )
 
     private val pestSpawnTimes: MutableList<Duration> = mutableListOf()

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -18,6 +18,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 
+@Suppress("TooManyFunctions")
 object TimeUtils {
 
     fun Duration.format(

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -9,6 +9,8 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import kotlin.math.absoluteValue
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -195,6 +197,48 @@ object TimeUtils {
 
     // TODO move into lorenz logger. then rewrite lorenz logger and use something different entirely
     fun SimpleDateFormat.formatCurrentTime(): String = this.format(System.currentTimeMillis())
+
+    fun String.getTablistEndTime(currentCooldownEnd: SimpleTimeMark?): SimpleTimeMark? =
+        UtilsPatterns.timeAmountPattern.matchMatcher(this.lowercase().trim()) {
+            val years = group("y")?.toLong()?.times(365.25)?.days ?: 0.seconds
+            val days = group("d")?.toLong()?.days ?: 0.seconds
+            val hours = group("h")?.toLong()?.hours ?: 0.seconds
+            val minutes = group("m")?.toLong()?.minutes
+            val seconds = group("s")?.toLong()?.seconds
+
+            // we don't care about precision with these values
+            val largerDuration = years + days + hours
+            if (minutes == null && seconds == null) {
+                return if (largerDuration == 0.seconds) {
+                    // assume passed string was invalid
+                    null
+                } else {
+                    SimpleTimeMark.now() + largerDuration
+                }
+            }
+
+            val tabCooldownEnd = SimpleTimeMark.now() + (minutes ?: 0.seconds) + (seconds ?: 0.seconds)
+            return if (shouldSetCooldown(tabCooldownEnd, currentCooldownEnd, seconds)) {
+                if (seconds == null) {
+                    tabCooldownEnd + 1.minutes + largerDuration
+                } else {
+                    tabCooldownEnd + largerDuration
+                }
+            } else {
+                currentCooldownEnd
+            }
+        }
+
+    private fun shouldSetCooldown(tabCooldownEnd: SimpleTimeMark, currentCooldownEnd: SimpleTimeMark?, seconds: Duration?): Boolean = when {
+        currentCooldownEnd == null -> true
+        // tablist can have up to 6 seconds of delay, besides this, there is no scenario where tablist will overestimate cooldown
+        tabCooldownEnd > ((currentCooldownEnd) + 6.seconds) -> true
+        // tablist sometimes rounds down to nearest min
+        (tabCooldownEnd + 1.minutes) < (currentCooldownEnd) && seconds == null -> true
+        // tablist shouldn't underestimate if it is displaying seconds
+        (tabCooldownEnd + 1.seconds) < (currentCooldownEnd) && seconds != null -> true
+        else -> false
+    }
 }
 
 private const val FACTOR_SECONDS = 1000L

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -220,6 +220,7 @@ object TimeUtils {
             val tabCooldownEnd = SimpleTimeMark.now() + (minutes ?: 0.seconds) + (seconds ?: 0.seconds)
             return if (shouldSetCooldown(tabCooldownEnd, currentCooldownEnd, seconds)) {
                 if (seconds == null) {
+                    // tablist always rounds down, so we'll assume it just updated and add a minute
                     tabCooldownEnd + 1.minutes + largerDuration
                 } else {
                     tabCooldownEnd + largerDuration

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -2,11 +2,13 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.util.regex.Matcher
 import kotlin.math.absoluteValue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -15,7 +17,6 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 object TimeUtils {
 
@@ -99,20 +100,7 @@ object TimeUtils {
     fun getDurationOrNull(string: String): Duration? = getMillis(string.preFixDurationString())
 
     private fun getMillis(string: String) = UtilsPatterns.timeAmountPattern.matchMatcher(string.lowercase().trim()) {
-        val years = group("y")?.toLong() ?: 0L
-        val days = group("d")?.toLong() ?: 0L
-        val hours = group("h")?.toLong() ?: 0L
-        val minutes = group("m")?.toLong() ?: 0L
-        val seconds = group("s")?.toLong() ?: 0L
-
-        var millis = 0L
-        millis += seconds * 1000
-        millis += minutes * 60 * 1000
-        millis += hours * 60 * 60 * 1000
-        millis += days * 24 * 60 * 60 * 1000
-        millis += (years * 365.25 * 24 * 60 * 60 * 1000).toLong()
-
-        millis.toDuration(DurationUnit.MILLISECONDS)
+        years("y") + days("d") + hours("h") + minutes("m") + seconds("s")
     } ?: tryAlternativeFormat(string)
 
     private fun tryAlternativeFormat(string: String): Duration? {
@@ -198,13 +186,13 @@ object TimeUtils {
     // TODO move into lorenz logger. then rewrite lorenz logger and use something different entirely
     fun SimpleDateFormat.formatCurrentTime(): String = this.format(System.currentTimeMillis())
 
-    fun String.getTablistEndTime(currentCooldownEnd: SimpleTimeMark?): SimpleTimeMark? =
-        UtilsPatterns.timeAmountPattern.matchMatcher(this.lowercase().trim()) {
-            val years = group("y")?.toLong()?.times(365.25)?.days ?: 0.seconds
-            val days = group("d")?.toLong()?.days ?: 0.seconds
-            val hours = group("h")?.toLong()?.hours ?: 0.seconds
-            val minutes = group("m")?.toLong()?.minutes
-            val seconds = group("s")?.toLong()?.seconds
+    fun getTablistEndTime(string: String, currentCooldownEnd: SimpleTimeMark?): SimpleTimeMark? =
+        UtilsPatterns.timeAmountPattern.matchMatcher(string.lowercase().trim()) {
+            val years = years("y")
+            val days = days("d")
+            val hours = hours("h")
+            val minutes = minutesOrNull("m")
+            val seconds = secondsOrNull("s")
 
             // we don't care about precision with these values
             val largerDuration = years + days + hours
@@ -222,12 +210,8 @@ object TimeUtils {
                 if (seconds == null) {
                     // tablist always rounds down, so we'll assume it just updated and add a minute
                     tabCooldownEnd + 1.minutes + largerDuration
-                } else {
-                    tabCooldownEnd + largerDuration
-                }
-            } else {
-                currentCooldownEnd
-            }
+                } else tabCooldownEnd + largerDuration
+            } else currentCooldownEnd
         }
 
     private fun shouldSetCooldown(tabCooldownEnd: SimpleTimeMark, currentCooldownEnd: SimpleTimeMark?, seconds: Duration?): Boolean = when {
@@ -240,6 +224,14 @@ object TimeUtils {
         (tabCooldownEnd + 1.seconds) < (currentCooldownEnd) && seconds != null -> true
         else -> false
     }
+
+    private fun Matcher.years(string: String) = groupOrNull(string)?.toLong()?.years ?: 0.seconds
+    private fun Matcher.days(string: String) = groupOrNull(string)?.toLong()?.days ?: 0.seconds
+    private fun Matcher.hours(string: String) = groupOrNull(string)?.toLong()?.hours ?: 0.seconds
+    private fun Matcher.minutesOrNull(string: String) = groupOrNull(string)?.toLong()?.minutes
+    private fun Matcher.minutes(string: String) = minutesOrNull(string) ?: 0.seconds
+    private fun Matcher.secondsOrNull(string: String) = groupOrNull(string)?.toLong()?.seconds
+    private fun Matcher.seconds(string: String) = secondsOrNull(string) ?: 0.seconds
 }
 
 private const val FACTOR_SECONDS = 1000L
@@ -279,3 +271,5 @@ val Duration.inPartialSeconds: Double get() = toDouble(DurationUnit.SECONDS)
 val Duration.inPartialMinutes: Double get() = inPartialSeconds / 60
 val Duration.inPartialHours: Double get() = inPartialSeconds / 3600
 val Duration.inPartialDays: Double get() = inPartialSeconds / 86_400
+val Duration.inPartialYears: Double get() = inPartialSeconds / (86_400 * 365.25)
+val Long.years: Duration get() = this.times(365.25).days


### PR DESCRIPTION
## What
Hypixel tablist time always rounds down and excludes seconds until (generally) less than 6 minutes are left, so added a timeutils function to more accurately estimate tablist times. Moved pest timer and plot spray timer over to this since they already did something similar. 

## Changelog Technical Details
+ Added getTablistEndTime, which better estimates when a tablist timer ends, to TimeUtils. - Chissl


