### PR TITLE
Fix: Infinite recursion in Reverse Party Transfer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyCommands.kt
@@ -115,6 +115,10 @@ object PartyCommands {
     @HandleEvent(priority = HandleEvent.LOW)
     fun onChat(event: SkyHanniChatEvent) {
         if (!config.reversePT.clickable) return
+
+        // The message was likely already modified by us, return to avoid infinite recursion
+        if (event.chatComponent.style.clickEvent != null) return
+
         if (!transferVoluntaryPattern.matches(event.message.trimWhiteSpace().removeColor())) return
         if (partyLeader != PlayerUtils.getName()) return
 


### PR DESCRIPTION
## What
Fixed infinite recursion leading to StackOverflowError in the Reverse Party Transfer clickable feature. This is because the chat message we send was getting passed back to us via the Fabric event. In the future we should probably have some general way to check if that message was from us, but this fixes the issue in this specific case for now.

## Changelog Fixes
+ Fixed error when someone transfers the party to you with Reverse Party Transfer Clickable Message enabled. - Luna