### PR TITLE
Improvement: Add compatibility with time changer mods

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
@@ -2,8 +2,8 @@ package at.hannibal2.skyhanni.features.garden
 
 import at.hannibal2.skyhanni.features.garden.fortuneguide.FarmingItemType
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.ServerTime
 import at.hannibal2.skyhanni.utils.compat.DyeCompat
-import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
 import net.minecraft.world.level.block.Blocks
@@ -120,7 +120,7 @@ enum class CropType(
         }
 
         fun getTimeFlower(): CropType {
-            val time = MinecraftCompat.localWorld.dayTime % 24000
+            val time = ServerTime.dayTime % 24000
             // pretty sure great spook will break this
             return if (time >= 12000) MOONFLOWER else SUNFLOWER
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ServerTime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ServerTime.kt
@@ -1,0 +1,18 @@
+package at.hannibal2.skyhanni.utils
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import net.minecraft.network.protocol.game.ClientboundSetTimePacket
+
+@SkyHanniModule
+object ServerTime {
+    var dayTime: Long = 0L
+        private set
+
+    @HandleEvent
+    fun onPacketReceived(event: PacketReceivedEvent) {
+        val packet = event.packet as? ClientboundSetTimePacket ?: return
+        dayTime = packet.dayTime
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockTime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockTime.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.utils
 
-import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import kotlin.time.Duration
 
 /**
@@ -140,7 +139,7 @@ data class SkyBlockTime(
             }
         }
 
-        fun isDay(): Boolean = MinecraftCompat.localWorld.dayTime % 24000 in 1..12000
+        fun isDay(): Boolean = ServerTime.dayTime % 24000 in 1..12000
 
         fun getSBMonthByName(month: String): Int {
             var monthNr = 0


### PR DESCRIPTION
## What
Added a new `ServerTime` class that records time packets from the server as the source of truth so that time changer mods don't break it, and changed existing code to use it.

## Changelog Improvements
+ Sunflower/Moonflower and animated pet skin variants are now correctly detected when using a time changer mod. - Luna
