### PR TITLE
Fix: Arachne Kill Timer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneKillTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneKillTimer.kt
@@ -41,7 +41,7 @@ object ArachneKillTimer {
      */
     private val arachneDeathPattern by patternGroup.pattern(
         "dead",
-        "§f.*§r§6§lARACHNE DOWN!",
+        " +§r§6§lARACHNE DOWN!",
     )
 
     /**
@@ -49,7 +49,7 @@ object ArachneKillTimer {
      */
     private val arachneDamagePattern by patternGroup.pattern(
         "damage",
-        "§f +§r§eYour Damage: §r§a[0-9,]+ §r§7\\(Position #[0-9,]+\\)",
+        " +§r§eYour Damage: §r§a[0-9,]+ §r§7\\(Position #[0-9,]+\\)",
     )
 
     private var arachneSpawnedTime = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneKillTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneKillTimer.kt
@@ -41,7 +41,7 @@ object ArachneKillTimer {
      */
     private val arachneDeathPattern by patternGroup.pattern(
         "dead",
-        " +§r§6§lARACHNE DOWN!",
+        ".*§r§6§lARACHNE DOWN!",
     )
 
     /**
@@ -49,7 +49,7 @@ object ArachneKillTimer {
      */
     private val arachneDamagePattern by patternGroup.pattern(
         "damage",
-        " +§r§eYour Damage: §r§a[0-9,]+ §r§7\\(Position #[0-9,]+\\)",
+        ".*§r§eYour Damage: §r§a[0-9,]+ §r§7\\(Position #[0-9,]+\\)",
     )
 
     private var arachneSpawnedTime = SimpleTimeMark.farPast()


### PR DESCRIPTION
## What
Fixed the Arachne Kill Timer feature not working on 1.21 due to the white colour codes at the beginning that are stripped.

## Changelog Fixes
+ Fixed Arachne Kill Timer. - MTOnline