### PR TITLE
Fix: Diana Mob Name not sharing in Rare Mob Waypoints

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
@@ -231,8 +231,8 @@ object RareMobWaypointShare {
         val x = location.x.toInt()
         val y = location.y.toInt()
         val z = location.z.toInt()
-        val mobName = rareMob.mob?.name.orEmpty()
-        val name = if (mobName.isEmpty()) "" else " | $mobName"
+        val mobName = rareMob.name.string.orEmpty()
+        val name = if (mobName.isEmpty()) "" else "| $mobName"
         HypixelCommands.partyChat("x: $x, y: $y, z: $z $name")
     }
 


### PR DESCRIPTION
## What
fixes diana mobs name not being shared from sharing the waypoint, ty nopo for the real fix, i just got rid of an extra space to fix the other part of it



## Changelog Fixes
+ Fixed Diana Rare Mob Waypoints not sharing the rare mob's name. - Stella