### PR TITLE
Fix: Rename pest/plot regex

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
@@ -108,7 +108,7 @@ object GardenPlotApi {
      * REGEX-TEST: Spray: §r§aHoney Jar §r§7(53s)
      */
     private val plotSprayedTablistPattern by patternGroup.pattern(
-        "tablist.spray",
+        "tablist.spraytime",
         "Spray: §r§[7a](?<spray>[\\w\\s]+)(?:§r§7\\((?<time>.*)\\))?",
     )
     var plots = listOf<Plot>()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -59,7 +59,7 @@ object PestSpawnTimer {
      */
 
     private val pestCooldownPattern by patternGroup.pattern(
-        "cooldown",
+        "cooldowntime",
         "\\sCooldown: §r§.(?:§.)?(?<time>\\d{1,2}[ms](?: \\d{1,2}s?)?)?(?<ready>READY)?(?<maxPests>MAX PESTS)?.*",
     )
 


### PR DESCRIPTION
exclude_from_changelog
#4678 Changed groupings of existing regexes without renaming them, causing issues with prior versions. Renamed them here.
