### PR TITLE
Improvement + Fix: Remember other chests in instance chest profit display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -214,16 +214,16 @@ object InstanceChestProfit {
         add(listOf(Renderable.emptyText()))
         add(listOf(Renderable.text("$color§lProfit"), Renderable.text("$color${total.formatCoin()}")))
 
-        if (IslandType.CATACOMBS.isCurrent() || IslandType.KUUDRA_ARENA.isCurrent()) {
-            add(listOf(Renderable.emptyText()))
-            add(listOf(Renderable.text("§d§lAll Chest Profits")))
+        if (!IslandType.CATACOMBS.isCurrent() && !IslandType.KUUDRA_ARENA.isCurrent()) return@buildList
 
-            for (it in chestProfits.entries.sortedByDescending { it.value }) {
-                color = if (it.value < 0) "§c"
-                else "§a"
+        add(listOf(Renderable.emptyText()))
+        add(listOf(Renderable.text("§d§lAll Chest Profits")))
 
-                add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))
-            }
+        for (it in chestProfits.entries.sortedByDescending { it.value }) {
+            color = if (it.value < 0) "§c"
+            else "§a"
+
+            add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -173,55 +173,58 @@ object InstanceChestProfit {
             }
         }
 
-        val newDisplay = buildList {
-            add(listOf(Renderable.text("§d§l$fixedInventoryName Profit")))
-            add(listOf(Renderable.emptyText()))
+        display = Renderable.table(buildDisplay(fixedInventoryName, itemsWithCost), ySpacing = 1)
+    }
 
-            var total = 0.0
-            var displayedCost = false
+    private fun buildDisplay(
+        fixedInventoryName: String,
+        itemsWithCost: MutableMap<String, Double>,
+    ) = buildList {
+        add(listOf(Renderable.text("§d§l$fixedInventoryName Profit")))
+        add(listOf(Renderable.emptyText()))
 
-            val revenue = itemsWithCost.values.filter { it > 0 }.sum()
-            add(listOf(Renderable.text("§a§lTotal Revenue"), Renderable.text("§a${revenue.formatCoin()}")))
+        var total = 0.0
+        var displayedCost = false
 
-            itemsWithCost.forEach {
-                val coinsColor = if (it.value < 0) "§c"
-                else "§a"
+        val revenue = itemsWithCost.values.filter { it > 0 }.sum()
+        add(listOf(Renderable.text("§a§lTotal Revenue"), Renderable.text("§a${revenue.formatCoin()}")))
 
-                if (!displayedCost && it.value < 0) {
-                    val cost = itemsWithCost.values.filter { cost -> cost < 0 }.sum()
-                    add(listOf(Renderable.emptyText()))
-                    add(listOf(Renderable.text("§c§lTotal Cost"), Renderable.text("§c${cost.formatCoin()}")))
-                    displayedCost = true
-                }
-
-                val coins = "$coinsColor${it.value.formatCoin()}"
-
-                total += it.value
-                add(listOf(Renderable.text(it.key), Renderable.text(coins)))
-            }
-
-            chestProfits[fixedInventoryName] = total
-
-            var color = if (total < 0) "§c"
+        itemsWithCost.forEach {
+            val coinsColor = if (it.value < 0) "§c"
             else "§a"
 
-            add(listOf(Renderable.emptyText()))
-            add(listOf(Renderable.text("$color§lProfit"), Renderable.text("$color${total.formatCoin()}")))
-
-            if (IslandType.CATACOMBS.isCurrent() || IslandType.KUUDRA_ARENA.isCurrent()) {
+            if (!displayedCost && it.value < 0) {
+                val cost = itemsWithCost.values.filter { cost -> cost < 0 }.sum()
                 add(listOf(Renderable.emptyText()))
-                add(listOf(Renderable.text("§d§lAll Chest Profits")))
-
-                for (it in chestProfits.entries.sortedByDescending { it.value }) {
-                    color = if (it.value < 0) "§c"
-                    else "§a"
-
-                    add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))
-                }
+                add(listOf(Renderable.text("§c§lTotal Cost"), Renderable.text("§c${cost.formatCoin()}")))
+                displayedCost = true
             }
+
+            val coins = "$coinsColor${it.value.formatCoin()}"
+
+            total += it.value
+            add(listOf(Renderable.text(it.key), Renderable.text(coins)))
         }
 
