### PR TITLE
Fix: Make BlockClickEvent use the right block

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
@@ -11,6 +11,7 @@ import net.minecraft.util.BlockPos
 import net.minecraft.util.MovingObjectPosition
 
 //#if MC > 1.21
+//$$ import new.minecraft.util.hit.BlockHitResult
 //$$ import net.minecraft.util.hit.EntityHitResult
 //#endif
 
@@ -68,10 +69,16 @@ object MinecraftInputHook {
             }
 
             MovingObjectPosition.MovingObjectType.BLOCK -> {
-                val position = blockHitResult.blockPos.toLorenzVec()
+                val position =
+                    //#if MC < 1.21
+                    blockHitResult.blockPos
+                    //#else
+                    //$$ (blockHitResult as BlockHitResult).blockPos
+                    //#endif
+
                 BlockClickEvent(
                     ClickType.LEFT_CLICK,
-                    position,
+                    position.toLorenzVec(),
                     InventoryUtils.getItemInHand(),
                 ).also {
                     if (clickCancelled) it.cancel()
@@ -104,7 +111,12 @@ object MinecraftInputHook {
     ): Boolean {
         if (blockHitResult == null || blockHitResult.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return false
 
-        val position = blockHitResult.blockPos
+        val position =
+            //#if MC < 1.21
+            blockHitResult.blockPos
+            //#else
+            //$$ (blockHitResult as BlockHitResult).blockPos
+            //#endif
 
         if (currentBlockPos == position) return false
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
@@ -11,7 +11,7 @@ import net.minecraft.util.BlockPos
 import net.minecraft.util.MovingObjectPosition
 
 //#if MC > 1.21
-//$$ import new.minecraft.util.hit.BlockHitResult
+//$$ import net.minecraft.util.hit.BlockHitResult
 //$$ import net.minecraft.util.hit.EntityHitResult
 //#endif
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
@@ -70,11 +70,11 @@ object MinecraftInputHook {
 
             MovingObjectPosition.MovingObjectType.BLOCK -> {
                 val position =
-                    //#if MC < 1.21
+                //#if MC < 1.21
                     blockHitResult.blockPos
-                    //#else
-                    //$$ (blockHitResult as BlockHitResult).blockPos
-                    //#endif
+                //#else
+                //$$     (blockHitResult as BlockHitResult).blockPos
+                //#endif
 
                 BlockClickEvent(
                     ClickType.LEFT_CLICK,
@@ -112,11 +112,11 @@ object MinecraftInputHook {
         if (blockHitResult == null || blockHitResult.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return false
 
         val position =
-            //#if MC < 1.21
+        //#if MC < 1.21
             blockHitResult.blockPos
-            //#else
-            //$$ (blockHitResult as BlockHitResult).blockPos
-            //#endif
+        //#else
+        //$$     (blockHitResult as BlockHitResult).blockPos
+        //#endif
 
         if (currentBlockPos == position) return false
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MinecraftInputHook.kt
@@ -70,7 +70,7 @@ object MinecraftInputHook {
 
             MovingObjectPosition.MovingObjectType.BLOCK -> {
                 val position =
-                //#if MC < 1.21
+                    //#if MC < 1.21
                     blockHitResult.blockPos
                 //#else
                 //$$     (blockHitResult as BlockHitResult).blockPos
@@ -112,7 +112,7 @@ object MinecraftInputHook {
         if (blockHitResult == null || blockHitResult.typeOfHit != MovingObjectPosition.MovingObjectType.BLOCK) return false
 
         val position =
-        //#if MC < 1.21
+            //#if MC < 1.21
             blockHitResult.blockPos
         //#else
         //$$     (blockHitResult as BlockHitResult).blockPos


### PR DESCRIPTION
## What
For some reason `MovingObjectPosition.blockPos` gets mapped into `HitResult.pos` and not `BlockHitResult.blockPos`

## Changelog Fixes
+ Fixed an issue with clicks. - bloxigus

