### PR TITLE
fix: use the proper config directory from forge

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -50,6 +50,7 @@ import net.minecraft.client.gui.GuiScreen
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import java.io.File
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -57,12 +58,16 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object SkyHanniMod {
 
-    fun preInit() {
+    fun preInit(configDirectory: File?) {
         PlatformUtils.checkIfNeuIsLoaded()
 
         LoadedModules.modules.forEach { SkyHanniModLoader.loadModule(it) }
 
         SkyHanniEvents.init(modules)
+
+        if (configDirectory != null) {
+            ConfigManager.configDirectory = File(configDirectory, "skyhanni")
+        }
 
         PreInitFinishedEvent.post()
     }

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniModLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniModLoader.kt
@@ -20,7 +20,7 @@ class SkyHanniModLoader {
     @Mod.EventHandler
     fun preInit(event: FMLPreInitializationEvent?) {
         HotswapSupport.load()
-        SkyHanniMod.preInit()
+        SkyHanniMod.preInit(event?.modConfigurationDirectory)
         loadedClasses.clear()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -57,7 +57,7 @@ class ConfigManager {
 //             .registerIfBeta(FeatureTogglesByDefaultAdapter)
             .create()
 
-        val configDirectory = File("config/skyhanni")
+        var configDirectory = File("config/skyhanni")
     }
 
     private val logger = LorenzLogger("config_manager")

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/SkyHanniModLoader.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/SkyHanniModLoader.kt
@@ -2,11 +2,12 @@ package at.hannibal2.skyhanni
 
 import at.hannibal2.skyhanni.SkyHanniMod.modules
 import net.fabricmc.api.ModInitializer
+import net.fabricmc.loader.api.FabricLoader;
 
 class SkyHanniModLoader : ModInitializer {
 
     override fun onInitialize() {
-        SkyHanniMod.preInit()
+        SkyHanniMod.preInit(FabricLoader.getInstance().getConfigDir().toFile())
         SkyHanniMod.init()
         loadedClasses.clear()
     }


### PR DESCRIPTION
## What
FML passes the config directory to use in the preinit event, since it is configurable. SkyHanni didn't check that value before, it is now properly passed around.

## Changelog Technical Details
+ Fix mod config not using Forge's configured config directory - Rigner


