### PR TITLE
Fix: Fairy soul error msg

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -666,10 +666,12 @@ object IslandGraphs {
             return
         }
 
+        val userReportedReason = args.joinToString(" ")
         sendReportLocation(
             playerPosition,
-            reasonForReport = "Manual reported graph location error",
-            userReason = args.joinToString(" "),
+            reasonForReport = userReportedReason,
+            technicalInfo = "Manual reported graph location error via /shreportlocation",
+            "reason provided by user" to userReportedReason,
         )
     }
 
@@ -681,8 +683,8 @@ object IslandGraphs {
     ) {
         sendReportLocation(
             location,
-            reasonForReport = "Automatic graph location error: $userFacingReason",
-            technicalInfo = technicalInfo,
+            reasonForReport = userFacingReason,
+            technicalInfo = "Automatic graph location error: $technicalInfo",
             extraData = extraData,
         )
     }
@@ -690,7 +692,6 @@ object IslandGraphs {
     private fun sendReportLocation(
         location: LorenzVec,
         reasonForReport: String,
-        userReason: String? = null,
         technicalInfo: String? = null,
         vararg extraData: Pair<String, Any?>,
     ) {
@@ -698,16 +699,15 @@ object IslandGraphs {
         val scoreboardArea = SkyBlockUtils.scoreboardArea ?: "unknown"
 
         val data = mutableMapOf<String, Any?>()
-        userReason?.let {
-            data["reason provided by user"] = it
-        }
         technicalInfo?.let {
             data["technical info"] = it
         }
         data.putAll(extraData.toMap())
         val island = SkyBlockUtils.currentIsland.name
+
+        data["generic data"] = "below"
         data["island"] = island
-        data["location"] = with(location.roundTo(1)) { "/shtestwaypoint $x $y $z pathfind" }
+        data["reported location"] = with(location.roundTo(1)) { "/shtestwaypoint $x $y $z pathfind" }
         if (graphArea != scoreboardArea) {
             data["area graph"] = graphArea.orEmpty()
             data["area scoreboard"] = scoreboardArea

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -670,24 +670,20 @@ object IslandGraphs {
             playerPosition,
             reasonForReport = "Manual reported graph location error",
             userReason = args.joinToString(" "),
-            ignoreCache = true,
-            betaOnly = false,
         )
     }
 
     fun reportLocation(
         location: LorenzVec,
         userFacingReason: String,
-        additionalInternalInfo: String? = null,
-        ignoreCache: Boolean = false,
-        betaOnly: Boolean = false,
+        technicalInfo: String? = null,
+        vararg extraData: Pair<String, Any?>,
     ) {
         sendReportLocation(
             location,
             reasonForReport = "Automatic graph location error: $userFacingReason",
-            additionalInternalInfo = additionalInternalInfo,
-            ignoreCache = ignoreCache,
-            betaOnly = betaOnly,
+            technicalInfo = technicalInfo,
+            extraData = extraData,
         )
     }
 
@@ -695,41 +691,39 @@ object IslandGraphs {
         location: LorenzVec,
         reasonForReport: String,
         userReason: String? = null,
-        additionalInternalInfo: String? = null,
-        ignoreCache: Boolean,
-        betaOnly: Boolean,
+        technicalInfo: String? = null,
+        vararg extraData: Pair<String, Any?>,
     ) {
         val graphArea = SkyBlockUtils.graphArea
         val scoreboardArea = SkyBlockUtils.scoreboardArea ?: "unknown"
 
-        val extraData = mutableMapOf<String, Any>()
+        val data = mutableMapOf<String, Any?>()
         userReason?.let {
-            extraData["reason provided by user"] = it
+            data["reason provided by user"] = it
         }
-        additionalInternalInfo?.let {
-            extraData["internal info"] = it
+        technicalInfo?.let {
+            data["technical info"] = it
         }
+        data.putAll(extraData.toMap())
         val island = SkyBlockUtils.currentIsland.name
-        extraData["island"] = island
-        extraData["location"] = with(location.roundTo(1)) { "/shtestwaypoint $x $y $z pathfind" }
+        data["island"] = island
+        data["location"] = with(location.roundTo(1)) { "/shtestwaypoint $x $y $z pathfind" }
         if (graphArea != scoreboardArea) {
-            extraData["area graph"] = graphArea.orEmpty()
-            extraData["area scoreboard"] = scoreboardArea
+            data["area graph"] = graphArea.orEmpty()
+            data["area scoreboard"] = scoreboardArea
         }
 
         SkyHanniRepoManager.localRepoCommit.let { (hash, time) ->
-            extraData["repo update time"] = time?.toString() ?: "none"
-            extraData["repo update age"] = time?.passedSince() ?: "unknown"
-            extraData["repo update hash"] = hash ?: "none"
+            data["repo update time"] = time?.toString() ?: "none"
+            data["repo update age"] = time?.passedSince() ?: "unknown"
+            data["repo update hash"] = hash ?: "none"
         }
 
         ErrorManager.logErrorStateWithData(
             reasonForReport,
             "",
             noStackTrace = true,
-            extraData = extraData.map { it.key to it.value }.normalizeAsArray(),
-            ignoreErrorCache = ignoreCache,
-            betaOnly = betaOnly,
+            extraData = data.map { it.key to it.value }.normalizeAsArray(),
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
@@ -107,9 +107,7 @@ object FishingHotspotRadar {
         IslandGraphs.reportLocation(
             location,
             userFacingReason = "Found no path to fishing hotspot",
-            additionalInternalInfo = "no node with tag 'fishing hotspot' found near the radar hotspot target",
-            ignoreCache = true,
-            betaOnly = true,
+            technicalInfo = "no node with tag 'fishing hotspot' found near the radar hotspot target",
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -101,16 +101,16 @@ object FastFairySoulsPathfinder {
 
             val inAir = PlayerUtils.inAir()
             if (inAir) {
-                val abovePlayer = LocationUtils.playerLocation().up(10)
+                val abovePlayer = playerLocation.up(10)
                 val aboveNearest = allSouls.minBy { it.distanceSq(abovePlayer) }
-                if (aboveNearest.distanceToPlayer() < 10) return aboveNearest
+                if (aboveNearest.distance(abovePlayer) < 10) return aboveNearest
             }
 
-            ErrorManager.logErrorStateWithData(
-                "unknown fairy soul",
-                "user clicked a fairy soul while far away from known fairy souls",
-                "nearest loc" to nearest,
-                "player loc" to LocationUtils.playerLocation(),
+            IslandGraphs.reportLocation(
+                playerLocation,
+                userFacingReason = "unknown fairy soul",
+                technicalInfo = "user clicked a fairy soul while far away from known fairy souls",
+                "nearest soul" to nearest,
                 "distance" to nearest.distanceToPlayer().roundTo(1),
                 "inAir" to inAir,
             )

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.features.misc.pathfind.NavigationFeedback
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LocationUtils


### PR DESCRIPTION
## What
when in air, previously we were comparing the wrong location. therefore a 10.5m distance below the soul (while falling) would still show an error.
also reused existing "report location" logic, and added support for extra data and cleanuped the function a bit

## Changelog Fixes
+ Fixed unnecessary Fairy Soul Helper error message. - hannibal2