### PR TITLE
Fix: kuudra Duplicated Chest in Croesus detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -44,6 +44,11 @@ object KuudraApi {
         "(?<tier>HOT|BURNING|FIERY|INFERNAL|)_?(?<type>AURORA|CRIMSON|TERROR|HOLLOW|FERVOR)_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS)",
     )
 
+    private val kuudraChestPattern by patternGroup.pattern(
+        "kuudrachest",
+        "(?<chesttype>(?:Paid|Free) Chest)(?: Chest)?"
+    )
+
     val kuudraTiers = listOf("", "HOT", "BURNING", "FIERY", "INFERNAL")
     val kuudraSets = listOf("AURORA", "CRIMSON", "TERROR", "HOLLOW", "FERVOR")
 
@@ -70,9 +75,16 @@ object KuudraApi {
         ;
 
         companion object {
-            fun getByInventoryName(inventory: String) = entries.firstOrNull { it.inventory == inventory }
+            fun getByInventoryName(inventory: String) {
+                var realInventory = inventory
+                kuudraChestPattern.matchMatcher(inventory) {
+                    realInventory = group("chesttype")
+                }
+                entries.firstOrNull { it.inventory == realInventory }
+            }
+            }
         }
-    }
+
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -75,12 +75,15 @@ object KuudraApi {
         ;
 
         companion object {
-            fun getByInventoryName(inventory: String) {
+            fun getByInventoryName(inventory: String): KuudraChest? {
                 var realInventory = inventory
-                kuudraChestPattern.matchMatcher(inventory) {
-                    realInventory = group("chesttype")
+                if (kuudraChestPattern.matches(inventory)) {
+                    kuudraChestPattern.matchMatcher(inventory) {
+                        realInventory = group("chesttype")
+                    }
                 }
-                entries.firstOrNull { it.inventory == realInventory }
+                return entries.firstOrNull { it.inventory == realInventory }
+
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -46,7 +46,7 @@ object KuudraApi {
 
     private val kuudraChestPattern by patternGroup.pattern(
         "kuudrachest",
-        "(?<chesttype>(?:Paid|Free) Chest)(?: Chest)?"
+        "(?<chesttype>(?:Paid|Free) Chest)(?: Chest)?",
     )
 
     val kuudraTiers = listOf("", "HOT", "BURNING", "FIERY", "INFERNAL")
@@ -82,8 +82,8 @@ object KuudraApi {
                 }
                 entries.firstOrNull { it.inventory == realInventory }
             }
-            }
         }
+    }
 
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -45,6 +45,7 @@ object KuudraApi {
     )
 
     /**
+     * Hypixel currently duplicate the word Chest in the inventory name of Kuudra chests in Croesus/Vesuvius
      * REGEX-TEST: Paid Chest
      * REGEX-TEST: Paid Chest Chest
      * REGEX-TEST: Free Chest

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -45,7 +45,7 @@ object KuudraApi {
     )
 
     /**
-     * Hypixel currently duplicate the word Chest in the inventory name of Kuudra chests in Croesus/Vesuvius
+     * Hypixel currently duplicate the word Chest in the inventory name (NOT ITEM STACKS) of Kuudra chests in Croesus/Vesuvius
      * REGEX-TEST: Paid Chest
      * REGEX-TEST: Paid Chest Chest
      * REGEX-TEST: Free Chest

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -90,11 +90,9 @@ object KuudraApi {
                     }
                 }
                 return entries.firstOrNull { it.inventory == realInventory }
-
             }
         }
     }
-
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -44,6 +44,12 @@ object KuudraApi {
         "(?<tier>HOT|BURNING|FIERY|INFERNAL|)_?(?<type>AURORA|CRIMSON|TERROR|HOLLOW|FERVOR)_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS)",
     )
 
+    /**
+     * REGEX-TEST: Paid Chest
+     * REGEX-TEST: Paid Chest Chest
+     * REGEX-TEST: Free Chest
+     * REGEX-TEST: Free Chest Chest
+     */
     private val kuudraChestPattern by patternGroup.pattern(
         "kuudrachest",
         "(?<chesttype>(?:Paid|Free) Chest)(?: Chest)?",


### PR DESCRIPTION
## What
Fixed the stupid issue where chest overlay didn't work because Paid/Free chests in Croesus/Vesuvius were called "Paid Chest Chest" or "Free Chest Chest"

<details>
<summary>Images</summary>

<img width="763" height="528" alt="image" src="https://github.com/user-attachments/assets/71c96175-7817-41e2-8525-8d1fdb97da9c" />

</details>

## Changelog Fixes
+ Fixed Instance Chest Value For Kuudra in Croesus. - Fazfoxy
