### PR TITLE
Backend: Update Detekt baseline

### DIFF
--- a/detekt/baseline-main.xml
+++ b/detekt/baseline-main.xml
@@ -1,308 +1,461 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
-    <ManuallySuppressedIssues></ManuallySuppressedIssues>
-    <CurrentIssues>
-        <ID>ArrayPrimitive:LorenzVec.kt$Array&lt;Double&gt;</ID>
-        <ID>ArrayPrimitive:LorenzVec.kt$LorenzVec$Array&lt;Double&gt;</ID>
-        <ID>ArrayPrimitive:LorenzVec.kt$LorenzVec$Array&lt;Float&gt;</ID>
-        <ID>ArrayPrimitive:LorenzVec.kt$LorenzVec$arrayOf(x, y, z)</ID>
-        <ID>ArrayPrimitive:LorenzVec.kt$LorenzVec$arrayOf(x.toFloat(), y.toFloat(), z.toFloat())</ID>
-        <ID>ChainWrapping:Renderable.kt$Renderable.Companion$||</ID>
-        <ID>CyclomaticComplexMethod:AdvancedPlayerList.kt$AdvancedPlayerList$fun newSorting(original: List&lt;String&gt;): List&lt;String&gt;</ID>
-        <ID>CyclomaticComplexMethod:DamageIndicatorManager.kt$DamageIndicatorManager$@HandleEvent fun onRenderWorld(event: SkyHanniRenderWorldEvent)</ID>
-        <ID>CyclomaticComplexMethod:DungeonHideItems.kt$DungeonHideItems$@HandleEvent(onlyOnIsland = IslandType.CATACOMBS) fun onCheckRender(event: CheckRenderEntityEvent&lt;Entity&gt;)</ID>
-        <ID>CyclomaticComplexMethod:EnoughUpdatesManager.kt$EnoughUpdatesManager$private fun getPetLoreReplacements(petName: String?, tier: String?, level: Int): Map&lt;String, String&gt;</ID>
-        <ID>CyclomaticComplexMethod:GardenCropMilestoneDisplay.kt$GardenCropMilestoneDisplay$private fun drawProgressDisplay(crop: CropType): List&lt;Renderable&gt;</ID>
-        <ID>CyclomaticComplexMethod:GardenVisitorFeatures.kt$GardenVisitorFeatures$private fun readToolTip(visitor: VisitorApi.Visitor, itemStack: ItemStack?, toolTip: MutableList&lt;String&gt;)</ID>
-        <ID>CyclomaticComplexMethod:GraphEditor.kt$GraphEditor$private fun input()</ID>
-        <ID>CyclomaticComplexMethod:ItemAbilityCooldown.kt$ItemAbilityCooldown$@HandleEvent fun onPlaySound(event: PlaySoundEvent)</ID>
-        <ID>CyclomaticComplexMethod:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$private fun getStackTip(item: ItemStack): String?</ID>
-        <ID>CyclomaticComplexMethod:MinecraftConsoleFilter.kt$MinecraftConsoleFilter$override fun filter(event: LogEvent?): Filter.Result</ID>
-        <ID>CyclomaticComplexMethod:PacketTest.kt$PacketTest$private fun Packet&lt;*&gt;.print()</ID>
-        <ID>CyclomaticComplexMethod:Renderable.kt$Renderable.Companion$internal fun shouldAllowLink(debug: Boolean = false, bypassChecks: Boolean): Boolean</ID>
-        <ID>CyclomaticComplexMethod:SoopyGuessBurrow.kt$SoopyGuessBurrow$@HandleEvent(onlyOnSkyblock = true) fun onReceiveParticle(event: ReceiveParticleEvent)</ID>
-        <ID>CyclomaticComplexMethod:ToolTooltipTweaks.kt$ToolTooltipTweaks$@HandleEvent(onlyOnSkyblock = true) fun onToolTip(event: ToolTipEvent)</ID>
-        <ID>CyclomaticComplexMethod:TrevorSolver.kt$TrevorSolver$fun findMob()</ID>
-        <ID>CyclomaticComplexMethod:VampireSlayerFeatures.kt$VampireSlayerFeatures$@HandleEvent fun onRenderWorld(event: SkyHanniRenderWorldEvent)</ID>
-        <ID>CyclomaticComplexMethod:VampireSlayerFeatures.kt$VampireSlayerFeatures$private fun EntityOtherPlayerMP.process()</ID>
-        <ID>CyclomaticComplexMethod:VisualWordGui.kt$VisualWordGui$override fun onDrawScreen(originalMouseX: Int, originalMouseY: Int, partialTicks: Float)</ID>
-        <ID>InjectDispatcher:ClipboardUtils.kt$ClipboardUtils$IO</ID>
-        <ID>InjectDispatcher:SkyHanniMod.kt$SkyHanniMod$IO</ID>
-        <ID>LargeClass:WorldRenderUtils.kt$WorldRenderUtils</ID>
-        <ID>LongMethod:DamageIndicatorManager.kt$DamageIndicatorManager$@HandleEvent fun onRenderWorld(event: SkyHanniRenderWorldEvent)</ID>
-        <ID>LongMethod:GraphEditor.kt$GraphEditor$private fun input()</ID>
-        <ID>LongMethod:ItemAbilityCooldown.kt$ItemAbilityCooldown$@HandleEvent fun onPlaySound(event: PlaySoundEvent)</ID>
-        <ID>LongMethod:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$private fun getStackTip(item: ItemStack): String?</ID>
-        <ID>LongMethod:ToolTooltipTweaks.kt$ToolTooltipTweaks$@HandleEvent(onlyOnSkyblock = true) fun onToolTip(event: ToolTipEvent)</ID>
-        <ID>LongMethod:VisualWordGui.kt$VisualWordGui$override fun onDrawScreen(originalMouseX: Int, originalMouseY: Int, partialTicks: Float)</ID>
-        <ID>LoopWithTooManyJumpStatements:AdvancedPlayerList.kt$AdvancedPlayerList$for</ID>
-        <ID>LoopWithTooManyJumpStatements:CropMoneyDisplay.kt$CropMoneyDisplay$for</ID>
-        <ID>LoopWithTooManyJumpStatements:DataWatcherApi.kt$DataWatcherApi$for</ID>
-        <ID>LoopWithTooManyJumpStatements:GardenComposterInventoryFeatures.kt$GardenComposterInventoryFeatures$for</ID>
-        <ID>LoopWithTooManyJumpStatements:GardenVisitorFeatures.kt$GardenVisitorFeatures$for</ID>
-        <ID>LoopWithTooManyJumpStatements:HighlightMissingRepoItems.kt$HighlightMissingRepoItems$for</ID>
-        <ID>LoopWithTooManyJumpStatements:IslandAreas.kt$IslandAreas$for</ID>
-        <ID>LoopWithTooManyJumpStatements:ItemResolutionQuery.kt$ItemResolutionQuery.Companion$for</ID>
-        <ID>LoopWithTooManyJumpStatements:RiftBloodEffigies.kt$RiftBloodEffigies$for</ID>
-        <ID>LoopWithTooManyJumpStatements:SkyBlockItemModifierUtils.kt$SkyBlockItemModifierUtils$for</ID>
-        <ID>LoopWithTooManyJumpStatements:SkyHanniConfigSearchResetCommand.kt$SkyHanniConfigSearchResetCommand$for</ID>
-        <ID>LoopWithTooManyJumpStatements:SuperpairsClicksAlert.kt$SuperpairsClicksAlert$for</ID>
-        <ID>MapGetWithNotNullAssertionOperator:NavigationHelper.kt$NavigationHelper$distances[node]!!</ID>
-        <ID>MaxLineLength:ItemUtils.kt$ItemUtils$"ewogICJ0aW1lc3RhbXAiIDogMTYzNTk1NzQ4ODQxNywKICAicHJvZmlsZUlkIiA6ICJmNThkZWJkNTlmNTA0MjIyOGY2MDIyMjExZDRjMTQwYyIsCiAgInByb2ZpbGVOYW1lIiA6ICJ1bnZlbnRpdmV0YWxlbnQiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2I5NTFmZWQ2YTdiMmNiYzIwMzY5MTZkZWM3YTQ2YzRhNTY0ODE1NjRkMTRmOTQ1YjZlYmMwMzM4Mjc2NmQzYiIsCiAgICAgICJtZXRhZGF0YSIgOiB7CiAgICAgICAgIm1vZGVsIiA6ICJzbGltIgogICAgICB9CiAgICB9CiAgfQp9"</ID>
-        <ID>MaxLineLength:ItemUtils.kt$ItemUtils$"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTM4MDcxNzIxY2M1YjRjZDQwNmNlNDMxYTEzZjg2MDgzYTg5NzNlMTA2NGQyZjg4OTc4Njk5MzBlZTZlNTIzNyJ9fX0="</ID>
-        <ID>MaxLineLength:ItemUtils.kt$ItemUtils$"eyJ0aW1lc3RhbXAiOjE2MzU5NTczOTM4MDMsInByb2ZpbGVJZCI6ImJiN2NjYTcxMDQzNDQ0MTI4ZDMwODllMTNiZGZhYjU5IiwicHJvZmlsZU5hbWUiOiJsYXVyZW5jaW8zMDMiLCJzaWduYXR1cmVSZXF1aXJlZCI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2M5Yjc3OTk5ZmVkM2EyNzU4YmZlYWYwNzkzZTUyMjgzODE3YmVhNjQwNDRiZjQzZWYyOTQzM2Y5NTRiYjUyZjYiLCJtZXRhZGF0YSI6eyJtb2RlbCI6InNsaW0ifX19fQo="</ID>
-        <ID>MemberNameEqualsClassName:CaptureFarmingGear.kt$CaptureFarmingGear$fun captureFarmingGear()</ID>
-        <ID>MemberNameEqualsClassName:FirstMinionTier.kt$FirstMinionTier$fun firstMinionTier( otherItems: Map&lt;NeuInternalName, Int&gt;, minions: MutableMap&lt;String, NeuInternalName&gt;, tierOneMinions: MutableList&lt;NeuInternalName&gt;, tierOneMinionsDone: MutableSet&lt;NeuInternalName&gt;, )</ID>
-        <ID>MemberNameEqualsClassName:LastServers.kt$LastServers$private val lastServers = mutableMapOf&lt;String, SimpleTimeMark&gt;()</ID>
-        <ID>MemberNameEqualsClassName:Shimmy.kt$Shimmy.Companion$private fun shimmy(source: Any?, fieldName: String): Any?</ID>
-        <ID>MemberNameEqualsClassName:TestBingo.kt$TestBingo$var testBingo = false</ID>
-        <ID>NoNameShadowing:ContributorManager.kt$ContributorManager${ it.isAllowed() }</ID>
-        <ID>NoNameShadowing:Graph.kt$Graph.Companion${ out.name("Name").value(it) }</ID>
-        <ID>NoNameShadowing:Graph.kt$Graph.Companion${ out.name("Tags") out.beginArray() for (tagName in it) { out.value(tagName) } out.endArray() }</ID>
-        <ID>NoNameShadowing:HoppityCollectionStats.kt$HoppityCollectionStats${ val displayAmount = it.amount.shortFormat() val operationFormat = when (milestoneType) { HoppityEggType.CHOCOLATE_SHOP_MILESTONE -&gt; "spending" HoppityEggType.CHOCOLATE_FACTORY_MILESTONE -&gt; "reaching" else -&gt; "" // Never happens } // List indexing is weird existingLore[replaceIndex - 1] = "§7Obtained by $operationFormat §6$displayAmount" existingLore[replaceIndex] = "§7all-time §6Chocolate." return existingLore }</ID>
-        <ID>NoNameShadowing:RenderableUtils.kt$RenderableUtils${ it != null }</ID>
-        <ID>NoNameShadowing:ReplaceRomanNumerals.kt$ReplaceRomanNumerals${ it.isValidRomanNumeral() &amp;&amp; it.removeFormatting().romanToDecimal() != 2000 }</ID>
-        <ID>NoNameShadowing:RepoPatternManager.kt$RepoPatternManager${ it == '.' }</ID>
-        <ID>NoNameShadowing:Shimmy.kt$Shimmy.Companion$source</ID>
-        <ID>RepoPatternRegexTestMissing:AshfangFreezeCooldown.kt$AshfangFreezeCooldown$by RepoPattern.pattern( "ashfang.freeze.cryogenic", "§cAshfang Follower's Cryogenic Blast hit you for .* damage!", )</ID>
-        <ID>RepoPatternRegexTestMissing:BazaarCancelledBuyOrderClipboard.kt$BazaarCancelledBuyOrderClipboard$by patternGroup.pattern( "cancelledmessage", "§6\\[Bazaar] §r§7§r§cCancelled! §r§7Refunded §r§6(?&lt;coins&gt;.*) coins §r§7from cancelling Buy Order!", )</ID>
-        <ID>RepoPatternRegexTestMissing:BeaconPower.kt$BeaconPower$by group.pattern( "stat", "§7Current Stat: (?&lt;stat&gt;.+)", )</ID>
-        <ID>RepoPatternRegexTestMissing:BeaconPower.kt$BeaconPower$by group.pattern( "time", "§7Power Remaining: §e(?&lt;time&gt;.+)", )</ID>
-        <ID>RepoPatternRegexTestMissing:BingoCardReader.kt$BingoCardReader$by patternGroup.pattern( "goalcomplete", "§6§lBINGO GOAL COMPLETE! §r§e(?&lt;name&gt;.*)" )</ID>
-        <ID>RepoPatternRegexTestMissing:BingoCardReader.kt$BingoCardReader$by patternGroup.pattern( "hiddengoal", ".*§7§eThe next hint will unlock in (?&lt;time&gt;.*)" )</ID>
-        <ID>RepoPatternRegexTestMissing:BingoCardReader.kt$BingoCardReader$by patternGroup.pattern( "percentage", " {2}§8Top §.(?&lt;percentage&gt;.*)%" )</ID>
-        <ID>RepoPatternRegexTestMissing:BingoCardTips.kt$BingoCardTips$by patternGroup.pattern( "reward.contribution", "(?:§.)+Contribution Rewards.*", )</ID>
-        <ID>RepoPatternRegexTestMissing:BingoNextStepHelper.kt$BingoNextStepHelper$by patternGroup.pattern( "crystal.found", " *§r§5§l✦ CRYSTAL FOUND §r§7\\(.§r§7/5§r§7\\)", )</ID>
-        <ID>RepoPatternRegexTestMissing:BingoNextStepHelper.kt$BingoNextStepHelper$by patternGroup.pattern( "crystal.obtain", "Obtain a (?&lt;name&gt;\\w+) Crystal in the Crystal Hollows\\.", )</ID>
-        <ID>RepoPatternRegexTestMissing:BingoNextStepHelper.kt$BingoNextStepHelper$by patternGroup.pattern( "crystal.obtained", " *§r§e(?&lt;crystalName&gt;Topaz|Sapphire|Jade|Amethyst|Amber) Crystal", )</ID>
-        <ID>RepoPatternRegexTestMissing:BlazeSlayerDaggerHelper.kt$BlazeSlayerDaggerHelper$by RepoPattern.pattern( "slayer.blaze.dagger.attunement", "§cStrike using the §r.+ §r§cattunement on your dagger!" )</ID>
-        <ID>RepoPatternRegexTestMissing:CaptureFarmingGear.kt$CaptureFarmingGear$by patternGroup.pattern( "anitabuff", "You tiered up the Extra Farming Drops upgrade to [+](?&lt;level&gt;.*)%!", )</ID>
-        <ID>RepoPatternRegexTestMissing:CaptureFarmingGear.kt$CaptureFarmingGear$by patternGroup.pattern( "fortuneupgrade", "You claimed the Garden Farming Fortune (?&lt;level&gt;.*) upgrade!", )</ID>
-        <ID>RepoPatternRegexTestMissing:CaptureFarmingGear.kt$CaptureFarmingGear$by patternGroup.pattern( "lotusupgrade", "Lotus (?&lt;piece&gt;.*) upgraded to [+].*☘!", )</ID>
-        <ID>RepoPatternRegexTestMissing:CarryTracker.kt$CarryTracker$by patternGroup.pattern( "trade.coins.gained", " §r§a§l\\+ §r§6(?&lt;coins&gt;.*) coins", )</ID>
-        <ID>RepoPatternRegexTestMissing:CarryTracker.kt$CarryTracker$by patternGroup.pattern( "trade.completed", "§6Trade completed with (?&lt;name&gt;.*)§r§6!", )</ID>
-        <ID>RepoPatternRegexTestMissing:ChatFilter.kt$ChatFilter$by RepoPattern.pattern( "chat.firesale", "§6§k§lA§r §c§lFIRE SALE §r§6§k§lA(?:\\n|.)*", )</ID>
-        <ID>RepoPatternRegexTestMissing:CityProjectFeatures.kt$CityProjectFeatures$by patternGroup.pattern( "completed", "§aProject is (?:being built|released)!", )</ID>
-        <ID>RepoPatternRegexTestMissing:CityProjectFeatures.kt$CityProjectFeatures$by patternGroup.pattern( "contribute", "§7Contribute again: §e(?&lt;time&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:CompactBingoChat.kt$CompactBingoChat$by patternGroup.pattern( "border", "§[e3]§l▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬" )</ID>
-        <ID>RepoPatternRegexTestMissing:CompactBingoChat.kt$CompactBingoChat$by patternGroup.pattern( "health", " {3}§r§7§8\\+§a.* §c❤ Health" )</ID>
-        <ID>RepoPatternRegexTestMissing:CompactBingoChat.kt$CompactBingoChat$by patternGroup.pattern( "strength", " {3}§r§7§8\\+§a. §c❁ Strength" )</ID>
-        <ID>RepoPatternRegexTestMissing:CroesusChestTracker.kt$CroesusChestTracker$by patternGroup.pattern("chest.master", ".*Master.*")</ID>
-        <ID>RepoPatternRegexTestMissing:DianaProfitTracker.kt$DianaProfitTracker$by patternGroup.pattern( "burrow.dug", "(?:§eYou dug out a Griffin Burrow!|§eYou finished the Griffin burrow chain!) .*", )</ID>
-        <ID>RepoPatternRegexTestMissing:DianaProfitTracker.kt$DianaProfitTracker$by patternGroup.pattern( "coins", "§6§lWow! §r§eYou dug out §r§6(?&lt;coins&gt;.*) coins§r§e!", )</ID>
-        <ID>RepoPatternRegexTestMissing:DicerRngDropTracker.kt$DicerRngDropTracker$by melonPatternGroup.pattern( "crazyrare", "§d§lCRAZY RARE DROP! §r§eDicer dropped §r§[a|9]\\d+x §r§[a|9]Enchanted Melon(?: Block| Slice)?§r§e!", )</ID>
-        <ID>RepoPatternRegexTestMissing:DicerRngDropTracker.kt$DicerRngDropTracker$by melonPatternGroup.pattern( "rare", "§9§lRARE DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Melon Slice§r§e!", )</ID>
-        <ID>RepoPatternRegexTestMissing:DicerRngDropTracker.kt$DicerRngDropTracker$by melonPatternGroup.pattern( "rngesus", "§5§lPRAY TO RNGESUS DROP! §r§eDicer dropped §r§9\\d+x §r§9Enchanted Melon§r§e!", )</ID>
-        <ID>RepoPatternRegexTestMissing:DicerRngDropTracker.kt$DicerRngDropTracker$by melonPatternGroup.pattern( "uncommon", "§a§lUNCOMMON DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Melon Slice§r§e!", )</ID>
-        <ID>RepoPatternRegexTestMissing:DicerRngDropTracker.kt$DicerRngDropTracker$by pumpkinPatternGroup.pattern( "crazyrare", "§d§lCRAZY RARE DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Pumpkin§r§e!", )</ID>
-        <ID>RepoPatternRegexTestMissing:DicerRngDropTracker.kt$DicerRngDropTracker$by pumpkinPatternGroup.pattern( "rare", "§9§lRARE DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Pumpkin§r§e!", )</ID>
-        <ID>RepoPatternRegexTestMissing:DicerRngDropTracker.kt$DicerRngDropTracker$by pumpkinPatternGroup.pattern( "rngesus", "§5§lPRAY TO RNGESUS DROP! §r§eDicer dropped §r§[a|9]\\d+x §r§(?:aEnchanted|9Polished) Pumpkin§r§e!", )</ID>
-        <ID>RepoPatternRegexTestMissing:DicerRngDropTracker.kt$DicerRngDropTracker$by pumpkinPatternGroup.pattern( "uncommon", "§a§lUNCOMMON DROP! §r§eDicer dropped §r§a\\d+x §r§aEnchanted Pumpkin§r§e!", )</ID>
-        <ID>RepoPatternRegexTestMissing:DojoRankDisplay.kt$DojoRankDisplay$by patternGroup.pattern( "name", "(?&lt;color&gt;§\\w)Test of (?&lt;name&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:DojoRankDisplay.kt$DojoRankDisplay$by patternGroup.pattern( "rank", "(?:§\\w)+Your Rank: (?&lt;rank&gt;§\\w.) §8\\((?&lt;score&gt;\\d+)\\)", )</ID>
-        <ID>RepoPatternRegexTestMissing:DungeonArchitectFeatures.kt$DungeonArchitectFeatures$by patternGroup.pattern( "puzzle.fail.normal", "(?:§c§lPUZZLE FAIL!|§4) §.§.(?&lt;name&gt;\\S*) .*", )</ID>
-        <ID>RepoPatternRegexTestMissing:DungeonArchitectFeatures.kt$DungeonArchitectFeatures$by patternGroup.pattern( "puzzle.fail.quiz", "§4\\[STATUE] Oruo the Omniscient§r§f: (?:§.)*(?&lt;name&gt;\\S*) (?:§.)*chose the wrong .*", )</ID>
-        <ID>RepoPatternRegexTestMissing:DungeonCopilot.kt$DungeonCopilot$by patternGroup.pattern( "countdown", ".* has started the dungeon countdown. The dungeon will begin in 1 minute.", )</ID>
-        <ID>RepoPatternRegexTestMissing:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "nonpug", "(?i).*(?:PERM|VC|DISCORD).*", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingContestApi.kt$FarmingContestApi$by patternGroup.pattern( "crop", "§8(?&lt;crop&gt;.*) Contest", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingContestApi.kt$FarmingContestApi$by patternGroup.pattern( "sidebarcrop", "\\s*(?:§e○|§6☘) §f(?&lt;crop&gt;.*) §a.*", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingContestApi.kt$FarmingContestApi$by patternGroup.pattern( "time", "§a(?&lt;month&gt;.*) (?&lt;day&gt;.*)(?:rd|st|nd|th), Year (?&lt;year&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "armorability", "Tiered Bonus: .* [(](?&lt;pieces&gt;.*)/4[)]", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "armorabilityfortune", "§7.*§7Grants §6(?&lt;bonus&gt;.*)☘.*", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "collection", "§7You have §6\\+(?&lt;ff&gt;\\d{1,3})☘ .*", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "lotusability", "§7Piece Bonus: §6+(?&lt;bonus&gt;.*)☘", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "tablist.cropspecific", " (?&lt;crop&gt;Wheat|Carrot|Potato|Pumpkin|Sugar Cane|Melon Slice|Cactus|Cocoa Beans|Mushroom|Nether Wart) Fortune: §r§6☘(?&lt;fortune&gt;\\d+)", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "tablist.universal", " Farming Fortune: §r§6☘(?&lt;fortune&gt;\\d+)", )</ID>
-        <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "tooltip.new", "^§7Farming Fortune: §6\\+(?&lt;display&gt;[\\d.]+)(?: §2\\(\\+\\d\\))?(?: §9\\(\\+(?&lt;reforge&gt;\\d+)\\))?(?: §d\\(\\+(?&lt;gemstone&gt;\\d+)\\))?\$", )</ID>
-        <ID>RepoPatternRegexTestMissing:GardenCropMilestoneFix.kt$GardenCropMilestoneFix$by patternGroup.pattern( "levelup", " {2}§r§b§lGARDEN MILESTONE §3(?&lt;crop&gt;.*) §8.*➜§3(?&lt;tier&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:GardenLevelDisplay.kt$GardenLevelDisplay$by patternGroup.pattern( "inventory.overflow", ".*§r §6(?&lt;overflow&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:GlacitePowderFeatures.kt$GlacitePowderFeatures$by patternGroup.pattern( "glacitepowder", "Glacite Powder x(?&lt;amount&gt;.*)" )</ID>
-        <ID>RepoPatternRegexTestMissing:HalloweenBasketWaypoints.kt$HalloweenBasketWaypoints$by patternGroup.pattern( "basket", "^(?:(?:§.)+You found a Candy Basket! (?:(?:§.)+\\((?:§.)+(?&lt;current&gt;\\d+)(?:§.)+/(?:§.)+(?&lt;max&gt;\\d+)(?:§.)+\\))?|(?:§.)+You already found this Candy Basket!)\$", )</ID>
-        <ID>RepoPatternRegexTestMissing:HalloweenBasketWaypoints.kt$HalloweenBasketWaypoints$by patternGroup.pattern( "main.scoreboard.basket", "^Baskets Found: §a\\d+§f/§a\\d+\$", )</ID>
-        <ID>RepoPatternRegexTestMissing:HalloweenBasketWaypoints.kt$HalloweenBasketWaypoints$by patternGroup.pattern( "main.scoreboard.halloween", "^§6Halloween \\d+$", )</ID>
-        <ID>RepoPatternRegexTestMissing:HighlightPlaceableNpcs.kt$HighlightPlaceableNpcs$by patternGroup.pattern( "location", "§7Location: §f\\[§e\\d+§f, §e\\d+§f, §e\\d+§f]", )</ID>
-        <ID>RepoPatternRegexTestMissing:HotmData.kt$HotmData.Companion$by patternGroup.pattern( "mayhem", "§b§lMAYHEM! §r§7(?&lt;perk&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:HypixelData.kt$HypixelData$by patternGroup.pattern( "lobbytype", "(?&lt;lobbyType&gt;.*lobby)\\d+", )</ID>
-        <ID>RepoPatternRegexTestMissing:HypixelData.kt$HypixelData$by patternGroup.pattern( "servername.connection", "(?&lt;prefix&gt;.+\\.)?hypixel\\.net", )</ID>
-        <ID>RepoPatternRegexTestMissing:ItemAbilityCooldown.kt$ItemAbilityCooldown$by patternGroup.pattern( "alignedother", "§eYou aligned §r§a.* §r§eother players?!", )</ID>
-        <ID>RepoPatternRegexTestMissing:ItemAbilityCooldown.kt$ItemAbilityCooldown$by patternGroup.pattern( "buffedyourself", "§aYou buffed yourself for §r§c\\+\\d+❁ Strength", )</ID>
-        <ID>RepoPatternRegexTestMissing:ItemAddManager.kt$ItemAddManager$by RepoPattern.pattern( "data.itemmanager.diceroll", "§eYour §r§(?:5|6High Class )Archfiend Dice §r§erolled a §r§.(?&lt;number&gt;.)§r§e! Bonus: §r§.(?&lt;hearts&gt;.*)❤", )</ID>
-        <ID>RepoPatternRegexTestMissing:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$by patternGroup.pattern( "bestiarystack", "§7Progress to Tier (?&lt;tier&gt;[\\dIVXC]+): §b[\\d.]+%", )</ID>
-        <ID>RepoPatternRegexTestMissing:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$by patternGroup.pattern( "bingogoalrank", "(?:§.)*You were the (?:§.)*(?&lt;rank&gt;\\w+)(?&lt;ordinal&gt;st|nd|rd|th) (?:§.)*to", )</ID>
-        <ID>RepoPatternRegexTestMissing:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$by patternGroup.pattern( "harvest", "§7§7You may harvest §6(?&lt;amount&gt;.).*", )</ID>
-        <ID>RepoPatternRegexTestMissing:KuudraApi.kt$KuudraApi$by patternGroup.pattern( "chat.complete", "§.\\s*(?:§.)*KUUDRA DOWN!", )</ID>
-        <ID>RepoPatternRegexTestMissing:MaxPurseItems.kt$MaxPurseItems$by patternGroup.pattern( "instant", ".*Price per unit: §6(?&lt;coins&gt;[\\d.,]+) coins.*", )</ID>
-        <ID>RepoPatternRegexTestMissing:MaxPurseItems.kt$MaxPurseItems$by patternGroup.pattern( "order", ".*§6(?&lt;coins&gt;[\\d.,]+) coins §7each.*", )</ID>
-        <ID>RepoPatternRegexTestMissing:MaxwellApi.kt$MaxwellApi$by patternGroup.pattern( "gui.noselectedpower", "(?:§.)*Visit Maxwell in the Hub to learn", )</ID>
-        <ID>RepoPatternRegexTestMissing:MaxwellApi.kt$MaxwellApi$by patternGroup.pattern( "gui.thaumaturgy.data", "§(?&lt;color&gt;.)\\+(?&lt;amount&gt;[^ ]+)(?&lt;icon&gt;.) (?&lt;name&gt;.+)", )</ID>
-        <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "filter.dojo", "^(?:(?&lt;points&gt;\\d+) pts|(?&lt;empty&gt;\\w+))$", )</ID>
-        <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "filter.summon", "^(?&lt;owner&gt;\\w+)'s (?&lt;name&gt;.*) \\d+.*", )</ID>
-        <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.dungeon.woke.golem", "(?:§c§lWoke|§5§lSleeping) Golem§r", )</ID>
-        <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.heavypearl.collect", "§.§lCOLLECT!", )</ID>
-        <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.jerry.magma.cube", "§c(?:Cubie|Maggie|Cubert|Cübe|Cubette|Magmalene|Lucky 7|8ball|Mega Cube|Super Cube)(?: ᛤ)? §a\\d+§8\\/§a\\d+§c❤", )</ID>
-        <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.petcare", "^\\[\\w+ (?&lt;level&gt;\\d+)\\] (?&lt;name&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.summon.owner", ".*Spawned by: (?&lt;name&gt;.*).*", )</ID>
-        <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern("displaynpc.name", "[a-z0-9]{10}")</ID>
-        <ID>RepoPatternRegexTestMissing:NewYearCakeReminder.kt$NewYearCakeReminder$by RepoPattern.pattern( "event.winter.newyearcake.reminder.sidebar", "§dNew Year Event!§f (?&lt;time&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:PartyApi.kt$PartyApi$by patternGroup.pattern( "kuudrafinder.join", "§dParty Finder §f&gt; (?&lt;name&gt;.*?) §ejoined the group! \\(§[a-fA-F0-9]+Combat Level \\d+§e\\)", )</ID>
-        <ID>RepoPatternRegexTestMissing:PestApi.kt$PestApi$by patternGroup.pattern( "inventory", "§4§lൠ §cThis plot has §6(?&lt;amount&gt;\\d) Pests?§c!", )</ID>
-        <ID>RepoPatternRegexTestMissing:PestApi.kt$PestApi$by patternGroup.pattern( "scoreboard.pests", " §7⏣ §[ac]The Garden §4§lൠ§7 x(?&lt;pests&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:PowderTracker.kt$PowderTracker$by patternGroup.pattern( "powder.bossbar", "§e§lPASSIVE EVENT §b§l2X POWDER §e§lRUNNING FOR §a§l(?&lt;time&gt;.*)§r", )</ID>
-        <ID>RepoPatternRegexTestMissing:PowderTracker.kt$PowderTracker$by patternGroup.pattern( "powder.ended", ".*§r§b§l2X POWDER ENDED!.*", )</ID>
-        <ID>RepoPatternRegexTestMissing:PowderTracker.kt$PowderTracker$by patternGroup.pattern( "powder.started", ".*§r§b§l2X POWDER STARTED!.*", )</ID>
-        <ID>RepoPatternRegexTestMissing:PresentWaypoints.kt$PresentWaypoints$by patternGroup.pattern( "found", "§aYou found a.*present! §r§e\\(§r§b\\d+§r§e/§r§b\\d+§r§e\\)", )</ID>
-        <ID>RepoPatternRegexTestMissing:QuiverApi.kt$QuiverApi$by chatGroup.pattern( "addedtoquiver", "(?:§.)*You've added (?:§.)*(?&lt;type&gt;.*) x(?&lt;amount&gt;.*) (?:§.)*to your quiver!", )</ID>
-        <ID>RepoPatternRegexTestMissing:QuiverApi.kt$QuiverApi$by chatGroup.pattern( "cleared", "§aCleared your quiver!|§c§lYour quiver is now completely empty!", )</ID>
-        <ID>RepoPatternRegexTestMissing:RestorePieceOfWizardPortalLore.kt$RestorePieceOfWizardPortalLore$by RepoPattern.pattern( "misc.restore.wizard.portal.earned", "§7Earned by:.*" )</ID>
-        <ID>RepoPatternRegexTestMissing:ScoreboardPattern.kt$ScoreboardPattern$by dungeonSB.pattern( "cleared", "(?:§.)*Cleared: (?:§.)*(?&lt;percent&gt;[\\w,.]+)% (?:§.)*\\((?:§.)*(?&lt;score&gt;[\\w,.]+)(?:§.)*\\)", )</ID>
-        <ID>RepoPatternRegexTestMissing:ScoreboardPattern.kt$ScoreboardPattern$by dungeonSB.pattern( "keys", "Keys: §.■ §.[✗✓] §.■ §a.x", )</ID>
-        <ID>RepoPatternRegexTestMissing:ShowMotesNpcSellPrice.kt$ShowMotesNpcSellPrice$by RepoPattern.pattern( "rift.everywhere.burger", ".*(?:§\\w)+You have (?:§\\w)+(?&lt;amount&gt;\\d) Grubber Stacks.*", )</ID>
-        <ID>RepoPatternRegexTestMissing:SkillExperience.kt$SkillExperience$by patternGroup.pattern( "actionbar", ".*§3\\+.* (?&lt;skill&gt;.*) \\((?&lt;overflow&gt;.*)/(?&lt;needed&gt;.*)\\).*" )</ID>
-        <ID>RepoPatternRegexTestMissing:SkillExperience.kt$SkillExperience$by patternGroup.pattern( "inventory", ".* §e(?&lt;number&gt;.*)§6/.*" )</ID>
-        <ID>RepoPatternRegexTestMissing:SlayerBossSpawnSoon.kt$SlayerBossSpawnSoon$by RepoPattern.pattern( "slayer.bosswarning.progress", " \\(?(?&lt;progress&gt;[0-9.,k]+)/(?&lt;total&gt;[0-9.,k]+)\\)?.*" )</ID>
-        <ID>RepoPatternRegexTestMissing:SlayerRngMeterDisplay.kt$SlayerRngMeterDisplay$by patternGroup.pattern( "changeditem", "§aYou set your §r.* RNG Meter §r§ato drop §r.*§a!", )</ID>
-        <ID>RepoPatternRegexTestMissing:SlayerRngMeterDisplay.kt$SlayerRngMeterDisplay$by patternGroup.pattern( "inventoryname", "(?&lt;name&gt;.*) RNG Meter", )</ID>
-        <ID>RepoPatternRegexTestMissing:SlayerRngMeterDisplay.kt$SlayerRngMeterDisplay$by patternGroup.pattern( "update", " {3}§dRNG Meter §f- §d(?&lt;exp&gt;.*) Stored XP", )</ID>
-        <ID>RepoPatternRegexTestMissing:SprayFeatures.kt$SprayFeatures$by RepoPattern.pattern( "garden.spray.material", "§a§lSPRAYONATOR! §r§7Your selected material is now §r§a(?&lt;spray&gt;.*)§r§7!", )</ID>
-        <ID>RepoPatternRegexTestMissing:TabListReader.kt$TabListReader$by patternGroup.pattern( "upgrades", "(?&lt;firstPart&gt;§e[A-Za-z ]+)(?&lt;secondPart&gt; §f[\\w ]+)" )</ID>
-        <ID>RepoPatternRegexTestMissing:TabListReader.kt$TabListReader$by patternGroup.pattern( "winterpowerups", "Active Power Ups(?:§.)*(?:\\n(?:§.)*§7.+)*" )</ID>
-        <ID>RepoPatternRegexTestMissing:TabListRenderer.kt$TabListRenderer$by RepoPattern.pattern( "tablist.firesaletitle", "§.§lFire Sales: §r§f\\([0-9]+\\)", )</ID>
-        <ID>RepoPatternRegexTestMissing:TeleportPadInventoryNumber.kt$TeleportPadInventoryNumber$by RepoPattern.pattern( "misc.teleportpad.number", "§.(?&lt;number&gt;.*) teleport pad" )</ID>
-        <ID>RepoPatternRegexTestMissing:TerracottaPhase.kt$TerracottaPhase$by patternGroup.pattern( "start", "§c\\[BOSS] Sadan§r§f: So you made it all the way here... Now you wish to defy me\\? Sadan\\?!", )</ID>
-        <ID>RepoPatternRegexTestMissing:TestCopyBestiaryValues.kt$TestCopyBestiaryValues$by RepoPattern.pattern( "test.bestiary.type", "\\[Lv(?&lt;lvl&gt;.*)] (?&lt;text&gt;.*)" )</ID>
-        <ID>RepoPatternRegexTestMissing:TotemOfCorruption.kt$TotemOfCorruption$by patternGroup.pattern( "owner", "§7Owner: §e(?&lt;owner&gt;.+)" )</ID>
-        <ID>RepoPatternRegexTestMissing:TotemOfCorruption.kt$TotemOfCorruption$by patternGroup.pattern( "timeremaining", "§7Remaining: §e(?:(?&lt;min&gt;\\d+)m )?(?&lt;sec&gt;\\d+)s" )</ID>
-        <ID>RepoPatternRegexTestMissing:TunnelsMaps.kt$TunnelsMaps$by RepoPattern.pattern( "mining.commisson.collector.invalid", "Glacite|Scrap", )</ID>
-        <ID>RepoPatternRegexTestMissing:TunnelsMaps.kt$TunnelsMaps$by RepoPattern.pattern( "mining.tunnels.maps.gem.new", ".*(?:Aquamarine|Onyx|Citrine|Peridot).*", )</ID>
-        <ID>RepoPatternRegexTestMissing:TunnelsMaps.kt$TunnelsMaps$by RepoPattern.pattern( "mining.tunnels.maps.gem.old", ".*(?:Ruby|Amethyst|Jade|Sapphire|Amber|Topaz).*", )</ID>
-        <ID>RepoPatternRegexTestMissing:UniqueGiftCounter.kt$UniqueGiftCounter$by RepoPattern.pattern( "event.winter.uniqugifts.counter.amount", "§7Unique Players Gifted: §a(?&lt;amount&gt;.*)", )</ID>
-        <ID>RepoPatternRegexTestMissing:UpgradeReminder.kt$UpgradeReminder$by patternGroup.pattern( "claimed", "§eYou claimed the §r§a(?&lt;upgrade&gt;.+) §r§eupgrade!", )</ID>
-        <ID>RepoPatternRegexTestMissing:UpgradeReminder.kt$UpgradeReminder$by patternGroup.pattern( "duration", "§8Duration: (?&lt;duration&gt;.+)", )</ID>
-        <ID>RepoPatternRegexTestMissing:UpgradeReminder.kt$UpgradeReminder$by patternGroup.pattern( "started", "§eYou started the §r§a(?&lt;upgrade&gt;.+) §r§eupgrade!", )</ID>
-        <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by RepoPattern.pattern( "string.isroman", "^M{0,3}(?:CM|CD|D?C{0,3})(?:XC|XL|L?X{0,3})(?:IX|IV|V?I{0,3})", )</ID>
-        <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "item.amount.behind", "(?&lt;name&gt;(?:§.)*(?:[^§] ?)+)(?:§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
-        <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "item.name.potion", ".*Potion", )</ID>
-        <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "item.neuitems.enchantmentname", "^(?&lt;format&gt;(?:§.)*)(?&lt;name&gt;[^§]+) (?&lt;level&gt;[IVXL]+)(?: Book)?$", )</ID>
-        <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "string.playerchat", "(?&lt;important&gt;.*?)(?:§[f7r])*: .*", )</ID>
-        <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "time.amount", "(?:(?&lt;y&gt;\\d+) ?y(?:\\w* ?)?)?(?:(?&lt;d&gt;\\d+) ?d(?:\\w* ?)?)?(?:(?&lt;h&gt;\\d+) ?h(?:\\w* ?)?)?(?:(?&lt;m&gt;\\d+) ?m(?:\\w* ?)?)?(?:(?&lt;s&gt;\\d+) ?s(?:\\w* ?)?)?", )</ID>
-        <ID>RepoPatternRegexTestMissing:VisitorListener.kt$VisitorListener$by RepoPattern.pattern( "garden.visitor.offersaccepted", "§7Offers Accepted: §a(?&lt;offersAccepted&gt;\\d+)", )</ID>
-        <ID>ReturnCount:ArachneChatMessageHider.kt$ArachneChatMessageHider$private fun shouldHide(message: String): Boolean</ID>
-        <ID>ReturnCount:BingoNextStepHelper.kt$BingoNextStepHelper$private fun readDescription(description: String): NextStep?</ID>
-        <ID>ReturnCount:BroodmotherFeatures.kt$BroodmotherFeatures$private fun onStageUpdate()</ID>
-        <ID>ReturnCount:ChatPeek.kt$ChatPeek$@JvmStatic fun peek(): Boolean</ID>
-        <ID>ReturnCount:CompactBingoChat.kt$CompactBingoChat$private fun onSkyBlockLevelUp(message: String): Boolean</ID>
-        <ID>ReturnCount:CrimsonMinibossRespawnTimer.kt$CrimsonMinibossRespawnTimer$private fun updateArea()</ID>
-        <ID>ReturnCount:EnchantParser.kt$EnchantParser$private fun parseEnchants( loreList: MutableList&lt;String&gt;, enchants: Map&lt;String, Int&gt;, chatComponent: IChatComponent?, )</ID>
-        <ID>ReturnCount:EnoughUpdatesManager.kt$EnoughUpdatesManager$private fun getPetLoreReplacements(petName: String?, tier: String?, level: Int): Map&lt;String, String&gt;</ID>
-        <ID>ReturnCount:GardenVisitorFeatures.kt$GardenVisitorFeatures$private fun showGui(): Boolean</ID>
-        <ID>ReturnCount:GraphEditor.kt$GraphEditor$private fun input()</ID>
-        <ID>ReturnCount:GraphParkour.kt$GraphParkour$private fun graphToList(graph: Graph): List&lt;LorenzVec&gt;?</ID>
-        <ID>ReturnCount:HideNotClickableItems.kt$HideNotClickableItems$private fun hideSalvage(chestName: String, stack: ItemStack): Boolean</ID>
-        <ID>ReturnCount:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$private fun getStackTip(item: ItemStack): String?</ID>
-        <ID>ReturnCount:ItemPriceUtils.kt$ItemPriceUtils$fun NeuInternalName.getPriceOrNull( priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_BUY, pastRecipes: List&lt;PrimitiveRecipe&gt; = emptyList(), ): Double?</ID>
-        <ID>ReturnCount:ItemResolutionQuery.kt$ItemResolutionQuery$private fun resolveContextualName(): String?</ID>
-        <ID>ReturnCount:MinecraftConsoleFilter.kt$MinecraftConsoleFilter$override fun filter(event: LogEvent?): Filter.Result</ID>
-        <ID>ReturnCount:MiningEventTracker.kt$MiningEventTracker$private fun sendData(eventName: String, time: String?)</ID>
-        <ID>ReturnCount:MobDetection.kt$MobDetection$private fun entitySpawn(entity: EntityLivingBase, roughType: Mob.Type): Boolean</ID>
-        <ID>ReturnCount:MobFilter.kt$MobFilter$internal fun createSkyblockEntity(baseEntity: EntityLivingBase): MobResult</ID>
-        <ID>ReturnCount:MobFilter.kt$MobFilter$private fun armorStandOnlyMobs(baseEntity: EntityLivingBase, armorStand: EntityArmorStand): MobResult?</ID>
-        <ID>ReturnCount:MobFilter.kt$MobFilter$private fun exceptions(baseEntity: EntityLivingBase, nextEntity: EntityLivingBase?): MobResult?</ID>
-        <ID>ReturnCount:MultiFilter.kt$MultiFilter$fun matchResult(string: String): String?</ID>
-        <ID>ReturnCount:PacketTest.kt$PacketTest$private fun Packet&lt;*&gt;.print()</ID>
-        <ID>ReturnCount:PowderMiningChatFilter.kt$PowderMiningChatFilter$@Suppress("CyclomaticComplexMethod") fun block(message: String): String?</ID>
-        <ID>ReturnCount:PurseApi.kt$PurseApi$private fun getCause(diff: Double): PurseChangeCause</ID>
-        <ID>ReturnCount:QuestLoader.kt$QuestLoader$private fun addQuest(name: String, state: QuestState, needAmount: Int): Quest</ID>
-        <ID>ReturnCount:SkyHanniConfigSearchResetCommand.kt$SkyHanniConfigSearchResetCommand$private suspend fun setCommand(args: Array&lt;String&gt;): String</ID>
-        <ID>SpreadOperator:ItemUtils.kt$ItemUtils$(tag, displayName, *lore.toTypedArray())</ID>
-        <ID>SpreadOperator:LimboPlaytime.kt$LimboPlaytime$( itemID.getItemStack().item, ITEM_NAME, *createItemLore() )</ID>
-        <ID>SpreadOperator:TextHelper.kt$TextHelper$(*component.toTypedArray(), separator = separator)</ID>
-        <ID>TooManyFunctions:EstimatedItemValueCalculator.kt$EstimatedItemValueCalculator</ID>
-        <ID>TooManyFunctions:GuiRenderUtils.kt$GuiRenderUtils</ID>
-        <ID>TooManyFunctions:ItemResolutionQuery.kt$ItemResolutionQuery</ID>
-        <ID>TooManyFunctions:MobFinder.kt$MobFinder</ID>
-        <ID>TooManyFunctions:NumberUtil.kt$NumberUtil</ID>
-        <ID>TooManyFunctions:OreBlock.kt$at.hannibal2.skyhanni.features.mining.OreBlock.kt</ID>
-        <ID>TooManyFunctions:RegexUtils.kt$RegexUtils</ID>
-        <ID>TooManyFunctions:SkyHanniBaseScreen.kt$SkyHanniBaseScreen : GuiScreen</ID>
-        <ID>TooManyFunctions:TextCompat.kt$at.hannibal2.skyhanni.utils.compat.TextCompat.kt</ID>
-        <ID>TooManyFunctions:WorldRenderUtils.kt$WorldRenderUtils</ID>
-        <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Double::plus)!!</ID>
-        <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Float::plus)!!</ID>
-        <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Int::plus)!!</ID>
-        <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Long::plus)!!</ID>
-        <ID>UnsafeCallOnNullableType:CompactBestiaryChatMessage.kt$CompactBestiaryChatMessage$it.groups[1]!!</ID>
-        <ID>UnsafeCallOnNullableType:ConfigManager.kt$ConfigManager$file!!</ID>
-        <ID>UnsafeCallOnNullableType:CorpseTracker.kt$CorpseTracker$applicableKeys.first().key!!</ID>
-        <ID>UnsafeCallOnNullableType:CropMoneyDisplay.kt$CropMoneyDisplay$cropNames[internalName]!!</ID>
-        <ID>UnsafeCallOnNullableType:DailyMiniBossHelper.kt$DailyMiniBossHelper$getByDisplayName(name)!!</ID>
-        <ID>UnsafeCallOnNullableType:DamageIndicatorManager.kt$DamageIndicatorManager$data.deathLocation!!</ID>
-        <ID>UnsafeCallOnNullableType:DefaultConfigFeatures.kt$DefaultConfigFeatures$resetSuggestionState[cat]!!</ID>
-        <ID>UnsafeCallOnNullableType:DefaultConfigOptionGui.kt$DefaultConfigOptionGui$resetSuggestionState[cat]!!</ID>
-        <ID>UnsafeCallOnNullableType:DicerRngDropTracker.kt$DicerRngDropTracker$event.toolItem!!</ID>
-        <ID>UnsafeCallOnNullableType:EasterEggWaypoints.kt$EasterEggWaypoints$EasterEgg.entries.minByOrNull { it.waypoint.distanceSqToPlayer() }!!</ID>
-        <ID>UnsafeCallOnNullableType:EntityMovementData.kt$EntityMovementData$entityLocation[entity]!!</ID>
-        <ID>UnsafeCallOnNullableType:EntityOutlineRenderer.kt$EntityOutlineRenderer$entityRenderCache.noXrayCache!!</ID>
-        <ID>UnsafeCallOnNullableType:EntityOutlineRenderer.kt$EntityOutlineRenderer$entityRenderCache.xrayCache!!</ID>
-        <ID>UnsafeCallOnNullableType:EntityOutlineRenderer.kt$EntityOutlineRenderer$frameToCopy!!</ID>
-        <ID>UnsafeCallOnNullableType:EntityOutlineRenderer.kt$EntityOutlineRenderer$frameToPaste!!</ID>
-        <ID>UnsafeCallOnNullableType:EntityOutlineRenderer.kt$EntityOutlineRenderer$isAntialiasing!!</ID>
-        <ID>UnsafeCallOnNullableType:EntityOutlineRenderer.kt$EntityOutlineRenderer$isFastRender!!</ID>
-        <ID>UnsafeCallOnNullableType:EntityOutlineRenderer.kt$EntityOutlineRenderer$isShaders!!</ID>
-        <ID>UnsafeCallOnNullableType:FarmingContestApi.kt$FarmingContestApi$contestCrop!!</ID>
-        <ID>UnsafeCallOnNullableType:FarmingContestApi.kt$FarmingContestApi$contests[bracket]!!</ID>
-        <ID>UnsafeCallOnNullableType:FarmingContestApi.kt$FarmingContestApi$currentCrop!!</ID>
-        <ID>UnsafeCallOnNullableType:FarmingWeightDisplay.kt$FarmingWeightDisplay$weightPerCrop[CropType.CACTUS]!!</ID>
-        <ID>UnsafeCallOnNullableType:FarmingWeightDisplay.kt$FarmingWeightDisplay$weightPerCrop[CropType.SUGAR_CANE]!!</ID>
-        <ID>UnsafeCallOnNullableType:FeatureToggleProcessor.kt$FeatureToggleProcessor$latestCategory!!</ID>
-        <ID>UnsafeCallOnNullableType:FeatureTogglesByDefaultAdapter.kt$FeatureTogglesByDefaultAdapter$gson!!</ID>
-        <ID>UnsafeCallOnNullableType:FortuneUpgrades.kt$FortuneUpgrades$nextTalisman.upgradeCost?.first!!</ID>
-        <ID>UnsafeCallOnNullableType:GardenComposterUpgradesData.kt$GardenComposterUpgradesData$ComposterUpgrade.getByName(name)!!</ID>
-        <ID>UnsafeCallOnNullableType:GardenCropMilestoneDisplay.kt$GardenCropMilestoneDisplay$cultivatingData[crop]!!</ID>
-        <ID>UnsafeCallOnNullableType:GardenCropMilestonesCommunityFix.kt$GardenCropMilestonesCommunityFix$map[crop]!!</ID>
-        <ID>UnsafeCallOnNullableType:GardenPlotIcon.kt$GardenPlotIcon$originalStack[index]!!</ID>
-        <ID>UnsafeCallOnNullableType:Graph.kt$Graph.Companion$position!!</ID>
-        <ID>UnsafeCallOnNullableType:Graph.kt$distances.distances[end]!!</ID>
-        <ID>UnsafeCallOnNullableType:GriffinBurrowHelper.kt$GriffinBurrowHelper$particleBurrows[targetLocation]!!</ID>
-        <ID>UnsafeCallOnNullableType:IslandGraphs.kt$IslandGraphs$currentTarget!!</ID>
-        <ID>UnsafeCallOnNullableType:ItemBlink.kt$ItemBlink$offsets[item]!!</ID>
-        <ID>UnsafeCallOnNullableType:ItemPickupLog.kt$ItemPickupLog$listToCheckAgainst[key]!!</ID>
-        <ID>UnsafeCallOnNullableType:ItemPickupLog.kt$ItemPickupLog$listToCheckAgainst[key]?.second!!</ID>
-        <ID>UnsafeCallOnNullableType:ItemStackTypeAdapterFactory.kt$ItemStackTypeAdapterFactory$gson!!</ID>
-        <ID>UnsafeCallOnNullableType:ItemUtils.kt$ItemUtils$itemAmountCache[input]!!</ID>
-        <ID>UnsafeCallOnNullableType:JacobContestTimeNeeded.kt$JacobContestTimeNeeded$map[crop]!!</ID>
-        <ID>UnsafeCallOnNullableType:KSerializable.kt$KotlinTypeAdapterFactory$param.name!!</ID>
-        <ID>UnsafeCallOnNullableType:MinionFeatures.kt$MinionFeatures$newMinion!!</ID>
-        <ID>UnsafeCallOnNullableType:NavigationHelper.kt$NavigationHelper$distances[node]!!</ID>
-        <ID>UnsafeCallOnNullableType:NumberUtil.kt$NumberUtil$romanSymbols[this]!!</ID>
-        <ID>UnsafeCallOnNullableType:ReminderManager.kt$ReminderManager$storage[args.drop(1).first()]!!</ID>
-        <ID>UnsafeCallOnNullableType:ReminderManager.kt$ReminderManager$storage[args.first()]!!</ID>
-        <ID>UnsafeCallOnNullableType:RenderEntityOutlineEvent.kt$RenderEntityOutlineEvent$entitiesToChooseFrom!!</ID>
-        <ID>UnsafeCallOnNullableType:RenderEntityOutlineEvent.kt$RenderEntityOutlineEvent$entitiesToOutline!!</ID>
-        <ID>UnsafeCallOnNullableType:RenderGlobalHook.kt$RenderGlobalHook$camera!!</ID>
-        <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$match.groups[1]!!</ID>
-        <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$match.groups[2]!!</ID>
-        <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$match.groups[3]!!</ID>
-        <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$oldData!!</ID>
-        <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$distance!!</ID>
-        <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$distance2!!</ID>
-        <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$firstParticlePoint?.distance(pos)!!</ID>
-        <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$lastParticlePoint2!!</ID>
-        <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$lastParticlePoint2?.distance(particlePoint!!)!!</ID>
-        <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$particlePoint!!</ID>
-        <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$particlePoint?.let { it - lastParticlePoint2!! }!!</ID>
-        <ID>UnsafeCallOnNullableType:SuperpairsClicksAlert.kt$SuperpairsClicksAlert$match.groups[1]!!</ID>
-        <ID>UnsafeCallOnNullableType:TiaRelayWaypoints.kt$TiaRelayWaypoints$waypointName!!</ID>
-        <ID>UnsafeCallOnNullableType:Translator.kt$Translator$messageContentRegex.find(message)!!</ID>
-        <ID>UnsafeCallOnNullableType:UpdateManager.kt$UpdateManager$potentialUpdate!!</ID>
-        <ID>UnsafeCallOnNullableType:VisitorRewardWarning.kt$VisitorRewardWarning$visitor.totalPrice!!</ID>
-        <ID>UnsafeCallOnNullableType:VisitorRewardWarning.kt$VisitorRewardWarning$visitor.totalReward!!</ID>
-        <ID>UnsafeCallOnNullableType:WorldRenderUtils.kt$WorldRenderUtils$it.name!!</ID>
-        <ID>UseIsNullOrEmpty:ItemUtils.kt$ItemUtils$name == null || name.isEmpty()</ID>
-        <ID>VarCouldBeVal:GuiScreenUtils.kt$GuiScreenUtils$var x = globalMouseX * scaledWindowWidth / displayWidth</ID>
-        <ID>VarCouldBeVal:GuiScreenUtils.kt$GuiScreenUtils$var y = globalMouseY * height / displayHeight</ID>
-        <ID>VarCouldBeVal:IslandAreas.kt$IslandAreas$var suffix = ""</ID>
-        <ID>VarCouldBeVal:RepoPatternGui.kt$RepoPatternGui$private var searchCache = ObservableList(mutableListOf&lt;RepoPatternInfo&gt;())</ID>
-        <ID>VarCouldBeVal:RepoPatternManager.kt$RepoPatternManager$/** * Map containing all keys and their repo patterns. Used for filling in new regexes after an update, and for * checking duplicate registrations. */ private var usedKeys: NavigableMap&lt;String, CommonPatternInfo&lt;*, *&gt;&gt; = TreeMap()</ID>
-        <ID>VarCouldBeVal:SkyHanniItemTracker.kt$SkyHanniItemTracker$private var scrollValue = ScrollValue()</ID>
-    </CurrentIssues>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>ArrayPrimitive:LorenzVec.kt$Array&lt;Double&gt;</ID>
+    <ID>ArrayPrimitive:LorenzVec.kt$LorenzVec$Array&lt;Double&gt;</ID>
+    <ID>ArrayPrimitive:LorenzVec.kt$LorenzVec$Array&lt;Float&gt;</ID>
+    <ID>ArrayPrimitive:LorenzVec.kt$LorenzVec$arrayOf(x, y, z)</ID>
+    <ID>ArrayPrimitive:LorenzVec.kt$LorenzVec$arrayOf(x.toFloat(), y.toFloat(), z.toFloat())</ID>
+    <ID>ChainWrapping:Renderable.kt$Renderable.Companion$||</ID>
+    <ID>ComplexCondition:TextCompat.kt$chatStyle.isNotEmpty() &amp;&amp; (leadingWhite || (wasFormatted &amp;&amp; (sb.length != 2 || sb[0] != '§' || sb[1] != 'r')) || chatStyle != "§f")</ID>
+    <ID>CustomImportOrdering:Enchant.kt$import at.hannibal2.skyhanni.SkyHanniMod import at.hannibal2.skyhanni.features.chroma.ChromaManager import at.hannibal2.skyhanni.utils.ItemCategory import at.hannibal2.skyhanni.utils.ItemUtils.extraAttributes import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName import at.hannibal2.skyhanni.utils.LorenzColor import at.hannibal2.skyhanni.utils.NumberUtil.roundTo import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat import at.hannibal2.skyhanni.utils.StringUtils.insert import at.hannibal2.skyhanni.utils.StringUtils.removeColor import at.hannibal2.skyhanni.utils.StringUtils.splitCamelCase import at.hannibal2.skyhanni.utils.compat.getDoubleOrDefault import at.hannibal2.skyhanni.utils.compat.withColor import com.google.gson.annotations.Expose import io.github.notenoughupdates.moulconfig.ChromaColour import io.github.notenoughupdates.moulconfig.observer.Property import java.util.TreeSet import net.minecraft.ChatFormatting import net.minecraft.network.chat.Component import net.minecraft.network.chat.Style import net.minecraft.network.chat.TextColor import net.minecraft.world.item.ItemStack</ID>
+    <ID>CustomImportOrdering:EnchantParser.kt$import at.hannibal2.skyhanni.SkyHanniMod import at.hannibal2.skyhanni.api.event.HandleEvent import at.hannibal2.skyhanni.config.features.inventory.EnchantParsingConfig import at.hannibal2.skyhanni.config.features.inventory.EnchantParsingConfig.CommaFormat import at.hannibal2.skyhanni.events.ChatHoverEvent import at.hannibal2.skyhanni.events.ConfigLoadEvent import at.hannibal2.skyhanni.events.RepositoryReloadEvent import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent import at.hannibal2.skyhanni.features.chroma.ChromaManager import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule import at.hannibal2.skyhanni.test.command.ErrorManager import at.hannibal2.skyhanni.utils.ChatUtils import at.hannibal2.skyhanni.utils.ConditionalUtils import at.hannibal2.skyhanni.utils.ItemCategory import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary import at.hannibal2.skyhanni.utils.OtherModsSettings import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getExtraAttributes import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHypixelEnchantments import at.hannibal2.skyhanni.utils.SkyBlockUtils import at.hannibal2.skyhanni.utils.StringUtils.removeColor import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent import at.hannibal2.skyhanni.utils.compat.append import at.hannibal2.skyhanni.utils.compat.createHoverEvent import at.hannibal2.skyhanni.utils.compat.formattedTextCompat import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat import at.hannibal2.skyhanni.utils.compat.withColor import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern import at.hannibal2.skyhanni.utils.system.PlatformUtils import com.mojang.blaze3d.systems.RenderSystem import java.util.TreeSet import net.minecraft.ChatFormatting import net.minecraft.network.chat.Component import net.minecraft.world.item.ItemStack</ID>
+    <ID>CustomImportOrdering:TheGreatSpook.kt$import at.hannibal2.skyhanni.SkyHanniMod import at.hannibal2.skyhanni.api.event.HandleEvent import at.hannibal2.skyhanni.data.jsonobjects.repo.EventsJson import at.hannibal2.skyhanni.data.model.SkyblockStat import at.hannibal2.skyhanni.events.ConfigLoadEvent import at.hannibal2.skyhanni.events.DebugDataCollectEvent import at.hannibal2.skyhanni.events.GuiRenderEvent import at.hannibal2.skyhanni.events.IslandChangeEvent import at.hannibal2.skyhanni.events.RepositoryReloadEvent import at.hannibal2.skyhanni.events.SecondPassedEvent import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule import at.hannibal2.skyhanni.utils.ChatUtils import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange import at.hannibal2.skyhanni.utils.DelayedRun import at.hannibal2.skyhanni.utils.HypixelCommands import at.hannibal2.skyhanni.utils.Calculator import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher import at.hannibal2.skyhanni.utils.RegexUtils.matches import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable import at.hannibal2.skyhanni.utils.RenderUtils.renderString import at.hannibal2.skyhanni.utils.SimpleTimeMark import at.hannibal2.skyhanni.utils.SoundUtils import at.hannibal2.skyhanni.utils.TimeUnit import at.hannibal2.skyhanni.utils.TimeUtils.format import at.hannibal2.skyhanni.utils.collection.CircularList import at.hannibal2.skyhanni.utils.renderables.Renderable import at.hannibal2.skyhanni.utils.renderables.primitives.text import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern import kotlin.time.Duration.Companion.minutes import kotlin.time.Duration.Companion.seconds</ID>
+    <ID>CyclomaticComplexMethod:AdvancedPlayerList.kt$AdvancedPlayerList$fun newSorting(original: List&lt;String&gt;): List&lt;String&gt;</ID>
+    <ID>CyclomaticComplexMethod:BetterContainers.kt$BetterContainers$private fun processChestIndices( handlerInventory: Container, horizontalTexMult: Int, verticalTexMult: Int, bufferedImageNew: BufferedImage )</ID>
+    <ID>CyclomaticComplexMethod:ComponentUtils.kt$ComponentUtils$private fun convertMinecraftIdToModern2(id: String, damage: Int): String</ID>
+    <ID>CyclomaticComplexMethod:CopyNearbyEntitiesCommand.kt$CopyNearbyEntitiesCommand$@OptIn(AllEntitiesGetter::class) private fun buildCommandResult(searchRadius: Int): List&lt;String&gt;</ID>
+    <ID>CyclomaticComplexMethod:DamageIndicatorManager.kt$DamageIndicatorManager$@HandleEvent fun onRenderWorld(event: SkyHanniRenderWorldEvent)</ID>
+    <ID>CyclomaticComplexMethod:DungeonHideItems.kt$DungeonHideItems$@HandleEvent(onlyOnIsland = IslandType.CATACOMBS) fun onCheckRender(event: CheckRenderEntityEvent&lt;Entity&gt;)</ID>
+    <ID>CyclomaticComplexMethod:EnoughUpdatesManager.kt$EnoughUpdatesManager$private fun getPetLoreReplacements(petName: String?, tier: String?, level: Int): Map&lt;String, String&gt;</ID>
+    <ID>CyclomaticComplexMethod:GardenCropMilestoneDisplay.kt$GardenCropMilestoneDisplay$private fun drawProgressDisplay(crop: CropType): List&lt;Renderable&gt;</ID>
+    <ID>CyclomaticComplexMethod:GardenVisitorFeatures.kt$GardenVisitorFeatures$private fun readToolTip(visitor: VisitorApi.Visitor, itemStack: ItemStack?, toolTip: MutableList&lt;String&gt;)</ID>
+    <ID>CyclomaticComplexMethod:GraphEditor.kt$GraphEditor$private fun input()</ID>
+    <ID>CyclomaticComplexMethod:ItemAbilityCooldown.kt$ItemAbilityCooldown$@HandleEvent fun onPlaySound(event: PlaySoundEvent)</ID>
+    <ID>CyclomaticComplexMethod:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$private fun getStackTip(item: ItemStack): String?</ID>
+    <ID>CyclomaticComplexMethod:MinecraftConsoleFilter.kt$MinecraftConsoleFilter$override fun filter(event: LogEvent?): Filter.Result</ID>
+    <ID>CyclomaticComplexMethod:OrderedTextUtils.kt$OrderedTextUtils$fun requiredStyleChangeString(from: Style, to: Style, exclusive: Boolean = false): String</ID>
+    <ID>CyclomaticComplexMethod:PacketTest.kt$PacketTest$private fun Packet&lt;*&gt;.print()</ID>
+    <ID>CyclomaticComplexMethod:SoopyGuessBurrow.kt$SoopyGuessBurrow$@HandleEvent(onlyOnSkyblock = true) fun onReceiveParticle(event: ReceiveParticleEvent)</ID>
+    <ID>CyclomaticComplexMethod:ToolTooltipTweaks.kt$ToolTooltipTweaks$@HandleEvent(onlyOnSkyblock = true) fun onToolTip(event: ToolTipEvent)</ID>
+    <ID>CyclomaticComplexMethod:VampireSlayerFeatures.kt$VampireSlayerFeatures$@HandleEvent fun onRenderWorld(event: SkyHanniRenderWorldEvent)</ID>
+    <ID>CyclomaticComplexMethod:VampireSlayerFeatures.kt$VampireSlayerFeatures$private fun RemotePlayer.process()</ID>
+    <ID>CyclomaticComplexMethod:VisualWordGui.kt$VisualWordGui$override fun onDrawScreen(originalMouseX: Int, originalMouseY: Int, partialTicks: Float)</ID>
+    <ID>EmptyKtFile:NeuCalculator.kt$.NeuCalculator.kt</ID>
+    <ID>InjectDispatcher:SkyHanniMod.kt$SkyHanniMod$IO</ID>
+    <ID>LongMethod:ComponentUtils.kt$ComponentUtils$private fun convertMinecraftIdToModern2(id: String, damage: Int): String</ID>
+    <ID>LongMethod:DamageIndicatorManager.kt$DamageIndicatorManager$@HandleEvent fun onRenderWorld(event: SkyHanniRenderWorldEvent)</ID>
+    <ID>LongMethod:GraphEditor.kt$GraphEditor$private fun input()</ID>
+    <ID>LongMethod:ItemAbilityCooldown.kt$ItemAbilityCooldown$@HandleEvent fun onPlaySound(event: PlaySoundEvent)</ID>
+    <ID>LongMethod:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$private fun getStackTip(item: ItemStack): String?</ID>
+    <ID>LongMethod:ToolTooltipTweaks.kt$ToolTooltipTweaks$@HandleEvent(onlyOnSkyblock = true) fun onToolTip(event: ToolTipEvent)</ID>
+    <ID>LongMethod:VisualWordGui.kt$VisualWordGui$override fun onDrawScreen(originalMouseX: Int, originalMouseY: Int, partialTicks: Float)</ID>
+    <ID>LoopWithTooManyJumpStatements:AdvancedPlayerList.kt$AdvancedPlayerList$for</ID>
+    <ID>LoopWithTooManyJumpStatements:BetterContainers.kt$BetterContainers$for</ID>
+    <ID>LoopWithTooManyJumpStatements:CropMoneyDisplay.kt$CropMoneyDisplay$for</ID>
+    <ID>LoopWithTooManyJumpStatements:DataWatcherApi.kt$DataWatcherApi$for</ID>
+    <ID>LoopWithTooManyJumpStatements:GardenComposterInventoryFeatures.kt$GardenComposterInventoryFeatures$for</ID>
+    <ID>LoopWithTooManyJumpStatements:GardenVisitorFeatures.kt$GardenVisitorFeatures$for</ID>
+    <ID>LoopWithTooManyJumpStatements:HighlightMissingRepoItems.kt$HighlightMissingRepoItems$for</ID>
+    <ID>LoopWithTooManyJumpStatements:IslandAreas.kt$IslandAreas$for</ID>
+    <ID>LoopWithTooManyJumpStatements:ItemResolutionQuery.kt$ItemResolutionQuery.Companion$for</ID>
+    <ID>LoopWithTooManyJumpStatements:RiftBloodEffigies.kt$RiftBloodEffigies$for</ID>
+    <ID>LoopWithTooManyJumpStatements:SkyBlockItemModifierUtils.kt$SkyBlockItemModifierUtils$for</ID>
+    <ID>LoopWithTooManyJumpStatements:SkyHanniConfigSearchResetCommand.kt$SkyHanniConfigSearchResetCommand$for</ID>
+    <ID>LoopWithTooManyJumpStatements:SuperpairsClicksAlert.kt$SuperpairsClicksAlert$for</ID>
+    <ID>MapGetWithNotNullAssertionOperator:NavigationHelper.kt$NavigationHelper$distances[node]!!</ID>
+    <ID>MaxLineLength:BestiaryData.kt$BestiaryData$val level = " ([IVX0-9]+$)".toRegex().find(stack.hoverName.formattedTextCompatLeadingWhiteLessResets())?.groupValues?.get(1) ?: "0"</ID>
+    <ID>MaxLineLength:BitsApi.kt$BitsApi$val stack = stacks.firstOrNull { fameRankGuiStackPattern.matches(it.hoverName.formattedTextCompatLeadingWhiteLessResets()) } ?: return</ID>
+    <ID>MaxLineLength:BitsApi.kt$BitsApi$val stack = stacks.firstOrNull { museumRewardStackPattern.matches(it.hoverName.formattedTextCompatLeadingWhiteLessResets()) } ?: return</ID>
+    <ID>MaxLineLength:CFStrayWarning.kt$CFStrayWarning$clickMeGoldenRabbitPattern.matches(stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) || stack.getSkullTexture() in specialRabbitTextures</ID>
+    <ID>MaxLineLength:CaptureFarmingGear.kt$CaptureFarmingGear$storage.farmingLevel = item.hoverName.formattedTextCompatLeadingWhiteLessResets().split(" ").last().romanToDecimalIfNecessary()</ID>
+    <ID>MaxLineLength:ColoredBlockCompat.kt$ColoredBlockCompat.Companion$block.glassBlock == this.block || block.glassPaneBlock == this.block || block.woolBlock == this.block || block.clayBlock == this.block</ID>
+    <ID>MaxLineLength:DailyQuestHelper.kt$DailyQuestHelper$val count = InventoryUtils.countItemsInLowerInventory { it.hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor() == itemName }</ID>
+    <ID>MaxLineLength:EntityClickEvent.kt$EntityClickEvent$class</ID>
+    <ID>MaxLineLength:EssenceShopHelper.kt$EssenceShopHelper$if</ID>
+    <ID>MaxLineLength:EstimatedItemValueCalculator.kt$EstimatedItemValueCalculator$"Wrong item rarity detected in estimated item value for item ${stack.hoverName.formattedTextCompatLeadingWhiteLessResets()}"</ID>
+    <ID>MaxLineLength:FishingHookDisplay.kt$FishingHookDisplay$val alertText = if (armorStand.name.string == "!!!") config.customAlertText.replace("&amp;", "§") else armorStand.name.formattedTextCompatLessResets()</ID>
+    <ID>MaxLineLength:FortuneUpgrades.kt$FortuneUpgrades$"§7Enchant your ${item.hoverName.formattedTextCompatLeadingWhiteLessResets()} §7with Green Thumb ${greenThumbLvl + 1}"</ID>
+    <ID>MaxLineLength:FortuneUpgrades.kt$FortuneUpgrades$"§7Enchant your ${tool.hoverName.formattedTextCompatLeadingWhiteLessResets()} §7with Dedication ${dedicationLvl + 1}"</ID>
+    <ID>MaxLineLength:FortuneUpgrades.kt$FortuneUpgrades$"§7Enchant your ${tool.hoverName.formattedTextCompatLeadingWhiteLessResets()} §7with Harvesting ${harvestingLvl + 1}"</ID>
+    <ID>MaxLineLength:FortuneUpgrades.kt$FortuneUpgrades$FortuneUpgrade("§7Enchant your ${tool.hoverName.formattedTextCompatLeadingWhiteLessResets()} §7with Cultivating", null, "CULTIVATING;1", 1, 12.0)</ID>
+    <ID>MaxLineLength:FortuneUpgrades.kt$FortuneUpgrades$FortuneUpgrade("§7Recombobulate your ${item.hoverName.formattedTextCompatLeadingWhiteLessResets()}", null, "RECOMBOBULATOR_3000", 1, increase)</ID>
+    <ID>MaxLineLength:GuiRenderUtils.kt$GuiRenderUtils$DrawContextUtils.drawContext.blit(RenderCompat.getMinecraftGuiTextured(), texture, x.toInt(), y.toInt(), uMin, vMin, uMax.toInt(), vMax.toInt(), width.toInt(), height.toInt())</ID>
+    <ID>MaxLineLength:HoppityApi.kt$HoppityApi$if (sideDishNamePattern.matches(slot.item.hoverName.formattedTextCompatLeadingWhiteLessResets())) EggFoundEvent(SIDE_DISH, event.slotId).post()</ID>
+    <ID>MaxLineLength:HoppityApi.kt$HoppityApi$it.key !in event.inventoryItems || event.inventoryItems[it.key]?.hoverName.formattedTextCompatLeadingWhiteLessResets() != it.value</ID>
+    <ID>MaxLineLength:HoppityCollectionStats.kt$HoppityCollectionStats$if</ID>
+    <ID>MaxLineLength:HoppityCollectionStats.kt$HoppityCollectionStats$stack.hoverName.formattedTextCompatLeadingWhiteLessResets().isNotEmpty() &amp;&amp; stack.isDye() &amp;&amp; (stack.isDye(8) || stack.isMilestoneRabbit())</ID>
+    <ID>MaxLineLength:InfernoMinionFeatures.kt$InfernoMinionFeatures$NeuInternalName.fromItemNameOrNull(event.container.getSlot(19).item.hoverName.formattedTextCompatLeadingWhiteLessResets()) in fuelItemIds</ID>
+    <ID>MaxLineLength:InfernoMinionFeatures.kt$InfernoMinionFeatures$val containsFuel = NeuInternalName.fromItemNameOrNull(event.itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()) in fuelItemIds</ID>
+    <ID>MaxLineLength:InvisibugHighlighter.kt$InvisibugHighlighter$val nearestArmorStand = EntityUtils.getEntitiesInBoundingBox&lt;ArmorStand&gt;(aabb).minByOrNull { it.distanceTo(event.location) } ?: return</ID>
+    <ID>MaxLineLength:IslandExceptions.kt$IslandExceptions$(armorStand.name.formattedTextCompatLessResets() == "§e﴾ §5♃ §c§lThe Watcher§r§r §e﴿" || armorStand.name.formattedTextCompatLessResets() == "§3§lWatchful Eye§r")</ID>
+    <ID>MaxLineLength:ItemUtils.kt$ItemUtils$"ewogICJ0aW1lc3RhbXAiIDogMTYzNTk1NzQ4ODQxNywKICAicHJvZmlsZUlkIiA6ICJmNThkZWJkNTlmNTA0MjIyOGY2MDIyMjExZDRjMTQwYyIsCiAgInByb2ZpbGVOYW1lIiA6ICJ1bnZlbnRpdmV0YWxlbnQiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2I5NTFmZWQ2YTdiMmNiYzIwMzY5MTZkZWM3YTQ2YzRhNTY0ODE1NjRkMTRmOTQ1YjZlYmMwMzM4Mjc2NmQzYiIsCiAgICAgICJtZXRhZGF0YSIgOiB7CiAgICAgICAgIm1vZGVsIiA6ICJzbGltIgogICAgICB9CiAgICB9CiAgfQp9"</ID>
+    <ID>MaxLineLength:ItemUtils.kt$ItemUtils$"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTM4MDcxNzIxY2M1YjRjZDQwNmNlNDMxYTEzZjg2MDgzYTg5NzNlMTA2NGQyZjg4OTc4Njk5MzBlZTZlNTIzNyJ9fX0="</ID>
+    <ID>MaxLineLength:ItemUtils.kt$ItemUtils$"eyJ0aW1lc3RhbXAiOjE2MzU5NTczOTM4MDMsInByb2ZpbGVJZCI6ImJiN2NjYTcxMDQzNDQ0MTI4ZDMwODllMTNiZGZhYjU5IiwicHJvZmlsZU5hbWUiOiJsYXVyZW5jaW8zMDMiLCJzaWduYXR1cmVSZXF1aXJlZCI6dHJ1ZSwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2M5Yjc3OTk5ZmVkM2EyNzU4YmZlYWYwNzkzZTUyMjgzODE3YmVhNjQwNDRiZjQzZWYyOTQzM2Y5NTRiYjUyZjYiLCJtZXRhZGF0YSI6eyJtb2RlbCI6InNsaW0ifX19fQo="</ID>
+    <ID>MaxLineLength:MiscConfig.kt$MiscConfig$@ConfigOption(name = "Color Particle Warning", desc = "§c§lThis can break particle Coloring in parts of Skyblock where it is done properly.§f")</ID>
+    <ID>MaxLineLength:MiscConfig.kt$MiscConfig$@SearchTag("Fixes Hypixel not setting colored particles properly such as Slayer Specific Spawn Particles or Motes Fix Colored Particles")</ID>
+    <ID>MaxLineLength:MobFilter.kt$MobFilter$(baseEntity is Pig || baseEntity is Horse) &amp;&amp; illegalEntitiesPattern.matches(armorStand.name.formattedTextCompatLessResets()) -&gt; MobResult.illegal</ID>
+    <ID>MaxLineLength:MobFilter.kt$MobFilter$extraEntityList.lastOrNull()?.name.formattedTextCompatLessResets() == "§e﴾ §c§lLivid§r§r §a7M§c❤ §e﴿"</ID>
+    <ID>MaxLineLength:OldSkyblockMenu.kt$OldSkyblockMenu$val isAlreadySbButton = event.originalItem?.hoverName?.formattedTextCompatLeadingWhiteLessResets()?.endsWith(sbButton.displayName) == true</ID>
+    <ID>MaxLineLength:RareDropMessages.kt$RareDropMessages$"(?&lt;start&gt;(?:§.)*⛃ (?:§.)*(?:GOOD|GREAT|OUTSTANDING) CATCH! (?:§.)*You caught a (?:§.)*\\[Lvl 1] )(?:§.)*§(?&lt;rarityColor&gt;.)(?&lt;petName&gt;[^§(.]+)(?&lt;end&gt;.*)"</ID>
+    <ID>MaxLineLength:SackApi.kt$SackApi$if (quality == GemstoneQuality.FINE || gemstoneStackFilter != null) gemstoneItem[value.hoverName.formattedTextCompatLeadingWhiteLessResets()] = gem</ID>
+    <ID>MaxLineLength:ShowFishingItemName.kt$ShowFishingItemName$val name = itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets().transformIf({ isBait }) { "§7" + this.removeColor() }</ID>
+    <ID>MaxLineLength:SkyBlockItemModifierUtils.kt$SkyBlockItemModifierUtils$ChatUtils.debug("Gemstone quality is null for item name().formattedTextCompatLeadingWhiteLessResets()§7: ('$key' = '$value')")</ID>
+    <ID>MaxLineLength:SkyBlockItemModifierUtils.kt$SkyBlockItemModifierUtils$ChatUtils.debug("Gemstone type is null for item name().formattedTextCompatLeadingWhiteLessResets()§7: ('$newKey' with '$key' = '$value')")</ID>
+    <ID>MaxLineLength:SkyBlockXPApi.kt$SkyBlockXPApi$val stack = event.inventoryItems.values.find { itemNamePattern.matches(it.hoverName.formattedTextCompatLeadingWhiteLessResets()) } ?: return</ID>
+    <ID>MaxLineLength:SuperPairsItemVisibility.kt$SuperPairsItemVisibility$if</ID>
+    <ID>MaxLineLength:SuperPairsItemVisibility.kt$SuperPairsItemVisibility$it.key in superpairsSlotsToRead &amp;&amp; !unknownSuperpairsClickPattern.matches(it.value.hoverName.formattedTextCompatLeadingWhiteLessResets())</ID>
+    <ID>MaxLineLength:SuperpairDataDisplay.kt$SuperpairDataDisplay$if (isOutOfBounds(event.slotId, currentTier) || item.hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor() == "?") return</ID>
+    <ID>MaxLineLength:TextCompat.kt$if</ID>
+    <ID>MayBeConst:RepoPatternManager.kt$RepoPatternManager$// idk what this is for private val insideTest = false</ID>
+    <ID>MemberNameEqualsClassName:CaptureFarmingGear.kt$CaptureFarmingGear$fun captureFarmingGear()</ID>
+    <ID>MemberNameEqualsClassName:FirstMinionTier.kt$FirstMinionTier$fun firstMinionTier( otherItems: Map&lt;NeuInternalName, Int&gt;, minions: MutableMap&lt;String, NeuInternalName&gt;, tierOneMinions: MutableList&lt;NeuInternalName&gt;, tierOneMinionsDone: MutableSet&lt;NeuInternalName&gt;, )</ID>
+    <ID>MemberNameEqualsClassName:LastServers.kt$LastServers$private val lastServers = mutableMapOf&lt;String, SimpleTimeMark&gt;()</ID>
+    <ID>MemberNameEqualsClassName:Shimmy.kt$Shimmy.Companion$private fun shimmy(source: Any?, fieldName: String): Any?</ID>
+    <ID>MemberNameEqualsClassName:TestBingo.kt$TestBingo$var testBingo = false</ID>
+    <ID>NoNameShadowing:ContributorManager.kt$ContributorManager${ it.isAllowed() }</ID>
+    <ID>NoNameShadowing:Graph.kt$Graph.Companion${ out.name("Name").value(it) }</ID>
+    <ID>NoNameShadowing:Graph.kt$Graph.Companion${ out.name("Tags") out.beginArray() for (tagName in it) { out.value(tagName) } out.endArray() }</ID>
+    <ID>NoNameShadowing:HoppityCollectionStats.kt$HoppityCollectionStats${ val displayAmount = it.amount.shortFormat() val operationFormat = when (milestoneType) { HoppityEggType.CHOCOLATE_SHOP_MILESTONE -&gt; "spending" HoppityEggType.CHOCOLATE_FACTORY_MILESTONE -&gt; "reaching" else -&gt; "" // Never happens } // List indexing is weird existingLore[replaceIndex - 1] = "§7Obtained by $operationFormat §6$displayAmount" existingLore[replaceIndex] = "§7all-time §6Chocolate." return existingLore }</ID>
+    <ID>NoNameShadowing:RenderableUtils.kt$RenderableUtils${ it != null }</ID>
+    <ID>NoNameShadowing:ReplaceRomanNumerals.kt$ReplaceRomanNumerals${ it.isValidRomanNumeral() &amp;&amp; it.removeFormatting().romanToDecimal() != 2000 }</ID>
+    <ID>NoNameShadowing:RepoPatternManager.kt$RepoPatternManager${ it == '.' }</ID>
+    <ID>NoNameShadowing:Shimmy.kt$Shimmy.Companion$source</ID>
+    <ID>NoUnusedImports:AnitaExtraFarmingFortune.kt$at.hannibal2.skyhanni.features.garden.inventory.AnitaExtraFarmingFortune.kt</ID>
+    <ID>NoUnusedImports:AshfangHider.kt$at.hannibal2.skyhanni.features.nether.ashfang.AshfangHider.kt</ID>
+    <ID>NoUnusedImports:BazaarCancelledBuyOrderClipboard.kt$at.hannibal2.skyhanni.features.inventory.bazaar.BazaarCancelledBuyOrderClipboard.kt</ID>
+    <ID>NoUnusedImports:BetterWikiFromMenus.kt$at.hannibal2.skyhanni.features.misc.BetterWikiFromMenus.kt</ID>
+    <ID>NoUnusedImports:BingoCardReader.kt$at.hannibal2.skyhanni.features.bingo.card.BingoCardReader.kt</ID>
+    <ID>NoUnusedImports:BingoNextStepHelper.kt$at.hannibal2.skyhanni.features.bingo.card.nextstephelper.BingoNextStepHelper.kt</ID>
+    <ID>NoUnusedImports:BlazeSlayerDaggerHelper.kt$at.hannibal2.skyhanni.features.slayer.blaze.BlazeSlayerDaggerHelper.kt</ID>
+    <ID>NoUnusedImports:BlobbercystsHighlight.kt$at.hannibal2.skyhanni.features.rift.area.colosseum.BlobbercystsHighlight.kt</ID>
+    <ID>NoUnusedImports:CarnivalQuickStart.kt$at.hannibal2.skyhanni.features.event.carnival.CarnivalQuickStart.kt</ID>
+    <ID>NoUnusedImports:CarnivalShopHelper.kt$at.hannibal2.skyhanni.features.inventory.CarnivalShopHelper.kt</ID>
+    <ID>NoUnusedImports:ChumBucketHider.kt$at.hannibal2.skyhanni.features.fishing.ChumBucketHider.kt</ID>
+    <ID>NoUnusedImports:CityProjectFeatures.kt$at.hannibal2.skyhanni.features.fame.CityProjectFeatures.kt</ID>
+    <ID>NoUnusedImports:CollectionApi.kt$at.hannibal2.skyhanni.api.CollectionApi.kt</ID>
+    <ID>NoUnusedImports:CollectionTracker.kt$at.hannibal2.skyhanni.features.misc.CollectionTracker.kt</ID>
+    <ID>NoUnusedImports:ContributorManager.kt$at.hannibal2.skyhanni.features.misc.ContributorManager.kt</ID>
+    <ID>NoUnusedImports:CraftMaterialCollector.kt$at.hannibal2.skyhanni.features.inventory.bazaar.CraftMaterialCollector.kt</ID>
+    <ID>NoUnusedImports:CrystalNucleusApi.kt$at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.kt</ID>
+    <ID>NoUnusedImports:DeepCavernsGuide.kt$at.hannibal2.skyhanni.features.mining.DeepCavernsGuide.kt</ID>
+    <ID>NoUnusedImports:DianaApi.kt$at.hannibal2.skyhanni.features.event.diana.DianaApi.kt</ID>
+    <ID>NoUnusedImports:DiscordStatus.kt$at.hannibal2.skyhanni.features.misc.discordrpc.DiscordStatus.kt</ID>
+    <ID>NoUnusedImports:DungeonApi.kt$at.hannibal2.skyhanni.features.dungeon.DungeonApi.kt</ID>
+    <ID>NoUnusedImports:EndermanSlayerFeatures.kt$at.hannibal2.skyhanni.features.slayer.enderman.EndermanSlayerFeatures.kt</ID>
+    <ID>NoUnusedImports:EnigmaSoulWaypoints.kt$at.hannibal2.skyhanni.features.rift.everywhere.EnigmaSoulWaypoints.kt</ID>
+    <ID>NoUnusedImports:ExcavatorTooltipHider.kt$at.hannibal2.skyhanni.features.mining.fossilexcavator.ExcavatorTooltipHider.kt</ID>
+    <ID>NoUnusedImports:ExperimentationTableApi.kt$at.hannibal2.skyhanni.api.ExperimentationTableApi.kt</ID>
+    <ID>NoUnusedImports:FastFairySoulsPathfinder.kt$at.hannibal2.skyhanni.features.misc.FastFairySoulsPathfinder.kt</ID>
+    <ID>NoUnusedImports:FavoritePowerStone.kt$at.hannibal2.skyhanni.features.inventory.FavoritePowerStone.kt</ID>
+    <ID>NoUnusedImports:FirstMinionTier.kt$at.hannibal2.skyhanni.features.bingo.FirstMinionTier.kt</ID>
+    <ID>NoUnusedImports:FossilExcavatorApi.kt$at.hannibal2.skyhanni.features.mining.fossilexcavator.FossilExcavatorApi.kt</ID>
+    <ID>NoUnusedImports:FossilSolverDisplay.kt$at.hannibal2.skyhanni.features.mining.fossilexcavator.solver.FossilSolverDisplay.kt</ID>
+    <ID>NoUnusedImports:FrozenTreasureHighlighter.kt$at.hannibal2.skyhanni.features.event.jerry.frozentreasure.FrozenTreasureHighlighter.kt</ID>
+    <ID>NoUnusedImports:GardenCropMilestonesCommunityFix.kt$at.hannibal2.skyhanni.data.GardenCropMilestonesCommunityFix.kt</ID>
+    <ID>NoUnusedImports:GardenCropUpgrades.kt$at.hannibal2.skyhanni.data.GardenCropUpgrades.kt</ID>
+    <ID>NoUnusedImports:GardenLevelDisplay.kt$at.hannibal2.skyhanni.features.garden.GardenLevelDisplay.kt</ID>
+    <ID>NoUnusedImports:GardenNextPlotPrice.kt$at.hannibal2.skyhanni.features.garden.inventory.plots.GardenNextPlotPrice.kt</ID>
+    <ID>NoUnusedImports:GardenVisitorFeatures.kt$at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorFeatures.kt</ID>
+    <ID>NoUnusedImports:GuiIngameHook.kt$at.hannibal2.skyhanni.mixins.hooks.GuiIngameHook.kt</ID>
+    <ID>NoUnusedImports:HideFarEntities.kt$at.hannibal2.skyhanni.features.misc.HideFarEntities.kt</ID>
+    <ID>NoUnusedImports:HighlightMiningCommissionMobs.kt$at.hannibal2.skyhanni.features.mining.HighlightMiningCommissionMobs.kt</ID>
+    <ID>NoUnusedImports:HitmanApi.kt$at.hannibal2.skyhanni.features.inventory.chocolatefactory.hitman.HitmanApi.kt</ID>
+    <ID>NoUnusedImports:HoeLevelDisplay.kt$at.hannibal2.skyhanni.features.garden.farming.HoeLevelDisplay.kt</ID>
+    <ID>NoUnusedImports:HotxFeatures.kt$at.hannibal2.skyhanni.features.mining.HotxFeatures.kt</ID>
+    <ID>NoUnusedImports:KloonHacking.kt$at.hannibal2.skyhanni.features.rift.area.westvillage.kloon.KloonHacking.kt</ID>
+    <ID>NoUnusedImports:MobFinder.kt$at.hannibal2.skyhanni.features.combat.damageindicator.MobFinder.kt</ID>
+    <ID>NoUnusedImports:MobHighlight.kt$at.hannibal2.skyhanni.features.combat.mobs.MobHighlight.kt</ID>
+    <ID>NoUnusedImports:NpcVisitorFix.kt$at.hannibal2.skyhanni.features.garden.visitor.NpcVisitorFix.kt</ID>
+    <ID>NoUnusedImports:OdgerTotalCaught.kt$at.hannibal2.skyhanni.features.fishing.trophy.OdgerTotalCaught.kt</ID>
+    <ID>NoUnusedImports:PabloHelper.kt$at.hannibal2.skyhanni.features.nether.PabloHelper.kt</ID>
+    <ID>NoUnusedImports:PartyMemberOutlines.kt$at.hannibal2.skyhanni.features.misc.PartyMemberOutlines.kt</ID>
+    <ID>NoUnusedImports:PetStorageApi.kt$at.hannibal2.skyhanni.api.pet.PetStorageApi.kt</ID>
+    <ID>NoUnusedImports:PlayerTabComplete.kt$at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerTabComplete.kt</ID>
+    <ID>NoUnusedImports:PlayerUtils.kt$at.hannibal2.skyhanni.utils.PlayerUtils.kt</ID>
+    <ID>NoUnusedImports:PunchcardHighlight.kt$at.hannibal2.skyhanni.features.rift.everywhere.PunchcardHighlight.kt</ID>
+    <ID>NoUnusedImports:QuickCraftFeatures.kt$at.hannibal2.skyhanni.features.inventory.QuickCraftFeatures.kt</ID>
+    <ID>NoUnusedImports:ReforgeHelper.kt$at.hannibal2.skyhanni.features.inventory.ReforgeHelper.kt</ID>
+    <ID>NoUnusedImports:RiftTimer.kt$at.hannibal2.skyhanni.features.rift.everywhere.RiftTimer.kt</ID>
+    <ID>NoUnusedImports:RngMeterInventory.kt$at.hannibal2.skyhanni.features.inventory.RngMeterInventory.kt</ID>
+    <ID>NoUnusedImports:SackApi.kt$at.hannibal2.skyhanni.data.SackApi.kt</ID>
+    <ID>NoUnusedImports:ShyCruxWarnings.kt$at.hannibal2.skyhanni.features.rift.area.wyldwoods.ShyCruxWarnings.kt</ID>
+    <ID>NoUnusedImports:SkillExperience.kt$at.hannibal2.skyhanni.data.SkillExperience.kt</ID>
+    <ID>NoUnusedImports:SkyBlockItemModifierUtils.kt$at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.kt</ID>
+    <ID>NoUnusedImports:SlayerQuestWarning.kt$at.hannibal2.skyhanni.features.slayer.SlayerQuestWarning.kt</ID>
+    <ID>NoUnusedImports:StatsTuning.kt$at.hannibal2.skyhanni.features.inventory.StatsTuning.kt</ID>
+    <ID>NoUnusedImports:TextHelper.kt$at.hannibal2.skyhanni.utils.chat.TextHelper.kt</ID>
+    <ID>NoUnusedImports:UniqueGiftingOpportunitiesFeatures.kt$at.hannibal2.skyhanni.features.gifting.UniqueGiftingOpportunitiesFeatures.kt</ID>
+    <ID>NoUnusedImports:UserLuckBreakdown.kt$at.hannibal2.skyhanni.features.misc.UserLuckBreakdown.kt</ID>
+    <ID>NoUnusedImports:VisitorListener.kt$at.hannibal2.skyhanni.features.garden.visitor.VisitorListener.kt</ID>
+    <ID>NoUnusedImports:VisitorRewardWarning.kt$at.hannibal2.skyhanni.features.garden.visitor.VisitorRewardWarning.kt</ID>
+    <ID>RepoPatternRegexTestMissing:AshfangFreezeCooldown.kt$AshfangFreezeCooldown$by RepoPattern.pattern( "ashfang.freeze.cryogenic", "§cAshfang Follower's Cryogenic Blast hit you for .* damage!", )</ID>
+    <ID>RepoPatternRegexTestMissing:BazaarCancelledBuyOrderClipboard.kt$BazaarCancelledBuyOrderClipboard$by patternGroup.pattern( "cancelledmessage", "§6\\[Bazaar] §r§7§r§cCancelled! §r§7Refunded §r§6(?&lt;coins&gt;.*) coins §r§7from cancelling Buy Order!", )</ID>
+    <ID>RepoPatternRegexTestMissing:BeaconPower.kt$BeaconPower$by group.pattern( "stat", "§7Current Stat: (?&lt;stat&gt;.+)", )</ID>
+    <ID>RepoPatternRegexTestMissing:BeaconPower.kt$BeaconPower$by group.pattern( "time", "§7Power Remaining: §e(?&lt;time&gt;.+)", )</ID>
+    <ID>RepoPatternRegexTestMissing:BingoCardReader.kt$BingoCardReader$by patternGroup.pattern( "goalcomplete", "§6§lBINGO GOAL COMPLETE! §r§e(?&lt;name&gt;.*)" )</ID>
+    <ID>RepoPatternRegexTestMissing:BingoCardReader.kt$BingoCardReader$by patternGroup.pattern( "hiddengoal", ".*§7§eThe next hint will unlock in (?&lt;time&gt;.*)" )</ID>
+    <ID>RepoPatternRegexTestMissing:BingoCardReader.kt$BingoCardReader$by patternGroup.pattern( "percentage", " {2}§8Top §.(?&lt;percentage&gt;.*)%" )</ID>
+    <ID>RepoPatternRegexTestMissing:BingoCardTips.kt$BingoCardTips$by patternGroup.pattern( "reward.contribution", "(?:§.)+Contribution Rewards.*", )</ID>
+    <ID>RepoPatternRegexTestMissing:BingoNextStepHelper.kt$BingoNextStepHelper$by patternGroup.pattern( "crystal.found", " *§r§5§l✦ CRYSTAL FOUND §r§7\\(.§r§7/5§r§7\\)", )</ID>
+    <ID>RepoPatternRegexTestMissing:BingoNextStepHelper.kt$BingoNextStepHelper$by patternGroup.pattern( "crystal.obtain", "Obtain a (?&lt;name&gt;\\w+) Crystal in the Crystal Hollows\\.", )</ID>
+    <ID>RepoPatternRegexTestMissing:BingoNextStepHelper.kt$BingoNextStepHelper$by patternGroup.pattern( "crystal.obtained", " *§r§e(?&lt;crystalName&gt;Topaz|Sapphire|Jade|Amethyst|Amber) Crystal", )</ID>
+    <ID>RepoPatternRegexTestMissing:BlazeSlayerDaggerHelper.kt$BlazeSlayerDaggerHelper$by RepoPattern.pattern( "slayer.blaze.dagger.attunement", "§cStrike using the §r.+ §r§cattunement on your dagger!" )</ID>
+    <ID>RepoPatternRegexTestMissing:CaptureFarmingGear.kt$CaptureFarmingGear$by patternGroup.pattern( "anitabuff", "You tiered up the Extra Farming Drops upgrade to [+](?&lt;level&gt;.*)%!", )</ID>
+    <ID>RepoPatternRegexTestMissing:CaptureFarmingGear.kt$CaptureFarmingGear$by patternGroup.pattern( "fortuneupgrade", "You claimed the Garden Farming Fortune (?&lt;level&gt;.*) upgrade!", )</ID>
+    <ID>RepoPatternRegexTestMissing:CaptureFarmingGear.kt$CaptureFarmingGear$by patternGroup.pattern( "lotusupgrade", "Lotus (?&lt;piece&gt;.*) upgraded to [+].*☘!", )</ID>
+    <ID>RepoPatternRegexTestMissing:CarryTracker.kt$CarryTracker$by patternGroup.pattern( "trade.coins.gained", " §r§a§l\\+ §r§6(?&lt;coins&gt;.*) coins", )</ID>
+    <ID>RepoPatternRegexTestMissing:CarryTracker.kt$CarryTracker$by patternGroup.pattern( "trade.completed", "§6Trade completed with (?&lt;name&gt;.*)§r§6!", )</ID>
+    <ID>RepoPatternRegexTestMissing:ChatFilter.kt$ChatFilter$by RepoPattern.pattern( "chat.firesale", "§6§k§lA§r §c§lFIRE SALE §r§6§k§lA(?:\\n|.)*", )</ID>
+    <ID>RepoPatternRegexTestMissing:CityProjectFeatures.kt$CityProjectFeatures$by patternGroup.pattern( "completed", "§aProject is (?:being built|released)!", )</ID>
+    <ID>RepoPatternRegexTestMissing:CityProjectFeatures.kt$CityProjectFeatures$by patternGroup.pattern( "contribute", "§7Contribute again: §e(?&lt;time&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:CompactBingoChat.kt$CompactBingoChat$by patternGroup.pattern( "border", "§[e3]§l▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬" )</ID>
+    <ID>RepoPatternRegexTestMissing:CompactBingoChat.kt$CompactBingoChat$by patternGroup.pattern( "health", " {3}§r§7§8\\+§a.* §c❤ Health" )</ID>
+    <ID>RepoPatternRegexTestMissing:CompactBingoChat.kt$CompactBingoChat$by patternGroup.pattern( "strength", " {3}§r§7§8\\+§a. §c❁ Strength" )</ID>
+    <ID>RepoPatternRegexTestMissing:CroesusChestTracker.kt$CroesusChestTracker$by patternGroup.pattern("chest.master", ".*Master.*")</ID>
+    <ID>RepoPatternRegexTestMissing:DianaProfitTracker.kt$DianaProfitTracker$by patternGroup.pattern( "burrow.dug", "(?:§eYou dug out a Griffin Burrow!|§eYou finished the Griffin burrow chain!) .*", )</ID>
+    <ID>RepoPatternRegexTestMissing:DianaProfitTracker.kt$DianaProfitTracker$by patternGroup.pattern( "coins", "§6§lWow! §r§eYou dug out §r§6(?&lt;coins&gt;.*) coins§r§e!", )</ID>
+    <ID>RepoPatternRegexTestMissing:DojoRankDisplay.kt$DojoRankDisplay$by patternGroup.pattern( "name", "(?&lt;color&gt;§\\w)Test of (?&lt;name&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:DojoRankDisplay.kt$DojoRankDisplay$by patternGroup.pattern( "rank", "(?:§\\w)+Your Rank: (?&lt;rank&gt;§\\w.) §8\\((?&lt;score&gt;\\d+)\\)", )</ID>
+    <ID>RepoPatternRegexTestMissing:DungeonArchitectFeatures.kt$DungeonArchitectFeatures$by patternGroup.pattern( "puzzle.fail.normal", "(?:§c§lPUZZLE FAIL!|§4) §.§.(?&lt;name&gt;\\S*) .*", )</ID>
+    <ID>RepoPatternRegexTestMissing:DungeonArchitectFeatures.kt$DungeonArchitectFeatures$by patternGroup.pattern( "puzzle.fail.quiz", "§4\\[STATUE] Oruo the Omniscient§r§f: (?:§.)*(?&lt;name&gt;\\S*) (?:§.)*chose the wrong .*", )</ID>
+    <ID>RepoPatternRegexTestMissing:DungeonCopilot.kt$DungeonCopilot$by patternGroup.pattern( "countdown", ".* has started the dungeon countdown. The dungeon will begin in 1 minute.", )</ID>
+    <ID>RepoPatternRegexTestMissing:DungeonFinderFeatures.kt$DungeonFinderFeatures$by patternGroup.pattern( "nonpug", "(?i).*(?:PERM|VC|DISCORD).*", )</ID>
+    <ID>RepoPatternRegexTestMissing:FarmingContestApi.kt$FarmingContestApi$by patternGroup.pattern( "crop", "§8(?&lt;crop&gt;.*) Contest", )</ID>
+    <ID>RepoPatternRegexTestMissing:FarmingContestApi.kt$FarmingContestApi$by patternGroup.pattern( "sidebarcrop", "\\s*(?:§e○|§6☘) §f(?&lt;crop&gt;.*) §a.*", )</ID>
+    <ID>RepoPatternRegexTestMissing:FarmingContestApi.kt$FarmingContestApi$by patternGroup.pattern( "time", "§a(?&lt;month&gt;.*) (?&lt;day&gt;.*)(?:rd|st|nd|th), Year (?&lt;year&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "armorability", "Tiered Bonus: .* [(](?&lt;pieces&gt;.*)/4[)]", )</ID>
+    <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "armorabilityfortune", "§7.*§7Grants §6(?&lt;bonus&gt;.*)☘.*", )</ID>
+    <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "collection", "§7You have §6\\+(?&lt;ff&gt;\\d{1,3})☘ .*", )</ID>
+    <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "lotusability", "§7Piece Bonus: §6+(?&lt;bonus&gt;.*)☘", )</ID>
+    <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "tablist.universal", " Farming Fortune: §r§6☘(?&lt;fortune&gt;\\d+)", )</ID>
+    <ID>RepoPatternRegexTestMissing:FarmingFortuneDisplay.kt$FarmingFortuneDisplay$by patternGroup.pattern( "tooltip.new", "^§7Farming Fortune: §6\\+(?&lt;display&gt;[\\d.]+)(?: §2\\(\\+\\d\\))?(?: §9\\(\\+(?&lt;reforge&gt;\\d+)\\))?(?: §d\\(\\+(?&lt;gemstone&gt;\\d+)\\))?\$", )</ID>
+    <ID>RepoPatternRegexTestMissing:GardenCropMilestoneFix.kt$GardenCropMilestoneFix$by patternGroup.pattern( "levelup", " {2}§r§b§lGARDEN MILESTONE §3(?&lt;crop&gt;.*) §8.*➜§3(?&lt;tier&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:GardenLevelDisplay.kt$GardenLevelDisplay$by patternGroup.pattern( "inventory.overflow", ".*§r §6(?&lt;overflow&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:GlacitePowderFeatures.kt$GlacitePowderFeatures$by patternGroup.pattern( "glacitepowder", "Glacite Powder x(?&lt;amount&gt;.*)" )</ID>
+    <ID>RepoPatternRegexTestMissing:HalloweenBasketWaypoints.kt$HalloweenBasketWaypoints$by patternGroup.pattern( "basket", "^(?:(?:§.)+You found a Candy Basket! (?:(?:§.)+\\((?:§.)+(?&lt;current&gt;\\d+)(?:§.)+/(?:§.)+(?&lt;max&gt;\\d+)(?:§.)+\\))?|(?:§.)+You already found this Candy Basket!)\$", )</ID>
+    <ID>RepoPatternRegexTestMissing:HalloweenBasketWaypoints.kt$HalloweenBasketWaypoints$by patternGroup.pattern( "main.scoreboard.basket", "^Baskets Found: §a\\d+§f/§a\\d+\$", )</ID>
+    <ID>RepoPatternRegexTestMissing:HalloweenBasketWaypoints.kt$HalloweenBasketWaypoints$by patternGroup.pattern( "main.scoreboard.halloween", "^§6Halloween \\d+$", )</ID>
+    <ID>RepoPatternRegexTestMissing:HighlightPlaceableNpcs.kt$HighlightPlaceableNpcs$by patternGroup.pattern( "location", "§7Location: §f\\[§e\\d+§f, §e\\d+§f, §e\\d+§f]", )</ID>
+    <ID>RepoPatternRegexTestMissing:HotmData.kt$HotmData.Companion$by patternGroup.pattern( "mayhem", "§b§lMAYHEM! §r§7(?&lt;perk&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:HypixelData.kt$HypixelData$by patternGroup.pattern( "lobbytype", "(?&lt;lobbyType&gt;.*lobby)\\d+", )</ID>
+    <ID>RepoPatternRegexTestMissing:HypixelData.kt$HypixelData$by patternGroup.pattern( "servername.connection", "(?&lt;prefix&gt;.+\\.)?hypixel\\.net", )</ID>
+    <ID>RepoPatternRegexTestMissing:ItemAbilityCooldown.kt$ItemAbilityCooldown$by patternGroup.pattern( "alignedother", "§eYou aligned §r§a.* §r§eother players?!", )</ID>
+    <ID>RepoPatternRegexTestMissing:ItemAbilityCooldown.kt$ItemAbilityCooldown$by patternGroup.pattern( "buffedyourself", "§aYou buffed yourself for §r§c\\+\\d+❁ Strength", )</ID>
+    <ID>RepoPatternRegexTestMissing:ItemAddManager.kt$ItemAddManager$by RepoPattern.pattern( "data.itemmanager.diceroll", "§eYour §r§(?:5|6High Class )Archfiend Dice §r§erolled a §r§.(?&lt;number&gt;.)§r§e! Bonus: §r§.(?&lt;hearts&gt;.*)❤", )</ID>
+    <ID>RepoPatternRegexTestMissing:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$by patternGroup.pattern( "bestiarystack", "§7Progress to Tier (?&lt;tier&gt;[\\dIVXC]+): §b[\\d.]+%", )</ID>
+    <ID>RepoPatternRegexTestMissing:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$by patternGroup.pattern( "bingogoalrank", "(?:§.)*You were the (?:§.)*(?&lt;rank&gt;\\w+)(?&lt;ordinal&gt;st|nd|rd|th) (?:§.)*to", )</ID>
+    <ID>RepoPatternRegexTestMissing:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$by patternGroup.pattern( "harvest", "§7§7You may harvest §6(?&lt;amount&gt;.).*", )</ID>
+    <ID>RepoPatternRegexTestMissing:KuudraApi.kt$KuudraApi$by patternGroup.pattern( "chat.complete", "§.\\s*(?:§.)*KUUDRA DOWN!", )</ID>
+    <ID>RepoPatternRegexTestMissing:MaxPurseItems.kt$MaxPurseItems$by patternGroup.pattern( "instant", ".*Price per unit: §6(?&lt;coins&gt;[\\d.,]+) coins.*", )</ID>
+    <ID>RepoPatternRegexTestMissing:MaxPurseItems.kt$MaxPurseItems$by patternGroup.pattern( "order", ".*§6(?&lt;coins&gt;[\\d.,]+) coins §7each.*", )</ID>
+    <ID>RepoPatternRegexTestMissing:MaxwellApi.kt$MaxwellApi$by patternGroup.pattern( "gui.noselectedpower", "(?:§.)*Visit Maxwell in the Hub to learn", )</ID>
+    <ID>RepoPatternRegexTestMissing:MaxwellApi.kt$MaxwellApi$by patternGroup.pattern( "gui.thaumaturgy.data", "§(?&lt;color&gt;.)\\+(?&lt;amount&gt;[^ ]+)(?&lt;icon&gt;.) (?&lt;name&gt;.+)", )</ID>
+    <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "filter.dojo", "^(?:(?&lt;points&gt;\\d+) pts|(?&lt;empty&gt;\\w+))$", )</ID>
+    <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "filter.summon", "^(?&lt;owner&gt;\\w+)'s (?&lt;name&gt;.*) \\d+.*", )</ID>
+    <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.dungeon.woke.golem", "(?:§c§lWoke|§5§lSleeping) Golem§r", )</ID>
+    <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.heavypearl.collect", "§.§lCOLLECT!", )</ID>
+    <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.jerry.magma.cube", "§c(?:Cubie|Maggie|Cubert|Cübe|Cubette|Magmalene|Lucky 7|8ball|Mega Cube|Super Cube)(?: ᛤ)? §a\\d+§8\\/§a\\d+§c❤", )</ID>
+    <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.petcare", "^\\[\\w+ (?&lt;level&gt;\\d+)\\] (?&lt;name&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern( "pattern.summon.owner", ".*Spawned by: (?&lt;name&gt;.*).*", )</ID>
+    <ID>RepoPatternRegexTestMissing:MobFilter.kt$MobFilter$by patternGroup.pattern("displaynpc.name", "[a-z0-9]{10}")</ID>
+    <ID>RepoPatternRegexTestMissing:NewYearCakeReminder.kt$NewYearCakeReminder$by RepoPattern.pattern( "event.winter.newyearcake.reminder.sidebar", "§dNew Year Event!§f (?&lt;time&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:PartyApi.kt$PartyApi$by patternGroup.pattern( "kuudrafinder.join", "§dParty Finder §f&gt; (?&lt;name&gt;.*?) §ejoined the group! \\(§[a-fA-F0-9]+Combat Level \\d+§e\\)", )</ID>
+    <ID>RepoPatternRegexTestMissing:PestApi.kt$PestApi$by patternGroup.pattern( "inventory", "§4§lൠ §cThis plot has §6(?&lt;amount&gt;\\d) Pests?§c!", )</ID>
+    <ID>RepoPatternRegexTestMissing:PestApi.kt$PestApi$by patternGroup.pattern( "scoreboard.pests", " §7⏣ §[ac]The Garden §4§lൠ§7 x(?&lt;pests&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:PowderTracker.kt$PowderTracker$by patternGroup.pattern( "powder.bossbar", "§e§lPASSIVE EVENT §b§l2X POWDER §e§lRUNNING FOR §a§l(?&lt;time&gt;.*)§r", )</ID>
+    <ID>RepoPatternRegexTestMissing:PowderTracker.kt$PowderTracker$by patternGroup.pattern( "powder.ended", ".*§r§b§l2X POWDER ENDED!.*", )</ID>
+    <ID>RepoPatternRegexTestMissing:PowderTracker.kt$PowderTracker$by patternGroup.pattern( "powder.started", ".*§r§b§l2X POWDER STARTED!.*", )</ID>
+    <ID>RepoPatternRegexTestMissing:PresentWaypoints.kt$PresentWaypoints$by patternGroup.pattern( "found", "§aYou found a.*present! §r§e\\(§r§b\\d+§r§e/§r§b\\d+§r§e\\)", )</ID>
+    <ID>RepoPatternRegexTestMissing:QuiverApi.kt$QuiverApi$by chatGroup.pattern( "addedtoquiver", "(?:§.)*You've added (?:§.)*(?&lt;type&gt;.*) x(?&lt;amount&gt;.*) (?:§.)*to your quiver!", )</ID>
+    <ID>RepoPatternRegexTestMissing:QuiverApi.kt$QuiverApi$by chatGroup.pattern( "cleared", "§aCleared your quiver!|§c§lYour quiver is now completely empty!", )</ID>
+    <ID>RepoPatternRegexTestMissing:RestorePieceOfWizardPortalLore.kt$RestorePieceOfWizardPortalLore$by RepoPattern.pattern( "misc.restore.wizard.portal.earned", "§7Earned by:.*" )</ID>
+    <ID>RepoPatternRegexTestMissing:ScoreboardPattern.kt$ScoreboardPattern$by dungeonSB.pattern( "cleared", "(?:§.)*Cleared: (?:§.)*(?&lt;percent&gt;[\\w,.]+)% (?:§.)*\\((?:§.)*(?&lt;score&gt;[\\w,.]+)(?:§.)*\\)", )</ID>
+    <ID>RepoPatternRegexTestMissing:ScoreboardPattern.kt$ScoreboardPattern$by dungeonSB.pattern( "keys", "Keys: §.■ §.[✗✓] §.■ §a.x", )</ID>
+    <ID>RepoPatternRegexTestMissing:ShowMotesNpcSellPrice.kt$ShowMotesNpcSellPrice$by RepoPattern.pattern( "rift.everywhere.burger", ".*(?:§\\w)+You have (?:§\\w)+(?&lt;amount&gt;\\d) Grubber Stacks.*", )</ID>
+    <ID>RepoPatternRegexTestMissing:SkillExperience.kt$SkillExperience$by patternGroup.pattern( "actionbar", ".*§3\\+.* (?&lt;skill&gt;.*) \\((?&lt;overflow&gt;.*)/(?&lt;needed&gt;.*)\\).*" )</ID>
+    <ID>RepoPatternRegexTestMissing:SkillExperience.kt$SkillExperience$by patternGroup.pattern( "inventory", ".* §e(?&lt;number&gt;.*)§6/.*" )</ID>
+    <ID>RepoPatternRegexTestMissing:SlayerBossSpawnSoon.kt$SlayerBossSpawnSoon$by RepoPattern.pattern( "slayer.bosswarning.progress", " \\(?(?&lt;progress&gt;[0-9.,k]+)/(?&lt;total&gt;[0-9.,k]+)\\)?.*" )</ID>
+    <ID>RepoPatternRegexTestMissing:SlayerRngMeterDisplay.kt$SlayerRngMeterDisplay$by patternGroup.pattern( "changeditem", "§aYou set your §r.* RNG Meter §r§ato drop §r.*§a!", )</ID>
+    <ID>RepoPatternRegexTestMissing:SlayerRngMeterDisplay.kt$SlayerRngMeterDisplay$by patternGroup.pattern( "inventoryname", "(?&lt;name&gt;.*) RNG Meter", )</ID>
+    <ID>RepoPatternRegexTestMissing:SlayerRngMeterDisplay.kt$SlayerRngMeterDisplay$by patternGroup.pattern( "update", " {3}§dRNG Meter §f- §d(?&lt;exp&gt;.*) Stored XP", )</ID>
+    <ID>RepoPatternRegexTestMissing:SprayFeatures.kt$SprayFeatures$by RepoPattern.pattern( "garden.spray.material", "§a§lSPRAYONATOR! §r§7Your selected material is now §r§a(?&lt;spray&gt;.*)§r§7!", )</ID>
+    <ID>RepoPatternRegexTestMissing:TabListReader.kt$TabListReader$by patternGroup.pattern( "upgrades", "(?&lt;firstPart&gt;§e[A-Za-z ]+)(?&lt;secondPart&gt; §f[\\w ]+)" )</ID>
+    <ID>RepoPatternRegexTestMissing:TabListReader.kt$TabListReader$by patternGroup.pattern( "winterpowerups", "Active Power Ups(?:§.)*(?:\\n(?:§.)*§7.+)*" )</ID>
+    <ID>RepoPatternRegexTestMissing:TabListRenderer.kt$TabListRenderer$by RepoPattern.pattern( "tablist.firesaletitle", "§.§lFire Sales: §r§f\\([0-9]+\\)", )</ID>
+    <ID>RepoPatternRegexTestMissing:TeleportPadInventoryNumber.kt$TeleportPadInventoryNumber$by RepoPattern.pattern( "misc.teleportpad.number", "§.(?&lt;number&gt;.*) teleport pad" )</ID>
+    <ID>RepoPatternRegexTestMissing:TerracottaPhase.kt$TerracottaPhase$by patternGroup.pattern( "start", "§c\\[BOSS] Sadan§r§f: So you made it all the way here... Now you wish to defy me\\? Sadan\\?!", )</ID>
+    <ID>RepoPatternRegexTestMissing:TestCopyBestiaryValues.kt$TestCopyBestiaryValues$by RepoPattern.pattern( "test.bestiary.type", "\\[Lv(?&lt;lvl&gt;.*)] (?&lt;text&gt;.*)" )</ID>
+    <ID>RepoPatternRegexTestMissing:TotemOfCorruption.kt$TotemOfCorruption$by patternGroup.pattern( "owner", "§7Owner: §e(?&lt;owner&gt;.+)" )</ID>
+    <ID>RepoPatternRegexTestMissing:TotemOfCorruption.kt$TotemOfCorruption$by patternGroup.pattern( "timeremaining", "§7Remaining: §e(?:(?&lt;min&gt;\\d+)m )?(?&lt;sec&gt;\\d+)s" )</ID>
+    <ID>RepoPatternRegexTestMissing:TunnelsMaps.kt$TunnelsMaps$by RepoPattern.pattern( "mining.commisson.collector.invalid", "Glacite|Scrap", )</ID>
+    <ID>RepoPatternRegexTestMissing:TunnelsMaps.kt$TunnelsMaps$by RepoPattern.pattern( "mining.tunnels.maps.gem.new", ".*(?:Aquamarine|Onyx|Citrine|Peridot).*", )</ID>
+    <ID>RepoPatternRegexTestMissing:TunnelsMaps.kt$TunnelsMaps$by RepoPattern.pattern( "mining.tunnels.maps.gem.old", ".*(?:Ruby|Amethyst|Jade|Sapphire|Amber|Topaz).*", )</ID>
+    <ID>RepoPatternRegexTestMissing:UniqueGiftCounter.kt$UniqueGiftCounter$by RepoPattern.pattern( "event.winter.uniqugifts.counter.amount", "§7Unique Players Gifted: §a(?&lt;amount&gt;.*)", )</ID>
+    <ID>RepoPatternRegexTestMissing:UpgradeReminder.kt$UpgradeReminder$by patternGroup.pattern( "claimed", "§eYou claimed the §r§a(?&lt;upgrade&gt;.+) §r§eupgrade!", )</ID>
+    <ID>RepoPatternRegexTestMissing:UpgradeReminder.kt$UpgradeReminder$by patternGroup.pattern( "duration", "§8Duration: (?&lt;duration&gt;.+)", )</ID>
+    <ID>RepoPatternRegexTestMissing:UpgradeReminder.kt$UpgradeReminder$by patternGroup.pattern( "started", "§eYou started the §r§a(?&lt;upgrade&gt;.+) §r§eupgrade!", )</ID>
+    <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by RepoPattern.pattern( "string.isroman", "^M{0,3}(?:CM|CD|D?C{0,3})(?:XC|XL|L?X{0,3})(?:IX|IV|V?I{0,3})", )</ID>
+    <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "item.amount.behind", "(?&lt;name&gt;(?:§.)*(?:[^§] ?)+)(?:§8x(?&lt;amount&gt;[\\d,]+))?", )</ID>
+    <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "item.name.potion", ".*Potion", )</ID>
+    <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "item.neuitems.enchantmentname", "^(?&lt;format&gt;(?:§.)*)(?&lt;name&gt;[^§]+) (?&lt;level&gt;[IVXL]+)(?: Book)?$", )</ID>
+    <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "string.playerchat", "(?&lt;important&gt;.*?)(?:§[f7r])*: .*", )</ID>
+    <ID>RepoPatternRegexTestMissing:UtilsPatterns.kt$UtilsPatterns$by patternGroup.pattern( "time.amount", "(?:(?&lt;y&gt;\\d+) ?y(?:\\w* ?)?)?(?:(?&lt;d&gt;\\d+) ?d(?:\\w* ?)?)?(?:(?&lt;h&gt;\\d+) ?h(?:\\w* ?)?)?(?:(?&lt;m&gt;\\d+) ?m(?:\\w* ?)?)?(?:(?&lt;s&gt;\\d+) ?s(?:\\w* ?)?)?", )</ID>
+    <ID>RepoPatternRegexTestMissing:VisitorListener.kt$VisitorListener$by RepoPattern.pattern( "garden.visitor.offersaccepted", "§7Offers Accepted: §a(?&lt;offersAccepted&gt;\\d+)", )</ID>
+    <ID>ReturnCount:ArachneChatMessageHider.kt$ArachneChatMessageHider$private fun shouldHide(message: String): Boolean</ID>
+    <ID>ReturnCount:BingoNextStepHelper.kt$BingoNextStepHelper$private fun readDescription(description: String): NextStep?</ID>
+    <ID>ReturnCount:BroodmotherFeatures.kt$BroodmotherFeatures$private fun onStageUpdate()</ID>
+    <ID>ReturnCount:ChatPeek.kt$ChatPeek$@JvmStatic fun peek(): Boolean</ID>
+    <ID>ReturnCount:CompactBingoChat.kt$CompactBingoChat$private fun onSkyBlockLevelUp(message: String): Boolean</ID>
+    <ID>ReturnCount:CrimsonMinibossRespawnTimer.kt$CrimsonMinibossRespawnTimer$private fun updateArea()</ID>
+    <ID>ReturnCount:EnchantParser.kt$EnchantParser$private fun parseEnchants( loreList: MutableList&lt;Component&gt;, enchants: Map&lt;String, Int&gt;, chatComponent: Component?, )</ID>
+    <ID>ReturnCount:EnoughUpdatesManager.kt$EnoughUpdatesManager$private fun getPetLoreReplacements(petName: String?, tier: String?, level: Int): Map&lt;String, String&gt;</ID>
+    <ID>ReturnCount:GardenVisitorFeatures.kt$GardenVisitorFeatures$private fun showGui(): Boolean</ID>
+    <ID>ReturnCount:GraphEditor.kt$GraphEditor$private fun input()</ID>
+    <ID>ReturnCount:GraphParkour.kt$GraphParkour$private fun graphToList(graph: Graph): List&lt;LorenzVec&gt;?</ID>
+    <ID>ReturnCount:HideNotClickableItems.kt$HideNotClickableItems$private fun hideSalvage(chestName: String, stack: ItemStack): Boolean</ID>
+    <ID>ReturnCount:ItemDisplayOverlayFeatures.kt$ItemDisplayOverlayFeatures$private fun getStackTip(item: ItemStack): String?</ID>
+    <ID>ReturnCount:ItemPriceUtils.kt$ItemPriceUtils$fun NeuInternalName.getPriceOrNull( priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_BUY, pastRecipes: List&lt;PrimitiveRecipe&gt; = emptyList(), ): Double?</ID>
+    <ID>ReturnCount:ItemResolutionQuery.kt$ItemResolutionQuery$private fun resolveContextualName(): String?</ID>
+    <ID>ReturnCount:MinecraftConsoleFilter.kt$MinecraftConsoleFilter$override fun filter(event: LogEvent?): Filter.Result</ID>
+    <ID>ReturnCount:MiningEventTracker.kt$MiningEventTracker$private fun sendData(eventName: String, time: String?)</ID>
+    <ID>ReturnCount:MobDetection.kt$MobDetection$private fun entitySpawn(entity: LivingEntity, roughType: Mob.Type): Boolean</ID>
+    <ID>ReturnCount:MobFilter.kt$MobFilter$internal fun createSkyblockEntity(baseEntity: LivingEntity): MobResult</ID>
+    <ID>ReturnCount:MobFilter.kt$MobFilter$private fun armorStandOnlyMobs(baseEntity: LivingEntity, armorStand: ArmorStand): MobResult?</ID>
+    <ID>ReturnCount:MobFilter.kt$MobFilter$private fun exceptions(baseEntity: LivingEntity, nextEntity: LivingEntity?): MobResult?</ID>
+    <ID>ReturnCount:MultiFilter.kt$MultiFilter$fun matchResult(string: String): String?</ID>
+    <ID>ReturnCount:NbtCompat.kt$NbtCompat$private fun getList(list: ListTag, type: Int): ListTag</ID>
+    <ID>ReturnCount:PacketTest.kt$PacketTest$private fun Packet&lt;*&gt;.print()</ID>
+    <ID>ReturnCount:PowderMiningChatFilter.kt$PowderMiningChatFilter$@Suppress("CyclomaticComplexMethod") fun block(message: String): String?</ID>
+    <ID>ReturnCount:PurseApi.kt$PurseApi$private fun getCause(diff: Double): PurseChangeCause</ID>
+    <ID>ReturnCount:QuestLoader.kt$QuestLoader$private fun addQuest(name: String, state: QuestState, needAmount: Int): Quest</ID>
+    <ID>ReturnCount:SkyHanniConfigSearchResetCommand.kt$SkyHanniConfigSearchResetCommand$private fun setCommand(args: Array&lt;String&gt;): String</ID>
+    <ID>SpreadOperator:LimboPlaytime.kt$LimboPlaytime$( itemID.getItemStack().item, ITEM_NAME, *createItemLore() )</ID>
+    <ID>SpreadOperator:TextHelper.kt$TextHelper$(*component.toTypedArray(), separator = separator)</ID>
+    <ID>TooManyFunctions:EstimatedItemValueCalculator.kt$EstimatedItemValueCalculator</ID>
+    <ID>TooManyFunctions:GuiRenderUtils.kt$GuiRenderUtils</ID>
+    <ID>TooManyFunctions:ItemResolutionQuery.kt$ItemResolutionQuery</ID>
+    <ID>TooManyFunctions:MobFinder.kt$MobFinder</ID>
+    <ID>TooManyFunctions:NumberUtil.kt$NumberUtil</ID>
+    <ID>TooManyFunctions:OreBlock.kt$at.hannibal2.skyhanni.features.mining.OreBlock.kt</ID>
+    <ID>TooManyFunctions:RegexUtils.kt$RegexUtils</ID>
+    <ID>TooManyFunctions:TextCompat.kt$at.hannibal2.skyhanni.utils.compat.TextCompat.kt</ID>
+    <ID>TooManyFunctions:WorldRenderUtils.kt$WorldRenderUtils</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.alphaFunc(GL11.GL_GREATER, 0.1f)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.alphaFunc(GL11.GL_GREATER, 1 / 255F)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.color(1f, 1f, 1f, 1f)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.color(1f, 1f, 1f, holographicness)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.depthMask(false)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.depthMask(true)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.disableBlend()</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.disableCull()</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.enableBlend()</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.enableRescaleNormal()</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.enableTexture2D()</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.popMatrix()</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.pushMatrix()</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.scale(-1f, -1f, 1f)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.translate(0F, -1.5078125f, 0f)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$ModernGlStateManager.translate(renderingOffset.x.toFloat(), renderingOffset.y.toFloat(), renderingOffset.z.toFloat())</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$if (!renderer.bindEntityTexture_skyhanni(entity)) return</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$renderer as? AccessorRendererLivingEntity&lt;T&gt; ?: error("can not cast to AccessorRendererLivingEntity")</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$renderer.mainModel.isChild = holographicEntity.isChild</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$renderer.mainModel.render( entity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scaleFactor, )</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$renderer.mainModel.setRotationAngles( limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scaleFactor, entity, )</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$renderer.setBrightness_skyhanni(entity, 0f, true)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$renderer.setRenderOutlines(false)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$renderer.unsetBrightness_skyhanni()</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$val ageInTicks = 1_000_000.toFloat()</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$val headPitch = 0F</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$val limbSwing = 0F</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$val limbSwingAmount = 0F</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$val mobPosition = holographicEntity.interpolatedPosition(partialTicks)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$val netHeadYaw = holographicEntity.interpolatedYaw(partialTicks)</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$val renderingOffset = mobPosition - viewerPosition</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$val scaleFactor = 0.0625f</ID>
+    <ID>UnreachableCode:HolographicEntities.kt$HolographicEntities$val viewerPosition = WorldRenderUtils.getViewerPos(partialTicks)</ID>
+    <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Double::plus)!!</ID>
+    <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Float::plus)!!</ID>
+    <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Int::plus)!!</ID>
+    <ID>UnsafeCallOnNullableType:CollectionUtils.kt$CollectionUtils$this.merge(key, number, Long::plus)!!</ID>
+    <ID>UnsafeCallOnNullableType:CompactBestiaryChatMessage.kt$CompactBestiaryChatMessage$it.groups[1]!!</ID>
+    <ID>UnsafeCallOnNullableType:ConfigManager.kt$ConfigManager$file!!</ID>
+    <ID>UnsafeCallOnNullableType:CorpseTracker.kt$CorpseTracker$applicableKeys.first().key!!</ID>
+    <ID>UnsafeCallOnNullableType:CropMoneyDisplay.kt$CropMoneyDisplay$cropNames[internalName]!!</ID>
+    <ID>UnsafeCallOnNullableType:DailyMiniBossHelper.kt$DailyMiniBossHelper$getByDisplayName(name)!!</ID>
+    <ID>UnsafeCallOnNullableType:DamageIndicatorManager.kt$DamageIndicatorManager$data.deathLocation!!</ID>
+    <ID>UnsafeCallOnNullableType:DefaultConfigFeatures.kt$DefaultConfigFeatures$resetSuggestionState[cat]!!</ID>
+    <ID>UnsafeCallOnNullableType:DefaultConfigOptionGui.kt$DefaultConfigOptionGui$resetSuggestionState[cat]!!</ID>
+    <ID>UnsafeCallOnNullableType:EasterEggWaypoints.kt$EasterEggWaypoints$EasterEgg.entries.minByOrNull { it.waypoint.distanceSqToPlayer() }!!</ID>
+    <ID>UnsafeCallOnNullableType:EntityMovementData.kt$EntityMovementData$entityLocation[entity]!!</ID>
+    <ID>UnsafeCallOnNullableType:FarmingContestApi.kt$FarmingContestApi$contestCrop!!</ID>
+    <ID>UnsafeCallOnNullableType:FarmingContestApi.kt$FarmingContestApi$contests[bracket]!!</ID>
+    <ID>UnsafeCallOnNullableType:FarmingContestApi.kt$FarmingContestApi$currentCrop!!</ID>
+    <ID>UnsafeCallOnNullableType:FarmingWeightDisplay.kt$FarmingWeightDisplay$weightPerCrop[CropType.CACTUS]!!</ID>
+    <ID>UnsafeCallOnNullableType:FarmingWeightDisplay.kt$FarmingWeightDisplay$weightPerCrop[CropType.SUGAR_CANE]!!</ID>
+    <ID>UnsafeCallOnNullableType:FeatureToggleProcessor.kt$FeatureToggleProcessor$latestCategory!!</ID>
+    <ID>UnsafeCallOnNullableType:FeatureTogglesByDefaultAdapter.kt$FeatureTogglesByDefaultAdapter$gson!!</ID>
+    <ID>UnsafeCallOnNullableType:FortuneUpgrades.kt$FortuneUpgrades$nextTalisman.upgradeCost?.first!!</ID>
+    <ID>UnsafeCallOnNullableType:GardenComposterUpgradesData.kt$GardenComposterUpgradesData$ComposterUpgrade.getByName(name)!!</ID>
+    <ID>UnsafeCallOnNullableType:GardenCropMilestoneDisplay.kt$GardenCropMilestoneDisplay$cultivatingData[crop]!!</ID>
+    <ID>UnsafeCallOnNullableType:GardenCropMilestonesCommunityFix.kt$GardenCropMilestonesCommunityFix$map[crop]!!</ID>
+    <ID>UnsafeCallOnNullableType:GardenPlotIcon.kt$GardenPlotIcon$originalStack[index]!!</ID>
+    <ID>UnsafeCallOnNullableType:Graph.kt$Graph.Companion$position!!</ID>
+    <ID>UnsafeCallOnNullableType:Graph.kt$distances.distances[end]!!</ID>
+    <ID>UnsafeCallOnNullableType:GriffinBurrowHelper.kt$GriffinBurrowHelper$particleBurrows[targetLocation]!!</ID>
+    <ID>UnsafeCallOnNullableType:IslandGraphs.kt$IslandGraphs$currentTarget!!</ID>
+    <ID>UnsafeCallOnNullableType:ItemBlink.kt$ItemBlink$offsets[item]!!</ID>
+    <ID>UnsafeCallOnNullableType:ItemPickupLog.kt$ItemPickupLog$listToCheckAgainst[key]!!</ID>
+    <ID>UnsafeCallOnNullableType:ItemPickupLog.kt$ItemPickupLog$listToCheckAgainst[key]?.second!!</ID>
+    <ID>UnsafeCallOnNullableType:ItemStackTypeAdapterFactory.kt$ItemStackTypeAdapterFactory$gson!!</ID>
+    <ID>UnsafeCallOnNullableType:ItemUtils.kt$ItemUtils$itemAmountCache[input]!!</ID>
+    <ID>UnsafeCallOnNullableType:JacobContestTimeNeeded.kt$JacobContestTimeNeeded$map[crop]!!</ID>
+    <ID>UnsafeCallOnNullableType:KSerializable.kt$KotlinTypeAdapterFactory$param.name!!</ID>
+    <ID>UnsafeCallOnNullableType:MinionFeatures.kt$MinionFeatures$newMinion!!</ID>
+    <ID>UnsafeCallOnNullableType:NavigationHelper.kt$NavigationHelper$distances[node]!!</ID>
+    <ID>UnsafeCallOnNullableType:NumberUtil.kt$NumberUtil$romanSymbols[this]!!</ID>
+    <ID>UnsafeCallOnNullableType:ReminderManager.kt$ReminderManager$storage[args.drop(1).first()]!!</ID>
+    <ID>UnsafeCallOnNullableType:ReminderManager.kt$ReminderManager$storage[args.first()]!!</ID>
+    <ID>UnsafeCallOnNullableType:RenderEntityOutlineEvent.kt$RenderEntityOutlineEvent$entitiesToChooseFrom!!</ID>
+    <ID>UnsafeCallOnNullableType:RenderEntityOutlineEvent.kt$RenderEntityOutlineEvent$entitiesToOutline!!</ID>
+    <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$match.groups[1]!!</ID>
+    <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$match.groups[2]!!</ID>
+    <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$match.groups[3]!!</ID>
+    <ID>UnsafeCallOnNullableType:SackApi.kt$SackApi$oldData!!</ID>
+    <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$distance!!</ID>
+    <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$distance2!!</ID>
+    <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$firstParticlePoint?.distance(pos)!!</ID>
+    <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$lastParticlePoint2!!</ID>
+    <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$lastParticlePoint2?.distance(particlePoint!!)!!</ID>
+    <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$particlePoint!!</ID>
+    <ID>UnsafeCallOnNullableType:SoopyGuessBurrow.kt$SoopyGuessBurrow$particlePoint?.let { it - lastParticlePoint2!! }!!</ID>
+    <ID>UnsafeCallOnNullableType:SuperpairsClicksAlert.kt$SuperpairsClicksAlert$match.groups[1]!!</ID>
+    <ID>UnsafeCallOnNullableType:TiaRelayWaypoints.kt$TiaRelayWaypoints$waypointName!!</ID>
+    <ID>UnsafeCallOnNullableType:Translator.kt$Translator$messageContentRegex.find(message)!!</ID>
+    <ID>UnsafeCallOnNullableType:UpdateManager.kt$UpdateManager$potentialUpdate!!</ID>
+    <ID>UnsafeCallOnNullableType:VisitorRewardWarning.kt$VisitorRewardWarning$visitor.totalPrice!!</ID>
+    <ID>UnsafeCallOnNullableType:VisitorRewardWarning.kt$VisitorRewardWarning$visitor.totalReward!!</ID>
+    <ID>UnsafeCallOnNullableType:WorldRenderUtils.kt$WorldRenderUtils$it.name!!</ID>
+    <ID>UnusedParameter:ChromaFontManager.kt$text: String</ID>
+    <ID>UnusedParameter:CropType.kt$CropType.Companion$pos: LorenzVec</ID>
+    <ID>UnusedParameter:MobUtils.kt$MobUtils$partialTicks: Float</ID>
+    <ID>UnusedParameter:ModernIslandExceptions.kt$ModernIslandExceptions$nextEntity: LivingEntity?</ID>
+    <ID>UnusedParameter:ParticleUtils.kt$ParticleUtils$shouldError: Boolean = false</ID>
+    <ID>UnusedParameter:RenderCompat.kt$RenderCompat$name: String</ID>
+    <ID>UnusedParameter:RenderEvents.kt$RenderEvents$tick: DeltaTracker</ID>
+    <ID>UnusedParameter:ToolTipData.kt$ToolTipData$stack: ItemStack</ID>
+    <ID>UnusedParameter:WorldRenderUtils.kt$WorldRenderUtils$drawVerticalBarriers: Boolean = true</ID>
+    <ID>UnusedPrivateProperty:KeyboardManager.kt$KeyboardManager$private var lastClickedMouseButton = -1</ID>
+    <ID>UnusedPrivateProperty:MoongladeBeacon.kt$MoongladeBeacon.BeaconTuneData$private val debugName = if (isEnchanted) "§aEnchanted Tuning" else "§dNormal Tuning"</ID>
+    <ID>UnusedPrivateProperty:ReceiveParticleEvent.kt$ReceiveParticleEvent$private val particleArgs: IntArray? = null</ID>
+    <ID>UseOrEmpty:ItemUtils.kt$ItemUtils$lore ?: emptyList()</ID>
+    <ID>UselessCallOnNotNull:EssenceShopHelper.kt$EssenceShopHelper$essenceHeaderStack?.hoverName.formattedTextCompatLeadingWhiteLessResets().orEmpty()</ID>
+    <ID>UselessCallOnNotNull:IslandExceptions.kt$IslandExceptions$armorStand?.name.formattedTextCompatLessResets().orEmpty()</ID>
+    <ID>UselessCallOnNotNull:MoongladeBeacon.kt$MoongladeBeacon$listOfNotNull(normalTuning, enchantedTuning)</ID>
+    <ID>UselessCallOnNotNull:OverviewPage.kt$OverviewPage$FarmingItemType.currentArmor?.getItem()?.hoverName.formattedTextCompatLeadingWhiteLessResets().orEmpty()</ID>
+    <ID>UselessCallOnNotNull:OverviewPage.kt$OverviewPage$FarmingItemType.currentEquip?.getItem()?.hoverName.formattedTextCompatLeadingWhiteLessResets().orEmpty()</ID>
+    <ID>UselessCallOnNotNull:ScoreboardData.kt$ScoreboardData$MinecraftCompat.localWorldOrNull?.scoreboard?.getSidebarObjective()?.displayName.formattedTextCompat().orEmpty()</ID>
+    <ID>VarCouldBeVal:CommandBuilder.kt$ComplexCommandBuilder$private var realDescription: String = ""</ID>
+    <ID>VarCouldBeVal:IslandAreas.kt$IslandAreas$var suffix = ""</ID>
+    <ID>VarCouldBeVal:KeyboardManager.kt$KeyboardManager$private var lastClickedMouseButton = -1</ID>
+    <ID>VarCouldBeVal:MoongladeBeacon.kt$MoongladeBeacon.BeaconTuneData$private var recentTicks: MutableList&lt;Int&gt; = mutableListOf()</ID>
+    <ID>VarCouldBeVal:RepoPatternGui.kt$RepoPatternGui$private var searchCache = ObservableList(mutableListOf&lt;RepoPatternInfo&gt;())</ID>
+    <ID>VarCouldBeVal:RepoPatternManager.kt$RepoPatternManager$/** * Map containing all keys and their repo patterns. Used for filling in new regexes after an update, and for * checking duplicate registrations. */ private var usedKeys: NavigableMap&lt;String, CommonPatternInfo&lt;*, *&gt;&gt; = TreeMap()</ID>
+    <ID>VarCouldBeVal:ScoreboardData.kt$ScoreboardData$var scores = scoreboard.listPlayerScores(objective)</ID>
+    <ID>VarCouldBeVal:SkyHanniItemTracker.kt$SkyHanniItemTracker$private var scrollValue = ScrollValue()</ID>
+    <ID>Wrapping:Calculator.kt$Calculator$(</ID>
+    <ID>Wrapping:Enchant.kt$Enchant$(</ID>
+  </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
## What
There's a lot of Detekt failures on the beta branch from dropping 1.8 and most of them are still unfixed weeks later. I don't have time to go through them, so I just updated the baseline to suppress them for now, so we don't get 100+ failures on every PR.

exclude_from_changelog