### PR TITLE
Fix: Small vs Big Arachne in Damage Indicator

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
@@ -425,7 +425,7 @@ class MobFinder {
         if (mob.name != "Arachne") return null
         return when (mob.levelOrTier) {
             300 -> EntityResult(bossType = BossType.ARACHNE_SMALL)
-            500 -> EntityResult(bossType = BossType.ARACHNE_SMALL)
+            500 -> EntityResult(bossType = BossType.ARACHNE_BIG)
             else -> null
         }
     }


### PR DESCRIPTION
## What
Fixes all Arachnes being marked as "Small Arachne" in the Damage Indicator.

## Changelog Fixes
+ Fixed Lv500 Arachne displaying as Small Arachne in Damage Indicator. - MTOnline