### PR TITLE
Fix: No item resolution query in Dye Compendium

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
@@ -342,6 +342,9 @@ class ItemResolutionQuery {
         if (guiName == "Hunting Box" || guiName == "Fusion Box" || guiName == "Shard Fusion") {
             return resolveItemInHuntingBoxMenu(displayName)
         }
+        if (guiName == "Dye Compendium") {
+            return findInternalNameByDisplayName(displayName, false)
+        }
         return null
     }
 


### PR DESCRIPTION
## What
Made item resoultion query work in another gui.

## Changelog Fixes
+ Fixed Open Wiki keybinds not working in Dye Compendium. - CalMWolfs
