### PR TITLE
Fix: ScreenDrawnEvent injection point on 1.21.8+

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGameRenderer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGameRenderer.java
@@ -36,8 +36,10 @@ public class MixinGameRenderer {
         GuiEditManager.renderLast(context);
     }
 
+    //#if MC < 1.21.6
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/gui/DrawContext;IIF)V"))
     private void onRenderTooltip(RenderTickCounter tickCounter, boolean tick, CallbackInfo ci, @Local DrawContext context) {
          new ScreenDrawnEvent(context, MinecraftClient.getInstance().currentScreen).post();
     }
+    //#endif
 }

--- a/versions/1.21.8/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinScreen.java
+++ b/versions/1.21.8/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinScreen.java
@@ -1,0 +1,21 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.events.render.gui.ScreenDrawnEvent;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Screen.class)
+public class MixinScreen {
+
+    // NOTE: 1.21.9+ Mojmap name is renderWithTooltipAndSubtitles
+    @WrapOperation(method = "renderWithTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderBackground(Lnet/minecraft/client/gui/DrawContext;IIF)V"))
+    private void wrapRenderBackground(Screen instance, DrawContext context, int mouseX, int mouseY, float deltaTicks, Operation<Void> original) {
+        original.call(instance, context, mouseX, mouseY, deltaTicks);
+        new ScreenDrawnEvent(context, MinecraftClient.getInstance().currentScreen).post();
+    }
+}


### PR DESCRIPTION
## What
Fixed `ScreenDrawnEvent` being injected too early on Minecraft 1.21.8 and above, causing things to render behind the background and appear dimmed.

https://discord.com/channels/997079228510117908/1431675832052617216

## Changelog Fixes
+ Fixed some overlays (e.g. Garden Optimal Angle & Speed) appearing dimmed on Minecraft 1.21.8 and above. - Luna
