### PR TITLE
Fix: Singular Croesus Pattern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -43,6 +43,9 @@ object CroesusChestTracker {
     private val kismetPattern by patternGroup.pattern("kismet.reroll", "§aReroll Chest")
     private val kismetUsedPattern by patternGroup.pattern("kismet.used", "§aYou already rerolled a chest!")
 
+    /**
+     * REGEX-TEST: §eFloor V
+     */
     private val floorPattern by patternGroup.pattern("chest.floor", "§eFloor (?<floor>[IV]+)")
     private val masterPattern by patternGroup.pattern("chest.master", ".*Master.*")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -43,7 +43,7 @@ object CroesusChestTracker {
     private val kismetPattern by patternGroup.pattern("kismet.reroll", "§aReroll Chest")
     private val kismetUsedPattern by patternGroup.pattern("kismet.used", "§aYou already rerolled a chest!")
 
-    private val floorPattern by patternGroup.pattern("chest.floor", "§7Tier: §eFloor (?<floor>[IV]+)")
+    private val floorPattern by patternGroup.pattern("chest.floor", "(§eFloor|§.Tier) (?<floor>[IV]+)")
     private val masterPattern by patternGroup.pattern("chest.master", ".*Master.*")
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -43,7 +43,7 @@ object CroesusChestTracker {
     private val kismetPattern by patternGroup.pattern("kismet.reroll", "§aReroll Chest")
     private val kismetUsedPattern by patternGroup.pattern("kismet.used", "§aYou already rerolled a chest!")
 
-    private val floorPattern by patternGroup.pattern("chest.floor", "(§eFloor|§.Tier) (?<floor>[IV]+)")
+    private val floorPattern by patternGroup.pattern("chest.floor", "§eFloor (?<floor>[IV]+)")
     private val masterPattern by patternGroup.pattern("chest.master", ".*Master.*")
 
     /**


### PR DESCRIPTION
## What
This would cause F0 to get saved into config since the pattern  didn't match

exclude_from_changelog
