### PR TITLE
Improvement: Sixth Visitor Config Searchability

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/TimerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/TimerConfig.kt
@@ -24,6 +24,7 @@ class TimerConfig {
         desc = "Estimate when the sixth visitor in the queue will arrive.\n" +
             "§eMay be inaccurate with co-op members farming simultaneously."
     )
+    @SearchTag("6th")
     @ConfigEditorBoolean
     var sixthVisitorEnabled: Boolean = true
 
@@ -33,6 +34,7 @@ class TimerConfig {
         desc = "Notify when it is believed that the sixth visitor has arrived.\n" +
             "§eMay be inaccurate with co-op members farming simultaneously."
     )
+    @SearchTag("6th")
     @ConfigEditorBoolean
     @FeatureToggle
     var sixthVisitorWarning: Boolean = true


### PR DESCRIPTION
## What
Added "6th" as search tag to "sixth visitor" related config options.

## Changelog Improvements
+ Made "sixth visitor" options findable by searching for "6th". - Luna