### PR TITLE
Fix: bingo reward line not found

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardTips.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardTips.kt
@@ -31,10 +31,11 @@ object BingoCardTips {
 
     /**
      * REGEX-TEST: §7Reward
+     * REGEX-TEST: §7Reward§r
      */
     private val rewardPattern by patternGroup.pattern(
         "reward",
-        "(?:§.)+Reward",
+        "(?:§.)+Reward(?:§.)?",
     )
     private val contributionRewardsPattern by patternGroup.pattern(
         "reward.contribution",


### PR DESCRIPTION
## What
SkyHanni 4.27.0 1.21.5: BingoCardTips reward line not found
 
Caused by java.lang.IndexOutOfBoundsException: null
    at SH.features.bingo.card.BingoCardTips.onToolTip(BingoCardTips.kt:78)
<Skyhanni event post>

Extra data:
goal displayName: 'Rock Solid'
slot slotNumber: '23'
toolTip: 
 - '§aRock Solid§r §7(§eMedium§7)'
 - '§8Personal Goal§r'
 - ''
 - '§7Equip a §r§9Rare §r§7or higher tiered §r§9Rock§r'
 - '§9Pet§r§7.§r'
 - ''
 - '§7Reward§r'
 - '§61 Bingo Point§r'
 - ''
 - '§cYou have not reached this goal!§r'

## Changelog Fixes
+ Fixed missing Bingo reward line. - nopo