### PR TITLE
Fix: add epilepsy warning to cf party mode.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/CFConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/chocolatefactory/CFConfig.kt
@@ -258,7 +258,7 @@ class CFConfig {
     @Expose
     @ConfigOption(
         name = "§6CF §zParty Mode",
-        desc = "Don't turn this on.\n§cRequires SkyHanni Chroma to be enabled to fully function.",
+        desc = "Don't turn this on. Epilepsy Warning.\n§cRequires SkyHanni Chroma to be enabled to fully function.",
     )
     @ConfigEditorBoolean
     val partyMode: Property<Boolean> = Property.of(false)


### PR DESCRIPTION
Noticed there was no epilepsy warning. Probably should be one. 

exclude_from_changelog