### PR TITLE
Backend: Improve enchant glint addition

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -26,6 +26,7 @@ import at.hannibal2.skyhanni.utils.ColorUtils.toColor
 import at.hannibal2.skyhanni.utils.DialogUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryDetector
+import at.hannibal2.skyhanni.utils.ItemUtils.addEnchantGlint
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
@@ -41,7 +42,6 @@ import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.EnchantmentsCompat
 import at.hannibal2.skyhanni.utils.json.toJsonArray
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.Renderable.Companion.renderBounds
@@ -402,7 +402,7 @@ object GardenNextJacobContest {
         for (crop in contest.crops) {
             val isBoosted = crop == contest.boostedCrop
             val cropStack = crop.getItemStackCopy("garden_next_jacob:$crop-$isBoosted-$activeContest").apply {
-                if (isBoosted) addEnchantment(EnchantmentsCompat.PROTECTION.enchantment, 1)
+                if (isBoosted) addEnchantGlint()
             }
             val stack = Renderable.item(cropStack, 1.0)
             if (config.additionalBoostedHighlight && isBoosted) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
@@ -7,11 +7,11 @@ import at.hannibal2.skyhanni.features.garden.pests.PestApi
 import at.hannibal2.skyhanni.features.garden.pests.PestType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.addEnchantGlint
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.setLore
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.compat.EnchantmentsCompat
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
 import net.minecraft.item.ItemStack
 
@@ -40,7 +40,7 @@ object StereoHarmonyDiscReplacer {
 
         val replacementStack = iconCache.getOrPut(iconId) {
             cropType.getItemStackCopy(iconId).apply {
-                if (isActiveVinyl) addEnchantment(EnchantmentsCompat.PROTECTION.enchantment, 1)
+                if (isActiveVinyl) addEnchantGlint()
                 setLore(event.originalItem.getLore())
                 setCustomItemName(event.originalItem.displayName)
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.events.render.gui.ReplaceItemEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.addEnchantGlint
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NumberUtil.formatIntOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
@@ -23,7 +24,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.EnchantmentsCompat
 import at.hannibal2.skyhanni.utils.compat.getIdentifierString
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
@@ -213,7 +213,7 @@ object ExperimentsAddonsHelper {
         val nextClickColor = hypixelChronomatronData.getOrNull(userChronomatronProgress.size) ?: return
         originalItem?.getLorenzColorOrNull()?.takeIf { it == nextClickColor } ?: return
         val newItem = originalItem.copy()
-        newItem.addEnchantment(EnchantmentsCompat.PROTECTION.enchantment, 1)
+        newItem.addEnchantGlint()
         replace(newItem)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -45,6 +45,7 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIfKey
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
+import at.hannibal2.skyhanni.utils.compat.EnchantmentsCompat
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.NbtCompat
 import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
@@ -308,16 +309,25 @@ object ItemUtils {
 
     fun ItemStack.isVanilla() = NeuItems.isVanillaItem(this)
 
-    // Checks for the enchantment glint as part of the minecraft enchantments
+    // Checks for the enchantment glint as part of the Minecraft enchantments
     fun ItemStack.isEnchanted(): Boolean =
         //#if MC < 1.21
         isItemEnchanted
     //#else
-    //$$ hasEnchantments() || this.get(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE) == true
+    //$$ hasGlint()
     //#endif
 
-    // Checks for hypixel enchantments in the attributes
-    fun ItemStack.hasHypixelEnchantments() = getHypixelEnchantments()?.isNotEmpty() ?: false
+    // Checks for Hypixel enchantments in the attributes
+    fun ItemStack.hasHypixelEnchantments(): Boolean =
+        getHypixelEnchantments()?.isNotEmpty() ?: false
+
+    fun ItemStack.addEnchantGlint(): ItemStack = apply {
+        //#if MC < 1.21
+        addEnchantment(EnchantmentsCompat.PROTECTION.enchantment, 1)
+        //#else
+        //$$ set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
+        //#endif
+    }
 
     fun ItemStack.removeEnchants(): ItemStack = apply {
         //#if MC < 1.21

--- a/src/main/java/at/hannibal2/skyhanni/utils/collection/RenderableCollectionUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/collection/RenderableCollectionUtils.kt
@@ -1,10 +1,10 @@
 package at.hannibal2.skyhanni.utils.collection
 
+import at.hannibal2.skyhanni.utils.ItemUtils.addEnchantGlint
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.RenderUtils
-import at.hannibal2.skyhanni.utils.compat.EnchantmentsCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils
 import at.hannibal2.skyhanni.utils.renderables.Searchable
@@ -55,8 +55,7 @@ object RenderableCollectionUtils {
         scale: Double = NeuItems.ITEM_FONT_SIZE,
     ) {
         if (highlight) {
-            // Hack to add enchant glint, like Hypixel does it
-            itemStack.addEnchantment(EnchantmentsCompat.PROTECTION.enchantment, 1)
+            itemStack.addEnchantGlint()
         }
         add(Renderable.item(itemStack, scale = scale))
     }


### PR DESCRIPTION
## What
Added an `ItemStack.addEnchantGlint()` extension method for applying enchantment glint to items, and made it use a less hacky way to do so on 1.21.

Also simplified the `ItemStack.isEnchanted()` check.

## Changelog Technical Details
+ Added `ItemStack.addEnchantGlint()`. - Luna
    * On 1.21, this now uses `ENCHANTMENT_GLINT_OVERRIDE` instead of a fake enchantment.

