### PR TITLE
Fix: Mooshroom Cow incrementing Mushroom milestone below Garden 9

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropMilestoneDisplay.kt
@@ -281,6 +281,14 @@ object GardenCropMilestoneDisplay {
     }
 
     private fun addMushroomCowData() {
+        if (GardenApi.getGardenLevel(overflow = false) < 9) {
+            mushroomCowPerkDisplay = listOf(
+                Renderable.text("§6Mooshroom Cow Perk"),
+                Renderable.text("§cMushroom crop not unlocked!"),
+            )
+            return
+        }
+
         val mushroom = CropType.MUSHROOM
         val allowOverflow = overflowConfig.cropMilestoneDisplay
         if (mushroom.isMaxed(allowOverflow)) {


### PR DESCRIPTION
## What
Fixed Crop Milestone Display incorrectly incrementing Mushroom milestone if the player is using a Rare or higher Mooshroom Cow Pet but does not have the Mushroom crop unlocked on the Garden (requires Garden Level 9). Below this level, the pet still drops Mushrooms, but they do not count towards the milestone, and the milestone progress starts at 0 once the player reaches Garden Level 9.

<details>
<summary>Images</summary>

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fixed Crop Milestone Display incrementing milestone from Mooshroom Cow Pet while below Garden Level 9. - Luna
