### PR TITLE
Backend: Fix scoreboard area in /shdebug skyblock

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -145,7 +145,7 @@ object DebugCommand {
             add("on Hypixel SkyBlock")
             add("skyBlockIsland: ${SkyBlockUtils.currentIsland}")
             add("skyBlockArea:")
-            add("  scoreboard: '${SkyBlockUtils.graphArea}'")
+            add("  scoreboard: '${SkyBlockUtils.scoreboardArea}'")
             add("  graph network: '${SkyBlockUtils.graphArea}'")
             with(MinecraftCompat.localPlayer.position.toLorenzVec().roundTo(1)) {
                 add(" /shtestwaypoint $x $y $z pathfind")


### PR DESCRIPTION
## What
Fixed `/shdebug skyblock` showing the graph area as the scoreboard area.

## Changelog Technical Details
+ Fixed `/shdebug skyblock` showing the graph area as the scoreboard area. - Luna