### PR TITLE
Fix: Stranded and bingo skyblock detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -133,7 +133,7 @@ object HypixelData {
      */
     private val scoreboardTitlePattern by patternGroup.pattern(
         "scoreboard.title",
-        "SK[YI]BLOCK(?: CO-OP| GUEST)??(?: [♲☀Ⓑ])?",
+        "SK[YI]BLOCK(?: CO-OP| GUEST)?(?: [♲☀Ⓑ])?",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -133,7 +133,7 @@ object HypixelData {
      */
     private val scoreboardTitlePattern by patternGroup.pattern(
         "scoreboard.title",
-        "SK[YI]BLOCK(?: CO-OP| GUEST)?(?: ♲|☀|Ⓑ)?",
+        "SK[YI]BLOCK(?: CO-OP| GUEST)??(?: [♲☀Ⓑ])?",
     )
 
     /**


### PR DESCRIPTION
## What
other profiles have space


## Changelog Fixes
+ Fixed Skyblock detection on stranded and bingo. - nopo

