### PR TITLE
Feature: Call shortening

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
@@ -68,6 +68,16 @@ class CommandsConfig {
     @FeatureToggle
     var shortenCall: Boolean = false
 
+    @ConfigOption(
+        name = "Warp or call on §e/forge",
+        desc = "If both §e/warp§7 and §e/call§7 shortening features enabled, controls §e/forge§7 behaviour\n" +
+            "When disabled, §e/forge§7 does §e/warp forge§7. Otherwise §e/forge§7 does §e/call forge§7. Or you can just use §e/fred§7 ",
+    )
+    @Expose
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var shortenForgeToCallNotWarp: Boolean = false
+
     @Expose
     @ConfigOption(name = "Replace §e/warp is", desc = "Add §e/warp is §7alongside §e/is§7. Idk why. Ask §cKaeso")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
@@ -69,14 +69,14 @@ class CommandsConfig {
     var shortenCall: Boolean = false
 
     @ConfigOption(
-        name = "Warp or call on §e/forge",
-        desc = "If both §e/warp§7 and §e/call§7 shortening features enabled, controls §e/forge§7 behaviour\n" +
-            "When disabled, §e/forge§7 does §e/warp forge§7. Otherwise §e/forge§7 does §e/call forge§7. Or you can just use §e/fred§7 ",
+        name = "Warp or call on shortening conflicts (e.g. §e/forge§7)",
+        desc = "If both §e/warp§7 and §e/call§7 shortening features enabled, controls behaviour on conflicts\n" +
+            "Example for §e/forge§7: when disabled, §e/forge§7 does §e/warp forge§7. Otherwise §e/forge§7 does " +
+            "§e/call forge§7. Or you can just use §e/fred§7",
     )
     @Expose
     @ConfigEditorBoolean
-    @FeatureToggle
-    var shortenForgeToCallNotWarp: Boolean = false
+    var preferCallOverWarp: Boolean = false
 
     @Expose
     @ConfigOption(name = "Replace §e/warp is", desc = "Add §e/warp is §7alongside §e/is§7. Idk why. Ask §cKaeso")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/CommandsConfig.kt
@@ -59,6 +59,15 @@ class CommandsConfig {
     @FeatureToggle
     var shortenWarp: Boolean = false
 
+    @ConfigOption(
+        name = "Shorten §e/call",
+        desc = "Allows calling without the need for the §ecall §7prefix.\n(§e/call maddox §7-> §e/maddox§7)",
+    )
+    @Expose
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var shortenCall: Boolean = false
+
     @Expose
     @ConfigOption(name = "Replace §e/warp is", desc = "Add §e/warp is §7alongside §e/is§7. Idk why. Ask §cKaeso")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenCallCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenCallCommand.kt
@@ -1,0 +1,108 @@
+package at.hannibal2.skyhanni.features.commands
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.MessageSendToServerEvent
+import at.hannibal2.skyhanni.events.chat.TabCompletionEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.HypixelCommands
+
+@SkyHanniModule
+object ShortenCallCommand {
+
+    private val config get() = SkyHanniMod.feature.misc.commands
+
+    // These are supposed to be in constants in that repo hannibal owns I guess
+    private val calls = mutableListOf(
+        "alchemist",
+        "anita",
+        "aranya",
+        "blacksmith",
+        "brynmor",
+        "builder",
+        "ahone",
+        "dean",
+        "duncan",
+        "dusk",
+        "einary",
+        "elizabeth",
+        "elle",
+        "fann",
+        "fearmongerer",
+        "fred",
+        "geo",
+        "george",
+        "hoppity",
+        "igrupan",
+        "jacob",
+        "jax",
+        "jotraeline",
+        "jotraelinegreatforge", // same as jotraeline
+        "forge", // same as  jotraeline
+        "kat",
+        "kaus",
+        "kiara",
+        "kuudra",
+        "kuudragatekeeper", // same as kuudra
+        "lumber",
+        "maddox",
+        "slayer", // same as  maddox
+        "maxwell",
+        "mort",
+        "odger",
+        "ophelia",
+        "oringo",
+        "pablo",
+        "plumberjoe",
+        "plumber", // same as plumberjoe
+        "mismyla",
+        "nyx",
+        "roddy",
+        "rollim",
+        "rusty",
+        "shifty",
+        "sirih",
+        "sirius",
+        "stjerry",
+        "suus",
+        "tiathefairy",
+        "tia", // same as tia the fairy
+        "tomioka",
+        "trevor",
+        "trinity",
+        "vincent",
+        "walter",
+        "woolweaver",
+        "wool", // same as woolweaver
+        "zog",
+        "bingo",
+        "alixer"
+    )
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onMessageSendToServer(event: MessageSendToServerEvent) {
+        if (!config.shortenCall) return
+
+        val message = event.message
+        if (!message.startsWith("/")) return
+
+        val command = message.lowercase().removePrefix("/").trimEnd()
+
+        if (command in calls) {
+            event.cancel()
+            HypixelCommands.call(command)
+        }
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onTabComplete(event: TabCompletionEvent) {
+        if (!config.shortenCall) return
+
+        if (event.leftOfCursor.contains(" ")) return
+
+        val lastWord = event.lastWord.lowercase().removePrefix("/")
+        val matchingCalls = calls.filter { it.startsWith(lastWord) }.map { "/$it" }
+
+        event.addSuggestions(matchingCalls)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenCallCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenCallCommand.kt
@@ -24,8 +24,9 @@ object ShortenCallCommand {
         val command = message.lowercase().removePrefix("/").trimEnd()
 
         val contacts = AbiphoneFeatures.abiphoneContacts
+        val warps = ShortenWarpCommand.warps
         if ((contacts != null) && (command in contacts)) {
-            if (!config.shortenForgeToCallNotWarp && command == "forge") return
+            if (command in warps && !config.preferCallOverWarp) return
             event.cancel()
             HypixelCommands.call(command)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenCallCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenCallCommand.kt
@@ -4,80 +4,16 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.chat.TabCompletionEvent
+import at.hannibal2.skyhanni.features.misc.AbiphoneFeatures
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.HypixelCommands.call
+
 
 @SkyHanniModule
 object ShortenCallCommand {
 
     private val config get() = SkyHanniMod.feature.misc.commands
-
-    // These are supposed to be in constants in that repo hannibal owns I guess
-    private val calls = mutableListOf(
-        "alchemist",
-        "anita",
-        "aranya",
-        "blacksmith",
-        "brynmor",
-        "builder",
-        "ahone",
-        "dean",
-        "duncan",
-        "dusk",
-        "einary",
-        "elizabeth",
-        "elle",
-        "fann",
-        "fearmongerer",
-        "fred",
-        "geo",
-        "george",
-        "hoppity",
-        "igrupan",
-        "jacob",
-        "jax",
-        "jotraeline",
-        "jotraelinegreatforge", // same as jotraeline
-        "forge", // same as  jotraeline
-        "kat",
-        "kaus",
-        "kiara",
-        "kuudra",
-        "kuudragatekeeper", // same as kuudra
-        "lumber",
-        "maddox",
-        "slayer", // same as  maddox
-        "maxwell",
-        "mort",
-        "odger",
-        "ophelia",
-        "oringo",
-        "pablo",
-        "plumberjoe",
-        "plumber", // same as plumberjoe
-        "mismyla",
-        "nyx",
-        "roddy",
-        "rollim",
-        "rusty",
-        "shifty",
-        "sirih",
-        "sirius",
-        "stjerry",
-        "suus",
-        "tiathefairy",
-        "tia", // same as tia the fairy
-        "tomioka",
-        "trevor",
-        "trinity",
-        "vincent",
-        "walter",
-        "woolweaver",
-        "wool", // same as woolweaver
-        "zog",
-        "bingo",
-        "alixer"
-    )
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onMessageSendToServer(event: MessageSendToServerEvent) {
@@ -88,7 +24,9 @@ object ShortenCallCommand {
 
         val command = message.lowercase().removePrefix("/").trimEnd()
 
-        if (command in calls) {
+        val contacts = AbiphoneFeatures.abiphoneContacts
+        if ((contacts != null) && (command in contacts)) {
+            if (!config.shortenForgeToCallNotWarp && command == "forge") return
             event.cancel()
             HypixelCommands.call(command)
         }
@@ -101,8 +39,11 @@ object ShortenCallCommand {
         if (event.leftOfCursor.contains(" ")) return
 
         val lastWord = event.lastWord.lowercase().removePrefix("/")
-        val matchingCalls = calls.filter { it.startsWith(lastWord) }.map { "/$it" }
 
-        event.addSuggestions(matchingCalls)
+        val contacts = AbiphoneFeatures.abiphoneContacts
+        if (contacts != null) {
+            val matchingCalls = contacts.filter { it.startsWith(lastWord) }.map { "/$it" }
+            event.addSuggestions(matchingCalls)
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenCallCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenCallCommand.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.chat.TabCompletionEvent
 import at.hannibal2.skyhanni.features.misc.AbiphoneFeatures
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.HypixelCommands.call
 
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ShortenWarpCommand.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.WarpsJson
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.TabCompletionEvent
+import at.hannibal2.skyhanni.features.misc.AbiphoneFeatures
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
 
@@ -14,7 +15,8 @@ import at.hannibal2.skyhanni.utils.HypixelCommands
 object ShortenWarpCommand {
 
     private val config get() = SkyHanniMod.feature.misc.commands
-    private var warps = emptyList<String>()
+    var warps = emptyList<String>()
+        private set
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
@@ -34,7 +36,9 @@ object ShortenWarpCommand {
         if (command == "jerry" && IslandType.PRIVATE_ISLAND.isCurrent()) return
         if (command == "barn" && IslandType.GARDEN.isCurrent() && SkyHanniMod.feature.garden.gardenCommands.warpCommands) return
 
+        val contacts = AbiphoneFeatures.abiphoneContacts
         if (command in warps) {
+            if (contacts != null && command in contacts && config.preferCallOverWarp) return
             event.cancel()
             HypixelCommands.warp(command)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/AbiphoneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/AbiphoneFeatures.kt
@@ -59,13 +59,17 @@ object AbiphoneFeatures {
         AbiphoneFeatures.acceptUUID = null
     }
 
-    private var abiphoneContacts: Set<String>? = null
+    var abiphoneContacts: Set<String>? = null
+        private set
 
     @HandleEvent
     fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
         val constant = event.getConstant<Map<String, AbiphoneContactInfo>>("abiphone", NeuAbiphoneJson.TYPE)
         abiphoneContacts = constant.flatMap { (key, value) ->
-            value.callNames ?: listOf(key.removeAllNonLettersAndNumbers().replace(" ", ""))
+            // In NEU repo, callNames are optional shortenings and do not include actual contact name
+            val cleanKey = key.removeAllNonLettersAndNumbers().replace(" ", "").lowercase()
+            val aliases = value.callNames?.map { it.lowercase() } ?: listOf()
+            listOf(cleanKey) + aliases
         }.toSet()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/AbiphoneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/AbiphoneFeatures.kt
@@ -66,10 +66,12 @@ object AbiphoneFeatures {
     fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
         val constant = event.getConstant<Map<String, AbiphoneContactInfo>>("abiphone", NeuAbiphoneJson.TYPE)
         abiphoneContacts = constant.flatMap { (key, value) ->
-            // In NEU repo, callNames are optional shortenings and do not include actual contact name
             val cleanKey = key.removeAllNonLettersAndNumbers().replace(" ", "").lowercase()
-            val aliases = value.callNames.orEmpty().map { it.lowercase() }
-            listOf(cleanKey) + aliases
+            value.callNames.orEmpty().let { callNames ->
+                if (callNames.isEmpty()) listOf(cleanKey)
+                // just in case, it is not explicitly stated anywhere that they are guaranteed to be lowercase
+                else callNames.map { it.lowercase() }
+            }
         }.toSet()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/AbiphoneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/AbiphoneFeatures.kt
@@ -68,7 +68,7 @@ object AbiphoneFeatures {
         abiphoneContacts = constant.flatMap { (key, value) ->
             // In NEU repo, callNames are optional shortenings and do not include actual contact name
             val cleanKey = key.removeAllNonLettersAndNumbers().replace(" ", "").lowercase()
-            val aliases = value.callNames?.map { it.lowercase() } ?: listOf()
+            val aliases = value.callNames.orEmpty().map { it.lowercase() }
             listOf(cleanKey) + aliases
         }.toSet()
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -55,6 +55,10 @@ object HypixelCommands {
         send("warp $warp")
     }
 
+    fun call(contact: String) {
+        send("call $contact")
+    }
+
     fun island() {
         send("is")
     }


### PR DESCRIPTION
## What
Adds `/call` shortening in the same way as `/warp` shortening works. I hardcoded all the commands, but they should be added to hannibal002/SkyHanni-REPO. I suppose there is an established process of doing so. Do i just open PR there with addition of "AbiphoneContacts" or smth?

<details>
<summary>Image: after typing `/ma` and pressing `TAB` with `/call` shortening enabled</summary>
<img width="646" height="100" alt="image" src="https://github.com/user-attachments/assets/1b5a32da-33d3-4267-a6b5-742c61abfb7f" />
</details>


## Changelog New Features
+ Added `/call` shortening. - platonvin
    * Lets you write `/maddox` instead of `/call maddox`.
