### PR TITLE
Fix: Use correct number sign placement for Crop Money Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -247,7 +247,7 @@ object CropMoneyDisplay {
 
         return Renderable.horizontal {
             if (!config.compact) {
-                addString("§7$number# ")
+                addString("§7#$number ")
             }
 
             if (isSeeds(internalName)) {


### PR DESCRIPTION
## What
I don't know how I haven't noticed it all this time.

## Changelog Fixes
+ Fixed Crop Money Display number-sign placement (was `1#`, now `#1`). - Luna