### PR TITLE
Fix: Tablist not rendering over other elements when using toggle tab

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -46,7 +46,7 @@ object TabListRenderer {
     private var isPressed = false
     private var isTabToggled = false
 
-    @HandleEvent(onlyOnSkyblock = true)
+    @HandleEvent(onlyOnSkyblock = true, priority = HandleEvent.LOWEST)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (GlobalRender.renderDisabled) return
         if (!config.enabled.get()) return


### PR DESCRIPTION
## What
toggle tab uses diff event to normal tab

## Changelog Fixes
+ Fixed Tablist not rendering over other elements when using toggle tab. - nopo

