### PR TITLE
Backend: Change some tooltip events to use the right event

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.event.hoppity
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.CFApi
 import at.hannibal2.skyhanni.features.misc.ContributorManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -48,7 +48,7 @@ object ReplaceHoppityWithContributor {
     }
 
     @HandleEvent(priority = HandleEvent.LOWEST)
-    fun onTooltip(event: ItemHoverEvent) {
+    fun onTooltip(event: ToolTipEvent) {
         if (!isEnabled()) return
         if (!HoppityCollectionStats.inInventory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/CarrolynHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/CarrolynHelper.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.ItemClickEvent
-import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -34,7 +34,7 @@ object CarrolynHelper {
     )
 
     @HandleEvent(priority = HandleEvent.LOWEST)
-    fun onTooltip(event: ItemHoverEvent) {
+    fun onTooltip(event: ToolTipEvent) {
         if (!isEnabled()) return
 
         if (!event.itemStack.isCarrolynItem()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
@@ -12,8 +12,8 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorOpenEvent
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorRenderEvent
-import at.hannibal2.skyhanni.events.item.ItemHoverEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketSentEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorApi.ACCEPT_SLOT
@@ -135,7 +135,7 @@ object VisitorListener {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onTooltip(event: ItemHoverEvent) {
+    fun onTooltip(event: ToolTipEvent) {
         if (!GardenApi.onBarnPlot) return
         if (!VisitorApi.inInventory) return
         val visitor = VisitorApi.getVisitor(lastClickedNpc) ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FixIronman.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FixIronman.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
-import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.TimeUtils
@@ -16,7 +16,7 @@ object FixIronman {
     private val sbLevelingInventory = InventoryDetector { name -> name == "SkyBlock Leveling" }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTooltipEvent(event: ItemHoverEvent) {
+    fun onTooltipEvent(event: ToolTipEvent) {
         // We don't need to always fix this
         if (!TimeUtils.isAprilFoolsDay) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorHexInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorHexInLore.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 
 @SkyHanniModule
 object ColorHexInLore {
@@ -37,6 +38,8 @@ object ColorHexInLore {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onTooltip(event: ToolTipEvent) {
+        // this feature wont work on 1.21 probably until we drop 1.8
+        if (!PlatformUtils.IS_LEGACY) return
         if (!isEnabled()) return
         val itemCategory = event.itemStack.getItemCategoryOrNull()
         if (itemCategory != ItemCategory.DYE &&

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorHexInLore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorHexInLore.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ExtendedChatColor
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -36,7 +36,7 @@ object ColorHexInLore {
     )
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTooltip(event: ItemHoverEvent) {
+    fun onTooltip(event: ToolTipEvent) {
         if (!isEnabled()) return
         val itemCategory = event.itemStack.getItemCategoryOrNull()
         if (itemCategory != ItemCategory.DYE &&

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.model.SkyblockStat
-import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.replace
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -27,7 +27,7 @@ object ColorfulItemStats {
     )
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTooltipEvent(event: ItemHoverEvent) {
+    fun onTooltipEvent(event: ToolTipEvent) {
         if (!config.enabled) return
 
         for ((index, line) in event.toolTip.withIndex()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.config.features.inventory.EnchantParsingConfig.Comm
 import at.hannibal2.skyhanni.events.ChatHoverEvent
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.features.chroma.ChromaManager
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -132,7 +132,7 @@ object EnchantParser {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTooltipEvent(event: ItemHoverEvent) {
+    fun onTooltipEvent(event: ToolTipEvent) {
         // If enchants doesn't have any enchant data then we have no data to parse enchants correctly
         if (!this.enchants.hasEnchantData()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FixChimeraDescription.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FixChimeraDescription.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.features.misc.items.enchants
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.item.ItemHoverEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.formatIntOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -22,7 +22,7 @@ object FixChimeraDescription {
     )
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTooltipEvent(event: ItemHoverEvent) {
+    fun onTooltipEvent(event: ToolTipEvent) {
         // We don't need to always fix this
         if (!TimeUtils.isAprilFoolsDay) return
 


### PR DESCRIPTION
## What
The fact that a tooltip event has rendering in it at all is pretty stupid, this can get fixed once we drop 1.8
Only like 3 of the uses of the 2 events needed to use it

## Changelog Technical Details
+ Changed some tooltip event uses to use the right event. - nopo
