### PR TITLE
Fix: Pet Drop Rarity for fished pets

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -46,11 +46,11 @@ object RareDropMessages {
     )
 
     /**
-     * REGEX-TEST: §5§lGREAT CATCH! §r§bYou found a §r§7[Lvl 1] §r§aGuardian§r§b.
+     * REGEX-TEST: §6⛃ §r§6§lGREAT CATCH! §r§fYou caught a §r§7[Lvl 1] §r§aSquid§r§f!
      */
     private val petFishedPattern by petGroup.pattern(
         "fishedmessage",
-        "(?<start>(?:§.)*GREAT CATCH! (?:§.)*You found a (?:§.)*\\[Lvl 1] )(?:§.)*§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end>.*)",
+        "(?<start>(?:§.)*⛃ (?:§.)*(?:GOOD|GREAT|OUTSTANDING) CATCH! (?:§.)*You caught a (?:§.)*\\[Lvl 1] )(?:§.)*§(?<rarityColor>.)(?<petName>[^§(.]+)(?<end>.*)",
     )
 
     /**


### PR DESCRIPTION
## What
Updated Pet Drop Rarity to the new drop message format for fished pets.

## Changelog Fixes
+ Fixed Pet Drop Rarity not working for fished pets. - Luna

