### PR TITLE
Fix: Only show when ready in /shtodos always hiding the todo

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/customtodos/CustomTodo.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/customtodos/CustomTodo.kt
@@ -147,8 +147,7 @@ data class CustomTodo(
         if (readyAt.isInPast()) {
             timer = if (this.totalTriggers == 1) "§aReady"
             else "§a$triggers Left"
-        }
-        if (this.showOnlyWhenReady) return null
+        } else if (this.showOnlyWhenReady) return null
         if (this.showWhen != 0 && readyAt.timeUntil().inWholeSeconds > this.showWhen) return null
         return timer
     }


### PR DESCRIPTION
## What
so turns out that pesky "else" word is important

## Changelog Fixes
+ Fixed Only Show When Ready /shtodos never showing. - nopo

