### PR TITLE
Improvement: Hoppity CF Shortcut Button Ctrl + Click to open config

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShortcut.kt
@@ -36,7 +36,7 @@ object CFShortcut {
             "§e/chocolatefactory",
             "",
             "§7Ctrl + Click",
-            "§7To open config"
+            "§7to open config"
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShortcut.kt
@@ -7,8 +7,10 @@ import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.render.gui.ReplaceItemEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import net.minecraft.client.player.inventory.ContainerLocalMenu
@@ -31,7 +33,10 @@ object CFShortcut {
             "§8(From SkyHanni)",
             "",
             "§7Click here to run",
-            "§e/chocolatefactory"
+            "§e/chocolatefactory",
+            "",
+            "§7Ctrl + Click",
+            "§7To open config"
         )
     }
 
@@ -58,8 +63,12 @@ object CFShortcut {
         if (!showItem || event.slotId != slotId) return
         event.cancel()
         if (lastClick.passedSince() > 2.seconds) {
-            HypixelCommands.chocolateFactory()
             lastClick = SimpleTimeMark.now()
+            if (KeyboardManager.isControlKeyDown()) {
+                config::hoppityMenuShortcut.jumpToEditor()
+                return
+            }
+            HypixelCommands.chocolateFactory()
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShortcut.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShortcut.kt
@@ -35,8 +35,7 @@ object CFShortcut {
             "§7Click here to run",
             "§e/chocolatefactory",
             "",
-            "§7Ctrl + Click",
-            "§7to open config"
+            "§7Ctrl + Click to open config"
         )
     }
 


### PR DESCRIPTION
## What
Adds option to ctrl+click the Hoppity CF Shortcut in sb menu to open its config option.

## Changelog Improvements
+ Added Ctrl+Click shortcut in Hoppity Chocolate Factory in SkyBlock Menu to open config. - Chissl