### PR TITLE
Fix: Craft Room Holographic Entities

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -40,7 +40,7 @@ object CraftRoomHolographicMob {
         EntityCaveSpider::class.java to HolographicEntities.caveSpider,
     )
 
-    private var holograms = mutableMapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()
+    private var holograms = mapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onTick() {
@@ -49,11 +49,13 @@ object CraftRoomHolographicMob {
         for (theMob in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(25.0)) {
             if (theMob is EntityPlayer) continue
 
-            val mobPos = theMob.getLorenzVec()
-            val lastTickMobPos = LorenzVec(theMob.lastTickPosX, theMob.lastTickPosY, theMob.lastTickPosZ) // used to interpolate movement
-            if (!craftRoomArea.isInside(mobPos) || !craftRoomArea.isInside(lastTickMobPos)) continue
-            val holographicMobPos = getMirroredPos(lastTickMobPos)
-            val mirroredPos = getMirroredPos(mobPos)
+            val currentLocation = theMob.getLorenzVec()
+
+            if (!craftRoomArea.isInside(currentLocation)) continue
+            val previousLocation = LorenzVec(theMob.lastTickPosX, theMob.lastTickPosY, theMob.lastTickPosZ) // used to interpolate movement
+            if (!craftRoomArea.isInside(previousLocation)) continue
+            val previousMirror = getMirroredLocation(previousLocation)
+            val currentMirror = getMirroredLocation(currentLocation)
 
             val displayString = buildString {
                 val mobName = theMob.displayName.formattedText
@@ -68,10 +70,10 @@ object CraftRoomHolographicMob {
             val mob = entityToHolographicEntity[theMob::class.java] ?: continue
 
             // we currently don't rotate the body so head rotations looked very weird
-            val instance = mob.instance(holographicMobPos, 0f)
+            val instance = mob.instance(previousMirror, 0f)
 
             instance.isChild = theMob.isChild
-            instance.moveTo(mirroredPos, 0f)
+            instance.moveTo(currentMirror, 0f)
 
             newMap[instance] = displayString
         }
@@ -103,7 +105,7 @@ object CraftRoomHolographicMob {
         }
     }
 
-    private fun getMirroredPos(pos: LorenzVec): LorenzVec {
+    private fun getMirroredLocation(pos: LorenzVec): LorenzVec {
         val wallZ = -116.5
         val dist = abs(pos.z - wallZ)
         return pos.add(z = dist * 2)

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
-import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.HolographicEntities
@@ -41,10 +40,12 @@ object CraftRoomHolographicMob {
     )
 
     private var holograms = mapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()
+    private var enabled = false
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onTick() {
-        if (!isEnabled()) return
+        enabled = config.enabled && craftRoomArea.isInside(playerLocation())
+        if (!enabled) return
         val newMap = mutableMapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()
         for (theMob in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(25.0)) {
             if (theMob is EntityPlayer) continue
@@ -79,7 +80,7 @@ object CraftRoomHolographicMob {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
-        if (!isEnabled()) return
+        if (!enabled) return
         for ((mob, string) in holograms) {
             event.renderHolographicEntity(mob)
 
@@ -91,7 +92,7 @@ object CraftRoomHolographicMob {
 
     @HandleEvent(receiveCancelled = true, onlyOnIsland = IslandType.THE_RIFT)
     fun onPlayerRender(event: CheckRenderEntityEvent<EntityOtherPlayerMP>) {
-        if (!isEnabled()) return
+        if (!enabled) return
         if (!config.hidePlayers) return
 
         if (craftRoomArea.isInside(event.entity.getLorenzVec())) {
@@ -104,6 +105,4 @@ object CraftRoomHolographicMob {
         val dist = abs(this.z - wallZ)
         return this.add(z = dist * 2)
     }
-
-    private fun isEnabled() = RiftApi.inRift() && config.enabled && craftRoomArea.isInside(playerLocation())
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -67,10 +67,11 @@ object CraftRoomHolographicMob {
 
             val mob = entityToHolographicEntity[theMob::class.java] ?: continue
 
-            val instance = mob.instance(holographicMobPos, -theMob.rotationYaw)
+            // we currently don't rotate the body so head rotations looked very weird
+            val instance = mob.instance(holographicMobPos, 0f)
 
             instance.isChild = theMob.isChild
-            instance.moveTo(mirroredPos, -theMob.rotationYaw)
+            instance.moveTo(mirroredPos, 0f)
 
             newMap[instance] = displayString
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -57,12 +57,12 @@ object CraftRoomHolographicMob {
             if (!craftRoomArea.isInside(previousLocation)) continue
 
             // we currently don't rotate the body so head rotations looked very weird
-            val instance = mob.instance(getMirroredLocation(previousLocation), 0f)
+            val instance = mob.instance(previousLocation.mirror(), 0f)
 
             instance.isChild = theMob.isChild
-            instance.moveTo(getMirroredLocation(currentLocation), 0f)
+            instance.moveTo(currentLocation.mirror(), 0f)
 
-            val displayString = buildString {
+            val display = buildString {
                 val mobName = theMob.displayName.formattedText
                 if (config.showName) {
                     append("§a$mobName ")
@@ -72,7 +72,7 @@ object CraftRoomHolographicMob {
                 }
             }.trim()
 
-            newMap[instance] = displayString
+            newMap[instance] = display
         }
         holograms = newMap
     }
@@ -80,9 +80,7 @@ object CraftRoomHolographicMob {
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
-        for (entity in holograms.entries) {
-            val mob = entity.key
-            val string = entity.value
+        for ((mob, string) in holograms) {
             event.renderHolographicEntity(mob)
 
             if (string != null) {
@@ -96,16 +94,15 @@ object CraftRoomHolographicMob {
         if (!isEnabled()) return
         if (!config.hidePlayers) return
 
-        val entity = event.entity
-        if (craftRoomArea.isInside(entity.getLorenzVec())) {
+        if (craftRoomArea.isInside(event.entity.getLorenzVec())) {
             event.cancel()
         }
     }
 
-    private fun getMirroredLocation(pos: LorenzVec): LorenzVec {
+    private fun LorenzVec.mirror(): LorenzVec {
         val wallZ = -116.5
-        val dist = abs(pos.z - wallZ)
-        return pos.add(z = dist * 2)
+        val dist = abs(this.z - wallZ)
+        return this.add(z = dist * 2)
     }
 
     private fun isEnabled() = RiftApi.inRift() && config.enabled && craftRoomArea.isInside(playerLocation())

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -84,8 +84,8 @@ object CraftRoomHolographicMob {
         for ((mob, string) in holograms) {
             event.renderHolographicEntity(mob)
 
-            if (string != null) {
-                event.drawString(mob.position.add(y = mob.entity.eyeHeight + .5), string)
+            string?.let {
+                event.drawString(mob.position.add(y = mob.entity.eyeHeight + .5), it)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -48,14 +48,19 @@ object CraftRoomHolographicMob {
         val newMap = mutableMapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()
         for (theMob in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(25.0)) {
             if (theMob is EntityPlayer) continue
+            val mob = entityToHolographicEntity[theMob::class.java] ?: continue
 
             val currentLocation = theMob.getLorenzVec()
 
             if (!craftRoomArea.isInside(currentLocation)) continue
             val previousLocation = LorenzVec(theMob.lastTickPosX, theMob.lastTickPosY, theMob.lastTickPosZ) // used to interpolate movement
             if (!craftRoomArea.isInside(previousLocation)) continue
-            val previousMirror = getMirroredLocation(previousLocation)
-            val currentMirror = getMirroredLocation(currentLocation)
+
+            // we currently don't rotate the body so head rotations looked very weird
+            val instance = mob.instance(getMirroredLocation(previousLocation), 0f)
+
+            instance.isChild = theMob.isChild
+            instance.moveTo(getMirroredLocation(currentLocation), 0f)
 
             val displayString = buildString {
                 val mobName = theMob.displayName.formattedText
@@ -66,14 +71,6 @@ object CraftRoomHolographicMob {
                     append("§c${theMob.health.roundTo(1)}♥")
                 }
             }.trim()
-
-            val mob = entityToHolographicEntity[theMob::class.java] ?: continue
-
-            // we currently don't rotate the body so head rotations looked very weird
-            val instance = mob.instance(previousMirror, 0f)
-
-            instance.isChild = theMob.isChild
-            instance.moveTo(currentMirror, 0f)
 
             newMap[instance] = displayString
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -67,10 +67,10 @@ object CraftRoomHolographicMob {
 
             val mob = entityToHolographicEntity[theMob::class.java] ?: continue
 
-            val instance = mob.instance(holographicMobPos, -theMob.rotationYaw, -theMob.renderYawOffset)
+            val instance = mob.instance(holographicMobPos, -theMob.rotationYaw)
 
             instance.isChild = theMob.isChild
-            instance.moveTo(mirroredPos, theMob.rotationYaw)
+            instance.moveTo(mirroredPos, -theMob.rotationYaw)
 
             newMap[instance] = displayString
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -40,12 +40,12 @@ object CraftRoomHolographicMob {
         EntityCaveSpider::class.java to HolographicEntities.caveSpider,
     )
 
-    private var hologramMap: MutableMap<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?> = mutableMapOf()
+    private var holograms = mutableMapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onTick() {
         if (!isEnabled()) return
-        val newMap: MutableMap<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?> = mutableMapOf()
+        val newMap = mutableMapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()
         for (theMob in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(25.0)) {
             if (theMob is EntityPlayer) continue
 
@@ -75,13 +75,13 @@ object CraftRoomHolographicMob {
 
             newMap[instance] = displayString
         }
-        hologramMap = newMap
+        holograms = newMap
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
-        for (entity in hologramMap.entries) {
+        for (entity in holograms.entries) {
             val mob = entity.key
             val string = entity.value
             event.renderHolographicEntity(mob)

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -92,10 +92,7 @@ object CraftRoomHolographicMob {
 
     @HandleEvent(receiveCancelled = true, onlyOnIsland = IslandType.THE_RIFT)
     fun onPlayerRender(event: CheckRenderEntityEvent<EntityOtherPlayerMP>) {
-        if (!enabled) return
-        if (!config.hidePlayers) return
-
-        if (craftRoomArea.isInside(event.entity.getLorenzVec())) {
+        if (enabled && config.hidePlayers) {
             event.cancel()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import net.minecraft.client.entity.EntityOtherPlayerMP
+import net.minecraft.entity.EntityLiving
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.monster.EntityCaveSpider
 import net.minecraft.entity.monster.EntitySlime
@@ -63,20 +64,20 @@ object CraftRoomHolographicMob {
             instance.isChild = theMob.isChild
             instance.moveTo(currentLocation.mirror(), 0f)
 
-            val display = buildString {
-                val mobName = theMob.displayName.formattedText
-                if (config.showName) {
-                    append("§a$mobName ")
-                }
-                if (config.showHealth) {
-                    append("§c${theMob.health.roundTo(1)}♥")
-                }
-            }.trim()
-
-            newMap[instance] = display
+            newMap[instance] = theMob.display()
         }
         holograms = newMap
     }
+
+    private fun EntityLivingBase.display() = buildString {
+        val mobName = displayName.formattedText
+        if (config.showName) {
+            append("§a$mobName ")
+        }
+        if (config.showHealth) {
+            append("§c${health.roundTo(1)}♥")
+        }
+    }.trim()
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -67,14 +67,14 @@ object CraftRoomHolographicMob {
     }
 
     private fun EntityLivingBase.display() = buildString {
-        val mobName = displayName.formattedText
         if (config.showName) {
+            val mobName = displayName.formattedText
             append("§a$mobName ")
         }
         if (config.showHealth) {
             append("§c${health.roundTo(1)}♥")
         }
-    }.trim()
+    }.trim().takeIf { it.isNotEmpty() }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import net.minecraft.client.entity.EntityOtherPlayerMP
-import net.minecraft.entity.EntityLiving
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.monster.EntityCaveSpider
 import net.minecraft.entity.monster.EntitySlime
@@ -47,26 +46,24 @@ object CraftRoomHolographicMob {
     fun onTick() {
         enabled = config.enabled && craftRoomArea.isInside(playerLocation())
         if (!enabled) return
-        val newMap = mutableMapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()
-        for (theMob in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(25.0)) {
-            if (theMob is EntityPlayer) continue
-            val mob = entityToHolographicEntity[theMob::class.java] ?: continue
 
-            val currentLocation = theMob.getLorenzVec()
+        val map = mutableMapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()
+        for (entity in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(25.0)) {
+            if (entity is EntityPlayer) continue
+            val holographicEntity = entityToHolographicEntity[entity::class.java] ?: continue
 
+            val currentLocation = entity.getLorenzVec()
             if (!craftRoomArea.isInside(currentLocation)) continue
-            val previousLocation = LorenzVec(theMob.lastTickPosX, theMob.lastTickPosY, theMob.lastTickPosZ) // used to interpolate movement
+            val previousLocation = LorenzVec(entity.lastTickPosX, entity.lastTickPosY, entity.lastTickPosZ) // used to interpolate movement
             if (!craftRoomArea.isInside(previousLocation)) continue
 
             // we currently don't rotate the body so head rotations looked very weird
-            val instance = mob.instance(previousLocation.mirror(), 0f)
-
-            instance.isChild = theMob.isChild
+            val instance = holographicEntity.instance(previousLocation.mirror(), 0f)
+            instance.isChild = entity.isChild
             instance.moveTo(currentLocation.mirror(), 0f)
-
-            newMap[instance] = theMob.display()
+            map[instance] = entity.display()
         }
-        holograms = newMap
+        holograms = map
     }
 
     private fun EntityLivingBase.display() = buildString {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -22,7 +22,6 @@ import net.minecraft.entity.monster.EntitySlime
 import net.minecraft.entity.monster.EntityZombie
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.util.AxisAlignedBB
-import kotlin.math.abs
 
 // TODO fix looking at direction, slime size, helmet/skull of zombie
 @SkyHanniModule
@@ -55,7 +54,6 @@ object CraftRoomHolographicMob {
             val currentLocation = entity.getLorenzVec()
             if (!craftRoomArea.isInside(currentLocation)) continue
             val previousLocation = LorenzVec(entity.lastTickPosX, entity.lastTickPosY, entity.lastTickPosZ) // used to interpolate movement
-            if (!craftRoomArea.isInside(previousLocation)) continue
 
             // we currently don't rotate the body so head rotations looked very weird
             val instance = holographicEntity.instance(previousLocation.mirror(), 0f)
@@ -95,9 +93,10 @@ object CraftRoomHolographicMob {
         }
     }
 
+    private const val WALL_Z = -116.5
     private fun LorenzVec.mirror(): LorenzVec {
-        val wallZ = -116.5
-        val dist = abs(this.z - wallZ)
-        return this.add(z = dist * 2)
+        require(z <= WALL_Z) { "mirror() assumes z <= WALL_Z, z was ${z.roundTo(1)} instead" }
+        val dist = WALL_Z - z
+        return add(z = dist * 2)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.HolographicEntities
 import at.hannibal2.skyhanni.utils.HolographicEntities.renderHolographicEntity
 import at.hannibal2.skyhanni.utils.LocationUtils.isInside
-import at.hannibal2.skyhanni.utils.LocationUtils.playerLocation
+import at.hannibal2.skyhanni.utils.LocationUtils.isPlayerInside
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.getLorenzVec
@@ -43,7 +43,7 @@ object CraftRoomHolographicMob {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onTick() {
-        enabled = config.enabled && craftRoomArea.isInside(playerLocation())
+        enabled = config.enabled && craftRoomArea.isPlayerInside()
         if (!enabled) return
 
         val map = mutableMapOf<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?>()

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -11,8 +11,9 @@ import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.HolographicEntities
 import at.hannibal2.skyhanni.utils.HolographicEntities.renderHolographicEntity
 import at.hannibal2.skyhanni.utils.LocationUtils.isInside
+import at.hannibal2.skyhanni.utils.LocationUtils.playerLocation
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import net.minecraft.client.entity.EntityOtherPlayerMP
@@ -33,39 +34,27 @@ object CraftRoomHolographicMob {
         -108.0, 58.0, -106.0,
         -117.0, 51.0, -128.0,
     )
-    private var entitiesList = listOf<HolographicEntities.HolographicEntity<out EntityLivingBase>>()
     private val entityToHolographicEntity = mapOf(
         EntityZombie::class.java to HolographicEntities.zombie,
         EntitySlime::class.java to HolographicEntities.slime,
         EntityCaveSpider::class.java to HolographicEntities.caveSpider,
     )
 
-    @HandleEvent
-    fun onTick() {
-        if (!isEnabled()) return
-        for (entity in entitiesList) {
-            entity.moveTo(entity.position.up(.1), (entity.yaw + 5) % 360)
-        }
-    }
-
-    @HandleEvent
-    fun onWorldChange() {
-        entitiesList = emptyList()
-    }
+    private var hologramMap: MutableMap<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?> = mutableMapOf()
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    fun onTick() {
         if (!isEnabled()) return
-
+        val newMap: MutableMap<HolographicEntities.HolographicEntity<out EntityLivingBase>, String?> = mutableMapOf()
         for (theMob in EntityUtils.getEntitiesNextToPlayer<EntityLivingBase>(25.0)) {
             if (theMob is EntityPlayer) continue
 
             val mobPos = theMob.getLorenzVec()
-            if (!craftRoomArea.isInside(mobPos)) continue
+            val lastTickMobPos = LorenzVec(theMob.lastTickPosX, theMob.lastTickPosY, theMob.lastTickPosZ) // used to interpolate movement
+            if (!craftRoomArea.isInside(mobPos) || !craftRoomArea.isInside(lastTickMobPos)) continue
+            val holographicMobPos = getMirroredPos(lastTickMobPos)
+            val mirroredPos = getMirroredPos(mobPos)
 
-            val wallZ = -116.5
-            val dist = abs(mobPos.z - wallZ)
-            val holographicMobPos = mobPos.add(z = dist * 2)
             val displayString = buildString {
                 val mobName = theMob.displayName.formattedText
                 if (config.showName) {
@@ -78,17 +67,27 @@ object CraftRoomHolographicMob {
 
             val mob = entityToHolographicEntity[theMob::class.java] ?: continue
 
-            val instance = mob.instance(holographicMobPos, -theMob.rotationYaw)
+            val instance = mob.instance(holographicMobPos, -theMob.rotationYaw, -theMob.renderYawOffset)
 
             instance.isChild = theMob.isChild
+            instance.moveTo(mirroredPos, theMob.rotationYaw)
 
-            event.renderHolographicEntity(instance)
+            newMap[instance] = displayString
+        }
+        hologramMap = newMap
+    }
 
-            if (displayString.isNotEmpty()) {
-                event.drawString(holographicMobPos.add(y = theMob.eyeHeight + .5), displayString)
+    @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
+    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+        if (!isEnabled()) return
+        for (entity in hologramMap.entries) {
+            val mob = entity.key
+            val string = entity.value
+            event.renderHolographicEntity(mob)
+
+            if (string != null) {
+                event.drawString(mob.position.add(y = mob.entity.eyeHeight + .5), string)
             }
-
-            entitiesList = entitiesList.editCopy { add(instance) }
         }
     }
 
@@ -103,5 +102,11 @@ object CraftRoomHolographicMob {
         }
     }
 
-    private fun isEnabled() = RiftApi.inRift() && config.enabled
+    private fun getMirroredPos(pos: LorenzVec): LorenzVec {
+        val wallZ = -116.5
+        val dist = abs(pos.z - wallZ)
+        return pos.add(z = dist * 2)
+    }
+
+    private fun isEnabled() = RiftApi.inRift() && config.enabled && craftRoomArea.isInside(playerLocation())
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
@@ -57,10 +57,13 @@ object HolographicEntities {
         val entity: T,
         var position: LorenzVec,
         var yaw: Float,
+        var bodyYaw: Float = entity.renderYawOffset,
+        var scale: Float = 1F
     ) {
         var isChild: Boolean = false
         var lastPosition: LorenzVec = position
         var lastYaw: Float = yaw
+        var lastBodyYaw: Float = bodyYaw
         val createdAt = SimpleTimeMark.now()
 
         val monotonicProgress get() = createdAt.passedSince().inWholeTicks
@@ -87,6 +90,10 @@ object HolographicEntities {
         fun interpolatedYaw(partialTicks: Float): Float {
             return interpolateRotation(lastYaw, yaw, partialTicks)
         }
+
+        fun interpolatedBodyYaw(partialTicks: Float): Float {
+            return interpolateRotation(lastBodyYaw, bodyYaw, partialTicks)
+        }
     }
 
     /**
@@ -97,8 +104,8 @@ object HolographicEntities {
      * world handling.
      */
     class HolographicBase<T : EntityLivingBase> internal constructor(private val entity: T) {
-        fun instance(position: LorenzVec, yaw: Float): HolographicEntity<T> {
-            return HolographicEntity(entity, position, yaw)
+        fun instance(position: LorenzVec, yaw: Float, bodyYaw: Float = yaw, scale: Float = 1f): HolographicEntity<T> {
+            return HolographicEntity(entity, position, yaw, bodyYaw, scale)
         }
     }
 
@@ -176,8 +183,8 @@ object HolographicEntities {
         GlStateManager.enableRescaleNormal()
         GlStateManager.scale(-1f, -1f, 1f)
         GlStateManager.translate(0F, -1.5078125f, 0f)
-        val limbSwing = 0F
-        val limbSwingAmount = 0F
+        val limbSwing = entity.limbSwing
+        val limbSwingAmount = entity.limbSwingAmount
         val ageInTicks = 1_000_000.toFloat()
         val netHeadYaw = holographicEntity.interpolatedYaw(partialTicks)
         val headPitch = 0F
@@ -190,6 +197,7 @@ object HolographicEntities {
         GlStateManager.alphaFunc(GL11.GL_GREATER, 1 / 255F)
 
         GlStateManager.enableTexture2D()
+        GlStateManager.rotate(-holographicEntity.interpolatedBodyYaw(partialTicks), 0f, 1f, 0f)
         renderer.mainModel.isChild = holographicEntity.isChild
         renderer.mainModel.setRotationAngles(
             limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scaleFactor, entity,

--- a/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
@@ -57,13 +57,10 @@ object HolographicEntities {
         val entity: T,
         var position: LorenzVec,
         var yaw: Float,
-        var bodyYaw: Float = entity.renderYawOffset,
-        var scale: Float = 1F
     ) {
         var isChild: Boolean = false
         var lastPosition: LorenzVec = position
         var lastYaw: Float = yaw
-        var lastBodyYaw: Float = bodyYaw
         val createdAt = SimpleTimeMark.now()
 
         val monotonicProgress get() = createdAt.passedSince().inWholeTicks
@@ -90,10 +87,6 @@ object HolographicEntities {
         fun interpolatedYaw(partialTicks: Float): Float {
             return interpolateRotation(lastYaw, yaw, partialTicks)
         }
-
-        fun interpolatedBodyYaw(partialTicks: Float): Float {
-            return interpolateRotation(lastBodyYaw, bodyYaw, partialTicks)
-        }
     }
 
     /**
@@ -104,8 +97,8 @@ object HolographicEntities {
      * world handling.
      */
     class HolographicBase<T : EntityLivingBase> internal constructor(private val entity: T) {
-        fun instance(position: LorenzVec, yaw: Float, bodyYaw: Float = yaw, scale: Float = 1f): HolographicEntity<T> {
-            return HolographicEntity(entity, position, yaw, bodyYaw, scale)
+        fun instance(position: LorenzVec, yaw: Float): HolographicEntity<T> {
+            return HolographicEntity(entity, position, yaw)
         }
     }
 
@@ -183,8 +176,8 @@ object HolographicEntities {
         GlStateManager.enableRescaleNormal()
         GlStateManager.scale(-1f, -1f, 1f)
         GlStateManager.translate(0F, -1.5078125f, 0f)
-        val limbSwing = entity.limbSwing
-        val limbSwingAmount = entity.limbSwingAmount
+        val limbSwing = 0F
+        val limbSwingAmount = 0F
         val ageInTicks = 1_000_000.toFloat()
         val netHeadYaw = holographicEntity.interpolatedYaw(partialTicks)
         val headPitch = 0F
@@ -197,7 +190,6 @@ object HolographicEntities {
         GlStateManager.alphaFunc(GL11.GL_GREATER, 1 / 255F)
 
         GlStateManager.enableTexture2D()
-        GlStateManager.rotate(-holographicEntity.interpolatedBodyYaw(partialTicks), 0f, 1f, 0f)
         renderer.mainModel.isChild = holographicEntity.isChild
         renderer.mainModel.setRotationAngles(
             limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scaleFactor, entity,


### PR DESCRIPTION
## What
Fixes performance issues caused by the craft room holographic mob feature (it was scanning and adding every entity in the room to a list every frame for no reason). Also disabled head yaw on the mobs as that looked weird since we don't rotate the bodies

## Changelog Fixes
+ Fixed major performance issues in the Rift caused by Mirrorverse Holographic Entities. - Chissl
