### PR TITLE
Fix: Composter Garden display Items sometimes not loading

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
@@ -7,9 +7,9 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/JyrreTimer.kt
@@ -7,10 +7,9 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
-import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
@@ -71,7 +70,7 @@ object JyrreTimer {
         display = drawDisplay()
     }
 
-    private val displayIcon by lazy { "REFINED_BOTTLE_OF_JYRRE".toInternalName().getItemStack() }
+    private val displayIcon by AutoUpdatingItemStack("REFINED_BOTTLE_OF_JYRRE")
 
     fun drawDisplay(): Renderable {
         duration -= 1.seconds

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -11,11 +11,11 @@ import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.SkyBlockUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -13,10 +13,9 @@ import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
-import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
@@ -42,7 +41,7 @@ object ComposterDisplay {
     private var display: Renderable? = null
     private var composterEmptyTime: Duration? = null
 
-    private val bucket by lazy { "BUCKET".toInternalName().getItemStack() }
+    private val bucket by AutoUpdatingItemStack("BUCKET")
     private var tabListData by ComposterApi::tabListData
 
     enum class DataType(rawPattern: String, val icon: String) {
@@ -51,7 +50,7 @@ object ComposterDisplay {
         TIME_LEFT(" Time Left: §r(.*)", "WATCH"),
         STORED_COMPOST(" Stored Compost: §r(.*)", "COMPOST");
 
-        val displayItem by lazy { icon.toInternalName().getItemStack() }
+        val displayItem by AutoUpdatingItemStack(icon)
 
         val pattern = rawPattern.toPattern()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.getBazaarData
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi.isBazaarItem
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPrice
@@ -34,7 +35,6 @@ import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeModifier
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addNotNull

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -31,10 +31,10 @@ import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems
-import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeModifier
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addNotNull
@@ -61,7 +61,7 @@ object CropMoneyDisplay {
     private var moneyPerHour: Map<NeuInternalName, CropMoneyData> = mutableMapOf()
     private val extraMoneyPerHour: ExtraMoneyData = ExtraMoneyData(0.0, 0.0, 0.0)
 
-    private val BOX_OF_SEEDS by lazy { "BOX_OF_SEEDS".toInternalName().getItemStack() }
+    private val BOX_OF_SEEDS by AutoUpdatingItemStack("BOX_OF_SEEDS")
     private val SEEDS = "SEEDS".toInternalName()
     private val ENCHANTED_SEEDS = "ENCHANTED_SEEDS".toInternalName()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.garden.visitor
 
 import at.hannibal2.skyhanni.config.features.garden.visitor.DropsStatisticsConfig
+import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
@@ -13,7 +14,7 @@ enum class VisitorReward(rawInternalName: String, val displayName: String) {
     GREEN_BANDANA("GREEN_BANDANA", "§9Green Bandana"),
     DEDICATION("DEDICATION;4", "§9Dedication IV"),
     MUSIC_RUNE("MUSIC_RUNE;1", "§9Music Rune"),
-    SPACE_HELMET("DCTR_SPACE_HELM", "§cSpace Helmet",),
+    SPACE_HELMET("DCTR_SPACE_HELM", "§cSpace Helmet"),
     CULTIVATING("CULTIVATING;1", "§9Cultivating I"),
     REPLENISH("REPLENISH;1", "§9Replenish I"),
     DELICATE("DELICATE;5", "§9Delicate V"),
@@ -24,7 +25,7 @@ enum class VisitorReward(rawInternalName: String, val displayName: String) {
     ;
 
     private val internalName = rawInternalName.toInternalName()
-    val itemStack by lazy { internalName.getItemStack() }
+    val itemStack by AutoUpdatingItemStack(internalName)
     // TODO use this instead of hard coded item names once moulconfig no longer calls toString before the neu repo gets loaded
 //     val displayName by lazy { itemStack.nameWithEnchantment ?: internalName.asString() }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.config.features.garden.visitor.DropsStatisticsConfi
 import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
-import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 
 private typealias StatsEntry = DropsStatisticsConfig.DropsStatisticsTextEntry
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
@@ -25,7 +25,6 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
-import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/PunchcardHighlight.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils
@@ -78,7 +79,7 @@ object PunchcardHighlight {
     private val playerQueue = mutableListOf<String>()
 
     private val PUNCHCARD_ARTIFACT = "PUNCHCARD_ARTIFACT".toInternalName()
-    private val displayIcon by lazy { PUNCHCARD_ARTIFACT.getItemStack() }
+    private val displayIcon by AutoUpdatingItemStack(PUNCHCARD_ARTIFACT)
     private var display: Renderable = Renderable.text("hello")
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)

--- a/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
@@ -1,5 +1,12 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
+import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
+import net.minecraft.item.ItemStack
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 import kotlin.time.Duration
@@ -20,5 +27,54 @@ class RecalculatingValue<T>(private val expireTime: Duration, private val calcul
 
     companion object {
         private val UNINITIALIZED_VALUE = Any()
+    }
+}
+
+class ResettableValue<T>(private val calculation: () -> T) : ReadOnlyProperty<Any?, T> {
+
+    private var currentValue: Any? = UNINITIALIZED_VALUE
+    private var dirty = true
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        if (dirty) {
+            currentValue = calculation()
+            dirty = false
+        }
+        @Suppress("UNCHECKED_CAST")
+        return currentValue as T
+    }
+
+    fun reset() {
+        dirty = true
+    }
+
+    companion object {
+        private val UNINITIALIZED_VALUE = Any()
+    }
+}
+
+class AutoUpdatingItemStack(internalName: NeuInternalName) : ReadOnlyProperty<Any?, ItemStack> {
+
+    constructor(rawInternalName: String) : this(rawInternalName.toInternalName())
+
+    private val value: ResettableValue<ItemStack> = ResettableValue {
+        internalName.getItemStack()
+    }.also { list.add(it) }
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): ItemStack = value.getValue(thisRef, property)
+
+    @SkyHanniModule
+    companion object {
+        val list = mutableListOf<ResettableValue<ItemStack>>()
+
+        @HandleEvent(RepositoryReloadEvent::class)
+        fun onRepoReload() {
+            list.forEach { it.reset() }
+        }
+
+        @HandleEvent(NeuRepositoryReloadEvent::class)
+        fun onNeuRepoReload() {
+            list.forEach { it.reset() }
+        }
     }
 }


### PR DESCRIPTION
## What
introducing AutoUpdatingItemStack, that is powered by the new ResettableValue class (RecalculatingValue, but instead of expire time uses a dirty boolean)
Resets the item display icon on repo update.

## Changelog Fixes
+ Fixed Composter Garden display items sometimes failing to load. - hannibal2