### PR TITLE
Fix: Disable Farming Fortune warnings if display is disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -319,6 +319,7 @@ object FarmingFortuneDisplay {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onTick(event: SkyHanniTickEvent) {
+        if (!isEnabled()) return
         if (event.isMod(2)) update()
         if (gardenJoinTime.passedSince() > 5.seconds && !foundTabUniversalFortune && !gardenJoinTime.isFarPast()) {
             if (lastUniversalFortuneMissingError.passedSince() < 20.seconds) return


### PR DESCRIPTION
## What
Don't send warnings about missing Farming Fortune/Crop Fortune if Farming Fortune Display is disabled.

## Changelog Fixes
+ Fixed warnings about missing Farming Fortune in tab list being sent even if Farming Fortune Display is disabled. - Luna