### PR TITLE
Backend: Allow setting a minimum affected version

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -27,7 +27,8 @@ object EnforcedConfigValues {
         val constant = event.getConstant<EnforcedConfigValuesJson>("misc/EnforcedConfigValues").enforcedConfigValues
         val oldEnforcedValues = enforcedConfigValuesData
         enforcedConfigValuesData = constant.filter {
-            SkyHanniMod.modVersion <= it.affectedVersion
+            SkyHanniMod.modVersion <= it.affectedVersion &&
+                (it.minimumAffectedVersion?.let { minVersion -> SkyHanniMod.modVersion >= minVersion } ?: true)
         }.filter {
             it.affectedMinecraftVersions?.contains(PlatformUtils.MC_VERSION) ?: true
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/EnforcedConfigValuesJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/EnforcedConfigValuesJson.kt
@@ -10,15 +10,16 @@ data class EnforcedConfigValuesJson(
 )
 
 data class EnforcedValueData(
-    @Expose var enforcedValues: List<EnforcedValue> = listOf(),
-    @Expose var notificationPSA: List<String>? = null,
-    @Expose var chatPSA: List<String>? = null,
-    @Expose var affectedVersion: ModVersion,
-    @Expose var affectedMinecraftVersions: List<String>? = null,
-    @Expose var extraMessage: String? = null,
+    @Expose val enforcedValues: List<EnforcedValue> = listOf(),
+    @Expose val notificationPSA: List<String>? = null,
+    @Expose val chatPSA: List<String>? = null,
+    @Expose val minimumAffectedVersion: ModVersion? = null,
+    @Expose val affectedVersion: ModVersion,
+    @Expose val affectedMinecraftVersions: List<String>? = null,
+    @Expose val extraMessage: String? = null,
 )
 
 data class EnforcedValue(
-    @Expose var path: String,
-    @Expose var value: JsonElement,
+    @Expose val path: String,
+    @Expose val value: JsonElement,
 )


### PR DESCRIPTION
## What
For stuff like the recent enforcing of disabling the double click feature. As that only affects 1 beta but now everyone on old betas also has it off.
By default no minimum enforced version means its all versions below the affected version

## Changelog Technical Details
+ Made it so enforced values could have a minimum mod version they start working for. - CalMWolfs
