### PR TITLE
Fix: Modified Chat Message Mod Compat

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
@@ -20,6 +20,9 @@ fun onGameMessage(message: Text, actionBar: Boolean, original: Operation<Void>) 
     }
     val (result, cancel) = ChatManager.onChatReceive(message)
     result?.let {
+        // Will send both the unmodified and modified message into the Fabric Pipeline
+        // This sadly isn't preventable without switching fully to Fabric Chat Events
+        // (which needs an event for cancelling and an event for modifying, which isn't a feasible split up with this code base size)
         ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message, actionBar)
         original.call(it, actionBar)
         return

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
@@ -20,7 +20,7 @@ fun onGameMessage(message: Text, actionBar: Boolean, original: Operation<Void>) 
     }
     val (result, cancel) = ChatManager.onChatReceive(message)
     result?.let {
-        // Will send both the unmodified and modified message into the Fabric Pipeline
+        // Will send both the unmodified and modified message into the Fabric Pipeline so other mods also get the old unmodified message
         // This sadly isn't preventable without switching fully to Fabric Chat Events
         // (which needs an event for cancelling and an event for modifying, which isn't a feasible split up with this code base size)
         ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message, actionBar)

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageHandlerHook.kt
@@ -20,6 +20,7 @@ fun onGameMessage(message: Text, actionBar: Boolean, original: Operation<Void>) 
     }
     val (result, cancel) = ChatManager.onChatReceive(message)
     result?.let {
+        ClientReceiveMessageEvents.ALLOW_GAME.invoker().allowReceiveGameMessage(message, actionBar)
         original.call(it, actionBar)
         return
     }
@@ -34,5 +35,5 @@ fun onGameMessage(message: Text, actionBar: Boolean, original: Operation<Void>) 
         ClientReceiveMessageEvents.GAME_CANCELED.invoker().onReceiveGameMessageCanceled(message, actionBar)
         return
     }
-    original.call(message, actionBar);
+    original.call(message, actionBar)
 }


### PR DESCRIPTION
## What
also send the old message through the chat event 
5.0.0 milestone pls ty

basically if hypixel sends "WOW! You found a Glacite Mineshaft portal!" skyhanni fetches it before fabric and then modifies it to their liking.
so with pity overlay its "WOW! You found a Glacite Mineshaft portal! (537)" and then that gets send into the fabric pipeline.
So then mods that check explicitly for "WOW! You found a Glacite Mineshaft portal!" fail bc the actual message never gets send in the pipeline.

## Changelog Fixes
+ Fixed SkyHanni conflicting with other mods when modifying chat messages on modern. - juna
