### PR TITLE
Fix: Manticore and Sphinx highlight

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
@@ -58,13 +58,14 @@ object DianaApi {
      */
     private val rareDianaMobNamePattern by group.pattern(
         "rare-mob-name",
-        "Minos Inquisitor|Sphinx|King Minos|Manticore",
+        "(?:Minos Inquisitor|Sphinx|King Minos|Manticore)\\s*",
     )
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onJoinWorld(event: EntityEnterWorldEvent<EntityOtherPlayerMP>) {
         val entity = event.entity
-        if (rareDianaMobNamePattern.matches(entity.name)) {
+        // TODO: fetch rare mobs from repo instead
+        if (rareDianaMobNamePattern.matches(entity.name.trim())) {
             RareDianaMobFoundEvent(entity).post()
         }
     }


### PR DESCRIPTION
## What
The mob names are actually `"Manticore "` and `"Sphinx "` (Hypixel does this to prevent people from buying mobs/NPCs OptiFine capes and such since the incident a few years ago), so the pattern wasn't matching.

I also added a `.trim()` for good measure, but I updated the pattern so this can be resolved without a full mod update, and we will probably change it to just use the mob list from the repo instead later.

## Changelog Fixes
+ Fixed Manticore and Sphinx not being highlighted. - Luna
