### PR TITLE
Fix: Non God Pot Display not showing multiple salts

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -256,12 +256,12 @@ object EffectApi {
     @HandleEvent(onlyOnIsland = IslandType.GALATEA)
     fun readSalts(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.SALTS)) return
-        saltTabPattern.firstMatcher(event.lines) {
+        saltTabPattern.matchAll(event.lines) {
             val effect = group("effect")
             val duration = TimeUtils.getDuration(group("time"))
             val salt = NonGodPotEffect.entries.firstOrNull {
                 it.tabListName == effect
-            } ?: return@firstMatcher
+            } ?: return@matchAll
             EffectDurationChangeEvent(salt, EffectDurationChangeType.SET, duration).post()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -43,5 +43,5 @@ enum class NonGodPotEffect(
     LUSHLILAC_BONBON("§r§5Lushlilac Bonbon§r§f"),
     PRIME_LUSHLILAC_BONBON("§r§5Prime Lushlilac Bonbon§r§f"),
     EXALTED_LUSHLILAC_BONBON("§r§5Exalted Lushlilac Bonbon§r§f"),
-    OCEANDY("§r§5Oceandy§r§f"),
+    OCEANDY("§r§5Candycomb§r§f"),
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -43,5 +43,6 @@ enum class NonGodPotEffect(
     LUSHLILAC_BONBON("§r§5Lushlilac Bonbon§r§f"),
     PRIME_LUSHLILAC_BONBON("§r§5Prime Lushlilac Bonbon§r§f"),
     EXALTED_LUSHLILAC_BONBON("§r§5Exalted Lushlilac Bonbon§r§f"),
-    OCEANDY("§r§5Candycomb§r§f"),
+    OCEANDY("§r§5Oceandy§r§f"),
+    CANDYCOMB("§r§5Candycomb§r§f"),
 }


### PR DESCRIPTION
## What
i didnt know u could have multiple salts at once
didnt test because my computer doesnt have enough ram to open the game rn
also attempted to add the candy comb 

## Changelog Fixes
+ Fixed Non-God Pot Display not showing multiple Salts. - nopo
