### PR TITLE
Improvement: Hide soulbound value from chest value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ChestValueConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ChestValueConfig.kt
@@ -106,6 +106,14 @@ class ChestValueConfig {
     var hideBelow: Int = 100000
 
     @Expose
+    @ConfigOption(
+        name = "Ignore Soulbound",
+        desc = "Exclude Soulbound items from being counted in total value."
+    )
+    @ConfigEditorBoolean
+    var ignoreSoulbound: Boolean = false
+
+    @Expose
     @ConfigLink(owner = ChestValueConfig::class, field = "enabled")
     val position: Position = Position(107, 141)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.isAnySoulbound
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemNameCompact
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -111,6 +112,7 @@ object ChestValue {
         val amountShowing = if (config.itemToShow > sortedList.size) sortedList.size else config.itemToShow
         addString("§7$featureName: §o(Showing $amountShowing of ${sortedList.size} items)")
         for ((index, amount, stack, total, tips) in sortedList) {
+            if (config.ignoreSoulbound && stack.isAnySoulbound()) continue
             totalPrice += total
             if (rendered >= config.itemToShow) continue
             if (total < config.hideBelow) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.inventory
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.HideNotClickableItemsJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.SalvageFilter
@@ -27,9 +28,8 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.ItemUtils.isCoopSoulBound
-import at.hannibal2.skyhanni.utils.ItemUtils.isEnchanted
-import at.hannibal2.skyhanni.utils.ItemUtils.isSoulBound
+import at.hannibal2.skyhanni.utils.ItemUtils.isAnySoulbound
+import at.hannibal2.skyhanni.utils.ItemUtils.isSoulbound
 import at.hannibal2.skyhanni.utils.ItemUtils.isVanilla
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -349,7 +349,7 @@ object HideNotClickableItems {
     private fun hidePrivateIslandChest(stack: ItemStack): Boolean {
         if (!InventoryUtils.isInNormalChest()) return false
         if (!IslandType.PRIVATE_ISLAND.isCurrent()) return false
-        if (!stack.isSoulBound()) return false
+        if (!stack.isSoulbound()) return false
 
         hideReason = "This item cannot be stored into a chest!"
         return true
@@ -456,7 +456,7 @@ object HideNotClickableItems {
     private fun hidePlayerTrade(chestName: String, stack: ItemStack): Boolean {
         if (!chestName.startsWith("You    ")) return false
 
-        if (stack.isCoopSoulBound()) {
+        if ((HypixelData.noTrade && stack.isSoulbound()) || (!HypixelData.noTrade && stack.isAnySoulbound())) {
             hideReason = "Soulbound items cannot be traded!"
             return true
         }
@@ -602,7 +602,7 @@ object HideNotClickableItems {
     }
 
     private fun isNotAuctionable(stack: ItemStack): Boolean {
-        if (stack.isCoopSoulBound()) {
+        if (stack.isAnySoulbound()) {
             hideReason = "Soulbound items cannot be auctioned!"
             return true
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -225,13 +225,15 @@ object ItemUtils {
         return this
     }
 
-    // TODO change else janni is sad
-    fun ItemStack.isCoopSoulBound(): Boolean = getLore().any {
-        it == "§8§l* §8Co-op Soulbound §8§l*" || it == "§8§l* §8Soulbound §8§l*"
+    fun ItemStack.isAnySoulbound(): Boolean = isCoopSoulbound() || isSoulbound()
+
+    fun ItemStack.isCoopSoulbound(): Boolean = getLoreComponent().any {
+        it.string == "* Co-op Soulbound *"
     }
 
-    // TODO change else janni is sad
-    fun ItemStack.isSoulBound(): Boolean = getLore().any { it == "§8§l* §8Soulbound §8§l*" }
+    fun ItemStack.isSoulbound(): Boolean = getLoreComponent().any {
+        it.string == "* Soulbound *"
+    }
 
     fun isRecombobulated(stack: ItemStack) = stack.isRecombobulated()
 


### PR DESCRIPTION
## What
add an option to hide soulbound items from chest value
also made it so not clickable items doesnt prevent coop soulbound items in trades on ironman (yes i know you can trade coop soulbound items on normal profiles but that requires way more code)

## Changelog Improvements
+ Added hide soulbound items from Chest Value. - nopo
+ Made Not Clickable Items not prevent soulbound items in trades on ironman. - nopo

