### PR TITLE
Fix: Tooltip Color Stripping

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
@@ -24,8 +24,8 @@ object ToolTipData {
     //$$     stack: ItemStack,
     //$$     originalToolTip: MutableList<Text>,
     //$$ ): MutableList<Text> {
-    //$$     val tooltip = originalToolTip.map { it.formattedTextCompatLessResets().removePrefix("§5") }.toMutableList()
-    //$$     val tooltipCopy = tooltip.toMutableList()
+    //$$     val tooltip = originalToolTip.mapTo(mutableListOf()) { it.formattedTextCompatLessResets().removePrefix("§5§o") }
+    //$$     val tooltipCopy = tooltip.toList()
     //$$     getTooltip(stack, tooltip)
     //$$     onHover(context, stack, tooltip)
     //$$     renderToolTip(context, stack)


### PR DESCRIPTION
## What
Fixes modern tooltip color stripping code to strip `§5§o` instead of just `§5`. The latter happens to work fine in vanilla because Hypixel starts every line with a color code, which also happens to reset the `§o` formatting code, but can break if certain mods, e.g. Catharsis, modify the tooltip to strip the `§5§o` prefix.

This is a quick band-aid fix and does not address several other underlying issues with the implementation (e.g. breaking modern components like fonts, the scuffed check for modified lines, and potentially incorrectly stripping formatting once again if Hypixel *did* ever genuinely start a lore line with `§5§o`).

## Changelog Fixes
+ Fixed some features incorrectly stripping purple color from item tooltips when used with certain mods. - Luna