### PR TITLE
Fix: Chocolate Factory Intern Upgrade Filter on 1.21

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -362,7 +362,7 @@ object ChatFilter {
         "(?:§f)? +§r§.§k#§r§. LEVEL UP! §r§.§k#".toPattern(),
     )
     private val factoryUpgradePatterns = listOf(
-        "§.* §r§7has been promoted to §r§7\\[.*§r§7] §r§.*§r§7!".toPattern(),
+        ".* §r§7has been promoted to §r§7\\[.*§r§7] §r§.*§r§7!".toPattern(),
         "§7Your §r§aRabbit Barn §r§7capacity has been increased to §r§a.* Rabbits§r§7!".toPattern(),
         "§7You will now produce §r§6.* Chocolate §r§7per click!".toPattern(),
         "§7You upgraded to §r§d.*?§r§7!".toPattern(),


### PR DESCRIPTION
## What
Fixed Chocolate Factory Upgrade chat filter not working on Intern (levels 1-9) due to the white color code at the beginning that we strip on 1.21:

```
Rabbit Dog §r§7has been promoted to §r§7[1§r§7] §r§fIntern§r§7!
```

## Changelog Fixes
+ Fixed Chocolate Factory Upgrade chat filter sometimes not hiding messages. - Luna
