### PR TITLE
Improvement: Prevent sensitivity reducer from reducing sensitivity while in greenhouse

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -67,6 +67,7 @@ object GardenApi {
         get() = CurrentPetApi.isCurrentPetOrHigherRarity(RARE_MOOSHROOM_COW_PET_ITEM)
     private var inBarn = false
     val onBarnPlot get() = inBarn && inGarden()
+    val onUnfarmablePlot get() = inGarden() && (inBarn || GardenPlotApi.inGreenhouse())
     val storage get() = ProfileStorageData.profileSpecific?.garden
     val config get() = SkyHanniMod.feature.garden
     var totalAmountVisitorsExisting = 0

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
@@ -20,8 +20,8 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RecalculatingValue
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
-import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SignUtils
 import at.hannibal2.skyhanni.utils.SignUtils.isRancherSign
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -163,13 +163,16 @@ object GardenOptimalSpeed {
 
         val colorCode = if (recentlySwitchedTool) "7" else if (speed != currentSpeed) "c" else "a"
 
-        if (config.showOnHUD) config.pos.renderString("§$colorCode$text", posLabel = "Garden Optimal Speed")
+        if (config.showOnHUD) config.pos.renderRenderable(
+            Renderable.text("§$colorCode$text"),
+            posLabel = "Garden Optimal Speed"
+        )
         if (speed != currentSpeed && !recentlySwitchedTool) warn(speed)
     }
 
     private fun warn(optimalSpeed: Int) {
         if (!MinecraftCompat.localPlayer.onGround) return
-        if (GardenApi.onBarnPlot) return
+        if (GardenApi.onUnfarmablePlot) return
         if (!config.warning) return
         if (!GardenApi.isCurrentlyFarming()) return
         if (lastWarnTime.passedSince() < 20.seconds) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
@@ -60,6 +60,14 @@ object GardenPlotApi {
     )
 
     /**
+     * REGEX-TEST: §7Greenhouse Plot
+     */
+    private val greenhousePlotPattern by patternGroup.pattern(
+        "greenhouse",
+        "§7Greenhouse Plot",
+    )
+
+    /**
      * REGEX-TEST: §7Cleanup: §b0% Completed
      */
     private val uncleanedPlotPattern by patternGroup.pattern(
@@ -117,6 +125,10 @@ object GardenPlotApi {
         return plots.firstOrNull { it.isPlayerInside() }
     }
 
+    fun inGreenhouse(): Boolean {
+        return currentPlot?.greenhouse ?: false
+    }
+
     class Plot(val id: Int, var inventorySlot: Int, val box: AxisAlignedBB, val middle: LorenzVec)
 
     private var currentPlot: Plot? = null
@@ -162,6 +174,9 @@ object GardenPlotApi {
 
         @Expose
         var uncleared: Boolean,
+
+        @Expose
+        var greenhouse: Boolean,
     )
 
     data class SprayData(
@@ -181,6 +196,7 @@ object GardenPlotApi {
             isPestCountInaccurate = false,
             locked = true,
             uncleared = false,
+            greenhouse = false,
         )
     }
 
@@ -230,6 +246,12 @@ object GardenPlotApi {
         get() = this.getData()?.locked ?: false
         set(value) {
             this.getData()?.locked = value
+        }
+
+    var Plot.greenhouse: Boolean
+        get() = this.getData()?.greenhouse ?: false
+        set(value) {
+            this.getData()?.greenhouse = value
         }
 
     fun Plot.markExpiredSprayAsNotified() {
@@ -355,12 +377,16 @@ object GardenPlotApi {
             }
             plot.locked = false
             plot.isBeingPasted = false
+            plot.greenhouse = false
             for (line in lore) {
                 if (line.contains("§7Cost:")) plot.locked = true
                 if (line.contains("§7Pasting in progress:")) plot.isBeingPasted = true
                 plot.uncleared = false
                 uncleanedPlotPattern.matchMatcher(line) {
                     plot.uncleared = true
+                }
+                greenhousePlotPattern.matchMatcher(line) {
+                    plot.greenhouse = true
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -115,7 +115,7 @@ object GardenCustomKeybinds {
             .let { values -> values.size != values.toSet().size }
     }
 
-    private fun isEnabled() = GardenApi.inGarden() && config.enabled && !(GardenApi.onBarnPlot && config.excludeBarn)
+    private fun isEnabled() = GardenApi.inGarden() && config.enabled && !(GardenApi.onUnfarmablePlot && config.excludeBarn)
 
     private fun isActive(): Boolean =
         isEnabled() && GardenApi.toolInHand != null && !isDuplicate && !hasGuiOpen() && lastWindowOpenTime.passedSince() > 300.milliseconds

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenStartLocation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenStartLocation.kt
@@ -55,6 +55,7 @@ object GardenStartLocation {
     fun onCropClick(event: CropClickEvent) {
         if (!isEnabled()) return
         if (event.clickType != ClickType.LEFT_CLICK || !GardenApi.hasFarmingToolInHand()) return
+        if (GardenApi.onUnfarmablePlot) return
         val startLocations = GardenApi.storage?.cropStartLocations ?: return
         val lastFarmedLocations = GardenApi.storage?.cropLastFarmedLocations ?: return
         val crop = GardenApi.getCurrentlyFarmedCrop() ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -14,8 +14,10 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
-import at.hannibal2.skyhanni.utils.RenderUtils.renderString
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import net.minecraft.client.Minecraft
 
 @SkyHanniModule
@@ -57,7 +59,7 @@ object SensitivityReducer {
     }
 
     private fun updatePlayerStatus() {
-        val newInBarn = GardenApi.onBarnPlot
+        val newInBarn = GardenApi.onUnfarmablePlot
         val newOnGround = MinecraftCompat.localPlayer.onGround
 
         if (inBarn != newInBarn) {
@@ -147,7 +149,10 @@ object SensitivityReducer {
     fun onRenderOverlay() {
         if (!isActive) return
         if (!config.showGui) return
-        config.position.renderString("§eSensitivity Lowered", posLabel = "Sensitivity Lowered")
+        config.position.renderRenderable(
+            Renderable.text("§eSensitivity Lowered"),
+            posLabel = "Sensitivity Lowered"
+        )
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
could be annoying to not be able to move mouse while in greenhouse

<details>
<summary>Images</summary>

<img width="202" height="40" alt="image" src="https://github.com/user-attachments/assets/850dc720-ae6a-4424-825c-280330f854d7" />
<img width="764" height="184" alt="image" src="https://github.com/user-attachments/assets/5046db85-7e57-4245-a91b-a90cb748337c" />

<!-- drop images here -->

</details>

## Changelog Improvements
+ Disabled Custom Garden Keybinds while on the greenhouse. - bloxigus
+ Disabled Sensitivity Reducer while on the greenhouse. - bloxigus
+ Disabled Saving last farmed location on the greenhouse. - bloxigus
