### PR TITLE
Fix: Zero prices and pets showing as NPC sellable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -40,6 +40,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.drawBorder
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getItemId
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.hasAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isMuseumDonated
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isRiftExportable
@@ -493,7 +494,9 @@ object HideNotClickableItems {
             name = name.substring(0, name.length - amountText.length)
         }
 
-        if (!clickToSellPattern.anyMatches(stack.getLore()) && stack.getInternalNameOrNull()?.getNpcPriceOrNull() == null) {
+        val sellable = clickToSellPattern.anyMatches(stack.getLore()) ||
+            (stack.getItemId() != "PET" && (stack.getInternalNameOrNull()?.getNpcPriceOrNull() ?: 0.0) > 0)
+        if (!sellable) {
             hideReason = "This item cannot be sold at the NPC!"
             return true
         }


### PR DESCRIPTION
## What
Fixed some edge cases incorrectly making "Not Clickable Items" show items with zero NPC sell price and pets as sellable (pets go to George, not regular NPCs).

## Changelog Fixes
+ Fixed some items being incorrectly shown as NPC sellable with Not Clickable Items enabled. - Luna