### PR TITLE
Fix: Halloween Baskets

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/waypoints/HalloweenBasketConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/waypoints/HalloweenBasketConfig.kt
@@ -16,7 +16,7 @@ class HalloweenBasketConfig {
     )
     @ConfigEditorBoolean
     @FeatureToggle
-    var enabled: Boolean = false
+    val enabled: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Only Closest", desc = "Only show the closest waypoint.")
@@ -24,7 +24,7 @@ class HalloweenBasketConfig {
     var onlyClosest: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Pathfind", desc = "Show a path to the closest basket.")
+    @ConfigOption(name = "Pathfinder", desc = "Show a path to the closest basket.")
     @ConfigEditorBoolean
     @FeatureToggle
     val pathfind: Property<Boolean> = Property.of(true)


### PR DESCRIPTION
## What
if the baskets cant load on first try (race condition with coroutine ig) we do not set the feature as active. now we retry until we can find data.
Also added check to restart pathfind if the player moves too far away from the target without clicking it.

## Changelog Fixes
+ Fixed Lobby Halloween Basket occasionally not loading. - hannibal2