### PR TITLE
Fix: item name resolver erroring in enchant name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -124,7 +124,7 @@ object ItemNameResolver {
             return "ULTIMATE_REITERATE;$tier".toInternalName()
         }
         // TODO USE SH-REPO
-        return originalName.toInternalName()
+        return originalName.removeColor().toInternalName()
     }
 
     private fun getInternalNameOrNullIgnoreCase(itemName: String): NeuInternalName? {


### PR DESCRIPTION
## What
this has caused many issues over time

## Changelog Fixes
+ Fixed SkyMart price per copper feature not working. - nopo
