### PR TITLE
Fix: Hoppity Inventory Check

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
@@ -33,6 +33,7 @@ import at.hannibal2.skyhanni.features.inventory.chocolatefactory.stray.CFStrayTr
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getSingleLineLore
 import at.hannibal2.skyhanni.utils.LorenzRarity
@@ -158,6 +159,10 @@ object HoppityApi {
 
     fun isHoppityEvent() = (SkyblockSeason.SPRING.isSeason() || SkyHanniMod.feature.dev.debug.alwaysHoppitys)
 
+    fun inInventory(): Boolean =
+        InventoryUtils.openInventoryName() == "Hoppity" &&
+            InventoryUtils.getItemsInOpenChestWithNull().getOrNull(29)?.item?.cleanName() != "Accept Offer"
+
     // First event was year 346 -> #1, 20th event was year 365, etc.
     fun getHoppityEventNumber(skyblockYear: Int): Int = (skyblockYear - 345)
 
@@ -226,7 +231,7 @@ object HoppityApi {
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!checkNextInvOpen) return
         checkNextInvOpen = false
-        if (event.inventoryName != "Hoppity") return
+        if (!inInventory()) return
         lastHoppityCallAccept = SimpleTimeMark.now()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityNpc.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityNpc.kt
@@ -41,7 +41,7 @@ object HoppityNpc {
 
     @HandleEvent
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (event.inventoryName != "Hoppity") return
+        if (!HoppityApi.inInventory()) return
         // TODO maybe we could add an annoying chat message that tells you how many years you have skipped
         //  or the last year you have opened the shop before.
         //  that way we verbally punish non active users in a funny and non harmful way

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityLiveDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityLiveDisplay.kt
@@ -195,7 +195,7 @@ object HoppityLiveDisplay {
         return when {
             currentScreen is InventoryScreen -> HoppityLiveDisplayInventoryType.OWN_INVENTORY
             inChocolateFactory -> HoppityLiveDisplayInventoryType.CHOCOLATE_FACTORY
-            inventoryName == "Hoppity" -> HoppityLiveDisplayInventoryType.HOPPITY
+            HoppityApi.inInventory() -> HoppityLiveDisplayInventoryType.HOPPITY
             mealEggInventoryPattern.matches(inventoryName) -> HoppityLiveDisplayInventoryType.MEAL_EGGS
             else -> return false
         } in setting

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.MilestoneJson
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.chroma.ChromaManager
+import at.hannibal2.skyhanni.features.event.hoppity.HoppityApi
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityCollectionStats
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.data.CFDataLoader
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.data.CFUpgrade
@@ -59,12 +60,11 @@ object CFApi {
     )
 
     /**
-     * REGEX-TEST: Hoppity
      * REGEX-TEST: Chocolate Factory Milestones
      */
-    private val chocolateFactoryInventoryNamePattern by patternGroup.pattern(
-        "inventory.name",
-        "Hoppity|Chocolate Factory Milestones",
+    private val chocolateFactoryMilestonesInventoryNamePattern by patternGroup.pattern(
+        "inventory.milestones",
+        "Chocolate Factory Milestones",
     )
 
     /**
@@ -139,7 +139,10 @@ object CFApi {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (chocolateFactoryInventoryNamePattern.matches(event.inventoryName)) {
+        if (
+            chocolateFactoryMilestonesInventoryNamePattern.matches(event.inventoryName) ||
+            HoppityApi.inInventory()
+        ) {
             if (config.enabled) {
                 chocolateFactoryPaused = true
                 CFStats.updateDisplay()


### PR DESCRIPTION
## What
Fixed Hoppity inventory checks to exclude the Garden visitor inventory.

## Changelog Fixes
+ Fixed Chocolate Factory Stats showing up when talking to Hoppity visitor on the Garden. - Luna

exclude_from_changelog