### PR TITLE
Fix: Debug HUD check on 1.21.10

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
@@ -24,7 +24,9 @@ object MinecraftCompat {
 
     //#if MC < 1.16
     val showDebugHud get(): Boolean = Minecraft.getMinecraft().gameSettings.showDebugInfo
-    //#else
+    //#elseif MC < 1.21.9
     //$$ val showDebugHud get(): Boolean = MinecraftClient.getInstance().debugHud.shouldShowDebugHud()
+    //#else
+    //$$ val showDebugHud get(): Boolean = MinecraftClient.getInstance().debugHudEntryList.isF3Enabled
     //#endif
 }


### PR DESCRIPTION
## What
Fixed the `MinecraftCompat.showDebugHud` check for 1.21.10+. `DebugHud#shouldShowDebugHud()` returns true if any debug HUD element is set to permanently visible, while `DebugHudEntryList#isF3Enabled` correctly returns true only if the F3 screen is actually toggled on.

## Changelog Fixes
+ Fixed "while F3 is open" features sometimes showing up while F3 is not open on Minecraft 1.21.10. - Luna

