### PR TITLE
Dont show the missing pity widget message every world swap

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -325,7 +325,6 @@ object MineshaftPityDisplay {
         if (event.newIsland == IslandType.MINESHAFT || event.oldIsland == IslandType.MINESHAFT) {
             resetCounter()
         }
-        everFoundPityWidget = false
     }
 
     private fun isDisplayEnabled() = (MiningApi.inGlacialTunnels() || MiningApi.inDwarvenBaseCamp()) && config.enabled


### PR DESCRIPTION
## What
people dont like the red text

<details>
<summary>Images</summary>

<img width="1324" height="529" alt="image" src="https://github.com/user-attachments/assets/255a1d6e-f11f-44f0-9742-ad93b01f7c37" />

</details>

exclude_from_changelog