### PR TITLE
Feature: Middle Click Fix

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.kt
@@ -369,5 +369,5 @@ class InventoryConfig {
     @FeatureToggle
     @SearchTag("pick block")
     @OnlyModern
-    var middleClickFix: Boolean = false
+    var middleClickFix: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/InventoryConfig.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.features.inventory
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyModern
 import at.hannibal2.skyhanni.config.features.inventory.chocolatefactory.CFConfig
 import at.hannibal2.skyhanni.config.features.inventory.customwardrobe.CustomWardrobeConfig
 import at.hannibal2.skyhanni.config.features.inventory.experimentationtable.ExperimentationTableConfig
@@ -358,4 +359,15 @@ class InventoryConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var savePrivateIslandChests: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Middle Click Fix",
+        desc = "Fixes not being able to middle click items in inventories (e.g. to disable a full set bonus or rune).",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    @SearchTag("pick block")
+    @OnlyModern
+    var middleClickFix: Boolean = false
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/inventory/MiddleClickFix.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/inventory/MiddleClickFix.kt
@@ -1,0 +1,12 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+
+@SkyHanniModule
+object MiddleClickFix {
+    private val config get() = SkyHanniMod.feature.inventory
+
+    fun isEnabled() = SkyBlockUtils.inSkyBlock && config.middleClickFix
+}

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
@@ -10,10 +10,12 @@ import at.hannibal2.skyhanni.events.GuiKeyPressEvent;
 import at.hannibal2.skyhanni.events.render.gui.DrawBackgroundEvent;
 import at.hannibal2.skyhanni.events.render.gui.GuiMouseInputEvent;
 import at.hannibal2.skyhanni.features.inventory.BetterContainers;
+import at.hannibal2.skyhanni.features.inventory.MiddleClickFix;
 import at.hannibal2.skyhanni.features.inventory.wardrobe.CustomWardrobe;
 import at.hannibal2.skyhanni.utils.DelayedRun;
 import at.hannibal2.skyhanni.utils.KeyboardManager;
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
@@ -124,4 +126,9 @@ public abstract class MixinHandledScreen {
         return BetterContainers.slotCanBeHighlighted(slot);
     }
 
+    @ModifyExpressionValue(method = "mouseClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isInCreativeMode()Z"))
+    private boolean fixMiddleClick(boolean original) {
+        if (!MiddleClickFix.INSTANCE.isEnabled()) return original;
+        return true;
+    }
 }


### PR DESCRIPTION
## What
Hypixel uses the Pick Block action (bound to middle click by default) on certain items to trigger special actions, e.g. disabling an armor full set bonus or a rune. Modern versions of Minecraft restrict Pick Block to creative mode only, but Mojang forgot to add the creative mode check for when the action is bound to a keyboard key, meaning it is still possible to do this in a vanilla client, so this is safe to do – and we already automatically translate left clicks to middle clicks in numerous places, this is no different.

## Changelog New Features
+ Added Middle Click Fix for 1.21.x. - Luna
    * This fixes not being able to middle click items in inventories (e.g. to disable a full set bonus or a rune).