### PR TITLE
Improvement: Add Farming Exp Boost (Epic) to rare visitor rewards

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/DropsStatisticsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/DropsStatisticsConfig.kt
@@ -39,6 +39,7 @@ class DropsStatisticsConfig {
             DropsStatisticsTextEntry.COPPER_DYE,
             DropsStatisticsTextEntry.HYPERCHARGE_CHIP,
             DropsStatisticsTextEntry.QUICKDRAW_CHIP,
+            DropsStatisticsTextEntry.FARMING_EXP_BOOST_EPIC,
         )
     )
 
@@ -79,6 +80,7 @@ class DropsStatisticsConfig {
         HARVEST_HARBINGER("§b1 §9Harvest Harbinger V"),
         HYPERCHARGE_CHIP("§b3 §9Hypercharge Chip"),
         QUICKDRAW_CHIP("§b7 §9Quickdraw Chip"),
+        FARMING_EXP_BOOST_EPIC("§b1 §5Farming Exp Boost"),
         ;
 
         override fun toString() = displayName

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/RewardWarningConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/RewardWarningConfig.kt
@@ -46,7 +46,8 @@ class RewardWarningConfig {
         VisitorReward.SPACE_HELMET,
         VisitorReward.CULTIVATING,
         VisitorReward.REPLENISH,
-        VisitorReward.COPPER_DYE
+        VisitorReward.COPPER_DYE,
+        VisitorReward.FARMING_EXP_BOOST_EPIC,
     )
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
@@ -23,6 +23,7 @@ enum class VisitorReward(rawInternalName: String, val displayName: String) {
     HARVEST_HARBINGER("POTION_HARVEST_HARBINGER;5", "§9Harvest Harbinger V"),
     HYPERCHARGE_CHIP("HYPERCHARGE_GARDEN_CHIP", "§9Hypercharge Chip"),
     QUICKDRAW_CHIP("QUICKDRAW_GARDEN_CHIP", "§9Quickdraw Chip"),
+    FARMING_EXP_BOOST_EPIC("PET_ITEM_FARMING_SKILL_BOOST_EPIC", "§5Farming Exp Boost"),
     ;
 
     private val internalName = rawInternalName.toInternalName()


### PR DESCRIPTION
## What
Adds Farming Exp Boost (Epic) to rare visitor rewards. This is a rare reward from Duncan. Normally costs like 1.5M so it can be useful for some people.

## Changelog Improvements
+ Added Farming Exp Boost (Epic) to rare visitor rewards. - Luna