### PR TITLE
Backend: Strict checking in NumberUtils.romanToDecimal

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -110,7 +110,13 @@ object NumberUtil {
         else NumberFormat.getNumberInstance(Locale.US).format(this)
     }
 
-    fun String.romanToDecimalIfNecessary() = toIntOrNull() ?: romanToDecimal()
+    fun String.romanToDecimalIfNecessary(): Int =
+        toIntOrNull()
+            ?: romanToDecimalOrNull()
+            ?: throw IllegalArgumentException("Failed to parse input string as either Arabic or Roman numerals: '$this'")
+
+    fun String.romanToDecimalIfNecessaryOrNull(): Int? =
+        runCatching { romanToDecimalIfNecessary() }.getOrElse { null }
 
     /**
      * This code was converted to Kotlin and taken under CC BY-SA 3.0 license
@@ -121,7 +127,7 @@ object NumberUtil {
         var lastNumber = 0
         val romanNumeral = this.uppercase()
         for (x in romanNumeral.length - 1 downTo 0) {
-            when (romanNumeral[x]) {
+            when (val c = romanNumeral[x]) {
                 'M' -> {
                     decimal = processDecimal(1000, lastNumber, decimal)
                     lastNumber = 1000
@@ -156,10 +162,17 @@ object NumberUtil {
                     decimal = processDecimal(1, lastNumber, decimal)
                     lastNumber = 1
                 }
+
+                else -> {
+                    throw IllegalArgumentException("Encountered invalid character while parsing Roman numeral: '$c'")
+                }
             }
         }
         return decimal
     }
+
+    fun String.romanToDecimalOrNull(): Int? =
+        runCatching { romanToDecimal() }.getOrElse { null }
 
     fun Int.toRoman(): String {
         if (this <= 0) error("$this must be positive!")

--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -164,7 +164,7 @@ object NumberUtil {
                 }
 
                 else -> {
-                    throw IllegalArgumentException("Encountered invalid character while parsing Roman numeral: '$c'")
+                    throw IllegalArgumentException("Encountered invalid character '$c' while parsing Roman numeral: '$this'")
                 }
             }
         }


### PR DESCRIPTION
## What
Added strict checking for invalid characters to `NumberUtils.romanToDecimal`. Did not bother validating illegal combinations of valid characters for now.

## Changelog Technical Details
+ `NumberUtils.romanToDecimal{,IfNecessary}` now throws an exception when the input contains illegal characters. - Luna