### PR TITLE
Fix: Sowdust in chunked stats & optimal speed/angle for new crops

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalAngles/CustomAnglesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalAngles/CustomAnglesConfig.kt
@@ -121,7 +121,7 @@ class CustomAnglesConfig {
     @Expose
     @ConfigOption(name = "Sunflower & Moonflower Yaw", desc = "Set Yaw for sunflower & moonflower farming.")
     @ConfigEditorSlider(minValue = -180f, maxValue = 180f, minStep = 0.1f)
-    val sunMoonFlowerYaw: Property<Float> = Property.of(90f)
+    val sunMoonFlowerYaw: Property<Float> = Property.of(45f)
 
     @Expose
     @ConfigOption(name = "Sunflower & Moonflower  Pitch", desc = "Set Pitch for sunflower & moonflower farming.")
@@ -132,7 +132,7 @@ class CustomAnglesConfig {
     @Expose
     @ConfigOption(name = "Wild Rose Yaw", desc = "Set Yaw for wild rose farming.")
     @ConfigEditorSlider(minValue = -180f, maxValue = 180f, minStep = 0.1f)
-    val wildRoseYaw: Property<Float> = Property.of(90f)
+    val wildRoseYaw: Property<Float> = Property.of(45f)
 
     @Expose
     @ConfigOption(name = "Wild Rose Pitch", desc = "Set Pitch for wild rose farming.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/CustomSpeedConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/optimalspeed/CustomSpeedConfig.kt
@@ -90,19 +90,19 @@ class CustomSpeedConfig {
     @ConfigOption(
         name = "Sunflower & Moonflower",
         desc = "Suggested farm speed:\n" +
-            "ask google",
+            "§eYaw 45§7: §f✦ 328 speed",
     )
     @ConfigEditorSlider(minValue = 1f, maxValue = 400f, minStep = 1f)
-    val sunMoonFlower: Property<Float> = Property.of(155f)
+    val sunMoonFlower: Property<Float> = Property.of(328f)
 
     @Expose
     @ConfigOption(
         name = "Wild Flower",
         desc = "Suggested farm speed:\n" +
-            "ask google",
+            "§eYaw 45§7: §f✦ 328 speed",
     )
     @ConfigEditorSlider(minValue = 1f, maxValue = 400f, minStep = 1f)
-    val wildRose: Property<Float> = Property.of(155f)
+    val wildRose: Property<Float> = Property.of(328f)
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ChunkedStatsLine.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ChunkedStatsLine.kt
@@ -65,7 +65,7 @@ enum class ChunkedStatsLine(
         configLine = "§cCopper",
     ),
     SOWDUST(
-        displayPair = { "§c${getSowdust()}" },
+        displayPair = { "§2${getSowdust()}" },
         showWhen = { !(hideEmptyLines && getSowdust() == "0") && ScoreboardElementSowdust.showWhen() },
         showIsland = { ScoreboardElementSowdust.showIsland() },
         configLine = "§2Sowdust",


### PR DESCRIPTION
## What
Made sowdust the correct color, also made optimal angles like the cane ones as thats what people are making? maybe? idk?

<details>
<summary>Images</summary>

Idk looks like a cane farm to me
<img width="3840" height="2088" alt="image" src="https://github.com/user-attachments/assets/2eb1a514-c3b0-4d56-b0f5-7e5023189d8d" />

</details>

## Changelog Fixes
+ Fixed sowdust displaying incorrectly in chunked stats on custom scoreboard. - CalMWolfs

