### PR TITLE
Fix: Ubik's Cube Reminder (for real this time)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
@@ -18,7 +18,7 @@ object UbikReminder {
 
     private val config get() = RiftApi.config.area.mountaintop
 
-    private var nextRemindTime = SimpleTimeMark.farPast()
+    private var nextRemindTime = SimpleTimeMark.farFuture()
     private val patternGroup = RepoPattern.group("rift.ubik")
 
     /**
@@ -43,6 +43,6 @@ object UbikReminder {
         if (config.ubikReminder) {
             ChatUtils.chat("§aUbik's Cube is ready in the Rift!")
         }
-        nextRemindTime = SimpleTimeMark.farPast()
+        nextRemindTime = SimpleTimeMark.farFuture()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
@@ -39,9 +39,9 @@ object UbikReminder {
 
     @HandleEvent
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (nextRemindTime.isInPast()) return
+        if (nextRemindTime.isInFuture()) return
         if (config.ubikReminder) {
-            ChatUtils.chat("§aUbik's cube is ready in the rift!")
+            ChatUtils.chat("§aUbik's Cube is ready in the Rift!")
         }
         nextRemindTime = SimpleTimeMark.farPast()
     }


### PR DESCRIPTION
## What
Fixed Ubik's Cube Reminder triggering immediately after doing it because of a wrong check (`isInPast()` instead of `isInFuture()`).

## Changelog Fixes
+ Fixed Ubik's Cube Reminder notifying immediately instead of after 2 hours. - Luna


merged changelog with https://github.com/hannibal002/SkyHanni/pull/4735, therefore
exclude_from_changelog