### PR TITLE
Fix: Dragon profit concurrent modification error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
@@ -28,15 +28,7 @@ object ProfitPerDragon {
     private fun scanForLoot() {
         val entities = EntityUtils.getEntities<EntityArmorStand>()
 
-        val scannedLootIterator = scannedLootUUIDs.iterator()
-
-        while (scannedLootIterator.hasNext()) {
-            val uuid = scannedLootIterator.next()
-
-            if (entities.none { it.uniqueID == uuid }) {
-                scannedLootIterator.remove()
-            }
-        }
+        scannedLootUUIDs.removeIf { uuid -> entities.none { it.uniqueID == uuid} }
 
         for (entity in entities) {
             val entityName = entity.name

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
@@ -28,7 +28,7 @@ object ProfitPerDragon {
     private fun scanForLoot() {
         val entities = EntityUtils.getEntities<EntityArmorStand>()
 
-        scannedLootUUIDs.removeIf { uuid -> entities.none { it.uniqueID == uuid} }
+        scannedLootUUIDs.removeIf { uuid -> entities.none { it.uniqueID == uuid } }
 
         for (entity in entities) {
             val entityName = entity.name

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
@@ -28,9 +28,13 @@ object ProfitPerDragon {
     private fun scanForLoot() {
         val entities = EntityUtils.getEntities<EntityArmorStand>()
 
-        for (uuid in scannedLootUUIDs) {
+        val scannedLootIterator = scannedLootUUIDs.iterator()
+
+        while (scannedLootIterator.hasNext()) {
+            val uuid = scannedLootIterator.next()
+
             if (entities.none { it.uniqueID == uuid }) {
-                scannedLootUUIDs.remove(uuid)
+                scannedLootIterator.remove()
             }
         }
 


### PR DESCRIPTION
## What
Addresses the dragon profit concurrent modification error

```
SkyHanni 4.18.0 1.8.9: Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.combat.end.ProfitPerDragon.onTick(at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent) at SkyHanniTickEvent: null
 
Caused by java.util.ConcurrentModificationException: null
    at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:711)
    at java.util.LinkedHashMap$LinkedKeyIterator.next(LinkedHashMap.java:734)
    at SH.features.combat.end.ProfitPerDragon.scanForLoot(ProfitPerDragon.kt:31)
    at SH.features.combat.end.ProfitPerDragon.onTick(ProfitPerDragon.kt:141)
    at SH.utils.ReflectionUtils$$Lambda$1576/498657274.accept(Unknown Source)
<Skyhanni event post>
```

<details>
<summary>Extreme example of adding all spawned entities to the scanned loot uuid's showing that no error is caused by removing items</summary>
<!-- drop images here -->
<img width="671" height="209" alt="image" src="https://github.com/user-attachments/assets/77bb3f06-a1ac-45c3-bb12-3cdab33b9565" />
</details>

## Changelog Fixes
+ Fixed Dragon Profit Display failing to handle rare drops. - Stuflo19

