### PR TITLE
Backend: Disable Pest Waypoint by default

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestWaypointConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestWaypointConfig.kt
@@ -15,7 +15,7 @@ class PestWaypointConfig {
     )
     @ConfigEditorBoolean
     @FeatureToggle
-    var enabled: Boolean = true
+    var enabled: Boolean = false
 
     @Expose
     @ConfigOption(name = "Hide Particles", desc = "Hide the particles of the ability.")


### PR DESCRIPTION
## What
Players can't easily tell what mod this feature comes from, and it's also inaccurate a lot of the time, so figured it'd be better to have it off by default so that new players are not confused. 

exclude_from_changelog