### PR TITLE
Fix: Fix tooltip format feature

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/TooltipTweaksConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/TooltipTweaksConfig.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features.garden
 import at.hannibal2.skyhanni.config.FeatureToggle
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import org.lwjgl.input.Keyboard
@@ -24,6 +25,25 @@ class TooltipTweaksConfig {
     )
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_LSHIFT)
     var fortuneTooltipKeybind: Int = Keyboard.KEY_LSHIFT
+
+    @Expose
+    @ConfigOption(
+        name = "Tooltip Format",
+        desc = "Show crop-specific Farming Fortune in tooltip.\n" +
+            "§fShow: §7Crop-specific Fortune indicated as §6[+196]\n" +
+            "§fReplace: §7Edits the total Fortune to include crop-specific Fortune."
+    )
+    @ConfigEditorDropdown
+    var cropTooltipFortune: CropTooltipFortuneEntry = CropTooltipFortuneEntry.SHOW
+
+    enum class CropTooltipFortuneEntry(private val displayName: String) {
+        DEFAULT("Default"),
+        SHOW("Show"),
+        REPLACE("Replace"),
+        ;
+
+        override fun toString() = displayName
+    }
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/TooltipTweaksConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/TooltipTweaksConfig.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.config.features.garden
 import at.hannibal2.skyhanni.config.FeatureToggle
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
-import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import org.lwjgl.input.Keyboard
@@ -25,25 +24,6 @@ class TooltipTweaksConfig {
     )
     @ConfigEditorKeybind(defaultKey = Keyboard.KEY_LSHIFT)
     var fortuneTooltipKeybind: Int = Keyboard.KEY_LSHIFT
