### PR TITLE
Fix: gui editor screen rendering on 1.21.8

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -61,8 +61,11 @@ class GuiPositionEditor(
         // Items aren't drawn due to a bug in neu rendering
         drawDefaultBackground(originalMouseX, originalMouseY, partialTicks)
         if (oldScreen != null) {
-            val accessor = oldScreen as AccessorGuiContainer
+            //#if MC > 1.21.5
+            //$$ oldScreen.drawBackground(DrawContextUtils.drawContext, partialTicks, originalMouseX, originalMouseY)
+            //#endif
             //#if MC < 1.21
+            val accessor = oldScreen as AccessorGuiContainer
             accessor.invokeDrawGuiContainerBackgroundLayer_skyhanni(partialTicks, -1, -1)
             //#else
             //$$ oldScreen.render(DrawContextUtils.drawContext, originalMouseX, originalMouseY, partialTicks)

--- a/versions/1.21.7/src/main/resources/skyhanni.accesswidener
+++ b/versions/1.21.7/src/main/resources/skyhanni.accesswidener
@@ -43,3 +43,4 @@ accessible field net/minecraft/client/option/StickyKeyBinding toggleGetter Ljava
 
 # 1.21.7 stuff
 accessible field net/minecraft/client/render/RenderLayer$MultiPhase pipeline Lcom/mojang/blaze3d/pipeline/RenderPipeline;
+accessible method net/minecraft/client/gui/screen/ingame/HandledScreen drawBackground (Lnet/minecraft/client/gui/DrawContext;FII)V


### PR DESCRIPTION
## What
Minecraft split up background from the rest of the code.

## Changelog Fixes
+ Fixed GUI Editor rendering the open inventory incorrectly on 1.21.8. - CalMWolfs

