### PR TITLE
Improvement: Finnegan Custom Pest Cooldown

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTimerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTimerConfig.kt
@@ -80,9 +80,17 @@ class PestTimerConfig {
     val customCooldown: Property<Boolean> = Property.of(false)
 
     @Expose
-    @ConfigOption(name = "Custom Pest Cooldown Time", desc = "Set pest cooldown to this amount after a pest spawns.")
-    @ConfigEditorSlider(minValue = 75f, maxValue = 135f, minStep = 5f)
+    @ConfigOption(name = "Custom Cooldown Time", desc = "Set pest cooldown to this amount after a pest spawns.")
+    @ConfigEditorSlider(minValue = 75f, maxValue = 300f, minStep = 5f)
     val customCooldownTime: Property<Int> = Property.of(135)
+
+    @Expose
+    @ConfigOption(
+        name = "Custom Cooldown Time (Finnegan)",
+        desc = "Set pest cooldown to this amount after a pest spawns when Finnegan's \"Pest Eradicator\" perk is active.",
+    )
+    @ConfigEditorSlider(minValue = 75f, maxValue = 300f, minStep = 5f)
+    val customCooldownTimeFinnegan: Property<Int> = Property.of(75)
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.config.features.garden.pests.PestTimerConfig.HeldIt
 import at.hannibal2.skyhanni.config.features.garden.pests.PestTimerConfig.PestTimerTextEntry
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleContext
 import at.hannibal2.skyhanni.data.title.TitleManager
@@ -79,6 +80,9 @@ object PestSpawnTimer {
     private var countdownTitleContext: TitleContext? = null
     private var lastPlayedSound: SimpleTimeMark = SimpleTimeMark.farPast()
 
+    private val customCooldownTime get(): Duration =
+        (if (Perk.PEST_ERADICATOR.isActive) config.customCooldownTimeFinnegan else config.customCooldownTime).get().seconds
+
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.PESTS)) return
@@ -95,7 +99,7 @@ object PestSpawnTimer {
             }
             if (time == null) return
             pestCooldownEndTime = if (config.customCooldown.get()) {
-                lastPestSpawnTime + config.customCooldownTime.get().seconds
+                lastPestSpawnTime + customCooldownTime
             } else time
 
             if (pestSpawned) {
@@ -196,7 +200,7 @@ object PestSpawnTimer {
     }
 
     private fun setCustomCooldown() {
-        if (config.customCooldown.get()) pestCooldownEndTime = lastPestSpawnTime + config.customCooldownTime.get().seconds
+        if (config.customCooldown.get()) pestCooldownEndTime = lastPestSpawnTime + customCooldownTime
     }
 
     private fun drawDisplay(): List<Renderable> {


### PR DESCRIPTION
## What
Added an option to use a different custom pest spawn cooldown time when Finnegan's Pest Eradicator perk is active, plus some small adjustments (made the max 300 for people with non-maxed setups).

## Changelog Improvements
+ Added an option to use a different custom pest spawn cooldown time when Finnegan's Pest Eradicator perk is active. - Luna

