### PR TITLE
Fix: Chroma compat issue with SBA

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinTextVisitFactory.java
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinTextVisitFactory.java
@@ -19,7 +19,7 @@ public class MixinTextVisitFactory {
         ),
         ordinal = 2
     )
-    private static Style onColorCodeCheck(Style style, @Local(argsOnly = true) String text, @Local(ordinal = 0) char colorCode) {
+    private static Style onColorCodeCheck(Style style, @Local(argsOnly = true) String text, @Local(index = 9) char colorCode) {
         return ChromaFontManagerKt.setChromaColorStyle(style, text, colorCode);
     }
 


### PR DESCRIPTION
## What
Use `index` param in `@Local` instead of `ordinal`, since when SBA is present, the possible candidates in the LVT seem to change, and not all `char`s are seen. So the ordinals of the `char` variables in TextVisitFactory.java change depending on whether SBA is present, but the indices of the LVT seem to stay the same regardless.

<details>
<summary>Images</summary>

With SBA present:
<img width="650" height="454" alt="sba_present" src="https://github.com/user-attachments/assets/300ec2b8-5852-409a-ad5e-99c4c3125538" />

Without SBA present:
<img width="653" height="457" alt="sba_not_present" src="https://github.com/user-attachments/assets/d315acc4-641a-4d04-874c-3695b823e81e" />

</details>

## Changelog Fixes
+ Fixed enchants appearing white when SBA is also installed. - Vixid
