### PR TITLE
Fix: Enchant regex and remove comma formatting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.kt
@@ -79,19 +79,6 @@ class EnchantParsingConfig {
     val advancedEnchantColors: AdvancedEnchantmentColors = AdvancedEnchantmentColors()
 
     @Expose
-    @ConfigOption(name = "Comma Format", desc = "Change the format of the comma after each enchant.")
-    @ConfigEditorDropdown
-    val commaFormat: Property<CommaFormat> = Property.of(CommaFormat.COPY_ENCHANT)
-
-    enum class CommaFormat(private val displayName: String) {
-        COPY_ENCHANT("Copy enchant format"),
-        DEFAULT("Default (Blue)"),
-        ;
-
-        override fun toString() = displayName
-    }
-
-    @Expose
     @ConfigOption(
         name = "Hide Vanilla Enchants",
         desc = "Hide the regular vanilla enchants usually found in the first 1-2 lines of lore."


### PR DESCRIPTION
## What
Fixes enchant regexes to account for Hypixel's new Component change, and remove the comma formatting config option.

## Changelog Fixes
+ Fixed enchant regex for new Hypixel formatting. - Vixid

## Changelog Removed Features
+ Removed comma formatting from Enchant Parser. - Vixid

