### PR TITLE
Fix: Enchants in Custom Wardrobe appearing white

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
-import at.hannibal2.skyhanni.events.minecraft.ToolTipEvent
 import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeApi.MAX_PAGES
 import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeApi.MAX_SLOT_PER_PAGE
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
@@ -43,7 +42,10 @@ import at.hannibal2.skyhanni.utils.renderables.primitives.WrappedStringRenderabl
 import at.hannibal2.skyhanni.utils.renderables.primitives.placeholder
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import net.minecraft.client.Minecraft
+import net.minecraft.network.chat.Component
+import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.TooltipFlag
 import java.awt.Color
 import kotlin.math.min
 import kotlin.time.Duration.Companion.milliseconds
@@ -234,7 +236,7 @@ object CustomWardrobe {
             val stack = slot.armor.getOrNull(armorIndex)?.copy()
             var renderable = Renderable.placeholder(containerWidth, hoverableSizes[armorIndex])
             if (stack != null) {
-                val toolTip = getToolTip(stack, slot, armorIndex)
+                val toolTip = getToolTip(stack, slot)
                 if (toolTip != null) {
                     renderable = Renderable.hoverTips(
                         renderable,
@@ -254,21 +256,11 @@ object CustomWardrobe {
         return Renderable.vertical(loreList, spacing = 1)
     }
 
-    private fun getToolTip(
-        stack: ItemStack,
-        slot: WardrobeSlot,
-        armorIndex: Int,
-    ): List<String>? {
+    private fun getToolTip(stack: ItemStack, slot: WardrobeSlot): List<Component>? {
         try {
             // Get tooltip from minecraft and other mods
             // TODO add support for advanced tooltip (F3+H)
-            val toolTips = stack.getTooltipCompat(false)
-
-            // Modify tooltip via SkyHanni Events
-            val mcSlotId = slot.inventorySlots[armorIndex]
-            // if the slot is null, we don't fire LorenzToolTipEvent at all.
-            val mcSlot = InventoryUtils.getSlotAtIndex(mcSlotId) ?: return toolTips
-            ToolTipEvent(mcSlot, stack, toolTips).post()
+            val toolTips = stack.getTooltipLines(Item.TooltipContext.EMPTY, Minecraft.getInstance().player, TooltipFlag.NORMAL)
 
             return toolTips
         } catch (e: Exception) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -40,6 +40,7 @@ import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.PauseScreen
 import net.minecraft.client.gui.screens.inventory.SignEditScreen
+import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.item.ItemStack
 import org.lwjgl.opengl.GL11
@@ -99,6 +100,7 @@ interface Renderable {
             null -> placeholder(12)
             is Renderable -> any
             is String -> text(any)
+            is Component -> text(any)
             is ItemStack -> item(any, itemScale)
             else -> null
         }


### PR DESCRIPTION
## What
Change Custom Wardrobe to use Components instead of Strings for the tooltip so custom colours are preserved.

## Changelog Fixes
+ Fixed enchants in Custom Wardrobe appearing white. - Vixid
