### PR TITLE
Fix: Attribtue shards in Instance Chest Profit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -37,6 +37,7 @@ object InstanceChestProfit {
 
     /**
      * REGEX-TEST: §6Kraken Shard §8x1
+     * REGEX-TEST: §6Apex Dragon Shard §8x1
      */
     private val attributeShardPattern by patternGroup.pattern(
         "attributeshard",

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -40,7 +40,7 @@ object InstanceChestProfit {
      */
     private val attributeShardPattern by patternGroup.pattern(
         "attributeshard",
-        "§.(?<name>\\w+ Shard) §.x(?<count>\\d+)",
+        "§.(?<name>.+ Shard) §.x(?<count>\\d+)",
     )
 
     /**


### PR DESCRIPTION
fixed attribute shard pattern for Apex + Power Dragon in Instance Chest Profit overlay for any shards with more than 1 word in its name.

<img width="373" height="395" alt="image" src="https://github.com/user-attachments/assets/2587567d-b962-47b2-8460-2a83028bc1a2" />
also since I did just remember that it does say "should work" in the commit, here's it working

exclude_from_changelog
