### PR TITLE
Fix: dont wipe matrix stack when rendering items in hud 1.21.8

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
@@ -470,7 +470,9 @@ object GuiRenderUtils {
     //$$     val guiHeight = window.height.toFloat() / window.guiScale.toFloat()
     //$$     val slice = projectionMatrix.getBuffer(guiWidth, guiHeight)
     //$$     RenderSystem.setProjectionMatrix(slice, ProjectionType.ORTHOGRAPHIC)
-    //$$     RenderSystem.setupDefaultState()
+    //$$     RenderSystem.getModelViewStack().pushMatrix()
+    //$$     RenderSystem.getModelViewStack().identity()
+    //$$     val textureMatrixBackup = Matrix4f(RenderSystem.getTextureMatrix())
     //$$     RenderSystem.resetTextureMatrix()
     //$$
     //$$     // We have to use our own MatrixStack, because the DrawContext matrices are a 2D matrix now
@@ -518,6 +520,8 @@ object GuiRenderUtils {
     //#endif
     //$$     matrices.popPose()
     //$$     RenderSystem.teardownOverlayColor()
+    //$$     RenderSystem.getModelViewStack().popMatrix()
+    //$$     RenderSystem.getTextureMatrix().set(textureMatrixBackup)
     //$$     RenderSystem.restoreProjectionMatrix()
     //$$ }
     //$$


### PR DESCRIPTION
## What
Removes the call to `RenderSystem.setupDefaultState()` when rendering items,
this call wipes the modelViewStack and the textureMatrix and the item rendering logic does not restore them after
This pr instead pushes to the modelViewStack and saves a copy of the textureMatrix, then restoring the state after rendering

That code is what's causing the crash with lunar when entering garden (and a few other situations) as lunar pushes before hud rendering and later fails to pop cus the matrix was wiped
This may also cause issues with other mods doing similar things around wrapping hud rendering


<details>
<summary>Images</summary>

<img width="1920" height="1009" alt="2026-01-05_17 38 40" src="https://github.com/user-attachments/assets/77d58be4-25e3-4aee-8239-305f2a16c5a2" />

</details>

## Changelog Fixes
+ Fixed crash with Lunar when entering the Garden. - Soopyboo32