-        display = Renderable.table(newDisplay, ySpacing = 1)
+        chestProfits[fixedInventoryName] = total
+
+        var color = if (total < 0) "§c"
+        else "§a"
+
+        add(listOf(Renderable.emptyText()))
+        add(listOf(Renderable.text("$color§lProfit"), Renderable.text("$color${total.formatCoin()}")))
+
+        if (IslandType.CATACOMBS.isCurrent() || IslandType.KUUDRA_ARENA.isCurrent()) {
+            add(listOf(Renderable.emptyText()))
+            add(listOf(Renderable.text("§d§lAll Chest Profits")))
+
+            for (it in chestProfits.entries.sortedByDescending { it.value }) {
+                color = if (it.value < 0) "§c"
+                else "§a"
+
+                add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))
+            }
+        }
     }
 
     private fun getKuudraEssenceBonus(): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -204,7 +204,6 @@ object InstanceChestProfit {
 
             if (chestProfits.isNotEmpty()) {
                 add(listOf(Renderable.emptyText()))
-                add(listOf(Renderable.emptyText()))
                 add(listOf(Renderable.text("§d§lAll Chest Profits")))
 
                 for (it in chestProfits.entries.sortedByDescending { it.value }) {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -129,6 +129,11 @@ object InstanceChestProfit {
     }
 
     private fun createDisplay(inventoryName: String, items: Map<Int, ItemStack>) {
+        /**
+         * Kuudra chests say "Free Chest Chest" and "Paid Chest Chest" due to Hypixel issue
+         */
+        val fixedInventoryName = inventoryName.replace("Chest Chest", "Chest")
+
         val itemsWithCost: MutableMap<String, Double> = mutableMapOf()
         items.forEach {
             if (fakeItemNamePattern.matches(it.value.hoverName.formattedTextCompatLeadingWhiteLessResets())) return@forEach
@@ -169,7 +174,7 @@ object InstanceChestProfit {
         }
 
         val newDisplay = buildList {
-            add(listOf(Renderable.text("§d§l$inventoryName Profit")))
+            add(listOf(Renderable.text("§d§l$fixedInventoryName Profit")))
             add(listOf(Renderable.emptyText()))
 
             var total = 0.0
@@ -195,7 +200,7 @@ object InstanceChestProfit {
                 add(listOf(Renderable.text(it.key), Renderable.text(coins)))
             }
 
-            chestProfits[inventoryName] = total
+            chestProfits[fixedInventoryName] = total
 
             var color = if (total < 0) "§c"
             else "§a"

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -239,12 +239,12 @@ object InstanceChestProfit {
     }
 
     @HandleEvent(DungeonEnterEvent::class)
-    fun onEnterDungeon() {
+    fun onDungeonEnter() {
         chestProfits.clear()
     }
 
     @HandleEvent(KuudraEnterEvent::class)
-    fun onEnterKuudra() {
+    fun onKuudraEnter() {
         chestProfits.clear()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -168,10 +168,7 @@ object InstanceChestProfit {
         }
 
         val newDisplay = buildList {
-            val chestName = if (inDungeonChest) "Dungeon"
-            else if (inKuudraChest) "Kuudra"
-            else ""
-            add(listOf(Renderable.text("§d§l$chestName Chest Profit")))
+            add(listOf(Renderable.text("§d§l$inventoryName Chest Profit")))
             add(listOf(Renderable.emptyText()))
 
             var total = 0.0

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -202,16 +202,14 @@ object InstanceChestProfit {
             add(listOf(Renderable.emptyText()))
             add(listOf(Renderable.text("$color§lProfit"), Renderable.text("$color${total.formatCoin()}")))
 
-            if (chestProfits.isNotEmpty()) {
-                add(listOf(Renderable.emptyText()))
-                add(listOf(Renderable.text("§d§lAll Chest Profits")))
+            add(listOf(Renderable.emptyText()))
+            add(listOf(Renderable.text("§d§lAll Chest Profits")))
 
-                for (it in chestProfits.entries.sortedByDescending { it.value }) {
-                    color = if (it.value < 0) "§c"
-                    else "§a"
+            for (it in chestProfits.entries.sortedByDescending { it.value }) {
+                color = if (it.value < 0) "§c"
+                else "§a"
 
-                    add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))
-                }
+                add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -6,6 +6,8 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.events.dungeon.DungeonEnterEvent
+import at.hannibal2.skyhanni.events.kuudra.KuudraEnterEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
@@ -97,6 +99,7 @@ object InstanceChestProfit {
     private var inDungeonChest = false
     private var inKuudraChest = false
     private var display: Renderable? = null
+    private val chestProfits: MutableMap<String, Double> = mutableMapOf()
 
     @HandleEvent
     fun onInventoryOpen(event: InventoryFullyOpenedEvent) {
@@ -115,7 +118,7 @@ object InstanceChestProfit {
             else -> return
         }
 
-        createDisplay(event.inventoryItems)
+        createDisplay(event.inventoryName, event.inventoryItems)
     }
 
     @HandleEvent(InventoryCloseEvent::class)
@@ -124,7 +127,7 @@ object InstanceChestProfit {
         inKuudraChest = false
     }
 
-    private fun createDisplay(items: Map<Int, ItemStack>) {
+    private fun createDisplay(inventoryName: String, items: Map<Int, ItemStack>) {
         val itemsWithCost: MutableMap<String, Double> = mutableMapOf()
         items.forEach {
             if (fakeItemNamePattern.matches(it.value.hoverName.formattedTextCompatLeadingWhiteLessResets())) return@forEach
@@ -194,11 +197,26 @@ object InstanceChestProfit {
                 add(listOf(Renderable.text(it.key), Renderable.text(coins)))
             }
 
+            chestProfits[inventoryName] = total
+
             val color = if (total < 0) "§c"
             else "§a"
 
             add(listOf(Renderable.emptyText()))
             add(listOf(Renderable.text("$color§lProfit"), Renderable.text("$color ${total.formatCoin()}")))
+
+            if (chestProfits.isNotEmpty()) {
+                add(listOf(Renderable.emptyText()))
+                add(listOf(Renderable.emptyText()))
+                add(listOf(Renderable.text("§d§lAll Chest Profits")))
+
+                for (it in chestProfits.entries.sortedByDescending { it.value }) {
+                    val color = if (it.value < 0) "§c"
+                    else "§a"
+
+                    add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))
+                }
+            }
         }
 
         display = Renderable.table(newDisplay, ySpacing = 1)
@@ -221,5 +239,15 @@ object InstanceChestProfit {
         if (!config.enabled || (!inDungeonChest && !inKuudraChest)) return
 
         config.position.renderRenderable(display, posLabel = "Instance Chest Profit")
+    }
+
+    @HandleEvent(DungeonEnterEvent::class)
+    fun onEnterDungeon() {
+        chestProfits.clear()
+    }
+
+    @HandleEvent(KuudraEnterEvent::class)
+    fun onEnterKuudra() {
+        chestProfits.clear()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -203,7 +203,7 @@ object InstanceChestProfit {
             else "§a"
 
             add(listOf(Renderable.emptyText()))
-            add(listOf(Renderable.text("$color§lProfit"), Renderable.text("$color ${total.formatCoin()}")))
+            add(listOf(Renderable.text("$color§lProfit"), Renderable.text("$color${total.formatCoin()}")))
 
             if (chestProfits.isNotEmpty()) {
                 add(listOf(Renderable.emptyText()))

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -168,7 +168,7 @@ object InstanceChestProfit {
         }
 
         val newDisplay = buildList {
-            add(listOf(Renderable.text("§d§l$inventoryName Chest Profit")))
+            add(listOf(Renderable.text("§d§l$inventoryName Profit")))
             add(listOf(Renderable.emptyText()))
 
             var total = 0.0

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -196,7 +196,7 @@ object InstanceChestProfit {
 
             chestProfits[inventoryName] = total
 
-            val color = if (total < 0) "§c"
+            var color = if (total < 0) "§c"
             else "§a"
 
             add(listOf(Renderable.emptyText()))
@@ -208,7 +208,7 @@ object InstanceChestProfit {
                 add(listOf(Renderable.text("§d§lAll Chest Profits")))
 
                 for (it in chestProfits.entries.sortedByDescending { it.value }) {
-                    val color = if (it.value < 0) "§c"
+                    color = if (it.value < 0) "§c"
                     else "§a"
 
                     add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -176,10 +176,7 @@ object InstanceChestProfit {
         display = Renderable.table(buildDisplay(fixedInventoryName, itemsWithCost), ySpacing = 1)
     }
 
-    private fun buildDisplay(
-        fixedInventoryName: String,
-        itemsWithCost: MutableMap<String, Double>,
-    ) = buildList {
+    private fun buildDisplay(fixedInventoryName: String, itemsWithCost: Map<String, Double>) = buildList {
         add(listOf(Renderable.text("§d§l$fixedInventoryName Profit")))
         add(listOf(Renderable.emptyText()))
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.combat
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
@@ -202,14 +203,16 @@ object InstanceChestProfit {
             add(listOf(Renderable.emptyText()))
             add(listOf(Renderable.text("$color§lProfit"), Renderable.text("$color${total.formatCoin()}")))
 
-            add(listOf(Renderable.emptyText()))
-            add(listOf(Renderable.text("§d§lAll Chest Profits")))
+            if (IslandType.CATACOMBS.isCurrent() || IslandType.KUUDRA_ARENA.isCurrent()) {
+                add(listOf(Renderable.emptyText()))
+                add(listOf(Renderable.text("§d§lAll Chest Profits")))
 
-            for (it in chestProfits.entries.sortedByDescending { it.value }) {
-                color = if (it.value < 0) "§c"
-                else "§a"
+                for (it in chestProfits.entries.sortedByDescending { it.value }) {
+                    color = if (it.value < 0) "§c"
+                    else "§a"
 
-                add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))
+                    add(listOf(Renderable.text(it.key), Renderable.text("$color${it.value.formatCoin()}")))
+                }
             }
         }
 


### PR DESCRIPTION
## What
1. Displays all current instance chest profits together on the instance chest profit display so you can pick the highest profit chest easier. Each chest is sorted by profit (descending).
2. Changes the title of the instance chest profit display to include the current chest ("Dungeon Chest Profit" -> "Wood Chest Profit" or "Bedrock Chest Profit")
3. Fixes an extra space between the coloring and the displayed text in the Profit line of the current chest, causing the number to be misaligned.

I've tested this in dungeons but I am not strong enough to do Kuudra, so I need someone to actually test it in Kuudra.

<img width="1003" height="693" alt="image" src="https://github.com/user-attachments/assets/fb9b572a-f084-48a8-a4d6-433c1da1b2f3" />

## Changelog Improvements
+ Show all instance chest profits in the instance chest profit display. - frostyy1905

## Changelog Fixes
+ Fixed current chest profit number misalignment. - frostyy1905
