### PR TITLE
Feature: greenhouse growth cycle display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.features.garden.composter.ComposterConfig
 import at.hannibal2.skyhanni.config.features.garden.contest.JacobContestConfig
 import at.hannibal2.skyhanni.config.features.garden.cropmilestones.CropMilestonesConfig
+import at.hannibal2.skyhanni.config.features.garden.greenhouse.GreenhouseConfig
 import at.hannibal2.skyhanni.config.features.garden.laneswitch.FarmingLaneConfig
 import at.hannibal2.skyhanni.config.features.garden.optimalAngles.OptimalAnglesConfig
 import at.hannibal2.skyhanni.config.features.garden.optimalspeed.OptimalSpeedConfig
@@ -95,6 +96,10 @@ class GardenConfig {
     @Expose
     @Category(name = "Pests", desc = "Pests Settings")
     val pests: PestsConfig = PestsConfig()
+
+    @Expose
+    @Category(name = "Greenhouse", desc = "Greenhouse Settings")
+    val greenhouse: GreenhouseConfig = GreenhouseConfig()
 
     @Expose
     @ConfigOption(name = "Farming Fortune Display", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.features.garden.greenhouse
 
+import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
@@ -14,9 +15,10 @@ class GreenhouseConfig {
         desc = "Show a timer for the next growth stage. Open the Crop Diagnostics menu in the Greenhouse to detect the time.",
     )
     @ConfigEditorBoolean
+    @FeatureToggle
     var showDisplay: Boolean = true
 
     @Expose
     @ConfigLink(owner = GreenhouseConfig::class, field = "showDisplay")
-    val position: Position = Position(-350, 220, 1.3f)
+    val position: Position = Position(-350, 220)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
@@ -19,6 +19,14 @@ class GreenhouseConfig {
     var showDisplay: Boolean = true
 
     @Expose
+    @ConfigOption(
+        name = "Only Show When Ready",
+        desc = "Only show the timer when it is ready.",
+    )
+    @ConfigEditorBoolean
+    var onlyShowWhenOverdue: Boolean = false
+
+    @Expose
     @ConfigLink(owner = GreenhouseConfig::class, field = "showDisplay")
     val position: Position = Position(-350, 220)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
@@ -1,0 +1,22 @@
+package at.hannibal2.skyhanni.config.features.garden.greenhouse
+
+import at.hannibal2.skyhanni.config.core.config.Position
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class GreenhouseConfig {
+
+    @Expose
+    @ConfigOption(
+        name = "Growth Cycle Timer",
+        desc = "Show a timer for the next growth stage. Open the Crop Diagnostics menu in the Greenhouse to detect the time.",
+    )
+    @ConfigEditorBoolean
+    var showDisplay: Boolean = true
+
+    @Expose
+    @ConfigLink(owner = GreenhouseConfig::class, field = "showDisplay")
+    val position: Position = Position(-350, 220, 1.3f)
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
@@ -28,5 +28,5 @@ class GreenhouseConfig {
 
     @Expose
     @ConfigLink(owner = GreenhouseConfig::class, field = "showDisplay")
-    val position: Position = Position(-350, 220)
+    val position: Position = Position(180, 40)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -969,4 +969,11 @@ class ProfileSpecificStorage(
 
     @Expose
     var hiddenCoopMembers: MutableSet<String> = mutableSetOf()
+
+    @Expose
+    var greenhouse: GreenHouseStorage = GreenHouseStorage()
+
+    class GreenHouseStorage(
+        @Expose var nextCycle: SimpleTimeMark = farPast(),
+    )
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -619,6 +619,13 @@ class ProfileSpecificStorage(
 
         @Expose
         var cropFeverTracker: CropFeverTracker.BucketData = CropFeverTracker.BucketData()
+
+        @Expose
+        var greenhouse: GreenHouseStorage = GreenHouseStorage()
+
+        class GreenHouseStorage(
+            @Expose var nextCycle: SimpleTimeMark = farPast(),
+        )
     }
 
     // - gui
@@ -969,11 +976,4 @@ class ProfileSpecificStorage(
 
     @Expose
     var hiddenCoopMembers: MutableSet<String> = mutableSetOf()
-
-    @Expose
-    var greenhouse: GreenHouseStorage = GreenHouseStorage()
-
-    class GreenHouseStorage(
-        @Expose var nextCycle: SimpleTimeMark = farPast(),
-    )
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryDetector
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
@@ -28,7 +28,7 @@ import kotlin.time.Duration.Companion.minutes
 object GrowthCycle {
 
     private val config get() = SkyHanniMod.feature.garden.greenhouse
-    private val storage get() = ProfileStorageData.profileSpecific?.greenhouse
+    private val storage get() = ProfileStorageData.profileSpecific?.garden?.greenhouse
 
     val patternGroup = RepoPattern.group("garden.greenhouse.growthcycle")
 
@@ -41,21 +41,21 @@ object GrowthCycle {
     )
 
     /**
-     * REGEX-TEST: §7Next Stage: §a1h 40m 20s
-     * REGEX-TEST: §7Next Stage: §a40m 20s
-     * REGEX-TEST: §7Next Stage: §a20s
+     * REGEX-TEST: Next Stage: 1h 40m 20s
+     * REGEX-TEST: Next Stage: 40m 20s
+     * REGEX-TEST: Next Stage: 20s
      */
     val nextStagePattern by patternGroup.pattern(
         "nextstage",
-        "§7Next Stage: §a(?<time>.*)",
+        "Next Stage: (?<time>.*)",
     )
 
     /**
-     * REGEX-TEST: §a§lFULLY GROWN
+     * REGEX-TEST: FULLY GROWN
      */
     val fullyGrownPattern by patternGroup.pattern(
         "fullygrown",
-        "§a§lFULLY GROWN",
+        "FULLY GROWN",
     )
 
     val cropDiagnosticInventory = InventoryDetector(inventoryPattern)
@@ -66,9 +66,9 @@ object GrowthCycle {
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!cropDiagnosticInventory.isInside()) return
         val item = event.inventoryItemsWithNull[20] ?: return
-        val lore = item.getLore()
+        val lore = item.getLoreComponent()
 
-        nextStagePattern.firstMatcher(lore) {
+        nextStagePattern.firstMatcher(lore.map { it.string }) {
             val timeString = group("time")
             if (fullyGrownPattern.matches(timeString)) return@firstMatcher
             val duration = TimeUtils.getDurationOrNull(timeString) ?: return
@@ -97,7 +97,7 @@ object GrowthCycle {
         val timeUntil = nextCycle.timeUntil()
         val color = timeUntil.timerColor("§a")
         val formatted = if (nextCycle.passedSince() > 10.minutes) "§cOVERDUE" else "$color${timeUntil.format(maxUnits = 2)}"
-        addString("§6Next Growth Stage: $formatted")
+        addString("§6Next Greenhouse Growth Stage: $formatted")
     }
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
@@ -43,19 +42,12 @@ object GrowthCycle {
     /**
      * REGEX-TEST: Next Stage: 1h 40m 20s
      * REGEX-TEST: Next Stage: 40m 20s
+     * REGEX-TEST: Next Stage: 20m 1s
      * REGEX-TEST: Next Stage: 20s
      */
     val nextStagePattern by patternGroup.pattern(
         "nextstage",
-        "Next Stage: (?<time>.*)",
-    )
-
-    /**
-     * REGEX-TEST: FULLY GROWN
-     */
-    val fullyGrownPattern by patternGroup.pattern(
-        "fullygrown",
-        "FULLY GROWN",
+        "Next Stage: (?<time>(?:\\d\\d?[hms] ?)+)",
     )
 
     val cropDiagnosticInventory = InventoryDetector(inventoryPattern)
@@ -70,7 +62,6 @@ object GrowthCycle {
 
         nextStagePattern.firstMatcher(lore.map { it.string }) {
             val timeString = group("time")
-            if (fullyGrownPattern.matches(timeString)) return@firstMatcher
             val duration = TimeUtils.getDurationOrNull(timeString) ?: return
             storage?.nextCycle = duration.fromNow()
             updateDisplay()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
@@ -8,18 +8,19 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
+import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.timerColor
-import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.renderables.Renderable
-import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.minutes
 
@@ -50,9 +51,10 @@ object GrowthCycle {
         "Next Stage: (?<time>(?:\\d\\d?[hms] ?)+)",
     )
 
-    val cropDiagnosticInventory = InventoryDetector(inventoryPattern)
+    private val cropDiagnosticInventory = InventoryDetector(inventoryPattern)
 
     private var display: Renderable? = null
+    private var beep = true
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
@@ -64,6 +66,7 @@ object GrowthCycle {
             val timeString = group("time")
             val duration = TimeUtils.getDurationOrNull(timeString) ?: return
             storage?.nextCycle = duration.fromNow()
+            beep = false
             updateDisplay()
         }
     }
@@ -79,16 +82,27 @@ object GrowthCycle {
         val nextCycle = storage?.nextCycle ?: return
         if (nextCycle.isFarPast() || nextCycle.passedSince() > 60.minutes) {
             display = null
+            beep = false
             return
         }
         display = drawDisplay(nextCycle)
     }
 
-    private fun drawDisplay(nextCycle: SimpleTimeMark) = Renderable.vertical {
+    private fun drawDisplay(nextCycle: SimpleTimeMark): Renderable? {
         val timeUntil = nextCycle.timeUntil()
         val color = timeUntil.timerColor("§a")
-        val formatted = if (nextCycle.passedSince() > 10.minutes) "§cOVERDUE" else "$color${timeUntil.format(maxUnits = 2)}"
-        addString("§6Next Greenhouse Growth Stage: $formatted")
+        val formatted = if (nextCycle.isInFuture()) {
+            if (!beep) {
+                SoundUtils.playPlingSound()
+                ChatUtils.chat("§aGreenhouse Growth Stage is ready in the Garden")
+                beep = true
+            }
+            "§cOVERDUE"
+        } else {
+            if (config.onlyShowWhenOverdue) return null
+            "$color${timeUntil.format(maxUnits = 2)}"
+        }
+        return Renderable.text("§6Next Greenhouse Growth Stage: $formatted")
     }
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
@@ -1,0 +1,109 @@
+package at.hannibal2.skyhanni.features.garden.greenhouse
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryDetector
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
+import at.hannibal2.skyhanni.utils.TimeUtils
+import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.TimeUtils.timerColor
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import kotlin.time.Duration.Companion.minutes
+
+@SkyHanniModule
+object GrowthCycle {
+
+    private val config get() = SkyHanniMod.feature.garden.greenhouse
+    private val storage get() = ProfileStorageData.profileSpecific?.greenhouse
+
+    val patternGroup = RepoPattern.group("garden.greenhouse.growthcycle")
+
+    /**
+     * REGEX-TEST: Crop Diagnostics
+     */
+    private val inventoryPattern by patternGroup.pattern(
+        "inventory",
+        "Crop Diagnostics",
+    )
+
+    /**
+     * REGEX-TEST: §7Next Stage: §a1h 40m 20s
+     * REGEX-TEST: §7Next Stage: §a40m 20s
+     * REGEX-TEST: §7Next Stage: §a20s
+     */
+    val nextStagePattern by patternGroup.pattern(
+        "nextstage",
+        "§7Next Stage: §a(?<time>.*)",
+    )
+
+    /**
+     * REGEX-TEST: §a§lFULLY GROWN
+     */
+    val fullyGrownPattern by patternGroup.pattern(
+        "fullygrown",
+        "§a§lFULLY GROWN",
+    )
+
+    val cropDiagnosticInventory = InventoryDetector(inventoryPattern)
+
+    private var display: Renderable? = null
+
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+        if (!cropDiagnosticInventory.isInside()) return
+        val item = event.inventoryItemsWithNull[20] ?: return
+        val lore = item.getLore()
+
+        nextStagePattern.firstMatcher(lore) {
+            val timeString = group("time")
+            if (fullyGrownPattern.matches(timeString)) return@firstMatcher
+            val duration = TimeUtils.getDurationOrNull(timeString) ?: return
+            storage?.nextCycle = duration.fromNow()
+            updateDisplay()
+        }
+    }
+
+    @HandleEvent
+    fun onSecondPassed(event: SecondPassedEvent) {
+        if (!config.showDisplay) return
+
+        updateDisplay()
+    }
+
+    private fun updateDisplay() {
+        val nextCycle = storage?.nextCycle ?: return
+        if (nextCycle.isFarPast() || nextCycle.passedSince() > 60.minutes) {
+            display = null
+            return
+        }
+        display = drawDisplay(nextCycle)
+    }
+
+    private fun drawDisplay(nextCycle: SimpleTimeMark) = Renderable.vertical {
+        val timeUntil = nextCycle.timeUntil()
+        val color = timeUntil.timerColor("§a")
+        val formatted = if (nextCycle.passedSince() > 10.minutes) "§cOVERDUE" else "$color${timeUntil.format(maxUnits = 2)}"
+        addString("§6Next Growth Stage: $formatted")
+    }
+
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
+    fun onRenderOverlay() {
+        if (!config.showDisplay) return
+
+        config.position.renderRenderable(display, posLabel = "Growth Cycle Timer")
+    }
+}


### PR DESCRIPTION
## What
Added a display for next growth cycle so players always know when the next cycle is.
The player needs to view at a crop/mutation that is not currently maxed.

<details>
<summary>Images</summary>

<img width="402" height="80" alt="image" src="https://github.com/user-attachments/assets/5f9616c3-2472-44bc-bb6d-c7149b505fe8" />

</details>

## Changelog New Features
+ Greenhouse Growth Cycle Display. - FabiHBBBT