### PR TITLE
Backend: Optimize SimpleTimeMark & bring ServerTimeMark in line

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
@@ -104,11 +104,11 @@ object GoldenFishTimer {
     private var lastFishEntity = SimpleTimeMark.farPast()
     private var lastChatMessage = SimpleTimeMark.farPast()
 
-    private var lastGoldenFishTime = ServerTimeMark.FAR_PAST
+    private var lastGoldenFishTime = ServerTimeMark.farPast()
 
-    private var lastRodThrowTime = ServerTimeMark.FAR_PAST
-    private var goldenFishDespawnTimer = ServerTimeMark.FAR_FUTURE
-    private var timePossibleSpawn = ServerTimeMark.FAR_FUTURE
+    private var lastRodThrowTime = ServerTimeMark.farPast()
+    private var goldenFishDespawnTimer = ServerTimeMark.farFuture()
+    private var timePossibleSpawn = ServerTimeMark.farFuture()
 
     private val isFishing get() = FishingApi.isFishing() || lastRodThrowTime.passedSince() < maxRodTime
     private var hasLavaRodInInventory = false
@@ -292,8 +292,8 @@ object GoldenFishTimer {
         if (!isActive()) return
 
         if (lastRodThrowTime.passedSince() > maxRodTime) {
-            timePossibleSpawn = ServerTimeMark.FAR_FUTURE
-            lastRodThrowTime = ServerTimeMark.FAR_PAST
+            timePossibleSpawn = ServerTimeMark.farFuture()
+            lastRodThrowTime = ServerTimeMark.farPast()
         }
         if (!lastRodThrowTime.isFarPast() && (lastRodThrowTime + maxRodTime).timeUntil() < config.throwRodWarningTime.seconds) {
             rodWarning()
@@ -345,10 +345,10 @@ object GoldenFishTimer {
     fun onWorldChange() {
         lastChatMessage = SimpleTimeMark.farPast()
         lastFishEntity = SimpleTimeMark.farPast()
-        lastGoldenFishTime = ServerTimeMark.FAR_PAST
+        lastGoldenFishTime = ServerTimeMark.farPast()
         possibleGoldenFishEntity = null
-        lastRodThrowTime = ServerTimeMark.FAR_PAST
-        timePossibleSpawn = ServerTimeMark.FAR_FUTURE
+        lastRodThrowTime = ServerTimeMark.farPast()
+        timePossibleSpawn = ServerTimeMark.farFuture()
         interactions = 0
         display = null
         removeGoldenFish()
@@ -391,7 +391,7 @@ object GoldenFishTimer {
     }
 
     private fun removeGoldenFish() {
-        goldenFishDespawnTimer = ServerTimeMark.FAR_FUTURE
+        goldenFishDespawnTimer = ServerTimeMark.farFuture()
         confirmedGoldenFishEntity?.let {
             confirmedGoldenFishEntity = null
             RenderLivingEntityHelper.removeEntityColor(it)

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -74,7 +74,7 @@ object VampireSlayerFeatures {
     private val KILLER_SPRING_TEXTURE by lazy { SkullTextureHolder.getTexture("KILLER_SPRING") }
 
     private var nextClawSend = 0L
-    private var lastWitherSpawnSound = ServerTimeMark.FAR_PAST
+    private var lastWitherSpawnSound = ServerTimeMark.farPast()
 
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ServerTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ServerTimeMark.kt
@@ -49,8 +49,11 @@ value class ServerTimeMark private constructor(val ticks: Long) : Comparable<Ser
         private const val FAR_PAST_TICKS = Long.MIN_VALUE
         private const val FAR_FUTURE_TICKS = Long.MAX_VALUE
 
-        val FAR_PAST = ServerTimeMark(FAR_PAST_TICKS)
-        val FAR_FUTURE = ServerTimeMark(FAR_FUTURE_TICKS)
+        private val FAR_PAST = ServerTimeMark(FAR_PAST_TICKS)
+        private val FAR_FUTURE = ServerTimeMark(FAR_FUTURE_TICKS)
+
+        fun farPast() = FAR_PAST
+        fun farFuture() = FAR_FUTURE
 
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
@@ -29,9 +29,9 @@ value class SimpleTimeMark(private val millis: Long) : Comparable<SimpleTimeMark
 
     fun isInFuture() = timeUntil().isPositive()
 
-    fun isFarPast() = millis == 0L
+    fun isFarPast() = millis == FAR_PAST_MS
 
-    fun isFarFuture() = millis == Long.MAX_VALUE
+    fun isFarFuture() = millis == FAR_FUTURE_MS
 
     fun takeIfInitialized() = if (isFarPast() || isFarFuture()) null else this
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
@@ -71,10 +71,16 @@ value class SimpleTimeMark(private val millis: Long) : Comparable<SimpleTimeMark
 
         fun now() = SimpleTimeMark(System.currentTimeMillis())
 
+        private const val FAR_PAST_MS = 0L
+        private const val FAR_FUTURE_MS = Long.MAX_VALUE
+
+        private val FAR_PAST = SimpleTimeMark(FAR_PAST_MS)
+        private val FAR_FUTURE = SimpleTimeMark(FAR_FUTURE_MS)
+
         @JvmStatic
         @JvmName("farPast")
-        fun farPast() = SimpleTimeMark(0)
-        fun farFuture() = SimpleTimeMark(Long.MAX_VALUE)
+        fun farPast() = FAR_PAST
+        fun farFuture() = FAR_FUTURE
 
         fun Duration.fromNow() = now() + this
 


### PR DESCRIPTION
## What
A small optimization to `SimpleTimeMark`, as well as making `ServerTimeMark`'s interface consistent with it.

## Changelog Technical Details
+ Optimized `SimpleTimeMark` to avoid recomputing `farPast` and `farFuture`. - Luna
+ Changed the interface of `ServerTimeMark` to match `SimpleTimeMark`. - Luna