### PR TITLE
Fix: Block clicks not being detected when farming

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
@@ -102,7 +102,7 @@ object MinecraftInputHook {
         blockHitResult: MovingObjectPosition?,
         currentBlockPos: BlockPos
     ): Boolean {
-        if (blockHitResult == null) return false
+        if (blockHitResult == null || blockHitResult.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return false
 
         val position = blockHitResult.blockPos
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
@@ -7,7 +7,9 @@ import at.hannibal2.skyhanni.events.entity.EntityClickEvent
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.network.play.client.C02PacketUseEntity
+import net.minecraft.util.BlockPos
 import net.minecraft.util.MovingObjectPosition
+
 //#if MC > 1.21
 //$$ import net.minecraft.util.hit.EntityHitResult
 //#endif
@@ -55,7 +57,7 @@ object MinecraftInputHook {
     }
 
     @JvmStatic
-    fun shouldCancelMouseLeftCLick(blockHitResult: MovingObjectPosition?): Boolean {
+    fun shouldCancelMouseLeftClick(blockHitResult: MovingObjectPosition?): Boolean {
         if (blockHitResult == null) return false
 
         val clickCancelled = ItemClickEvent(InventoryUtils.getItemInHand(), ClickType.LEFT_CLICK).post()
@@ -91,6 +93,31 @@ object MinecraftInputHook {
                 }.post()
             }
         }
+
+        return cancelled
+    }
+
+    @JvmStatic
+    fun shouldCancelContinuedBlockBreak(
+        blockHitResult: MovingObjectPosition?,
+        currentBlockPos: BlockPos
+    ): Boolean {
+        if (blockHitResult == null) return false
+
+        val position = blockHitResult.blockPos
+
+        if (currentBlockPos == position) return false
+
+        val clickCancelled = ItemClickEvent(InventoryUtils.getItemInHand(), ClickType.LEFT_CLICK).post()
+
+        val cancelled = BlockClickEvent(
+            ClickType.LEFT_CLICK,
+            position.toLorenzVec(),
+            InventoryUtils.getItemInHand(),
+        ).also {
+            if (clickCancelled) it.cancel()
+        }.post()
+
 
         return cancelled
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/AccessorPlayerControllerMP.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/AccessorPlayerControllerMP.java
@@ -1,0 +1,15 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import net.minecraft.util.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.multiplayer.PlayerControllerMP;
+
+@Mixin(
+    PlayerControllerMP.class
+)
+public interface AccessorPlayerControllerMP {
+    @Accessor("currentBlock")
+    BlockPos skyhanni_getCurrentBlock();
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/AccessorPlayerControllerMP.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/AccessorPlayerControllerMP.java
@@ -6,9 +6,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import net.minecraft.client.multiplayer.PlayerControllerMP;
 
-@Mixin(
-    PlayerControllerMP.class
-)
+@Mixin(PlayerControllerMP.class)
 public interface AccessorPlayerControllerMP {
     @Accessor("currentBlock")
     BlockPos skyhanni_getCurrentBlock();

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMinecraftInputs.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMinecraftInputs.java
@@ -11,11 +11,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
 //#if MC > 1.21
 //$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 //#endif
-
 
 @Mixin(Minecraft.class)
 public class MixinMinecraftInputs {
@@ -58,9 +56,9 @@ public class MixinMinecraftInputs {
         if (MinecraftInputHook.shouldCancelMouseLeftClick(this.objectMouseOver))
             //#if MC < 1.21
             ci.cancel();
-            //#else
-            //$$ cir.setReturnValue(false);
-            //#endif
+        //#else
+        //$$ cir.setReturnValue(false);
+        //#endif
     }
 
     @ModifyVariable(
@@ -71,9 +69,9 @@ public class MixinMinecraftInputs {
     public boolean handleBlockClick(boolean isLeftClick) {
         if (isLeftClick && this.leftClickCounter <= 0) {
             if (MinecraftInputHook.shouldCancelContinuedBlockBreak(
-                    this.objectMouseOver,
-                    ((AccessorPlayerControllerMP) this.playerController).skyhanni_getCurrentBlock()
-                )) return false;
+                this.objectMouseOver,
+                ((AccessorPlayerControllerMP) this.playerController).skyhanni_getCurrentBlock()
+            )) return false;
         }
         return isLeftClick;
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMinecraftInputs.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMinecraftInputs.java
@@ -1,13 +1,17 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.mixins.hooks.MinecraftInputHook;
+import net.minecraft.client.multiplayer.PlayerControllerMP;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.MovingObjectPosition;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
 //#if MC > 1.21
 //$$ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 //#endif
@@ -19,12 +23,21 @@ public class MixinMinecraftInputs {
     @Shadow
     public MovingObjectPosition objectMouseOver;
 
+    @Shadow
+    private int leftClickCounter;
+
+    @Shadow
+    @Nullable
+    public PlayerControllerMP playerController;
+
     @Inject(
         at = @At("HEAD"),
         method = "rightClickMouse",
         cancellable = true
     )
     public void handleRightClickMouse(CallbackInfo ci) {
+        if (this.playerController.getIsHittingBlock()) return;
+
         if (MinecraftInputHook.shouldCancelMouseRightClick(this.objectMouseOver)) ci.cancel();
     }
 
@@ -40,11 +53,28 @@ public class MixinMinecraftInputs {
         //$$ CallbackInfoReturnable<Boolean> cir
         //#endif
     ) {
-        if (MinecraftInputHook.shouldCancelMouseLeftCLick(this.objectMouseOver))
+        if (this.leftClickCounter > 0) return;
+
+        if (MinecraftInputHook.shouldCancelMouseLeftClick(this.objectMouseOver))
             //#if MC < 1.21
             ci.cancel();
             //#else
             //$$ cir.setReturnValue(false);
             //#endif
+    }
+
+    @ModifyVariable(
+        at = @At(value = "HEAD"),
+        method = "sendClickBlockToController",
+        argsOnly = true
+    )
+    public boolean handleBlockClick(boolean isLeftClick) {
+        if (isLeftClick && this.leftClickCounter <= 0) {
+            if (MinecraftInputHook.shouldCancelContinuedBlockBreak(
+                    this.objectMouseOver,
+                    ((AccessorPlayerControllerMP) this.playerController).skyhanni_getCurrentBlock()
+                )) return false;
+        }
+        return isLeftClick;
     }
 }

--- a/versions/mapping-1.16.5-fabric-1.16.5-forge.txt
+++ b/versions/mapping-1.16.5-fabric-1.16.5-forge.txt
@@ -14,7 +14,7 @@ net.minecraft.client.network.ClientPlayerEntity sendChatMessage() chat()
 net.minecraft.client.network.ClientPlayerEntity setExperience() setExperienceValues()
 
 net.minecraft.client.network.ClientPlayerInteractionManager currentBreakingPos currentBlock
-net.minecraft.client.network.ClientPlayerInteractionManager isBreakingBlock() getIsHittingBlock()
+net.minecraft.client.network.ClientPlayerInteractionManager isBreakingBlock() isDestroying()
 
 net.minecraft.client.option.KeyBinding net.minecraft.client.KeyMapping
 net.minecraft.client.option.Perspective net.minecraft.client.CameraType

--- a/versions/mapping-1.16.5-fabric-1.16.5-forge.txt
+++ b/versions/mapping-1.16.5-fabric-1.16.5-forge.txt
@@ -7,10 +7,14 @@ net.fabricmc.loader.api.ModContainer net.minecraftforge.fml.ModContainer
 net.minecraft.client.gui.screen.GameMenuScreen net.minecraft.client.gui.screens.PauseScreen
 
 net.minecraft.client.network.ClientPlayerEntity net.minecraft.client.player.LocalPlayer
+net.minecraft.client.network.ClientPlayerInteractionManager net.minecraft.client.multiplayer.MultiPlayerGameMode
 
 net.minecraft.client.network.ClientPlayerEntity networkHandler connection
 net.minecraft.client.network.ClientPlayerEntity sendChatMessage() chat()
 net.minecraft.client.network.ClientPlayerEntity setExperience() setExperienceValues()
+
+net.minecraft.client.network.ClientPlayerInteractionManager currentBreakingPos currentBlock
+net.minecraft.client.network.ClientPlayerInteractionManager isBreakingBlock() getIsHittingBlock()
 
 net.minecraft.client.option.KeyBinding net.minecraft.client.KeyMapping
 net.minecraft.client.option.Perspective net.minecraft.client.CameraType

--- a/versions/mapping-1.16.5-forge-1.8.9.txt
+++ b/versions/mapping-1.16.5-forge-1.8.9.txt
@@ -73,6 +73,7 @@ net.minecraft.client.gui.screens.inventory.SignEditScreen sign tileSign
 
 net.minecraft.client.multiplayer.ClientLevel net.minecraft.client.multiplayer.WorldClient
 net.minecraft.client.multiplayer.ClientPacketListener net.minecraft.client.network.NetHandlerPlayClient
+net.minecraft.client.multiplayer.MultiPlayerGameMode net.minecraft.client.multiplayer.PlayerControllerMP
 net.minecraft.client.multiplayer.PlayerInfo net.minecraft.client.network.NetworkPlayerInfo
 
 net.minecraft.client.multiplayer.ClientLevel players() getPlayers()

--- a/versions/mapping-1.16.5-forge-1.8.9.txt
+++ b/versions/mapping-1.16.5-forge-1.8.9.txt
@@ -78,6 +78,8 @@ net.minecraft.client.multiplayer.PlayerInfo net.minecraft.client.network.Network
 
 net.minecraft.client.multiplayer.ClientLevel players() getPlayers()
 
+net.minecraft.client.multiplayer.MultiPlayerGameMode isDestroying() getIsHittingBlock()
+
 net.minecraft.client.multiplayer.PlayerInfo getGameMode() getGameType()
 net.minecraft.client.multiplayer.PlayerInfo getProfile() getGameProfile()
 net.minecraft.client.multiplayer.PlayerInfo getSkinLocation() getLocationSkin()
@@ -400,6 +402,7 @@ net.minecraft.world.entity.item.ItemEntity net.minecraft.entity.item.EntityItem
 
 net.minecraft.world.entity.item.ItemEntity getItem() getEntityItem()
 
+net.minecraft.world.entity.monster.AbstractSkeleton net.minecraft.entity.monster.EntitySkeleton
 net.minecraft.world.entity.monster.Blaze net.minecraft.entity.monster.EntityBlaze
 net.minecraft.world.entity.monster.CaveSpider net.minecraft.entity.monster.EntityCaveSpider
 net.minecraft.world.entity.monster.Creeper net.minecraft.entity.monster.EntityCreeper
@@ -411,7 +414,6 @@ net.minecraft.world.entity.monster.Guardian net.minecraft.entity.monster.EntityG
 net.minecraft.world.entity.monster.MagmaCube net.minecraft.entity.monster.EntityMagmaCube
 net.minecraft.world.entity.monster.Monster net.minecraft.entity.monster.EntityMob
 net.minecraft.world.entity.monster.Silverfish net.minecraft.entity.monster.EntitySilverfish
-net.minecraft.world.entity.monster.AbstractSkeleton net.minecraft.entity.monster.EntitySkeleton
 net.minecraft.world.entity.monster.Slime net.minecraft.entity.monster.EntitySlime
 net.minecraft.world.entity.monster.Spider net.minecraft.entity.monster.EntitySpider
 net.minecraft.world.entity.monster.Witch net.minecraft.entity.monster.EntityWitch


### PR DESCRIPTION
## What
Works in 1.8, unable to test on 1.21 as I cannot figure out how to remap a method correctly

<details>
<summary>Images</summary>
<img width="232" height="127" alt="image" src="https://github.com/user-attachments/assets/bf4a32cf-c7ba-409e-9824-1551199c5d5d" />

</details>

## Changelog Fixes
+ Fixed blocks being broken without releasing the mouse not being detected. - bloxigus