### PR TITLE
Improvement: Credits in rich presence

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/DiscordRPCConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/DiscordRPCConfig.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
@@ -93,4 +94,11 @@ class DiscordRPCConfig {
 
         override fun toString() = displayName
     }
+
+    
+    @ConfigOption(name = "Credits", desc = "Rich presence assets were created by\n" +
+        "Hypixel Pack HQ (packshq.com) for the old images\n" +
+        "and @unfamiliartunes (unfamiliartunes.straw.page) for the new images")
+    @ConfigEditorInfoText
+    val credits = ""
 }


### PR DESCRIPTION
## What
Adds credits for art assets in the discord rich presence config (I couldn't figure out how to get it to hyperlink).

Also I'm not sure if this should be in the changelog, it doesn't seem big enough.

## Changelog Improvements
+ Added credits for Discord Rich Presence images. - NetheriteMiner