### PR TITLE
Fix: missing damage indicator options

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/CrimsonIsleConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/CrimsonIsleConfig.kt
@@ -89,4 +89,9 @@ class CrimsonIsleConfig {
     @Expose
     @ConfigLink(owner = CrimsonIsleConfig::class, field = "showDojoRankDisplay")
     val dojoRankDisplayPosition: Position = Position(-378, 206)
+
+    @Expose
+    @ConfigOption(name = "Magma Boss Phase", desc = "Show the current phase of the Magma Boss.")
+    @ConfigEditorBoolean
+    var magmaBossDisplay: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/colosseum/ColosseumConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/colosseum/ColosseumConfig.kt
@@ -17,4 +17,9 @@ class ColosseumConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var tentacleWaypoints: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Bacte Phase", desc = "Show the current phase of Bacte.")
+    @ConfigEditorBoolean
+    var bactePhaseDisplay: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
@@ -16,6 +16,11 @@ import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 class SlayerConfig {
 
     @Expose
+    @ConfigOption(name = "Zombie", desc = "")
+    @Accordion
+    val zombie: ZombieConfig = ZombieConfig()
+
+    @Expose
     @ConfigOption(name = "Spider", desc = "")
     @Accordion
     val spider: SpiderConfig = SpiderConfig()

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/ZombieConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/ZombieConfig.kt
@@ -1,0 +1,13 @@
+package at.hannibal2.skyhanni.config.features.slayer
+
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class ZombieConfig {
+
+    @Expose
+    @ConfigOption(name = "Boom Display", desc = "Show BOOM for Revenant 5 when the boss is about to explode.")
+    @ConfigEditorBoolean
+    var boomDisplay: Boolean = false
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/blaze/BlazeHellionConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/blaze/BlazeHellionConfig.kt
@@ -9,10 +9,13 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class BlazeHellionConfig {
+
+
+    // TODO rename to highlight phase or similar
     @Expose
     @ConfigOption(
         name = "Colored Mobs",
-        desc = "Color the Blaze Slayer boss and the demons in the right hellion shield color."
+        desc = "Color the Blaze Slayer boss and the demons in the right hellion shield color and show the name."
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/spider/SpiderConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/spider/SpiderConfig.kt
@@ -21,4 +21,9 @@ class SpiderConfig {
     @ConfigEditorColour
     val highlightInvincibleColor: Property<ChromaColour> = Property.of(ChromaColour.fromStaticRGB(255, 255, 0, 60))
 
+    @Expose
+    @ConfigOption(name = "Phase Display", desc = "Show the current phase of the Tara 5 Slayer boss.")
+    @ConfigEditorBoolean
+    var phaseDisplay: Boolean = false
+
 }


### PR DESCRIPTION
## What
after the recent "separated dmg indicator highlgihts from actual dmg indicator toggle" change, many small lines remained untoggleable without disabling dmg indicator in the dev config.

## Changelog Fixes
+ Fixed missing toggles for many various Damage Indicator-related features. - hannibal2
    * Includes: Magma Boss (Crimson Isle) phase, Bacte (Rift) phase, Zombie Slayer Boom, Blaze Slayer Helion Shield name, Spider Slayer phase.
    * These options are disabled by default. If you use Damage Indicator, please re-enable them.