### PR TITLE
Fix: Increased Wardrobe pages to 3

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
@@ -53,7 +53,7 @@ object WardrobeApi {
     private const val FIRST_LEGGINGS_SLOT = 18
     private const val FIRST_BOOTS_SLOT = 27
     const val MAX_SLOT_PER_PAGE = 9
-    const val MAX_PAGES = 2
+    const val MAX_PAGES = 3
 
     var slots = listOf<WardrobeSlot>()
     var inCustomWardrobe = false


### PR DESCRIPTION
## What
Increased Wardrobe pages to 3

<details>
<summary>Images</summary>

<img width="2558" height="1438" alt="image" src="https://github.com/user-attachments/assets/788987d7-6ac9-41be-88ef-8ba4872d5748" />
<img width="2558" height="1439" alt="image" src="https://github.com/user-attachments/assets/3fb49f22-f664-417f-8b75-c71cc41f2bf4" />


</details>

## Changelog Fixes
+ Fixed Custom Wardrobe not having 3 pages. - FabiHBBBT
