### PR TITLE
Improvement: Add Fishing Rod to be configurable in Sensitivity Reducer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 115
+    const val CONFIG_VERSION = 116
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
-import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
@@ -16,12 +15,12 @@ class SensitivityReducerConfig {
     @Expose
     @ConfigOption(name = "Enabled", desc = "Lower mouse sensitivity while in the garden.")
     @ConfigEditorBoolean
-    var enabled: Property<Boolean> = Property.of(false)
+    val enabled: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Mode", desc = "Decide when the mouse sensitivity should be lowered.")
     @ConfigEditorDraggableList
-    var mode: MutableList<Mode> = mutableListOf(Mode.TOOL)
+    val mode: MutableList<Mode> = mutableListOf(Mode.TOOL)
 
     enum class Mode(private val displayName: String) {
         TOOL("Farming tool"),

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features.garden
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
@@ -13,13 +14,18 @@ import org.lwjgl.glfw.GLFW
 
 class SensitivityReducerConfig {
     @Expose
-    @ConfigOption(name = "Mode", desc = "Lower mouse sensitivity while in the garden.")
-    @ConfigEditorDropdown
-    var mode: Mode = Mode.OFF
+    @ConfigOption(name = "Enabled", desc = "Lower mouse sensitivity while in the garden.")
+    @ConfigEditorBoolean
+    var enabled: Property<Boolean> = Property.of(false)
+
+    @Expose
+    @ConfigOption(name = "Mode", desc = "Decide when the mouse sensitivity should be lowered.")
+    @ConfigEditorDraggableList
+    var mode: MutableList<Mode> = mutableListOf(Mode.TOOL)
 
     enum class Mode(private val displayName: String) {
-        OFF("Disabled"),
-        TOOL("Holding farming tool"),
+        TOOL("Farming tool"),
+        FISHING_ROD("Fishing Rod"),
         KEYBIND("Holding Keybind"),
         ;
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -20,8 +20,6 @@ import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import com.google.gson.JsonArray
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import net.minecraft.client.Minecraft
 
@@ -175,8 +173,8 @@ object SensitivityReducer {
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(80, "garden.sensitivityReducerConfig", "garden.sensitivityReducer")
         event.move(81, "garden.sensitivityReducer.showGUI", "garden.sensitivityReducer.showGui")
-        event.transform(115, "garden.sensitivityReducer.mode") { element ->
-            event.add(115, "garden.sensitivityReducer.enabled") { JsonPrimitive("OFF" != element.asString) }
+        event.transform(116, "garden.sensitivityReducer.mode") { element ->
+            event.add(116, "garden.sensitivityReducer.enabled") { JsonPrimitive("OFF" != element.asString) }
             val newList = JsonArray()
             when (element.asString) {
                 "OFF" -> {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -90,12 +90,11 @@ object SensitivityReducer {
     }
 
     private fun autoToggleIfNeeded() {
-        val shouldActivate =
-            (config.mode.contains(SensitivityReducerConfig.Mode.TOOL) && isHoldingTool()) || (config.mode.contains(SensitivityReducerConfig.Mode.FISHING_ROD) && isHoldingFishingRod()) || (config.mode.contains(
-                SensitivityReducerConfig.Mode.KEYBIND,
-            ) && isHoldingKey())
+        val holdingTool = config.mode.contains(SensitivityReducerConfig.Mode.TOOL) && isHoldingTool()
+        val holdingFishingRod = config.mode.contains(SensitivityReducerConfig.Mode.FISHING_ROD) && isHoldingFishingRod()
+        val holdenKeybind = config.mode.contains(SensitivityReducerConfig.Mode.KEYBIND) && isHoldingKey()
 
-        toggleIfCondition { shouldActivate }
+        toggleIfCondition { holdingTool || holdingFishingRod || holdenKeybind }
     }
 
     private fun toggleIfCondition(check: () -> Boolean) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -19,6 +19,10 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
 import net.minecraft.client.Minecraft
 
 @SkyHanniModule
@@ -171,6 +175,17 @@ object SensitivityReducer {
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(80, "garden.sensitivityReducerConfig", "garden.sensitivityReducer")
         event.move(81, "garden.sensitivityReducer.showGUI", "garden.sensitivityReducer.showGui")
+        event.transform(115, "garden.sensitivityReducer.mode") { element ->
+            event.add(115, "garden.sensitivityReducer.enabled") { JsonPrimitive("OFF" != element.asString) }
+            val newList = JsonArray()
+            when (element.asString) {
+                "OFF" -> {
+                    newList.add("TOOL")
+                }
+                else -> newList.add(element.asString)
+            }
+            newList
+        }
     }
 
     private fun isHoldingTool(): Boolean = GardenApi.toolInHand != null

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.features.garden.SensitivityReducerConfig
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.features.fishing.FishingApi
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.sensitivity.MouseSensitivityManager.SensitivityState
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -50,6 +51,9 @@ object SensitivityReducer {
         config.reducingFactor.afterChange {
             MouseSensitivityManager.destroyCache()
         }
+        config.enabled.afterChange {
+            autoToggle()
+        }
         config.onlyPlot.afterChange {
             autoToggle()
         }
@@ -86,11 +90,12 @@ object SensitivityReducer {
     }
 
     private fun autoToggleIfNeeded() {
-        when (config.mode) {
-            SensitivityReducerConfig.Mode.OFF -> toggleIfCondition { false }
-            SensitivityReducerConfig.Mode.TOOL -> toggleIfCondition(::isHoldingTool)
-            SensitivityReducerConfig.Mode.KEYBIND -> toggleIfCondition(::isHoldingKey)
-        }
+        val shouldActivate =
+            (config.mode.contains(SensitivityReducerConfig.Mode.TOOL) && isHoldingTool()) || (config.mode.contains(SensitivityReducerConfig.Mode.FISHING_ROD) && isHoldingFishingRod()) || (config.mode.contains(
+                SensitivityReducerConfig.Mode.KEYBIND,
+            ) && isHoldingKey())
+
+        toggleIfCondition { shouldActivate }
     }
 
     private fun toggleIfCondition(check: () -> Boolean) {
@@ -101,6 +106,10 @@ object SensitivityReducer {
     }
 
     private fun autoToggle() {
+        if (!config.enabled.get()) {
+            if (isActive) disable()
+            return
+        }
         if (config.onlyPlot.get() && inBarn) {
             if (isActive) disable()
             return
@@ -162,5 +171,6 @@ object SensitivityReducer {
     }
 
     private fun isHoldingTool(): Boolean = GardenApi.toolInHand != null
+    private fun isHoldingFishingRod(): Boolean = FishingApi.holdingRod
     private fun isHoldingKey(): Boolean = config.keybind.isKeyHeld() && Minecraft.getInstance().screen == null
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -90,11 +90,15 @@ object SensitivityReducer {
     }
 
     private fun autoToggleIfNeeded() {
-        val holdingTool = config.mode.contains(SensitivityReducerConfig.Mode.TOOL) && isHoldingTool()
-        val holdingFishingRod = config.mode.contains(SensitivityReducerConfig.Mode.FISHING_ROD) && isHoldingFishingRod()
-        val holdenKeybind = config.mode.contains(SensitivityReducerConfig.Mode.KEYBIND) && isHoldingKey()
+        val shouldReduce = config.mode.any {
+            when (it) {
+                SensitivityReducerConfig.Mode.TOOL -> isHoldingTool()
+                SensitivityReducerConfig.Mode.FISHING_ROD -> isHoldingFishingRod()
+                SensitivityReducerConfig.Mode.KEYBIND -> isHoldingKey()
+            }
+        }
 
-        toggleIfCondition { holdingTool || holdingFishingRod || holdenKeybind }
+        toggleIfCondition { shouldReduce }
     }
 
     private fun toggleIfCondition(check: () -> Boolean) {


### PR DESCRIPTION
## What
Adding the Fishing Rod to Sensitivity Reducer to allow Rod swapping pets with reduced sensitivity

## Changelog Improvements
+ Improved Sensitivity Reducer to allow Fishing Rods. - FabiHBBBT