### PR TITLE
Fix: Sun Gecko combo timer with no Combo Mania accessory

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
@@ -15,6 +15,8 @@ import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.findMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/SunGeckoHelper.kt
@@ -69,6 +69,8 @@ object SunGeckoHelper {
         "§6§l▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
     )
 
+    private val COMBO_MANIA_TALISMAN = "COMBO_MANIA_TALISMAN".toInternalName()
+
     private var healthLeft = 250
     private var totalHealth = 250
     private var actionBarFormatted: String = ""
@@ -113,7 +115,10 @@ object SunGeckoHelper {
 
         // this is just a total guess but it looks right enough
         // i think its inconsistent because of how often the action bar updates
-        var expiryTime = 5.seconds + 200.milliseconds
+        var expiryTime = 4.seconds + 700.milliseconds
+        if (InventoryUtils.isItemInInventory(COMBO_MANIA_TALISMAN)) {
+            expiryTime += 500.milliseconds
+        }
         if (modifiers.contains(Modifiers.COLLECTIVE)) {
             expiryTime += (modifiers.size * 200).milliseconds
         }


### PR DESCRIPTION
## What
Fixed Sun Gecko Helper assuming the player has the Combo Mania accessory instead of checking for it, sometimes resulting in a wrong combo timer.

## Changelog Fixes
+ Fixed Sun Gecko Helper showing the wrong combo timer if you don't have the Combo Mania accessory. - Luna