### PR TITLE
Fix: some items incorrectly being converted to enchant book format

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -91,8 +91,10 @@ class NeuInternalName private constructor(private val internalName: String) {
         get() = when {
             isPet -> internalName.split(";").first()
             isEnchantedBook -> {
-                val (name, level) = internalName.split(";", limit = 2)
-                "ENCHANTED_BOOK_${name}_$level"
+                if (internalName.contains(";")) {
+                    val (name, level) = internalName.split(";", limit = 2)
+                    "ENCHANTED_BOOK_${name}_$level"
+                } else internalName
             }
 
             else -> internalName


### PR DESCRIPTION
first time doing anything in kotlin

## What
Checks if "Enchanted Book" items are actually enchanted books before converting them to Skyblock's enchanted book format.

## Changelog Fixes
+ Fixed the /viewrecipe command failing for some items. - AfkUserMC