### PR TITLE
Improvement: Label Great Spook Garden features as such

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/TimerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/TimerConfig.kt
@@ -6,6 +6,7 @@ import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class TimerConfig {
     @Expose
@@ -40,8 +41,9 @@ class TimerConfig {
     @ConfigOption(
         name = "New Visitor Ping",
         desc = "Ping you when you are less than 10 seconds away from getting a new visitor.\n" +
-            "§eUseful for getting Ephemeral Gratitudes during the 2023 Halloween event."
+            "§eUseful for getting Ephemeral Gratitudes during the Great Spook event."
     )
+    @SearchTag("halloween")
     @ConfigEditorBoolean
     var newVisitorPing: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/VisitorConfig.kt
@@ -7,6 +7,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 import org.lwjgl.input.Keyboard
 
 class VisitorConfig {
@@ -93,8 +94,9 @@ class VisitorConfig {
     @ConfigOption(
         name = "Accept Hotkey",
         desc = "Accept a visitor when you press this keybind while in the visitor GUI.\n" +
-            "§eUseful for getting Ephemeral Gratitudes during the 2023 Halloween event."
+            "§eUseful for getting Ephemeral Gratitudes during the Great Spook event."
     )
+    @SearchTag("halloween")
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     var acceptHotkey: Int = Keyboard.KEY_NONE
 


### PR DESCRIPTION
## What
Updated Great Spook-related Garden features to actually mention the event by its proper name instead of "2023 Halloween event", since it's reoccurring.

## Changelog Improvements
+ Made Great Spook-related Garden features easier to find. - Luna

