### PR TITLE
Fix: vinyl replacer not working the last disk

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
@@ -27,7 +27,7 @@ object StereoHarmonyDiscReplacer {
     fun replaceItem(event: ReplaceItemEvent) {
         if (!config.replaceMenuIcons) return
         if (!PestApi.stereoInventory.isInside()) return
-        if (event.slot !in 11..15 && event.slot !in 20..24 && event.slot !in 29..31) return
+        if (event.slot !in 11..15 && event.slot !in 20..24 && event.slot !in 30..32) return
 
         val item = event.originalItem
         val internalName = item?.getInternalNameOrNull() ?: return


### PR DESCRIPTION
## What
off by one error gg

## Changelog Fixes
+ Fixed Stereo Harmony Disc Replacer not working on 1 vinyl. - nopo

