### PR TITLE
Feature + Fix: Mantid Bonus Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/MantidDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/MantidDisplayConfig.kt
@@ -1,0 +1,42 @@
+package at.hannibal2.skyhanni.config.features.garden.pests
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class MantidDisplayConfig {
+    @Expose
+    @FeatureToggle
+    @ConfigOption(name = "Enabled", desc = "Enables the display")
+    @ConfigEditorBoolean
+    var enabled: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "When to show", desc = "When to show this display")
+    @ConfigEditorDraggableList
+    val whenToShow: List<WhenShowDisplay> = listOf(WhenShowDisplay.MANTID)
+
+    enum class WhenShowDisplay(val displayName: String) {
+        ALWAYS("Always on Garden"),
+        ARMOR("Wearing farming Armor"),
+        MANTID("Using Mantid Reforge"),
+        TOOL("Holding farming tool"),
+        VACUUM("Holding vacuum"),
+        ;
+        override fun toString(): String = displayName
+    }
+
+    @Expose
+    @ConfigOption(name = "Group Similar Expires", desc = "Group pests that expire within this many seconds together.")
+    @ConfigEditorSlider(minValue = 0.0F, maxValue = 120F, minStep = 5f)
+    var groupSimilarExpire: Int = 30
+
+    @Expose
+    @ConfigLink(owner = MantidDisplayConfig::class, field = "enabled")
+    val pos: Position = Position(200, 50)
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/MantidDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/MantidDisplayConfig.kt
@@ -19,7 +19,7 @@ class MantidDisplayConfig {
     @Expose
     @ConfigOption(name = "When to show", desc = "When to show this display")
     @ConfigEditorDraggableList
-    val whenToShow: List<WhenShowDisplay> = listOf(WhenShowDisplay.MANTID)
+    val whenToShow: MutableList<WhenShowDisplay> = mutableListOf(WhenShowDisplay.MANTID)
 
     enum class WhenShowDisplay(val displayName: String) {
         ALWAYS("Always on Garden"),

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/MantidDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/MantidDisplayConfig.kt
@@ -10,6 +10,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class MantidDisplayConfig {
+
     @Expose
     @FeatureToggle
     @ConfigOption(name = "Enabled", desc = "Enables the display")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/MantidDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/MantidDisplayConfig.kt
@@ -28,11 +28,12 @@ class MantidDisplayConfig {
         TOOL("Holding farming tool"),
         VACUUM("Holding vacuum"),
         ;
+
         override fun toString(): String = displayName
     }
 
     @Expose
-    @ConfigOption(name = "Group Similar Expires", desc = "Group pests that expire within this many seconds together.")
+    @ConfigOption(name = "Group Similar Expiry", desc = "Group pests that expire within this many seconds together.")
     @ConfigEditorSlider(minValue = 0.0F, maxValue = 120F, minStep = 5f)
     var groupSimilarExpire: Int = 30
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestsConfig.kt
@@ -56,6 +56,11 @@ class PestsConfig {
     val pesthunterShop: PesthunterShopConfig = PesthunterShopConfig()
 
     @Expose
+    @ConfigOption(name = "Mantid Kill Display", desc = "")
+    @Accordion
+    val mantidDisplay: MantidDisplayConfig = MantidDisplayConfig()
+
+    @Expose
     @ConfigOption(
         name = "Mute Vacuum",
         desc = "Mute the pest vacuum when using its right click ability.",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -53,7 +53,7 @@ object MantidKillDisplay {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onSecondPassed(event: SecondPassedEvent) {
-        checkForExpires()
+        checkForExpired()
         updateDisplay()
     }
 
@@ -78,7 +78,7 @@ object MantidKillDisplay {
         return false
     }
 
-    private fun checkForExpires() {
+    private fun checkForExpired() {
         while (pestExpireQueue.peek()?.isInPast() == true) {
             pestExpireQueue.poll()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -109,7 +109,7 @@ object MantidKillDisplay {
         add(Renderable.text("§2Mantid Bonus: $bonusColor$bonus§7/§a$MAX_BONUS"))
 
         if (bonus > 0) {
-            val pestString = if (bonus == 1) "Next Pest Expires" else "$nextExpireGroup Pests Expire"
+            val pestString = if (nextExpireGroup == 1) "1 Pest Expires" else "$nextExpireGroup Pests Expire"
             add(Renderable.text("§e$pestString: §b${nextExpire.timeUntil().format()}"))
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -122,6 +122,7 @@ object MantidKillDisplay {
 
     private fun isEnabled() = config.enabled && GardenApi.inGarden()
     private fun shouldShow() = isEnabled() && checkShowConditions()
+    @Suppress("checkShowConditions")
     private fun checkShowConditions(): Boolean {
         for (condition in config.whenToShow) {
             when (condition) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -48,8 +48,7 @@ object MantidKillDisplay {
     // mantid bonus resets on world change
     @HandleEvent
     fun onWorldChange(event: WorldChangeEvent) {
-        pestExpireQueue.clear()
-        updateNextExpireGroup()
+        resetKills()
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
@@ -113,6 +112,11 @@ object MantidKillDisplay {
             val pestString = if (bonus == 1) "Next Pest Expires" else "$nextExpireGroup Pests Expire"
             add(Renderable.text("§e$pestString: §b${nextExpire.timeUntil().format()}"))
         }
+    }
+
+    private fun resetKills() {
+        pestExpireQueue.clear()
+        updateNextExpireGroup()
     }
 
     private fun isEnabled() = config.enabled && GardenApi.inGarden()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -54,7 +54,7 @@ object MantidKillDisplay {
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onSecondPassed(event: SecondPassedEvent) {
         checkForExpires()
-        update()
+        updateDisplay()
     }
 
     @HandleEvent(GuiRenderEvent::class, onlyOnIsland = IslandType.GARDEN)
@@ -99,7 +99,7 @@ object MantidKillDisplay {
         nextExpireGroup = count
     }
 
-    private fun update() {
+    private fun updateDisplay() {
         displayCache = drawDisplay()
     }
 
@@ -117,7 +117,7 @@ object MantidKillDisplay {
     private fun resetKills() {
         pestExpireQueue.clear()
         updateNextExpireGroup()
-        update()
+        updateDisplay()
     }
 
     private fun isEnabled() = config.enabled && GardenApi.inGarden()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -26,6 +26,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object MantidKillDisplay {
+
     private const val MAX_BONUS = 20
     private val EXPIRE_TIME = 10.minutes
     private val config get() = PestApi.config.mantidDisplay
@@ -57,7 +58,7 @@ object MantidKillDisplay {
         updateDisplay()
     }
 
-    @HandleEvent(GuiRenderEvent::class, onlyOnIsland = IslandType.GARDEN)
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, onlyOnIsland = IslandType.GARDEN)
     fun onRenderOverlay() {
         if (!shouldShow()) return
         config.pos.renderRenderables(displayCache, posLabel = "Pest Spawn Timer")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -1,0 +1,132 @@
+package at.hannibal2.skyhanni.features.garden.pests
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.features.garden.pests.MantidDisplayConfig
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.garden.pests.PestKillEvent
+import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import at.hannibal2.skyhanni.features.garden.GardenApi
+import at.hannibal2.skyhanni.features.garden.tracker.ArmorDropTracker
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.RecalculatingValue
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeModifier
+import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import java.util.LinkedList
+import java.util.Queue
+import kotlin.math.min
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@SkyHanniModule
+object MantidKillDisplay {
+    private const val MAX_BONUS = 20
+    private val EXPIRE_TIME = 10.minutes
+    private val config get() = PestApi.config.mantidDisplay
+    // mantid reforge does not work like refrigerate; each pest kill time is individually stored
+    private val pestExpireQueue: Queue<SimpleTimeMark> = LinkedList()
+    private val isWearingMantid by RecalculatingValue(1.seconds) {
+        GardenApi.inGarden() && checkMantid()
+    }
+    private var nextExpire: SimpleTimeMark = SimpleTimeMark.farPast()
+    private var nextExpireGroup: Int = 0
+    private var displayCache = emptyList<Renderable>()
+
+    @HandleEvent
+    fun onPestKill(event: PestKillEvent) {
+        if (!checkMantid()) return
+        pestExpireQueue.add(SimpleTimeMark.now() + EXPIRE_TIME)
+        removeExtraEntries()
+    }
+
+    // mantid bonus resets on world change
+    @HandleEvent
+    fun onWorldChange(event: WorldChangeEvent) {
+        pestExpireQueue.clear()
+        updateNextExpireGroup()
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onSecondPassed(event: SecondPassedEvent) {
+        checkForExpires()
+        update()
+    }
+
+    @HandleEvent(GuiRenderEvent::class, onlyOnIsland = IslandType.GARDEN)
+    fun onRenderOverlay() {
+        if (!shouldShow()) return
+        config.pos.renderRenderables(displayCache, posLabel = "Pest Spawn Timer")
+    }
+
+    private fun removeExtraEntries() {
+        while (pestExpireQueue.size > MAX_BONUS) {
+            pestExpireQueue.poll()
+        }
+        updateNextExpireGroup()
+    }
+
+    // mantid bonus is a profile value that is incremented whenever you get a kill while wearing any armor piece that has the reforge
+    private fun checkMantid(): Boolean {
+        InventoryUtils.getArmor().forEach { armor ->
+            if (armor?.getReforgeModifier() == "mantid") return true
+        }
+        return false
+    }
+
+    private fun checkForExpires() {
+        while (pestExpireQueue.peek()?.isInPast() == true) {
+            pestExpireQueue.poll()
+        }
+        updateNextExpireGroup()
+    }
+
+    private fun updateNextExpireGroup() {
+        var count = 0
+        nextExpire = SimpleTimeMark.farPast()
+        pestExpireQueue.forEach {
+            if (nextExpire.isFarPast()) nextExpire = it
+            if (it - nextExpire < config.groupSimilarExpire.seconds) {
+                count++
+            } else {
+                return@forEach
+            }
+        }
+        nextExpireGroup = count
+    }
+
+    private fun update() {
+        displayCache = drawDisplay()
+    }
+
+    private fun drawDisplay(): List<Renderable> = buildList {
+        val bonus = min(pestExpireQueue.size, MAX_BONUS)
+        val bonusColor = if (bonus < MAX_BONUS) "§c" else "§a"
+        add(Renderable.text("§2Mantid Bonus: $bonusColor$bonus§7/§a$MAX_BONUS"))
+
+        if (bonus > 0) {
+            val pestString = if (bonus == 1) "Next Pest Expires" else "$nextExpireGroup Pests Expire"
+            add(Renderable.text("§e$pestString: §b${nextExpire.timeUntil().format()}"))
+        }
+    }
+
+    private fun isEnabled() = config.enabled && GardenApi.inGarden()
+    private fun shouldShow() = isEnabled() && checkShowConditions()
+    private fun checkShowConditions(): Boolean {
+        for (condition in config.whenToShow) {
+            when (condition) {
+                MantidDisplayConfig.WhenShowDisplay.ALWAYS -> return true
+                MantidDisplayConfig.WhenShowDisplay.ARMOR -> if (ArmorDropTracker.hasArmor) return true
+                MantidDisplayConfig.WhenShowDisplay.MANTID -> if (isWearingMantid) return true
+                MantidDisplayConfig.WhenShowDisplay.TOOL -> if (GardenApi.hasFarmingToolInHand()) return true
+                MantidDisplayConfig.WhenShowDisplay.VACUUM -> if (PestApi.hasVacuumInHand()) return true
+            }
+        }
+        return false
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -117,6 +117,7 @@ object MantidKillDisplay {
     private fun resetKills() {
         pestExpireQueue.clear()
         updateNextExpireGroup()
+        update()
     }
 
     private fun isEnabled() = config.enabled && GardenApi.inGarden()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -122,7 +122,7 @@ object MantidKillDisplay {
 
     private fun isEnabled() = config.enabled && GardenApi.inGarden()
     private fun shouldShow() = isEnabled() && checkShowConditions()
-    @Suppress("checkShowConditions")
+    @Suppress("ReturnCount")
     private fun checkShowConditions(): Boolean {
         for (condition in config.whenToShow) {
             when (condition) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -22,7 +22,6 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotApi.locked
 import at.hannibal2.skyhanni.features.garden.GardenPlotApi.name
 import at.hannibal2.skyhanni.features.garden.GardenPlotApi.pests
 import at.hannibal2.skyhanni.features.garden.GardenPlotApi.uncleared
-import at.hannibal2.skyhanni.features.garden.tracker.PestProfitTracker.DUNG_ITEM
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -35,7 +34,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LocationUtils.isInside
-import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
@@ -280,20 +278,16 @@ object PestApi {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onChat(event: SkyHanniChatEvent) {
-        pestDeathChatPattern.matchMatcher(event.message) {
-            val pest = PestType.getByNameOrNull(group("pest")) ?: return
-            val item = NeuInternalName.fromItemNameOrNull(group("item")) ?: return
-
-            // Field Mice drop 6 separate items, but we only want to count the kill once
-            if (pest == PestType.FIELD_MOUSE && item != DUNG_ITEM) return
-            lastPestKillTime = SimpleTimeMark.now()
-            removeNearestPest()
-            GardenPlotApi.getCurrentPlot()?.let { gardenPestTypes.removeFromPlot(it, pest) }
-            PestKillEvent(pest).post()
-        }
         if (noPestsChatPattern.matches(event.message)) {
             resetAllPests()
         }
+    }
+
+    @HandleEvent
+    fun onPestKill(event: PestKillEvent) {
+        lastPestKillTime = SimpleTimeMark.now()
+        removeNearestPest()
+        GardenPlotApi.getCurrentPlot()?.let { gardenPestTypes.removeFromPlot(it, event.pestType) }
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -472,7 +472,7 @@ object PestApi {
         event.registerBrigadier("shtestpestkill") {
             description = "Simulates a pest kill"
             category = CommandCategory.DEVELOPER_TEST
-            argCallback("pestType", EnumArgumentType.custom<PestType>({it.name}, isGreedy = true)) { pestType ->
+            argCallback("pestType", EnumArgumentType.custom<PestType>({ it.name }, isGreedy = true)) { pestType ->
                 PestKillEvent(pestType).post()
             }
             simpleCallback { PestKillEvent(PestType.UNKNOWN).post() }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -1,6 +1,9 @@
 package at.hannibal2.skyhanni.features.garden.pests
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.EnumArgumentType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.data.model.TabWidget
@@ -461,6 +464,18 @@ object PestApi {
                 add(" pests: ${it.pests}")
                 add(" ")
             }
+        }
+    }
+
+    @HandleEvent
+    fun onCommand(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shtestpestkill") {
+            description = "Simulates a pest kill"
+            category = CommandCategory.DEVELOPER_TEST
+            argCallback("pestType", EnumArgumentType.custom<PestType>({it.name}, isGreedy = true)) { pestType ->
+                PestKillEvent(pestType).post()
+            }
+            simpleCallback { PestKillEvent(PestType.UNKNOWN).post() }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/ArmorDropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/ArmorDropTracker.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RecalculatingValue
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
@@ -46,7 +47,9 @@ object ArmorDropTracker {
         "(?:HELIANTHUS|FERMENTO|CROPIE|SQUASH|MELON)_(?:LEGGINGS|CHESTPLATE|BOOTS|HELMET)",
     )
 
-    private var hasArmor = false
+    val hasArmor by RecalculatingValue(1.seconds) {
+        GardenApi.inGarden() && checkArmor()
+    }
 
     private val tracker = SkyHanniTracker("Armor Drop Tracker", ::Data, { it.garden.armorDropTracker }) {
         drawDisplay(it)
@@ -72,11 +75,6 @@ object ArmorDropTracker {
             name.lowercase(),
             chatMessage,
         )
-    }
-
-    @HandleEvent
-    fun onProfileJoin() {
-        hasArmor = false
     }
 
     @HandleEvent
@@ -124,18 +122,6 @@ object ArmorDropTracker {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onSecondPassed() {
-        checkArmor()
-    }
-
-    private fun checkArmor() {
-        val armorPieces = InventoryUtils.getArmor()
-            .mapNotNull { it?.getInternalName()?.asString() }
-            .count { armorPattern.matcher(it).matches() }
-        hasArmor = armorPieces > 1
-    }
-
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<ArmorDropsJson>("ArmorDrops")
@@ -145,6 +131,13 @@ object ArmorDropTracker {
     private var armorDropInfo = mapOf<String, ArmorDropInfo>()
     private var currentArmorDropChance = 0.0
     private var lastCalculationTime = SimpleTimeMark.farPast()
+
+    private fun checkArmor(): Boolean {
+        val armorPieces = InventoryUtils.getArmor()
+            .mapNotNull { it?.getInternalName()?.asString() }
+            .count { armorPattern.matcher(it).matches() }
+        return armorPieces > 0
+    }
 
     fun getDropsPerHour(crop: CropType?): Double {
         if (crop == null) return 0.0

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/ArmorDropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/ArmorDropTracker.kt
@@ -136,7 +136,7 @@ object ArmorDropTracker {
         val armorPieces = InventoryUtils.getArmor()
             .mapNotNull { it?.getInternalName()?.asString() }
             .count { armorPattern.matcher(it).matches() }
-        return armorPieces > 0
+        return armorPieces > 1
     }
 
     fun getDropsPerHour(crop: CropType?): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -256,6 +256,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
         modify {
             it.pestKills.addOrPut(type, 1)
         }
+        PestKillEvent(type).post()
         lastPestKillTimes[type] = SimpleTimeMark.now()
     }
 


### PR DESCRIPTION
## What
Adds a display to show when mantid pest bonuses expire

<details>
<summary>Images</summary>

<img width="314" height="82" alt="image" src="https://github.com/user-attachments/assets/1263b82d-219b-4c49-977b-03616d1f86a4" />

</details>

## Changelog New Features
+ Added display for the Mantid reforge pest kill bonus. - Chissl

## Changelog Fixes
+ Fixed Armor Drop Tracker showing when not wearing farming armor. - Chissl

## Changelog Technical Details
+ Added /shtestpestkill. - Chissl
    * Sends a pest kill event.

