### PR TITLE
Improvement: Make tab list warnings less aggressive

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
@@ -128,7 +128,7 @@ object ProfileStorageData {
         if (foundSkyBlockTabList) {
             ChatUtils.clickableChat(
                 "§cCannot read profile name from tab list! Open /widget and make sure the Profile Widget " +
-                    "is enabled and visible."
+                    "is enabled and visible.",
                 onClick = {
                     HypixelCommands.widget()
                 },

--- a/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
@@ -115,22 +115,20 @@ object ProfileStorageData {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTick() {
-        if (noTabListTime.isFarPast()) return
+    fun onSecondPassed() {
+        if (noTabListTime.isFarPast() || noTabListTime.passedSince() < 10.seconds) return
 
         playerSpecific?.let {
-            // do not try to load the data when hypixel has not yet send the profile loaded message
+            // Do not try to load the data when Hypixel has not yet sent the profile loaded message
             if (it.multipleProfiles && !hypixelDataLoaded) return
         }
 
-        if (noTabListTime.passedSince() < 3.seconds) return
         noTabListTime = SimpleTimeMark.now()
         val foundSkyBlockTabList = TabWidget.AREA.isActive
         if (foundSkyBlockTabList) {
             ChatUtils.clickableChat(
-                "§cCan not read profile name from tab list! Open /widget, enable the Profile Widget, " +
-                    "and give it high enough priority so that it is visible in tab list. " +
-                    "This is needed for the mod to function and therefore this warning cannot be disabled!",
+                "§cCannot read profile name from tab list! Open /widget and make sure the Profile Widget " +
+                    "is enabled and visible."
                 onClick = {
                     HypixelCommands.widget()
                 },


### PR DESCRIPTION
## What
Made tab list profile warnings less aggressive, only triggering once every 10 seconds instead of 3 seconds. We could probably do a proper check for the tab list being fully loaded, but this should be good enough for now, it should give ample time to avoid false postives due to lag in the majority of cases.

I also simplified the message because the lengthy explanation only annoys users and makes them complain more and does not result in them understanding it any better.

## Changelog Improvements
+ Made warnings about missing tab list info less frequent and aggressive. - Luna