### PR TITLE
Fix: Burrowing Spores Pattern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
@@ -20,6 +20,9 @@ object GardenBurrowingSporesNotifier {
 
     private val config get() = GardenApi.config
     private val patternGroup = RepoPattern.group("garden.burrowingspores")
+    /**
+     * REGEX-TEST: §6§lVERY RARE CROP! §r§f§r§9Burrowing Spores
+     */
     private val sporeDropMessage by patternGroup.pattern(
         "drop",
         "§6§lVERY RARE CROP! (?:§.)*§9Burrowing Spores",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
@@ -20,6 +20,7 @@ object GardenBurrowingSporesNotifier {
 
     private val config get() = GardenApi.config
     private val patternGroup = RepoPattern.group("garden.burrowingspores")
+
     /**
      * REGEX-TEST: §6§lVERY RARE CROP! §r§f§r§9Burrowing Spores
      */

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenBurrowingSporesNotifier.kt
@@ -22,7 +22,7 @@ object GardenBurrowingSporesNotifier {
     private val patternGroup = RepoPattern.group("garden.burrowingspores")
     private val sporeDropMessage by patternGroup.pattern(
         "drop",
-        "§6§lVERY RARE CROP! §r§f§r§9Burrowing Spores\\.",
+        "§6§lVERY RARE CROP! (?:§.)*§9Burrowing Spores",
     )
     private val BURROWING_SPORES = "BURROWING_SPORES".toInternalName()
 


### PR DESCRIPTION
## What
Removed a stray `\.` at the end of the Burrowing Spores pattern causing it to not match. Also made the color matching more lenient just in case, because I do not have a message with color codes in my logs to confirm.

## Changelog Fixes
+ Fixed Burrowing Spores notification not working. - Luna