### PR TITLE
Fix: Chocolate Factory Custom Reminder with middle/right click

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
+import at.hannibal2.skyhanni.features.inventory.chocolatefactory.data.CFDataLoader
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.data.ChocolateAmount
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -16,11 +17,13 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.minutes
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -92,9 +95,11 @@ object CFCustomReminder {
 
     @HandleEvent(receiveCancelled = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!isEnabled()) return
+        if (!isEnabled() || !inChocolateMenu()) return
         val item = event.item ?: return
-        if (event.clickedButton != 0) return
+        CFDataLoader.upgradeTierPattern.matchMatcher(item.displayName.removeColor()) {
+            if (group("upgrade") == "Time Tower" && event.clickedButton == 1) return
+        }
         val (cost, name) = getCostAndName(item) ?: return
         val duration = ChocolateAmount.CURRENT.timeUntilGoal(cost)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
@@ -176,9 +176,9 @@ object CFDataLoader {
     /**
      * REGEX-TEST: Time Tower I
      */
-    private val upgradeTierPattern by CFApi.patternGroup.pattern(
+    val upgradeTierPattern by CFApi.patternGroup.pattern(
         "upgradetier",
-        ".*\\s(?<tier>[IVXLC]+)",
+        "(?<upgrade>.*)\\s(?<tier>[IVXLC]+)",
     )
 
     /**


### PR DESCRIPTION
## What
Fixed Chocolate Factory Custom Reminder not working on middle and right clicks. Added an exception for Time Tower which is activated by right click.

While we're at it, I also added the missing inventory title check.

## Changelog Fixes
+ Fixed Chocolate Factory Custom Reminder not working if you use middle or right click to buy the upgrade or item. - Luna