### PR TITLE
Fix: Key presses in Spirit Leap Overlay being picked up outside of leap menu

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
@@ -88,12 +88,8 @@ object DungeonSpiritLeapOverlay {
 
     @HandleEvent
     fun onKeyPress(event: KeyDownEvent) {
-        if (!isEnabled() ||
-            !config.spiritLeapKeybindConfig.enableKeybind ||
-            InventoryUtils.openInventoryName().removeColor() !in validInventoryNames
-        ) {
-            return
-        }
+        if (!isEnabled() || !config.spiritLeapKeybindConfig.enableKeybind) return
+        if (InventoryUtils.openInventoryName().removeColor() !in validInventoryNames) return
         val index = getKeybindIndex(event.keyCode)
         if (index !in 0..<playerList.count()) return
         leapToPlayer(playerList[index])

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
@@ -91,7 +91,7 @@ object DungeonSpiritLeapOverlay {
         if (!isEnabled() ||
             !config.spiritLeapKeybindConfig.enableKeybind ||
             InventoryUtils.openInventoryName().removeColor() !in validInventoryNames
-            ) {
+        ) {
             return
         }
         val index = getKeybindIndex(event.keyCode)

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
@@ -88,7 +88,12 @@ object DungeonSpiritLeapOverlay {
 
     @HandleEvent
     fun onKeyPress(event: KeyDownEvent) {
-        if (!isEnabled() || !config.spiritLeapKeybindConfig.enableKeybind) return
+        if (!isEnabled() ||
+            !config.spiritLeapKeybindConfig.enableKeybind ||
+            InventoryUtils.openInventoryName().removeColor() !in validInventoryNames
+            ) {
+            return
+        }
         val index = getKeybindIndex(event.keyCode)
         if (index !in 0..<playerList.count()) return
         leapToPlayer(playerList[index])

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
@@ -19,7 +19,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
+import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
@@ -46,6 +47,7 @@ object DungeonSpiritLeapOverlay {
     private var containerHeight = 0
     private var playerList = emptyList<PlayerStackInfo>()
     private val validInventoryNames = setOf("Spirit Leap", "Teleport to Player")
+    private val inventory = InventoryDetector { it in validInventoryNames }
 
     data class PlayerStackInfo(val playerInfo: DungeonApi.TeamMember?, val stack: ItemStack, val slotNumber: Int)
 
@@ -55,7 +57,7 @@ object DungeonSpiritLeapOverlay {
 
         val gui = event.gui
         // TODO find a way to make InventoryDetector usable here.
-        if (gui !is GuiChest || InventoryUtils.openInventoryName().removeColor() !in validInventoryNames) return
+        if (gui !is GuiChest || !inventory.isInside()) return
         containerWidth = gui.width
         containerHeight = gui.height
         scaleFactor = min(containerWidth, containerHeight).toDouble() / max(containerWidth, containerHeight).toDouble()
@@ -89,7 +91,7 @@ object DungeonSpiritLeapOverlay {
     @HandleEvent
     fun onKeyPress(event: KeyDownEvent) {
         if (!isEnabled() || !config.spiritLeapKeybindConfig.enableKeybind) return
-        if (InventoryUtils.openInventoryName().removeColor() !in validInventoryNames) return
+        if (!inventory.isInside()) return
         val index = getKeybindIndex(event.keyCode)
         if (index !in 0..<playerList.count()) return
         leapToPlayer(playerList[index])


### PR DESCRIPTION
## What
Fixed keyPress function not checking if you're in a leap menu causing your chat to get spammed with could not leap messages

## Changelog Fixes
+ Fixed Dungeon Spirit Leap Overlay keybinds triggering outside the Leap Menu. - Wapic