### PR TITLE
Improvement: Only show coa tracker during diana

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.itemabilities
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.itemability.CrownOfAvariceConfig.CrownOfAvariceLines
+import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -203,7 +204,7 @@ object CrownOfAvariceCounter {
     }
 
 
-    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.enable
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.enable && Perk.MYTHOLOGICAL_RITUAL.isActive
 
     private fun reset() {
         coinsEarned = 0L


### PR DESCRIPTION
## What
Coa only gains coins during diana, no need to show it outside

## Changelog Improvements
+ Only Show Coa counter during diana. - nopo
