### PR TITLE
Improvement: Attempt to prevent launching if Lunar or Feather is detected

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -53,7 +53,10 @@
         "minecraft": "${minecraft}"
     },
     "breaks": {
-        "exordium": "*"
+        "exordium": "*",
+        "ichor": "*",
+        "feather": "*",
+        "feather-loader": "*"
     },
     "contact": {
         "homepage": "https://modrinth.com/mod/skyhanni",


### PR DESCRIPTION
## What
The FMJ allows preventing launching the game if certain mod IDs are detected. Lunar client's weird custom mixin thing is called "ichor" (if you ever look at lunar crash logs you'll see their obfuscation also uses those characters) and is the mod id used to detect for lunar. Unfortunately this makes the crash message not that clear to users (wtf is ichor), but at least makes it instantly obvious to support staff that the user is using lunar.

I've also added Feather to the breaks (as can be seen in logs, they do use the mod id "feather"). However I am not sure if this actually works or not as they might try and bypass breaks clause against them, but I won't be testing that.

## Changelog Improvements
+ Instantly crash the game if Lunar or Feather is detected. - Microcontrollers