### PR TITLE
Feature: Require Zorro's Cape for Contest Claims

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/contest/JacobContestConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/contest/JacobContestConfig.kt
@@ -47,7 +47,7 @@ class JacobContestConfig {
     @Expose
     @ConfigOption(
         name = "Zorro's Cape Protection",
-        desc = "Block Jacob Farming Contest claims when not wearing a Zorro's Cape. Do not waste the 20% chance of duplicate medals!",
+        desc = "Block Jacob's Farming Contest claims when not wearing a §6Zorro's Cape§f. Do not waste the 20% chance of duplicate medals!",
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/contest/JacobContestConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/contest/JacobContestConfig.kt
@@ -34,7 +34,7 @@ class JacobContestConfig {
     @Expose
     @ConfigOption(
         name = "FF for Contest",
-        desc = "Show the minimum needed Farming Fortune for reaching each medal in Jacob's Farming Contest inventory."
+        desc = "Show the minimum needed Farming Fortune for reaching each medal in Jacob's Farming Contest inventory.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -43,4 +43,13 @@ class JacobContestConfig {
     @Expose
     @ConfigLink(owner = JacobContestConfig::class, field = "ffForContest")
     val ffForContestPosition: Position = Position(180, 156)
+
+    @Expose
+    @ConfigOption(
+        name = "Claim with Zorro's Cape",
+        desc = "Block Jacob Farming Contest claims when without wearing a Zorro's Cape. Do not waste the 20% chance of duplicate medals!",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var claimWithZorroCape: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/contest/JacobContestConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/contest/JacobContestConfig.kt
@@ -46,10 +46,10 @@ class JacobContestConfig {
 
     @Expose
     @ConfigOption(
-        name = "Claim with Zorro's Cape",
-        desc = "Block Jacob Farming Contest claims when without wearing a Zorro's Cape. Do not waste the 20% chance of duplicate medals!",
+        name = "Zorro's Cape Protection",
+        desc = "Block Jacob Farming Contest claims when not wearing a Zorro's Cape. Do not waste the 20% chance of duplicate medals!",
     )
     @ConfigEditorBoolean
     @FeatureToggle
-    var claimWithZorroCape: Boolean = false
+    var zorroCapeProtection: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
@@ -69,13 +69,9 @@ object PartyChatCommands {
             requiresPartyLead = false,
             executable = {
                 if (!CurrentPing.isEnabled()) {
-                    ChatUtils.clickableChat(
+                    ChatUtils.notifyOrDisable(
                         "Ping API is disabled, the ping command won't work!",
-                        prefixColor = "§c",
-                        onClick = {
-                            devConfig::pingApi.jumpToEditor()
-                        },
-                        hover = "§eClick to find setting in the config!",
+                        devConfig::pingApi,
                     )
                     return@PartyChatCommand
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.features.misc.CurrentPing
 import at.hannibal2.skyhanni.features.misc.TpsCounter
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
@@ -165,7 +165,7 @@ object GardenOptimalSpeed {
 
         if (config.showOnHUD) config.pos.renderRenderable(
             Renderable.text("§$colorCode$text"),
-            posLabel = "Garden Optimal Speed"
+            posLabel = "Garden Optimal Speed",
         )
         if (speed != currentSpeed && !recentlySwitchedTool) warn(speed)
     }
@@ -194,12 +194,7 @@ object GardenOptimalSpeed {
                 action = { HypixelCommands.setMaxSpeed(optimalSpeed) },
             )
         } else {
-            ChatUtils.clickableChat(
-                text,
-                onClick = { config::onlyWarnRanchers.jumpToEditor() },
-                hover = "§eClick to disable this feature!",
-                replaceSameMessage = true,
-            )
+            ChatUtils.notifyOrDisable(text, config::onlyWarnRanchers,)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenOptimalSpeed.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.events.render.gui.ScreenDrawnEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
-import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -31,6 +31,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.world.inventory.ChestMenu
 import net.minecraft.world.inventory.Slot
+import net.minecraft.world.item.ItemStack
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -175,11 +176,13 @@ object JacobFarmingContestsInventory {
         val chest = event.container as ChestMenu
 
         for ((slot, stack) in chest.getUpperItems()) {
-            if (stack.getLore().any { it == "§eClick to claim reward!" }) {
+            if (isClaimableContest(stack)) {
                 slot.highlight(LorenzColor.GREEN)
             }
         }
     }
+
+    fun isClaimableContest(stack: ItemStack): Boolean = stack.getLore().lastOrNull() == "§eClick to claim reward!"
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onToolTip(event: ToolTipTextEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestClaim.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestClaim.kt
@@ -1,0 +1,44 @@
+package at.hannibal2.skyhanni.features.garden.contest
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.title.TitleManager
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.features.inventory.EquipmentApi
+import at.hannibal2.skyhanni.features.inventory.EquipmentSlot
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import kotlin.time.Duration.Companion.seconds
+
+@SkyHanniModule
+object ZorroCapeContestClaim {
+
+    private val config get() = SkyHanniMod.feature.garden.jacobContest
+    private val zorroCape = "ZORROS_CAPE".toInternalName()
+
+    @HandleEvent
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!isEnabled()) return
+        if (!FarmingContestApi.inInventory) return
+        val cloak = EquipmentApi.getEquipment(EquipmentSlot.CLOAK)?.getInternalNameOrNull()
+        if (cloak == zorroCape) return
+        val stack = event.item ?: return
+        if (!JacobFarmingContestsInventory.isClaimableContest(stack)) return
+
+        event.cancel()
+        TitleManager.sendTitle(
+            titleText = "§cNo Zorro's Cape equipped!",
+            duration = 2.seconds,
+            location = TitleManager.TitleLocation.INVENTORY,
+        )
+        ChatUtils.notifyOrDisable(
+            "§cBlocked claiming Jacob Contest reward! §eUse a Zorro's Cape while opening farming contests.",
+            config::claimWithZorroCape,
+        )
+    }
+
+    private fun isEnabled() = IslandType.GARDEN.isCurrent() && config.claimWithZorroCape
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
@@ -23,10 +23,10 @@ object ZorroCapeContestProtection {
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled()) return
         if (!FarmingContestApi.inInventory) return
-        val cloak = EquipmentApi.getEquipment(EquipmentSlot.CLOAK)?.getInternalNameOrNull()
-        if (cloak == zorroCape) return
         val stack = event.item ?: return
         if (!JacobFarmingContestsInventory.isClaimableContest(stack)) return
+        val cloak = EquipmentApi.getEquipment(EquipmentSlot.CLOAK)?.getInternalNameOrNull()
+        if (cloak == zorroCape) return
 
         event.cancel()
         TitleManager.sendTitle(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
-object ZorroCapeContestClaim {
+object ZorroCapeContestProtection {
 
     private val config get() = SkyHanniMod.feature.garden.jacobContest
     private val zorroCape = "ZORROS_CAPE".toInternalName()
@@ -36,9 +36,9 @@ object ZorroCapeContestClaim {
         )
         ChatUtils.notifyOrDisable(
             "§cBlocked claiming Jacob Contest reward! §eUse a Zorro's Cape while opening farming contests.",
-            config::claimWithZorroCape,
+            config::zorroCapeProtection,
         )
     }
 
-    private fun isEnabled() = IslandType.GARDEN.isCurrent() && config.claimWithZorroCape
+    private fun isEnabled() = IslandType.GARDEN.isCurrent() && config.zorroCapeProtection
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
@@ -35,7 +35,7 @@ object ZorroCapeContestProtection {
             location = TitleManager.TitleLocation.INVENTORY,
         )
         ChatUtils.notifyOrDisable(
-            "§cBlocked claiming Jacob Contest reward! §eUse a Zorro's Cape while opening farming contests.",
+            "§cBlocked Jacob's Contest reward claim! §eEquip §6Zorro's Cape §ewhen claiming contest rewards.",
             config::zorroCapeProtection,
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
@@ -30,7 +30,7 @@ object ZorroCapeContestProtection {
 
         val stack = event.item ?: return
         val claimableContest = JacobFarmingContestsInventory.isClaimableContest(stack)
-        val isBulkClaim = stack.realDisplayName == "§6Bulk Claim"
+        val isBulkClaim = stack.realDisplayName == "Bulk Claim"
         if (claimableContest || isBulkClaim) {
             event.cancel()
             notifyUser()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
@@ -33,11 +33,11 @@ object ZorroCapeContestProtection {
         val isBulkClaim = stack.realDisplayName == "§6Bulk Claim"
         if (claimableContest || isBulkClaim) {
             event.cancel()
-            notify()
+            notifyUser()
         }
     }
 
-    private fun notify() {
+    private fun notifyUser() {
         TitleManager.sendTitle(
             titleText = "§cNo Zorro's Cape equipped!",
             duration = 2.seconds,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.features.inventory.EquipmentSlot
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.realDisplayName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import kotlin.time.Duration.Companion.seconds
 
@@ -23,12 +24,20 @@ object ZorroCapeContestProtection {
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!config.zorroCapeProtection) return
         if (!FarmingContestApi.inInventory) return
-        val stack = event.item ?: return
-        if (!JacobFarmingContestsInventory.isClaimableContest(stack)) return
+
         val cloak = EquipmentApi.getEquipment(EquipmentSlot.CLOAK)?.getInternalNameOrNull()
         if (cloak == zorroCape) return
 
-        event.cancel()
+        val stack = event.item ?: return
+        val claimableContest = JacobFarmingContestsInventory.isClaimableContest(stack)
+        val isBulkClaim = stack.realDisplayName == "§6Bulk Claim"
+        if (claimableContest || isBulkClaim) {
+            event.cancel()
+            notify()
+        }
+    }
+
+    private fun notify() {
         TitleManager.sendTitle(
             titleText = "§cNo Zorro's Cape equipped!",
             duration = 2.seconds,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/ZorroCapeContestProtection.kt
@@ -19,9 +19,9 @@ object ZorroCapeContestProtection {
     private val config get() = SkyHanniMod.feature.garden.jacobContest
     private val zorroCape = "ZORROS_CAPE".toInternalName()
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (!isEnabled()) return
+        if (!config.zorroCapeProtection) return
         if (!FarmingContestApi.inInventory) return
         val stack = event.item ?: return
         if (!JacobFarmingContestsInventory.isClaimableContest(stack)) return
@@ -39,6 +39,4 @@ object ZorroCapeContestProtection {
             config::zorroCapeProtection,
         )
     }
-
-    private fun isEnabled() = IslandType.GARDEN.isCurrent() && config.zorroCapeProtection
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HuntrapMisclickPrevention.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HuntrapMisclickPrevention.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.SimpleTimeMark

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HuntrapMisclickPrevention.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HuntrapMisclickPrevention.kt
@@ -36,10 +36,9 @@ object HuntrapMisclickPrevention {
 
         if (lastNotified.passedSince() < 10.seconds) return
         lastNotified = SimpleTimeMark.now()
-        ChatUtils.clickableChat(
-            "Prevented clicking an empty trap in Hunting Toolkit! Click here to disable this feature.",
-            { config::huntrapMisclick.jumpToEditor() },
-            replaceSameMessage = true,
+        ChatUtils.notifyOrDisable(
+            "Prevented clicking an empty trap in Hunting Toolkit!",
+            config::huntrapMisclick,
         )
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ChargeBottleNotification.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ChargeBottleNotification.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.features.fishing.IsFishingDetection.isFishing
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalNames

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ChargeBottleNotification.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ChargeBottleNotification.kt
@@ -49,12 +49,10 @@ object ChargeBottleNotification {
         if (bottlesInInventory.isEmpty()) return
         val size = bottlesInInventory.size
 
-        ChatUtils.clickableChat(
+        ChatUtils.notifyOrDisable(
             "You are currently fishing, but " +
-                "${bottlesInInventory.createCommaSeparatedList()} ${StringUtils.pluralize(size, "is", "are")} full. " +
-                "Click here to disable this notification.",
-            { config::chargeBottleNotification.jumpToEditor() },
-            replaceSameMessage = true,
+                "${bottlesInInventory.createCommaSeparatedList()} ${StringUtils.pluralize(size, "is", "are")} full",
+            config::chargeBottleNotification,
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -405,6 +405,11 @@ object ChatUtils {
         )
     }
 
+    /**
+     * Almost identical to chatAndOpenConfig and clickToActionOrDisable.
+     * Diff to chatAndOpenConfig: uses the wording "disable" as alternative, not "open config".
+     * Diff to clickToActionOrDisable: does not offer a normal click and action behavior.
+     */
     fun notifyOrDisable(
         message: String,
         option: KProperty0<*>,
@@ -414,9 +419,7 @@ object ChatUtils {
             "\n§e[CLICK to disable this feature]"
         clickableChat(
             "$message$hint",
-            onClick = {
-                option.jumpToEditor()
-            },
+            onClick = { option.jumpToEditor() },
             hover = "§eClick to disable this feature!",
             oneTimeClick = oneTimeClick,
             replaceSameMessage = true,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -405,6 +405,24 @@ object ChatUtils {
         )
     }
 
+    fun notifyOrDisable(
+        message: String,
+        option: KProperty0<*>,
+        oneTimeClick: Boolean = false,
+    ) {
+        val hint = if (SkyHanniMod.feature.chat.hideClickableHint) "" else
+            "\n§e[CLICK to disable this feature]"
+        clickableChat(
+            "$message$hint",
+            onClick = {
+                option.jumpToEditor()
+            },
+            hover = "§eClick to disable this feature!",
+            oneTimeClick = oneTimeClick,
+            replaceSameMessage = true,
+        )
+    }
+
     @Suppress("CAST_NEVER_SUCCEEDS")
     var GuiMessage.fullComponent: Component
         get() = (this as ChatLineData).skyHanni_fullComponent

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.EnumUtils.next
 import at.hannibal2.skyhanni.utils.EnumUtils.previous
 import at.hannibal2.skyhanni.utils.TimeUtils.format

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -94,11 +94,10 @@ object ComputerTimeOffset {
             if (timeoutWarned.passedSince() > 10.minutes) {
                 timeoutMap[ntpServer] = 0
                 timeoutWarned = SimpleTimeMark.now()
-                ChatUtils.clickableChat(
+                ChatUtils.notifyOrDisable(
                     "NTP server $ntpServer is not responding ($timeouts failures). Check your connection, " +
                         "try disconnecting from any VPNs/proxies, or click here to change NTP servers.",
-                    hover = "Click to open Dev Config",
-                    onClick = { devConfig::ntpServer.jumpToEditor() }
+                    devConfig::ntpServer,
                 )
             }
             return@runCatching null

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -78,6 +78,7 @@ import java.util.regex.Matcher
 import kotlin.time.Duration.Companion.INFINITE
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+
 //#if MC > 1.21.8
 //$$ import com.google.common.collect.ImmutableMultimap
 //$$ import com.mojang.authlib.properties.PropertyMap
@@ -901,4 +902,10 @@ object ItemUtils {
         val itemModel = BuiltInRegistries.ITEM.getValue(identifier)
         return if (itemModel == Items.AIR || itemModel == this.item) null else itemModel
     }
+
+    /**
+     * Returns the display name of the item stack as string.
+     */
+    // TODO rename to name or displayName or whatever better version, once its possible to do so.
+    val ItemStack.realDisplayName get() = hoverName.string
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -905,6 +905,7 @@ object ItemUtils {
 
     /**
      * Returns the display name of the item stack as string.
+     * This name is currently without color codes, we might wanna bring them back.
      */
     // TODO rename to name or displayName or whatever better version, once its possible to do so.
     val ItemStack.realDisplayName get() = hoverName.string


### PR DESCRIPTION
## What
Adds a safety check to prevent claiming Jacob's Farming Contest rewards if Zorro's Cape is not equipped, ensuring the 20% extra medal chance is utilized. Includes a config toggle and chat notification link.

<details>
<summary>Images</summary>

<img width="1207" height="780" alt="image" src="https://github.com/user-attachments/assets/43e60956-e8e1-44b5-a2a6-d171ff85474b" />

</details>

## Changelog New Features
+ Added Zorro's Cape Contest Protection. - hannibal2
    * Requires equipping Zorro's Cape to claim Jacob's Farming Contest rewards.