### PR TITLE
Fix: ETA not recognising xp gain over 1k per second

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -497,7 +497,7 @@ object SkillProgress {
 
         if (xpInfo.lastTotalXP > 0) {
             val delta = totalXP - xpInfo.lastTotalXP
-            if (delta > 0 && delta < 1000) {
+            if (delta > 0) {
 
                 xpInfo.timer = when (SkillApi.activeSkill) {
                     SkillType.FARMING -> etaConfig.farmingPauseTime


### PR DESCRIPTION
## What
Fix ETA not adding xp gain over 1k per seconds to the xpGainQueue

<details>
<summary>Images</summary>

<img width="240" height="128" alt="image" src="https://github.com/user-attachments/assets/90d07763-6033-42fd-ba25-c65b2c6904a0" />

</details>

## Changelog Fixes
+ Fixed Skill ETA being wrong when gaining to much xp per second. - FabiHBBBT

