### PR TITLE
Improvement: Reset GUI position

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -174,6 +174,7 @@ class GuiPositionEditor(
     private fun getScaledHeight() = GuiScreenUtils.scaledWindowHeight
     private fun getScaledWidth() = GuiScreenUtils.scaledWindowWidth
 
+    @Suppress("LoopWithTooManyJumpStatements")
     override fun onMouseClicked(originalMouseX: Int, originalMouseY: Int, mouseButton: Int) {
         val (mouseX, mouseY) = GuiScreenUtils.mousePos
 

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -84,29 +84,27 @@ class GuiPositionEditor(
     }
 
     private fun renderLabels(hoveredPos: Int) {
-        var displayPos = -1
-        if (clickedPos != -1 && positions[clickedPos].clicked) {
-            displayPos = clickedPos
-        }
-        if (displayPos == -1) {
-            displayPos = hoveredPos
+        val displayPos = when {
+            clickedPos != -1 && positions[clickedPos].clicked -> clickedPos
+            else -> hoveredPos
         }
 
         // When the mouse isn't currently hovering over a gui element
-        if (displayPos == -1) {
+        val text = if (displayPos == -1) {
             val extraInfo = SkyHanniMod.feature.gui.keyBindOpen == Keyboard.KEY_NONE
-            renderHover(
-                buildList {
-                    add("§cSkyHanni Position Editor")
-                    if (extraInfo) {
-                        add("§aTo edit hidden GUI elements set a key in /sh edit")
-                        add("§athen click that key while the GUI element is visible")
-                    }
-                },
-            )
-            return
+
+            buildList {
+                add("§cSkyHanni Position Editor")
+                if (extraInfo) {
+                    add("§aTo edit hidden GUI elements set a key in /sh edit")
+                    add("§athen click that key while the GUI element is visible")
+                }
+            }
+        } else {
+            getTextForPos(positions[displayPos])
         }
-        renderHover(getTextForPos(positions[displayPos]))
+
+        renderHover(text)
     }
 
     private fun getTextForPos(pos: Position): List<String> {
@@ -119,8 +117,14 @@ class GuiPositionEditor(
             "",
             "§eRight-Click to open associated config options!",
             "§eUse Scroll-Wheel to resize!",
-            "§eMiddle-Click to reset to default position!",
+            "§e${getKeyName(config.keyBindReset)}to reset to default position!",
         )
+    }
+
+    private fun getKeyName(keyCode: Int): String = when (keyCode) {
+        -98 -> "Middle-Click"
+        Keyboard.KEY_NONE -> "Unbound"
+        else -> Keyboard.getKeyName(keyCode) ?: "Unknown"
     }
 
     private fun renderHover(text: List<String>) {
@@ -129,52 +133,48 @@ class GuiPositionEditor(
 
     private fun renderRectangles(): Int {
         var hoveredPos = -1
-        DrawContextUtils.pushMatrix()
-        width = getScaledWidth()
-        height = getScaledHeight()
+        DrawContextUtils.pushPop {
+            width = getScaledWidth()
+            height = getScaledHeight()
 
-        val (mouseX, mouseY) = GuiScreenUtils.mousePos
+            val (mouseX, mouseY) = GuiScreenUtils.mousePos
+            var alreadyHadHover = false
 
-        var alreadyHadHover = false
-        for ((index, position) in positions.withIndex().reversed()) {
-            var elementWidth = position.getDummySize(true).x
-            var elementHeight = position.getDummySize(true).y
-            if (position.clicked) {
-                grabbedX += position.moveX(mouseX - grabbedX, elementWidth)
-                grabbedY += position.moveY(mouseY - grabbedY, elementHeight)
-            }
+            for ((index, position) in positions.withIndex().reversed()) {
+                val dummy = position.getDummySize(true)
+                if (position.clicked) {
+                    grabbedX += position.moveX(mouseX - grabbedX, dummy.x)
+                    grabbedY += position.moveY(mouseY - grabbedY, dummy.y)
+                }
 
-            val isHovering = position.isHovered() && !alreadyHadHover
+                val isHovering = position.isHovered() && !alreadyHadHover
 
-            val x = position.getAbsX()
-            val y = position.getAbsY()
+                val x = position.getAbsX()
+                val y = position.getAbsY()
 
-            elementWidth = position.getDummySize().x
-            elementHeight = position.getDummySize().y
+                val gray = -0x7fbfbfc0 // #40404080
+                val selected = -0x7F0F0F10 // #F0F0F080
+                GuiRenderUtils.drawRect(
+                    x - border,
+                    y - border,
+                    x + position.getDummySize().x + border * 2,
+                    y + position.getDummySize().y + border * 2,
+                    if (isHovering) selected else gray,
+                )
 
-            val gray = -0x7fbfbfc0 // #40404080
-            val selected = -0x7F0F0F10 // #F0F0F080
-            GuiRenderUtils.drawRect(
-                x - border,
-                y - border,
-                x + elementWidth + border * 2,
-                y + elementHeight + border * 2,
-                if (isHovering) selected else gray,
-            )
-
-            if (isHovering) {
-                alreadyHadHover = true
-                hoveredPos = index
+                if (isHovering) {
+                    alreadyHadHover = true
+                    hoveredPos = index
+                }
             }
         }
-        DrawContextUtils.popMatrix()
+
         return hoveredPos
     }
 
     private fun getScaledHeight() = GuiScreenUtils.scaledWindowHeight
     private fun getScaledWidth() = GuiScreenUtils.scaledWindowWidth
 
-    @Suppress("LoopWithTooManyJumpStatements")
     override fun onMouseClicked(originalMouseX: Int, originalMouseY: Int, mouseButton: Int) {
         val (mouseX, mouseY) = GuiScreenUtils.mousePos
 
@@ -182,27 +182,24 @@ class GuiPositionEditor(
             val position = positions[i]
             if (!position.isHovered()) continue
 
-            if (mouseButton == 1) {
-                position.jumpToConfigOptions()
-                break
+            when (mouseButton) {
+                1 -> position.jumpToConfigOptions()
+                2 -> if (config.keyBindReset == -98) position.resetPositionAndScale()
+                0 -> if (!position.clicked) {
+                    clickedPos = i
+                    position.clicked = true
+                    grabbedX = mouseX
+                    grabbedY = mouseY
+                }
             }
-            if (mouseButton == 2 && config.keyBindReset == -98) {
-                position.resetPositionAndScale()
-                break
-            }
-            if (!position.clicked && mouseButton == 0) {
-                clickedPos = i
-                position.clicked = true
-                grabbedX = mouseX
-                grabbedY = mouseY
-                break
-            }
+
+            break
         }
     }
 
     override fun onKeyTyped(typedChar: Char?, keyCode: Int?) {
         if (keyCode == config.keyBindReset) {
-            positions.first { it.isHovered() }.resetPositionAndScale()
+            positions.firstOrNull { it.isHovered() }?.resetPositionAndScale()
             return
         }
         if (clickedPos == -1) return
@@ -217,10 +214,8 @@ class GuiPositionEditor(
             Keyboard.KEY_UP -> position.moveY(-dist, elementHeight)
             Keyboard.KEY_LEFT -> position.moveX(-dist, elementWidth)
             Keyboard.KEY_RIGHT -> position.moveX(dist, elementWidth)
-            Keyboard.KEY_MINUS -> position.scale -= .1F
-            Keyboard.KEY_EQUALS -> position.scale += .1F
-            Keyboard.KEY_SUBTRACT -> position.scale -= .1F
-            Keyboard.KEY_ADD -> position.scale += .1F
+            Keyboard.KEY_MINUS, Keyboard.KEY_SUBTRACT -> position.scale -= .1F
+            Keyboard.KEY_EQUALS, Keyboard.KEY_ADD -> position.scale += .1F
         }
     }
 
@@ -281,16 +276,9 @@ class GuiPositionEditor(
     }
 
     override fun onHandleMouseInput() {
-        val mw = MouseCompat.getScrollDelta()
-        if (mw == 0) return
-
-        val (mouseX, mouseY) = GuiScreenUtils.mousePos
-
+        val scroll = MouseCompat.getScrollDelta().takeIf { it != 0 } ?: return
         val hovered = positions.firstOrNull { it.clicked } ?: positions.lastOrNull { it.isHovered() } ?: return
-        if (mw < 0)
-            hovered.scale -= .1F
-        else
-            hovered.scale += .1F
+        hovered.scale += if (scroll > 0) .1F else -.1F
     }
 
     //#if MC > 1.21

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -117,7 +117,7 @@ class GuiPositionEditor(
             "",
             "§eRight-Click to open associated config options!",
             "§eUse Scroll-Wheel to resize!",
-            "§e${KeyboardManager.getKeyName(config.keyBindReset)}to reset to default position!",
+            "§e${KeyboardManager.getKeyName(config.keyBindReset)} to reset to default position!",
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -117,14 +117,8 @@ class GuiPositionEditor(
             "",
             "§eRight-Click to open associated config options!",
             "§eUse Scroll-Wheel to resize!",
-            "§e${getKeyName(config.keyBindReset)}to reset to default position!",
+            "§e${KeyboardManager.getKeyName(config.keyBindReset)}to reset to default position!",
         )
-    }
-
-    private fun getKeyName(keyCode: Int): String = when (keyCode) {
-        -98 -> "Middle-Click"
-        Keyboard.KEY_NONE -> "Unbound"
-        else -> Keyboard.getKeyName(keyCode) ?: "Unknown"
     }
 
     private fun renderHover(text: List<String>) {
@@ -184,7 +178,7 @@ class GuiPositionEditor(
 
             when (mouseButton) {
                 1 -> position.jumpToConfigOptions()
-                2 -> if (config.keyBindReset == -98) position.resetPositionAndScale()
+                2 -> if (config.keyBindReset == KeyboardManager.MIDDLE_MOUSE) position.resetPositionAndScale()
                 0 -> if (!position.clicked) {
                     clickedPos = i
                     position.clicked = true

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -49,6 +49,7 @@ class GuiPositionEditor(
     private val oldScreen: GuiContainer? = null,
 ) : SkyhanniBaseScreen() {
 
+    private val config get() = SkyHanniMod.feature.gui
     private var grabbedX = 0
     private var grabbedY = 0
     private var clickedPos = -1
@@ -142,20 +143,14 @@ class GuiPositionEditor(
                 grabbedX += position.moveX(mouseX - grabbedX, elementWidth)
                 grabbedY += position.moveY(mouseY - grabbedY, elementHeight)
             }
+
+            val isHovering = position.isHovered() && !alreadyHadHover
+
             val x = position.getAbsX()
             val y = position.getAbsY()
 
             elementWidth = position.getDummySize().x
             elementHeight = position.getDummySize().y
-
-            val isHovering = GuiRenderUtils.isPointInRect(
-                mouseX,
-                mouseY,
-                x - border,
-                y - border,
-                elementWidth + border * 2,
-                elementHeight + border * 2,
-            ) && !alreadyHadHover
 
             val gray = -0x7fbfbfc0 // #40404080
             val selected = -0x7F0F0F10 // #F0F0F080
@@ -184,40 +179,14 @@ class GuiPositionEditor(
 
         for (i in positions.indices.reversed()) {
             val position = positions[i]
-            val elementWidth = position.getDummySize().x
-            val elementHeight = position.getDummySize().y
-            val x = position.getAbsX()
-            val y = position.getAbsY()
-            val isHovered = GuiRenderUtils.isPointInRect(
-                mouseX,
-                mouseY,
-                x - border,
-                y - border,
-                elementWidth + border * 2,
-                elementHeight + border * 2,
-            )
-            if (!isHovered) continue
+            if (!position.isHovered()) continue
+
             if (mouseButton == 1) {
                 position.jumpToConfigOptions()
                 break
             }
-            if (mouseButton == 2) {
-                val field = position.linkField ?: return
-                val clazz = field.declaringClass.kotlin
-                val instance = clazz.createInstance()
-
-                val defaultPosition = clazz.declaredMemberProperties
-                    .firstNotNullOfOrNull { property ->
-                        property.javaField
-                            ?.getAnnotation(ConfigLink::class.java)
-                            ?.takeIf { it.field == field.name }
-                            ?.let { property.getter.call(instance) as? Position }
-                    } ?: return
-
-                with(position) {
-                    moveTo(defaultPosition.x, defaultPosition.y)
-                    scale = defaultPosition.scale
-                }
+            if (mouseButton == 2 && config.keyBindReset == -98) {
+                position.resetPositionAndScale()
                 break
             }
             if (!position.clicked && mouseButton == 0) {
@@ -231,6 +200,10 @@ class GuiPositionEditor(
     }
 
     override fun onKeyTyped(typedChar: Char?, keyCode: Int?) {
+        if (keyCode == config.keyBindReset) {
+            positions.first { it.isHovered() }.resetPositionAndScale()
+            return
+        }
         if (clickedPos == -1) return
         val position = positions[clickedPos]
         if (position.clicked) return
@@ -247,6 +220,42 @@ class GuiPositionEditor(
             Keyboard.KEY_EQUALS -> position.scale += .1F
             Keyboard.KEY_SUBTRACT -> position.scale -= .1F
             Keyboard.KEY_ADD -> position.scale += .1F
+        }
+    }
+
+    private fun Position.isHovered(): Boolean {
+        val (mouseX, mouseY) = GuiScreenUtils.mousePos
+
+        val elementWidth = getDummySize().x
+        val elementHeight = getDummySize().y
+        val x = getAbsX()
+        val y = getAbsY()
+        return GuiRenderUtils.isPointInRect(
+            mouseX,
+            mouseY,
+            x - border,
+            y - border,
+            elementWidth + border * 2,
+            elementHeight + border * 2,
+        )
+    }
+
+    private fun Position.resetPositionAndScale() {
+        val field = linkField ?: return
+        val clazz = field.declaringClass.kotlin
+        val instance = clazz.createInstance()
+
+        val defaultPosition = clazz.declaredMemberProperties
+            .firstNotNullOfOrNull { property ->
+                property.javaField
+                    ?.getAnnotation(ConfigLink::class.java)
+                    ?.takeIf { it.field == field.name }
+                    ?.let { property.getter.call(instance) as? Position }
+            } ?: return
+
+        with(this) {
+            moveTo(defaultPosition.x, defaultPosition.y)
+            scale = defaultPosition.scale
         }
     }
 
@@ -276,15 +285,7 @@ class GuiPositionEditor(
 
         val (mouseX, mouseY) = GuiScreenUtils.mousePos
 
-        val hovered = positions.firstOrNull { it.clicked }
-            ?: positions.lastOrNull {
-                val size = it.getDummySize()
-                GuiRenderUtils.isPointInRect(
-                    mouseX, mouseY,
-                    it.getAbsX() - border, it.getAbsY() - border,
-                    size.x + border * 2, size.y + border * 2,
-                )
-            } ?: return
+        val hovered = positions.firstOrNull { it.clicked } ?: positions.lastOrNull { it.isHovered() } ?: return
         if (mw < 0)
             hovered.scale -= .1F
         else

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -35,9 +35,13 @@ import at.hannibal2.skyhanni.utils.compat.MouseCompat
 import at.hannibal2.skyhanni.utils.compat.SkyhanniBaseScreen
 import at.hannibal2.skyhanni.utils.renderables.RenderableTooltips
 import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.renderer.GlStateManager
 import org.lwjgl.input.Keyboard
+import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.jvm.javaField
 
 class GuiPositionEditor(
     private val positions: List<Position>,
@@ -114,6 +118,7 @@ class GuiPositionEditor(
             "",
             "§eRight-Click to open associated config options!",
             "§eUse Scroll-Wheel to resize!",
+            "§eMiddle-Click to reset to default position!",
         )
     }
 
@@ -194,6 +199,25 @@ class GuiPositionEditor(
             if (!isHovered) continue
             if (mouseButton == 1) {
                 position.jumpToConfigOptions()
+                break
+            }
+            if (mouseButton == 2) {
+                val field = position.linkField ?: return
+                val clazz = field.declaringClass.kotlin
+                val instance = clazz.createInstance()
+
+                val defaultPosition = clazz.declaredMemberProperties
+                    .firstNotNullOfOrNull { property ->
+                        property.javaField
+                            ?.getAnnotation(ConfigLink::class.java)
+                            ?.takeIf { it.field == field.name }
+                            ?.let { property.getter.call(instance) as? Position }
+                    } ?: return
+
+                with(position) {
+                    moveTo(defaultPosition.x, defaultPosition.y)
+                    scale = defaultPosition.scale
+                }
                 break
             }
             if (!position.clicked && mouseButton == 0) {

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
@@ -41,7 +41,7 @@ class GuiConfig {
 
     @ConfigOption(
         name = "Edit GUI Locations",
-        desc = "Opens the Position Editor, allows changing the position of SkyHanni's overlays."
+        desc = "Opens the Position Editor, allows changing the position of SkyHanni's overlays.",
     )
     @ConfigEditorButton(buttonText = "Edit")
     val positions: Runnable = Runnable { openGuiPositionEditor(true) }
@@ -50,6 +50,11 @@ class GuiConfig {
     @ConfigOption(name = "Open Hotkey", desc = "Press this key to open the GUI Editor.")
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
     var keyBindOpen: Int = Keyboard.KEY_NONE
+
+    @Expose
+    @ConfigOption(name = "Reset Hotkey", desc = "Key to press hovering a gui element to reset it's position and scale in the GUI Editor.")
+    @ConfigEditorKeybind(defaultKey = Keyboard.KEY_R)
+    var keyBindReset: Int = Keyboard.KEY_R
 
     @Expose
     @ConfigOption(name = "Global GUI Scale", desc = "Globally scale all SkyHanni GUIs.")
@@ -126,7 +131,7 @@ class GuiConfig {
     @Expose
     @ConfigOption(
         name = "Real Time",
-        desc = "Display the current computer time, a handy feature when playing in full-screen mode."
+        desc = "Display the current computer time, a handy feature when playing in full-screen mode.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -135,7 +140,7 @@ class GuiConfig {
     @Expose
     @ConfigOption(
         name = "Real Time 12h Format",
-        desc = "Display the current computer time in 12hr Format rather than 24h Format."
+        desc = "Display the current computer time in 12hr Format rather than 24h Format.",
     )
     @ConfigEditorBoolean
     var realTimeFormatToggle: Boolean = false


### PR DESCRIPTION
## What
Adds an 'option' to reset gui positions by middle-clicking them in the gui-position editor.

<details>
<summary>Images</summary>

<img width="588" height="243" alt="grafik" src="https://github.com/user-attachments/assets/17edcdc2-2663-4f7e-b6e5-602116e4e88e" />

</details>

## Changelog Improvements
+ Added option to reset a gui's position and scale in the editor. - ILike2WatchMemes