### PR TITLE
Fix: Active vinyl not updating

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDisplay.kt
@@ -78,6 +78,7 @@ object StereoHarmonyDisplay {
     private fun updateActiveVinyl(stack: ItemStack?) {
         PestApi.stereoPlayingPattern.firstMatcher(stack?.getLore() ?: return) {
             gardenStorage?.activeVinyl = VinylType.getByName(group("vinyl").trim()).takeIf { it != VinylType.NONE }
+            update()
         }
     }
 


### PR DESCRIPTION
## What
The update call got lost in the code cleanup.

## Changelog Fixes
+ Fixed Stereo Harmony Display not updating the active vinyl until you leave and rejoin the Garden. - Luna