### PR TITLE
Backend: Another ItemHoverEvent injection point

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiGraphics.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiGraphics.java
@@ -1,8 +1,13 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
+import at.hannibal2.skyhanni.data.ToolTipData;
+import at.hannibal2.skyhanni.features.inventory.wardrobe.CustomWardrobe;
 import at.hannibal2.skyhanni.mixins.hooks.RenderItemHookKt;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -11,8 +16,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Mixin(GuiGraphics.class)
-public class MixinDrawContext {
+public class MixinGuiGraphics {
 
     //#if MC < 1.21.6
     @Inject(method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;IIII)V", at = @At("RETURN"))
@@ -27,5 +35,14 @@ public class MixinDrawContext {
     @Inject(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V", at = @At("RETURN"))
     private void drawItemPost(Font textRenderer, ItemStack stack, int x, int y, String stackCountText, CallbackInfo ci) {
         RenderItemHookKt.renderItemOverlayPost((GuiGraphics) (Object) this, stack, x, y, stackCountText);
+    }
+
+
+    @ModifyExpressionValue(method = "renderTooltip(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;II)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;getTooltipFromItem(Lnet/minecraft/client/Minecraft;Lnet/minecraft/world/item/ItemStack;)Ljava/util/List;"))
+    private List<Component> sh$renderTooltipInternal(List<Component> textTooltip, @Local(argsOnly = true) ItemStack itemStack, @Local(argsOnly = true) Font font) {
+        if (CustomWardrobe.shouldHideNormalTooltip()) {
+            return new ArrayList<>();
+        }
+        return ToolTipData.processModernTooltip((GuiGraphics) (Object) this, itemStack, textTooltip);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHandledScreen.java
@@ -19,9 +19,9 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.inventory.Slot;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -29,13 +29,14 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.ArrayList;
+import java.util.List;
 //#if MC > 1.21.8
 //$$ import net.minecraft.client.input.MouseButtonEvent;
 //$$ import net.minecraft.client.input.KeyEvent;
 //#endif
 
-import java.util.ArrayList;
-import java.util.List;
 
 @Mixin(AbstractContainerScreen.class)
 public abstract class MixinHandledScreen {


### PR DESCRIPTION
## What
ItemStacks can also render their tooltips through GuiGraphics.renderTooltip, which SbPv uses soon:tm: to allow for sh chroma in pv itself.


## Changelog Technical Details
+ Added secondary ItemHoverEvent injection point. - juna, mona

