### PR TITLE
Feature: keyboard control

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.kt
@@ -31,6 +31,10 @@ class InventoryConfig {
     val bazaar: BazaarConfig = BazaarConfig()
 
     @Expose
+    @Category(name = "Keyboard Control", desc = "Lets you control different menus with keyboard")
+    val keyboardControl: KeyboardControlConfig = KeyboardControlConfig()
+
+    @Expose
     @Category(name = "Experimentation Table", desc = "QOL features for the Experimentation Table.")
     val experimentationTable: ExperimentationTableConfig = ExperimentationTableConfig()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/KeyboardControlConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/KeyboardControlConfig.kt
@@ -1,0 +1,313 @@
+package at.hannibal2.skyhanni.config.features.inventory
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
+import org.lwjgl.input.Keyboard
+
+class KeyboardControlConfig {
+
+    @Expose
+    @ConfigOption(name = "Keybinds", desc = "Enable keyboard controls for Bazaar, Auction House, Sacks, and other inventories.")
+    @ConfigEditorBoolean
+    @SearchTag("keyboard")
+    @FeatureToggle
+    var keybindsEnabled: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Keybind cooldown", desc = "Set minimum time (ms) between two distinct clicks in the same inventory.")
+    @ConfigEditorSlider(minValue = 0f, maxValue = 300f, minStep = 1f)
+    var clickCooldown: Float = 150f
+
+    @Expose
+    @ConfigOption(name = "Render", desc = "Render available keybinds on corresponding slots in inventories.")
+    @ConfigEditorBoolean
+    var renderEnabled: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Selector", desc = "Enable keyboard controlled selector that works in all inventories.")
+    @ConfigEditorBoolean
+    var selectorEnabled: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Shared Keybinds", desc = "")
+    @Accordion
+    var shared: SharedConfig = SharedConfig()
+
+    class SharedConfig {
+        @Expose
+        @ConfigOption(name = "Back", desc = "Go back button.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_C)
+        var back: Int = Keyboard.KEY_C
+
+        @Expose
+        @ConfigOption(name = "Confirm", desc = "Confirm actions like purchases, bids, orders, etc.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_RETURN)
+        var confirm: Int = Keyboard.KEY_RETURN
+
+        @Expose
+        @ConfigOption(name = "Search", desc = "Open search in Bazaar or Auction Browser.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_S)
+        var search: Int = Keyboard.KEY_S
+
+        @Expose
+        @ConfigOption(name = "Claim All", desc = "Claim coins from orders/bids.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_RETURN)
+        var claim: Int = Keyboard.KEY_RETURN
+
+        @Expose
+        @ConfigOption(name = "Previous Page", desc = "Go to previous page in (auction/recipes/etc.) browser.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_P)
+        var previousPage: Int = Keyboard.KEY_P
+
+        @Expose
+        @ConfigOption(name = "Next Page", desc = "Go to next page in (auction/recipes/etc.) browser.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_N)
+        var nextPage: Int = Keyboard.KEY_N
+
+        @Expose
+        @ConfigOption(name = "Number 1", desc = "Select first item or option.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_1)
+        var number1: Int = Keyboard.KEY_1
+
+        @Expose
+        @ConfigOption(name = "Number 2", desc = "Select second item or option.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_2)
+        var number2: Int = Keyboard.KEY_2
+
+        @Expose
+        @ConfigOption(name = "Number 3", desc = "Select third item or option.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_3)
+        var number3: Int = Keyboard.KEY_3
+
+        @Expose
+        @ConfigOption(name = "Number 4", desc = "Select fourth item or option.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_4)
+        var number4: Int = Keyboard.KEY_4
+
+        @Expose
+        @ConfigOption(name = "Number 5", desc = "Select fifth item or option.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_5)
+        var number5: Int = Keyboard.KEY_5
+
+        @Expose
+        @ConfigOption(name = "Number 6", desc = "Select sixth item or option.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_6)
+        var number6: Int = Keyboard.KEY_6
+
+        @Expose
+        @ConfigOption(name = "Number 7", desc = "Select seventh item or option.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_7)
+        var number7: Int = Keyboard.KEY_7
+
+        @Expose
+        @ConfigOption(name = "Number 8", desc = "Select eighth item or option.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_8)
+        var number8: Int = Keyboard.KEY_8
+
+        @Expose
+        @ConfigOption(name = "Number 9", desc = "Select ninth item or option.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_9)
+        var number9: Int = Keyboard.KEY_9
+    }
+
+    @Expose
+    @ConfigOption(name = "Bazaar Keybinds", desc = "")
+    @SearchTag("bz")
+    @Accordion
+    var bazaar: BazaarConfig = BazaarConfig()
+
+    class BazaarConfig {
+        @Expose
+        @ConfigOption(name = "Manage Orders", desc = "Open Manage Orders menu.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_RETURN)
+        var manageOrders: Int = Keyboard.KEY_RETURN
+
+        @Expose
+        @ConfigOption(name = "Cancel Order", desc = "Cancel selected order.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_X)
+        var cancelOrder: Int = Keyboard.KEY_X
+
+        @Expose
+        @ConfigOption(name = "Flip Order", desc = "Flip selected order.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_F)
+        var flipOrder: Int = Keyboard.KEY_F
+
+        @Expose
+        @ConfigOption(name = "Buy Instantly", desc = "Buy item instantly.")
+        @SearchTag("instabuy")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
+        var buyInstantly: Int = Keyboard.KEY_NONE
+
+        @Expose
+        @ConfigOption(name = "Sell Instantly", desc = "Sell item instantly.")
+        @SearchTag("instasell")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
+        var sellInstantly: Int = Keyboard.KEY_NONE
+
+        @Expose
+        @ConfigOption(name = "Create Buy Order", desc = "Open Buy Order setup.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_B)
+        var createBuyOrder: Int = Keyboard.KEY_B
+
+        @Expose
+        @ConfigOption(name = "Create Sell Offer", desc = "Open Sell Offer setup.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_S)
+        var createSellOffer: Int = Keyboard.KEY_S
+
+        @Expose
+        @ConfigOption(name = "View Graphs", desc = "View price graphs for item.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_V)
+        var viewGraphs: Int = Keyboard.KEY_V
+
+        @Expose
+        @ConfigOption(name = "Ignore Item", desc = "Ignore selected item.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_I)
+        var ignoreItem: Int = Keyboard.KEY_I
+    }
+
+    @Expose
+    @ConfigOption(name = "Auction House Keybinds", desc = "")
+    @SearchTag("ah")
+    @Accordion
+    var auctionHouse: AuctionHouseConfig = AuctionHouseConfig()
+
+    class AuctionHouseConfig {
+        @Expose
+        @ConfigOption(name = "Browser", desc = "Open Auction Browser from main menu.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_A)
+        var browser: Int = Keyboard.KEY_A
+
+        @Expose
+        @ConfigOption(name = "Manage Bids", desc = "Open Manage Bids from main menu.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_B)
+        var manageBids: Int = Keyboard.KEY_B
+
+        @Expose
+        @ConfigOption(name = "Manage Auctions", desc = "Open Manage Auctions from main menu.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_M)
+        var manageAuctions: Int = Keyboard.KEY_M
+
+        @Expose
+        @ConfigOption(name = "Sort", desc = "Change sort options in Browser or Manage Auctions.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_S)
+        var sort: Int = Keyboard.KEY_S
+
+        @Expose
+        @ConfigOption(name = "Item Tier Filter", desc = "Change item tier filter in Browser.")
+        @SearchTag("rarity")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_T)
+        var itemTierFilter: Int = Keyboard.KEY_T
+
+        @Expose
+        @ConfigOption(name = "BIN Filter", desc = "Change BIN filter in Browser.")
+        @SearchTag("buy it now")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_B)
+        var binFilter: Int = Keyboard.KEY_B
+
+        @Expose
+        @ConfigOption(name = "Create Auction", desc = "Start creating auction in Manage Auctions.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_RETURN)
+        var createAuction: Int = Keyboard.KEY_RETURN
+
+        @Expose
+        @ConfigOption(name = "Cancel Auction", desc = "Cancel auction in view menu.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_X)
+        var cancelAuction: Int = Keyboard.KEY_X
+
+        @Expose
+        @ConfigOption(name = "Set Price", desc = "Open price setup in Create Auction.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_P)
+        var setPrice: Int = Keyboard.KEY_P
+
+        @Expose
+        @ConfigOption(name = "Set Duration", desc = "Open duration setup in Create Auction.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_D)
+        var setDuration: Int = Keyboard.KEY_D
+
+        @Expose
+        @ConfigOption(name = "Custom Duration", desc = "Select custom duration in duration menu.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_D)
+        var customDuration: Int = Keyboard.KEY_D
+    }
+
+    @Expose
+    @ConfigOption(name = "Sacks Keybinds", desc = "")
+    @SearchTag("sax")
+    @Accordion
+    var sacks: SacksConfig = SacksConfig()
+
+    class SacksConfig {
+        @Expose
+        @ConfigOption(name = "Insert Inventory", desc = "Insert inventory into Sack of Sacks or specific sack.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_RETURN)
+        var insertInventory: Int = Keyboard.KEY_RETURN
+
+        @Expose
+        @ConfigOption(name = "Pickup All", desc = "Pickup all items from sack.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_P)
+        var pickupAll: Int = Keyboard.KEY_P
+    }
+
+    @Expose
+    @ConfigOption(name = "Recipes Keybinds", desc = "")
+    @SearchTag("supercraft")
+    @Accordion
+    var recipes: RecipesConfig = RecipesConfig()
+
+    class RecipesConfig {
+        @Expose
+        @ConfigOption(name = "Supercraft Recipes", desc = "Use Supercraft in Recipes menu. Hold SHIFT or CTRL to max/custom.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_RETURN)
+        var supercraft: Int = Keyboard.KEY_RETURN
+    }
+
+    @Expose
+    @ConfigOption(name = "Inventory Selector", desc = "")
+    @SearchTag("cursor")
+    @Accordion
+    var inventorySelector: InventorySelectorConfig = InventorySelectorConfig()
+
+    class InventorySelectorConfig {
+        @Expose
+        @ConfigOption(name = "Remember Position", desc = "Remember selector position per (newly opened) menu.")
+        @SearchTag("cache, memorize")
+        @ConfigEditorBoolean
+        var rememberPosition: Boolean = false
+
+        @Expose
+        @ConfigOption(name = "Wrap Selector", desc = "Wrap selector around inventories or clamp it on border.")
+        @ConfigEditorBoolean
+        var wrap: Boolean = false
+
+        @Expose
+        @ConfigOption(name = "Click", desc = "Click selected slot.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_RSHIFT)
+        var click: Int = Keyboard.KEY_RSHIFT
+
+        @Expose
+        @ConfigOption(name = "Move Up", desc = "Move selector up.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_UP)
+        var up: Int = Keyboard.KEY_UP
+
+        @Expose
+        @ConfigOption(name = "Move Down", desc = "Move selector down.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_DOWN)
+        var down: Int = Keyboard.KEY_DOWN
+
+        @Expose
+        @ConfigOption(name = "Move Left", desc = "Move selector left.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_LEFT)
+        var left: Int = Keyboard.KEY_LEFT
+
+        @Expose
+        @ConfigOption(name = "Move Right", desc = "Move selector right.")
+        @ConfigEditorKeybind(defaultKey = Keyboard.KEY_RIGHT)
+        var right: Int = Keyboard.KEY_RIGHT
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/MenuAuction.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/MenuAuction.kt
@@ -1,0 +1,286 @@
+package at.hannibal2.skyhanni.features.inventory.keyboardcontrol
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.bindNumberKeysToItems
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.bindNumberKeysToSlots
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.createPatternBindings
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object MenuAuction {
+    private val config get() = SkyHanniMod.feature.inventory.keyboardControl
+    private val patternGroup = RepoPattern.group("keyboardcontrol.auction")
+
+    // -- BUTTONS --
+
+    // Main menu
+    private val browserButtonPattern by patternGroup.pattern("button.main.browser", "Auctions Browser")
+    private val bidsButtonPatternPrimary by patternGroup.pattern("button.main.bids", "Manage Bids")
+
+    // for whatever reason, name of this button changes when you click it (and go back to see it). Hypixel moment
+    private val bidsButtonPatternAlt by patternGroup.pattern("button.main.bidsalt", "View Bids")
+
+    private val manageAuctionsButtonPattern by patternGroup.pattern("button.main.manage", "Manage Auctions")
+    private val manageAuctionsButtonPatternAlt by patternGroup.pattern("button.main.managealt", "Auctions Management")
+
+    private val statsButtonPattern by patternGroup.pattern("button.main.stats", "Auction Stats")
+
+    // Browser
+    private val searchButtonPattern by patternGroup.pattern("button.search", "Search")
+    private val sortButtonPattern by patternGroup.pattern("button.browser.sort", "Sort")
+    private val tierFilterButtonPattern by patternGroup.pattern("button.browser.tierfilter", "Item Tier")
+    private val binFilterButtonPattern by patternGroup.pattern("button.browser.binfilter", "BIN Filter")
+
+    private val backButtonPattern by patternGroup.pattern("button.back", "Go Back")
+    private val closeButtonPattern by patternGroup.pattern("button.close", "Close")
+    private val prevPageButtonPattern by patternGroup.pattern("button.page.previous", "Previous Page")
+    private val nextPageButtonPattern by patternGroup.pattern("button.page.next", "Next Page")
+
+    /**
+     * REGEX-TEST: Claim All
+     */
+    private val claimButtonPattern by patternGroup.pattern("button.manage.claim", "Claim .*")
+
+    /**
+     * REGEX-TEST: Create Auction
+     * REGEX-TEST: Create BIN Auction
+     */
+    private val createAuctionButtonPattern by patternGroup.pattern("button.manage.create", "Create.* Auction")
+
+    /**
+     * REGEX-TEST: Confirm
+     * REGEX-TEST: Confirm Auction Creation
+     */
+    private val confirmButtonPattern by patternGroup.pattern("button.confirm.confirm", "Confirm.*")
+    // used for different things actually
+    /**
+     * REGEX-TEST: Cancel Auction
+     * REGEX-TEST: Cancel
+     */
+    private val cancelButtonPattern by patternGroup.pattern("button.confirm.cancel", "Cancel.*")
+
+    /**
+     * REGEX-TEST: Item price: 10000
+     */
+    private val setPriceButtonPattern by patternGroup.pattern("button.create.setprice", "Item price: .*")
+
+    /**
+     * REGEX-TEST: Duration: 2 Days
+     */
+    private val setDurationButtonPattern by patternGroup.pattern("button.create.setduration", "Duration: .*")
+    private val customDurationButtonPattern by patternGroup.pattern("button.duration.custom", "Custom Duration")
+    private val buyNowButtonPattern by patternGroup.pattern("button.view.buynow", "Buy Item Right Now")
+    private val placeBidButtonPattern by patternGroup.pattern("button.view.placebid", "Submit Bid")
+    private val cancelAuctionButtonPattern by patternGroup.pattern("button.view.cancel", "Cancel Auction")
+    private val collectAuctionButtonPattern by patternGroup.pattern("button.view.collect", "Collect Auction")
+
+    // -- TITLES --
+    /**
+     * REGEX-TEST: Co-op Auction House
+     */
+    private val mainMenuTitlePattern by patternGroup.pattern("title.main", ".*Auction House")
+    private val browserTitlePattern by patternGroup.pattern("title.browser", "Auctions Browser")
+    private val manageAuctionsTitlePattern by patternGroup.pattern("title.manage", "Manage Auctions")
+
+    /**
+     * REGEX-TEST: BIN Auction View
+     * REGEX-TEST: Auction View
+     */
+    private val lotViewTitlePattern by patternGroup.pattern("title.view", ".*Auction View")
+    private val manageBidsTitlePattern by patternGroup.pattern("title.bids", "Your Bids")
+
+    /**
+     * REGEX-TEST: Create BIN Auction
+     * REGEX-TEST: Create Auction
+     */
+    private val createAuctionTitlePattern by patternGroup.pattern("title.create", "Create.* Auction")
+    private val confirmPurchaseTitlePattern by patternGroup.pattern("title.confirm.purchase", "Confirm Purchase")
+
+    /**
+     * REGEX-TEST: Confirm BIN Auction
+     * REGEX-TEST: Confirm Auction
+     */
+    private val confirmAuctionTitlePattern by patternGroup.pattern("title.confirm.auction", "Confirm.* Auction")
+    private val setDurationMenuTitlePattern by patternGroup.pattern("title.duration", "Auction Duration")
+
+    // Selection grid used in browser
+    @Suppress("MagicNumber")
+    private val itemGridSlots = intArrayOf(
+        11, 12, 13, 14, 15, 16,
+        20, 21, 22, 23, 24, 25,
+        29, 30, 31, 32, 33, 34,
+        38, 39, 40, 41, 42, 43,
+    )
+
+    private val menus = arrayOf(
+        // Main menu
+        UiMenu(
+            titlePattern = mainMenuTitlePattern,
+            buttonPatterns = arrayOf(
+                browserButtonPattern,
+                bidsButtonPatternPrimary,
+                bidsButtonPatternAlt,
+                manageAuctionsButtonPattern,
+                manageAuctionsButtonPatternAlt,
+                closeButtonPattern,
+                statsButtonPattern,
+            ),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.auctionHouse.browser to browserButtonPattern
+                    // "Manage Bids" button changes name on click-and-return. Hypixel moment
+                    config.auctionHouse.manageBids to bidsButtonPatternPrimary
+                    config.auctionHouse.manageBids to bidsButtonPatternAlt
+                    config.auctionHouse.manageAuctions to manageAuctionsButtonPattern
+                    config.auctionHouse.manageAuctions to manageAuctionsButtonPatternAlt
+                    // Convenience aliases via option keys for main menu navigation
+                    config.shared.number1 to browserButtonPattern
+                    config.shared.number2 to bidsButtonPatternPrimary
+                    config.shared.number2 to bidsButtonPatternAlt
+                    config.shared.number3 to manageAuctionsButtonPattern
+                    config.shared.number3 to manageAuctionsButtonPatternAlt
+                }
+            },
+        ),
+
+        // Auction Browser
+        UiMenu(
+            titlePattern = browserTitlePattern,
+            buttonPatterns = arrayOf(
+                searchButtonPattern,
+                backButtonPattern,
+                sortButtonPattern,
+                tierFilterButtonPattern,
+                binFilterButtonPattern,
+                prevPageButtonPattern,
+                nextPageButtonPattern,
+            ),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.shared.search to searchButtonPattern
+                    config.auctionHouse.sort to sortButtonPattern
+                    config.auctionHouse.itemTierFilter to tierFilterButtonPattern
+                    config.auctionHouse.binFilter to binFilterButtonPattern
+                    config.shared.previousPage to prevPageButtonPattern
+                    config.shared.nextPage to nextPageButtonPattern
+                    config.shared.back to backButtonPattern
+                } + bindNumberKeysToSlots(config, itemGridSlots)
+            },
+        ),
+
+        // Lot view (single item)
+        UiMenu(
+            titlePattern = lotViewTitlePattern,
+            buttonPatterns = arrayOf(
+                backButtonPattern,
+                buyNowButtonPattern,
+                placeBidButtonPattern,
+                cancelAuctionButtonPattern,
+                collectAuctionButtonPattern,
+            ),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.shared.confirm to buyNowButtonPattern
+                    config.shared.confirm to placeBidButtonPattern
+                    config.auctionHouse.cancelAuction to cancelAuctionButtonPattern
+                    config.shared.confirm to collectAuctionButtonPattern
+                    config.shared.back to backButtonPattern
+                }
+            },
+        ),
+
+        // Manage Bids
+        UiMenu(
+            titlePattern = manageBidsTitlePattern,
+            buttonPatterns = arrayOf(claimButtonPattern, backButtonPattern),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.shared.claim to claimButtonPattern
+                    config.shared.back to backButtonPattern
+                } + bindNumberKeysToItems(config, snapshot)
+            },
+        ),
+
+        // Manage (your/coop) Auctions
+        UiMenu(
+            titlePattern = manageAuctionsTitlePattern,
+            buttonPatterns = arrayOf(
+                claimButtonPattern,
+                backButtonPattern,
+                sortButtonPattern,
+                createAuctionButtonPattern,
+            ),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.shared.claim to claimButtonPattern
+                    config.auctionHouse.sort to sortButtonPattern
+                    config.auctionHouse.createAuction to createAuctionButtonPattern
+                    config.shared.back to backButtonPattern
+                } + bindNumberKeysToItems(config, snapshot)
+            },
+        ),
+
+        // Create Auction
+        UiMenu(
+            titlePattern = createAuctionTitlePattern,
+            buttonPatterns = arrayOf(
+                backButtonPattern,
+                createAuctionButtonPattern,
+                setPriceButtonPattern,
+                setDurationButtonPattern,
+            ),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.shared.confirm to createAuctionButtonPattern
+                    config.auctionHouse.setPrice to setPriceButtonPattern
+                    config.auctionHouse.setDuration to setDurationButtonPattern
+                    config.shared.back to backButtonPattern
+                }
+            },
+        ),
+
+        // Confirm Auction
+        UiMenu(
+            titlePattern = confirmAuctionTitlePattern,
+            buttonPatterns = arrayOf(confirmButtonPattern, cancelButtonPattern),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.shared.back to cancelButtonPattern
+                    config.shared.confirm to confirmButtonPattern
+                    config.shared.back to backButtonPattern
+                }
+            },
+        ),
+
+        // Confirm Purchase
+        UiMenu(
+            titlePattern = confirmPurchaseTitlePattern,
+            buttonPatterns = arrayOf(confirmButtonPattern, cancelButtonPattern),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.shared.back to cancelButtonPattern
+                    config.shared.confirm to confirmButtonPattern
+                    config.shared.back to backButtonPattern
+                }
+            },
+        ),
+
+        // Set Duration
+        UiMenu(
+            titlePattern = setDurationMenuTitlePattern,
+            buttonPatterns = arrayOf(customDurationButtonPattern, backButtonPattern),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.auctionHouse.customDuration to customDurationButtonPattern
+                    config.shared.back to backButtonPattern
+                } + bindNumberKeysToItems(config, snapshot)
+            },
+        ),
+    )
+
+
+    init {
+        Registry.registerMenus(menus)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/MenuBazaar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/MenuBazaar.kt
@@ -1,0 +1,269 @@
+package at.hannibal2.skyhanni.features.inventory.keyboardcontrol
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.bindNumberKeysToItems
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.bindNumberKeysToSlots
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.createPatternBindings
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object MenuBazaar {
+    private val config get() = SkyHanniMod.feature.inventory.keyboardControl
+    private val patternGroup = RepoPattern.group("keyboardcontrol.bazaar")
+
+    // -- BUTTONS --
+
+    // Main menu
+    private val manageOrdersButtonPattern by patternGroup.pattern("button.main.manageorders", "Manage Orders")
+    private val searchButtonPattern by patternGroup.pattern("button.search", "Search")
+
+    // Manage orders menu
+    private val claimAllButtonPattern by patternGroup.pattern("button.manageorders.claimall", "Claim All Coins")
+
+    // Order options menu
+    private val cancelOrderButtonPattern by patternGroup.pattern("button.orderoptions.cancel", "Cancel Order")
+    private val flipOrderButtonPattern by patternGroup.pattern("button.orderoptions.flip", "Flip Order")
+
+    // (specific) Item options
+    private val buyInstantlyButtonPattern by patternGroup.pattern("button.item.buyinstantly", "Buy Instantly")
+    private val sellInstantlyButtonPattern by patternGroup.pattern("button.item.sellinstantly", "Sell Instantly")
+    private val buyOrderButtonPattern by patternGroup.pattern("button.item.createbuyorder", "Create Buy Order")
+    private val sellOfferButtonPattern by patternGroup.pattern("button.item.createselloffer", "Create Sell Offer")
+    private val viewGraphsButtonPattern by patternGroup.pattern("button.item.viewgraphs", "View Graphs")
+    private val ignoreItemButtonPattern by patternGroup.pattern("button.item.ignore", "Instasell Ignore")
+
+    // Confirmations
+    // For whatever reason, confirm insta buy for custom amount is called custom amount
+    private val confirmInstaBuyPattern by patternGroup.pattern("button.confirm.instabuy", "Custom Amount")
+
+    // But confirm for insta sell (if any), is called just "Confirm" (same as its title!)
+    private val confirmInstaSellPattern by patternGroup.pattern("button.confirm.instasell", "Confirm")
+    private val confirmBuyOrderButtonPattern by patternGroup.pattern("button.confirm.buyorder", "Buy Order")
+    private val confirmSellOfferButtonPattern by patternGroup.pattern("button.confirm.selloffer", "Sell Offer")
+
+    // Shared buttons
+    private val goBackButtonPattern by patternGroup.pattern("button.back", "Go Back")
+    private val sellSacksNowButtonPattern by patternGroup.pattern("button.item.sellsacks", "Sell Sacks Now")
+    private val AdvancedModeButtonPattern by patternGroup.pattern("button.item.advancedmode", "Advanced Mode")
+    private val sellInventoryNowButtonPattern by patternGroup.pattern("button.item.sellinventory", "Sell Inventory Now")
+    private val closeButtonPattern by patternGroup.pattern("button.close", "Close")
+
+    // -- TITLES --
+
+    // Confirm instasell is just confirm. Hypixel really likes exceptions
+    // We are really lucky there is nothing else with such name...
+    private val confirmInstaSellTitlePattern by patternGroup.pattern("title.confirm.instasell", "Confirm")
+    private val confirmInstaBuyTitlePattern by patternGroup.pattern("title.confirm.instabuy", "Confirm Instant Buy")
+
+    /**
+     * REGEX-TEST: Bazaar ➜ Oddities
+     * REGEX-TEST: Bazaar ➜ Inferno Minion
+     */
+    private val mainBazaarTitlePattern by patternGroup.pattern("title.main", "Bazaar ➜ .*")
+    private val buyQuantityTitlePattern by patternGroup.pattern("title.buy.quantity", "How many do you want\\?")
+    private val buyPriceTitlePattern by patternGroup.pattern("title.buy.price", "How much do you want to pay\\?")
+    private val confirmBuyTitlePattern by patternGroup.pattern("title.confirm.buyorder", "Confirm Buy Order")
+
+    /**
+     * REGEX-TEST: Confirm Instant Buy
+     * REGEX-TEST: Confirm Instant Sell
+     */
+    private val confirmSellTitlePattern by patternGroup.pattern("title.confirm.selloffer", "Confirm Sell Offer")
+    private val sellPriceTitlePattern by patternGroup.pattern("title.sell.price", "At what price are you selling\\?")
+    private val orderOptionsTitlePattern by patternGroup.pattern("title.orderoptions", "Order options")
+
+    /**
+     * REGEX-TEST: Co-op Bazaar Orders
+     */
+    private val bazaarOrdersTitlePattern by patternGroup.pattern("title.manageorders", ".*Bazaar Orders")
+
+    // We could hardcode (aka explicitly list in some regex) all submenu names,
+    // but such system would require manual fixing once Hypixel adds new ones
+    // Instead, we detect submenu as *Not* item menus, which have buy/sell buttons
+    /**
+     * REGEX-TEST: Reaper Pepper ➜ Instant Buy
+     * REGEX-TEST: Bazaar ➜ Inferno Minion
+     */
+    private val categoryMenuTitlePattern by patternGroup.pattern("title.category", ".* ➜ .*")
+
+    // fixed selection grid used on Bazaar main/search screen
+    @Suppress("MagicNumber")
+    private val searchItemSelectionSlots = intArrayOf(
+        11, 12, 13, 14, 15, 16,
+        20, 21, 22, 23, 24, 25,
+        29, 30, 31, 32, 33, 34,
+        38, 39, 40, 41, 42, 43,
+    )
+
+    private val menus = arrayOf(
+        // Main menu
+        UiMenu(
+            titlePattern = mainBazaarTitlePattern,
+            buttonPatterns = arrayOf(
+                manageOrdersButtonPattern,
+                searchButtonPattern,
+                goBackButtonPattern,
+                closeButtonPattern,
+            ),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.bazaar.manageOrders to manageOrdersButtonPattern
+                    config.shared.search to searchButtonPattern
+                    config.shared.back to goBackButtonPattern
+                } + bindNumberKeysToSlots(config, searchItemSelectionSlots)
+            },
+        ),
+
+        // Manage orders
+        UiMenu(
+            titlePattern = bazaarOrdersTitlePattern,
+            buttonPatterns = arrayOf(claimAllButtonPattern, goBackButtonPattern, closeButtonPattern),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.shared.claim to claimAllButtonPattern
+                    config.shared.back to goBackButtonPattern
+                } + bindNumberKeysToItems(config, snapshot)
+            },
+        ),
+
+        // Specific order options
+        UiMenu(
+            titlePattern = orderOptionsTitlePattern,
+            buttonPatterns = arrayOf(
+                cancelOrderButtonPattern,
+                flipOrderButtonPattern,
+                goBackButtonPattern,
+                closeButtonPattern,
+            ),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.bazaar.cancelOrder to cancelOrderButtonPattern
+                    config.bazaar.flipOrder to flipOrderButtonPattern
+                    config.shared.back to goBackButtonPattern
+                }
+            },
+        ),
+
+        // shared 4-option menus (quantity | price, e.g. Stack/160/1024/Custom | Same/+0.1/+5%/Custom)
+        UiMenu(
+            titlePattern = buyQuantityTitlePattern,
+            buttonPatterns = arrayOf(goBackButtonPattern, closeButtonPattern),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.shared.back to goBackButtonPattern
+                } + bindNumberKeysToItems(config, snapshot)
+            },
+        ),
+
+        UiMenu(
+            titlePattern = buyPriceTitlePattern,
+            buttonPatterns = arrayOf(goBackButtonPattern, closeButtonPattern),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.shared.back to goBackButtonPattern
+                } + bindNumberKeysToItems(config, snapshot)
+            },
+        ),
+
+        UiMenu(
+            titlePattern = sellPriceTitlePattern,
+            buttonPatterns = arrayOf(goBackButtonPattern, closeButtonPattern),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.shared.back to goBackButtonPattern
+                } + bindNumberKeysToItems(config, snapshot)
+            },
+        ),
+
+        // Confirm buy
+        UiMenu(
+            titlePattern = confirmBuyTitlePattern,
+            buttonPatterns = arrayOf(goBackButtonPattern, confirmBuyOrderButtonPattern, closeButtonPattern),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.shared.confirm to confirmBuyOrderButtonPattern
+                    config.shared.back to goBackButtonPattern
+                }
+            },
+        ),
+
+        // Confirm sell
+        UiMenu(
+            titlePattern = confirmSellTitlePattern,
+            buttonPatterns = arrayOf(confirmSellOfferButtonPattern, goBackButtonPattern, closeButtonPattern),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.shared.confirm to confirmSellOfferButtonPattern
+                    config.shared.back to goBackButtonPattern
+                }
+            },
+        ),
+
+        // Confirm instasell
+        UiMenu(
+            titlePattern = confirmInstaSellTitlePattern,
+            buttonPatterns = arrayOf(confirmInstaSellPattern, goBackButtonPattern, closeButtonPattern),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.shared.confirm to confirmInstaSellPattern
+                    config.shared.back to goBackButtonPattern
+                }
+            },
+        ),
+
+        // Confirm instabuy
+        UiMenu(
+            titlePattern = confirmInstaBuyTitlePattern,
+            buttonPatterns = arrayOf(confirmInstaBuyPattern, goBackButtonPattern, closeButtonPattern),
+            getBindings = { _ ->
+                createPatternBindings {
+                    config.shared.confirm to confirmInstaBuyPattern
+                    config.shared.back to goBackButtonPattern
+                }
+            },
+        ),
+
+        // Category (e.g. Fuels) / item-options (Fuels ➜ Oil Barrel) screen
+        UiMenu(
+            titlePattern = categoryMenuTitlePattern,
+            buttonPatterns = arrayOf(
+                buyInstantlyButtonPattern,
+                sellInstantlyButtonPattern,
+                buyOrderButtonPattern,
+                sellOfferButtonPattern,
+                viewGraphsButtonPattern,
+                ignoreItemButtonPattern,
+                manageOrdersButtonPattern,
+                goBackButtonPattern,
+                sellInventoryNowButtonPattern,
+                closeButtonPattern,
+                sellSacksNowButtonPattern,
+                AdvancedModeButtonPattern,
+            ),
+            variantIndicators = setOf(buyInstantlyButtonPattern, buyOrderButtonPattern, sellOfferButtonPattern),
+            getBindings = { snapshot ->
+                if (snapshot.isVariantMenu) {
+                    createPatternBindings {
+                        config.bazaar.buyInstantly to buyInstantlyButtonPattern
+                        config.bazaar.sellInstantly to sellInstantlyButtonPattern
+                        config.bazaar.createBuyOrder to buyOrderButtonPattern
+                        config.bazaar.createSellOffer to sellOfferButtonPattern
+                        config.bazaar.viewGraphs to viewGraphsButtonPattern
+                        config.bazaar.ignoreItem to ignoreItemButtonPattern
+                        config.bazaar.manageOrders to manageOrdersButtonPattern
+                        config.shared.back to goBackButtonPattern
+                    }
+                } else {
+                    createPatternBindings {
+                        config.shared.back to goBackButtonPattern
+                    } + bindNumberKeysToItems(config, snapshot)
+                }
+            },
+        ),
+    )
+
+    init {
+        Registry.registerMenus(menus)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/MenuRecipes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/MenuRecipes.kt
@@ -1,0 +1,102 @@
+package at.hannibal2.skyhanni.features.inventory.keyboardcontrol
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.bindNumberKeysToItems
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.bindNumberKeysToSlots
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.createPatternBindings
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import org.lwjgl.input.Keyboard
+
+@SkyHanniModule
+object MenuRecipes {
+    private val config get() = SkyHanniMod.feature.inventory.keyboardControl
+    private val patternGroup = RepoPattern.group("keyboardcontrol.recipes")
+
+    // -- BUTTONS --
+    private val previousPageButtonPattern by patternGroup.pattern("button.page.previous", "Previous Page")
+    private val nextPageButtonPattern by patternGroup.pattern("button.page.next", "Next Page")
+    private val closeButtonPattern by patternGroup.pattern("button.close", "Close")
+    private val searchRecipesButtonPattern by patternGroup.pattern("button.list.search", "Search Recipes")
+
+    /**
+     * REGEX-TEST: Supercraft
+     * REGEX-TEST: Supercraft (69/420)
+     */
+    private val supercraftButtonPattern by patternGroup.pattern("button.specific.supercraft", "Supercraft.*")
+    private val goBackButtonPattern by patternGroup.pattern("button.back", "Go Back")
+    private val previousRecipeButtonPattern by patternGroup.pattern("button.specific.previousrecipe", "Previous Recipe")
+    private val nextRecipeButtonPattern by patternGroup.pattern("button.specific.nextrecipe", "Next Recipe")
+
+    // -- TITLES --
+    /**
+     * REGEX-TEST: "sa" Recipes (1/3)
+     * REGEX-TEST: "golden c" Recipes (1/1)
+     */
+    private val recipesListTitlePattern by patternGroup.pattern("title.list", ".* Recipes .*")
+
+    /**
+     * REGEX-TEST: Spooky Sack Recipe
+     */
+    private val specificRecipeTitlePattern by patternGroup.pattern("title.specific", ".* Recipe")
+
+    // 3x3 crafting table grid.
+    @Suppress("MagicNumber")
+    private val recipeItemsSelectionSlots = intArrayOf(
+        10, 11, 12,
+        19, 20, 21,
+        28, 29, 30,
+    )
+
+    private val menus = arrayOf(
+        // Top-level recipe list menu
+        UiMenu(
+            titlePattern = recipesListTitlePattern,
+            buttonPatterns = arrayOf(
+                searchRecipesButtonPattern,
+                previousPageButtonPattern,
+                nextPageButtonPattern,
+                goBackButtonPattern,
+                closeButtonPattern,
+            ),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.shared.search to searchRecipesButtonPattern
+                    config.shared.previousPage to previousPageButtonPattern
+                    config.shared.nextPage to nextPageButtonPattern
+                    config.shared.back to goBackButtonPattern
+                } + bindNumberKeysToItems(config, snapshot, intArrayOf(), 1)
+            },
+        ),
+
+        // Specific recipe menu
+        UiMenu(
+            titlePattern = specificRecipeTitlePattern,
+            buttonPatterns = arrayOf(
+                supercraftButtonPattern,
+                previousRecipeButtonPattern,
+                nextRecipeButtonPattern,
+                goBackButtonPattern,
+                closeButtonPattern,
+            ),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    // normal key press maps to LMB click (craft one)
+                    config.recipes.supercraft to supercraftButtonPattern
+                    // shift-press maps to shift LMB click (set craft amount to max)
+                    config.recipes.supercraft to supercraftButtonPattern with intArrayOf(Keyboard.KEY_LSHIFT) mouse 0 mode 1
+                    // ctrl-press maps to RMB click (pick amount)
+                    config.recipes.supercraft to supercraftButtonPattern with intArrayOf(Keyboard.KEY_LCONTROL) mouse 1 mode 0
+                    config.shared.previousPage to previousRecipeButtonPattern
+                    config.shared.nextPage to nextRecipeButtonPattern
+                    config.shared.back to goBackButtonPattern
+                } + bindNumberKeysToSlots(config, recipeItemsSelectionSlots)
+            },
+        ),
+    )
+
+
+    init {
+        Registry.registerMenus(menus)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/MenuSacks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/MenuSacks.kt
@@ -1,0 +1,58 @@
+package at.hannibal2.skyhanni.features.inventory.keyboardcontrol
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.bindNumberKeysToItems
+import at.hannibal2.skyhanni.features.inventory.keyboardcontrol.KeyBinding.Companion.createPatternBindings
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object MenuSacks {
+    private val config get() = SkyHanniMod.feature.inventory.keyboardControl
+    private val patternGroup = RepoPattern.group("keyboardcontrol.sacks")
+
+    // -- BUTTONS --
+    private val insertInventoryButtonPattern by patternGroup.pattern("button.insertinventory", "Insert inventory")
+    private val goBackButtonPattern by patternGroup.pattern("button.back", "Go Back")
+    private val closeButtonPattern by patternGroup.pattern("button.close", "Close")
+    private val pickupAllButtonPattern by patternGroup.pattern("button.single.pickupall", "Pickup All")
+
+    // -- TITLES --
+    private val sackOfSacksTitlePattern by patternGroup.pattern("title.main", "Sack of Sacks")
+
+    /**
+     * REGEX-TEST: Dungeon Sack
+     */
+    private val singleSackTitlePattern by patternGroup.pattern("title.single", ".* Sack")
+
+    private val menus = arrayOf(
+        // Top level "Sack of Sacks" menu
+        UiMenu(
+            titlePattern = sackOfSacksTitlePattern,
+            buttonPatterns = arrayOf(insertInventoryButtonPattern, goBackButtonPattern, closeButtonPattern),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.sacks.insertInventory to insertInventoryButtonPattern
+                    config.shared.back to goBackButtonPattern
+                } + bindNumberKeysToItems(config, snapshot, intArrayOf(), 1)
+            },
+        ),
+
+        // Individual sack page
+        UiMenu(
+            titlePattern = singleSackTitlePattern,
+            buttonPatterns = arrayOf(pickupAllButtonPattern, insertInventoryButtonPattern, goBackButtonPattern),
+            getBindings = { snapshot ->
+                createPatternBindings {
+                    config.sacks.pickupAll to pickupAllButtonPattern
+                    config.sacks.insertInventory to insertInventoryButtonPattern
+                    config.shared.back to goBackButtonPattern
+                } + bindNumberKeysToItems(config, snapshot)
+            },
+        ),
+    )
+
+    init {
+        Registry.registerMenus(menus)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/Renderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/Renderer.kt
@@ -1,0 +1,42 @@
+package at.hannibal2.skyhanni.features.inventory.keyboardcontrol
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.KeyboardManager
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import org.lwjgl.input.Keyboard
+
+@SkyHanniModule
+object Renderer {
+    private val config get() = SkyHanniMod.feature.inventory.keyboardControl
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onRenderItemTip(event: RenderInventoryItemTipEvent) {
+        if (!isEnabled()) return
+        val slotNumber = event.slot.slotNumber
+        val keyActions = InventoryKeybindSystem.handler.context?.slotToKeybinds?.get(slotNumber) ?: return
+
+        val keybindText = keyActions
+            .filter { it.key != Keyboard.KEY_NONE }
+            .joinToString(separator = "/") { formatKeybind(it) }
+
+        if (keybindText.isNotEmpty()) {
+            event.stackTip = "§7[§b$keybindText§7]"
+        }
+    }
+
+    private fun formatKeybind(action: SlotActionEntry): String {
+        val modifiers = action.modifiers.joinToString(" + ") { KeyboardManager.getKeyName(it) }
+        val mainKey = KeyboardManager.getKeyName(action.key)
+        // TODO compact key & modifiers
+        return if (modifiers.isNotEmpty()) {
+            "$modifiers + $mainKey"
+        } else {
+            mainKey
+        }
+    }
+
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.renderEnabled && (config.keybindsEnabled || config.selectorEnabled)
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/Selector.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/Selector.kt
@@ -1,0 +1,123 @@
+package at.hannibal2.skyhanni.features.inventory.keyboardcontrol
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.GuiKeyPressEvent
+import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
+import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.RenderUtils.drawBorder
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.inventory.GuiChest
+import net.minecraft.inventory.Slot
+import org.lwjgl.input.Keyboard
+
+@SkyHanniModule
+object Selector {
+
+    private val config get() = SkyHanniMod.feature.inventory.keyboardControl
+
+    private const val INITIAL_ROW = 3
+    private const val INITIAL_COL = 4
+    private const val COLUMN_COUNT = 9
+
+    private data class SelectorPosition(val row: Int, val col: Int)
+
+    private val positionCache = mutableMapOf<String, SelectorPosition>()
+    private var currentPosition = SelectorPosition(INITIAL_ROW, INITIAL_COL)
+    private var currentTitle = ""
+    private var totalRows = 0
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onInventoryOpened(event: InventoryUpdatedEvent) {
+        if (!isEnabled()) return
+        currentTitle = event.inventoryName.removeColor()
+
+        updateTotalRows()
+
+        var row = currentPosition.row
+        var col = currentPosition.col
+        if (config.inventorySelector.rememberPosition) {
+            positionCache[currentTitle]?.let {
+                row = it.row
+                col = it.col
+            }
+        }
+        row = row.coerceIn(0, totalRows - 1)
+        col = col.coerceIn(0, COLUMN_COUNT - 1)
+        currentPosition = SelectorPosition(row, col)
+    }
+
+    // event.inventoryItems is out of sync with currentScreen.inventorySlots, but we need to see all empty slots
+    private fun updateTotalRows() {
+        val gui = Minecraft.getMinecraft().currentScreen as? GuiChest ?: return
+        totalRows = gui.inventorySlots.inventorySlots.size / COLUMN_COUNT
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onGuiKeyPress(event: GuiKeyPressEvent) {
+        if (!isEnabled()) return
+
+        updateTotalRows()
+
+        var row = currentPosition.row
+        var col = currentPosition.col
+        val oldRow = row
+        val oldCol = col
+
+        if (config.inventorySelector.up.isKeyHeld()) row--
+        if (config.inventorySelector.down.isKeyHeld()) row++
+        if (config.inventorySelector.left.isKeyHeld()) col--
+        if (config.inventorySelector.right.isKeyHeld()) col++
+
+        val moved = row != oldRow || col != oldCol
+        var clicked = false
+        if (moved) {
+            if (config.inventorySelector.wrap) {
+                row = (row + totalRows) % totalRows
+                col = (col + COLUMN_COUNT) % COLUMN_COUNT
+            } else {
+                row = row.coerceIn(0, totalRows - 1)
+                col = col.coerceIn(0, COLUMN_COUNT - 1)
+            }
+        }
+
+        if (config.inventorySelector.click.isKeyHeld()) {
+            getSelectedSlot(row, col)?.let { slot ->
+                val mouseButton = if (Keyboard.KEY_LCONTROL.isKeyHeld()) 1 else 0
+                val mode = if (Keyboard.KEY_LSHIFT.isKeyHeld()) 1 else 0
+                InventoryUtils.clickSlot(slot.slotNumber, mouseButton = mouseButton, mode = mode)
+                clicked = true
+            }
+        }
+
+        if (moved || clicked) {
+            event.cancel()
+            currentPosition = SelectorPosition(row, col)
+            if (config.inventorySelector.rememberPosition) {
+                positionCache[currentTitle] = currentPosition
+            }
+        }
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+        if (!isEnabled()) return
+        getSelectedSlot(currentPosition.row, currentPosition.col)?.drawBorder(LorenzColor.BLUE, 2)
+    }
+
+    private fun getSelectedSlot(row: Int, col: Int): Slot? {
+        val gui = Minecraft.getMinecraft().currentScreen as? GuiChest ?: return null
+        val slotNumber = row * COLUMN_COUNT + col
+        val slots = gui.inventorySlots.inventorySlots
+        if (slotNumber < 0 || slotNumber >= slots.size) return null
+        return slots.find { it.slotNumber == slotNumber }
+    }
+
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.selectorEnabled
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/System.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/keyboardcontrol/System.kt
@@ -1,0 +1,359 @@
+package at.hannibal2.skyhanni.features.inventory.keyboardcontrol
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.features.inventory.KeyboardControlConfig
+import at.hannibal2.skyhanni.events.GuiKeyPressEvent
+import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedGlassPane
+import net.minecraft.item.ItemStack
+import org.lwjgl.input.Keyboard
+import java.util.regex.Pattern
+import kotlin.time.Duration.Companion.milliseconds
+
+// All menu definitions from all keyboard control classes (auction, bazaar, etc.)
+// This way we can centralize processing to avoid (some of) redundant work
+object Registry {
+    private val allMenuDefinitions = arrayListOf<UiMenu>()
+
+    fun registerMenu(menu: UiMenu) {
+        allMenuDefinitions.add(menu)
+    }
+
+    fun registerMenus(menus: Array<UiMenu>) {
+        allMenuDefinitions.addAll(menus)
+    }
+
+    fun getAllDefinitions(): ArrayList<UiMenu> {
+        return allMenuDefinitions
+    }
+}
+
+// Snapshot of opened inventory (menu) state
+data class MenuSnapshot(
+    val patternToSlot: Map<String, Int>,
+    // items are all non-empty non-glass-pane stacks before first ui button (corresponding to how most Hypixel UIs work atm)
+    val itemSlots: IntArray,
+    // Sometimes you have 2 menus that cannot be distinguished by name pattern
+    // There is "menuIndicatorPatterns" to provide a way to check which one it is by matched slots inside
+    // So far, having boolean flag to tell 2 menus apart is enough (for bazaar specific item options and some submenu)
+    // In the future, more generic way to do so might be required
+    val isVariantMenu: Boolean,
+)
+
+// for key -> list of possible (slot + condition + mouse & mode) for this key
+data class KeyActionEntry(
+    val slot: Int,
+    val modifiers: IntArray,
+    val mouseButton: Int,
+    val mode: Int,
+)
+
+// for slot -> list of possible (key + condition + mouse & mode) that map to this slot
+data class SlotActionEntry(
+    val key: Int,
+    val modifiers: IntArray,
+    val mouseButton: Int,
+    val mode: Int,
+)
+
+sealed class KeyBinding {
+    abstract val key: Int
+    abstract val modifiers: IntArray
+    abstract val mouseButton: Int
+    abstract val mode: Int
+
+    // lf Sized tagged union
+    data class PatternBinding(
+        override val key: Int,
+        val pattern: Pattern,
+        override val modifiers: IntArray = intArrayOf(),
+        override val mouseButton: Int = 0,
+        override val mode: Int = 0,
+    ) : KeyBinding()
+
+    data class SlotBinding(
+        override val key: Int,
+        val slot: Int,
+        override val modifiers: IntArray = intArrayOf(),
+        override val mouseButton: Int = 0,
+        override val mode: Int = 0,
+    ) : KeyBinding()
+
+    companion object {
+        private fun getNumberKeys(config: KeyboardControlConfig) = intArrayOf(
+            config.shared.number1, config.shared.number2, config.shared.number3,
+            config.shared.number4, config.shared.number5, config.shared.number6,
+            config.shared.number7, config.shared.number8, config.shared.number9,
+        )
+
+        fun bindKeysToSlots(
+            keys: IntArray,
+            slots: IntArray,
+            modifiers: IntArray = intArrayOf(),
+            mouseButton: Int = 0,
+            mode: Int = 0,
+        ): List<KeyBinding> {
+            val n = minOf(keys.size, slots.size)
+            val out = ArrayList<KeyBinding>(n)
+            for (i in 0 until n) {
+                out.add(KeyBinding.SlotBinding(keys[i], slots[i], modifiers, mouseButton, mode))
+            }
+            return out
+        }
+
+        fun bindNumberKeysToSlots(
+            config: KeyboardControlConfig,
+            slots: IntArray,
+            modifiers: IntArray = intArrayOf(),
+            mouseButton: Int = 0,
+            mode: Int = 0,
+        ): List<KeyBinding> =
+            bindKeysToSlots(getNumberKeys(config), slots, modifiers, mouseButton, mode)
+
+        fun bindNumberKeysToItems(
+            config: KeyboardControlConfig,
+            snapshot: MenuSnapshot,
+            modifiers: IntArray = intArrayOf(),
+            mouseButton: Int = 0,
+            mode: Int = 0,
+        ): List<KeyBinding> =
+            bindNumberKeysToSlots(config, snapshot.itemSlots, modifiers, mouseButton, mode)
+
+        // Some nicety
+        fun createPatternBindings(builder: BindingBuilder.() -> Unit): List<KeyBinding> {
+            val builderInstance = BindingBuilder()
+            builderInstance.builder()
+            return builderInstance.bindings
+        }
+
+        // Even more nicety
+        class BindingBuilder {
+            internal val bindings = mutableListOf<PatternBinding>()
+            infix fun Int.to(pattern: Pattern) = PatternBinding(this, pattern).also { bindings.add(it) }
+            infix fun PatternBinding.with(modifierKeys: IntArray) = also {
+                bindings.removeLast()
+                bindings.add(copy(modifiers = modifierKeys))
+            }
+
+            infix fun PatternBinding.mouse(mb: Int) = also {
+                bindings.removeLast()
+                bindings.add(copy(mouseButton = mb))
+            }
+
+            infix fun PatternBinding.mode(m: Int) = also {
+                bindings.removeLast()
+                bindings.add(copy(mode = m))
+            }
+        }
+    }
+}
+
+data class UiMenu(
+    // how to recognize this menu title (regex pattern)
+    val titlePattern: Pattern,
+    // patterns for all UI buttons inside this menu (used to separate name UI buttons from "item" options)
+    // if anything missing, some UI buttons might be parsed as "items"
+    val buttonPatterns: Array<Pattern> = arrayOf(),
+    // patterns that mark alternative menus we want to detect (affects snapshot.isItemOptionsMenu)
+    val variantIndicators: Set<Pattern> = emptySet(),
+    // produce KeyBinding's for this menu given the MenuSnapshot
+    val getBindings: (snapshot: MenuSnapshot) -> List<KeyBinding>,
+)
+
+
+// Context that stores both raw and resolved/precomputed maps
+data class KeybindContext(
+    val snapshot: MenuSnapshot,
+    val rawBinds: List<KeyBinding>,
+    // key -> array of {slot + actions}
+    val keyToActions: Map<Int, Array<KeyActionEntry>>,
+    // track keybinds per slot
+    val slotToKeybinds: Map<Int, Array<SlotActionEntry>>,
+)
+
+
+class MenuKeybindHandler {
+    private val menuDefinitions: ArrayList<UiMenu> get() = Registry.getAllDefinitions()
+    private val config get() = SkyHanniMod.feature.inventory.keyboardControl
+    var context: KeybindContext? = null
+
+    // track last click time for each key for cooldown
+    private val lastClickTime = mutableMapOf<Int, SimpleTimeMark>()
+
+    // Scan an inventory and produce a MenuSnapshot
+    fun scanMenu(
+        slotsMap: Map<Int, ItemStack>,
+        // patterns for all the buttons in menu we are currently working with
+        buttonPatternsForThisMenu: Array<Pattern>,
+        // patterns to determine if menu is second variant we want to distinguish
+        menuIndicatorPatterns: Set<Pattern>,
+    ): MenuSnapshot {
+        // order to detect "before first button"
+        // TODO already sorted?
+        val entries = slotsMap.entries.sortedBy { it.key }
+
+        val buttonByPattern = linkedMapOf<String, Int>()
+        val itemSlots = arrayListOf<Int>()
+        var isVariantMenu = false
+        var hasHitFirstButton = false
+
+        for ((slot, stack) in entries) {
+            val display = stack.displayName?.removeColor() ?: continue
+            // TODO
+            val internal = stack.getInternalNameOrNull()?.asString()?.removeColor() ?: display
+
+            // try to match any button pattern
+            for (pattern in buttonPatternsForThisMenu) {
+                if (pattern.matches(display) || pattern.matches(internal)) {
+                    val key = pattern.pattern()
+                    buttonByPattern.putIfAbsent(key, slot)
+                    if (pattern in menuIndicatorPatterns) isVariantMenu = true
+                    hasHitFirstButton = true
+                    break
+                }
+            }
+
+            // collect items only until we encounter the first button
+            if (!hasHitFirstButton && !stack.isStainedGlassPane()) {
+                itemSlots.add(slot)
+            }
+        }
+
+        return MenuSnapshot(buttonByPattern, itemSlots.toIntArray(), isVariantMenu)
+    }
+
+    // Called when an inventory is opened. Scans the inventory, obtains
+    // KeyBinding's from the matched UiMenu, resolves patterns to slots and precomputes
+    // lookup maps used by the keypress handler.
+    fun calculateBindings(inventoryItems: Map<Int, ItemStack>, title: String) {
+        val currentMenu = menuDefinitions.firstOrNull { it.titlePattern.matcher(title).matches() } ?: return
+
+        val snapshot = try {
+            scanMenu(inventoryItems, currentMenu.buttonPatterns, currentMenu.variantIndicators)
+        } catch (ex: Exception) {
+            ChatUtils.debug("Menu scan failed: ${ex.message}")
+            return
+        }
+
+        val rawBinds = try {
+            currentMenu.getBindings(snapshot)
+        } catch (ex: Exception) {
+            ChatUtils.debug("getBindings threw: ${ex.message}")
+            return
+        }
+
+        val keyToActionsMutable = mutableMapOf<Int, ArrayList<KeyActionEntry>>()
+        val slotToActionsMutable = mutableMapOf<Int, ArrayList<SlotActionEntry>>()
+
+        for (bind in rawBinds) {
+            val slot = when (bind) {
+                is KeyBinding.SlotBinding -> bind.slot
+                is KeyBinding.PatternBinding -> snapshot.patternToSlot[bind.pattern.pattern()]
+            } ?: continue
+
+            val key = bind.key
+            val modifiers = bind.modifiers
+            val mouseButton = bind.mouseButton
+            val mode = bind.mode
+
+            keyToActionsMutable.getOrPut(key) { arrayListOf() }
+                .add(KeyActionEntry(slot, modifiers, mouseButton, mode))
+
+            slotToActionsMutable.getOrPut(slot) { arrayListOf() }
+                .add(SlotActionEntry(key, modifiers, mouseButton, mode))
+        }
+
+        // more specific (more modifiers) first ordering
+        keyToActionsMutable.values.forEach { actions ->
+            actions.sortWith(compareByDescending<KeyActionEntry> { it.modifiers.size }.thenBy { it.slot })
+        }
+        slotToActionsMutable.values.forEach { list ->
+            list.sortWith(compareByDescending<SlotActionEntry> { it.modifiers.size }.thenBy { it.key })
+        }
+
+        val keyToActions = keyToActionsMutable.mapValues { it.value.toTypedArray() }
+        val slotToActions = slotToActionsMutable.mapValues { it.value.toTypedArray() }
+
+        context = KeybindContext(snapshot, rawBinds, keyToActions, slotToActions)
+        return
+    }
+
+    // Check the precomputed context for actions for this key,
+    // find actions whose modifiers are currently held, and execute them
+    internal fun handleKeyPress(event: GuiKeyPressEvent, pressedKey: Int) {
+        val ctx = context ?: return
+        val actionsForKey = ctx.keyToActions[pressedKey] ?: return
+        val currentTime = SimpleTimeMark.now()
+
+        for (action in actionsForKey) {
+            if (action.modifiers.all { it.isKeyHeld() }) {
+                val lastTime = lastClickTime.getOrDefault(pressedKey, SimpleTimeMark.farPast())
+                if (currentTime - lastTime >= config.clickCooldown.toLong().milliseconds) {
+                    InventoryUtils.clickSlot(action.slot, null, action.mouseButton, action.mode)
+                    lastClickTime[pressedKey] = currentTime
+                    event.cancel()
+                    return
+                }
+            }
+        }
+    }
+
+
+    internal fun clearContext() {
+        context = null
+        lastClickTime.clear()
+    }
+}
+
+@SkyHanniModule
+object InventoryKeybindSystem {
+    val handler = MenuKeybindHandler()
+    private val config get() = SkyHanniMod.feature.inventory.keyboardControl
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onInventoryFullyOpened(event: InventoryUpdatedEvent) {
+        if (!isEnabled()) return
+        handler.clearContext()
+        // InventoryUtils.getItemsInOpenChest is out-of-sync so we use event.inventoryItems
+        // builds (somewhat expensive) context (key to action map) once and then reuses on clicks
+        // in worst case, we will use it once (no time saved / lost)
+        handler.calculateBindings(event.inventoryItems, event.inventoryName.removeColor())
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onGuiKeyPress(event: GuiKeyPressEvent) {
+        if (!isEnabled()) return
+        //#if MC < 1.21
+        val pressed = Keyboard.getEventKey()
+        try {
+            handler.handleKeyPress(event, pressed)
+        } catch (e: Exception) {
+            ChatUtils.debug("handleKeyPress threw: ${e.message}")
+        }
+        //#else
+        //$$ val ctx = handler.context ?: return
+        //$$ for (key in ctx.keyToActions.keys) {
+        //$$     try {
+        //$$         if (key.isKeyHeld()) {
+        //$$             handler.handleKeyPress(event, key)
+        //$$             return
+        //$$         }
+        //$$     } catch (e: Exception) {
+        //$$         ChatUtils.debug("handleKeyPress threw: ${e.message}")
+        //$$     }
+        //$$ }
+        //#endif
+    }
+
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.keybindsEnabled
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -124,12 +124,12 @@ object RenderUtils {
         GlStateManager.enableLighting()
     }
 
-    fun Slot.drawBorder(color: LorenzColor) {
-        drawBorder(color.toColor())
+    fun Slot.drawBorder(color: LorenzColor, thickness: Int = 1) {
+        drawBorder(color.toColor(), thickness)
     }
 
-    fun Slot.drawBorder(color: Color) {
-        drawBorder(color, xDisplayPosition, yDisplayPosition)
+    fun Slot.drawBorder(color: Color, thickness: Int = 1) {
+        drawBorder(color, xDisplayPosition, yDisplayPosition, thickness)
     }
 
     fun RenderGuiItemOverlayEvent.drawBorder(color: LorenzColor) {
@@ -140,7 +140,7 @@ object RenderUtils {
         drawBorder(color, x, y)
     }
 
-    fun drawBorder(color: Color, x: Int, y: Int) {
+    fun drawBorder(color: Color, x: Int, y: Int, thickness: Int = 1) {
         GlStateManager.disableLighting()
         GlStateManager.disableDepth()
         DrawContextUtils.pushMatrix()
@@ -150,10 +150,10 @@ object RenderUtils {
         //$$ val zLevel = 50f
         //#endif
         DrawContextUtils.translate(0f, 0f, 110 + zLevel)
-        GuiRenderUtils.drawRect(x, y, x + 1, y + 16, color.rgb)
-        GuiRenderUtils.drawRect(x, y, x + 16, y + 1, color.rgb)
-        GuiRenderUtils.drawRect(x, y + 15, x + 16, y + 16, color.rgb)
-        GuiRenderUtils.drawRect(x + 15, y, x + 16, y + 16, color.rgb)
+        GuiRenderUtils.drawRect(x, y, x + thickness, y + 16, color.rgb)
+        GuiRenderUtils.drawRect(x, y, x + 16, y + thickness, color.rgb)
+        GuiRenderUtils.drawRect(x, y + (16 - thickness), x + 16, y + 16, color.rgb)
+        GuiRenderUtils.drawRect(x + (16 - thickness), y, x + 16, y + 16, color.rgb)
         DrawContextUtils.popMatrix()
         GlStateManager.enableDepth()
         GlStateManager.enableLighting()


### PR DESCRIPTION
## What
Adds a structured way to define keybinds for skyblock menus, some keybinds themself, keybind rendering plus generic "selector" ("slot cursor") to make no-mouse menu interaction always an option.

<details>
<summary>Images</summary>
/bz -> pressing "4" -> pressing "3"
blue square is "selector" ("slot cursor"), can be moved with arrow keys

<img width="693" height="880" alt="image" src="https://github.com/user-attachments/assets/ce74cbb8-7e6b-4392-be25-4452357a3850" />
<img width="698" height="738" alt="image" src="https://github.com/user-attachments/assets/3c7840a0-b5fd-4d0e-98db-edb91c139e0e" />
<img width="696" height="736" alt="image" src="https://github.com/user-attachments/assets/869aad52-f7ba-47f2-ac39-2305ae026cbc" />

*idk why first one is not dark* 
</details>

## Changelog New Features
+ Added keyboard control feature. - platonvin
    * Bazaar, Auction House, Sacks, and Recipes (Supercraft) menus.
    * Ability to display available keybinds.
    * "Selector" ("slot cursor") controlled with keyboard that works in every menu.

## Changelog Improvements
+ Thickness selection for immediate mode border rendering. - platonvin

## Changelog Technical Details
+ Centralized keybinds definition and made it declarative. - platonvin