### PR TITLE
Fix: NoSuchElementException in Zombie Shootout helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -227,7 +227,7 @@ object CarnivalZombieShootout {
 
     private fun updateZombies() {
         val nearbyZombies = getZombies()
-        maxType = nearbyZombies.maxBy { it.type.points }.type
+        maxType = nearbyZombies.maxByOrNull { it.type.points }?.type ?: ZombieType.LEATHER
         val maxZombies = nearbyZombies.filter { it.type == maxType }
 
         drawZombies = when {


### PR DESCRIPTION
## What
Fixed a potential NoSuchElementException in the Carnival Zombie Shootout helper.

https://discord.com/channels/997079228510117908/1429509803968958485

## Changelog Fixes
+ Fixed chat errors when Zombie Shootout Helper cannot find zombies. - Luna