### PR TITLE
Improvement: Profile name warning clarification

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
@@ -127,7 +127,8 @@ object ProfileStorageData {
         val foundSkyBlockTabList = TabWidget.AREA.isActive
         if (foundSkyBlockTabList) {
             ChatUtils.clickableChat(
-                "§cCan not read profile name from tab list! Open /widget and enable Profile Widget. " +
+                "§cCan not read profile name from tab list! Open /widget, enable the Profile Widget, " +
+                    "and give it high enough priority that it shows up in tab list. " +
                     "This is needed for the mod to function! And therefore this warning cannot be disabled",
                 onClick = {
                     HypixelCommands.widget()

--- a/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
@@ -128,8 +128,8 @@ object ProfileStorageData {
         if (foundSkyBlockTabList) {
             ChatUtils.clickableChat(
                 "§cCan not read profile name from tab list! Open /widget, enable the Profile Widget, " +
-                    "and give it high enough priority that it shows up in tab list. " +
-                    "This is needed for the mod to function! And therefore this warning cannot be disabled",
+                    "and give it high enough priority so that it is visible in tab list. " +
+                    "This is needed for the mod to function and therefore this warning cannot be disabled!",
                 onClick = {
                     HypixelCommands.widget()
                 },


### PR DESCRIPTION
## What
Added a line to the profile name warning specifying that the profile name widget must be high enough priority for it to be visible.

## Changelog Improvements
+ Clarified profile name widget warning. - Chissl