-
-    @Expose
-    @ConfigOption(
-        name = "Tooltip Format",
-        desc = "Show crop-specific Farming Fortune in tooltip.\n" +
-            "§fShow: §7Crop-specific Fortune indicated as §6[+196]\n" +
-            "§fReplace: §7Edits the total Fortune to include crop-specific Fortune."
-    )
-    @ConfigEditorDropdown
-    var cropTooltipFortune: CropTooltipFortuneEntry = CropTooltipFortuneEntry.SHOW
-
-    enum class CropTooltipFortuneEntry(private val displayName: String) {
-        DEFAULT("Default"),
-        SHOW("Show"),
-        REPLACE("Replace"),
-        ;
-
-        override fun toString() = displayName
-    }
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
@@ -80,10 +80,8 @@ object ToolTooltipTweaks {
                 val greenThumbFortune = FarmingFortuneDisplay.greenThumbFortune
                 val pesterminatorFortune = FarmingFortuneDisplay.pesterminatorFortune
 
-                // TODO Rework/remove this feature
                 if (config.fortuneTooltipKeybind.isKeyHeld()) {
                     iterator.addStat("  §7Base: §6+", baseFortune)
-                    iterator.addStat("  §7Tool: §6+", toolFortune)
                     iterator.addStat("  §7${reforgeName ?: "Reforge"}: §9+", reforgeFortune)
                     iterator.addStat("  §7Gemstone: §d+", gemstoneFortune)
                     iterator.addStat("  §7Ability: §2+", abilityFortune)
@@ -93,6 +91,7 @@ object ToolTooltipTweaks {
                     iterator.addStat("  §7Harvesting: §a+", harvestingFortune)
                     iterator.addStat("  §7Cultivating: §a+", cultivatingFortune)
                     iterator.addStat("  §7Farming for Dummies: §2+", ffdFortune)
+                    iterator.addStat("  §7Tool: §6+", toolFortune)
                     iterator.addStat("  §7Counter: §6+", counterFortune)
                     iterator.addStat("  §7Collection: §6+", collectionFortune)
                     iterator.addStat("  §7Dedication: §6+", dedicationFortune)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.garden
 import at.hannibal2.skyhanni.api.ReforgeApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.config.features.garden.TooltipTweaksConfig.CropTooltipFortuneEntry
 import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.features.garden.FarmingFortuneDisplay.getAbilityFortune
 import at.hannibal2.skyhanni.features.garden.GardenApi.getCropType
@@ -17,7 +16,6 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getFarmingForDummie
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeModifier
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import java.text.DecimalFormat
-import kotlin.math.roundToInt
 
 @SkyHanniModule
 object ToolTooltipTweaks {
@@ -62,8 +60,6 @@ object ToolTooltipTweaks {
         val abilityFortune = getAbilityFortune(internalName, itemLore)
 
         val ffdFortune = itemStack.getFarmingForDummiesCount() ?: 0
-        val hiddenFortune =
-            (toolFortune + counterFortune + collectionFortune + turboCropFortune + dedicationFortune + abilityFortune)
         val iterator = event.toolTip.listIterator()
 
         var removingFarmhandDescription = false
@@ -78,31 +74,13 @@ object ToolTooltipTweaks {
 
                 FarmingFortuneDisplay.loadFortuneLineData(itemStack, enchantmentFortune)
 
-                val displayedFortune = FarmingFortuneDisplay.displayedFortune
                 val reforgeFortune = FarmingFortuneDisplay.reforgeFortune
                 val gemstoneFortune = FarmingFortuneDisplay.gemstoneFortune
                 val baseFortune = FarmingFortuneDisplay.itemBaseFortune
                 val greenThumbFortune = FarmingFortuneDisplay.greenThumbFortune
                 val pesterminatorFortune = FarmingFortuneDisplay.pesterminatorFortune
 
-                val totalFortune = displayedFortune + hiddenFortune
-
-                val ffdString = if (ffdFortune != 0) " §2(+${ffdFortune.formatStat()})" else ""
-                val reforgeString = if (reforgeFortune != 0.0) " §9(+${reforgeFortune.formatStat()})" else ""
-                val cropString = if (hiddenFortune != 0.0) " §6[+${hiddenFortune.roundToInt()}]" else ""
-
-                val fortuneLine = when (config.cropTooltipFortune) {
-                    CropTooltipFortuneEntry.DEFAULT ->
-                        "§7Farming Fortune: §6+${displayedFortune.formatStat()}$ffdString$reforgeString"
-
-                    CropTooltipFortuneEntry.SHOW ->
-                        "§7Farming Fortune: §6+${displayedFortune.formatStat()}$ffdString$reforgeString$cropString"
-
-                    else ->
-                        "§7Farming Fortune: §6+${totalFortune.formatStat()}$ffdString$reforgeString$cropString"
-                }
-                iterator.set(fortuneLine)
-
+                // TODO Rework/remove this feature
                 if (config.fortuneTooltipKeybind.isKeyHeld()) {
                     iterator.addStat("  §7Base: §6+", baseFortune)
                     iterator.addStat("  §7Tool: §6+", toolFortune)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/ToolTooltipTweaks.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.garden
 import at.hannibal2.skyhanni.api.ReforgeApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.features.garden.TooltipTweaksConfig.CropTooltipFortuneEntry
 import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.features.garden.FarmingFortuneDisplay.getAbilityFortune
 import at.hannibal2.skyhanni.features.garden.GardenApi.getCropType
@@ -16,6 +17,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getFarmingForDummie
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeModifier
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import java.text.DecimalFormat
+import kotlin.math.roundToInt
 
 @SkyHanniModule
 object ToolTooltipTweaks {
@@ -60,6 +62,8 @@ object ToolTooltipTweaks {
         val abilityFortune = getAbilityFortune(internalName, itemLore)
 
         val ffdFortune = itemStack.getFarmingForDummiesCount() ?: 0
+        val hiddenFortune =
+            (toolFortune + counterFortune + collectionFortune + turboCropFortune + dedicationFortune + abilityFortune)
         val iterator = event.toolTip.listIterator()
 
         var removingFarmhandDescription = false
@@ -74,14 +78,34 @@ object ToolTooltipTweaks {
 
                 FarmingFortuneDisplay.loadFortuneLineData(itemStack, enchantmentFortune)
 
+                val displayedFortune = FarmingFortuneDisplay.displayedFortune
                 val reforgeFortune = FarmingFortuneDisplay.reforgeFortune
                 val gemstoneFortune = FarmingFortuneDisplay.gemstoneFortune
                 val baseFortune = FarmingFortuneDisplay.itemBaseFortune
                 val greenThumbFortune = FarmingFortuneDisplay.greenThumbFortune
                 val pesterminatorFortune = FarmingFortuneDisplay.pesterminatorFortune
 
+                val totalFortune = displayedFortune + hiddenFortune
+
+                val ffdString = if (ffdFortune != 0) " §2(+${ffdFortune.formatStat()})" else ""
+                val reforgeString = if (reforgeFortune != 0.0) " §9(+${reforgeFortune.formatStat()})" else ""
+                val cropString = if (hiddenFortune != 0.0) " §6[+${hiddenFortune.roundToInt()}]" else ""
+                val gemstoneString = if (gemstoneFortune != 0.0) " §6[+${gemstoneFortune.formatStat()}]" else ""
+
+                val fortuneLine = when (config.cropTooltipFortune) {
+                    CropTooltipFortuneEntry.SHOW ->
+                        "§7Farming Fortune: §6+${displayedFortune.formatStat()}$ffdString$reforgeString$gemstoneString$cropString"
+
+                    CropTooltipFortuneEntry.REPLACE ->
+                        "§7Farming Fortune: §6+${totalFortune.formatStat()}$ffdString$reforgeString$gemstoneString$cropString"
+
+                    else -> line
+                }
+                iterator.set(fortuneLine)
+
                 if (config.fortuneTooltipKeybind.isKeyHeld()) {
                     iterator.addStat("  §7Base: §6+", baseFortune)
+                    iterator.addStat("  §7Tool: §6+", toolFortune)
                     iterator.addStat("  §7${reforgeName ?: "Reforge"}: §9+", reforgeFortune)
                     iterator.addStat("  §7Gemstone: §d+", gemstoneFortune)
                     iterator.addStat("  §7Ability: §2+", abilityFortune)
@@ -91,7 +115,6 @@ object ToolTooltipTweaks {
                     iterator.addStat("  §7Harvesting: §a+", harvestingFortune)
                     iterator.addStat("  §7Cultivating: §a+", cultivatingFortune)
                     iterator.addStat("  §7Farming for Dummies: §2+", ffdFortune)
-                    iterator.addStat("  §7Tool: §6+", toolFortune)
                     iterator.addStat("  §7Counter: §6+", counterFortune)
                     iterator.addStat("  §7Collection: §6+", collectionFortune)
                     iterator.addStat("  §7Dedication: §6+", dedicationFortune)


### PR DESCRIPTION
## What
Fixes the Tooltip Format feature so that default actually turns it off.
This feature was [hiding gemstone fortune](https://discord.com/channels/997079228510117908/1094190239532208228/1447835166847533086), which is fixed, but it's still using a method that could very easily hide stats in future updates when this feature is turned on.

Also moves the tool fortune in the FF breakdown feature to be with the other crop specific stats.

I haven't tested this in game, but it's pretty minor changes, so it should work.

<details>
<summary>Images</summary>

<img width="597" height="173" alt="image" src="https://github.com/user-attachments/assets/20061470-51de-42ff-b92e-f3eb004910cf" />

</details>

## Changelog Fixes
+ Fixed farming tool tooltip format hiding gemstones and not having an off option. - Obsidian