### PR TITLE
Improvement: Add Event EXP to GEXP filter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -11,7 +11,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 106
+    const val CONFIG_VERSION = 107
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.kt
@@ -63,12 +63,11 @@ class FilterTypesConfig {
     @FeatureToggle
     var welcome: Boolean = false
 
-    //TODO rename to guildEventExp
     @Expose
     @ConfigOption(name = "Guild/Event EXP", desc = "Hide Guild and Event EXP messages.")
     @ConfigEditorBoolean
     @FeatureToggle
-    var guildExp: Boolean = false
+    var guildEventExp: Boolean = false
 
     @Expose
     @ConfigOption(name = "Friend Join/Left", desc = "Hide friend join/left messages.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.kt
@@ -64,7 +64,7 @@ class FilterTypesConfig {
     var welcome: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Guild EXP", desc = "Hide Guild EXP messages.")
+    @ConfigOption(name = "Guild/Event EXP", desc = "Hide Guild and Event EXP messages.")
     @ConfigEditorBoolean
     @FeatureToggle
     var guildExp: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.kt
@@ -63,6 +63,7 @@ class FilterTypesConfig {
     @FeatureToggle
     var welcome: Boolean = false
 
+    //TODO rename to guildEventExp
     @Expose
     @ConfigOption(name = "Guild/Event EXP", desc = "Hide Guild and Event EXP messages.")
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -102,9 +102,10 @@ object ChatFilter {
     /**
      * REGEX-TEST: §aYou earned §r§22 GEXP §r§afrom playing SkyBlock!
      * REGEX-TEST: §aYou earned §r§22 GEXP §r§a+ §r§c210 Event EXP §r§afrom playing SkyBlock!
+     * REGEX-TEST: §aYou earned §r§510 Event EXP §r§afrom playing SkyBlock!
      */
     private val guildExpPatterns = listOf(
-        "§aYou earned §r§2.* GEXP (§r§a\\+ §r§.* Event EXP )?§r§afrom playing SkyBlock!".toPattern(),
+        "§aYou earned §r§[0-9a-f]\\d+ (?:GEXP|Event EXP) (?:§r§a\\+ §r§[0-9a-f]\\d+ Event EXP )?§r§afrom playing SkyBlock!".toPattern(),
     )
 
     // Kill Combo

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -104,6 +104,7 @@ object ChatFilter {
      * REGEX-TEST: §aYou earned §r§22 GEXP §r§a+ §r§c210 Event EXP §r§afrom playing SkyBlock!
      * REGEX-TEST: §aYou earned §r§510 Event EXP §r§afrom playing SkyBlock!
      */
+    @Suppress("MaxLineLength")
     private val guildExpPatterns = listOf(
         "§aYou earned §r§[0-9a-f][\\d,]+ (?:GEXP|Event EXP) (?:§r§a\\+ §r§[0-9a-f][\\d,]+ Event EXP )?§r§afrom playing SkyBlock!".toPattern(),
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -105,7 +105,7 @@ object ChatFilter {
      * REGEX-TEST: §aYou earned §r§510 Event EXP §r§afrom playing SkyBlock!
      */
     private val guildExpPatterns = listOf(
-        "§aYou earned §r§[0-9a-f]\\d+ (?:GEXP|Event EXP) (?:§r§a\\+ §r§[0-9a-f]\\d+ Event EXP )?§r§afrom playing SkyBlock!".toPattern(),
+        "§aYou earned §r§[0-9a-f][\\d,]+ (?:GEXP|Event EXP) (?:§r§a\\+ §r§[0-9a-f][\\d,]+ Event EXP )?§r§afrom playing SkyBlock!".toPattern(),
     )
 
     // Kill Combo

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -98,7 +98,7 @@ object ChatFilter {
         "§eWelcome to §r§aHypixel SkyBlock§r§e!",
     )
 
-    // Guild EXP
+    // Guild & Event EXP
     /**
      * REGEX-TEST: §aYou earned §r§22 GEXP §r§afrom playing SkyBlock!
      * REGEX-TEST: §aYou earned §r§22 GEXP §r§a+ §r§c210 Event EXP §r§afrom playing SkyBlock!

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -707,7 +707,7 @@ object ChatFilter {
         event.move(3, "chat.hypixelHub", "chat.filterType.hypixelHub")
         event.move(3, "chat.empty", "chat.filterType.empty")
         event.move(3, "chat.warping", "chat.filterType.warping")
-        event.move(3, "chat.guildExp", "chat.filterType.guildEventExp")
+        event.move(3, "chat.guildExp", "chat.filterType.guildExp")
         event.move(3, "chat.friendJoinLeft", "chat.filterType.friendJoinLeft")
         event.move(3, "chat.winterGift", "chat.filterType.winterGift")
         event.move(3, "chat.powderMining", "chat.filterType.powderMining")

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -105,7 +105,7 @@ object ChatFilter {
      * REGEX-TEST: §aYou earned §r§510 Event EXP §r§afrom playing SkyBlock!
      */
     @Suppress("MaxLineLength")
-    private val guildExpPatterns = listOf(
+    private val guildEventExpPatterns = listOf(
         "§aYou earned §r§[0-9a-f][\\d,]+ (?:GEXP|Event EXP) (?:§r§a\\+ §r§[0-9a-f][\\d,]+ Event EXP )?§r§afrom playing SkyBlock!".toPattern(),
     )
 
@@ -502,7 +502,7 @@ object ChatFilter {
     private val patternsMap: Map<String, List<Pattern>> = mapOf(
         "lobby" to lobbyPatterns,
         "warping" to warpingPatterns,
-        "guild_exp" to guildExpPatterns,
+        "guild_event_exp" to guildEventExpPatterns,
         "kill_combo" to killComboPatterns,
         "slayer" to slayerPatterns,
         "slayer_drop" to slayerDropPatterns,
@@ -585,7 +585,7 @@ object ChatFilter {
         config.empty && StringUtils.isEmpty(message) -> "empty"
         config.warping && message.isPresent("warping") -> "warping"
         config.welcome && message.isPresent("welcome") -> "welcome"
-        config.guildExp && message.isPresent("guild_exp") -> "guild_exp"
+        config.guildEventExp && message.isPresent("guild_event_exp") -> "guild_event_exp"
         config.killCombo && message.isPresent("kill_combo") -> "kill_combo"
         config.profileJoin && message.isPresent("profile_join") -> "profile_join"
         config.parkour && message.isPresent("parkour") -> "parkour"
@@ -707,7 +707,7 @@ object ChatFilter {
         event.move(3, "chat.hypixelHub", "chat.filterType.hypixelHub")
         event.move(3, "chat.empty", "chat.filterType.empty")
         event.move(3, "chat.warping", "chat.filterType.warping")
-        event.move(3, "chat.guildExp", "chat.filterType.guildExp")
+        event.move(3, "chat.guildExp", "chat.filterType.guildEventExp")
         event.move(3, "chat.friendJoinLeft", "chat.filterType.friendJoinLeft")
         event.move(3, "chat.winterGift", "chat.filterType.winterGift")
         event.move(3, "chat.powderMining", "chat.filterType.powderMining")
@@ -724,5 +724,6 @@ object ChatFilter {
         }
         event.move(61, "chat.filterType.powderMiningFilter", "chat.filterType.powderMining")
         event.move(61, "chat.filterType.gemstoneFilterConfig", "chat.filterType.powderMining.gemstone")
+        event.move(107, "chat.filterType.guildExp", "chat.filterType.guildEventExp")
     }
 }


### PR DESCRIPTION
## What
Change "Guild EXP" chat filter to "Guild/Event EXP"
Previously, it would only hide Event EXP messages if you also gained Guild Exp, now it also hides standalone Event EXP messages.

## Changelog Improvements
+ Added Event EXP to Guild EXP Chat Filter. - AfkUserMC
    * Renamed filter from "Guild EXP" to "Guild/Event EXP".