### PR TITLE
Fix: "On Collection Gained" pet rule breaks double hook detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -410,6 +410,8 @@ object PetStorageApi {
         )
     }
 
+    fun isAutopetMessage(message: String): Boolean = autoPetMessagePattern.matches(message)
+
     fun resolvePetDataOrNull(
         name: String,
         rarity: LorenzRarity? = null,

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.fishing
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.api.pet.PetStorageApi
 import at.hannibal2.skyhanni.data.jsonobjects.repo.SeaCreatureJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -27,7 +28,7 @@ object SeaCreatureManager {
      */
     private val doubleHookPattern by patternGroup.pattern(
         "doublehook",
-        "§eIt's a §r§aDouble Hook§r§e!(?: Woot woot!)?"
+        "§eIt's a §r§aDouble Hook§r§e!(?: Woot woot!)?",
     )
 
     /**
@@ -35,7 +36,7 @@ object SeaCreatureManager {
      */
     private val thunderBottleChargedPattern by patternGroup.pattern(
         "thundercharged",
-        "§e> Your bottle of thunder has fully charged!"
+        "§e> Your bottle of thunder has fully charged!",
     )
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -45,13 +46,18 @@ object SeaCreatureManager {
                 event.blockedReason = "double_hook"
             }
             doubleHook = true
-        } else if (!doubleHook || !thunderBottleChargedPattern.matches(event.message)) {
-            val seaCreature = getSeaCreatureFromMessage(event.message)
-            if (seaCreature != null) {
-                SeaCreatureFishEvent(seaCreature, event, doubleHook).post()
-            }
-            doubleHook = false
+            return
         }
+
+        if (thunderBottleChargedPattern.matches(event.message) ||
+            PetStorageApi.isAutopetMessage(event.message)
+        ) return
+
+        getSeaCreatureFromMessage(event.message)?.let {
+            SeaCreatureFishEvent(it, event, doubleHook).post()
+        }
+
+        doubleHook = false
     }
 
     @HandleEvent


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by a plus. For example, `Feature + Fix: Add new command and fix bug in command`.
Commonly used labels are Improvement, Backend, Feature and Fix.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

-->

## What
When using the "You increase your [Collection] collection" pet rule while using a sinker which increases that collection (e.g. sponge or prismarine sinker), the autopet message goes in between the double hook message and the sea creature message. This prevents SkyHanni from properly detecting that sea creature as a double hook.

Fixed by preventing resetting the double hook flag when an autopet message is detected - there's already an exception for thunder messages. Still want to manually match certain messages because it seems worse to assign double hook to the wrong sea creatures than to accidentally miss some double hooks when unexpected messages go in between.

## Changelog Fixes
+ Fixed some pet rules breaking double hook detection. - appable