### PR TITLE
Backend + Fix: Update moulconfig

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 libautoupdate = "1.3.1"
-moulconfig = "4.1.0-beta"
+moulconfig = "4.1.1-beta"
 headlessLwjgl = "1.7.2"
 jbAnnotations = "24.1.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 libautoupdate = "1.3.1"
-moulconfig = "4.0.1-beta"
+moulconfig = "4.1.0-beta"
 headlessLwjgl = "1.7.2"
 jbAnnotations = "24.1.0"
 

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -2,7 +2,7 @@ import at.skyhanni.sharedvariables.ProjectTarget
 import com.replaymod.gradle.preprocess.Node
 
 plugins {
-    id("com.github.SkyHanniStudios.SkyHanni-Preprocessor") version "1.0.6"
+    id("com.github.SkyHanniStudios.SkyHanni-Preprocessor") version "1.0.7"
     id("gg.essential.loom") version "1.10.34" apply false
     kotlin("jvm") version "2.0.0" apply false
     kotlin("plugin.power-assert") version "2.0.0" apply false

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiForgeInterop.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiForgeInterop.kt
@@ -13,15 +13,16 @@ import java.io.IOException
 class ConfigGuiForgeInterop : IModGuiFactory {
 
     @Suppress("EmptyFunctionBlock")
-    override fun initialize(minecraft: Minecraft) {}
+    override fun initialize(minecraft: Minecraft) {
+    }
+
     override fun mainConfigGuiClass() = WrappedSkyHanniConfig::class.java
 
     override fun runtimeGuiCategories(): Set<RuntimeOptionCategoryElement>? = null
 
     override fun getHandlerFor(element: RuntimeOptionCategoryElement): RuntimeOptionGuiHandler? = null
 
-    class WrappedSkyHanniConfig(private val parent: GuiScreen) :
-        GuiScreenElementWrapper(ConfigGuiManager.getEditorInstance()) {
+    class WrappedSkyHanniConfig(private val parent: GuiScreen) : GuiScreenElementWrapper(ConfigGuiManager.getEditorInstance()) {
 
         @Throws(IOException::class)
         override fun handleKeyboardInput() {

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
-import io.github.notenoughupdates.moulconfig.gui.GuiScreenElementWrapper
+import at.hannibal2.skyhanni.utils.ConfigUtils
 import io.github.notenoughupdates.moulconfig.gui.MoulConfigEditor
 
 @SkyHanniModule
@@ -31,6 +31,6 @@ object ConfigGuiManager {
         if (search != null) {
             editor.search(search)
         }
-        SkyHanniMod.screenToOpen = GuiScreenElementWrapper(editor)
+        ConfigUtils.openEditor(editor)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/Features.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/Features.kt
@@ -20,12 +20,14 @@ import at.hannibal2.skyhanni.config.features.rift.RiftConfig
 import at.hannibal2.skyhanni.config.features.skillprogress.SkillProgressConfig
 import at.hannibal2.skyhanni.config.features.slayer.SlayerConfig
 import at.hannibal2.skyhanni.config.storage.Storage
+import at.hannibal2.skyhanni.utils.ConfigUtils.asStructuredText
 import at.hannibal2.skyhanni.utils.TimeUtils
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.Config
 import io.github.notenoughupdates.moulconfig.Social
 import io.github.notenoughupdates.moulconfig.annotations.Category
 import io.github.notenoughupdates.moulconfig.common.MyResourceLocation
+import io.github.notenoughupdates.moulconfig.common.text.StructuredText
 import io.github.notenoughupdates.moulconfig.gui.HorizontalAlign
 import io.github.notenoughupdates.moulconfig.processor.ProcessedCategory
 
@@ -46,9 +48,9 @@ class Features : Config() {
 
     override fun getSocials(): List<Social> {
         return listOf(
-            Social.forLink("Discord", discord, "https://discord.com/invite/skyhanni-997079228510117908"),
-            Social.forLink("GitHub", github, "https://github.com/hannibal002/SkyHanni"),
-            Social.forLink("Patreon", patreon, "https://www.patreon.com/hannibal2"),
+            Social.forLink("Discord".asStructuredText(), discord, "https://discord.com/invite/skyhanni-997079228510117908"),
+            Social.forLink("GitHub".asStructuredText(), github, "https://github.com/hannibal002/SkyHanni"),
+            Social.forLink("Patreon".asStructuredText(), patreon, "https://www.patreon.com/hannibal2"),
         )
     }
 
@@ -56,9 +58,9 @@ class Features : Config() {
         SkyHanniMod.configManager.saveConfig(ConfigFileType.FEATURES, "close-gui")
     }
 
-    override fun getTitle(): String {
+    override fun getTitle(): StructuredText {
         val modName = if (TimeUtils.isAprilFoolsDay) "SkyHanni".reversed() else "SkyHanni"
-        return "$modName ${SkyHanniMod.VERSION} by §channibal2§r, config by §5Moulberry §rand §5nea89"
+        return "$modName ${SkyHanniMod.VERSION} by §channibal2§r, config by §5Moulberry §rand §5nea89".asStructuredText()
     }
 
     /*

--- a/src/main/java/at/hannibal2/skyhanni/config/GuiOptionEditorBlocked.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/GuiOptionEditorBlocked.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config
 
+import at.hannibal2.skyhanni.utils.ConfigUtils.asStructuredText
 import io.github.notenoughupdates.moulconfig.common.MyResourceLocation
 import io.github.notenoughupdates.moulconfig.common.RenderContext
 import io.github.notenoughupdates.moulconfig.gui.GuiOptionEditor
@@ -21,13 +22,13 @@ class GuiOptionEditorBlocked(private val base: GuiOptionEditor, private val extr
         val oneThird: Float = height / 3f
 
         context.drawStringScaledMaxWidth(
-            "This option is currently not available.",
+            "This option is currently not available.".asStructuredText(),
             fontRenderer,
             (x + iconWidth).toInt(), (y + oneThird - fontRenderer.height / 2f).toInt(),
             true, (width - iconWidth).toInt(), -0xbbbc,
         )
         context.drawStringScaledMaxWidth(
-            extraMessage,
+            extraMessage.asStructuredText(),
             fontRenderer,
             (x + iconWidth).toInt(), (y + (oneThird * 2) - fontRenderer.height / 2f).toInt(),
             true, (width - iconWidth).toInt(), -0xbbbc,

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/Position.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/Position.kt
@@ -23,11 +23,11 @@ package at.hannibal2.skyhanni.config.core.config
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.ConfigGuiManager.getEditorInstance
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
 import com.google.gson.JsonElement
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
-import io.github.notenoughupdates.moulconfig.gui.GuiScreenElementWrapper
 import java.lang.reflect.Field
 
 class Position @JvmOverloads constructor(
@@ -205,7 +205,7 @@ class Position @JvmOverloads constructor(
         val option = editor.getOptionFromField(field) ?: return
         editor.search("")
         if (!editor.goToOption(option)) return
-        SkyHanniMod.screenToOpen = GuiScreenElementWrapper(editor)
+        ConfigUtils.openEditor(editor)
     }
 
     fun setLink(configLink: ConfigLink) {

--- a/src/main/java/at/hannibal2/skyhanni/config/core/elements/GuiElementButton.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/elements/GuiElementButton.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.core.elements
 
+import at.hannibal2.skyhanni.utils.ConfigUtils.asStructuredText
 import io.github.notenoughupdates.moulconfig.common.RenderContext
 import java.awt.Color
 
@@ -19,6 +20,6 @@ class GuiElementButton {
         context.drawColoredRect(x.toFloat(), y.toFloat(), (x + width).toFloat(), (y + 18).toFloat(), Color.WHITE.rgb)
         context.drawColoredRect((x + 1).toFloat(), (y + 1).toFloat(), (x + width - 1).toFloat(), (y + 18 - 1).toFloat(), Color.BLACK.rgb)
         val fr = context.minecraft.defaultFontRenderer
-        context.drawString(fr, text, x + 5, y + 5, -1, true)
+        context.drawString(fr, text.asStructuredText(), x + 5, y + 5, -1, true)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatPeek.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatPeek.kt
@@ -4,10 +4,10 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.GuiEditManager
 import at.hannibal2.skyhanni.features.garden.fortuneguide.FFGuideGui
 import at.hannibal2.skyhanni.features.misc.visualwords.VisualWordGui
+import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import io.github.notenoughupdates.moulconfig.gui.GuiScreenElementWrapper
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.inventory.GuiEditSign
 import org.lwjgl.input.Keyboard
@@ -21,7 +21,7 @@ object ChatPeek {
         if (!MinecraftCompat.localPlayerExists) return false
         if (key <= Keyboard.KEY_NONE) return false
         if (Minecraft.getMinecraft().currentScreen is GuiEditSign) return false
-        if (Minecraft.getMinecraft().currentScreen is GuiScreenElementWrapper) return false
+        if (ConfigUtils.configScreenCurrentlyOpen) return false
 
         if (NeuItems.neuHasFocus()) return false
         if (GuiEditManager.isInGui() || FFGuideGui.isInGui() || VisualWordGui.isInGui()) return false

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.misc.update
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.core.elements.GuiElementButton
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ConfigUtils.asStructuredText
 import at.hannibal2.skyhanni.utils.compat.MouseCompat
 import io.github.notenoughupdates.moulconfig.common.RenderContext
 import io.github.notenoughupdates.moulconfig.gui.GuiOptionEditor
@@ -42,7 +43,7 @@ class GuiOptionEditorUpdateCheck(option: ProcessedOption) : GuiOptionEditor(opti
 
         if (UpdateManager.updateState == UpdateManager.UpdateState.DOWNLOADED) {
             context.drawStringCenteredScaledMaxWidth(
-                "§aThe update will be installed after your next restart.",
+                "§aThe update will be installed after your next restart.".asStructuredText(),
                 fr,
                 widthRemaining / 2F,
                 40F,
@@ -54,9 +55,11 @@ class GuiOptionEditorUpdateCheck(option: ProcessedOption) : GuiOptionEditor(opti
 
         context.scale(2F, 2F)
         val sameVersion = currentVersion.equals(nextVersion, ignoreCase = true)
+        val versionText = "${if (UpdateManager.updateState == UpdateManager.UpdateState.NONE) "§a" else "§c"}$currentVersion" +
+            if (nextVersion != null && !sameVersion) "➜ §a$nextVersion" else ""
+
         context.drawStringCenteredScaledMaxWidth(
-            "${if (UpdateManager.updateState == UpdateManager.UpdateState.NONE) "§a" else "§c"}$currentVersion" +
-                if (nextVersion != null && !sameVersion) "➜ §a$nextVersion" else "",
+            versionText.asStructuredText(),
             fr,
             widthRemaining / 4F,
             10F,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.ConfigGuiManager
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
+import io.github.notenoughupdates.moulconfig.common.text.StructuredText
 import io.github.notenoughupdates.moulconfig.gui.GuiScreenElementWrapper
 import io.github.notenoughupdates.moulconfig.gui.MoulConfigEditor
 import io.github.notenoughupdates.moulconfig.processor.ProcessedOption
@@ -50,4 +51,6 @@ object ConfigUtils {
         SkyHanniMod.screenToOpen = GuiScreenElementWrapper(editor)
         return true
     }
+
+    fun String.asStructuredText() = StructuredText.of(this)
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
@@ -6,11 +6,19 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
 import io.github.notenoughupdates.moulconfig.common.text.StructuredText
-import io.github.notenoughupdates.moulconfig.gui.GuiScreenElementWrapper
 import io.github.notenoughupdates.moulconfig.gui.MoulConfigEditor
 import io.github.notenoughupdates.moulconfig.processor.ProcessedOption
+import net.minecraft.client.Minecraft
 import kotlin.reflect.KProperty0
 import kotlin.reflect.jvm.javaField
+//#if FORGE
+import io.github.notenoughupdates.moulconfig.gui.GuiScreenElementWrapper
+//#else
+//$$ import io.github.notenoughupdates.moulconfig.gui.GuiContext
+//$$ import io.github.notenoughupdates.moulconfig.gui.GuiElementComponent
+//$$ import io.github.notenoughupdates.moulconfig.platform.MoulConfigScreenComponent
+//$$ import net.minecraft.text.Text
+//#endif
 
 object ConfigUtils {
 
@@ -48,9 +56,25 @@ object ConfigUtils {
         val option = tryFindEditor(editor) ?: return false
         editor.search("")
         if (!editor.goToOption(option)) return false
-        SkyHanniMod.screenToOpen = GuiScreenElementWrapper(editor)
+        openEditor(editor)
         return true
     }
+
+    fun openEditor(editor: MoulConfigEditor<*>) {
+        //#if FORGE
+        SkyHanniMod.screenToOpen = GuiScreenElementWrapper(editor)
+        //#else
+        //$$ SkyHanniMod.screenToOpen = MoulConfigScreenComponent(Text.empty(), GuiContext(GuiElementComponent(editor)), null)
+        //#endif
+    }
+
+    val configScreenCurrentlyOpen: Boolean
+        get() =
+            //#if FORGE
+            Minecraft.getMinecraft().currentScreen is GuiScreenElementWrapper
+    //#else
+    //$$ MinecraftClient.getInstance().currentScreen is MoulConfigScreenComponent
+    //#endif
 
     fun String.asStructuredText() = StructuredText.of(this)
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KeyboardManager.kt
@@ -238,7 +238,7 @@ object KeyboardManager {
         false
     }
 
-    fun getKeyName(keyCode: Int): String = IMinecraft.instance.getKeyName(keyCode)
+    fun getKeyName(keyCode: Int): String = IMinecraft.INSTANCE.getKeyName(keyCode).toString()
 
     object WasdInputMatrix : Iterable<KeyBinding> {
         operator fun contains(keyBinding: KeyBinding) = when (keyBinding) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.utils.ColorUtils.getFirstColorCode
+import at.hannibal2.skyhanni.utils.ConfigUtils.asStructuredText
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RegexUtils.findAll
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -206,9 +207,9 @@ object StringUtils {
         //#else
         //$$ fun String.splitLines(width: Int): String = splitText(
         //#endif
-        this,
+        this.asStructuredText(),
         width,
-    ).joinToString("\n") { it.removePrefix("§r") }
+    ).joinToString("\n") { it.toString().removePrefix("§r") }
 
     //#if MC > 1.21
     //$$ private fun splitText(text: String, width: Int): List<String> {

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -204,10 +204,11 @@ object StringUtils {
 
     //#if FORGE
     fun String.splitLines(width: Int): String = ForgeFontRenderer(Minecraft.getMinecraft().fontRendererObj).splitText(
+        this.asStructuredText(),
         //#else
         //$$ fun String.splitLines(width: Int): String = splitText(
+        //$$ this,
         //#endif
-        this.asStructuredText(),
         width,
     ).joinToString("\n") { it.toString().removePrefix("§r") }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.darker
+import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.GuiRenderUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.LEFT_MOUSE
@@ -34,7 +35,6 @@ import at.hannibal2.skyhanni.utils.renderables.container.table.SearchableScrollT
 import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
 import at.hannibal2.skyhanni.utils.renderables.primitives.placeholder
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import io.github.notenoughupdates.moulconfig.gui.GuiScreenElementWrapper
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiIngameMenu
 import net.minecraft.client.gui.inventory.GuiEditSign
@@ -325,7 +325,7 @@ interface Renderable {
                 ToolTipData.lastSlot == null
                     || GuiData.preDrawEventCancelled
             } else true
-            val isConfigScreen = guiScreen !is GuiScreenElementWrapper
+            val isConfigScreen = !ConfigUtils.configScreenCurrentlyOpen
 
             val openGui = guiScreen.javaClass.name ?: "none"
             val isInNeuPv = openGui == "io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer"
@@ -626,7 +626,7 @@ interface Renderable {
                     //#if MC < 1.21
                     GuiRenderUtils.drawTexturedRect(
                         mouseOffsetX, mouseOffsetY, width, height, uMin, uMax, vMin, vMax, createResourceLocation(texture.path),
-                        alpha = 1f, filter = GL11.GL_NEAREST
+                        alpha = 1f, filter = GL11.GL_NEAREST,
                     )
                     //#else
                     //$$ if (texture == SkillProgressBarConfig.TexturedBar.UsedTexture.MATCH_PACK) {
@@ -645,7 +645,7 @@ interface Renderable {
                         GuiRenderUtils.drawTexturedRect(
                             mouseOffsetX, mouseOffsetY, progress, height, uMin, uMin + (progress * scale),
                             vMin + (height * scale), vMin + (2 * height * scale), createResourceLocation(texture.path),
-                            alpha = 1f, filter = GL11.GL_NEAREST
+                            alpha = 1f, filter = GL11.GL_NEAREST,
                         )
                         //#else
                         //$$ if (texture == SkillProgressBarConfig.TexturedBar.UsedTexture.MATCH_PACK) {
@@ -662,7 +662,7 @@ interface Renderable {
                         GuiRenderUtils.drawTexturedRect(
                             mouseOffsetX, mouseOffsetY, progress, height, uMin, uMin + (progress * scale),
                             vMin + (height * scale), vMin + (2 * height * scale), createResourceLocation(texture.path),
-                            alpha = 1f, filter = GL11.GL_NEAREST
+                            alpha = 1f, filter = GL11.GL_NEAREST,
                         )
                         //#else
                         //$$ if (texture == SkillProgressBarConfig.TexturedBar.UsedTexture.MATCH_PACK) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternGui.kt
@@ -5,12 +5,19 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ConfigUtils.asStructuredText
 import io.github.notenoughupdates.moulconfig.common.MyResourceLocation
-import io.github.notenoughupdates.moulconfig.gui.GuiComponentWrapper
+import io.github.notenoughupdates.moulconfig.common.text.StructuredText
 import io.github.notenoughupdates.moulconfig.gui.GuiContext
 import io.github.notenoughupdates.moulconfig.observer.ObservableList
 import io.github.notenoughupdates.moulconfig.xml.Bind
 import io.github.notenoughupdates.moulconfig.xml.XMLUniverse
+//#if FORGE
+import io.github.notenoughupdates.moulconfig.gui.GuiComponentWrapper
+//#else
+//$$ import io.github.notenoughupdates.moulconfig.platform.MoulConfigScreenComponent
+//$$ import net.minecraft.text.Text
+//#endif
 
 /**
  * Gui for analyzing [RepoPattern]s
@@ -33,7 +40,11 @@ class RepoPatternGui private constructor() {
                     val location = MyResourceLocation("skyhanni", "gui/regexes.xml")
                     val universe = XMLUniverse.getDefaultUniverse()
                     val context = GuiContext(universe.load(RepoPatternGui(), location))
+                    //#if FORGE
                     SkyHanniMod.screenToOpen = GuiComponentWrapper(context)
+                    //#else
+                    //$$ SkyHanniMod.screenToOpen = MoulConfigScreenComponent(Text.empty(), context, null)
+                    //#endif
                 }
             }
         }
@@ -52,7 +63,7 @@ class RepoPatternGui private constructor() {
     ) {
 
         @field:Bind
-        val key: String = repoPatternImpl.key
+        val key: StructuredText = repoPatternImpl.key.asStructuredText()
 
         val remoteData = when (repoPatternImpl) {
             is RepoPatternList -> repoPatternImpl.value.map { it.pattern() }
@@ -60,7 +71,7 @@ class RepoPatternGui private constructor() {
         }
 
         @field:Bind
-        val regex: String = remoteData.joinToString("\n")
+        val regex: StructuredText = remoteData.joinToString("\n").asStructuredText()
 
         @field:Bind
         val hoverRegex: List<String> = run {
@@ -84,20 +95,21 @@ class RepoPatternGui private constructor() {
         val keyW = listOf(key)
 
         @field:Bind
-        val overriden: String =
+        val overriden: StructuredText = (
             if (repoPatternImpl.wasOverridden) "§9Overriden"
             else if (repoPatternImpl.isLoadedRemotely) "§aRemote"
             else "§cLocal"
+            ).asStructuredText()
     }
 
     @Bind
-    fun poll(): String {
+    fun poll(): StructuredText {
         if (search != lastSearch) {
             searchCache.clear()
-            searchCache.addAll(allKeys.filter { search in it.key })
+            searchCache.addAll(allKeys.filter { search in it.key.text })
             lastSearch = search
         }
-        return ""
+        return "".asStructuredText()
     }
 
     @Bind

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/compat/ConfigModMenuInterop.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/compat/ConfigModMenuInterop.kt
@@ -3,11 +3,18 @@ package at.hannibal2.skyhanni.compat
 import at.hannibal2.skyhanni.config.ConfigGuiManager
 import com.terraformersmc.modmenu.api.ConfigScreenFactory
 import com.terraformersmc.modmenu.api.ModMenuApi
-import io.github.notenoughupdates.moulconfig.gui.GuiElementWrapper
+import io.github.notenoughupdates.moulconfig.gui.GuiContext
+import io.github.notenoughupdates.moulconfig.gui.GuiElementComponent
+import io.github.notenoughupdates.moulconfig.platform.MoulConfigScreenComponent
 import net.minecraft.client.gui.screen.Screen
+import net.minecraft.text.Text
 
 class ConfigModMenuInterop : ModMenuApi {
     override fun getModConfigScreenFactory(): ConfigScreenFactory<*> {
-        return ConfigScreenFactory<Screen> { GuiElementWrapper(ConfigGuiManager.getEditorInstance()) }
+        return ConfigScreenFactory<Screen> {
+            MoulConfigScreenComponent(
+                Text.empty(), GuiContext(GuiElementComponent(ConfigGuiManager.getEditorInstance())), null,
+            )
+        }
     }
 }

--- a/versions/mapping-1.16.5-forge-1.8.9.txt
+++ b/versions/mapping-1.16.5-forge-1.8.9.txt
@@ -11,8 +11,6 @@ com.mojang.blaze3d.systems.RenderSystem blendFuncSeparate() tryBlendFuncSeparate
 com.mojang.blaze3d.systems.RenderSystem disableDepthTest() disableDepth()
 com.mojang.blaze3d.systems.RenderSystem enableDepthTest() enableDepth()
 
-io.github.notenoughupdates.moulconfig.gui.GuiElementWrapper io.github.notenoughupdates.moulconfig.gui.GuiScreenElementWrapper
-
 net.minecraft.ChatFormatting net.minecraft.util.EnumChatFormatting
 
 net.minecraft.block.ButtonBlock net.minecraft.block.BlockButtonWood


### PR DESCRIPTION
## What
Update moulconfig.
- Fixes the config option text not having colours
- Fixed the arrows in the config on 1.21.8

Bumped preprocessor as i needed it bumped to build
I was told the /shrepopatterns gui was already broken on 1.8 so i didnt make that work

## Changelog Fixes
+ Fixed config options on modern versions not having colored text. - CalMWolfs
+ Fixed arrows rendering incorrectly in the config on 1.21.8. - CalMWolfs

## Changelog Technical Details
+ Bumped moulconfig and preprocessor. - CalMWolfs
