### PR TITLE
Fix: HotX currencies being reset on opening SkyBlock Menu

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -470,12 +470,6 @@ enum class HotfData(
             }
         }
 
-        // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
-        override fun onInventoryClose(event: InventoryCloseEvent) = super.onInventoryClose(event)
-
-        // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
-        override fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) = super.onInventoryFullyOpened(event)
-
         @HandleEvent(onlyOnSkyblock = true)
         override fun onChat(event: SkyHanniChatEvent) = super.onChat(event)
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -470,10 +470,10 @@ enum class HotfData(
             }
         }
 
-        @HandleEvent
+        // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
         override fun onInventoryClose(event: InventoryCloseEvent) = super.onInventoryClose(event)
 
-        @HandleEvent(onlyOnSkyblock = true)
+        // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
         override fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) = super.onInventoryFullyOpened(event)
 
         @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -7,8 +7,6 @@ import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
-import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -614,10 +614,10 @@ enum class HotmData(
             }
         }
 
-        @HandleEvent
+        // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
         override fun onInventoryClose(event: InventoryCloseEvent) = super.onInventoryClose(event)
 
-        @HandleEvent(onlyOnSkyblock = true)
+        // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
         override fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) = super.onInventoryFullyOpened(event)
 
         override fun extraInventoryHandling() {

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -10,8 +10,6 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
-import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -110,7 +110,7 @@ enum class HotmData(
         140,
         { level -> (level + 1.0).pow(2.3) },
         { level -> mapOf(HotmReward.MINING_SPEED to 50.0 + (level * 5.0)) },
-        HotmApi.PowderType.GEMSTONE
+        HotmApi.PowderType.GEMSTONE,
     ),
     MOLE(
         "Mole",

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -614,12 +614,6 @@ enum class HotmData(
             }
         }
 
-        // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
-        override fun onInventoryClose(event: InventoryCloseEvent) = super.onInventoryClose(event)
-
-        // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
-        override fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) = super.onInventoryFullyOpened(event)
-
         override fun extraInventoryHandling() {
             abilities.filter { it.isUnlocked }.forEach {
                 it.rawLevel = if (CORE_OF_THE_MOUNTAIN.rawLevel >= 1) 2 else 1

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -178,6 +178,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
         )
     }
 
+    // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
     open fun onInventoryClose(event: InventoryCloseEvent) {
         data.forEach {
             it.slot = null
@@ -186,6 +187,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
         heartItem = null
     }
 
+    // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
     open fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         DelayedRun.runNextTick {
             InventoryUtils.getItemsInOpenChest().forEach { it.parse() }

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -179,6 +179,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
     }
 
     // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
+    @Suppress("UnusedParameter")
     fun onInventoryClose(event: InventoryCloseEvent) {
         data.forEach {
             it.slot = null
@@ -188,6 +189,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
     }
 
     // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
+    @Suppress("UnusedParameter")
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         DelayedRun.runNextTick {
             InventoryUtils.getItemsInOpenChest().forEach { it.parse() }

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -179,7 +179,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
     }
 
     // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
-    open fun onInventoryClose(event: InventoryCloseEvent) {
+    fun onInventoryClose(event: InventoryCloseEvent) {
         data.forEach {
             it.slot = null
             it.item = null
@@ -188,7 +188,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
     }
 
     // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
-    open fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         DelayedRun.runNextTick {
             InventoryUtils.getItemsInOpenChest().forEach { it.parse() }
             extraInventoryHandling()

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -179,7 +179,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
     }
 
     // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
-    @Suppress("UnusedParameter")
+    @Suppress("UNUSED_PARAMETER")
     fun onInventoryClose(event: InventoryCloseEvent) {
         data.forEach {
             it.slot = null
@@ -189,7 +189,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
     }
 
     // This event is fired by an InventoryDetector, and should NOT have @HandleEvent
-    @Suppress("UnusedParameter")
+    @Suppress("UNUSED_PARAMETER")
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         DelayedRun.runNextTick {
             InventoryUtils.getItemsInOpenChest().forEach { it.parse() }


### PR DESCRIPTION
## What
Fixes a regression of a previously fixed issue where HotM (and now also HotF) currencies reset upon opening the SkyBlock Menu while on a mining/foraging island—the event was firing in inventories not matched by the InventoryDetector due to unnecessary `@HandleEvent` annotations.

## Changelog Fixes
+ Fixed Total Powder/Forest Whispers resetting upon opening the SkyBlock Menu on mining/foraging islands. - Luna