### PR TITLE
Backend: Show Total Tracker Uptime by default

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.kt
@@ -116,7 +116,7 @@ class TrackerConfig {
         name = "AFK timeout",
         desc = "Pause the tracker if it is not modified for this amount of seconds."
     )
-    @Searchtag("uptime")
+    @SearchTag("uptime")
     @ConfigEditorSlider(minValue = 15f, maxValue = 900f, minStep = 15f)
     var afkTimeout: Int = 60
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.kt
@@ -109,7 +109,7 @@ class TrackerConfig {
         desc = "Only show uptime and profit per hour when the tracker is on session mode."
     )
     @ConfigEditorBoolean
-    val onlyShowSession: Property<Boolean> = Property.of(true)
+    val onlyShowSession: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrackerConfig.kt
@@ -116,8 +116,9 @@ class TrackerConfig {
         name = "AFK timeout",
         desc = "Pause the tracker if it is not modified for this amount of seconds."
     )
+    @Searchtag("uptime")
     @ConfigEditorSlider(minValue = 15f, maxValue = 900f, minStep = 15f)
-    var afkTimeout: Int = 30
+    var afkTimeout: Int = 60
 
     @Expose
     @ConfigOption(name = "Tracker Search", desc = "Add a search bar to tracker GUIs.")


### PR DESCRIPTION
Tracker uptime on total was disabled by default since it'd be wrong for people who had trackers prior to its inclusion. Enough time has passed that most people with prior tracker data have updated so there's no point keeping it off. 

exclude_from_changelog