### PR TITLE
Fix: Basic Kuudra Key cost not being added

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -78,7 +78,7 @@ object InstanceChestProfit {
      */
     private val kuudraChestKey by patternGroup.pattern(
         "kuudrachestkey",
-        "§.\\w+ Kuudra Key",
+        "§.(?:\\w+ )?Kuudra Key",
     )
 
     private val config get() = SkyHanniMod.feature.combat.instanceChestProfit

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -75,6 +75,7 @@ object InstanceChestProfit {
     /**
      * REGEX-TEST: §6Infernal Kuudra Key
      * REGEX-TEST: §5Burning Kuudra Key
+     * REGEX-TEST: §9Kuudra Key
      */
     private val kuudraChestKey by patternGroup.pattern(
         "kuudrachestkey",


### PR DESCRIPTION
## What
This should fix the kuudra key part of https://discord.com/channels/997079228510117908/1441587782295490600 I'll look into wheel of fate when I'm not playing a different thing

## Changelog Fixes
+ Fixed Instance Chest Profit ignoring Basic Kuudra Key Cost. - Fazfoxy
