### PR TITLE
Fix: Not being able to move the mantid display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/MantidKillDisplay.kt
@@ -61,7 +61,7 @@ object MantidKillDisplay {
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, onlyOnIsland = IslandType.GARDEN)
     fun onRenderOverlay() {
         if (!shouldShow()) return
-        config.pos.renderRenderables(displayCache, posLabel = "Pest Spawn Timer")
+        config.pos.renderRenderables(displayCache, posLabel = "Mantid Kill Display")
     }
 
     private fun removeExtraEntries() {


### PR DESCRIPTION
## What
dupe posLabel = bad

## Changelog Fixes
+ Fixed mantid kill display not being able to be moved. - nopo
