### PR TITLE
Fix + Remove: Walk Speed Rounding + Sneak Handling

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -46,7 +46,7 @@ object PlayerUtils {
         //#if MC < 1.21
         val speed = MinecraftCompat.localPlayer.capabilities.walkSpeed.toDouble()
         //#else
-        //$$ val speed = MinecraftCompat.localPlayer.getAttributeValue(EntityAttributes.MOVEMENT_SPEED)
+        //$$ val speed = MinecraftCompat.localPlayer.getAttributeBaseValue(EntityAttributes.MOVEMENT_SPEED)
         //#endif
 
         // Round to avoid floating point inaccuracies (in-game precision is at most 2 decimals anyway)

--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.StringUtils.toUnDashedUUID
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.client.Minecraft
@@ -41,12 +42,15 @@ object PlayerUtils {
         //#endif
     }
 
-    fun getWalkSpeed(): Int {
+    fun getWalkSpeed(): Float {
         //#if MC < 1.21
-        return (MinecraftCompat.localPlayer.capabilities.walkSpeed * 1000).toInt()
+        val speed = MinecraftCompat.localPlayer.capabilities.walkSpeed.toDouble()
         //#else
-        //$$ return (MinecraftCompat.localPlayer.getAttributeValue(EntityAttributes.MOVEMENT_SPEED) * 1000).toInt()
+        //$$ val speed = MinecraftCompat.localPlayer.getAttributeValue(EntityAttributes.MOVEMENT_SPEED)
         //#endif
+
+        // Round to avoid floating point inaccuracies (in-game precision is at most 2 decimals anyway)
+        return (speed * 1000).roundTo(2).toFloat()
     }
 
     fun getUuid() = getRawUuid().toUnDashedUUID()


### PR DESCRIPTION
## What
Fixed Garden optimal speed calculation sometimes estimating the player's speed incorrectly due to two reasons:
* Floating point errors (e.g. 308 would register as 307.99999833106995, which is then rounded down to 307).
* Walking forwards while sprinting was incorrectly applying a 1.3x speed multiplier on 1.21.

Note: I purposely didn't change this to just round to the nearest integer. We intentionally round down, as due to how farming mechanics work, being slightly over the optimal speed is pretty much always preferable to being slightly under. Therefore, now we round to 2 decimal places first to avoid floating point errors. (Players can have fractional speeds such as 307.5 if they are not using Rancher's Boots, which we want to continue rounding down to 307.)

Also cleaned up the code in general, including removal of the sneak handling I added myself a while back, because I believe it was misguided and is more confusing than useful. For example, if the player wants to farm a 93 speed farm with Fermento Boots, which requires sneaking to achieve, it's better for them to just set their optimal speed to what they will see, which is 310, rather than SkyHanni trying to interpolate it and interpreting their speed as 93 due to sneaking. We don't do that for other things like Depth Strider or soul sand either.

## Changelog Fixes
+ Fixed Garden Optimal Speed sometimes reporting the wrong speed. - Luna

## Changelog Technical Details
+ Removed special handling for sneaking in Garden Optimal Speed. - Luna