### PR TITLE
Fix: Sun Gecko Modifiers on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
@@ -56,10 +56,12 @@ object SunGeckoHelper {
      * REGEX-TEST: §f                           §r§c§lACTIVE MODIFIERS!
      * REGEX-TEST: §f                           §r§c§lACTIVE MODIFIERS!
      * REGEX-TEST: §f                           §r§c§lACTIVE MODIFIERS!
+     * WRAPPED-REGEX-TEST: "                           §r§c§lACTIVE MODIFIERS!"
      */
     private val sunGeckoActiveModifiers by patternGroup.pattern(
         "modifiers",
-        "§f {27}§r§c§lACTIVE MODIFIERS!",
+        "(?:§.)* {27}§r§c§lACTIVE MODIFIERS!",
+
     )
 
     private val sunGeckoChatLine by patternGroup.pattern(


### PR DESCRIPTION
## What
Made a color code optional so that the Sun Gecko Helper can detect modifiers on 1.21.

## Changelog Fixes
+ Fixed Sun Gecko Helper always showing no active modifiers on 1.21. - Luna
