### PR TITLE
Improvement: Detect cooldown message for Ubik's Cube

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/mountaintop/MountaintopConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/mountaintop/MountaintopConfig.kt
@@ -22,26 +22,27 @@ class MountaintopConfig {
 
     @Expose
     @ConfigOption(
-        name = "Enigma Rose' End Flowerpot",
-        desc = "Show the dropdown location to the hard Flowerpot point while in the Enigma Rose' End quest.",
+        name = "Mountaintop Flower Pot Enigma Soul Helper",
+        desc = "Show the dropdown location to the hard to reach flower pot during the parkour for the Enigma Soul in Rose's End.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
     var enigmaRoseFlowerpot: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Ubik's Cube Reminder", desc = "Reminder when the 2 hours are over for Ubik's Cube in the Rift.")
+    @ConfigOption(name = "Ubik's Cube Reminder", desc = "Reminder when the 2 hour cooldown is over for Ubik's Cube in the Rift.")
     @ConfigEditorBoolean
     @FeatureToggle
     var ubikReminder: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Ubik's Cube Gui", desc = "Gui that shows how long until Ubik's Cube is ready.")
+    @ConfigOption(name = "Ubik's Cube GUI", desc = "GUI that shows how long until Ubik's Cube is ready.")
     @ConfigEditorBoolean
-    var ubikGui: Boolean = true
+    @FeatureToggle
+    var ubikGui: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Only Show When Ready", desc = "Only show the Ubik's Gui when it is ready.")
+    @ConfigOption(name = "Only Show When Ready", desc = "Only show the Ubik's Cube GUI when it is ready.")
     @ConfigEditorBoolean
     var ubikOnlyWhenReady: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/mountaintop/MountaintopConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/mountaintop/MountaintopConfig.kt
@@ -22,7 +22,7 @@ class MountaintopConfig {
 
     @Expose
     @ConfigOption(
-        name = "Mountaintop Flower Pot Enigma Soul Helper",
+        name = "Flower Pot Enigma Soul Helper",
         desc = "Show the dropdown location to the hard to reach flower pot during the parkour for the Enigma Soul in Rose's End.",
     )
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
@@ -10,10 +10,13 @@ import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.AutoUpdatingItemStack
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
@@ -32,20 +35,38 @@ object UbikReminder {
     private val cube by AutoUpdatingItemStack("UBIKS_CUBE")
 
     /**
-     * REGEX-TEST: §6§lROUND 7 §r§6(§r§lFINAL§r§6)§r§l: §r§eYou chose §r§c§lSTEAL §r§eand gained §r§55,000 Motes§r§e!
-     * REGEX-TEST: §6§lROUND 7 §r§6(§r§6§lFINAL§r§6)§r§6§l: §r§eYou chose §r§c§lSTEAL §r§eand gained §r§55,000 Motes§r§e!
+     * REGEX-TEST: ROUND 7 (FINAL): You chose STEAL and gained 55,000 Motes!
      */
     private val ubikRoundPattern by patternGroup.pattern(
-        "reminder",
-        "§6§lROUND [5-9] §r§6\\(§r(?:§6)?§lFINAL§r§6\\)§r(?:§6)?§l: §r§eYou chose .*",
+        "reminder-nocolor",
+        "ROUND \\d+ \\(FINAL\\): You chose \\w+ and gained [\\d,]+ Motes!",
+    )
+
+    /**
+     * REGEX-TEST: SPLIT! You need to wait 1h 23m 45s before you can play again.
+     * REGEX-TEST: SPLIT! You need to wait 1h 23m before you can play again.
+     * REGEX-TEST: SPLIT! You need to wait 12m 34s before you can play again.
+     * REGEX-TEST: SPLIT! You need to wait 12m before you can play again.
+     * REGEX-TEST: SPLIT! You need to wait 12s before you can play again.
+     */
+    private val cooldownPattern by patternGroup.pattern(
+        "cooldown",
+        "SPLIT! You need to wait (?<duration>.+) before you can play again\\.",
     )
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
     fun onChat(event: SkyHanniChatEvent) {
         if (!config.ubikReminder) return
         val storage = ProfileStorageData.profileSpecific?.rift ?: return
-        if (ubikRoundPattern.matches(event.message)) {
+        val message = event.message.removeColor()
+
+        if (ubikRoundPattern.matches(message)) {
             storage.ubikRemindTime = 2.hours.fromNow()
+            return
+        }
+
+        cooldownPattern.matchMatcher(message) {
+            storage.ubikRemindTime = TimeUtils.getDuration(group("duration")).fromNow()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
@@ -57,7 +57,7 @@ object UbikReminder {
     fun onChat(event: SkyHanniChatEvent) {
         if (!config.ubikReminder) return
         val storage = ProfileStorageData.profileSpecific?.rift ?: return
-        val message = event.chatComponent.string
+        val message = event.cleanMessage
 
         if (ubikRoundPattern.matches(message)) {
             storage.ubikRemindTime = 2.hours.fromNow()

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/UbikReminder.kt
@@ -58,7 +58,7 @@ object UbikReminder {
     fun onChat(event: SkyHanniChatEvent) {
         if (!config.ubikReminder) return
         val storage = ProfileStorageData.profileSpecific?.rift ?: return
-        val message = event.message.removeColor()
+        val message = event.chatComponent.string
 
         if (ubikRoundPattern.matches(message)) {
             storage.ubikRemindTime = 2.hours.fromNow()


### PR DESCRIPTION
## What
Allow players to resync their Ubik's Cube timer by attempting to use it while it is on cooldown. While I'm at it, I also changed the existing pattern to not rely on color codes, as we really should be moving away from those going forward.

## Changelog Improvements
+ Ubik's Cube timer will now automatically update if you try to use it while on cooldown. - Luna

