### PR TITLE
Fix: Inquisitor Waypoint Sharing on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -142,26 +142,19 @@ object InquisitorWaypointShare {
 
     @HandleEvent(onlyOnIsland = IslandType.HUB, receiveCancelled = true)
     fun onChat(event: SkyHanniChatEvent) {
-        ChatUtils.debug("InquisitorWaypointShare: onChat")
-        if (!isEnabled()) {
-            ChatUtils.debug("InquisitorWaypointShare: not enabled")
-            return
-        }
+        if (!isEnabled()) return
         val message = event.message
 
         if (inquisitorFoundChatPattern.matches(message)) {
-            ChatUtils.debug("InquisitorWaypointShare: inquis found")
             checkInquisFound()
         }
 
         inquisitorCoordsPattern.matchMatchers(message) {
-            ChatUtils.debug("InquisitorWaypointShare: inquis from chat")
             if (!detectFromChat()) return@matchMatchers
             event.blockedReason = "inquisitor_waypoint"
         }
 
         diedPattern.matchMatcher(message) {
-            ChatUtils.debug("InquisitorWaypointShare: inquis died")
             if (block()) return
             val rawName = group("playerName")
             val name = rawName.cleanPlayerName()
@@ -173,8 +166,6 @@ object InquisitorWaypointShare {
     }
 
     private fun foundInquisitor(inquisId: Int) {
-        ChatUtils.debug("InquisitorWaypointShare: foundInquisitor")
-
         lastShareTime = SimpleTimeMark.farPast()
         inquisitor = inquisId
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityOtherPlayerMP
+import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Matcher
 import kotlin.time.Duration.Companion.seconds
 
@@ -72,11 +73,9 @@ object InquisitorWaypointShare {
     private var lastInquisitor = -1
     private var lastShareTime = SimpleTimeMark.farPast()
 
-    private val inquisitorsNearby = mutableListOf<EntityOtherPlayerMP>()
-    private val inquisitorsNearbyLock = Any()
+    private val inquisitorsNearby = ConcurrentHashMap<Int, EntityOtherPlayerMP>()
 
-    private val _waypoints = mutableMapOf<String, SharedInquisitor>()
-    private val waypointsLock = Any()
+    private val _waypoints = ConcurrentHashMap<String, SharedInquisitor>()
     val waypoints: Map<String, SharedInquisitor>
         get() = _waypoints
 
@@ -92,24 +91,16 @@ object InquisitorWaypointShare {
         if (!isEnabled()) return
 
         if (event.repeatSeconds(3)) {
-            synchronized(inquisitorsNearbyLock) {
-                inquisitorsNearby.removeIf { it.isDead }
-            }
+            inquisitorsNearby.removeIf { it.value.isDead }
         }
 
-        synchronized(waypointsLock) {
-            _waypoints.removeIf { it.value.spawnTime.passedSince() > 75.seconds }
-        }
+        _waypoints.removeIf { it.value.spawnTime.passedSince() > 75.seconds }
     }
 
     @HandleEvent
     fun onWorldChange() {
-        synchronized(waypointsLock) {
-            _waypoints.clear()
-        }
-        synchronized(inquisitorsNearbyLock) {
-            inquisitorsNearby.clear()
-        }
+        _waypoints.clear()
+        inquisitorsNearby.clear()
     }
 
     private val inquisitorTime = mutableListOf<SimpleTimeMark>()
@@ -117,9 +108,7 @@ object InquisitorWaypointShare {
     @HandleEvent
     fun onInquisitorFound(event: InquisitorFoundEvent) {
         val inquisitor = event.inquisitorEntity
-        synchronized(inquisitorsNearbyLock) {
-            inquisitorsNearby.add(inquisitor)
-        }
+        inquisitorsNearby[inquisitor.entityId] = inquisitor
         GriffinBurrowHelper.update()
 
         lastInquisitor = inquisitor.entityId
@@ -158,9 +147,7 @@ object InquisitorWaypointShare {
             if (block()) return
             val rawName = group("playerName")
             val name = rawName.cleanPlayerName()
-            synchronized(waypointsLock) {
-                _waypoints.remove(name)
-            }
+            _waypoints.remove(name)
             GriffinBurrowHelper.update()
         }
     }
@@ -195,11 +182,7 @@ object InquisitorWaypointShare {
         if (entityId == inquisitor) {
             sendDeath()
         }
-        synchronized(inquisitorsNearbyLock) {
-            inquisitorsNearby.find { it.entityId == entityId }?.let {
-                inquisitorsNearby.remove(it)
-            }
-        }
+        inquisitorsNearby.remove(entityId)
     }
 
     @HandleEvent
@@ -266,9 +249,7 @@ object InquisitorWaypointShare {
             }
         }
         val inquis = SharedInquisitor(name, displayName, location, SimpleTimeMark.now())
-        synchronized(waypointsLock) {
-            _waypoints[name] = inquis
-        }
+        _waypoints[name] = inquis
         GriffinBurrowHelper.update()
         return true
     }
@@ -277,9 +258,7 @@ object InquisitorWaypointShare {
 
     fun maybeRemove(inquis: SharedInquisitor) {
         if (inquisitorsNearby.isEmpty()) {
-            synchronized(waypointsLock) {
-                _waypoints.remove(inquis.fromPlayer)
-            }
+            _waypoints.remove(inquis.fromPlayer)
             GriffinBurrowHelper.update()
             ChatUtils.chat("Inquisitor from ${inquis.displayName} §enot found, deleting.")
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/InquisitorWaypointShare.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.diana.InquisitorFoundEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
-import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
@@ -19,24 +18,18 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.hasGroup
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
-import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityOtherPlayerMP
-//#if MC < 1.21
-import net.minecraft.network.play.server.S02PacketChat
-//#else
-//$$ import net.minecraft.network.packet.s2c.play.ChatMessageS2CPacket
-//#endif
 import java.util.regex.Matcher
-import java.util.regex.Pattern
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -44,44 +37,24 @@ object InquisitorWaypointShare {
 
     private val config get() = SkyHanniMod.feature.event.diana.inquisitorSharing
 
-    private val patternGroup = RepoPattern.group("diana.waypoints")
+    private val patternGroup = RepoPattern.group("diana.waypoints.inquisitor")
 
     /**
-     * REGEX-TEST: §9Party §8> User Name§f: §rx: 2.3, y: 4.5, z: 6.7
-     */
-    private val partyOnlyCoordsPattern by patternGroup.pattern(
-        "party.onlycoords",
-        "(?<party>§9Party §8> )?(?<playerName>.+)§f: §rx: (?<x>[^ ,]+),? y: (?<y>[^ ,]+),? z: (?<z>[^ ,]+)",
-    )
-
-    // Support for https://www.chattriggers.com/modules/v/inquisitorchecker
-    /**
-     * REGEX-TEST: §9Party §8> UserName§f: §rA MINOS INQUISITOR has spawned near [Foraging Island ] at Coords 1 2 3
+     * REGEX-TEST: §9Party §8> User Name§f: §rx: 2.3, y: 4.5, z: -6.7
+     * REGEX-TEST: §9Party §8> UserName§f: §rA MINOS INQUISITOR has spawned near [Foraging Island ] at Coords 1 2 -3
+     * REGEX-TEST: §9Party §8> §b[MVP§9+§b] _088§f: §rx: 86, y: 73, z: -29 I dug up an inquisitor come over here!
+     * REGEX-TEST: §9Party §8> §6[MVP§0++§6] scaryron§f: §rx: -67, y: 75, z: 116 | Minos Inquisitor spawned at [ ⏣ Mountain ]!
      */
     @Suppress("MaxLineLength")
-    private val partyInquisitorCheckerPattern by patternGroup.pattern(
-        "party.inquisitorchecker",
+    private val inquisitorCoordsPattern by patternGroup.list(
+        "coords",
+        "(?<party>§9Party §8> )?(?<playerName>.+)§f: §rx: (?<x>[^ ,]+),? y: (?<y>[^ ,]+),? z: (?<z>[^ ,]+).*",
         "(?<party>§9Party §8> )?(?<playerName>.+)§f: §rA MINOS INQUISITOR has spawned near \\[(?<area>.*)] at Coords (?<x>[^ ]+) (?<y>[^ ]+) (?<z>[^ ]+)",
     )
 
     /**
-     * REGEX-TEST: §9Party §8> §b[MVP§9+§b] _088§f: §rx: 86, y: 73, z: -29 I dug up an inquisitor come over here!
+     * REGEX-TEST: §9Party §8> User Name§f: §rInquisitor dead!
      */
-    @Suppress("MaxLineLength")
-    private val odinPattern by patternGroup.pattern(
-        "party.odin",
-        "(?<party>§9Party §8> )?(?<playerName>.+)§f: §rx: (?<x>[^ ]+), y: (?<y>[^ ]+), z: (?<z>[^ ]+) I dug up an inquisitor come over here!",
-    )
-
-    /**
-     * REGEX-TEST: §9Party §8> §6[MVP§0++§6] scaryron§f: §rx: -67, y: 75, z: 116 | Minos Inquisitor spawned at [ ⏣ Mountain ]!
-     */
-    @Suppress("MaxLineLength")
-    private val volcaddonsPattern by patternGroup.pattern(
-        "party.volc",
-        "(?<party>§9Party §8> )?(?<playerName>.+)§f: §rx: (?<x>[^ ]+), y: (?<y>[^ ]+), z: (?<z>[^ ]+) \\| Minos Inquisitor spawned at (?<area>.*)!",
-    )
-
     private val diedPattern by patternGroup.pattern(
         "died",
         "(?<party>§9Party §8> )?(?<playerName>.*)§f: §rInquisitor dead!",
@@ -91,16 +64,21 @@ object InquisitorWaypointShare {
      * REGEX-TEST: §c§lUh oh! §r§eYou dug out a §r§2Minos Inquisitor§r§e!
      */
     private val inquisitorFoundChatPattern by patternGroup.pattern(
-        "inquisitor.dug",
+        "dug",
         ".* §r§eYou dug out a §r§2Minos Inquisitor§r§e!",
     )
 
     private var inquisitor = -1
     private var lastInquisitor = -1
     private var lastShareTime = SimpleTimeMark.farPast()
-    private var inquisitorsNearby = emptyList<EntityOtherPlayerMP>()
 
-    var waypoints = mapOf<String, SharedInquisitor>()
+    private val inquisitorsNearby = mutableListOf<EntityOtherPlayerMP>()
+    private val inquisitorsNearbyLock = Any()
+
+    private val _waypoints = mutableMapOf<String, SharedInquisitor>()
+    private val waypointsLock = Any()
+    val waypoints: Map<String, SharedInquisitor>
+        get() = _waypoints
 
     class SharedInquisitor(
         val fromPlayer: String,
@@ -114,16 +92,24 @@ object InquisitorWaypointShare {
         if (!isEnabled()) return
 
         if (event.repeatSeconds(3)) {
-            inquisitorsNearby = inquisitorsNearby.editCopy { removeIf { it.isDead } }
+            synchronized(inquisitorsNearbyLock) {
+                inquisitorsNearby.removeIf { it.isDead }
+            }
         }
 
-        waypoints = waypoints.editCopy { values.removeIf { it.spawnTime.passedSince() > 75.seconds } }
+        synchronized(waypointsLock) {
+            _waypoints.removeIf { it.value.spawnTime.passedSince() > 75.seconds }
+        }
     }
 
     @HandleEvent
     fun onWorldChange() {
-        waypoints = emptyMap()
-        inquisitorsNearby = emptyList()
+        synchronized(waypointsLock) {
+            _waypoints.clear()
+        }
+        synchronized(inquisitorsNearbyLock) {
+            inquisitorsNearby.clear()
+        }
     }
 
     private val inquisitorTime = mutableListOf<SimpleTimeMark>()
@@ -131,7 +117,9 @@ object InquisitorWaypointShare {
     @HandleEvent
     fun onInquisitorFound(event: InquisitorFoundEvent) {
         val inquisitor = event.inquisitorEntity
-        inquisitorsNearby = inquisitorsNearby.editCopy { add(inquisitor) }
+        synchronized(inquisitorsNearbyLock) {
+            inquisitorsNearby.add(inquisitor)
+        }
         GriffinBurrowHelper.update()
 
         lastInquisitor = inquisitor.entityId
@@ -152,17 +140,41 @@ object InquisitorWaypointShare {
         }
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.HUB, receiveCancelled = true)
     fun onChat(event: SkyHanniChatEvent) {
-        if (!isEnabled()) return
+        ChatUtils.debug("InquisitorWaypointShare: onChat")
+        if (!isEnabled()) {
+            ChatUtils.debug("InquisitorWaypointShare: not enabled")
+            return
+        }
         val message = event.message
 
         if (inquisitorFoundChatPattern.matches(message)) {
+            ChatUtils.debug("InquisitorWaypointShare: inquis found")
             checkInquisFound()
+        }
+
+        inquisitorCoordsPattern.matchMatchers(message) {
+            ChatUtils.debug("InquisitorWaypointShare: inquis from chat")
+            if (!detectFromChat()) return@matchMatchers
+            event.blockedReason = "inquisitor_waypoint"
+        }
+
+        diedPattern.matchMatcher(message) {
+            ChatUtils.debug("InquisitorWaypointShare: inquis died")
+            if (block()) return
+            val rawName = group("playerName")
+            val name = rawName.cleanPlayerName()
+            synchronized(waypointsLock) {
+                _waypoints.remove(name)
+            }
+            GriffinBurrowHelper.update()
         }
     }
 
     private fun foundInquisitor(inquisId: Int) {
+        ChatUtils.debug("InquisitorWaypointShare: foundInquisitor")
+
         lastShareTime = SimpleTimeMark.farPast()
         inquisitor = inquisId
 
@@ -192,8 +204,10 @@ object InquisitorWaypointShare {
         if (entityId == inquisitor) {
             sendDeath()
         }
-        inquisitorsNearby.find { it.entityId == entityId }?.let {
-            inquisitorsNearby = inquisitorsNearby.editCopy { remove(it) }
+        synchronized(inquisitorsNearbyLock) {
+            inquisitorsNearby.find { it.entityId == entityId }?.let {
+                inquisitorsNearby.remove(it)
+            }
         }
     }
 
@@ -241,48 +255,6 @@ object InquisitorWaypointShare {
         HypixelCommands.partyChat("x: $x, y: $y, z: $z ")
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.HUB, priority = HandleEvent.LOW, receiveCancelled = true)
-    fun onFirstChatEvent(event: PacketReceivedEvent) {
-        if (!isEnabled()) return
-        val packet = event.packet
-        //#if MC < 1.21
-        if (packet !is S02PacketChat) return
-        val messageComponent = packet.chatComponent
-        //#else
-        //$$ if (packet !is ChatMessageS2CPacket) return
-        //$$ val messageComponent = packet.unsignedContent
-        //#endif
-
-        val message = messageComponent.formattedText.stripHypixelMessage()
-        //#if MC < 1.16
-        if (packet.type.toInt() != 0) return
-        //#endif
-
-        if (partyInquisitorCheckerPattern.isDetected(message)) {
-            event.cancel()
-        }
-        if (odinPattern.isDetected(message)) {
-            event.cancel()
-        }
-        if (partyOnlyCoordsPattern.isDetected(message)) {
-            event.cancel()
-        }
-        if (volcaddonsPattern.isDetected(message)) {
-            event.cancel()
-        }
-        diedPattern.matchMatcher(message) {
-            if (block()) return
-            val rawName = group("playerName")
-            val name = rawName.cleanPlayerName()
-            waypoints = waypoints.editCopy { remove(name) }
-            GriffinBurrowHelper.update()
-        }
-    }
-
-    private fun Pattern.isDetected(message: String): Boolean = matchMatcher(message) {
-        detectFromChat()
-    } ?: false
-
     private fun Matcher.block(): Boolean = !hasGroup("party") && !config.globalChat
 
     private fun Matcher.detectFromChat(): Boolean {
@@ -303,7 +275,9 @@ object InquisitorWaypointShare {
             }
         }
         val inquis = SharedInquisitor(name, displayName, location, SimpleTimeMark.now())
-        waypoints = waypoints.editCopy { this[name] = inquis }
+        synchronized(waypointsLock) {
+            _waypoints[name] = inquis
+        }
         GriffinBurrowHelper.update()
         return true
     }
@@ -312,7 +286,9 @@ object InquisitorWaypointShare {
 
     fun maybeRemove(inquis: SharedInquisitor) {
         if (inquisitorsNearby.isEmpty()) {
-            waypoints = waypoints.editCopy { remove(inquis.fromPlayer) }
+            synchronized(waypointsLock) {
+                _waypoints.remove(inquis.fromPlayer)
+            }
             GriffinBurrowHelper.update()
             ChatUtils.chat("Inquisitor from ${inquis.displayName} §enot found, deleting.")
         }


### PR DESCRIPTION
## What
Fixed Inquisitor Waypoint Sharing not working on 1.21 due to it looking for ChatMessage instead of GameMessage, and took the opportunity to refactor the code a bit. Also made the pattern for Inquisitors a bit more lenient to support more modern mod formats (I think it's either Skyblocker or SBO) and manual `/sendcoords` with text after it.

## Changelog Fixes
+ Fixed Inquisitor Waypoint Sharing not working on 1.21. - Luna

## Changelog Improvements
+ Improved Inquisitor Waypoint detection to handle any text after coordinates in chat. - Luna