### PR TITLE
Fix: Island guest amount not detected at cap

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -119,11 +119,12 @@ object HypixelData {
     )
 
     /**
-     * REGEX-TEST:  §a✌ §7(§a11§7/20)
+     * WRAPPED-REGEX-TEST: " §a✌ §7(§a11§7/20)"
+     * WRAPPED-REGEX-TEST: " §a✌ §7(§e1/1§7)"
      */
     private val scoreboardVisitingAmountPattern by patternGroup.pattern(
         "scoreboard.visiting.amount",
-        "\\s+§.✌ §.\\(§.(?<currentamount>\\d+)§./(?<maxamount>\\d+)\\)",
+        "\\s+§.✌ §.\\(§.(?<currentamount>\\d+)(?:§.)?/(?<maxamount>\\d+)(?:§.)?\\)",
     )
     private val guestPattern by patternGroup.pattern(
         "guesting.scoreboard",


### PR DESCRIPTION
## What
Fixed the pattern for island/garden guest amount so that it still matches with the shifted around color codes when it's at the cap.

## Changelog Fixes
+ Fixed guest count detection on Private Island/Garden at max guests. - Luna