### PR TITLE
Improvement: New Crops in Basket of Seeds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -90,7 +90,7 @@ object HideNotClickableItems {
      */
     private val seedsPattern by patternGroup.pattern(
         "inventory.hidenotclickable.seeds",
-        "SEEDS|CARROT_ITEM|POTATO_ITEM|PUMPKIN_SEEDS|SUGAR_CANE|MELON_SEEDS|CACTUS|INK_SACK-3",
+        "SEEDS|CARROT_ITEM|POTATO_ITEM|PUMPKIN_SEEDS|SUGAR_CANE|MELON_SEEDS|CACTUS|INK_SACK-3|DOUBLE_PLANT|MOONFLOWER|WILD_ROSE",
     )
 
     private val netherWart = "NETHER_STALK".toInternalName()


### PR DESCRIPTION
## What
Added new crops to Basket of Seeds pattern. (Yes, I tested it, both Moonflower and Sunflower can be placed in and planted from it.)

## Changelog Improvements
+ Added support for Moonflower, Sunflower, and Wild Rose in Basket of Seeds for Not Clickable Items. - Luna

