### PR TITLE
Fix + Improvement: Foraging Tracker Forest Essence + faster update

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
@@ -113,33 +113,19 @@ object ForagingTrackerLegacy {
     )
 
     /**
-     * REGEX-TEST: §2Forest Essence §8x4
-     * REGEX-TEST: §2Forest Essence §8x6
-     * REGEX-TEST: §2Forest Essence §8x12
-     * REGEX-TEST: §2Forest Essence §8x16
-     * REGEX-TEST: §2Forest Whispers §8x40
-     * REGEX-TEST: §2Forest Whispers §8x60
-     * REGEX-TEST: §2Forest Whispers §8x100
-     * REGEX-TEST: §2Forest Whispers §8x160
-     * REGEX-TEST: §3Foraging Experience §8x1,000
-     * REGEX-TEST: §3Foraging Experience §8x2,000
-     * REGEX-TEST: §3Foraging Experience §8x2,500
-     * REGEX-TEST: §3Foraging Experience §8x5,000
-     * REGEX-TEST: §3Foraging Experience §8x8,000
+     * REGEX-TEST: §2Forest Essence§r§8 x4
+     * REGEX-TEST: §2Forest Essence§r§8 x12
+     * REGEX-TEST: §2Forest Whispers §r§8x40
+     * REGEX-TEST: §2Forest Whispers §r§8x100
+     * REGEX-TEST: §3Foraging Experience §r§8x1,000
      * REGEX-TEST: §aHOTF Experience §8x10
-     * REGEX-TEST: §aHOTF Experience §8x30
-     * REGEX-TEST: §aHOTF Experience §8x50
-     * REGEX-TEST: §aHOTF Experience §8x80
-     * REGEX-TEST: §aTender Wood §8x0-2
-     * REGEX-TEST: §aTender Wood §8x0-3
-     * REGEX-TEST: §aTender Wood §8x0-5
-     * REGEX-TEST: §aTender Wood §8x0-9
+     * REGEX-TEST: §aTender Wood §r§8x0-2
      * REGEX-TEST: §aVinesap §8x0-3
      * REGEX-TEST: §6Signal Enhancer §8(§a0.4%§8)
      */
     val hoverRewardPattern by patternGroup.pattern(
         "hover-reward",
-        "(?:§.)*(?<item>.*) (?:§.)*§8x?(?:(?<amount>[\\d,-]+)|\\((?:§.)*(?<percentage>[\\d.]+)%(?:§.)*\\))"
+        "(?:§.)*(?<item>[^§]+)\\s*(?:§.)*\\s*(?:§.)*§8\\s*x?(?:(?:0-)?(?<amount>\\d+)|\\((?:§.)*(?<percentage>[\\d.]+)%(?:§.)*\\))"
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
@@ -125,7 +125,7 @@ object ForagingTrackerLegacy {
      */
     val hoverRewardPattern by patternGroup.pattern(
         "hover-reward",
-        "(?:§.)*(?<item>[^§]+)\\s*(?:§.)*\\s*(?:§.)*§8\\s*x?(?:(?:0-)?(?<amount>\\d+)|\\((?:§.)*(?<percentage>[\\d.]+)%(?:§.)*\\))"
+        "(?:§.)*(?<item>[^§]+)\\s*(?:§.)*\\s*(?:§.)*§8\\s*x?(?:(?:0-)?(?<amount>[\\d,]+)|\\((?:§.)*(?<percentage>[\\d.]+)%(?:§.)*\\))"
     )
 
     /**


### PR DESCRIPTION
## What
Fixed Foraging Tracker not tracking Forest Essence due to Hypixel putting the formatting codes in a different place.

While we're at it, I also removed the ranged item logic, because these "ranged" rewards are just bugged to say "0-n", they always drop the highest amount listed (which is obviously intended behavior, because why would they not tell you the exact amount when it's what you *just* got). It was fixed by Hypixel once to not show the "0-" but then they unfixed it. The way I did it, it *should* work fine on old mod versions as well, since the ranged logic will just never trigger.

I also cleaned up the code a bit, including removing redundant regex tests. I left some without `§r` because I don't have a copy of an up-to-date message containing those rewards on hand, plus it's a good test to ensure we are being lenient enough with the formatting codes anyway.

## Changelog Improvements
+ Foraging Tracker now adds all Tree Gift rewards to the tracker immediately instead of waiting for a sack update. - Luna

## Changelog Fixes
+ Fixed Forest Essence from Tree Gifts not being tracked on Foraging Tracker. - Luna
