### PR TITLE
Fix: Hideonleaf finder navigating when typing

### DIFF
--- a/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/hunting/HideonleafFinder.kt
+++ b/versions/1.21.5/src/main/java/at/hannibal2/skyhanni/features/hunting/HideonleafFinder.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.navigation.NavigationUtils
+import net.minecraft.client.MinecraftClient
 
 @SkyHanniModule
 object HideonleafFinder {
@@ -22,6 +23,7 @@ object HideonleafFinder {
 
     @HandleEvent(onlyOnIsland = IslandType.GALATEA)
     fun onKeyPress(event: KeyPressEvent) {
+        if (MinecraftClient.getInstance().currentScreen != null) return
         if (event.keyCode != config.nextHideonleafKeybind) return
         if (!config.hideonleafFinder) return
         if (navigating) return


### PR DESCRIPTION
## What
it would navigate when you were just trying to write out a lovely message to the level 45 non who stole your green fella

## Changelog Fixes
+ Fixed Hideonleaf finder navigating when typing. - nopo
