### PR TITLE
Fix: BingoCardTips reward line not found

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardTips.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardTips.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.features.bingo.BingoApi.getData
 import at.hannibal2.skyhanni.features.bingo.card.goals.GoalType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getAllItems
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -24,6 +25,7 @@ object BingoCardTips {
     private val config get() = SkyHanniMod.feature.event.bingo.bingoCard
 
     private val patternGroup = RepoPattern.group("bingo.card.tips")
+
     private val inventoryPattern by patternGroup.pattern(
         "card",
         "Bingo Card",
@@ -50,10 +52,12 @@ object BingoCardTips {
         "(?:§.)+Row #.*",
     )
 
+    private val bingoCardInventory = InventoryDetector(inventoryPattern)
+
     @HandleEvent
     fun onToolTip(event: ToolTipEvent) {
         if (!isEnabled()) return
-        if (!inventoryPattern.matches(InventoryUtils.openInventoryName())) return
+        if (!bingoCardInventory.isInside()) return
 
         val slot = event.slot
         val goal = BingoApi.bingoGoals[slot.slotNumber] ?: return
@@ -72,9 +76,9 @@ object BingoCardTips {
             toolTip.indexOfFirst { rewardPattern.matches(it) }
         } else {
             toolTip.indexOfFirst { contributionRewardsPattern.matches(it) }
-        } - 1
+        } - 2
 
-        if (index == -2) {
+        if (index < 0) {
             ErrorManager.logErrorWithData(
                 IndexOutOfBoundsException(),
                 "BingoCardTips reward line not found",
@@ -85,13 +89,13 @@ object BingoCardTips {
             return
         }
 
-        toolTip.add(index++, "")
-        toolTip.add(index++, "§eGuide:")
+        toolTip.add(++index, "")
+        toolTip.add(++index, "§eGuide:")
         for (line in bingoTip.guide) {
-            toolTip.add(index++, " $line")
+            toolTip.add(++index, " $line")
         }
         bingoTip.found?.let {
-            toolTip.add(index++, "§7Found by: §e$it")
+            toolTip.add(++index, "§7Found by: §e$it")
         }
     }
 


### PR DESCRIPTION
## What
Fixed the Bingo Card Tips feature trying to parse tooltips before the inventory was fully loaded, resulting in random errors like the below.

Also changed the code to use pre-increment (`++index`) because it is cleaner this way and IntelliJ will no longer complain about the value of the last increment being unused.

<details>
<summary>Error</summary>

```
SkyHanni 5.0.1 1.21.8: BingoCardTips reward line not found
 
Caused by java.lang.IndexOutOfBoundsException: null
    at SH.features.bingo.card.BingoCardTips.onToolTip(BingoCardTips.kt:79)
<Skyhanni event post>

Extra data:
goal displayName: 'Slaughterer'
slot slotNumber: '14'
toolTip: 
 - '§f§o§6Bingo Card §7(§aEasy§7)'
 - '§8November 2025'
 - ''
 - '§7View your Bingo Card progress for'
 - '§7this §6Bingo Event§7, including your'
 - '§7personal and Community Goals!'
 - ''
 - '§eClick to view!'
 - '§8minecraft:paper'
 - '§812 component(s)'
```

</details>

## Changelog Fixes
+ Fixed occasional Bingo Card Tips "reward line not found" errors in chat. - Luna