### PR TITLE
Fix: Skill Level Parsing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/SkillExperience.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SkillExperience.kt
@@ -62,7 +62,7 @@ object SkillExperience {
                 if (next) {
                     val split = name.split(" ")
                     val skillName = split[0].lowercase()
-                    val level = split[1].romanToDecimal()
+                    val level = split[1].romanToDecimalIfNecessary()
                     val baseExp = getExpForLevel(level)
                     inventoryPattern.matchMatcher(line) {
                         val overflow = group("number").formatLong()

--- a/src/main/java/at/hannibal2/skyhanni/data/SkillExperience.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SkillExperience.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
-import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
+import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern


### PR DESCRIPTION
## What
Fixed a `.romanToDecimal()` call to use `.romanToDecimalIfNecessary()` instead. This happened to silently work before #4927.

## Changelog Fixes
+ Fixed error when opening Your Skills menu with Roman numerals disabled in Hypixel settings. - Luna