### PR TITLE
Fix: Not Clickable Items sometimes marking all items as not sellable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -20,6 +20,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getLowerItems
 import at.hannibal2.skyhanni.utils.ItemCategory
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
@@ -492,7 +493,7 @@ object HideNotClickableItems {
             name = name.substring(0, name.length - amountText.length)
         }
 
-        if (!clickToSellPattern.anyMatches(stack.getLore())) {
+        if (!clickToSellPattern.anyMatches(stack.getLore()) && stack.getInternalNameOrNull()?.getNpcPriceOrNull() == null) {
             hideReason = "This item cannot be sold at the NPC!"
             return true
         }


### PR DESCRIPTION
## What
If you double click an NPC, it opens their GUI twice, and doesn't show the "Click to sell" in the lore, meaning all items show up as "This item cannot be sold to the NPC". This PR fixes it by falling back to checking `getNpcPriceOrNull()`. Both checks are done intentionally because there are certain items such as random runes you drop from mobs that currently get marked as non-sellable if we only use `getNpcPriceOrNull()`.

## Changelog Fixes
+ Fixed Not Clickable Items sometimes marking all items as unsellable to NPC. - Luna