### PR TITLE
Fix: Clicks not working

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
@@ -138,7 +138,7 @@ object VisitorListener {
         val inventory = event.guiContainer as? AccessorGuiContainer ?: return
         inventory as GuiContainer
         val slot = inventory.slots()[29]
-        InventoryCompat.clickInventorySlot(slot.slotIndex, mouseButton = 0, mode = 0)
+        InventoryCompat.mouseClickInventorySlot(slot.slotIndex, mouseButton = 0, mode = 0)
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -70,8 +70,18 @@ object InventoryCompat {
         //#endif
     }
 
-
     fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int, mode: Int) {
+        windowId ?: return
+        val controller = Minecraft.getMinecraft().playerController ?: return
+        val player = Minecraft.getMinecraft().thePlayer ?: return
+        //#if FORGE
+        controller.windowClick(windowId, slot, mouseButton, mode, player)
+        //#else
+        //$$ controller.clickSlot(windowId, slot, mouseButton, SlotActionType.entries[mode], player)
+        //#endif
+    }
+
+    fun mouseClickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int, mode: Int) {
         windowId ?: return
         if (slot < 0) return
         val gui = Minecraft.getMinecraft().currentScreen


### PR DESCRIPTION
## What
Prior PR changed all skyhanni clicks to be mouse clicks. Should not have done that. Restored prior functionality and added a new function for mouse clicks.

## Changelog Fixes
+ Fixed enchanting table click prevention, wardrobe hotkeys and some other click-related features. - Chissl
