### PR TITLE
Fix: Crops per hour for Seeds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -301,7 +301,7 @@ object CropMoneyDisplay {
         var speed = crop.getSpeed()?.toDouble() ?: return null
 
         val isSeeds = isSeeds(internalName)
-        if (isSeeds) speed *= 1.36
+        if (isSeeds) speed *= 1.5
         val replenishReduction = if (crop.replenish) (crop.multiplier * GardenCropSpeed.getRecentBPS()) else 0.0
         speed -= replenishReduction
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -302,7 +302,7 @@ object CropMoneyDisplay {
 
         val isSeeds = isSeeds(internalName)
         if (isSeeds) speed *= 1.5
-        val replenishReduction = if (crop.replenish) (crop.multiplier * GardenCropSpeed.getRecentBPS()) else 0.0
+        val replenishReduction = if (crop.replenish || isSeeds) (crop.multiplier * GardenCropSpeed.getRecentBPS()) else 0.0
         speed -= replenishReduction
 
         val speedPerHour = speed * 60 * 60


### PR DESCRIPTION
## What
Changed the weird 1.36 magic number we've been rolling with [since 2023](https://github.com/hannibal002/SkyHanni/commit/d9191de0d4670d8e710c556210fea64b351090e2#diff-449d7e6081e39edd44ecdb5aa9d48a0edc2dd5cd1825ad999ba73545427b3c39R197) apparently to be the actual correct 1.5 base drop rate for seeds, and made it account for Replenish.

## Changelog Fixes
+ Fixed crops per hour for Seeds being incorrect (usually underestimated). - Luna
    * The base drop rate was 1.36 instead of 1.5, and it wasn't accounting for Replenish.