### PR TITLE
Improvement: Add bits to pest profit tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
@@ -29,12 +29,12 @@ class PestProfitTrackerConfig {
     @Expose
     @ConfigOption(name = "Include Bits", desc = "Add bits gained from killing pests to the tracker.")
     @ConfigEditorBoolean
-    var includeBits: Property<Boolean> = Property.of(false)
+    val includeBits: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Coins Per Bit", desc = "Set how much bits gained from killing pests are worth.")
     @ConfigEditorSlider(minValue = 0f, maxValue = 2000f, minStep = 100f)
-    var coinsPerBit: Property<Int> = Property.of(700)
+    val coinsPerBit: Property<Int> = Property.of(700)
 
     @Expose
     @ConfigLink(owner = PestProfitTrackerConfig::class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
@@ -7,6 +7,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
 
 class PestProfitTrackerConfig {
     @Expose
@@ -24,6 +25,16 @@ class PestProfitTrackerConfig {
     @ConfigOption(name = "Time Displayed", desc = "Time displayed after killing a pest.")
     @ConfigEditorSlider(minValue = 5f, maxValue = 60f, minStep = 1f)
     var timeDisplayed: Int = 30
+
+    @Expose
+    @ConfigOption(name = "Include Bits", desc = "Add bits gained from killing pests to the tracker.")
+    @ConfigEditorBoolean
+    var includeBits: Property<Boolean> = Property.of(false)
+
+    @Expose
+    @ConfigOption(name = "Coins Per Bit", desc = "Set how much bits gained from killing pests are worth.")
+    @ConfigEditorSlider(minValue = 0f, maxValue = 2000f, minStep = 100f)
+    var coinsPerBit: Property<Int> = Property.of(700)
 
     @Expose
     @ConfigLink(owner = PestProfitTrackerConfig::class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/data/BitsApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BitsApi.kt
@@ -276,9 +276,11 @@ object BitsApi {
         }
     }
 
-    fun bitsPerCookie(): Int {
+    fun bitsPerCookie(): Int = (DEFAULT_COOKIE_BITS * bitsMultiplier()).toInt()
+
+    fun bitsMultiplier(): Double {
         val museumBonus = profileStorage?.museumMilestone?.let { 1 + it * 0.01 } ?: 1.0 // Adds 1% per level
-        return (DEFAULT_COOKIE_BITS * museumBonus * (fameRank?.bitsMultiplier ?: 1.0)).toInt()
+        return museumBonus * (fameRank?.bitsMultiplier ?: 1.0)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestKillEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestKillEvent.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.events.garden.pests
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.features.garden.pests.PestType
 
-object PestKillEvent : SkyHanniEvent()
+class PestKillEvent(val pestType: PestType) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -289,7 +289,7 @@ object PestApi {
             lastPestKillTime = SimpleTimeMark.now()
             removeNearestPest()
             GardenPlotApi.getCurrentPlot()?.let { gardenPestTypes.removeFromPlot(it, pest) }
-            PestKillEvent.post()
+            PestKillEvent(pest).post()
         }
         if (noPestsChatPattern.matches(event.message)) {
             resetAllPests()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -35,7 +35,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -25,6 +25,7 @@ import at.hannibal2.skyhanni.features.garden.pests.PestProfitTracker.drawDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.ItemPriceSource
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
@@ -92,7 +93,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     val DUNG_ITEM = "DUNG".toInternalName()
     val OVERCLOCKER = "OVERCLOCKER_3000".toInternalName()
     val BITS = "SKYBLOCK_BIT".toInternalName()
-    val KILL_BITS = 5
+    const val KILL_BITS = 5
     private val PEST_SHARD = "ATTRIBUTE_SHARD_PEST_LUCK;1".toInternalName()
     private val lastPestKillTimes = TimeLimitedCache<PestType, SimpleTimeMark>(15.seconds)
     private var adjustmentMap: Map<PestType, Map<NeuInternalName, Int>> = mapOf()
@@ -120,11 +121,14 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
         }
 
         private fun getBitsPrice(): Double {
-            return if (SkyBlockUtils.noTradeMode) 0.0 else config.coinsPerBit.get().toDouble()
+            return if (SkyHanniMod.feature.misc.tracker.priceSource == ItemPriceSource.NPC_SELL) 0.0 else config.coinsPerBit.get()
+                .toDouble()
         }
 
-        override val selectedBucketItems get() =
-            if (config.includeBits.get()) super.selectedBucketItems else super.selectedBucketItems.filter { it.key != BITS }.toMutableMap()
+        override val selectedBucketItems
+            get() =
+                if (config.includeBits.get()) super.selectedBucketItems else super.selectedBucketItems.filter { it.key != BITS }
+                    .toMutableMap()
 
         override fun getCoinName(bucket: PestType?, item: TrackedItem) = "§6Pest Kill Coins"
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestProfitTracker.kt
@@ -7,20 +7,24 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.features.garden.pests.PestProfitTrackerConfig
+import at.hannibal2.skyhanni.data.BitsApi
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.data.jsonobjects.repo.GardenJson
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.PurseChangeCause
 import at.hannibal2.skyhanni.events.PurseChangeEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.garden.pests.PestKillEvent
 import at.hannibal2.skyhanni.events.item.ShardGainEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.pests.PestProfitTracker.drawDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
@@ -30,6 +34,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
@@ -86,6 +91,8 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
 
     val DUNG_ITEM = "DUNG".toInternalName()
     val OVERCLOCKER = "OVERCLOCKER_3000".toInternalName()
+    val BITS = "SKYBLOCK_BIT".toInternalName()
+    val KILL_BITS = 5
     private val PEST_SHARD = "ATTRIBUTE_SHARD_PEST_LUCK;1".toInternalName()
     private val lastPestKillTimes = TimeLimitedCache<PestType, SimpleTimeMark>(15.seconds)
     private var adjustmentMap: Map<PestType, Map<NeuInternalName, Int>> = mapOf()
@@ -103,6 +110,21 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
                 "§7Your drop rate: §c$dropRate.",
             )
         }
+
+        override fun getCustomPricePer(internalName: NeuInternalName): Double {
+            return if (internalName == BITS) {
+                getBitsPrice()
+            } else {
+                super.getCustomPricePer(internalName)
+            }
+        }
+
+        private fun getBitsPrice(): Double {
+            return if (SkyBlockUtils.noTradeMode) 0.0 else config.coinsPerBit.get().toDouble()
+        }
+
+        override val selectedBucketItems get() =
+            if (config.includeBits.get()) super.selectedBucketItems else super.selectedBucketItems.filter { it.key != BITS }.toMutableMap()
 
         override fun getCoinName(bucket: PestType?, item: TrackedItem) = "§6Pest Kill Coins"
 
@@ -138,6 +160,19 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     fun onChat(event: SkyHanniChatEvent) {
         event.checkPestChats()
         event.checkSprayChats()
+    }
+
+    @HandleEvent
+    fun onPestKill(event: PestKillEvent) {
+        if (BitsApi.bitsAvailable > 0) {
+            val bitsAmount = KILL_BITS * BitsApi.bitsMultiplier()
+            addItem(event.pestType, BITS, bitsAmount.toInt(), false)
+        }
+    }
+
+    @HandleEvent
+    fun onConfigLoad(event: ConfigLoadEvent) {
+        ConditionalUtils.onToggle(config.coinsPerBit, config.includeBits) { update() }
     }
 
     private fun SkyHanniChatEvent.checkPestChats() {

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
@@ -78,10 +78,10 @@ abstract class BucketedItemTrackerData<E : Enum<E>>(clazz: KClass<E>) : ItemTrac
     @Expose
     val bucketedItems: MutableMap<E, MutableMap<NeuInternalName, TrackedItem>> = mutableMapOf()
 
-    fun getBucketedItems(bucket: E) = bucketedItems[bucket] ?: flattenBucketsItems()
+    open fun getBucketedItems(bucket: E) = bucketedItems[bucket] ?: flattenBucketsItems()
 
     private val E.items get() = bucketedItems[this] ?: mutableMapOf()
-    val selectedBucketItems get() = selectedBucket?.items ?: flattenBucketsItems()
+    open val selectedBucketItems get() = selectedBucket?.items ?: flattenBucketsItems()
 
     private fun flattenBucketsItems(): MutableMap<NeuInternalName, TrackedItem> =
         buckets.distinct().fold(mutableMapOf()) { acc, bucket ->


### PR DESCRIPTION
## What
Added option to include bits in pest profit tracker, off by default

## Changelog Improvements
+ Added option to include bits from pest kills to pest profit tracker. - Chissl

