### PR TITLE
Backend: Update for regex101 delimiter change

### DIFF
--- a/.live-plugins/regexr/plugin.kts
+++ b/.live-plugins/regexr/plugin.kts
@@ -82,7 +82,7 @@ inner class RenameKotlinFunctionToUseCamelCaseIntention : PsiElementBaseIntentio
 
     override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
         val info = findRegexInfo(element) ?: return
-        val regex = info.getRegexText()?.replace("/", "\\/")
+        val regex = info.getRegexText()?.replace("\"", "\\\"")
         if (regex == null) {
             show("Regex needs to be a bare string literal in order to open it in the browser!")
             return

--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -20,7 +20,7 @@ class RepoPatternElement private constructor(
     val pattern by lazy { rawPattern.toPattern() }
 
     val regex101Url: String by lazy {
-        val encodedPattern = URLEncoder.encode(rawPattern.replace("/", "\\/"), "UTF-8")
+        val encodedPattern = URLEncoder.encode(rawPattern.replace("\"", "\\\""), "UTF-8")
         val urlEncodedNewLine = URLEncoder.encode("\n", "UTF-8")
         val encodedTests = regexTests.joinToString(urlEncodedNewLine) { URLEncoder.encode(it, "UTF-8") }
         "https://regex101.com/?regex=$encodedPattern&testString=$encodedTests&flavor=java"


### PR DESCRIPTION
Regex101 seems to be forcing `"` delimiter for the Java flavor now, so I've updated the relevant code to escape that delimiter instead of `/`.

exclude_from_changelog