### PR TITLE
Improvement: Add /shresetburrows and /shresetdianamobs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -571,6 +571,15 @@ object GriffinBurrowHelper {
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shresetburrows") {
+            description = "Resets all saved griffin burrow locations"
+            category = CommandCategory.USERS_RESET
+            callback {
+                resetAllData()
+                ChatUtils.chat("Manually reset all burrow data.")
+            }
+        }
+
         event.registerBrigadier("shtestburrow") {
             description = "Sets a test burrow waypoint at your location"
             category = CommandCategory.DEVELOPER_TEST

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
-import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.SecondPassedEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
@@ -2,6 +2,9 @@ package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -284,6 +287,19 @@ object RareMobWaypointShare {
     fun playUserSound() {
         with(config.sound) {
             SoundUtils.createSound(name, pitch).playSound()
+        }
+    }
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shresetdianamobs") {
+            description = "Resets all saved rare Diana mob locations"
+            category = CommandCategory.USERS_RESET
+            callback {
+                _waypoints.clear()
+                rareMobsNearby.clear()
+                ChatUtils.chat("Manually reset all rare mob data.")
+            }
         }
     }
 }


### PR DESCRIPTION
## What
Added `/shresetburrows` command (more discoverable than `/shtestburrow reset`) and `/shresetdianamobs` command (new, can help while we fix mob waypoints not disappearing).

## Changelog Improvements
+ Added `/shresetburrows` command to reset saved burrow locations during Diana's Mythological Ritual. - Luna
+ Added `/shresetdianamobs` command to reset rare mob locations during Diana's Mythological Ritual. - Luna