### PR TITLE
Fix: Pest Vinyl Stuff

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -594,7 +594,7 @@ class ProfileSpecificStorage(
         var pestProfitTracker: PestProfitTracker.BucketData = PestProfitTracker.BucketData()
 
         @Expose
-        var activeVinyl: VinylType = VinylType.NONE
+        var activeVinyl: VinylType? = null
     }
 
     // - gui

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -594,7 +594,7 @@ class ProfileSpecificStorage(
         var pestProfitTracker: PestProfitTracker.BucketData = PestProfitTracker.BucketData()
 
         @Expose
-        var activeVinyl: VinylType? = null
+        var activeVinyl: VinylType = VinylType.NONE
     }
 
     // - gui

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -27,6 +27,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
@@ -136,6 +137,32 @@ object PestApi {
     val pestTrapPattern by patternGroup.pattern(
         "entity.pesttrap",
         "(?:§.)+§l(?<type>PEST|MOUSE) TRAP(?: #(?<number>\\d+))?(?:§.)*",
+    )
+
+    /**
+     * REGEX-TEST: Stereo Harmony
+     */
+    private val stereoInventoryPattern by patternGroup.pattern(
+        "stereo.inventory",
+        "Stereo Harmony"
+    )
+    val stereoInventory = InventoryDetector { name -> stereoInventoryPattern.matches(name) }
+
+    /**
+     * REGEX-TEST: §7Now Playing: §aWings of Harmony §8(Moth)
+     * REGEX-TEST: §7Now Playing: §a§cNone
+     */
+    val stereoPlayingPattern by patternGroup.pattern(
+        "stereo.playing",
+        "§7Now Playing: (?:§.)*(?<vinyl>[^§]+).*"
+    )
+
+    /**
+     * REGEX-TEST: §a§lPLAYING
+     */
+    val stereoPlayingItemPattern by patternGroup.pattern(
+        "stereo.playing.item",
+        "§a§lPLAYING",
     )
 
     private var gardenJoinTime = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -107,6 +107,7 @@ enum class PestType(
         "PEST_SLUG_MONSTER".toInternalName(),
         CropType.MUSHROOM,
     ),
+    // TODO replace with null
     // For use in the Pest Profit Tracker, in cases where an item cannot have an identified PestType
     // Display name intentionally omitted to aid in filtering out this entry.
     UNKNOWN(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
@@ -28,17 +28,19 @@ object StereoHarmonyDiscReplacer {
         if (!PestApi.stereoInventory.isInside()) return
         if (event.slot !in 11..15 && event.slot !in 20..24) return
 
-        val internalName = event.originalItem?.getInternalNameOrNull() ?: return
+        val item = event.originalItem
+        val internalName = item?.getInternalNameOrNull() ?: return
         val vinylType = VinylType.getByInternalNameOrNull(internalName) ?: return
         val cropType = PestType.getByVinylOrNull(vinylType)?.crop ?: return
-        val isActiveVinyl = PestApi.stereoPlayingItemPattern.anyMatches(event.originalItem.getLore())
+        val lore = item.getLore()
+        val isActiveVinyl = PestApi.stereoPlayingItemPattern.anyMatches(lore)
         val iconId = "stereo_harmony_replacer:${vinylType.name}-$isActiveVinyl"
 
         val replacementStack = iconCache.getOrPut(iconId) {
             cropType.getItemStackCopy(iconId).apply {
                 if (isActiveVinyl) addEnchantGlint()
-                setLore(event.originalItem.getLore())
-                setCustomItemName(event.originalItem.displayName)
+                setLore(lore)
+                setCustomItemName(item.displayName)
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
@@ -6,12 +6,11 @@ import at.hannibal2.skyhanni.features.garden.GardenApi.getItemStackCopy
 import at.hannibal2.skyhanni.features.garden.pests.PestApi
 import at.hannibal2.skyhanni.features.garden.pests.PestType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.addEnchantGlint
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.setLore
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
 import net.minecraft.item.ItemStack
 
@@ -19,23 +18,20 @@ import net.minecraft.item.ItemStack
 object StereoHarmonyDiscReplacer {
 
     private val config get() = PestApi.config.stereoHarmony
-    private val inventoryPattern by PestApi.patternGroup.pattern(
-        "stereo.inventory",
-        "Stereo Harmony"
-    )
+
     private val iconCache: MutableMap<String, ItemStack> = mutableMapOf()
 
-    // TODO cache. load on invenotry open only once, then read from a map slotId -> item stack
+    // TODO cache. load on inventory open only once, then read from a map slotId -> item stack
     @HandleEvent
     fun replaceItem(event: ReplaceItemEvent) {
         if (!config.replaceMenuIcons) return
-        if (!inventoryPattern.matches(InventoryUtils.openInventoryName())) return
+        if (!PestApi.stereoInventory.isInside()) return
         if (event.slot !in 11..15 && event.slot !in 20..24) return
 
         val internalName = event.originalItem?.getInternalNameOrNull() ?: return
         val vinylType = VinylType.getByInternalNameOrNull(internalName) ?: return
         val cropType = PestType.getByVinylOrNull(vinylType)?.crop ?: return
-        val isActiveVinyl = StereoHarmonyDisplay.activeVinyl == vinylType
+        val isActiveVinyl = PestApi.stereoPlayingItemPattern.anyMatches(event.originalItem.getLore())
         val iconId = "stereo_harmony_replacer:${vinylType.name}-$isActiveVinyl"
 
         val replacementStack = iconCache.getOrPut(iconId) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDisplay.kt
@@ -77,7 +77,7 @@ object StereoHarmonyDisplay {
 
     private fun updateActiveVinyl(stack: ItemStack?) {
         PestApi.stereoPlayingPattern.firstMatcher(stack?.getLore() ?: return) {
-            gardenStorage?.activeVinyl = VinylType.getByName(group("vinyl").trim())
+            gardenStorage?.activeVinyl = VinylType.getByName(group("vinyl").trim()).takeIf { it != VinylType.NONE }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDisplay.kt
@@ -1,19 +1,21 @@
 package at.hannibal2.skyhanni.features.garden.pests.stereo
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
+import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.pests.PestApi
 import at.hannibal2.skyhanni.features.garden.pests.PestType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
@@ -23,38 +25,21 @@ import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.item.ItemStack
 
 @SkyHanniModule
 object StereoHarmonyDisplay {
 
     private val config get() = PestApi.config.stereoHarmony
 
-    var activeVinyl: VinylType?
-        get() = ProfileStorageData.profileSpecific?.garden?.activeVinyl
+    var activeVinyl: VinylType
+        get() = ProfileStorageData.profileSpecific?.garden?.activeVinyl ?: VinylType.NONE
         private set(type) {
             ProfileStorageData.profileSpecific?.garden?.activeVinyl = type
+            update()
         }
 
     private fun VinylType.getPest() = PestType.filterableEntries.find { it.vinyl == this }
-
-    private val vinylTypeGroup = RepoPattern.group("garden.vinyl")
-
-    /**
-     * REGEX-TEST: §aYou are now playing §r§eNot Just a Pest§r§a!
-     */
-    private val selectVinylPattern by vinylTypeGroup.pattern(
-        "select",
-        "§aYou are now playing §r§e(?<type>.*)§r§a!",
-    )
-
-    /**
-     * REGEX-TEST: §aYou are no longer playing §r§eNot Just a Pest§r§a!
-     */
-    private val unselectVinylPattern by vinylTypeGroup.pattern(
-        "unselect",
-        "§aYou are no longer playing §r§e.*§r§a!",
-    )
 
     private var display = emptyList<Renderable>()
 
@@ -71,16 +56,14 @@ object StereoHarmonyDisplay {
     }
 
     private fun drawDisplay() = buildList {
-        val vinyl = activeVinyl ?: return@buildList
-        val pest = vinyl.getPest()
-
+        val pest = activeVinyl.getPest()
 
         if (config.showHead.get()) {
             val itemScale = 1.67
             add(pest?.internalName?.let { Renderable.item(it, itemScale) } ?: Renderable.item(questionMarkSkull))
         }
         val displayList = buildList {
-            val vinylName = vinyl.displayName
+            val vinylName = activeVinyl.displayName
             val pestName = pest?.displayName ?: "None"
             addString("§ePlaying: §a$vinylName")
             val pestLine = buildList {
@@ -92,20 +75,29 @@ object StereoHarmonyDisplay {
         add(Renderable.vertical(displayList, verticalAlign = RenderUtils.VerticalAlignment.CENTER))
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onChat(event: SkyHanniChatEvent) {
-        selectVinylPattern.matchMatcher(event.message) {
-            activeVinyl = VinylType.getByName(group("type"))
-            update()
+    private fun updateActiveVinyl(stack: ItemStack) =
+        PestApi.stereoPlayingPattern.firstMatcher(stack.getLore()) {
+            val vinyl = group("vinyl").trim()
+            activeVinyl = VinylType.getByNameOrNull(vinyl) ?: error("Unknown active vinyl: \"$vinyl\"")
         }
-        if (unselectVinylPattern.matches(event.message)) {
-            activeVinyl = VinylType.NONE
-            update()
-        }
+
+    // NOTE: Do not mark this as Garden only, it is possible to change the active vinyl outside the Garden
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+        if (!PestApi.stereoInventory.isInside()) return
+        event.inventoryItemsWithNull[4]?.let { updateActiveVinyl(it) }
     }
 
-    @HandleEvent
-    fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    // NOTE: Do not mark this as Garden only, it is possible to change the active vinyl outside the Garden
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
+        val stack = event.itemStack
+        if (stack.getItemCategoryOrNull() != ItemCategory.VACUUM) return
+        updateActiveVinyl(stack)
+    }
+
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
+    fun onRenderOverlay() {
         if (!isEnabled()) return
         if (!GardenApi.isCurrentlyFarming() && !config.alwaysShow) return
 
@@ -122,8 +114,8 @@ object StereoHarmonyDisplay {
         display = emptyList()
     }
 
-    @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    @HandleEvent(ConfigLoadEvent::class)
+    fun onConfigLoad() {
         ConditionalUtils.onToggle(config.showHead, config.showCrop) { update() }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDisplay.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.pests.stereo
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
@@ -25,6 +24,7 @@ import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
+import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
 import net.minecraft.item.ItemStack
 
 @SkyHanniModule
@@ -32,14 +32,10 @@ object StereoHarmonyDisplay {
 
     private val config get() = PestApi.config.stereoHarmony
 
-    var activeVinyl: VinylType
-        get() = ProfileStorageData.profileSpecific?.garden?.activeVinyl ?: VinylType.NONE
-        private set(type) {
-            ProfileStorageData.profileSpecific?.garden?.activeVinyl = type
-            update()
-        }
+    private val gardenStorage get() = GardenApi.storage
 
-    private fun VinylType.getPest() = PestType.filterableEntries.find { it.vinyl == this }
+    private fun VinylType.getPest(): PestType =
+        PestType.filterableEntries.find { it.vinyl == this } ?: error("no PestType for VinylType $this")
 
     private var display = emptyList<Renderable>()
 
@@ -55,45 +51,50 @@ object StereoHarmonyDisplay {
         display = drawDisplay()
     }
 
+    // TODO cleanup: we don't want three nested buildList calls
     private fun drawDisplay() = buildList {
-        val pest = activeVinyl.getPest()
-
+        val vinyl = gardenStorage?.activeVinyl ?: run {
+            add(Renderable.item(questionMarkSkull))
+            add(Renderable.vertical(listOf(StringRenderable("§ePlaying: §7Nothing")), verticalAlign = RenderUtils.VerticalAlignment.CENTER))
+            return@buildList
+        }
+        val pest = vinyl.getPest()
         if (config.showHead.get()) {
-            val itemScale = 1.67
-            add(pest?.internalName?.let { Renderable.item(it, itemScale) } ?: Renderable.item(questionMarkSkull))
+            add(Renderable.item(pest.internalName, scale = 1.67))
         }
         val displayList = buildList {
-            val vinylName = activeVinyl.displayName
-            val pestName = pest?.displayName ?: "None"
-            addString("§ePlaying: §a$vinylName")
+            addString("§ePlaying: §a${vinyl.displayName}")
             val pestLine = buildList {
-                addString("§ePest: §c$pestName ")
-                if (pest?.crop != null && config.showCrop.get()) addItemStack(pest.crop.icon)
+                addString("§ePest: §c${pest.displayName} ")
+                pest.crop?.let {
+                    if (config.showCrop.get()) addItemStack(it.icon)
+                }
             }
             add(Renderable.horizontal(pestLine))
         }
         add(Renderable.vertical(displayList, verticalAlign = RenderUtils.VerticalAlignment.CENTER))
     }
 
-    private fun updateActiveVinyl(stack: ItemStack) =
-        PestApi.stereoPlayingPattern.firstMatcher(stack.getLore()) {
-            val vinyl = group("vinyl").trim()
-            activeVinyl = VinylType.getByNameOrNull(vinyl) ?: error("Unknown active vinyl: \"$vinyl\"")
+    private fun updateActiveVinyl(stack: ItemStack?) {
+        PestApi.stereoPlayingPattern.firstMatcher(stack?.getLore() ?: return) {
+            gardenStorage?.activeVinyl = VinylType.getByName(group("vinyl").trim())
         }
+    }
 
     // NOTE: Do not mark this as Garden only, it is possible to change the active vinyl outside the Garden
     @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
-        if (!PestApi.stereoInventory.isInside()) return
-        event.inventoryItemsWithNull[4]?.let { updateActiveVinyl(it) }
+        if (PestApi.stereoInventory.isInside()) {
+            updateActiveVinyl(event.inventoryItemsWithNull[4])
+        }
     }
 
     // NOTE: Do not mark this as Garden only, it is possible to change the active vinyl outside the Garden
     @HandleEvent(onlyOnSkyblock = true)
     fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
-        val stack = event.itemStack
-        if (stack.getItemCategoryOrNull() != ItemCategory.VACUUM) return
-        updateActiveVinyl(stack)
+        if (event.itemStack.getItemCategoryOrNull() == ItemCategory.VACUUM) {
+            updateActiveVinyl(event.itemStack)
+        }
     }
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
@@ -101,7 +102,7 @@ object StereoHarmonyDisplay {
         if (!isEnabled()) return
         if (!GardenApi.isCurrentlyFarming() && !config.alwaysShow) return
 
-        if (activeVinyl == VinylType.NONE && config.hideWhenNone) return
+        if (gardenStorage?.activeVinyl == null && config.hideWhenNone) return
         else if (display.isEmpty()) update()
         if (display.isEmpty()) return
         val content = Renderable.horizontal(display, 1, verticalAlign = RenderUtils.VerticalAlignment.CENTER)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.garden.pests.stereo
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 
-enum class VinylType(val displayName: String) {
+enum class VinylType(val displayName: String, private val internalNameOverride: String? = null) {
     PRETTY_FLY("Pretty Fly"),
     CRICKET_CHOIR("Cricket Choir"),
     CICADA_SYMPHONY("Cicada Symphony"),
@@ -13,19 +13,18 @@ enum class VinylType(val displayName: String) {
     DYNAMITES("DynaMITES"),
     WINGS_OF_HARMONY("Wings of Harmony"),
     SLOW_AND_GROOVY("Slow and Groovy"),
-    NOT_JUST_A_PEST("Not Just a Pest"),
-    NONE("Nothing")
+    NOT_JUST_A_PEST("Not Just a Pest", "VINYL_BEETLE"),
+    NONE("None")
     ;
 
-    companion object {
-        private val BEETLE_VINYL = "VINYL_BEETLE".toInternalName()
+    val internalName: NeuInternalName =
+        (internalNameOverride ?: "VINYL_$name").toInternalName()
 
-        fun getByName(name: String) = VinylType.entries.firstOrNull { it.displayName == name } ?: NONE
-        fun getByInternalNameOrNull(internalName: NeuInternalName) = when (internalName) {
-            BEETLE_VINYL -> NOT_JUST_A_PEST
-            else -> VinylType.entries.firstOrNull {
-                internalName.asString() == "VINYL_${it.name}"
-            }
-        }
+    companion object {
+        fun getByNameOrNull(name: String): VinylType? =
+            VinylType.entries.firstOrNull { it.displayName == name }
+
+        fun getByInternalNameOrNull(internalName: NeuInternalName): VinylType? =
+            VinylType.entries.firstOrNull { it.internalName == internalName }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
@@ -14,7 +14,6 @@ enum class VinylType(val displayName: String, private val internalNameOverride: 
     WINGS_OF_HARMONY("Wings of Harmony"),
     SLOW_AND_GROOVY("Slow and Groovy"),
     NOT_JUST_A_PEST("Not Just a Pest", "VINYL_BEETLE"),
-    NONE("None")
     ;
 
     val internalName: NeuInternalName =

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.garden.pests.stereo
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 
-enum class VinylType(val displayName: String, private val internalNameOverride: String? = null) {
+enum class VinylType(val displayName: String, internalNameOverride: String? = null) {
     PRETTY_FLY("Pretty Fly"),
     CRICKET_CHOIR("Cricket Choir"),
     CICADA_SYMPHONY("Cicada Symphony"),

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
@@ -14,6 +14,7 @@ enum class VinylType(val displayName: String, private val internalNameOverride: 
     WINGS_OF_HARMONY("Wings of Harmony"),
     SLOW_AND_GROOVY("Slow and Groovy"),
     NOT_JUST_A_PEST("Not Just a Pest", "VINYL_BEETLE"),
+    NONE("None"),
     ;
 
     val internalName: NeuInternalName =

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/VinylType.kt
@@ -21,10 +21,10 @@ enum class VinylType(val displayName: String, private val internalNameOverride: 
         (internalNameOverride ?: "VINYL_$name").toInternalName()
 
     companion object {
-        fun getByNameOrNull(name: String): VinylType? =
-            VinylType.entries.firstOrNull { it.displayName == name }
+        fun getByName(name: String): VinylType =
+            VinylType.entries.find { it.displayName == name } ?: error("Unknown vinyl: '$name'")
 
         fun getByInternalNameOrNull(internalName: NeuInternalName): VinylType? =
-            VinylType.entries.firstOrNull { it.internalName == internalName }
+            VinylType.entries.find { it.internalName == internalName }
     }
 }


### PR DESCRIPTION
## What
Fixed various issues related to active pest vinyl detection and refactored the code a bit.

The nullability changes aren't arbitrary, the idea is:
* The stored active vinyl should never be `null`, it is better to just default to `VinylType.NONE` if we don't know, `null` suggests an error state.
* The `getByNameOrNull` and `getByInternalNameOrNull` methods can return `null`, because there is a distinction:
  * A return value of `VinylType.NONE` means "the inputted name represents the state where no vinyl is active"
  * A return value of `null` means "the inputted name does not represent any known vinyl"

## Changelog Fixes
+ Fixed Stereo Harmony Display not updating the active vinyl when changed outside the Garden or when SkyHanni is not installed. - Luna
+ Fixed Replace Menu Icons in Stereo Harmony sometimes highlighting the wrong vinyl as active. - Luna