### PR TITLE
Fix: Ping API always showing network charts on 1.21.9+

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinClientPlayNetworkHandler.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinClientPlayNetworkHandler.java
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent;
+import at.hannibal2.skyhanni.features.misc.CurrentPing;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
@@ -19,5 +21,11 @@ public class MixinClientPlayNetworkHandler {
         packet.getEquipmentList().forEach((equipment) -> {
             new EntityEquipmentChangeEvent(entity, equipment.getFirst().getIndex(), equipment.getSecond()).post();
         });
+    }
+
+    @ModifyExpressionValue(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/DebugHud;shouldShowPacketSizeAndPingCharts()Z"))
+    public boolean shouldShowPacketSizeAndPingCharts(boolean original) {
+        if (!CurrentPing.INSTANCE.isEnabled()) return original;
+        return true;
     }
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinDebugHud.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinDebugHud.java
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
-import at.hannibal2.skyhanni.features.misc.CurrentPing;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.MinecraftClient;
@@ -9,9 +8,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Slice;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
 
@@ -31,12 +28,4 @@ public class MixinDebugHud {
         return false;
     }
     //#endif
-
-    @Inject(method = "shouldShowPacketSizeAndPingCharts", at = @At("HEAD"), cancellable = true)
-    public void shouldShowPacketSizeAndPingCharts(CallbackInfoReturnable<Boolean> cir) {
-        // This does not actually make any charts permanently visible,
-        // it simply makes the client always send ping packets.
-        if (!CurrentPing.INSTANCE.isEnabled()) return;
-        cir.setReturnValue(true);
-    }
 }


### PR DESCRIPTION
## What
Fixes Ping API being enabled causing network and ping charts to always show while F3 is open on 1.21.9/1.21.10.

## Changelog Fixes
+ Fixed not being able to hide network and ping charts on the F3 Debug Screen in 1.21.9/1.21.10. - Luna