### PR TITLE
Fix: "first plot name is null" errors

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/garden/farming/CropClickEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/farming/CropClickEvent.kt
@@ -7,6 +7,9 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import net.minecraft.block.state.IBlockState
 import net.minecraft.item.ItemStack
 
+/**
+ * When the player clicks on a block that is linked to a CropType while in the garden.
+ */
 class CropClickEvent(
     val position: LorenzVec,
     val crop: CropType,

--- a/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
@@ -4,8 +4,6 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
 class PestSpawnEvent(val amountPests: Int?, val plotNames: List<String>) : SkyHanniEvent() {
     init {
-        if (amountPests != null && amountPests < 1) {
-            throw IllegalArgumentException("amountPests must be a positive integer or null")
-        }
+        require(amountPests == null || amountPests > 0) { "amountPests must be a positive integer or null" }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
@@ -2,4 +2,10 @@ package at.hannibal2.skyhanni.events.garden.pests
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-class PestSpawnEvent(val amountPests: Int, val plotNames: List<String>, val unknownAmount: Boolean) : SkyHanniEvent()
+class PestSpawnEvent(val amountPests: Int?, val plotNames: List<String>) : SkyHanniEvent() {
+    init {
+        if (amountPests != null && amountPests < 1) {
+            throw IllegalArgumentException("amountPests must be a positive integer or null")
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
@@ -2,6 +2,10 @@ package at.hannibal2.skyhanni.events.garden.pests
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
+
+/**
+ * When a pest spawn message gets detected while in the garden.
+ */
 class PestSpawnEvent(val amountPests: Int?, val plotNames: List<String>) : SkyHanniEvent() {
     init {
         require(amountPests == null || amountPests > 0) { "amountPests must be a positive integer or null" }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -3,11 +3,12 @@ package at.hannibal2.skyhanni.features.garden.pests
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ScoreboardData
+import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
-import at.hannibal2.skyhanni.events.TabListUpdateEvent
+import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestKillEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestSpawnEvent
@@ -187,14 +188,12 @@ object PestApi {
                 ChatUtils.userError("Open Plot Management Menu to load plot names and pest locations!")
                 return
             }
-            if (event.unknownAmount) {
-                plot.isPestCountInaccurate = true
-            } else {
-                plot.pests += event.amountPests
-                plot.isPestCountInaccurate = false
-            }
+            plot.isPestCountInaccurate = event.amountPests?.let {
+                plot.pests += it
+                false
+            } ?: true
         }
-        if (!event.unknownAmount) scoreboardPests += event.amountPests
+        event.amountPests?.let { scoreboardPests += it }
         updatePests()
     }
 
@@ -215,24 +214,24 @@ object PestApi {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onTabListUpdate(event: TabListUpdateEvent) {
-        for (line in event.tabList) {
-            infectedPlotsTablistPattern.matchMatcher(line) {
-                val plotList = group("plots").removeColor().split(", ").map { it.toInt() }
-                if (plotList.sorted() == getInfestedPlots().map { it.id }.sorted()) return
+    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+        if (!event.isWidget(TabWidget.PESTS)) return
 
-                for (plot in GardenPlotApi.plots) {
-                    if (plotList.contains(plot.id)) {
-                        if (!plot.isPestCountInaccurate && plot.pests == 0) {
-                            plot.isPestCountInaccurate = true
-                        }
-                    } else {
-                        plot.pests = 0
-                        plot.isPestCountInaccurate = false
+        infectedPlotsTablistPattern.firstMatcher(event.widget.lines) {
+            val plotList = group("plots").removeColor().split(", ").map { it.toInt() }
+            if (plotList.sorted() == getInfestedPlots().map { it.id }.sorted()) return
+
+            for (plot in GardenPlotApi.plots) {
+                if (plotList.contains(plot.id)) {
+                    if (!plot.isPestCountInaccurate && plot.pests == 0) {
+                        plot.isPestCountInaccurate = true
                     }
+                } else {
+                    plot.pests = 0
+                    plot.isPestCountInaccurate = false
                 }
-                updatePests()
             }
+            updatePests()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -109,7 +109,7 @@ object PestApi {
     /**
      * REGEX-TEST:  Plots: §r§b4§r§f, §r§b12§r§f, §r§b13§r§f, §r§b18§r§f, §r§b20
      */
-    private val infectedPlotsTablistPattern by patternGroup.pattern(
+    private val infestedPlotsTabListPattern by patternGroup.pattern(
         "tablist.infectedplots",
         "\\sPlots: (?<plots>.*)",
     )
@@ -217,12 +217,14 @@ object PestApi {
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.PESTS)) return
 
-        infectedPlotsTablistPattern.firstMatcher(event.widget.lines) {
-            val plotList = group("plots").removeColor().split(", ").map { it.toInt() }
-            if (plotList.sorted() == getInfestedPlots().map { it.id }.sorted()) return
+        infestedPlotsTabListPattern.firstMatcher(event.widget.lines) {
+            val tabListPlots = group("plots").removeColor().split(", ").map { it.toInt() }.toSet()
+            val apiPlots = getInfestedPlots().map { it.id }.toSet()
+
+            if (tabListPlots == apiPlots) return
 
             for (plot in GardenPlotApi.plots) {
-                if (plotList.contains(plot.id)) {
+                if (plot.id in tabListPlots) {
                     if (!plot.isPestCountInaccurate && plot.pests == 0) {
                         plot.isPestCountInaccurate = true
                     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -34,7 +34,7 @@ object PestSpawn {
     /**
      * REGEX-TEST: §6§lYUCK! §24 §2ൠ Pest §7have spawned in §aPlot §7- §b14§7!
      */
-    private val multiplePestsSpawn by patternGroup.pattern(
+    private val multiplePestsPattern by patternGroup.pattern(
         "multiple",
         "§6§l.*! §2(?<amount>\\d) §2ൠ Pests? §7have spawned in §aPlot §7- §b(?<plot>.*)§7!",
     )
@@ -42,40 +42,37 @@ object PestSpawn {
     /**
      * REGEX-TEST: §6§lGROSS! §7While you were offline, §2ൠ §2Pest §7spawned in §aPlots §r§b12§r§7, §r§b9§r§7, §r§b5§r§7, §r§b11§r§7 and §r§b3§r§r§7!
      */
-    private val offlinePestsSpawn by patternGroup.pattern(
+    private val offlinePestsPattern by patternGroup.pattern(
         "offline",
         "§6§l.*! §7While you were offline, §2ൠ §2Pests? §7spawned in §aPlots (?<plots>.*)!",
     )
-    private var plotNames = mutableListOf<String>()
+    /**
+     * WRAPPED-REGEX-TEST: "  §r§e§lCLICK HERE §eto teleport to the plot!"
+     */
+    private val clickToTpPattern by patternGroup.pattern(
+        "teleport",
+        "\\s*§r§e§lCLICK HERE §eto teleport to the plot!",
+    )
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onChat(event: SkyHanniChatEvent) {
         val message = event.message
         var blocked = false
 
-        plotNames.clear()
-
         onePestPattern.matchMatcher(message) {
-            val plotName = group("plot")
-            plotNames.add(plotName)
-            pestSpawn(1, plotNames, false)
+            pestSpawn(1, listOf(group("plot")))
             blocked = true
         }
-        multiplePestsSpawn.matchMatcher(message) {
-            val plotName = group("plot")
-            plotNames.add(plotName)
-            val amount = group("amount").toInt()
-            pestSpawn(amount, plotNames, false)
+        multiplePestsPattern.matchMatcher(message) {
+            pestSpawn(group("amount").toInt(), listOf(group("plot")))
             blocked = true
         }
-        offlinePestsSpawn.matchMatcher(message) {
-            val plots = group("plots")
-            plotNames = plots.removeColor().split(", ", " and ").toMutableList()
-            pestSpawn(0, plotNames, true)
+        offlinePestsPattern.matchMatcher(message) {
+            pestSpawn(null, group("plots").removeColor().split(", ", " and ").toList())
             // blocked = true
         }
 
-        if (event.message == "  §r§e§lCLICK HERE §eto teleport to the plot!") {
+        clickToTpPattern.matchMatcher(message) {
             if (lastPestSpawnTime.passedSince() < 1.seconds) {
                 blocked = true
             }
@@ -86,10 +83,10 @@ object PestSpawn {
         }
     }
 
-    private fun pestSpawn(amount: Int, plotNames: List<String>, unknownAmount: Boolean) {
-        PestSpawnEvent(amount, plotNames, unknownAmount).post()
+    private fun pestSpawn(amount: Int?, plotNames: List<String>) {
+        PestSpawnEvent(amount, plotNames).post()
 
-        if (unknownAmount) return // todo make this work with offline pest spawn messages
+        if (amount == null) return // todo make this work with offline pest spawn messages
         val plotName = plotNames.firstOrNull() ?: error("first plot name is null")
         val pestName = StringUtils.pluralize(amount, "Pest")
         val message = "§e$amount §a$pestName Spawned in §b$plotName§a!"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -49,7 +49,7 @@ object PestSpawn {
     /**
      * WRAPPED-REGEX-TEST: "  §r§e§lCLICK HERE §eto teleport to the plot!"
      */
-    private val clickToTpPattern by patternGroup.pattern(
+    private val clickToTPPattern by patternGroup.pattern(
         "teleport",
         "\\s*§r§e§lCLICK HERE §eto teleport to the plot!",
     )
@@ -60,19 +60,19 @@ object PestSpawn {
         var blocked = false
 
         onePestPattern.matchMatcher(message) {
-            pestSpawn(1, listOf(group("plot")))
+            spawn(1, listOf(group("plot")))
             blocked = true
         }
         multiplePestsPattern.matchMatcher(message) {
-            pestSpawn(group("amount").toInt(), listOf(group("plot")))
+            spawn(group("amount").toInt(), listOf(group("plot")))
             blocked = true
         }
         offlinePestsPattern.matchMatcher(message) {
-            pestSpawn(null, group("plots").removeColor().split(", ", " and ").toList())
+            spawn(null, group("plots").removeColor().split(", ", " and ").toList())
             // blocked = true
         }
 
-        clickToTpPattern.matchMatcher(message) {
+        clickToTPPattern.matchMatcher(message) {
             if (lastPestSpawnTime.passedSince() < 1.seconds) {
                 blocked = true
             }
@@ -83,10 +83,10 @@ object PestSpawn {
         }
     }
 
-    private fun pestSpawn(amount: Int?, plotNames: List<String>) {
+    private fun spawn(amount: Int?, plotNames: List<String>) {
         PestSpawnEvent(amount, plotNames).post()
 
-        if (amount == null) return // todo make this work with offline pest spawn messages
+        if (amount == null) return // TODO make this work with offline pest spawn messages
         val plotName = plotNames.firstOrNull() ?: error("first plot name is null")
         val pestName = StringUtils.pluralize(amount, "Pest")
         val message = "§e$amount §a$pestName Spawned in §b$plotName§a!"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -105,7 +105,7 @@ object PestSpawnTimer {
         }
     }
 
-    @HandleEvent(PestSpawnEvent::class, onlyOnIsland = IslandType.GARDEN)
+    @HandleEvent(PestSpawnEvent::class)
     fun onPestSpawn() {
         shouldRepeatWarning = false
         val spawnTime = lastPestSpawnTime.passedSince()
@@ -131,7 +131,7 @@ object PestSpawnTimer {
         config.position.renderRenderables(display, posLabel = "Pest Spawn Timer")
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    @HandleEvent
     fun onCropBreak(event: CropClickEvent) {
         if (event.clickType != ClickType.LEFT_CLICK) return
         val timeDiff = lastCropBrokenTime.passedSince()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -54,11 +54,11 @@ object PestSpawnTimer {
     private val patternGroup = RepoPattern.group("garden.pests")
 
     /**
-     * REGEX-TEST:  Cooldown: §r§a§lREADY
-     * REGEX-TEST:  Cooldown: §r§e1m 58s
-     * REGEX-TEST:  Cooldown: §r§e1m
-     * REGEX-TEST:  Cooldown: §r§e58s
-     * REGEX-TEST:  Cooldown: §r§c§lMAX PESTS
+     * WRAPPED-REGEX-TEST: " Cooldown: §r§a§lREADY"
+     * WRAPPED-REGEX-TEST: " Cooldown: §r§e1m 58s"
+     * WRAPPED-REGEX-TEST: " Cooldown: §r§e1m"
+     * WRAPPED-REGEX-TEST: " Cooldown: §r§e58s"
+     * WRAPPED-REGEX-TEST: " Cooldown: §r§c§lMAX PESTS"
      */
 
     private val pestCooldownPattern by patternGroup.pattern(
@@ -105,8 +105,8 @@ object PestSpawnTimer {
         }
     }
 
-    @HandleEvent
-    fun onPestSpawn(event: PestSpawnEvent) {
+    @HandleEvent(PestSpawnEvent::class, onlyOnIsland = IslandType.GARDEN)
+    fun onPestSpawn() {
         shouldRepeatWarning = false
         val spawnTime = lastPestSpawnTime.passedSince()
 
@@ -131,7 +131,7 @@ object PestSpawnTimer {
         config.position.renderRenderables(display, posLabel = "Pest Spawn Timer")
     }
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onCropBreak(event: CropClickEvent) {
         if (event.clickType != ClickType.LEFT_CLICK) return
         val timeDiff = lastCropBrokenTime.passedSince()


### PR DESCRIPTION
## What
Fixes pest spawn processing failing with a "first plot name is null" error if another chat message is received between the pest spawn message and the moment of processing (consistently reproducible with "Pest Spawn Time Chat Message" enabled).

Also includes miscellaneous code cleanup.

## Changelog Fixes
+ Fixed error on pest spawn with Pest Spawn Time Chat Message enabled, and sometimes without it. - Luna