### PR TITLE
Fix: Thunder Sparks not being Highlighted

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
@@ -10,7 +10,8 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
-import at.hannibal2.skyhanni.utils.EntityUtils.getWornSkullTexture
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.EntityUtils.holdingSkullTexture
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
@@ -31,7 +32,9 @@ object ThunderSparksHighlight {
     fun onEntityEquipmentChange(event: EntityEquipmentChangeEvent<ArmorStand>) {
         if (!isEnabled()) return
         val entity = event.entity
-        if (entity.getWornSkullTexture() == THUNDER_SPARK_TEXTURE) sparks.add(entity)
+        DelayedRun.runNextTick {
+            if (entity.holdingSkullTexture(THUNDER_SPARK_TEXTURE)) sparks.add(entity)
+        }
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
Fixes Thunder Sparks not being Highlighted due to incorrect method selection (Seriously how many times to Hypixel ACTUALLY make it Held instead of worn)

## Changelog Fixes
+ Fixed Thunder Spark Highlight not working. - Fazfoxy
