### PR TITLE
Fix: Timite Tracker now correctly tracks Highlite craftability

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/TimiteTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/TimiteTracker.kt
@@ -70,7 +70,7 @@ object TimiteTracker {
                 }
             }
             val craftableAmountArray = listOf(craftableAmountByYoungite, craftableAmountByTimite, craftableAmountByObsolite)
-            var craftableAmount = craftableAmountArray.min()
+            val craftableAmount = craftableAmountArray.min()
             val motes = HIGHLITE.motesNpcPrice()?.times(craftableAmount)?.shortFormat() ?: "0"
             if (craftableAmount > 0) {
                 addSearchString(" §7${craftableAmount.shortFormat()}x ${HIGHLITE.repoItemName} Craftable§7: §5$motes motes")

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/TimiteTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/TimiteTracker.kt
@@ -54,18 +54,23 @@ object TimiteTracker {
         val profit = tracker.drawItems(data, { true }, this)
 
         NeuItems.getRecipes(HIGHLITE).singleOrNull()?.let { highliteRecipe ->
-            var craftableAmount = 0
+            var craftableAmountByYoungite = 0
+            var craftableAmountByTimite = 0
+            var craftableAmountByObsolite = 0
 
             for (neededItem in ItemUtils.neededItems(highliteRecipe)) {
                 if (neededItem.key in validItems) {
                     data.items[neededItem.key]?.let {
-                        val amountCanCraft = it.totalAmount.toInt() / neededItem.value
-                        if (craftableAmount == 0 || amountCanCraft < craftableAmount) {
-                            craftableAmount = amountCanCraft
+                        when (neededItem.key) {
+                            "YOUNGITE".toInternalName() -> craftableAmountByYoungite = it.totalAmount.toInt() / neededItem.value
+                            TIMITE -> craftableAmountByTimite = it.totalAmount.toInt() / neededItem.value
+                            "OBSOLITE".toInternalName() -> craftableAmountByObsolite = it.totalAmount.toInt() / neededItem.value
                         }
                     }
                 }
             }
+            val craftableAmountArray = listOf(craftableAmountByYoungite, craftableAmountByTimite, craftableAmountByObsolite)
+            var craftableAmount = craftableAmountArray.min()
             val motes = HIGHLITE.motesNpcPrice()?.times(craftableAmount)?.shortFormat() ?: "0"
             if (craftableAmount > 0) {
                 addSearchString(" §7${craftableAmount.shortFormat()}x ${HIGHLITE.repoItemName} Craftable§7: §5$motes motes")


### PR DESCRIPTION
## What
fixed an issue with the Timite Tracker which caused it to display incorrect Highlite craft potential if you hadn't gathered enough of one or more ages of Timite. it now correctly counts how much Highlite you can craft with how much of each age you've collected, then picks the smallest number to display (or not display if the minimum is 0)

## Changelog Fixes
+ Fixed the Timite Tracker's Highlite craft display showing the wrong amount of Highlite in certain cases. - ThomasThePencil
