### PR TITLE
Fix: Index out of Range in onRenderItemTipIsKismetable maybe

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -192,7 +192,7 @@ object CroesusChestTracker {
                     currentPage++
                 }
 
-                BACK_ARROW_SLOT -> if (pageSwitchable && event.slot.stack.isArrow()) {
+                BACK_ARROW_SLOT -> if (pageSwitchable && event.slot.stack.isArrow() && currentPage != 0) { // People are getting Index out of range errors and I hope this fixes it?
                     pageSwitchable = false
                     currentPage--
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -192,7 +192,7 @@ object CroesusChestTracker {
                     currentPage++
                 }
 
-                BACK_ARROW_SLOT -> if (pageSwitchable && event.slot.stack.isArrow() && currentPage != 0) { // People are getting Index out of range errors and I hope this fixes it?
+                BACK_ARROW_SLOT -> if (pageSwitchable && event.slot.stack.isArrow() && currentPage != 0) { // People are getting Index out of range errors presumably due to negative pages.
                     pageSwitchable = false
                     currentPage--
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -181,6 +181,7 @@ object CroesusChestTracker {
         chestInventory = null
     }
 
+    @Suppress("MaxLineLength")
     @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!config.showUsedKismets) return

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -181,7 +181,6 @@ object CroesusChestTracker {
         chestInventory = null
     }
 
-    @Suppress("MaxLineLength")
     @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!config.showUsedKismets) return
@@ -193,7 +192,8 @@ object CroesusChestTracker {
                     currentPage++
                 }
 
-                BACK_ARROW_SLOT -> if (pageSwitchable && event.slot.stack.isArrow() && currentPage != 0) { // People are getting Index out of range errors presumably due to negative pages.
+                // People are getting Index out of range errors presumably due to negative pages.
+                BACK_ARROW_SLOT -> if (pageSwitchable && currentPage != 0 && event.slot.stack.isArrow()) {
                     pageSwitchable = false
                     currentPage--
                 }


### PR DESCRIPTION
## What
This, might, fix index out of range errors that have been reported for the last two days in this feature that I haven't even attempted to recreate yet
(also I don't think this really needs a changelog)

exclude_from_changelog
