### PR TITLE
Backend: Made EntityHealthDisplayEvent use Text instead of strings

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -15,13 +15,16 @@ import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.util.ChatComponentText
 import kotlin.time.Duration.Companion.milliseconds
+//#if MC < 1.21
+import at.hannibal2.skyhanni.utils.compat.Text
+//#endif
 
 @SkyHanniModule
 object EntityData {
 
     private val maxHealthMap = mutableMapOf<Int, Int>()
     private val nametagCache = TimeLimitedCache<Entity, ChatComponentText>(50.milliseconds)
-    private val healthDisplayCache = TimeLimitedCache<String, String>(50.milliseconds)
+    private val healthDisplayCache = TimeLimitedCache<Text, Text>(50.milliseconds)
     private val lastVisibilityCheck = TimeLimitedCache<Int, Boolean>(200.milliseconds)
 
     // TODO replace with packet detection
@@ -65,7 +68,7 @@ object EntityData {
     }
 
     @JvmStatic
-    fun getHealthDisplay(text: String) = healthDisplayCache.getOrPut(text) {
+    fun getHealthDisplay(text: Text) = healthDisplayCache.getOrPut(text) {
         val event = EntityHealthDisplayEvent(text)
         event.post()
         event.text

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityHealthDisplayEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityHealthDisplayEvent.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.utils.compat.Text
 
-class EntityHealthDisplayEvent(var text: String) : SkyHanniEvent()
+class EntityHealthDisplayEvent(var text: Text) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/RiftTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/RiftTimer.kt
@@ -17,10 +17,14 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import at.hannibal2.skyhanni.utils.compat.Text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+//#if MC > 1.21
+//$$ import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+//#endif
 
 @SkyHanniModule
 object RiftTimer {
@@ -134,10 +138,15 @@ object RiftTimer {
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onEntityHealthDisplay(event: EntityHealthDisplayEvent) {
         if (!config.nametag) return
-        val time = nametagPattern.matchMatcher(event.text) {
+        //#if MC < 1.21
+        val nametag = event.text.text
+        //#else
+        //$$ val nametag = event.text.formattedTextCompatLessResets()
+        //#endif
+        val time = nametagPattern.matchMatcher(nametag) {
             group("time")?.toIntOrNull()
         } ?: return
-        event.text = "${time.seconds.format()} §aф"
+        event.text = Text.of("${time.seconds.format()} §aф")
     }
 
     fun isEnabled() = RiftApi.inRift() && config.enabled

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderPlayer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinRenderPlayer.java
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.data.EntityData;
+import at.hannibal2.skyhanni.utils.compat.Text;
 import net.minecraft.client.renderer.entity.RenderPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -18,6 +19,6 @@ public class MixinRenderPlayer {
         index = 1
     )
     private String modifyRenderLivingLabelArgs(String string) {
-        return EntityData.getHealthDisplay(string);
+        return EntityData.getHealthDisplay(Text.Companion.of(string)).getText();
     }
 }

--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinPlayerEntityRenderer.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinPlayerEntityRenderer.java
@@ -27,7 +27,7 @@ public class MixinPlayerEntityRenderer {
     //#endif
     private Text modifyRenderLabelIfPresentArgs(Text text) {
         if (SkyBlockUtils.INSTANCE.getInSkyBlock()) {
-            return Text.of(EntityData.getHealthDisplay(TextCompatKt.formattedTextCompatLessResets(text)));
+            return EntityData.getHealthDisplay(text);
         }
         return text;
     }


### PR DESCRIPTION
## What
This should fix any issues with the name tags from now on

## Changelog Technical Details
+ Made EntityHealthDisplayEvent use Text instead of strings. - nopo
