### PR TITLE
Backend: Update (NEU) Repo Auto Update config descriptions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
@@ -23,7 +23,7 @@ class DevConfig {
     val repo: RepositoryConfig = RepositoryConfig()
 
     @Expose
-    @ConfigOption(name = "Neu Repository", desc = "")
+    @ConfigOption(name = "NEU Repository", desc = "")
     @Accordion
     val neuRepo: NeuRepositoryConfig = NeuRepositoryConfig()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
@@ -15,9 +15,7 @@ class NeuRepositoryConfig : AbstractRepoConfig<NeuRepositoryConfig.NeuRepository
     @Expose
     @ConfigOption(
         name = "NEU Repo Auto Update",
-        desc = "Update the NEU repository on every startup and tries to auto fix bugs.\n" +
-            "§cOnly disable this if you know what you are doing!\n " +
-            "§eThis only works if NEU is not installed, if it is use their settings.",
+        desc = "Update the NEU repository on every startup and try to auto fix bugs.\n" +
     )
     @ConfigEditorBoolean
     override var repoAutoUpdate: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
@@ -16,6 +16,7 @@ class NeuRepositoryConfig : AbstractRepoConfig<NeuRepositoryConfig.NeuRepository
     @ConfigOption(
         name = "NEU Repo Auto Update",
         desc = "Update the NEU repository on every startup and try to auto fix bugs.\n" +
+            "§cOnly disable this if you know what you are doing!",
     )
     @ConfigEditorBoolean
     override var repoAutoUpdate: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.kt
@@ -14,7 +14,7 @@ class RepositoryConfig : AbstractRepoConfig<RepositoryConfig.RepositoryLocation>
     @Expose
     @ConfigOption(
         name = "Repo Auto Update",
-        desc = "Update the repository on every startup and tries to auto fix bugs.\n" +
+        desc = "Update the repository on every startup and try to auto fix bugs.\n" +
             "§cOnly disable this if you know what you are doing!",
     )
     @ConfigEditorBoolean


### PR DESCRIPTION
## What
Just some small adjustments (consistent tense, Neu -> NEU, removed reference to NEU being installed which is impossible since we're modern only now).

exclude_from_changelog