### PR TITLE
Feature: Trick or Treat/Party chest Alert

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
@@ -30,6 +30,10 @@ class EventConfig {
     @Expose
     val gifting: GiftingConfig = GiftingConfig()
 
+    @Category(name = "Spooky", desc = "Spooky Festival")
+    @Expose
+    val spooky: SpookyConfig = SpookyConfig()
+
     @Expose
     @Category(name = "Hoppity Eggs", desc = "Features for the Hoppity event that happens every SkyBlock spring.")
     val hoppityEggs: HoppityEggsConfig = HoppityEggsConfig()

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/SpookyChestConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/SpookyChestConfig.kt
@@ -1,0 +1,26 @@
+package at.hannibal2.skyhanni.config.features.event
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class SpookyChestConfig {
+
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Shows a title when a Trick or Treat/Party Chest appears.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enabled: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Play Sound", desc = "Play a sound when triggering a spooky/party chest.")
+    @ConfigEditorBoolean
+    var playSound: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Compact Title", desc = "Only show the name of the chest in the title.")
+    @ConfigEditorBoolean
+    var compactTitle: Boolean = false
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/SpookyConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/SpookyConfig.kt
@@ -1,20 +1,14 @@
 package at.hannibal2.skyhanni.config.features.event
 
-import at.hannibal2.skyhanni.config.FeatureToggle
 import com.google.gson.annotations.Expose
-import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class SpookyConfig {
-    @Expose
-    @ConfigOption(name = "Trick or Treat Chest Alert", desc = "Shows a title when a Trick or Treat/Party Chest appears.")
-    @ConfigEditorBoolean
-    @FeatureToggle
-    var spookyChestAlert: Boolean = false
 
+    @Accordion
+    @ConfigOption(name = "Spooky", desc = "Spooky Festival")
     @Expose
-    @ConfigOption(name = "Compact Message", desc = "Only show the name of the chest.")
-    @ConfigEditorBoolean
-    @FeatureToggle
-    var compactSpookyChest: Boolean = false
+    val spookyChests: SpookyChestConfig = SpookyChestConfig()
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/SpookyConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/SpookyConfig.kt
@@ -11,4 +11,10 @@ class SpookyConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var spookyChestAlert: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Compact Message", desc = "Only show the name of the chest.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var compactSpookyChest: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/SpookyConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/SpookyConfig.kt
@@ -1,0 +1,14 @@
+package at.hannibal2.skyhanni.config.features.event
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class SpookyConfig {
+    @Expose
+    @ConfigOption(name = "Trick or Treat Chest Alert", desc = "Shows a title when a Trick or Treat/Party Chest appears.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var spookyChestAlert: Boolean = false
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyChestAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyChestAlert.kt
@@ -17,6 +17,7 @@ object SpookyChestAlert {
 
     /**
      * REGEX-TEST: §6§lSPOOKY! §r§7A §r§6Trick or Treat Chest §r§7has appeared!
+     * REGEX-TEST: §c§lPARTY! §r§7A §r§cParty Chest §r§7has appeared!
      */
     private val chestMessagePattern by patternGroup.pattern(
         "chat.chest",

--- a/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyChestAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyChestAlert.kt
@@ -6,16 +6,17 @@ import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
-object SpookyFestival {
-    private val config get() = SkyHanniMod.feature.event.spooky
+object SpookyChestAlert {
+    private val config get() = SkyHanniMod.feature.event.spooky.spookyChests
 
     private val patternGroup = RepoPattern.group("event.spooky")
 
     /**
-     * REGEX-TEST: §r§6§lSPOOKY! §r§7A §r§6Trick or Treat Chest §r§7has appeared!§r§7
+     * REGEX-TEST: §6§lSPOOKY! §r§7A §r§6Trick or Treat Chest §r§7has appeared!
      */
     private val chestMessagePattern by patternGroup.pattern(
         "chat.chest",
@@ -24,16 +25,18 @@ object SpookyFestival {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onChat(event: SkyHanniChatEvent) {
-        if (config.spookyChestAlert) {
-            chestMessagePattern.matchMatcher(event.message) {
-                TitleManager.sendTitle(
-                    "§l§${group("color")}" + if (config.compactSpookyChest) {
-                        "${group("type")} CHEST"
-                    } else {
-                        "${group("chest").uppercase()}!"
-                    }
-                )
-            }
-        }
+        if (!config.enabled) return
+        chestMessagePattern.matchMatcher(event.message) {
+            TitleManager.sendTitle(
+                "§l§${group("color")}" + if (config.compactTitle) {
+                    "${group("type")} CHEST"
+                } else {
+                    "${group("chest").uppercase()}!"
+                },
+            )
+        } ?: return
+
+        if (!config.playSound) return
+        SoundUtils.playBeepSound()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyFestival.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyFestival.kt
@@ -19,7 +19,7 @@ object SpookyFestival {
      */
     private val chestMessagePattern by patternGroup.pattern(
         "chat.chest",
-        "§r§[6c]§l(?:SPOOKY|PARTY)! §r§7A §r§(?<color>[6c])(?<chest>Trick or Treat Chest|Party Chest) §r§7has appeared!§r§7",
+        "§[6c]§l(?:SPOOKY|PARTY)! §r§7A §r§(?<color>[6c])(?<chest>Trick or Treat Chest|Party Chest) §r§7has appeared!",
     )
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyFestival.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyFestival.kt
@@ -19,14 +19,18 @@ object SpookyFestival {
      */
     private val chestMessagePattern by patternGroup.pattern(
         "chat.chest",
-        "§[6c]§l(?:SPOOKY|PARTY)! §r§7A §r§(?<color>[6c])(?<chest>Trick or Treat Chest|Party Chest) §r§7has appeared!",
+        "§[6c]§l(?<type>SPOOKY|PARTY)! §r§7A §r§(?<color>[6c])(?<chest>Trick or Treat Chest|Party Chest) §r§7has appeared!",
     )
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onChat(event: SkyHanniChatEvent) {
         if (config.spookyChestAlert) {
             chestMessagePattern.matchMatcher(event.message) {
-                TitleManager.sendTitle("§l§${group("color")}${group("chest").uppercase()}!")
+                TitleManager.sendTitle("§l§${group("color")}" + if (config.compactSpookyChest) {
+                    "${group("type")} CHEST"
+                } else {
+                    "${group("chest").uppercase()}!"
+                })
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyFestival.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyFestival.kt
@@ -26,11 +26,13 @@ object SpookyFestival {
     fun onChat(event: SkyHanniChatEvent) {
         if (config.spookyChestAlert) {
             chestMessagePattern.matchMatcher(event.message) {
-                TitleManager.sendTitle("§l§${group("color")}" + if (config.compactSpookyChest) {
-                    "${group("type")} CHEST"
-                } else {
-                    "${group("chest").uppercase()}!"
-                })
+                TitleManager.sendTitle(
+                    "§l§${group("color")}" + if (config.compactSpookyChest) {
+                        "${group("type")} CHEST"
+                    } else {
+                        "${group("chest").uppercase()}!"
+                    }
+                )
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyFestival.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/spook/SpookyFestival.kt
@@ -1,0 +1,33 @@
+package at.hannibal2.skyhanni.features.event.spook
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.title.TitleManager
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object SpookyFestival {
+    private val config get() = SkyHanniMod.feature.event.spooky
+
+    private val patternGroup = RepoPattern.group("event.spooky")
+
+    /**
+     * REGEX-TEST: §r§6§lSPOOKY! §r§7A §r§6Trick or Treat Chest §r§7has appeared!§r§7
+     */
+    private val chestMessagePattern by patternGroup.pattern(
+        "chat.chest",
+        "§r§[6c]§l(?:SPOOKY|PARTY)! §r§7A §r§(?<color>[6c])(?<chest>Trick or Treat Chest|Party Chest) §r§7has appeared!§r§7",
+    )
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onChat(event: SkyHanniChatEvent) {
+        if (config.spookyChestAlert) {
+            chestMessagePattern.matchMatcher(event.message) {
+                TitleManager.sendTitle("§l§${group("color")}${group("chest").uppercase()}!")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds a Trick or Treat and Party chest alert in the form of a title with the name of the chest and an exclamation mark showing up on the default duration all capitalized and colored to the color of the chat message.

## Changelog New Features
+ Added Trick-or-Treat/Party Chest Alert. - Mayaqq

