### PR TITLE
Fix + Backend: Performance issues when checking inventory name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import net.minecraft.item.ItemStack
 import net.minecraft.network.play.server.S2DPacketOpenWindow
@@ -25,12 +24,15 @@ object OtherInventoryData {
     private var acceptItems = false
     private var lateEvent: InventoryUpdatedEvent? = null
 
+    val currentInventoryName: String
+        get() = currentInventory?.title ?: ""
+
     @HandleEvent
     fun onCloseWindow(event: GuiContainerEvent.CloseWindowEvent) {
         close()
     }
 
-    fun close(title: String = InventoryUtils.openInventoryName(), reopenSameName: Boolean = false) {
+    fun close(title: String = currentInventoryName, reopenSameName: Boolean = false) {
         InventoryCloseEvent(title, reopenSameName).post()
         currentInventory = null
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
@@ -13,7 +13,9 @@ import net.minecraft.network.play.server.S2DPacketOpenWindow
 import net.minecraft.network.play.server.S2EPacketCloseWindow
 import net.minecraft.network.play.server.S2FPacketSetSlot
 //#if MC > 1.21
+//$$ import at.hannibal2.skyhanni.events.minecraft.packet.PacketSentEvent
 //$$ import at.hannibal2.skyhanni.test.command.ErrorManager
+//$$ import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket
 //$$ import net.minecraft.screen.ScreenHandlerType
 //#endif
 
@@ -31,6 +33,15 @@ object OtherInventoryData {
     fun onCloseWindow(event: GuiContainerEvent.CloseWindowEvent) {
         close()
     }
+
+    //#if MC > 1.21
+    //$$ @HandleEvent
+    //$$ fun onPacketSent(event: PacketSentEvent) {
+    //$$     if (event.packet is CloseHandledScreenC2SPacket) {
+    //$$         close()
+    //$$     }
+    //$$ }
+    //#endif
 
     fun close(title: String = currentInventoryName, reopenSameName: Boolean = false) {
         InventoryCloseEvent(title, reopenSameName).post()

--- a/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
@@ -27,7 +27,7 @@ object OtherInventoryData {
     private var lateEvent: InventoryUpdatedEvent? = null
 
     val currentInventoryName: String
-        get() = currentInventory?.title ?: ""
+        get() = currentInventory?.title.orEmpty()
 
     @HandleEvent
     fun onCloseWindow(event: GuiContainerEvent.CloseWindowEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.data.OtherInventoryData
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacks
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -61,7 +62,7 @@ object InventoryUtils {
             .filter { it.inventory is InventoryPlayer && it.stack.isNotEmpty() }
     }
 
-    fun openInventoryName(): String = InventoryCompat.getOpenChestName()
+    fun openInventoryName(): String = OtherInventoryData.currentInventoryName
 
     fun inInventory() = Minecraft.getMinecraft().currentScreen is GuiChest
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -6,12 +6,10 @@ import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.inventory.Container
-import net.minecraft.inventory.ContainerChest
 import net.minecraft.inventory.Slot
 import net.minecraft.item.ItemStack
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
-
 //#if FABRIC
 //$$ import net.minecraft.screen.slot.SlotActionType
 //$$ import at.hannibal2.skyhanni.compat.ReiCompat
@@ -57,18 +55,6 @@ val GuiChest.container: Container
 //#endif
 
 object InventoryCompat {
-
-    // TODO add cache that persists until the next gui/window open/close packet is sent/received
-    fun getOpenChestName(): String {
-        val currentScreen = Minecraft.getMinecraft().currentScreen
-        //#if MC < 1.16
-        if (currentScreen !is GuiChest) return ""
-        val value = currentScreen.inventorySlots as ContainerChest
-        return value.lowerChestInventory?.displayName?.unformattedText.orEmpty()
-        //#else
-        //$$ return currentScreen?.title.formattedTextCompat()
-        //#endif
-    }
 
     fun clickInventorySlot(slot: Int, windowId: Int? = getWindowId(), mouseButton: Int, mode: Int) {
         windowId ?: return


### PR DESCRIPTION
## What
Now we use `OtherInventoryData.currentInventory` to find out the current inventory name. I also made it correctly recognise inventory closures on 1.21. From testing this seems to even be slightly more accurate on both 1.8 and 1.21 than it was previously

## Changelog Fixes
+ Fixed performance issues with Firmament on 1.21.8. - CalMWolfs

## Changelog Technical Details
+ Cache the currently open inventory name. - CalMWolfs

