### PR TITLE
Fix: Separate shard events from shard gain event

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
@@ -342,6 +342,9 @@ class ItemResolutionQuery {
         if (guiName == "Hunting Box" || guiName == "Fusion Box" || guiName == "Shard Fusion") {
             return resolveItemInHuntingBoxMenu(displayName)
         }
+        if (guiName == "Confirm Fusion") {
+            return resolveItemInHuntingBoxMenu(compound.getLore().firstOrNull() ?: return null)
+        }
         return null
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
@@ -1,0 +1,6 @@
+package at.hannibal2.skyhanni.events.item
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.utils.NeuInternalName
+
+open class ShardEvent(val shardInternalName: NeuInternalName, val amount: Int) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
@@ -3,7 +3,13 @@ package at.hannibal2.skyhanni.events.item
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.utils.NeuInternalName
 
+/**
+ * All shard events
+ */
 open class ShardEvent(val shardInternalName: NeuInternalName, val amount: Int) : SkyHanniEvent()
 
+/**
+ * Shard events that are explicitly the player gaining shards. For use in stuff like profit trackers
+ */
 class ShardGainEvent(shardInternalName: NeuInternalName, amount: Int) : ShardEvent(shardInternalName, amount)
 

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
@@ -4,3 +4,6 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.utils.NeuInternalName
 
 open class ShardEvent(val shardInternalName: NeuInternalName, val amount: Int) : SkyHanniEvent()
+
+class ShardGainEvent(shardInternalName: NeuInternalName, amount: Int) : ShardEvent(shardInternalName, amount)
+

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ShardEvent.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.utils.NeuInternalName
 
 /**
- * All shard events
+ * All shard events, e.g. fusions and syphoning
  */
 open class ShardEvent(val shardInternalName: NeuInternalName, val amount: Int) : SkyHanniEvent()
 

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ShardGainEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ShardGainEvent.kt
@@ -1,5 +1,0 @@
-package at.hannibal2.skyhanni.events.item
-
-import at.hannibal2.skyhanni.utils.NeuInternalName
-
-class ShardGainEvent(shardInternalName: NeuInternalName, amount: Int) : ShardEvent(shardInternalName, amount)

--- a/src/main/java/at/hannibal2/skyhanni/events/item/ShardGainEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/item/ShardGainEvent.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.events.item
 
-import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.utils.NeuInternalName
 
-class ShardGainEvent(val shardInternalName: NeuInternalName, val amount: Int) : SkyHanniEvent()
+class ShardGainEvent(shardInternalName: NeuInternalName, amount: Int) : ShardEvent(shardInternalName, amount)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.PurseChangeEvent
 import at.hannibal2.skyhanni.events.SackChangeEvent
-import at.hannibal2.skyhanni.events.item.ShardGainEvent
+import at.hannibal2.skyhanni.events.item.ShardEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -134,7 +134,7 @@ object ItemPickupLog {
     }
 
     @HandleEvent
-    fun onShardGain(event: ShardGainEvent) {
+    fun onShardGain(event: ShardEvent) {
         if (!isEnabled() || !config.shards) return
 
         val itemStack = event.shardInternalName.getItemStack()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
@@ -61,6 +61,9 @@ object AttributeShardsData {
         pattern = "\\(\\d+/\\d+\\) Oddities ➜ Shards".toPattern(),
         openInventory = { DelayedRun.runNextTick { AttributeShardOverlay.updateDisplay() } },
     )
+    val confirmFusionInventory = InventoryDetector(
+        openInventory = { DelayedRun.runNextTick { FusionData.updateFusionData() } },
+    ) { name -> name == "Confirm Fusion" }
 
     private var lastSyphonedMessage = SimpleTimeMark.farPast()
 
@@ -81,7 +84,7 @@ object AttributeShardsData {
      * REGEX-TEST: §7Enabled: §aYes
      * REGEX-TEST: §7Enabled: §cNo
      */
-    val attributeStatePattern by patternGroup.pattern(
+    private val attributeStatePattern by patternGroup.pattern(
         "state",
         "§7Enabled: §.(?<state>.+)",
     )
@@ -114,6 +117,14 @@ object AttributeShardsData {
     val amountOwnedPattern by patternGroup.pattern(
         "owned",
         "§7Owned: §b(?<amount>[\\d,]+) Shards?",
+    )
+
+    /**
+     * REGEX-TEST: §7Required to fuse: §b5
+     */
+    val requiredToFusePattern by patternGroup.pattern(
+        "fuse.required",
+        "§7Required to fuse: §b(?<amount>\\d)",
     )
 
     /**
@@ -189,14 +200,14 @@ object AttributeShardsData {
     )
 
     /**
-     * REGEX-TEST: §5§lFUSION! §r§7You obtained §r§9Bolt Shard §r§8x2§r§7!
-     * REGEX-TEST: §5§lFUSION! §r§7You obtained §r§9Bolt Shard §r§8x2§r§7! §r§d§lNEW!
-     * REGEX-TEST: §5§lFUSION! §r§7You obtained a §r§fTadgang Shard§r§7!
-     * REGEX-TEST: §5§lFUSION! §r§7You obtained a §r§fTadgang Shard§r§7! §r§d§lNEW!
+     * REGEX-TEST: §5§lFUSION! §7You obtained §9Bolt Shard §8x2§7!
+     * REGEX-TEST: §5§lFUSION! §7You obtained §9Bolt Shard §8x2§7! §d§lNEW!
+     * REGEX-TEST: §5§lFUSION! §7You obtained a §fTadgang Shard§7!
+     * REGEX-TEST: §5§lFUSION! §7You obtained a §fTadgang Shard§7! §d§lNEW!
      */
     private val fusionShardPattern by patternGroup.pattern(
         "fusion.shard",
-        "§5§lFUSION! §r§7You obtained(?: an?)? (?:§.)+(?<shardName>.+) Shard(?: §r§8x(?<amount>\\d+))?§r§7!(?: §r§d§lNEW!)?",
+        "§5§lFUSION! §7You obtained(?: an?)? (?:§.)+(?<shardName>.+) Shard(?: §8x(?<amount>\\d+))?§7!(?: §d§lNEW!)?",
     )
 
     /**
@@ -226,7 +237,6 @@ object AttributeShardsData {
         caughtShardsPattern to true,
         lootShareShardPattern to true,
         charmedShardPattern to true,
-        fusionShardPattern to false,
         sentToHuntingBoxPattern to false,
     )
 
@@ -317,6 +327,14 @@ object AttributeShardsData {
                 }
                 return
             }
+        }
+
+        fusionShardPattern.matchMatcher(event.message) {
+            val currentFusionData = FusionData.currentFusionData ?: return
+            val amount = groupOrNull("amount")?.toInt() ?: 1
+            ShardEvent(currentFusionData.outputShard, amount).post()
+            ShardEvent(currentFusionData.firstShard.internalName, -currentFusionData.firstShard.amount).post()
+            ShardEvent(currentFusionData.secondShard.internalName, -currentFusionData.secondShard.amount).post()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuAttributeShardJson
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.item.ShardEvent
 import at.hannibal2.skyhanni.events.item.ShardGainEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -221,12 +222,12 @@ object AttributeShardsData {
         "§7You sent (?:§a)?(?:an?|(?<amount>\\d+)) §.(?<shardName>.+) Shards? §7to your §aHunting Box§7.",
     )
 
-    private val shardChatPatterns = setOf(
-        caughtShardsPattern,
-        lootShareShardPattern,
-        fusionShardPattern,
-        charmedShardPattern,
-        sentToHuntingBoxPattern,
+    private val shardGainChatPatterns = mapOf(
+        caughtShardsPattern to true,
+        lootShareShardPattern to true,
+        charmedShardPattern to true,
+        fusionShardPattern to false,
+        sentToHuntingBoxPattern to false,
     )
 
     @HandleEvent(priority = HandleEvent.LOWEST)
@@ -254,7 +255,7 @@ object AttributeShardsData {
             val shardInternalName = shardNameToInternalName(shardName) ?: return
             processShard(shardInternalName, level, untilNext)
 
-            ShardGainEvent(shardInternalName, -group("amount").toInt()).post()
+            ShardEvent(shardInternalName, -group("amount").toInt()).post()
 
             lastSyphonedMessage = SimpleTimeMark.now()
             return
@@ -266,7 +267,7 @@ object AttributeShardsData {
             val shardInternalName = shardNameToInternalName(shardName) ?: return
             processShard(shardInternalName, 10, 0)
 
-            ShardGainEvent(shardInternalName, -group("amount").toInt()).post()
+            ShardEvent(shardInternalName, -group("amount").toInt()).post()
 
             lastSyphonedMessage = SimpleTimeMark.now()
             return
@@ -298,7 +299,7 @@ object AttributeShardsData {
             setAttributeState(shardInternalName, false)
         }
 
-        for (pattern in shardChatPatterns) {
+        for ((pattern, shouldPostGainEvent) in shardGainChatPatterns) {
             pattern.matchMatcher(event.message) {
                 val shardName = group("shardName")
                 val amount = groupOrNull("amount")?.toInt() ?: 1
@@ -309,7 +310,11 @@ object AttributeShardsData {
                     return
                 }
 
-                ShardGainEvent(shardInternalName, amount).post()
+                if (shouldPostGainEvent) {
+                    ShardGainEvent(shardInternalName, amount).post()
+                } else {
+                    ShardEvent(shardInternalName, amount).post()
+                }
                 return
             }
         }
@@ -396,7 +401,7 @@ object AttributeShardsData {
     }
 
     @HandleEvent
-    fun onShardGain(event: ShardGainEvent) {
+    fun onShardGain(event: ShardEvent) {
         val attributeName = shardInternalNameToShardName(event.shardInternalName)
         val existing = storage?.get(attributeName)?.amountInBox ?: 0
         val newAmount = (existing + event.amount).coerceAtLeast(0)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/FusionData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/FusionData.kt
@@ -1,0 +1,50 @@
+package at.hannibal2.skyhanni.features.inventory.attribute
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
+import net.minecraft.item.ItemStack
+
+@SkyHanniModule
+object FusionData {
+
+    private const val FIRST_SHARD_SLOT = 12
+    private const val SECOND_SHARD_SLOT = 14
+    private const val OUTPUT_SHARD_SLOT = 31
+
+    var currentFusionData: CurrentFusionData? = null
+
+    fun updateFusionData() {
+        val firstShard = processShard(InventoryUtils.getItemAtSlotIndex(FIRST_SHARD_SLOT))
+        val secondShard = processShard(InventoryUtils.getItemAtSlotIndex(SECOND_SHARD_SLOT))
+        val outputShard = InventoryUtils.getItemAtSlotIndex(OUTPUT_SHARD_SLOT)?.getInternalNameOrNull()
+        if (firstShard == null || secondShard == null || outputShard == null) return
+        currentFusionData = CurrentFusionData(firstShard, secondShard, outputShard)
+    }
+
+    private fun processShard(stack: ItemStack?): FusionShard? {
+        val internalName = stack?.getInternalNameOrNull() ?: return null
+        val amount = AttributeShardsData.requiredToFusePattern.firstMatcher(stack.getLore()) {
+            group("amount").toInt()
+        } ?: return null
+        return FusionShard(internalName, amount)
+    }
+
+    @HandleEvent
+    fun onWorldChange() {
+        currentFusionData = null
+    }
+
+}
+
+data class FusionShard(val internalName: NeuInternalName, val amount: Int)
+
+data class CurrentFusionData(
+    val firstShard: FusionShard,
+    val secondShard: FusionShard,
+    val outputShard: NeuInternalName,
+)


### PR DESCRIPTION
## What
Separated generic shard stuff for internal tracking from the shard gain event that trackers use.
Fixed the pattern for shard fusions being incorrect
Fixed not subtracting the fusion costs from the stored amount in your hunting box

## Changelog Fixes
+ Fixed some profit trackers double-counting shard gains. - CalMWolfs
+ Fixed shard fusions not being tracked correctly in Attribute Shard features and Item Pickup Log. - CalMWolfs
