### PR TITLE
Backend: DelayedRun standardization

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -225,7 +225,7 @@ object ChatManager {
         predicate: (GuiMessage) -> Boolean,
         reason: String? = null,
     ) {
-        DelayedRun.onThread.execute {
+        DelayedRun.runOrNextTick {
             indexOfFirst {
                 predicate(it)
             }.takeIf { it != -1 }?.let {
@@ -254,7 +254,7 @@ object ChatManager {
         reason: String? = null,
         predicate: (GuiMessage) -> Boolean,
     ) {
-        DelayedRun.onThread.execute {
+        DelayedRun.runOrNextTick {
             val iterator = iterator()
             var removed = 0
             while (iterator.hasNext() && removed < amount) {

--- a/src/main/java/at/hannibal2/skyhanni/data/FixedRateTimerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/FixedRateTimerManager.kt
@@ -12,8 +12,8 @@ object FixedRateTimerManager {
 
     init {
         fixedRateTimer(name = "skyhanni-fixed-rate-timer-manager", period = 1000L) {
-            DelayedRun.onThread.execute {
-                if (!SkyBlockUtils.onHypixel) return@execute
+            DelayedRun.runOrNextTick {
+                if (!SkyBlockUtils.onHypixel) return@runOrNextTick
                 SecondPassedEvent(totalSeconds).post()
                 totalSeconds++
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
@@ -9,9 +9,9 @@ import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketSentEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
-import net.minecraft.client.Minecraft
 import net.minecraft.network.protocol.game.ClientboundContainerClosePacket
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket
@@ -137,7 +137,7 @@ object OtherInventoryData {
     }
 
     private fun done(inventory: Inventory) {
-        Minecraft.getInstance().execute {
+        DelayedRun.runOrNextTick {
             InventoryFullyOpenedEvent(inventory).post()
             inventory.fullyOpenedOnce = true
             InventoryUpdatedEvent(inventory).post()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -23,6 +23,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
@@ -45,7 +46,6 @@ import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import net.minecraft.client.Minecraft
 
 @SkyHanniModule
 object CropMoneyDisplay {
@@ -381,7 +381,7 @@ object CropMoneyDisplay {
             multipliers = map
 
             ready = true
-            Minecraft.getInstance().execute {
+            DelayedRun.runOrNextTick {
                 update()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/hunting/InvisibugHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/hunting/InvisibugHighlighter.kt
@@ -44,7 +44,7 @@ object InvisibugHighlighter {
 
         if (!nearestArmorStand.isCompletelyDefault()) return
 
-        DelayedRun.onThread.execute { invisibugEntities.add(nearestArmorStand) }
+        DelayedRun.runOrNextTick { invisibugEntities.add(nearestArmorStand) }
 
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -140,7 +140,7 @@ object HarpFeatures {
     private var isGuiScaled = false
 
     private fun setGuiScale() {
-        Minecraft.getInstance().execute {
+        DelayedRun.runOrNextTick {
             guiSetting = getMinecraftGuiScale()
             setMinecraftGuiScale(0)
             isGuiScaled = true
@@ -150,7 +150,7 @@ object HarpFeatures {
 
     private fun unSetGuiScale() {
         if (!isGuiScaled) return
-        Minecraft.getInstance().execute {
+        DelayedRun.runOrNextTick {
             setMinecraftGuiScale(guiSetting)
             isGuiScaled = false
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
-import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.api.ApiInternalUtils
 import at.hannibal2.skyhanni.utils.system.ModVersion
@@ -28,6 +27,7 @@ import moe.nea.libautoupdate.PotentialUpdate
 import moe.nea.libautoupdate.UpdateContext
 import moe.nea.libautoupdate.UpdateTarget
 import moe.nea.libautoupdate.UpdateUtils
+import net.minecraft.client.Minecraft
 import java.util.concurrent.CompletableFuture
 import javax.net.ssl.HttpsURLConnection
 import kotlin.time.Duration
@@ -134,7 +134,7 @@ object UpdateManager {
                     ChatUtils.chat("§aSkyHanni didn't find a new update.")
                 }
             },
-            DelayedRun.onThread,
+            Minecraft.getInstance()
         )
     }
 
@@ -154,7 +154,7 @@ object UpdateManager {
                 ChatUtils.chat("Download of update complete. ")
                 ChatUtils.chat("§aThe update will be installed after your next restart.")
             },
-            DelayedRun.onThread,
+            Minecraft.getInstance(),
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -134,7 +134,7 @@ object UpdateManager {
                     ChatUtils.chat("§aSkyHanni didn't find a new update.")
                 }
             },
-            Minecraft.getInstance()
+            Minecraft.getInstance(),
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -8,6 +8,9 @@ import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.mixins.hooks.ChatLineData
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils.CHAT_PREFIX
+import at.hannibal2.skyhanni.utils.ChatUtils.DEBUG_PREFIX
+import at.hannibal2.skyhanni.utils.ChatUtils.USER_ERROR_PREFIX
 import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
@@ -303,7 +306,7 @@ object ChatUtils {
     }
 
     private fun refreshChat() {
-        DelayedRun.onThread.execute {
+        DelayedRun.runOrNextTick {
             chatGui.rescaleChat()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -8,9 +8,6 @@ import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.mixins.hooks.ChatLineData
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils.CHAT_PREFIX
-import at.hannibal2.skyhanni.utils.ChatUtils.DEBUG_PREFIX
-import at.hannibal2.skyhanni.utils.ChatUtils.USER_ERROR_PREFIX
 import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -82,7 +82,7 @@ object NeuItems {
 
     @HandleEvent
     fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
-        DelayedRun.onThread.execute {
+        DelayedRun.runOrNextTick {
             readAllNeuItems()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -24,7 +24,7 @@ object SoundUtils {
     val centuryActiveTimerAlert by lazy { createSound("skyhanni:centurytimer.active", 1f) }
 
     fun SoundInstance.playSound() {
-        DelayedRun.onThread.execute {
+        DelayedRun.runOrNextTick {
             val category = this.source
 
             val oldLevel = Minecraft.getInstance().options.getSoundSourceVolume(category)
@@ -33,7 +33,7 @@ object SoundUtils {
             try {
                 Minecraft.getInstance().soundManager.play(this)
             } catch (e: IllegalArgumentException) {
-                if (e.message?.startsWith("value already present:") == true) return@execute
+                if (e.message?.startsWith("value already present:") == true) return@runOrNextTick
                 ErrorManager.logErrorWithData(
                     e,
                     "Failed to play a sound",


### PR DESCRIPTION
## What
Cleaned up and standardized `DelayedRun` and related calls.

## Changelog Technical Details
+ `DelayedRun.runNextTick` now uses Minecraft's built-in scheduler. - Luna
+ Added `DelayedRun.runNextTick`, which calls `Minecraft#execute`, and replaces `DelayedRun.onThread.execute`. - Luna
    * Where an `Executor` is required, `Minecraft.getInstance()` is passed directly, since it serves as one.
