### PR TITLE
Improvement: Block Break Particle Hider Searchability

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/BlockBreakParticleConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/BlockBreakParticleConfig.kt
@@ -18,7 +18,7 @@ class BlockBreakParticleConfig {
 
     @JvmField
     @Expose
-    @ConfigOption(name = "Only on Garden", desc = "Hide Block Break particles only on garden.")
+    @ConfigOption(name = "Only on Garden", desc = "Hide Block Break particles only on the Garden.")
     @SearchTag("breaking")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/BlockBreakParticleConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/BlockBreakParticleConfig.kt
@@ -4,12 +4,14 @@ import at.hannibal2.skyhanni.config.FeatureToggle
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class BlockBreakParticleConfig {
 
     @JvmField
     @Expose
     @ConfigOption(name = "Block Break Particles", desc = "Hide Block Break particles.")
+    @SearchTag("breaking")
     @ConfigEditorBoolean
     @FeatureToggle
     var hide: Boolean = false
@@ -17,6 +19,7 @@ class BlockBreakParticleConfig {
     @JvmField
     @Expose
     @ConfigOption(name = "Only on Garden", desc = "Hide Block Break particles only on garden.")
+    @SearchTag("breaking")
     @ConfigEditorBoolean
     @FeatureToggle
     var onlyInGarden: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/ParticleHiderConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/ParticleHiderConfig.kt
@@ -5,10 +5,12 @@ import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class ParticleHiderConfig {
     @Expose
     @ConfigOption(name = "Block Break Particle", desc = "")
+    @SearchTag("breaking")
     @Accordion
     val blockBreakParticle: BlockBreakParticleConfig = BlockBreakParticleConfig()
 


### PR DESCRIPTION
## What
Added "breaking" as a search tag to the Block Break Particle Hider feature to improve searchability, plus a small grammar fix.

## Changelog Improvements
+ Made Block Break Prticle Hider searchable by typing "breaking". - Luna

