### PR TITLE
Improvement: Entity Distance Performance

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -37,10 +37,13 @@ import net.minecraft.util.AxisAlignedBB
 //$$ import net.minecraft.entity.EquipmentSlot
 //#else
 import net.minecraft.entity.SharedMonsterAttributes
+
 //#endif
 
 @SkyHanniModule
 object EntityUtils {
+
+    inline val ALWAYS get(): (Entity) -> Boolean = { true }
 
     // TODO remove this relatively heavy call everywhere
     @Deprecated("Use Mob Detection Instead")
@@ -138,11 +141,13 @@ object EntityUtils {
             .firstOrNull { it.name == "textures" }?.value
     }
 
-    inline fun <reified T : Entity> getEntitiesNextToPlayer(radius: Double): Sequence<T> =
-        getEntitiesNearby<T>(LocationUtils.playerLocation(), radius)
+    inline fun <reified T : Entity> getEntitiesNextToPlayer(radius: Double, noinline predicate: (T) -> Boolean = ALWAYS): List<T> =
+        getEntitiesNearby<T>(LocationUtils.playerLocation(), radius, predicate)
 
-    inline fun <reified T : Entity> getEntitiesNearby(location: LorenzVec, radius: Double): Sequence<T> =
-        getEntities<T>().filter { it.distanceTo(location) < radius }
+    // First filters for a bounding box because it's faster, and then filters based on distance
+    inline fun <reified T : Entity> getEntitiesNearby(location: LorenzVec, radius: Double, noinline predicate: (T) -> Boolean = ALWAYS): List<T> {
+        return getEntitiesInBox<T>(location, radius) { it.distanceTo(location) < radius && predicate(it)}
+    }
 
     inline fun <reified T : Entity> getEntitiesNearbyIgnoreY(location: LorenzVec, radius: Double): Sequence<T> =
         getEntities<T>().filter { it.distanceToIgnoreY(location) < radius }
@@ -179,9 +184,13 @@ object EntityUtils {
 
     inline fun <reified R : Entity> getEntities(): Sequence<R> = getAllEntities().filterIsInstance<R>()
 
+    inline fun <reified E : Entity> getEntitiesInBox(pos: LorenzVec, radius: Double, noinline predicate: (E) -> Boolean = ALWAYS): List<E> {
+        return getEntitiesInBoundingBox(pos.boundingCenter(radius), predicate)
+    }
+
     // More efficient than filtering by type, and then for distance, as Minecraft already first filters the chunks that contain the aabb,
     // and then filters both for entity type and with the predicate for entities inside those chunks.
-    inline fun <reified E : Entity> getEntitiesInBoundingBox(aabb: AxisAlignedBB, noinline predicate: (E) -> Boolean = { true }): List<E> {
+    inline fun <reified E : Entity> getEntitiesInBoundingBox(aabb: AxisAlignedBB, noinline predicate: (E) -> Boolean = ALWAYS): List<E> {
         val world = MinecraftCompat.localWorldOrNull ?: return emptyList()
         //#if MC < 1.21
         return world.getEntitiesWithinAABB(E::class.java, aabb) { it != null && predicate(it) }

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -145,8 +145,12 @@ object EntityUtils {
         getEntitiesNearby<T>(LocationUtils.playerLocation(), radius, predicate)
 
     // First filters for a bounding box because it's faster, and then filters based on distance
-    inline fun <reified T : Entity> getEntitiesNearby(location: LorenzVec, radius: Double, noinline predicate: (T) -> Boolean = ALWAYS): List<T> {
-        return getEntitiesInBox<T>(location, radius) { it.distanceTo(location) < radius && predicate(it)}
+    inline fun <reified T : Entity> getEntitiesNearby(
+        location: LorenzVec,
+        radius: Double,
+        noinline predicate: (T) -> Boolean = ALWAYS
+    ): List<T> {
+        return getEntitiesInBox<T>(location, radius) { it.distanceTo(location) < radius && predicate(it) }
     }
 
     inline fun <reified T : Entity> getEntitiesNearbyIgnoreY(location: LorenzVec, radius: Double): Sequence<T> =

--- a/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
@@ -33,11 +33,10 @@ object MobUtils {
         EntityUtils.getEntitiesNearby<EntityArmorStand>(entity.getLorenzVec(), range)
 
     fun getClosestArmorStand(entity: Entity, range: Double) =
-        getArmorStandByRangeAll(entity, range).sortedBy { it.distanceTo(entity) }.firstOrNull()
+        getArmorStandByRangeAll(entity, range).minByOrNull { it.distanceTo(entity) }
 
     fun getClosestArmorStandWithName(entity: Entity, range: Double, name: String) =
-        getArmorStandByRangeAll(entity, range).filter { it.cleanName().startsWith(name) }
-            .sortedBy { it.distanceTo(entity) }.firstOrNull()
+        getArmorStandByRangeAll(entity, range).filter { it.cleanName().startsWith(name) }.minByOrNull { it.distanceTo(entity) }
 
     fun EntityArmorStand.isDefaultValue() = this.name == defaultArmorStandName
 


### PR DESCRIPTION
## What
This PR makes it so that the functions that get entities within a distance internally first filter using the bounding box function I added on another PR. From my testing, this seemed to improve the actual performance of the function by roughly 10x.

## Changelog Improvements
+ Improved performance of Mob Detection and other features that detect entities by 10x. - Empa