### PR TITLE
Feature: add an option to force diana

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/DianaConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/DianaConfig.kt
@@ -13,6 +13,15 @@ import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 import org.lwjgl.input.Keyboard
 
 class DianaConfig {
+    @Expose
+    @ConfigOption(
+        name = "Forcibly enable Diana",
+        desc = "Enables Diana features, even if no event has been detected."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var forceEnabled: Boolean = false
+
     // TODO rename to highlightRareMobs
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
@@ -32,7 +32,7 @@ object DianaApi {
 
     fun hasGriffinPet() = CurrentPetApi.isCurrentPet("Griffin")
 
-    fun isDoingDiana() = IslandType.HUB.isCurrent() && isRitualActive() && hasSpadeInInventory()
+    fun isDoingDiana() = SkyHanniMod.feature.event.diana.forceEnabled || (IslandType.HUB.isCurrent() && isRitualActive() && hasSpadeInInventory())
 
     val ItemStack.isDianaSpade get() = getInternalName() in spades
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
@@ -27,8 +27,9 @@ object DianaApi {
 
     fun hasSpadeInHand() = InventoryUtils.itemInHandId in spades
 
-    private fun isRitualActive() = SkyHanniMod.feature.event.diana.forceEnabled || ((Perk.MYTHOLOGICAL_RITUAL.isActive || Perk.PERKPOCALYPSE.isActive) ||
-        SkyHanniMod.feature.dev.debug.assumeMayor.get() == ElectionCandidate.DIANA)
+    private fun isRitualActive() = (Perk.MYTHOLOGICAL_RITUAL.isActive || Perk.PERKPOCALYPSE.isActive) ||
+        SkyHanniMod.feature.dev.debug.assumeMayor.get() == ElectionCandidate.DIANA ||
+        SkyHanniMod.feature.event.diana.forceEnabled
 
     fun hasGriffinPet() = CurrentPetApi.isCurrentPet("Griffin")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
@@ -27,12 +27,12 @@ object DianaApi {
 
     fun hasSpadeInHand() = InventoryUtils.itemInHandId in spades
 
-    private fun isRitualActive() = (Perk.MYTHOLOGICAL_RITUAL.isActive || Perk.PERKPOCALYPSE.isActive) ||
-        SkyHanniMod.feature.dev.debug.assumeMayor.get() == ElectionCandidate.DIANA
+    private fun isRitualActive() = SkyHanniMod.feature.event.diana.forceEnabled || ((Perk.MYTHOLOGICAL_RITUAL.isActive || Perk.PERKPOCALYPSE.isActive) ||
+        SkyHanniMod.feature.dev.debug.assumeMayor.get() == ElectionCandidate.DIANA)
 
     fun hasGriffinPet() = CurrentPetApi.isCurrentPet("Griffin")
 
-    fun isDoingDiana() = SkyHanniMod.feature.event.diana.forceEnabled || (IslandType.HUB.isCurrent() && isRitualActive() && hasSpadeInInventory())
+    fun isDoingDiana() = IslandType.HUB.isCurrent() && isRitualActive() && hasSpadeInInventory()
 
     val ItemStack.isDianaSpade get() = getInternalName() in spades
 


### PR DESCRIPTION
## What
Adds an option to forcibly enable Diana. This just adds the config option in the ``Events -> Diana`` category and modifies the ``isDoingDiana`` function.

This does allow any player to use Diana features when none is detected, but also might cause some negligible performance usages (e.g. the player enables the option but doesn't disable it afterwards).

Only tested on 1.21.8, but should work on any. Defaults to being disabled.

<details>
<summary>Images</summary>
<img width="1008" height="805" alt="image" src="https://github.com/user-attachments/assets/484ebe71-2bc5-4e8d-a3f1-0975c960b72e" />
</details>

## Changelog New Features
+ Enable toggle to forcibly enable Diana. - SteinGaming