### PR TITLE
Fix: SlotClickEvent not firing on clickInventorySlot

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -74,8 +74,6 @@ object InventoryCompat {
     fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int, mode: Int) {
         windowId ?: return
         if (slot < 0) return
-        val controller = Minecraft.getMinecraft().playerController ?: return
-        val player = Minecraft.getMinecraft().thePlayer ?: return
         val gui = Minecraft.getMinecraft().currentScreen
         //#if FORGE
         if (gui is GuiContainer) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -15,6 +15,7 @@ import kotlin.contracts.contract
 //#if FABRIC
 //$$ import net.minecraft.screen.slot.SlotActionType
 //$$ import at.hannibal2.skyhanni.compat.ReiCompat
+//$$ import net.minecraft.client.gui.screen.ingame.HandledScreen
 //#endif
 
 fun EntityPlayerSP.getItemOnCursor(): ItemStack? {
@@ -72,17 +73,23 @@ object InventoryCompat {
 
     fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int, mode: Int) {
         windowId ?: return
+        if (slot < 0) return
         val controller = Minecraft.getMinecraft().playerController ?: return
         val player = Minecraft.getMinecraft().thePlayer ?: return
-        //#if FORGE
         val gui = Minecraft.getMinecraft().currentScreen
+        //#if FORGE
         if (gui is GuiContainer) {
             val accessor = gui as AccessorGuiContainer
-            val slotObj = if (slot >= 0) gui.inventorySlots.getSlot(slot) else null
+            val slotObj = gui.inventorySlots.getSlot(slot)
             accessor.handleMouseClick_skyhanni(slotObj, slot, mouseButton, mode)
         }
         //#else
-        //$$ controller.clickSlot(windowId, slot, mouseButton, SlotActionType.entries[mode], player)
+        //$$ if (gui is HandledScreen<*>) {
+        //$$ val accessor = gui as AccessorHandledScreen
+        //$$ val slotObj = gui.screenHandler.getSlot(slot)
+        //$$ val actionType = SlotActionType.entries[mode]
+        //$$ accessor.handleMouseClick_skyhanni(slotObj, slot, mouseButton, actionType)
+        //$$ }
         //#endif
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -72,6 +72,8 @@ object InventoryCompat {
 
     fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int, mode: Int) {
         windowId ?: return
+        val controller = Minecraft.getMinecraft().playerController ?: return
+        val player = Minecraft.getMinecraft().thePlayer ?: return
         //#if FORGE
         val gui = Minecraft.getMinecraft().currentScreen
         if (gui is GuiContainer) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils.compat
 
+import at.hannibal2.skyhanni.mixins.transformers.gui.AccessorGuiContainer
 import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.client.gui.inventory.GuiChest
@@ -71,10 +72,13 @@ object InventoryCompat {
 
     fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int, mode: Int) {
         windowId ?: return
-        val controller = Minecraft.getMinecraft().playerController ?: return
-        val player = Minecraft.getMinecraft().thePlayer ?: return
         //#if FORGE
-        controller.windowClick(windowId, slot, mouseButton, mode, player)
+        val gui = Minecraft.getMinecraft().currentScreen
+        if (gui is GuiContainer) {
+            val accessor = gui as AccessorGuiContainer
+            val slotObj = if (slot >= 0) gui.inventorySlots.getSlot(slot) else null
+            accessor.handleMouseClick_skyhanni(slotObj, slot, mouseButton, mode)
+        }
         //#else
         //$$ controller.clickSlot(windowId, slot, mouseButton, SlotActionType.entries[mode], player)
         //#endif


### PR DESCRIPTION
## What
Changes InventoryCompat.clickInventorySlot to send a mouse click instead of a window click so SlotClickEvent gets posted

## Changelog Fixes
+ Fixed Visitors not marked as accepted when using Accept Hotkey. - Chissl