### PR TITLE
Fix: Broodmother messages sending twice/incorrectly

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/broodmother/BroodmotherConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/broodmother/BroodmotherConfig.kt
@@ -45,10 +45,7 @@ class BroodmotherConfig {
             "§cThe 'Alive!' and 'Imminent' stages are overridden by the \"Spawn Alert\" and \"Imminent Warning\" features."
     )
     @ConfigEditorDraggableList
-    val stages: MutableList<StageEntry> = mutableListOf(
-        StageEntry.SLAIN,
-        StageEntry.ALIVE
-    )
+    val stages: MutableList<StageEntry> = mutableListOf()
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import at.hannibal2.skyhanni.utils.StringUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import kotlin.reflect.KProperty0
 import kotlin.time.Duration
@@ -48,10 +49,11 @@ object BroodmotherFeatures {
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.BROODMOTHER)) return
         val newStage = event.widget.matchMatcherFirstLine { group("stage") }.orEmpty()
-        if (newStage.isNotEmpty() && newStage != lastStage.toString()) {
+        if (newStage.isNotEmpty() && newStage != lastStage.toString().removeColor()) {
             lastStage = currentStage
             currentStage = StageEntry.valueOf(newStage.replace("!", "").uppercase())
             onStageUpdate()
+            if (lastStage == null) lastStage = currentStage
         }
     }
 
@@ -96,7 +98,9 @@ object BroodmotherFeatures {
             val duration = currentStage?.duration
             var message = "The Broodmother's current stage in this server is ${currentStage.toString().replace("!", "")}§e."
             if (duration != 0.minutes) {
-                message += " It will spawn §bwithin $duration§e."
+                val minutes = duration?.inWholeMinutes?.toInt() ?: 0
+                val pluralize = StringUtils.pluralize(minutes, "minute")
+                message += " It will spawn §bwithin ${duration?.inWholeMinutes} $pluralize§e."
             }
             ChatUtils.chat(message)
             return true


### PR DESCRIPTION
## What
Fixes some bugs with the Broodmother features (namely spam messages), and a config change that hannibal was intending on doing in #4528 (but done properly without breaking things)

## Changelog Fixes
+ Fixed Broodmother chat messages sending twice or incorrectly. - MTOnline

