### PR TITLE
Backend: in game logging of repo stuff

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -78,6 +78,7 @@ object SkyHanniMod {
             SkyHanniRepoManager.initRepo()
         } catch (e: Exception) {
             Exception("Error reading repo data", e).printStackTrace()
+            SkyHanniRepoManager.progress.end("Error reading repo data: ${e.message}")
         }
         InitFinishedEvent.post()
     }
@@ -224,13 +225,13 @@ object SkyHanniMod {
             launch {
                 delay(timeout)
                 if (mainJob.isActive) {
-                    mainJob.cancel(CancellationException("Coroutine timed out after $timeout"))
                     ErrorManager.logErrorStateWithData(
                         "Coroutine timed out",
                         "The coroutine took longer than the specified timeout of $timeout",
                         "timeout" to timeout,
                         "coroutine name" to name,
                     )
+                    mainJob.cancel(CancellationException("Coroutine $name timed out after $timeout"))
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -227,7 +227,7 @@ object SkyHanniMod {
                 if (mainJob.isActive) {
                     ErrorManager.logErrorStateWithData(
                         "Coroutine timed out",
-                        "The coroutine took longer than the specified timeout of $timeout",
+                        "The coroutine '$name' took longer than the specified timeout of $timeout",
                         "timeout" to timeout,
                         "coroutine name" to name,
                     )

--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
@@ -35,8 +35,8 @@ import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.nbt.NBTTagList
 import java.io.File
 import java.util.TreeMap
-import kotlin.math.floor
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.floor
 //#if MC > 1.21
 //$$ import net.minecraft.registry.Registries
 //$$ import net.minecraft.util.Identifier

--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.data.jsonobjects.other.NeuNbtInfoJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuPetsJson
+import at.hannibal2.skyhanni.data.repo.ChatProgressUpdates
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -35,6 +36,7 @@ import net.minecraft.nbt.NBTTagList
 import java.io.File
 import java.util.TreeMap
 import kotlin.math.floor
+import java.util.concurrent.atomic.AtomicInteger
 //#if MC > 1.21
 //$$ import net.minecraft.registry.Registries
 //$$ import net.minecraft.util.Identifier
@@ -46,6 +48,7 @@ import kotlin.math.floor
 //$$ import at.hannibal2.skyhanni.utils.ItemUtils.setLore
 //#else
 import net.minecraft.nbt.NBTTagString
+
 //#endif
 
 // Most functions are taken from NotEnoughUpdates
@@ -73,7 +76,9 @@ object EnoughUpdatesManager {
     /**
      * Called by the Neu Repo Manager when the NEU repo is reloaded.
      */
-    suspend fun reloadItemsFromRepo() = loadingMutex.withLock {
+    suspend fun reloadItemsFromRepo(progress: ChatProgressUpdates) = loadingMutex.withLock {
+        progress.update("call reloadItemsFromRepo")
+        progress.update("clearing caches and maps")
         itemStackCache.clear()
         displayNameCache.clear()
         itemMap.clear()
@@ -81,31 +86,41 @@ object EnoughUpdatesManager {
         recipesMap.clear()
 
         val tempItemMap = TreeMap<String, JsonObject>()
-        loadItemMap(tempItemMap)
+        loadItemMap(progress, tempItemMap)
 
+        progress.update("call synchronized itemMap")
         synchronized(itemMap) {
             itemMap.clear()
             itemMap.putAll(tempItemMap)
+            progress.update("putAll tempItemMap")
         }
     }
 
     fun getRecipesFor(internalName: NeuInternalName): Set<PrimitiveRecipe> = recipesMap.getOrDefault(internalName, emptySet())
 
-    private suspend fun loadItemMap(tempItemMap: TreeMap<String, JsonObject>) = coroutineScope {
+    private suspend fun loadItemMap(progress: ChatProgressUpdates, tempItemMap: TreeMap<String, JsonObject>) = coroutineScope {
+        progress.update("call loadItemMap")
         val fileSystem = EnoughUpdatesRepoManager.repoFileSystem
-        fileSystem.list("items").mapNotNullAsync { name ->
+        val list = fileSystem.list("items")
+        progress.innerProgress(0, list.size)
+        val done = AtomicInteger(0)
+        val async = list.mapNotNullAsync { name ->
             try {
                 val internalName = name.removeSuffix(".json")
-                val parsed = parseItem(
+                val item = parseItem(
                     internalName = internalName,
                     json = fileSystem.readAllBytesAsJsonElement("items/$name").asJsonObject,
-                ) ?: return@mapNotNullAsync null
+                )
+                progress.innerProgress(done.incrementAndGet(), list.size)
+                val parsed = item ?: return@mapNotNullAsync null
                 internalName to parsed
             } catch (e: Exception) {
+                progress.update("Failed to parse item: $name")
                 ErrorManager.logErrorWithData(e, "Failed to parse item: $name")
                 null
             }
-        }.forEach { (internalName, item) ->
+        }
+        async.forEach { (internalName, item) ->
             tempItemMap[internalName] = item
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesRepoManager.kt
@@ -31,5 +31,5 @@ object EnoughUpdatesRepoManager : AbstractRepoManager<NeuRepositoryReloadEvent>(
     fun onCommandRegistration(event: CommandRegistrationEvent) = super.registerCommands(event)
 
     override fun reportExtraStatusInfo() = EnoughUpdatesManager.reportItemStatus()
-    override suspend fun extraReloadCoroutineWork() = EnoughUpdatesManager.reloadItemsFromRepo()
+    override suspend fun extraReloadCoroutineWork() = EnoughUpdatesManager.reloadItemsFromRepo(progress)
 }

--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/NeuEventWrappers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/NeuEventWrappers.kt
@@ -72,6 +72,7 @@ object NeuEventWrappers {
 
     @SubscribeEvent
     fun onNeuRepoReload(event: RepositoryReloadEvent) {
+        EnoughUpdatesRepoManager.progress.start("listened on RepositoryReloadEvent: NEU repo")
         EnoughUpdatesRepoManager.reloadLocalRepo()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierBuilder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierBuilder.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.isGreedy
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.toSuggestionProvider
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.StringUtils.hasWhitespace
 import at.hannibal2.skyhanni.utils.StringUtils.splitLastWhitespace
 import com.mojang.brigadier.CommandDispatcher
@@ -15,6 +16,7 @@ import com.mojang.brigadier.suggestion.SuggestionProvider
 import com.mojang.brigadier.tree.CommandNode
 //#if MC < 1.21
 import net.minecraft.command.ICommand
+
 //#endif
 
 typealias LiteralCommandBuilder = BrigadierBuilder<LiteralArgumentBuilder<Any?>>
@@ -47,7 +49,11 @@ open class BrigadierBuilder<B : ArgumentBuilder<Any?, B>>(
     /** Executes the code block when the command is executed. */
     fun callback(block: ArgContext.() -> Unit) {
         this.builder.executes {
-            block(ArgContext(it))
+            try {
+                block(ArgContext(it))
+            } catch (e: Exception) {
+                ErrorManager.logErrorWithData(e)
+            }
             1
         }
     }
@@ -55,7 +61,11 @@ open class BrigadierBuilder<B : ArgumentBuilder<Any?, B>>(
     /** Alternative to [callback] when no arguments are needed. */
     fun simpleCallback(block: () -> Unit) {
         this.builder.executes {
-            block()
+            try {
+                block()
+            } catch (e: Exception) {
+                ErrorManager.logErrorWithData(e)
+            }
             1
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
@@ -24,7 +24,7 @@ class NeuRepositoryConfig : AbstractRepoConfig<NeuRepositoryConfig.NeuRepository
 
     @ConfigOption(name = "Update NEU Repo Now", desc = "Update your NEU repository to the latest version")
     @ConfigEditorButton(buttonText = "Update")
-    override val updateRepo: Runnable = Runnable(EnoughUpdatesRepoManager::updateRepo)
+    override val updateRepo: Runnable = Runnable { EnoughUpdatesRepoManager.updateRepo("config button") }
 
     @Expose
     @ConfigOption(name = "NEU Repository Location", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.kt
@@ -1,8 +1,8 @@
 package at.hannibal2.skyhanni.config.features.dev
 
+import at.hannibal2.skyhanni.api.enoughupdates.EnoughUpdatesRepoManager
 import at.hannibal2.skyhanni.data.repo.AbstractRepoConfig
 import at.hannibal2.skyhanni.data.repo.AbstractRepoLocationConfig
-import at.hannibal2.skyhanni.data.repo.SkyHanniRepoManager
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
@@ -22,7 +22,7 @@ class RepositoryConfig : AbstractRepoConfig<RepositoryConfig.RepositoryLocation>
 
     @ConfigOption(name = "Update Repo Now", desc = "Update your repository to the latest version")
     @ConfigEditorButton(buttonText = "Update")
-    override val updateRepo: Runnable = Runnable(SkyHanniRepoManager::updateRepo)
+    override val updateRepo: Runnable = Runnable { EnoughUpdatesRepoManager.updateRepo("config button") }
 
     @Expose
     @ConfigOption(name = "Repository Location", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
@@ -25,6 +25,7 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 @Suppress("TooManyFunctions")
 abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
@@ -171,7 +172,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
 
     // <editor-fold desc="Repo Management">
     fun updateRepo(reason: String, forceReset: Boolean = false) {
-        progress.start("updateRepo $commonName")
+        progress.start("updateRepo $commonName Repo")
         progress.update("reason: $reason")
         progress.update("Remove and re-download, forceReset=$forceReset")
         shouldManuallyReload = true
@@ -180,7 +181,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
             resetRepositoryLocation()
         }
 
-        SkyHanniMod.launchIOCoroutine("$commonName updateRepo") {
+        SkyHanniMod.launchIOCoroutine("$commonName updateRepo", timeout = 20.seconds) {
             if (!fetchAndUnpackRepo(command = true, forceReset = forceReset).canContinue) {
                 logger.warn("Failed to fetch & unpack repo - aborting repository reload.")
                 return@launchIOCoroutine
@@ -458,7 +459,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
 
         progress.update("done with newInstance")
         if (answerMessage.isNotEmpty() && !loadingError) {
-            progress.end("done: $answerMessage")
+            progress.end(answerMessage)
             logger.logToChat("§a$answerMessage")
         } else if (loadingError) {
             progress.end("Error with the $commonShortName Repo detected")

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
@@ -25,7 +25,6 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
 @Suppress("TooManyFunctions")
 abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
@@ -24,6 +24,7 @@ import java.lang.reflect.Type
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 @Suppress("TooManyFunctions")
 abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
@@ -102,6 +103,8 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
     private var loadingError: Boolean = false
     private var latestError = SimpleTimeMark.farPast()
 
+    val progress = ChatProgressUpdates()
+
     fun getFailedConstants() = unsuccessfulConstants.toList()
     fun getGitHubRepoPath(): String = githubRepoLocation.location
 
@@ -111,10 +114,10 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
         if (shouldRegisterUpdateCommand) event.registerBrigadier(updateCommand) {
             description = "Remove and re-download the $commonName repo"
             category = CommandCategory.USERS_BUG_FIX
-            simpleCallback { updateRepo(forceReset = true) }
+            simpleCallback { updateRepo("/$updateCommand", forceReset = true) }
             argCallback("force", BoolArgumentType.bool()) {
                 description = "optionally only re-download if the repo is out of date"
-                updateRepo(forceReset = it)
+                updateRepo("/$updateCommand force", forceReset = it)
             }
         }
         if (shouldRegisterStatusCommand) event.registerBrigadier(statusCommand) {
@@ -125,7 +128,10 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
         if (shouldRegisterReloadCommand) event.registerBrigadier(reloadCommand) {
             description = "Reloads the local $commonName repo"
             category = CommandCategory.DEVELOPER_TEST
-            simpleCallback { reloadLocalRepo() }
+            simpleCallback {
+                progress.start("Reloading the local $commonName repo via /$reloadCommand")
+                reloadLocalRepo()
+            }
         }
     }
 
@@ -164,7 +170,10 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
     }
 
     // <editor-fold desc="Repo Management">
-    fun updateRepo(forceReset: Boolean = false) {
+    fun updateRepo(reason: String, forceReset: Boolean = false) {
+        progress.start("updateRepo $commonName")
+        progress.update("reason: $reason")
+        progress.update("Remove and re-download, forceReset=$forceReset")
         shouldManuallyReload = true
         if (!config.location.valid) {
             logger.errorToChat("Invalid $commonName Repo settings detected, resetting default settings.")
@@ -200,25 +209,34 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
         ChatUtils.clickableChat(
             "Reset $commonName Repo settings to default. " +
                 "Click §aUpdate Repo Now §ein config or run /$updateCommand to update!",
-            onClick = ::updateRepo,
+            onClick = { updateRepo("click in chat after reset") },
             "§eClick to update the $commonShortNameCased Repo!",
         )
     }
 
     fun initRepo() {
+        progress.start("init $commonName repo")
         shouldManuallyReload = true
         SkyHanniMod.launchIOCoroutine("$commonName repo init") {
             if (config.repoAutoUpdate && !fetchAndUnpackRepo(command = false).canContinue) {
+                progress.end("Failed to fetch & unpack repo - aborting repository reload.")
                 logger.warn("Failed to fetch & unpack repo - aborting repository reload.")
                 return@launchIOCoroutine
             }
             reloadRepository()
         }
+        progress.update("outside job")
+        job.invokeOnCompletion {
+            progress.update("invokeOnCompletion")
+            progress.update("launchIOCoroutine.isCancelled ${job.isCancelled}")
+        }
     }
 
     // Code taken + adapted from NotEnoughUpdates
     private fun switchToBackupRepo(): FetchUnpackResult = runCatching {
+        progress.update("call switchToBackupRepo")
         if (backupRepoResourcePath == null) {
+            progress.update("No backup repo resource path provided, cannot switch to backup repo.")
             logger.warn("No backup repo resource path provided, cannot switch to backup repo.")
             return FetchUnpackResult.FAILED
         }
@@ -235,16 +253,20 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
         }
 
         isUsingBackup = true
+        progress.update("writeToFile: switchToBackupRepo")
         commitStorage.writeToFile(RepoCommit("backup-repo", time = null))
+        progress.update("Successfully switched to backup repo")
         logger.debug("Successfully switched to backup repo")
         return FetchUnpackResult.SWITCHED_TO_BACKUP
     }.onFailure { e ->
         logger.logNonDestructiveError("Failed to switch to backup repo: ${e.message}")
+        progress.update("Failed to switch to backup repo: ${e.message}")
     }.getOrDefault(FetchUnpackResult.FAILED)
 
     open fun reportExtraStatusInfo(): Unit = Unit
 
     private suspend fun isRepeatErrorOrFixed(): Boolean {
+        progress.update("call isRepeatErrorOrFixed")
         if (latestError.passedSince() < 5.minutes || !config.repoAutoUpdate) return true
         latestError = SimpleTimeMark.now()
 
@@ -258,8 +280,12 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
             val result = fetchAndUnpackRepo(command = false)
             if (result == FetchUnpackResult.SUCCESS) {
                 logger.logToChat("§a$commonName Repo updated successfully!")
+                progress.update("repo update successfully!")
                 return true
-            } else logger.logToChat("§cFailed to update the $commonName Repo.")
+            } else {
+                logger.logToChat("§cFailed to update the $commonName Repo.")
+                progress.update("Failed to update the $commonName Repo.")
+            }
         }
         return false
     }
@@ -319,7 +345,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
     private suspend fun getCommitComparison(silentError: Boolean): RepoComparison? {
         localRepoCommit = commitStorage.readFromFile() ?: RepoCommit()
         val latestRepoCommit = githubRepoLocation.getLatestCommit(silentError) ?: return null
-        return RepoComparison(localRepoCommit, latestRepoCommit)
+        return RepoComparison(commonName, localRepoCommit, latestRepoCommit)
     }
 
     /**
@@ -342,6 +368,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
         forceReset: Boolean = false,
         switchToBackupOnFail: Boolean = true,
     ): FetchUnpackResult = repoMutex.withLock {
+        progress.update("call fetchAndUnpackRepo")
         val comparison = getCommitComparison(silentError) ?: run {
             return if (switchToBackupOnFail) switchToBackupRepo()
             else FetchUnpackResult.FAILED
@@ -353,18 +380,27 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
             }
             return FetchUnpackResult.SUCCESS
         } else if (command) {
-            if (!comparison.hashesMatch) comparison.reportRepoOutdated()
-            else if (forceReset) comparison.reportForceRebuild()
+            if (!comparison.hashesMatch) {
+                progress.update("hashes dont match, outdated!")
+                comparison.reportRepoOutdated()
+            } else if (forceReset) comparison.reportForceRebuild()
         }
 
+        progress.update("call prepCleanRepoFileSystem")
         prepCleanRepoFileSystem()
 
+        progress.update("call downloadCommitZipToFile")
         if (!githubRepoLocation.downloadCommitZipToFile(repoZipFile)) {
+            progress.update("Failed to download the repo zip file from GitHub.")
             logger.logNonDestructiveError("Failed to download the repo zip file from GitHub.")
             return if (switchToBackupOnFail) switchToBackupRepo()
-            else FetchUnpackResult.FAILED
+            else {
+                progress.update("FetchUnpackResult.FAILED")
+                FetchUnpackResult.FAILED
+            }
         }
 
+        progress.update("call loadFromZip")
         // Actually unpack the repo zip file into our local 'file system'
         if (!repoFileSystem.loadFromZip(repoZipFile, logger)) {
             logger.logNonDestructiveError("Failed to unpack the downloaded zip file.")
@@ -372,12 +408,14 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
             else FetchUnpackResult.FAILED
         }
 
+        progress.update("writeToFile: fetchAndUnpackRepo")
         commitStorage.writeToFile(comparison.latest)
         isUsingBackup = false
         return FetchUnpackResult.SUCCESS
     }
 
     private fun prepCleanRepoFileSystem() {
+        println("call prepCleanRepoFileSystem")
         repoDirectory.deleteRecursively()
         repoFileSystem = RepoFileSystem.createAndClean(repoDirectory, config.unzipToMemory)
         repoDirectory.mkdirs()
@@ -385,6 +423,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
     }
 
     fun reloadLocalRepo(answerMessage: String = "$commonName Repo loaded from local files successfully.") {
+        progress.update("call reloadLocalRepo")
         shouldManuallyReload = true
         SkyHanniMod.launchIOCoroutine("$commonName reloadLocalRepo") {
             reloadRepository(answerMessage)
@@ -397,13 +436,17 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
     open suspend fun extraReloadCoroutineWork() = Unit
 
     private suspend fun reloadRepository(answerMessage: String = "") = repoMutex.withLock {
+        progress.update("call reloadRepository")
         if (!shouldManuallyReload) return
         loadingError = false
         successfulConstants.clear()
         unsuccessfulConstants.clear()
+        progress.update("call extraReloadCoroutineWork")
         extraReloadCoroutineWork()
 
+        progress.update("call eventCtor.newInstance")
         eventCtor.newInstance(this).post { error ->
+            progress.update("Error while posting repo reload event")
             logger.logErrorWithData(error, "Error while posting repo reload event")
             loadingError = true
         }
@@ -411,11 +454,15 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
         // the MemoryRepoFileSystem for the event, and writing to disk after the event.
         repoFileSystem = repoFileSystem.transitionAfterReload()
 
-        if (answerMessage.isNotEmpty() && !loadingError) logger.logToChat("§a$answerMessage")
-        else if (loadingError) {
+        progress.update("done with newInstance")
+        if (answerMessage.isNotEmpty() && !loadingError) {
+            progress.end("done: $answerMessage")
+            logger.logToChat("§a$answerMessage")
+        } else if (loadingError) {
+            progress.end("Error with the $commonShortName Repo detected")
             ChatUtils.clickableChat(
                 "Error with the $commonShortName Repo detected, try /$updateCommand to fix it!",
-                onClick = ::updateRepo,
+                onClick = { updateRepo("click on chat after error") },
                 "§eClick to update the Repo!",
                 prefixColor = "§c",
             )

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
@@ -23,8 +23,8 @@ import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
 @Suppress("TooManyFunctions")
 abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
@@ -217,18 +217,20 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
     fun initRepo() {
         progress.start("init $commonName repo")
         shouldManuallyReload = true
-        SkyHanniMod.launchIOCoroutine("$commonName repo init") {
+        val loaded = AtomicBoolean(false)
+        val job = SkyHanniMod.launchIOCoroutine("$commonName repo init", timeout = 2.minutes) {
             if (config.repoAutoUpdate && !fetchAndUnpackRepo(command = false).canContinue) {
                 progress.end("Failed to fetch & unpack repo - aborting repository reload.")
                 logger.warn("Failed to fetch & unpack repo - aborting repository reload.")
                 return@launchIOCoroutine
             }
+            loaded.set(true)
             reloadRepository()
         }
-        progress.update("outside job")
         job.invokeOnCompletion {
-            progress.update("invokeOnCompletion")
-            progress.update("launchIOCoroutine.isCancelled ${job.isCancelled}")
+            if (!loaded.get()) {
+                progress.update("reached timeout")
+            }
         }
     }
 
@@ -381,7 +383,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
             return FetchUnpackResult.SUCCESS
         } else if (command) {
             if (!comparison.hashesMatch) {
-                progress.update("hashes dont match, outdated!")
+                progress.update("hashes don't match, outdated!")
                 comparison.reportRepoOutdated()
             } else if (forceReset) comparison.reportForceRebuild()
         }
@@ -467,6 +469,8 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
                 prefixColor = "§c",
             )
             if (unsuccessfulConstants.isEmpty()) unsuccessfulConstants.add("All Constants")
+        } else {
+            progress.end("done.")
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
@@ -181,7 +181,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
             resetRepositoryLocation()
         }
 
-        SkyHanniMod.launchIOCoroutine("$commonName updateRepo", timeout = 20.seconds) {
+        SkyHanniMod.launchIOCoroutine("$commonName updateRepo", timeout = 2.minutes) {
             if (!fetchAndUnpackRepo(command = true, forceReset = forceReset).canContinue) {
                 logger.warn("Failed to fetch & unpack repo - aborting repository reload.")
                 return@launchIOCoroutine
@@ -457,7 +457,6 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
         // the MemoryRepoFileSystem for the event, and writing to disk after the event.
         repoFileSystem = repoFileSystem.transitionAfterReload()
 
-        progress.update("done with newInstance")
         if (answerMessage.isNotEmpty() && !loadingError) {
             progress.end(answerMessage)
             logger.logToChat("§a$answerMessage")

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/ChatProgressUpdates.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/ChatProgressUpdates.kt
@@ -112,9 +112,9 @@ class ChatProgressUpdates {
             if (!currentlyRunning) {
                 error("trying to end an not running chat: $nextStep")
             }
+            currentlyRunning = false
             update()
             currentStep = null
-            currentlyRunning = false
             startOfCurrent = null
             previousSteps.clear()
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/ChatProgressUpdates.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/ChatProgressUpdates.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.hover
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -25,10 +26,10 @@ class ChatProgressUpdates {
     private var startOfFirst: SimpleTimeMark? = null
     private var title: String? = null
 
-    private val currentlyRunning get() = currentStep != null
+    private var currentlyRunning = false
     private var chatId: Int? = null
 
-    private var previousSteps = mutableListOf<String>()
+    private val previousSteps = mutableListOf<String>()
 
     private var startOfCurrent: SimpleTimeMark? = null
     private var currentStep: String? = null
@@ -97,7 +98,7 @@ class ChatProgressUpdates {
 
         currentStep?.let {
             val format = startOfCurrent?.format() ?: error("start of current is null")
-            previousSteps.add("$it $innerProgress$format")
+            previousSteps.add("§8- §f$it $innerProgress$format")
         }
         innerProgress = ""
         if (!SkyBlockUtils.debug) return
@@ -105,6 +106,7 @@ class ChatProgressUpdates {
         val time = SimpleTimeMark.now().toLocalDateTime()
         println("$time: $nextStep")
         currentStep = nextStep
+        currentlyRunning = true
 
         if (phase == Phase.END) {
             if (!currentlyRunning) {
@@ -112,6 +114,7 @@ class ChatProgressUpdates {
             }
             update()
             currentStep = null
+            currentlyRunning = false
             startOfCurrent = null
             previousSteps.clear()
         } else {
@@ -123,9 +126,10 @@ class ChatProgressUpdates {
     private fun SimpleTimeMark.format(): String {
         val duration = passedSince()
         val color = when {
-            duration < 100.milliseconds -> "§8"
-            duration < 10.seconds -> "§b"
-            else -> "§c"
+            duration < 100.milliseconds -> "§7"
+            duration < 5.seconds -> "§b"
+            duration < 1.minutes -> "§c"
+            else -> "§4"
         }
 
         val format = duration.format(showMilliSeconds = true)
@@ -146,7 +150,8 @@ class ChatProgressUpdates {
         }
 
         val hover = mutableListOf<String>()
-        hover.add(title)
+        hover.add("§e$title")
+        hover.add("§8SkyHanni Debug Log")
         hover.add("")
         hover.addAll(previousSteps)
 
@@ -155,15 +160,15 @@ class ChatProgressUpdates {
             val currentLine = "$currentStep $innerProgress$currentTime"
             hover.add(currentLine)
             hover.add("")
-            hover.add("running for: $totalTime")
+            hover.add("§7Running for: $totalTime")
             currentLine
         } else {
             hover.add("")
-            hover.add("done after: $totalTime")
+            hover.add("§aDone after: $totalTime")
             "$currentStep $totalTime"
         }
 
-        val delayedSending = DelayedSending(text, hover.joinToString("\n"))
+        val delayedSending = DelayedSending("§e[Debug-Log] §f$text §7(hover for more info)", hover.joinToString("\n"))
         if (MinecraftCompat.localPlayerOrNull != null) {
             delayedSending.send(chatId)
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/ChatProgressUpdates.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/ChatProgressUpdates.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
@@ -24,7 +25,7 @@ class ChatProgressUpdates {
     private var startOfFirst: SimpleTimeMark? = null
     private var title: String? = null
 
-    private var currentlyRunning = false
+    private val currentlyRunning get() = currentStep != null
     private var chatId: Int? = null
 
     private var previousSteps = mutableListOf<String>()
@@ -56,6 +57,7 @@ class ChatProgressUpdates {
 
         @HandleEvent(onlyOnSkyblock = true)
         fun onTick(event: SkyHanniTickEvent) {
+            if (!SkyBlockUtils.debug) return
             if (event.isMod(2)) {
                 for (update in updates) {
                     if (update.currentlyRunning) {
@@ -89,7 +91,6 @@ class ChatProgressUpdates {
                 error("trying to start an already running chat: $nextStep")
             }
             startOfFirst = SimpleTimeMark.now()
-            currentlyRunning = true
             chatId = ChatUtils.getUniqueMessageId()
             title = nextStep
         }
@@ -99,6 +100,7 @@ class ChatProgressUpdates {
             previousSteps.add("$it $innerProgress$format")
         }
         innerProgress = ""
+        if (!SkyBlockUtils.debug) return
 
         val time = SimpleTimeMark.now().toLocalDateTime()
         println("$time: $nextStep")
@@ -108,10 +110,10 @@ class ChatProgressUpdates {
             if (!currentlyRunning) {
                 error("trying to end an not running chat: $nextStep")
             }
-            currentlyRunning = false
             update()
             currentStep = null
             startOfCurrent = null
+            previousSteps.clear()
         } else {
             startOfCurrent = SimpleTimeMark.now()
             update()

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/ChatProgressUpdates.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/ChatProgressUpdates.kt
@@ -1,0 +1,177 @@
+package at.hannibal2.skyhanni.data.repo
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import at.hannibal2.skyhanni.utils.compat.hover
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * This class allows to log actions and their duration of long, async tasks in chat.
+ * Ideally for repo reload.
+ */
+class ChatProgressUpdates {
+    private var startOfFirst: SimpleTimeMark? = null
+    private var title: String? = null
+
+    private var currentlyRunning = false
+    private var chatId: Int? = null
+
+    private var previousSteps = mutableListOf<String>()
+
+    private var startOfCurrent: SimpleTimeMark? = null
+    private var currentStep: String? = null
+    private var innerProgress = ""
+
+    private var delayedSending: DelayedSending? = null
+
+    class DelayedSending(val text: String, val hover: String) {
+        fun send(chatId: Int) {
+            val hover = hover.asComponent()
+            val nextSend = TextHelper.text(text) {
+                this.hover = hover
+            }
+            nextSend.send(chatId)
+        }
+    }
+
+    init {
+        updates.add(this)
+    }
+
+    @SkyHanniModule
+    companion object {
+
+        private val updates = mutableListOf<ChatProgressUpdates>()
+
+        @HandleEvent(onlyOnSkyblock = true)
+        fun onTick(event: SkyHanniTickEvent) {
+            if (event.isMod(2)) {
+                for (update in updates) {
+                    if (update.currentlyRunning) {
+                        update.update()
+                    }
+                }
+            }
+        }
+    }
+
+    fun innerProgress(min: Int, max: Int) {
+        val percentage = ((min.toDouble() / max.toDouble()) * 100).roundTo(2)
+        this.innerProgress = "($percentage% ${min.addSeparators()}/${max.addSeparators()}) "
+    }
+
+    fun start(nextStep: String) {
+        statusUpdate(nextStep, Phase.START)
+    }
+
+    fun update(nextStep: String) {
+        statusUpdate(nextStep, Phase.MIDDLE)
+    }
+
+    fun end(nextStep: String) {
+        statusUpdate(nextStep, Phase.END)
+    }
+
+    private fun statusUpdate(nextStep: String, phase: Phase) {
+        if (phase == Phase.START) {
+            if (currentlyRunning) {
+                error("trying to start an already running chat: $nextStep")
+            }
+            startOfFirst = SimpleTimeMark.now()
+            currentlyRunning = true
+            chatId = ChatUtils.getUniqueMessageId()
+            title = nextStep
+        }
+
+        currentStep?.let {
+            val format = startOfCurrent?.format() ?: error("start of current is null")
+            previousSteps.add("$it $innerProgress$format")
+        }
+        innerProgress = ""
+
+        val time = SimpleTimeMark.now().toLocalDateTime()
+        println("$time: $nextStep")
+        currentStep = nextStep
+
+        if (phase == Phase.END) {
+            if (!currentlyRunning) {
+                error("trying to end an not running chat: $nextStep")
+            }
+            currentlyRunning = false
+            update()
+            currentStep = null
+            startOfCurrent = null
+        } else {
+            startOfCurrent = SimpleTimeMark.now()
+            update()
+        }
+    }
+
+    private fun SimpleTimeMark.format(): String {
+        val duration = passedSince()
+        val color = when {
+            duration < 100.milliseconds -> "§8"
+            duration < 10.seconds -> "§b"
+            else -> "§c"
+        }
+
+        val format = duration.format(showMilliSeconds = true)
+        return "$color$format§f"
+    }
+
+    private fun update() {
+        val title = title ?: error("currentStep is null")
+        val currentStep = currentStep ?: error("currentStep is null")
+        val chatId = chatId ?: error("chatId is null: $currentStep")
+        val totalTime = startOfFirst?.format() ?: error("startOfFirst is null: $currentStep")
+
+        delayedSending?.let {
+            if (MinecraftCompat.localPlayerOrNull != null) {
+                it.send(chatId)
+                delayedSending = null
+            }
+        }
+
+        val hover = mutableListOf<String>()
+        hover.add(title)
+        hover.add("")
+        hover.addAll(previousSteps)
+
+        val text = if (currentlyRunning) {
+            val currentTime = startOfCurrent?.format() ?: error("startOfCurrent is null")
+            val currentLine = "$currentStep $innerProgress$currentTime"
+            hover.add(currentLine)
+            hover.add("")
+            hover.add("running for: $totalTime")
+            currentLine
+        } else {
+            hover.add("")
+            hover.add("done after: $totalTime")
+            "$currentStep $totalTime"
+        }
+
+        val delayedSending = DelayedSending(text, hover.joinToString("\n"))
+        if (MinecraftCompat.localPlayerOrNull != null) {
+            delayedSending.send(chatId)
+        } else {
+            this.delayedSending = delayedSending
+        }
+    }
+
+    private enum class Phase {
+        START,
+        MIDDLE,
+        END,
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoComparison.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoComparison.kt
@@ -5,15 +5,18 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 
 data class RepoComparison(
+    val repoName: String,
     val localSha: String?,
     val localCommitTime: SimpleTimeMark?,
     val latestSha: String?,
     val latestCommitTime: SimpleTimeMark?,
 ) {
     constructor(
+        repoName: String,
         localCommit: RepoCommit?,
         latestCommit: RepoCommit?,
     ) : this(
+        repoName = repoName,
         localSha = localCommit?.sha,
         localCommitTime = localCommit?.time,
         latestSha = latestCommit?.sha,
@@ -26,8 +29,10 @@ data class RepoComparison(
     val hashesMatch = localSha == latestSha
 
     fun reportRepoUpToDate() = ChatUtils.clickToClipboard(
-        "§7The repo is already up to date!",
+        "§7The $repoName repo is already up to date!",
         lines = buildList {
+            add("Repo: $repoName")
+            add("")
             add("latest commit sha: §e$localSha")
             latestCommitTime?.let { latestTime ->
                 add("latest commit time: §b$latestTime")
@@ -39,10 +44,12 @@ data class RepoComparison(
     fun reportForceRebuild() = reportRepoOutdated("Force redownloading repo..")
 
     fun reportRepoOutdated(
-        mainMessage: String = "Repo is outdated, updating..",
+        mainMessage: String = "$repoName Repo is outdated, updating..",
     ) = ChatUtils.clickToClipboard(
         mainMessage,
         lines = buildList {
+            add("Repo: $repoName")
+            add("")
             add("local commit sha: §e$latestSha")
             localCommitTime?.let { localTime ->
                 add("local commit time: §b$localTime")

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/RepoFileSystem.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/RepoFileSystem.kt
@@ -16,6 +16,7 @@ import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.ZipFile
 import kotlin.sequences.forEach
+import kotlin.time.Duration.Companion.minutes
 
 sealed interface RepoFileSystem {
     fun exists(path: String): Boolean
@@ -51,7 +52,7 @@ sealed interface RepoFileSystem {
                     val outPath = root.toPath().resolve(relative).normalize()
                     if (!outPath.startsWith(root.toPath())) throw RuntimeException(
                         "SkyHanni detected an invalid zip file. This is a potential security risk, " +
-                            "please report this on the SkyHanni discord."
+                            "please report this on the SkyHanni discord.",
                     )
                 }
 
@@ -112,8 +113,9 @@ class MemoryRepoFileSystem(private val diskRoot: File) : RepoFileSystem, Disposa
     }.map { it.removePrefix("$path/") }
 
     override fun loadFromZip(zipFile: File, logger: RepoLogger): Boolean {
+        println("loadFromZip")
         val success = super.loadFromZip(zipFile, logger)
-        if (flushJob == null) flushJob = SkyHanniMod.launchIOCoroutine("repo file saveToDisk") { saveToDisk(diskRoot) }
+        if (flushJob == null) flushJob = SkyHanniMod.launchIOCoroutine("repo file saveToDisk", timeout = 2.minutes) { saveToDisk(diskRoot) }
         return success
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/DeepCavernsGuide.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/DeepCavernsGuide.kt
@@ -125,7 +125,7 @@ object DeepCavernsGuide {
             ChatUtils.clickableChat(
                 "DeepCavernsParkour missing in SkyHanni Repo! Try /shupdaterepo to fix it!",
                 onClick = {
-                    SkyHanniRepoManager.updateRepo()
+                    SkyHanniRepoManager.updateRepo("click on chat after deep caverns parkour error")
                 },
                 "§eClick to update the repo!",
                 prefixColor = "§c",

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/DanceRoomHelper.kt
@@ -44,9 +44,7 @@ object DanceRoomHelper {
             addString("§cError fetching Dance Room Instructions!")
             Renderable.optionalLink(
                 "§cTry §e/shreloadlocalrepo §cor §e/shupdaterepo §c(Click to update now)",
-                onLeftClick = {
-                    SkyHanniRepoManager::updateRepo
-                }
+                onLeftClick = { SkyHanniRepoManager.updateRepo("click on chat after dance doom error") },
             ).let { add(it) }
         }
     }
@@ -67,6 +65,7 @@ object DanceRoomHelper {
                 val countdown = countdown?.let { "${color.countdown.formatColor()}$it" }.orEmpty()
                 "${now.formatColor()} $formattedLine $countdown"
             }
+
             index + 1 == lineIndex -> "${next.formatColor()} $formattedLine"
             lineIndex in (index + 2..index + config.lineToShow) -> "${later.formatColor()} $formattedLine"
             else -> null

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -184,6 +184,7 @@ object ErrorManager {
 
     data class CachedError(val className: String, val lineNumber: Int, val errorMessage: String)
 
+    @Suppress("ReturnCount")
     private fun logError(
         originalThrowable: Throwable,
         message: String,

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -175,7 +175,7 @@ object ErrorManager {
     // log with stack trace from other try catch block
     fun logErrorWithData(
         throwable: Throwable,
-        message: String,
+        message: String = throwable.message ?: "message is null",
         vararg extraData: Pair<String, Any?>,
         ignoreErrorCache: Boolean = false,
         noStackTrace: Boolean = false,
@@ -193,6 +193,9 @@ object ErrorManager {
         betaOnly: Boolean = false,
         condition: () -> Boolean = { true },
     ): Boolean {
+        if (MinecraftCompat.localPlayerOrNull == null) {
+            println("extra data:\n${getExtraDataOrCached(extraData)}")
+        }
         if (betaOnly && !SkyHanniMod.isBetaVersion) return false
         val throwable = originalThrowable.maybeSkipError()
         if (!ignoreErrorCache) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -53,7 +53,7 @@ object ComputerTimeOffset {
     }
 
     init {
-        SkyHanniMod.launchIOCoroutine("computer time offset init", timeout = 25.seconds) {
+        SkyHanniMod.launchIOCoroutine("computer time offset init", timeout = 5.minutes) {
             while (state != State.TOTALLY_OFF) {
                 delay(state.duration)
                 detectTimeChange()

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -53,7 +53,7 @@ object ComputerTimeOffset {
     }
 
     init {
-        SkyHanniMod.launchIOCoroutine("computer time offset init") {
+        SkyHanniMod.launchIOCoroutine("computer time offset init", timeout = 25.seconds) {
             while (state != State.TOTALLY_OFF) {
                 delay(state.duration)
                 detectTimeChange()

--- a/src/main/java/at/hannibal2/skyhanni/utils/GitHubUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GitHubUtils.kt
@@ -65,6 +65,7 @@ object GitHubUtils {
                 ApiUtils.getZipResponse(destinationZip, fullArchiveUrl, apiName, !shouldError)
                 true
             } catch (e: Exception) {
+                ErrorManager.logErrorWithData(e, "Failed to download archive from $fullArchiveUrl")
                 SkyHanniMod.logger.error("Failed to download archive from $fullArchiveUrl", e)
                 false
             }
@@ -138,9 +139,10 @@ object GitHubUtils {
         @Expose val payload: String? = null,
         @Expose @field:SerializedName("verified_at") private val verifiedAtString: String? = null,
     ) {
-        val verifiedAt: SimpleTimeMark? get() = verifiedAtString?.let {
-            Instant.parse(it).toEpochMilli().asTimeMark()
-        }
+        val verifiedAt: SimpleTimeMark?
+            get() = verifiedAtString?.let {
+                Instant.parse(it).toEpochMilli().asTimeMark()
+            }
     }
 
     data class CommitStats(


### PR DESCRIPTION
## What
since its almost impossible for me to understand when what task of the repo does what and how long it takes, and what times out forever, im adding logging via in game chat to it. 
the new class ChatProgressUpdates handles all this, and works independent of repo. this can be reused for e.g. graph loading or other heavy and time consuming tasks in the future.
the log only shows up when debug is enabled in the dev option!

## Changelog Technical Details
+ Added in-game logging for repo loading. - hannibal2