### PR TITLE
Fix: dont do reflection if aarons isnt installed

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -169,6 +169,7 @@ object EnchantParser {
     }
 
     private fun warnAaronMaxEnchant() {
+        if (!PlatformUtils.isModInstalled("aaron-mod")) return
         val aaron = OtherModsSettings.aaron()
 
         if (aaron.isEnabled("skyblock.enchantments.rainbowMaxEnchants")) {


### PR DESCRIPTION
## What
Fixed reflection performance loss if aarons mod isnt installed

<details>
<summary>Images</summary>

before 
<img width="2527" height="1303" alt="image" src="https://github.com/user-attachments/assets/919a4d06-f48e-4817-8e82-f12cfd71f1bc" />

after
<img width="2503" height="1299" alt="image" src="https://github.com/user-attachments/assets/ceeda9e0-92ba-4044-bd28-e595b85285aa" />

</details>

## Changelog Fixes
+ Fixed small performance issue with enchant parsing. - nopo

