### PR TITLE
Fix: /gfs with calculation suffixes (ie 5s)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
@@ -170,8 +170,8 @@ object GetFromSackApi {
     private fun commandValidator(args: List<String>): Pair<CommandResult, PrimitiveItemStack?> {
         if (args.isEmpty()) return CommandResult.WRONG_ARGUMENT to null
 
-        // The last parameter could be "2*3". This does not support ending with ")", but it is good enough
-        val argsNull = !args.last().last().isDigit()
+        val preCalc = Calculator.calculateOrNull(args.last())
+        val argsNull = preCalc == null
         val arguments = if (argsNull) {
             args + config.defaultAmountGFS.toString()
         } else args


### PR DESCRIPTION
## What
Fixed gfs calculation not working for suffixes (ie 1s for 64 and 1e for 160)

## Changelog Fixes
+ Fixed /gfs calculation not working with suffixes (i.e. 1s or 1e). - nopo
