### PR TITLE
Backend: Mark as incompatible with Exordium

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -52,6 +52,9 @@
         "fabric-language-kotlin": ">=1.13.2+kotlin.2.1.20",
         "minecraft": "1.21.5"
     },
+    "breaks": {
+        "exordium": "*"
+    },
     "contact": {
         "homepage": "https://modrinth.com/mod/skyhanni",
         "issues": "https://discord.gg/skyhanni-997079228510117908"

--- a/versions/1.21.10/src/main/resources/fabric.mod.json
+++ b/versions/1.21.10/src/main/resources/fabric.mod.json
@@ -46,6 +46,9 @@
         "fabric-language-kotlin": ">=1.13.2+kotlin.2.1.20",
         "minecraft": "1.21.10"
     },
+    "breaks": {
+        "exordium": "*"
+    },
     "contact": {
         "homepage": "https://modrinth.com/mod/skyhanni",
         "issues": "https://discord.gg/skyhanni-997079228510117908"

--- a/versions/1.21.8/src/main/resources/fabric.mod.json
+++ b/versions/1.21.8/src/main/resources/fabric.mod.json
@@ -46,6 +46,9 @@
         "fabric-language-kotlin": ">=1.13.2+kotlin.2.1.20",
         "minecraft": "1.21.8"
     },
+    "breaks": {
+        "exordium": "*"
+    },
     "contact": {
         "homepage": "https://modrinth.com/mod/skyhanni",
         "issues": "https://discord.gg/skyhanni-997079228510117908"


### PR DESCRIPTION
The mod actively causes issues, and in [their own words](https://modrinth.com/mod/exordium):

> This mod is not actively maintained! No new features will be added or bugs with other mods fixed! There will be visual issues/compatibility issues with other mods or even vanilla! Just don't use the mod if you have a problem with that.

exclude_from_changelog