### PR TITLE
Fix: Moulconfig Draggable List empty

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementEmptyLine.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/elements/ScoreboardElementEmptyLine.kt
@@ -5,5 +5,5 @@ package at.hannibal2.skyhanni.features.gui.customscoreboard.elements
 object ScoreboardElementEmptyLine : ScoreboardElement() {
     override fun getDisplay() = ""
 
-    override val configLine = ""
+    override val configLine = "----- Separator -----"
 }


### PR DESCRIPTION
## What
i think this fixes it idk i cant be bothered to wait 20mins for it to import

<details>
<summary>Images</summary>

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/ca2a857f-5435-4760-bcff-10375699f7e5" />

</details>

## Changelog Fixes
+ Fixed Custom Scoreboard empty lines showing as blank in the config. - juna
