### PR TITLE
Fix: Overall mod performance on modern versions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -282,6 +282,7 @@ object HoppityCollectionStats {
 
     @HandleEvent
     fun replaceItem(event: ReplaceItemEvent) {
+        if (!inInventory || replacementCache.isEmpty()) return
         if (event.originalItem == null) return
         replacementCache[event.originalItem.displayName]?.let { event.replace(it) }
     }


### PR DESCRIPTION
## What
Now the expensive displayName calculation on 1.21 is only done if we are in the hoppity collection inventory and we have stuff in the replacementCache.

## Changelog Fixes
+ Fixed menu performance issues with a custom texture pack on modern Minecraft versions. - CalMWolfs