### PR TITLE
Backend: Change Stonecutter commenter style for shader files

### DIFF
--- a/src/main/resources/assets/skyhanni/shaders/circle.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/circle.fsh
@@ -12,20 +12,20 @@ uniform mat4 modelViewMatrix;
 uniform float angle1;
 uniform float angle2;
 //?} else {
-/*layout(std140) uniform SkyHanniRoundedUniforms {
-    float scaleFactor;
-    float radius;
-    float smoothness;
-    vec2 halfSize;
-    vec2 centerPos;
-    mat4 modelViewMatrix;
-};
-
-layout(std140) uniform SkyHanniCircleUniforms {
-    float angle1;
-    float angle2;
-};
-*///?}
+//layout(std140) uniform SkyHanniRoundedUniforms {
+//    float scaleFactor;
+//    float radius;
+//    float smoothness;
+//    vec2 halfSize;
+//    vec2 centerPos;
+//    mat4 modelViewMatrix;
+//};
+//
+//layout(std140) uniform SkyHanniCircleUniforms {
+//    float angle1;
+//    float angle2;
+//};
+//?}
 out vec4 fragColor;
 
 void main() {

--- a/src/main/resources/assets/skyhanni/shaders/circle.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/circle.vsh
@@ -1,17 +1,14 @@
 #version 150
-//? < 1.21.6 {
+
 in vec3 Position;
 in vec4 Color;
-
+//? < 1.21.6 {
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 //?} else {
-/*#moj_import <minecraft:dynamictransforms.glsl>
-#moj_import <minecraft:projection.glsl>
-
-in vec3 Position;
-in vec4 Color;
-*///?}
+//#moj_import <minecraft:dynamictransforms.glsl>
+//#moj_import <minecraft:projection.glsl>
+//?}
 out vec4 vertexColor;
 
 void main() {

--- a/src/main/resources/assets/skyhanni/shaders/radial_gradient_circle.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/radial_gradient_circle.fsh
@@ -16,24 +16,24 @@ uniform float progress;
 uniform float phaseOffset;
 uniform int reverse;
 //?} else {
-/*layout(std140) uniform SkyHanniRoundedUniforms {
-    float scaleFactor;
-    float radius;
-    float smoothness;
-    vec2 halfSize;
-    vec2 centerPos;
-    mat4 modelViewMatrix;
-};
-
-layout(std140) uniform SkyHanniRadialGradientCircleUniforms {
-    float angle;
-    vec4 startColor;
-    vec4 endColor;
-    float progress;
-    float phaseOffset;
-    int reverse;
-};
-*///?}
+//layout(std140) uniform SkyHanniRoundedUniforms {
+//    float scaleFactor;
+//    float radius;
+//    float smoothness;
+//    vec2 halfSize;
+//    vec2 centerPos;
+//    mat4 modelViewMatrix;
+//};
+//
+//layout(std140) uniform SkyHanniRadialGradientCircleUniforms {
+//    float angle;
+//    vec4 startColor;
+//    vec4 endColor;
+//    float progress;
+//    float phaseOffset;
+//    int reverse;
+//};
+//?}
 out vec4 fragColor;
 
 void main() {

--- a/src/main/resources/assets/skyhanni/shaders/radial_gradient_circle.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/radial_gradient_circle.vsh
@@ -1,15 +1,13 @@
 #version 150
-//? < 1.21.6 {
-in vec3 Position;
 
+in vec3 Position;
+//? < 1.21.6 {
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 //?} else {
-/*#moj_import <minecraft:dynamictransforms.glsl>
-#moj_import <minecraft:projection.glsl>
-
-in vec3 Position;
-*///?}
+//#moj_import <minecraft:dynamictransforms.glsl>
+//#moj_import <minecraft:projection.glsl>
+//?}
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 }

--- a/src/main/resources/assets/skyhanni/shaders/rounded_rect.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_rect.fsh
@@ -9,15 +9,15 @@ uniform vec2 halfSize;
 uniform vec2 centerPos;
 uniform mat4 modelViewMatrix;
 //?} else {
-/*layout(std140) uniform SkyHanniRoundedUniforms {
-    float scaleFactor;
-    float radius;
-    float smoothness;
-    vec2 halfSize;
-    vec2 centerPos;
-    mat4 modelViewMatrix;
-};
-*///?}
+//layout(std140) uniform SkyHanniRoundedUniforms {
+//    float scaleFactor;
+//    float radius;
+//    float smoothness;
+//    vec2 halfSize;
+//    vec2 centerPos;
+//    mat4 modelViewMatrix;
+//};
+//?}
 out vec4 fragColor;
 
 // From https://www.shadertoy.com/view/WtdSDs

--- a/src/main/resources/assets/skyhanni/shaders/rounded_rect.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_rect.vsh
@@ -1,17 +1,14 @@
 #version 150
-//? < 1.21.6 {
+
 in vec3 Position;
 in vec4 Color;
-
+//? < 1.21.6 {
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 //?} else {
-/*#moj_import <minecraft:dynamictransforms.glsl>
-#moj_import <minecraft:projection.glsl>
-
-in vec3 Position;
-in vec4 Color;
-*///?}
+//#moj_import <minecraft:dynamictransforms.glsl>
+//#moj_import <minecraft:projection.glsl>
+//?}
 out vec4 vertexColor;
 
 void main() {

--- a/src/main/resources/assets/skyhanni/shaders/rounded_rect_outline.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_rect_outline.fsh
@@ -13,22 +13,22 @@ uniform mat4 modelViewMatrix;
 uniform float borderThickness;
 uniform float borderBlur;
 //?} else {
-/*// Rect specific uniforms
-layout(std140) uniform SkyHanniRoundedUniforms {
-    float scaleFactor;
-    float radius;
-    float smoothness;
-    vec2 halfSize;
-    vec2 centerPos;
-    mat4 modelViewMatrix;
-};
-
-// Outline specific uniforms
-layout(std140) uniform SkyHanniRoundedOutlineUniforms {
-    float borderThickness;
-    float borderBlur;
-};
-*///?}
+//// Rect specific uniforms
+//layout(std140) uniform SkyHanniRoundedUniforms {
+//    float scaleFactor;
+//    float radius;
+//    float smoothness;
+//    vec2 halfSize;
+//    vec2 centerPos;
+//    mat4 modelViewMatrix;
+//};
+//
+//// Outline specific uniforms
+//layout(std140) uniform SkyHanniRoundedOutlineUniforms {
+//    float borderThickness;
+//    float borderBlur;
+//};
+//?}
 out vec4 outColor;
 
 // From https://www.shadertoy.com/view/WtdSDs

--- a/src/main/resources/assets/skyhanni/shaders/rounded_rect_outline.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_rect_outline.vsh
@@ -1,17 +1,14 @@
 #version 150
-//? < 1.21.6 {
+
 in vec3 Position;
 in vec4 Color;
-
+//? < 1.21.6 {
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 //?} else {
-/*#moj_import <minecraft:dynamictransforms.glsl>
-#moj_import <minecraft:projection.glsl>
-
-in vec3 Position;
-in vec4 Color;
-*///?}
+//#moj_import <minecraft:dynamictransforms.glsl>
+//#moj_import <minecraft:projection.glsl>
+//?}
 out vec4 vertexColor;
 
 void main() {

--- a/src/main/resources/assets/skyhanni/shaders/rounded_texture.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_texture.fsh
@@ -9,15 +9,15 @@ uniform vec2 halfSize;
 uniform vec2 centerPos;
 uniform mat4 modelViewMatrix;
 //?} else {
-/*layout(std140) uniform SkyHanniRoundedUniforms {
-    float scaleFactor;
-    float radius;
-    float smoothness;
-    vec2 halfSize;
-    vec2 centerPos;
-    mat4 modelViewMatrix;
-};
-*///?}
+//layout(std140) uniform SkyHanniRoundedUniforms {
+//    float scaleFactor;
+//    float radius;
+//    float smoothness;
+//    vec2 halfSize;
+//    vec2 centerPos;
+//    mat4 modelViewMatrix;
+//};
+//?}
 uniform sampler2D textureSampler;
 
 out vec4 outColor;

--- a/src/main/resources/assets/skyhanni/shaders/rounded_texture.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/rounded_texture.vsh
@@ -1,17 +1,14 @@
 #version 150
-//? < 1.21.6 {
+
 in vec3 Position;
 in vec2 UV0;
-
+//? < 1.21.6 {
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 //?} else {
-/*#moj_import <minecraft:dynamictransforms.glsl>
-#moj_import <minecraft:projection.glsl>
-
-in vec3 Position;
-in vec2 UV0;
-*///?}
+//#moj_import <minecraft:dynamictransforms.glsl>
+//#moj_import <minecraft:projection.glsl>
+//?}
 out vec2 texCoord;
 
 void main() {

--- a/src/main/resources/assets/skyhanni/shaders/standard_chroma.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/standard_chroma.fsh
@@ -7,13 +7,13 @@ uniform float timeOffset;
 uniform float saturation;
 uniform bool forwardDirection;
 //?} else {
-/*layout(std140) uniform SkyHanniChromaUniforms {
-    float chromaSize;
-    float timeOffset;
-    float saturation;
-    int forwardDirection;
-};
-*///?}
+//layout(std140) uniform SkyHanniChromaUniforms {
+//    float chromaSize;
+//    float timeOffset;
+//    float saturation;
+//    int forwardDirection;
+//};
+//?}
 out vec4 fragColor;
 
 float rgb2b(vec3 rgb) {

--- a/src/main/resources/assets/skyhanni/shaders/standard_chroma.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/standard_chroma.vsh
@@ -1,17 +1,14 @@
 #version 150
-//? < 1.21.6 {
+
 in vec3 Position;
 in vec4 Color;
-
+//? < 1.21.6 {
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 //?} else {
-/*#moj_import <minecraft:dynamictransforms.glsl>
-#moj_import <minecraft:projection.glsl>
-
-in vec3 Position;
-in vec4 Color;
-*///?}
+//#moj_import <minecraft:dynamictransforms.glsl>
+//#moj_import <minecraft:projection.glsl>
+//?}
 out vec4 vertexColor;
 
 void main() {

--- a/src/main/resources/assets/skyhanni/shaders/textured_chroma.fsh
+++ b/src/main/resources/assets/skyhanni/shaders/textured_chroma.fsh
@@ -8,13 +8,13 @@ uniform float timeOffset;
 uniform float saturation;
 uniform int forwardDirection;
 //?} else {
-/*layout(std140) uniform SkyHanniChromaUniforms {
-    float chromaSize;
-    float timeOffset;
-    float saturation;
-    int forwardDirection;
-};
-*///?}
+//layout(std140) uniform SkyHanniChromaUniforms {
+//    float chromaSize;
+//    float timeOffset;
+//    float saturation;
+//    int forwardDirection;
+//};
+//?}
 uniform sampler2D Sampler0;
 
 out vec4 fragColor;

--- a/src/main/resources/assets/skyhanni/shaders/textured_chroma.vsh
+++ b/src/main/resources/assets/skyhanni/shaders/textured_chroma.vsh
@@ -1,19 +1,15 @@
 #version 150
-//? < 1.21.6 {
+
 in vec3 Position;
 in vec2 UV0;
 in vec4 Color;
-
+//? < 1.21.6 {
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 //?} else {
-/*#moj_import <minecraft:dynamictransforms.glsl>
-#moj_import <minecraft:projection.glsl>
-
-in vec3 Position;
-in vec2 UV0;
-in vec4 Color;
-*///?}
+//#moj_import <minecraft:dynamictransforms.glsl>
+//#moj_import <minecraft:projection.glsl>
+//?}
 out vec4 vertexColor;
 out vec2 texCoord0;
 

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -123,6 +123,12 @@ allprojects {
 
 stonecutter active "1.21.5"
 
+stonecutter handlers {
+    configure("fsh", "vsh") {
+        commenter = line("//")
+    }
+}
+
 stonecutter parameters {
     replacements {
         string(current.parsed >= "1.21.6") {


### PR DESCRIPTION
## What
Change Stonecutter's commenter for shader files to stop Minecraft (and potentially other mods) trying to process code for other versions.

## Changelog Technical Details
+ Change Stonecutter commenter style for shader files. - Vixid

