### PR TITLE
Fix: Shupdate command not working

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -87,8 +87,13 @@ object UpdateManager {
     fun checkUpdate(forceDownload: Boolean = false, forcedUpdateStream: UpdateStream = config.updateStream.get()) {
         var updateStream = forcedUpdateStream
         if (updateState != UpdateState.NONE) {
-            logger.log("Trying to perform update check while another update is already in progress")
-            return
+            if (updateState == UpdateState.AVAILABLE && forceDownload) {
+                updateState = UpdateState.NONE
+                logger.log("Resetting update state to force download")
+            } else {
+                logger.log("Trying to perform update check while another update is already in progress")
+                return
+            }
         }
         logger.log("Starting update check")
         val currentStream = config.updateStream.get()


### PR DESCRIPTION
## What
Fixed the `/shupdate` command not working for people that ignored the first update notification.

## Changelog Fixes
+ Fixed /shupdate not working if the mod already checked for updates since launch. - CalMWolfs

