### PR TITLE
Fix: Carnival Baby Zombie Hitbox on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -30,6 +30,7 @@ import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Co
 import at.hannibal2.skyhanni.utils.renderables.primitives.empty
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import net.minecraft.entity.monster.EntityZombie
 import net.minecraft.init.Blocks
 import net.minecraft.init.Items
@@ -134,8 +135,13 @@ object CarnivalZombieShootout {
             val entity = EntityUtils.getEntityByID(zombie.entityId) ?: continue
             val isSmall = (entity as? EntityZombie)?.isChild ?: false
 
-            val boundingBox = if (isSmall) entity.entityBoundingBox.expand(0.0, -0.4, 0.0).offset(0.0, -0.4, 0.0)
-            else entity.entityBoundingBox
+            val boundingBox = entity.entityBoundingBox.let {
+                if (PlatformUtils.IS_LEGACY && isSmall) {
+                    it.expand(0.0, -0.4, 0.0).offset(0.0, -0.4, 0.0)
+                } else {
+                    it
+                }
+            }
 
             drawHitbox(
                 boundingBox.expand(0.1, 0.05, 0.0).offset(0.0, 0.05, 0.0),


### PR DESCRIPTION
## What
On 1.21, the Zombie Shootout helper was making the hitboxes of baby zombies way too small—unlike 1.8, their default hitbox is already normal size, so the adjustment that was being applied is not appropriate.

Unfortunately I wasn't able to test this before the Carnival ended, but it's a pretty straightforward fix.

<details>
<summary>Images</summary>

How it looked without this fix:
<img width="1440" height="847" alt="2025-09-23_00 29 41" src="https://github.com/user-attachments/assets/6f5ae626-eba6-461d-b8de-081dc486b75f" />

</details>

## Changelog Fixes
+ Fixed colored hitboxes for Baby Zombies in Zombie Shootout being too small on 1.21. - Luna
