### PR TITLE
Fix: Box rendering in world not always rendering as intended

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -151,7 +151,7 @@ object WorldRenderUtils {
         drawVerticalBarriers: Boolean = true,
         seeThroughBlocks: Boolean = false,
     ) {
-        drawFilledBoundingBox(aabb, c.toColor(), alphaMultiplier, renderRelativeToCamera, drawVerticalBarriers)
+        drawFilledBoundingBox(aabb, c.toColor(), alphaMultiplier, renderRelativeToCamera, drawVerticalBarriers, seeThroughBlocks)
     }
 
     // TODO make deprecated


### PR DESCRIPTION
## What
seeThroughBlocks wasnt being passed in one of the functions on 1.21

## Changelog Fixes
+ Fixed some box rendering on modern. - nopo
