### PR TITLE
Backend: Remove usage of Netty internal API

### DIFF
--- a/.github/workflows/illegal-imports.txt
+++ b/.github/workflows/illegal-imports.txt
@@ -13,5 +13,6 @@ at/hannibal2/skyhanni/ io.github.moulberry.notenoughupdates.util.Utils
 at/hannibal2/skyhanni/ java.util.function.Supplier
 at/hannibal2/skyhanni/ com.mojang.realmsclient.
 at/hannibal2/skyhanni/ com.ibm.icu.
+at/hannibal2/skyhanni/ io.netty.util.internal.
 # Here because SkyHanniDebugsAndTests references way to much stuff and this way we keep the internal dependencies lower
 at/hannibal2/skyhanni/ at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests

--- a/.github/workflows/illegal-imports.txt
+++ b/.github/workflows/illegal-imports.txt
@@ -14,5 +14,5 @@ at/hannibal2/skyhanni/ java.util.function.Supplier
 at/hannibal2/skyhanni/ com.mojang.realmsclient.
 at/hannibal2/skyhanni/ com.ibm.icu.
 at/hannibal2/skyhanni/ io.netty.util.internal.
-# Here because SkyHanniDebugsAndTests references way to much stuff and this way we keep the internal dependencies lower
+# Here because SkyHanniDebugsAndTests references way too much stuff and this way we keep the internal dependencies lower
 at/hannibal2/skyhanni/ at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests


### PR DESCRIPTION
## What
Removed unnecessary usage of a Netty internal API, and added it to banned imports. 

Could have used `ConcurrentHashMap.newKeySet`, but since this was storing a `Pair` in a `Set` anyway and no logic depends on needing to keep track of multiple `SimpleTimeMark`s for a single `LorenzVec`, I just made it a proper `ConcurrentHashMap`.

## Changelog Technical Details
+ Replaced Netty internal `ConcurrentSet` usage with `ConcurrentHashMap`. - Luna
