### PR TITLE
Backend: Don't store entities in two spots

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.features.misc
 
-
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
@@ -15,10 +14,8 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat.Companion.hasPotionEffect
 import net.minecraft.client.entity.EntityPlayerSP
-import net.minecraft.entity.Entity
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
-
 
 @SkyHanniModule
 object HideArmor {
@@ -75,22 +72,5 @@ object HideArmor {
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(91, "misc.hideArmor2", "misc.hideArmor")
 
-    }
-
-    private val CURRENT_RENDERED_ENTITY: ThreadLocal<Entity> = ThreadLocal<Entity>()
-
-    @JvmStatic
-    fun setCurrentEntity(entity: Entity) {
-        CURRENT_RENDERED_ENTITY.set(entity)
-    }
-
-    @JvmStatic
-    fun getCurrentEntity(): Entity? {
-        return CURRENT_RENDERED_ENTITY.get()
-    }
-
-    @JvmStatic
-    fun clearCurrentEntity() {
-        CURRENT_RENDERED_ENTITY.remove()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderManager.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderManager.java
@@ -8,12 +8,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-//#if MC > 1.21
-//$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-//$$ import at.hannibal2.skyhanni.features.misc.HideArmor;
-//$$ import net.minecraft.client.util.math.MatrixStack;
-//$$ import net.minecraft.client.render.VertexConsumerProvider;
-//#endif
 
 @Mixin(RenderManager.class)
 public class MixinRenderManager {
@@ -24,16 +18,4 @@ public class MixinRenderManager {
             cir.setReturnValue(false);
         }
     }
-
-    //#if MC > 1.21
-    //$$ @Inject(method = "render(Lnet/minecraft/entity/Entity;DDDFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At("HEAD"))
-    //$$ private void onRenderStart(Entity entity, double x, double y, double z, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-    //$$     HideArmor.setCurrentEntity(entity);
-    //$$ }
-    //$$
-    //$$ @Inject(method = "render(Lnet/minecraft/entity/Entity;DDDFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At("RETURN"))
-    //$$ private void onRenderEnd(Entity entity, double x, double y, double z, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-    //$$     HideArmor.clearCurrentEntity();
-    //$$ }
-    //#endif
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/HideArmorHook.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/HideArmorHook.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.features.misc.HideArmor
 import net.minecraft.entity.EquipmentSlot
 import net.minecraft.entity.player.PlayerEntity
 
-fun shouldHideArmor(): Boolean = HideArmor.getCurrentEntity()?.let {
+fun shouldHideArmor(): Boolean = getEntity()?.let {
     it is PlayerEntity && HideArmor.shouldHideArmor(it)
 } ?: false
 


### PR DESCRIPTION
## What
Entities already get stored in `EntityRenderDispatcherHook` there is no reason to also store them in `HideArmor`. Plus with 1.21.9 changing around entity rendering a bit its much easier to just have to fix one instance of entity storage

## Changelog Technical Details
+ Hide Armor now uses the stored entity in EntityRenderDispatcherHook like every other feature. - CalMWolfs

