### PR TITLE
Backend: Support dropping mc versions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/DiscontinuedMinecraftVersionsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/DiscontinuedMinecraftVersionsJson.kt
@@ -1,0 +1,12 @@
+package at.hannibal2.skyhanni.data.jsonobjects.repo
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+
+data class DiscontinuedMinecraftVersionsJson(
+    @Expose val versions: Map<String, DiscontinuedMinecraftVersion>? = mapOf(),
+)
+
+data class DiscontinuedMinecraftVersion(
+    @Expose @SerializedName("extra_info") val extraInfo: List<String>? = null,
+)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/CustomGithubReleaseUpdateSource.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/CustomGithubReleaseUpdateSource.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.misc.update
 
 import at.hannibal2.skyhanni.utils.VersionConstants
 import at.hannibal2.skyhanni.utils.system.ModVersion
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import com.google.gson.JsonPrimitive
 import moe.nea.libautoupdate.GithubReleaseUpdateData
 import moe.nea.libautoupdate.GithubReleaseUpdateSource
@@ -30,7 +31,7 @@ class CustomGithubReleaseUpdateSource(owner: String, repository: String) : Githu
         name ?: return false
         browserDownloadUrl ?: return false
         if (!name.endsWith(".jar")) return false
-        return name.contains(VersionConstants.MC_VERSION)
+        return name.contains(VersionConstants.MC_VERSION) || name.contains(PlatformUtils.MC_VERSION)
     }
 
     private fun GithubRelease.Download.createReleaseData(release: GithubRelease): GithubReleaseUpdateData {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -8,8 +8,8 @@ import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.config.features.About.UpdateStream
 import at.hannibal2.skyhanni.data.NotificationManager
 import at.hannibal2.skyhanni.data.SkyHanniNotification
-import at.hannibal2.skyhanni.data.jsonobjects.repo.DiscontinuedMinecraftVersionsJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.DiscontinuedMinecraftVersion
+import at.hannibal2.skyhanni.data.jsonobjects.repo.DiscontinuedMinecraftVersionsJson
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
@@ -250,7 +250,7 @@ object UpdateManager {
                     "§cPlaying on a discontinued version is not recommended and may lead to issues.",
                     "§cPlease update to a newer Minecraft version.",
                 ) + extraInfo,
-                Duration.INFINITE
+                Duration.INFINITE,
             )
 
             NotificationManager.queueNotification(notification)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -6,7 +6,13 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.config.features.About.UpdateStream
+import at.hannibal2.skyhanni.data.NotificationManager
+import at.hannibal2.skyhanni.data.SkyHanniNotification
+import at.hannibal2.skyhanni.data.jsonobjects.repo.DiscontinuedMinecraftVersionsJson
+import at.hannibal2.skyhanni.data.jsonobjects.repo.DiscontinuedMinecraftVersion
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
+import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
@@ -14,6 +20,7 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.api.ApiInternalUtils
 import at.hannibal2.skyhanni.utils.system.ModVersion
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import com.google.gson.JsonElement
 import io.github.notenoughupdates.moulconfig.processor.MoulConfigProcessor
 import moe.nea.libautoupdate.CurrentVersion
@@ -23,6 +30,7 @@ import moe.nea.libautoupdate.UpdateTarget
 import moe.nea.libautoupdate.UpdateUtils
 import java.util.concurrent.CompletableFuture
 import javax.net.ssl.HttpsURLConnection
+import kotlin.time.Duration
 
 @SkyHanniModule
 object UpdateManager {
@@ -216,5 +224,38 @@ object UpdateManager {
                 updateCommand("current")
             }
         }
+    }
+
+    private var discontinuedVersions: Map<String, DiscontinuedMinecraftVersion> = mapOf()
+    private var hasWarned = false
+
+    @HandleEvent
+    fun onRepoReload(event: RepositoryReloadEvent) {
+        val constant = event.getConstant<DiscontinuedMinecraftVersionsJson>("DiscontinuedMinecraftVersions")
+        constant.versions?.let {
+            discontinuedVersions = it
+        }
+    }
+
+    @HandleEvent(HypixelJoinEvent::class)
+    fun onHypixelJoin() {
+        if (hasWarned) return
+
+        if (PlatformUtils.MC_VERSION in discontinuedVersions) {
+            val extraInfo = discontinuedVersions[PlatformUtils.MC_VERSION]?.extraInfo ?: listOf()
+
+            val notification = SkyHanniNotification(
+                listOf(
+                    "§cSkyHanni is no longer receiving updates for Minecraft §e${PlatformUtils.MC_VERSION}§c.",
+                    "§cPlaying on a discontinued version is not recommended and may lead to issues.",
+                    "§cPlease update to a newer Minecraft version.",
+                ) + extraInfo,
+                Duration.INFINITE
+            )
+
+            NotificationManager.queueNotification(notification)
+        }
+
+        hasWarned = true
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -242,7 +242,7 @@ object UpdateManager {
         if (hasWarned) return
 
         if (PlatformUtils.MC_VERSION in discontinuedVersions) {
-            val extraInfo = discontinuedVersions[PlatformUtils.MC_VERSION]?.extraInfo ?: listOf()
+            val extraInfo = discontinuedVersions[PlatformUtils.MC_VERSION]?.extraInfo.orEmpty()
 
             val notification = SkyHanniNotification(
                 listOf(


### PR DESCRIPTION
## What
In anticipation of dropping support for 1.21.7 in favour of 1.21.8 so i can finally fix the custom wardrobe ive added a way to notify users of a discontinued version that they should update.

<details>
<summary>Images</summary>

<img width="813" height="125" alt="image" src="https://github.com/user-attachments/assets/d1af8976-abfc-4fa4-8706-101979166438" />

</details>

## Changelog Technical Details
+ Added ability to drop Minecraft versions and announce it via the repo. - CalMWolfs
    * Allows dropping 1.21.7 in the coming days.

