### PR TITLE
 Fix: garden vistior rainbow rune v2

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorFeatures.kt
@@ -480,7 +480,7 @@ object GardenVisitorFeatures {
                 readingShoppingList = false
             }
             val (itemName, amount) = ItemUtils.readItemAmount(formattedLine) ?: continue
-            val internalName = NeuInternalName.fromItemNameOrNull(itemName)?.replace("◆_", "") ?: continue
+            val internalName = NeuInternalName.fromItemNameOrNull(itemName.removeColor())?.replace("◆_", "") ?: continue
 
             // Ignoring custom NEU items like copper
             if (internalName.startsWith("SKYBLOCK_")) continue


### PR DESCRIPTION
## What
expands on #4624, since i forgot to add the fix to both functions.

## Changelog Fixes
+ Fixed Garden Visitor detection not working with Rainbow Rune again. - hannibal2
    * Unlike the last fix, this time it actually works.