### PR TITLE
Fix: Skyhanni modifiying its own chat messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -7,7 +7,9 @@ import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
 import at.hannibal2.skyhanni.events.minecraft.ResourcePackReloadEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import at.hannibal2.skyhanni.mixins.hooks.ComponentCreatedStore
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -107,6 +109,12 @@ object ClientEvents {
     private var lastResult: Component? = null
 
     private fun onAllow(message: Component, actionBar: Boolean): Boolean {
+        // if we created the message we don't want to pipe it back into our events
+        try {
+            if ((message as ComponentCreatedStore).`skyhanni$didCreate`()) return true
+        } catch (exception: Exception) {
+            ErrorManager.logErrorWithData(exception, "Unable to work out if message was created by SkyHanni")
+        }
         lastMessage = message
         if (actionBar) {
             // we never cancel the action bar
@@ -128,6 +136,11 @@ object ClientEvents {
     }
 
     private fun onModify(message: Component, actionBar: Boolean): Component {
+        try {
+            if ((message as ComponentCreatedStore).`skyhanni$didCreate`()) return message
+        } catch (exception: Exception) {
+            ErrorManager.logErrorWithData(exception, "Unable to work out if message was created by SkyHanni")
+        }
         // we check if the message is the same as the one from allow
         // if someone else modifies the message it won't be the same but what can you do about that
         if (lastMessage == message && !actionBar) {

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -115,11 +115,11 @@ object ClientEvents {
         } catch (exception: Exception) {
             ErrorManager.logErrorWithData(exception, "Unable to work out if message was created by SkyHanni")
         }
-        lastMessage = message
         if (actionBar) {
             // we never cancel the action bar
             return true
         }
+        lastMessage = message
 
         val (result, cancel) = ChatManager.onChatReceive(message)
         lastResult = result

--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -182,7 +182,7 @@ object ChatManager {
         var modified = false
         loggerAllowed.log("[allowed] $message")
         loggerAll.log("[allowed] $message")
-        if (modifiedComponent.formattedTextCompat() != component.formattedTextCompat()) {
+        if (modifiedComponent != component) {
             val reason = replacementReasonMap[key].orEmpty().uppercase()
             modified = true
             loggerModified.log(" ")
@@ -202,7 +202,7 @@ object ChatManager {
             // even if we "meant" to replace the component.
             modified = false
         }
-        return Pair(component.takeIf { modified }, cancelled)
+        return Pair(modifiedComponent.takeIf { modified }, cancelled)
     }
 
     // TODO: Add another predicate to stop searching after a certain amount of lines have been searched

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/ComponentCreatedStore.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/ComponentCreatedStore.java
@@ -1,0 +1,8 @@
+package at.hannibal2.skyhanni.mixins.hooks;
+
+public interface ComponentCreatedStore {
+
+    void skyhanni$setCreated();
+
+    boolean skyhanni$didCreate();
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinComponent.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinComponent.java
@@ -1,0 +1,23 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.mixins.hooks.ComponentCreatedStore;
+import net.minecraft.network.chat.MutableComponent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(MutableComponent.class)
+public abstract class MixinComponent implements ComponentCreatedStore {
+
+    @Unique
+    private boolean skyhanni$createdMessage = false;
+
+    @Override
+    public void skyhanni$setCreated() {
+        this.skyhanni$createdMessage = true;
+    }
+
+    @Override
+    public boolean skyhanni$didCreate() {
+        return this.skyhanni$createdMessage;
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.chat.TextHelper.send
+import at.hannibal2.skyhanni.utils.compat.addChatMessageToChat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.unformattedTextForChatCompat
@@ -29,7 +29,6 @@ object TestChatCommand {
                 "   §7[-complex]§e: §7Parse the message as a JSON chat component",
                 "   §7[-clipboard]§e: §7Read the message from the clipboard",
                 "   §7[-s]§e: §7Hide the testing message",
-                "   §7[-sa]§e: §7Hide everything but the final message", // Not really sure why you'd want this
             )
             ChatUtils.userError("Specify a chat message to test!\n${syntaxStrings.joinToString("\n")}")
             return
@@ -41,22 +40,21 @@ object TestChatCommand {
             val isComplex = mutArgs.remove("-complex")
             // cant use multi lines without clipboard
             val isClipboard = mutArgs.remove("-clipboard") || multiLines
-            val isSilentAll = mutArgs.remove("-sa")
-            val isSilent = mutArgs.remove("-s") || isSilentAll
+            val isSilent = mutArgs.remove("-s")
             val text = if (isClipboard) {
                 OSUtils.readFromClipboard() ?: return@launchCoroutine ChatUtils.userError("Clipboard does not contain a string!")
             } else mutArgs.joinToString(" ")
             if (multiLines) {
                 for (line in text.split("\n")) {
-                    extracted(isComplex, line, isSilent, isSilentAll)
+                    extracted(isComplex, line, isSilent)
                 }
             } else {
-                extracted(isComplex, text, isSilent, isSilentAll)
+                extracted(isComplex, text, isSilent)
             }
         }
     }
 
-    private fun extracted(isComplex: Boolean, text: String, isSilent: Boolean, isSilentAll: Boolean) {
+    private fun extracted(isComplex: Boolean, text: String, isSilent: Boolean) {
         val component = if (isComplex) try {
             ComponentSerialization.CODEC.decode(JsonOps.INSTANCE, JsonParser.parseString(text)).getOrThrow().first
         } catch (ex: Exception) {
@@ -77,7 +75,7 @@ object TestChatCommand {
 
     private fun test(componentText: Component) {
         // the fabric event will pick up on the message so it goes through the normal chat event
-        componentText.send(bypassSelfMessages = true)
+        addChatMessageToChat(componentText, true)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
@@ -4,12 +4,12 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
-import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.unformattedTextForChatCompat
@@ -72,23 +72,12 @@ object TestChatCommand {
         val rawText = component.formattedTextCompat().stripHypixelMessage().replace("§", "&").replace("\n", "\\n")
         if (!isSilent) ChatUtils.chat("Testing message: §7$rawText", prefixColor = "§a")
 
-        test(component, isSilentAll)
+        test(component)
     }
 
-    private fun test(componentText: Component, isHidden: Boolean) {
-        val message = componentText.formattedTextCompat().stripHypixelMessage()
-        val event = SkyHanniChatEvent(message, componentText)
-        event.post()
-
-        if (event.blockedReason != null) {
-            if (!isHidden) ChatUtils.chat("§cChat blocked: ${event.blockedReason}")
-            return
-        }
-        val finalMessage = event.chatComponent
-        if (!isHidden && finalMessage.formattedTextCompat().stripHypixelMessage() != message) {
-            ChatUtils.chat("§eChat modified!")
-        }
-        ChatUtils.chat(finalMessage, prefix = false)
+    private fun test(componentText: Component) {
+        // the fabric event will pick up on the message so it goes through the normal chat event
+        componentText.send(bypassSelfMessages = true)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -153,7 +153,7 @@ object ChatUtils {
         log.log(formattedMessage)
 
         if (!MinecraftCompat.localPlayerExists) {
-            consoleLog(formattedMessage.removeColor())
+            consoleLog(message.string.removeColor())
             return false
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -77,17 +77,17 @@ object TextHelper {
         return join(" ".repeat(padding / spaceWidth), this)
     }
 
-    fun Component.send(id: Int = 0) =
-        addDeletableMessageToChat(this, id)
+    fun Component.send(id: Int = 0, bypassSelfMessages: Boolean = false) =
+        addDeletableMessageToChat(this, id, bypassSelfMessages)
 
-    fun List<Component>.send(id: Int = 0) {
+    fun List<Component>.send(id: Int = 0, bypassSelfMessages: Boolean = false) {
         val parent = "".asComponent()
         forEach {
             parent.siblings.add(it)
             parent.siblings.add("\n".asComponent())
         }
 
-        parent.send(id)
+        parent.send(id, bypassSelfMessages)
     }
 
     fun Component.onClick(expiresAt: SimpleTimeMark = SimpleTimeMark.farFuture(), oneTime: Boolean = true, onClick: () -> Any) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -229,13 +229,13 @@ fun Style.setHoverShowText(text: Component): Style {
     return this.withHoverEvent(HoverEvent.ShowText(text))
 }
 
-fun addChatMessageToChat(message: Component) {
-    (message as ComponentCreatedStore).`skyhanni$setCreated`()
+fun addChatMessageToChat(message: Component, bypassSelfMessages: Boolean = false) {
+    if (!bypassSelfMessages) (message as ComponentCreatedStore).`skyhanni$setCreated`()
     Minecraft.getInstance().player?.displayClientMessage(message, false)
 }
 
-fun addDeletableMessageToChat(component: Component, id: Int) {
-    (component as ComponentCreatedStore).`skyhanni$setCreated`()
+fun addDeletableMessageToChat(component: Component, id: Int, bypassSelfMessages: Boolean = false) {
+    if (!bypassSelfMessages) (component as ComponentCreatedStore).`skyhanni$setCreated`()
     Minecraft.getInstance().execute {
         Minecraft.getInstance().gui.chat.deleteMessage(idToMessageSignature(id))
         Minecraft.getInstance().gui.chat.addMessage(component, idToMessageSignature(id), GuiMessageTag.system())

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils.compat
 
+import at.hannibal2.skyhanni.mixins.hooks.ComponentCreatedStore
 import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
@@ -229,10 +230,12 @@ fun Style.setHoverShowText(text: Component): Style {
 }
 
 fun addChatMessageToChat(message: Component) {
+    (message as ComponentCreatedStore).`skyhanni$setCreated`()
     Minecraft.getInstance().player?.displayClientMessage(message, false)
 }
 
 fun addDeletableMessageToChat(component: Component, id: Int) {
+    (component as ComponentCreatedStore).`skyhanni$setCreated`()
     Minecraft.getInstance().execute {
         Minecraft.getInstance().gui.chat.deleteMessage(idToMessageSignature(id))
         Minecraft.getInstance().gui.chat.addMessage(component, idToMessageSignature(id), GuiMessageTag.system())


### PR DESCRIPTION
## What
im not entirely sure if this is the correct way to do this
mixin wouldnt let me make it for Component, only MutableComponent. Unsure if this is a skill issue from me.
Changed shtestmessage to not spawn its own chat event so now it works 100% as getting the message fr ong

## Changelog Fixes
+ Fixed some SkyHanni messages appearing wrong with some settings enabled. - nopo
+ Maybe fixed SkyHanni not editing some messages correctly. - nopo
