### PR TITLE
Improvement: Setting to hide/show PestProfitTracker while farming

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
@@ -22,6 +22,11 @@ class PestProfitTrackerConfig {
     var hideChat: Boolean = true
 
     @Expose
+    @ConfigOption(name = "Hide while farming", desc = "Hide profit tracker while farming.")
+    @ConfigEditorBoolean
+    var hideWhileFarming: Boolean = true
+
+    @Expose
     @ConfigOption(name = "Time Displayed", desc = "Time displayed after killing a pest.")
     @ConfigEditorSlider(minValue = 5f, maxValue = 60f, minStep = 1f)
     var timeDisplayed: Int = 30

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
@@ -30,7 +30,9 @@ class PestProfitTrackerConfig {
     )
     @ConfigEditorDraggableList
     val onlyWhenHolding: MutableList<HeldItem> = mutableListOf(
-        HeldItem.FARMING_TOOL,
+        HeldItem.SPRAYONATOR,
+        HeldItem.VACUUM,
+        HeldItem.TIMEOUT,
     )
 
     enum class HeldItem(val displayName: String) {

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestProfitTrackerConfig.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
@@ -20,6 +21,28 @@ class PestProfitTrackerConfig {
     @ConfigOption(name = "Hide messages", desc = "Hide regular pest drop messages.")
     @ConfigEditorBoolean
     var hideChat: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Only When Holding",
+        desc = "Only show the time display when holding the specified items.\n" +
+            "Leave empty to always show.",
+    )
+    @ConfigEditorDraggableList
+    val onlyWhenHolding: MutableList<HeldItem> = mutableListOf(
+        HeldItem.FARMING_TOOL,
+    )
+
+    enum class HeldItem(val displayName: String) {
+        FARMING_TOOL("Farming Tool"),
+        SPRAYONATOR("Sprayonator"),
+        VACUUM("Vacuum"),
+        LASSO("Lasso"),
+        TIMEOUT("Timeout"),
+        ;
+
+        override fun toString() = displayName
+    }
 
     @Expose
     @ConfigOption(name = "Hide while farming", desc = "Hide profit tracker while farming.")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -330,11 +330,19 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     private fun shouldShowDisplay(): Boolean {
         if (!config.enabled || !GardenApi.inGarden()) return false
         if (GardenApi.isCurrentlyFarming() && config.hideWhileFarming) return false
+        if (config.onlyWhenHolding.isEmpty()) return true
         val allInactive = lastPestKillTimes.all {
             it.value.passedSince() > config.timeDisplayed.seconds
         }
-        val notHoldingTool = !PestApi.hasVacuumInHand() && !PestApi.hasSprayonatorInHand()
-        return !(allInactive && notHoldingTool)
+        return config.onlyWhenHolding.any {
+            when (it) {
+                PestProfitTrackerConfig.HeldItem.FARMING_TOOL -> GardenApi.hasFarmingToolInHand()
+                PestProfitTrackerConfig.HeldItem.VACUUM -> PestApi.hasVacuumInHand()
+                PestProfitTrackerConfig.HeldItem.SPRAYONATOR -> PestApi.hasSprayonatorInHand()
+                PestProfitTrackerConfig.HeldItem.LASSO -> PestApi.hasLassoInHand()
+                PestProfitTrackerConfig.HeldItem.TIMEOUT -> !allInactive
+            }
+        }
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -329,7 +329,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
 
     private fun shouldShowDisplay(): Boolean {
         if (!config.enabled || !GardenApi.inGarden()) return false
-        if (GardenApi.isCurrentlyFarming()) return false
+        if (GardenApi.isCurrentlyFarming() && config.hideWhileFarming) return false
         val allInactive = lastPestKillTimes.all {
             it.value.passedSince() > config.timeDisplayed.seconds
         }


### PR DESCRIPTION
## What
Added ability to show/hide pest profit tracker while farming

## Changelog Improvements
+ Added Option to Show/Hide Pest Profit Tracker while farming. - FabiHBBBT
