### PR TITLE
Improvement: Fall back to tab list for slayer quest detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -23,7 +23,6 @@ import at.hannibal2.skyhanni.utils.RecalculatingValue
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.toLorenzVec

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -2,9 +2,11 @@ package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.SlayerQuestCompleteEvent
+import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.slayer.SlayerChangeEvent
@@ -153,14 +155,16 @@ object SlayerApi {
         // wait with sending SlayerChangeEvent until profile is detected
         if (ProfileStorageData.profileSpecific == null) return
 
-        val slayerQuest = ScoreboardData.sidebarLinesFormatted.nextAfter("Slayer Quest").orEmpty()
+        val lines = getSlayerLines()
+
+        val slayerQuest = lines.getOrNull(1).orEmpty()
         if (slayerQuest != latestCategory) {
             val old = latestCategory
             latestCategory = slayerQuest
             SlayerChangeEvent(old, latestCategory).post()
         }
 
-        val slayerProgress = ScoreboardData.sidebarLinesFormatted.nextAfter("Slayer Quest", 2).orEmpty()
+        val slayerProgress = lines.getOrNull(2).orEmpty()
         if (latestProgress != slayerProgress) {
             SlayerProgressChangeEvent(latestProgress, slayerProgress).post()
             latestProgress = slayerProgress
@@ -177,13 +181,21 @@ object SlayerApi {
         }
     }
 
-    @HandleEvent
-    fun onScoreboardChange(event: ScoreboardUpdateEvent) {
-        val slayerType = event.new.nextAfter("Slayer Quest")
-        val type = slayerType?.let { Type.getByName(it) }
+    private fun getSlayerLines(): List<String> =
+        ScoreboardData.sidebarLinesFormatted.dropWhile { it != "Slayer Quest" }.ifEmpty { TabWidget.SLAYER.lines }.map { it.trim() }
 
-        val slayerProgress = event.new.nextAfter("Slayer Quest", skip = 2) ?: "no slayer"
+    private fun updateSlayerState() {
+        val lines = getSlayerLines()
+
+        val slayerType = lines.getOrNull(1)
+        ChatUtils.debug("slayerType: $slayerType")
+        val type = slayerType?.let { Type.getByName(it) }
+        ChatUtils.debug("type: ${type?.name}")
+
+        val slayerProgress = lines.getOrNull(2) ?: "no slayer"
+        ChatUtils.debug("slayerProgress: $slayerProgress")
         val newState = slayerProgress.removeColor()
+        ChatUtils.debug("newState: $newState")
 
         val slayerData = getCurrentData()
         if (slayerData.currentStateRaw == newState) return
@@ -193,10 +205,19 @@ object SlayerApi {
         slayerData.currentStateRaw = newState
         val state = detectState(old, newState)
         if (slayerData.currentState == state) return
-        ChatUtils.chat("${slayerData.currentState} -> $state")
+        ChatUtils.debug("${slayerData.currentState} -> $state")
         slayerData.currentState = state
         SlayerStateChangeEvent(state).post()
+    }
 
+    @HandleEvent(ScoreboardUpdateEvent::class, onlyOnSkyblock = true)
+    fun onScoreboardChange() {
+        updateSlayerState()
+    }
+
+    @HandleEvent(TabListUpdateEvent::class, onlyOnSkyblock = true)
+    fun onTabListUpdate() {
+        updateSlayerState()
     }
 
     private fun String.inGrind() = contains("Combat") || contains("Kills")

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.SlayerQuestCompleteEvent
-import at.hannibal2.skyhanni.events.TabListUpdateEvent
+import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.slayer.SlayerChangeEvent
@@ -210,8 +210,9 @@ object SlayerApi {
         updateSlayerState()
     }
 
-    @HandleEvent(TabListUpdateEvent::class, onlyOnSkyblock = true)
-    fun onTabListUpdate() {
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+        if (!event.isWidget(TabWidget.SLAYER)) return
         updateSlayerState()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -188,14 +188,10 @@ object SlayerApi {
         val lines = getSlayerLines()
 
         val slayerType = lines.getOrNull(1)
-        ChatUtils.debug("slayerType: $slayerType")
         val type = slayerType?.let { Type.getByName(it) }
-        ChatUtils.debug("type: ${type?.name}")
 
         val slayerProgress = lines.getOrNull(2) ?: "no slayer"
-        ChatUtils.debug("slayerProgress: $slayerProgress")
         val newState = slayerProgress.removeColor()
-        ChatUtils.debug("newState: $newState")
 
         val slayerData = getCurrentData()
         if (slayerData.currentStateRaw == newState) return


### PR DESCRIPTION
## What
SlayerApi will now try to parse slayer quest information from the scoreboard first (as before), but if it is not found (e.g. due to it being overridden by an objective), it will try to use the tab list widget instead.

## Changelog Improvements
+ Improved Slayer quest detection: uses the Tab List widget when Hypixel omits them from the Scoreboard (common in The Park). - Luna