### PR TITLE
Fix: Griffin Burrow Coins being tracked while being Consumed

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.DianaDropsJson
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.features.itemabilities.CrownOfAvariceCounter.isAvariceConsuming
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
@@ -63,7 +64,7 @@ object DianaProfitTracker {
     ) { drawDisplay(it) }
 
     data class Data(
-        @Expose var burrowsDug: Long = 0
+        @Expose var burrowsDug: Long = 0,
     ) : ItemTrackerData() {
         override fun getDescription(timesGained: Long): List<String> {
             val percentage = timesGained.toDouble() / burrowsDug
@@ -133,10 +134,12 @@ object DianaProfitTracker {
             }
             tryHide(event)
         }
-        chatDugOutCoinsPattern.matchMatcher(message) {
-            BurrowApi.lastBurrowRelatedChatMessage = SimpleTimeMark.now()
-            tryAddItem(NeuInternalName.SKYBLOCK_COIN, group("coins").formatInt(), command = false)
-            tryHide(event)
+        if (!(isAvariceConsuming())) {
+            chatDugOutCoinsPattern.matchMatcher(message) {
+                BurrowApi.lastBurrowRelatedChatMessage = SimpleTimeMark.now()
+                tryAddItem(NeuInternalName.SKYBLOCK_COIN, group("coins").formatInt(), command = false)
+                tryHide(event)
+            }
         }
 
         if (message == "§6§lRARE DROP! §r§eYou dug out a §r§9Griffin Feather§r§e!" ||

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaProfitTracker.kt
@@ -134,7 +134,7 @@ object DianaProfitTracker {
             }
             tryHide(event)
         }
-        if (!(isAvariceConsuming())) {
+        if (!isAvariceConsuming()) {
             chatDugOutCoinsPattern.matchMatcher(message) {
                 BurrowApi.lastBurrowRelatedChatMessage = SimpleTimeMark.now()
                 tryAddItem(NeuInternalName.SKYBLOCK_COIN, group("coins").formatInt(), command = false)

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
@@ -106,6 +106,11 @@ object CrownOfAvariceCounter {
         update()
     }
 
+    fun isAvariceConsuming(): Boolean {
+        if (!isWearingCrown) return false
+        return totalCoins?.toDouble() != MAX_AVARICE_COINS
+    }
+
     @HandleEvent(IslandChangeEvent::class)
     fun onIslandChange() {
         if (config.resetOnWorldChange) reset()

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
@@ -106,10 +106,8 @@ object CrownOfAvariceCounter {
         update()
     }
 
-    fun isAvariceConsuming(): Boolean {
-        if (!isWearingCrown) return false
-        return totalCoins?.toDouble() != MAX_AVARICE_COINS
-    }
+    fun isAvariceConsuming(): Boolean =
+        isWearingCrown && (totalCoins ?: 0) < MAX_AVARICE_COINS
 
     @HandleEvent(IslandChangeEvent::class)
     fun onIslandChange() {


### PR DESCRIPTION
## What
Fixes Crown of Avarice Buffed and Consumed coins being sent into the Diana Profit Tracker making Profit/H inaccurate

<details>
<summary>Images</summary>
<img width="731" height="883" alt="image" src="https://github.com/user-attachments/assets/acede5fc-6463-41a8-ba3e-9ea9e9ce57ee" />

<!-- drop images here -->

</details>

## Changelog Fixes
+ Fixed Burrow coins adding to Tracker while wearing Crown of Avarice. - fazfoxy