### PR TITLE
Improvement: Add NPC sell toggle for Not Clickable Items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/HideNotClickableConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/HideNotClickableConfig.kt
@@ -11,11 +11,20 @@ class HideNotClickableConfig {
     @Expose
     @ConfigOption(
         name = "Enabled",
-        desc = "Hide items that are not clickable in the current inventory: ah, bz, accessory bag, etc.",
+        desc = "Gray out items that are not clickable in the current inventory: Auction House, Bazaar, Accessory Bag, etc.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
     var enabled: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Protect Rarely Sold Items",
+        desc = "Also gray out items that are not commonly sold to NPCs in NPC shop menus.\n" +
+            "§eRequires main toggle to be enabled!",
+    )
+    @ConfigEditorBoolean
+    var protectRarelySoldItems: Boolean = false
 
     @Expose
     @ConfigOption(name = "Block Clicks", desc = "Block the clicks on these items.")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -20,6 +20,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getLowerItems
 import at.hannibal2.skyhanni.utils.ItemCategory
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
@@ -499,8 +500,17 @@ object HideNotClickableItems {
             }
         }
 
-        hideReason = "This item should not be sold at the NPC!"
-        return true
+        if (stack.getInternalNameOrNull()?.getNpcPriceOrNull() == null) {
+            hideReason = "This item cannot be sold at the NPC!"
+            return true
+        }
+
+        if (config.protectRarelySoldItems) {
+            hideReason = "This item should not be sold at the NPC!"
+            return true
+        }
+
+        return false
     }
 
     private fun hideInStorage(chestName: String, stack: ItemStack): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -72,7 +72,7 @@ object HideNotClickableItems {
 
     private val patternGroup = RepoPattern.group("inventory.hidenotclickable")
 
-    private val clickToSellPattern = patternGroup.pattern(
+    private val clickToSellPattern by patternGroup.pattern(
         "clicktosell",
         "§eClick to sell!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -70,6 +70,13 @@ object HideNotClickableItems {
     private val hidePlayerTradeFilter = MultiFilter()
     private val notAuctionableFilter = MultiFilter()
 
+    private val patternGroup = RepoPattern.group("inventory.hidenotclickable")
+
+    private val clickToSellPattern = patternGroup.pattern(
+        "clicktosell",
+        "§eClick to sell!",
+    )
+
     /**
      * REGEX-TEST: SEEDS
      * REGEX-TEST: CARROT_ITEM
@@ -80,7 +87,7 @@ object HideNotClickableItems {
      * REGEX-TEST: CACTUS
      * REGEX-TEST: INK_SACK-3
      */
-    private val seedsPattern by RepoPattern.pattern(
+    private val seedsPattern by patternGroup.pattern(
         "inventory.hidenotclickable.seeds",
         "SEEDS|CARROT_ITEM|POTATO_ITEM|PUMPKIN_SEEDS|SUGAR_CANE|MELON_SEEDS|CACTUS|INK_SACK-3",
     )
@@ -485,7 +492,7 @@ object HideNotClickableItems {
             name = name.substring(0, name.length - amountText.length)
         }
 
-        if (stack.getInternalNameOrNull()?.getNpcPriceOrNull() == null) {
+        if (!clickToSellPattern.anyMatches(stack.getLore())) {
             hideReason = "This item cannot be sold at the NPC!"
             return true
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -489,6 +489,11 @@ object HideNotClickableItems {
             return true
         }
 
+        if (stack.isMuseumDonated()) {
+            hideReason = "This item cannot be sold at the NPC! (Donated to Museum)"
+            return true
+        }
+
         if (ItemUtils.isRecombobulated(stack)) {
             hideReason = "This item should not be sold at the NPC! (Recombobulated)"
             return true

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -470,6 +470,7 @@ object HideNotClickableItems {
         return result
     }
 
+    @Suppress("ReturnCount")
     private fun hideNpcSell(stack: ItemStack): Boolean {
         if (RiftApi.inRift()) return false
         if (!ShiftClickNpcSell.inInventory) return false

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -474,6 +474,7 @@ object HideNotClickableItems {
         if (RiftApi.inRift()) return false
         if (!ShiftClickNpcSell.inInventory) return false
         if (VisitorApi.inInventory) return false
+
         showGreenLine = true
 
         var name = stack.cleanName()
@@ -483,29 +484,21 @@ object HideNotClickableItems {
             name = name.substring(0, name.length - amountText.length)
         }
 
-        if (ItemUtils.isSkyBlockMenuItem(stack)) {
-            hideReason = "The SkyBlock Menu cannot be sold at the NPC!"
-            return true
-        }
-
-        if (!ItemUtils.isRecombobulated(stack)) {
-            if (SkyBlockUtils.noTradeMode && BazaarApi.isBazaarItem(stack)) {
-                return false
-            }
-
-            if (hideNpcSellFilter.match(name)) return false
-
-            if (stack.isVanilla() && !stack.isEnchanted()) {
-                return false
-            }
-        }
-
         if (stack.getInternalNameOrNull()?.getNpcPriceOrNull() == null) {
             hideReason = "This item cannot be sold at the NPC!"
             return true
         }
 
+        if (ItemUtils.isRecombobulated(stack)) {
+            hideReason = "This item should not be sold at the NPC! (Recombobulated)"
+            return true
+        }
+
         if (config.protectRarelySoldItems) {
+            if (stack.isVanilla() && !stack.isEnchanted()) return false
+            if (SkyBlockUtils.noTradeMode && BazaarApi.isBazaarItem(stack)) return false
+            if (hideNpcSellFilter.match(name)) return false
+
             hideReason = "This item should not be sold at the NPC!"
             return true
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -500,16 +500,13 @@ object HideNotClickableItems {
             return true
         }
 
-        if (config.protectRarelySoldItems) {
-            if (stack.isVanilla() && !stack.isEnchanted()) return false
-            if (SkyBlockUtils.noTradeMode && BazaarApi.isBazaarItem(stack)) return false
-            if (hideNpcSellFilter.match(name)) return false
+        if (!config.protectRarelySoldItems) return false
+        if (stack.isVanilla() && !stack.isEnchanted()) return false
+        if (SkyBlockUtils.noTradeMode && BazaarApi.isBazaarItem(stack)) return false
+        if (hideNpcSellFilter.match(name)) return false
 
-            hideReason = "This item should not be sold at the NPC!"
-            return true
-        }
-
-        return false
+        hideReason = "This item should not be sold at the NPC!"
+        return true
     }
 
     private fun hideInStorage(chestName: String, stack: ItemStack): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getLowerItems
 import at.hannibal2.skyhanni.utils.ItemCategory
-import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
@@ -35,6 +34,7 @@ import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.MultiFilter
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.drawBorder
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight


### PR DESCRIPTION
## What
Adjusted the Not Clickable Items feature so that by default, in NPC trade menus, only items that cannot be sold or are recombobulated are grayed out, but added a default off toggle to also gray out items that "should not" be sold (our whitelist for that is quite outdated and hasn't been touched in ages, but it can be improved in the future).

## Changelog Improvements
+ Improved the "Not Clickable Items" feature in NPC trade menus. - Luna
    * By default, it only grays out items that cannot be sold to NPCs, or are recombobulated.
    * You can re-enable graying out items that are not commonly sold to NPCs in the config.
