### PR TITLE
Backend + Fix: Add Component.replace + Fix Shorten coins breaking formatting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FixIronman.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FixIronman.kt
@@ -30,14 +30,14 @@ object FixIronman {
 
         for ((index, line) in event.toolTip.withIndex()) {
             if (line.string.contains("Ironman")) {
-                event.toolTip[index] = line.replace("Ironman", "Ironperson")
+                event.toolTip[index] = line.replace("Ironman", "Ironperson") ?: line
             }
         }
 
         if (selectModeInventory.isInside()) {
             for ((index, line) in event.toolTip.withIndex()) {
                 if (line.string.contains("No Auction House!")) {
-                    event.toolTip[index] = line.replace("No Auction House!", "Ironperson-Only Auction House!")
+                    event.toolTip[index] = line.replace("No Auction House!", "Ironperson-Only Auction House!") ?: line
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
@@ -93,7 +93,7 @@ object StockOfStonkFeature {
                 }
             }
         }
-        event.toolTip.transformAt(bestValueIndex) { replace("§6§6", "§a") }
+        event.toolTip.transformAt(bestValueIndex) { replace("§6§6", "§a") ?: this }
     }
 
     private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.stonkOfStonkPrice

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FixChimeraDescription.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/FixChimeraDescription.kt
@@ -30,12 +30,12 @@ object FixChimeraDescription {
         for ((index, line) in event.toolTip.withIndex()) {
             // hypixel doesn't show the 100% for chimera 5
             if (line.string.contains("Copies your active pet's stats.")) {
-                event.toolTip[index] = line.replace("Copies your active pet's stats.", "Copies §a75% §7of your active pet's stats.")
+                event.toolTip[index] = line.replace("Copies your active pet's stats.", "Copies §a75% §7of your active pet's stats.") ?: line
             }
             percentagePattern.matchMatcher(line) {
                 group("percentage").formatIntOrNull()?.let { old ->
                     val new = newChimeraValue(old)
-                    event.toolTip[index] = line.replace("$old", "$new")
+                    event.toolTip[index] = line.replace("$old", "$new") ?: line
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.utils.compat
 import at.hannibal2.skyhanni.mixins.hooks.ComponentCreatedStore
 import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import net.minecraft.ChatFormatting
 import net.minecraft.client.GuiMessageTag
@@ -19,6 +20,7 @@ import net.minecraft.network.chat.contents.TranslatableContents
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.item.ItemStack
 import java.net.URI
+import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 import kotlin.math.abs
 import kotlin.time.Duration.Companion.minutes
@@ -363,13 +365,41 @@ fun List<Any>.mapToComponents(): List<Component> {
     return newList
 }
 
-fun Component.replace(oldValue: String, newValue: String): Component {
-    // this isnt perfect
-    for (index in this.siblings.indices) {
-        val sibling = this.siblings[index]
-        this.siblings[index] = Component.literal(sibling.string.replace(oldValue, newValue)).withStyle(sibling.style)
-    }
-    return this
+/**
+ * Replace a string within a Component with another string
+ * The strings have to exist within 1 sibling
+ * AKA they have to have the same Style
+ */
+fun Component.replace(oldValue: String, newValue: String): MutableComponent? {
+    val newComp = Component.empty()
+    var hasEdited = false
+
+    this.visit( { style: Style?, string: String? ->
+        val edit = string?.replace(oldValue, newValue)
+        if (edit != string) hasEdited = true
+
+        newComp.append(Component.literal(edit).withStyle(style))
+        Optional.empty<Component>()
+    }, Style.EMPTY)
+
+    if (!hasEdited) return null
+    return newComp
+}
+
+fun Component.replace(oldValue: Regex, newValue: String): MutableComponent? {
+    val newComp = Component.empty()
+    var hasEdited = false
+
+    this.visit( { style: Style?, string: String? ->
+        val edit = string?.replace(oldValue, newValue)
+        if (edit != string) hasEdited = true
+
+        newComp.append(Component.literal(edit).withStyle(style))
+        Optional.empty<Component>()
+    }, Style.EMPTY)
+
+    if (!hasEdited) return null
+    return newComp
 }
 
 operator fun Component.plus(string: String): Component {

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -433,7 +433,6 @@ fun Component.replace(oldValue: String, newValue: Component, onlyReplaceFirst: B
     return newComp
 }
 
-
 operator fun Component.plus(string: String): Component {
     return this.append(string)
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -423,7 +423,8 @@ fun Component.replace(oldValue: String, newValue: Component, onlyReplaceFirst: B
                             }
                         }
                     }
-            })
+                }
+            )
         } else {
             newComp.append(Component.literal(string).withStyle(currentStyle))
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -1,9 +1,9 @@
 package at.hannibal2.skyhanni.utils.compat
 
 import at.hannibal2.skyhanni.mixins.hooks.ComponentCreatedStore
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import net.minecraft.ChatFormatting
 import net.minecraft.client.GuiMessageTag
@@ -371,27 +371,26 @@ fun List<Any>.mapToComponents(): List<Component> {
  * AKA they have to have the same Style
  */
 fun Component.replace(oldValue: String, newValue: String): MutableComponent? {
-    val newComp = Component.empty()
-    var hasEdited = false
-
-    this.visit( { style: Style?, string: String? ->
-        val edit = string?.replace(oldValue, newValue)
-        if (edit != string) hasEdited = true
-
-        newComp.append(Component.literal(edit).withStyle(style))
-        Optional.empty<Component>()
-    }, Style.EMPTY)
-
-    if (!hasEdited) return null
-    return newComp
+    return replace(this, oldValue, newValue)
 }
 
 fun Component.replace(oldValue: Regex, newValue: String): MutableComponent? {
+    return replace(this, oldValue, newValue)
+}
+
+private fun replace(component: Component, oldValue: Any, newValue: String): MutableComponent? {
     val newComp = Component.empty()
     var hasEdited = false
 
-    this.visit( { style: Style?, string: String? ->
-        val edit = string?.replace(oldValue, newValue)
+    component.visit( { style: Style?, string: String? ->
+        val edit: String?
+        if (oldValue is String) {
+            edit = string?.replace(oldValue, newValue)
+        } else if (oldValue is Regex) {
+            edit = string?.replace(oldValue, newValue)
+        } else {
+            ErrorManager.skyHanniError("replace oldValue is not Regex or String")
+        }
         if (edit != string) hasEdited = true
 
         newComp.append(Component.literal(edit).withStyle(style))
@@ -401,6 +400,39 @@ fun Component.replace(oldValue: Regex, newValue: String): MutableComponent? {
     if (!hasEdited) return null
     return newComp
 }
+
+fun Component.replace(oldValue: String, newValue: Component, onlyReplaceFirst: Boolean = false): MutableComponent? {
+    val newComp = Component.empty()
+    var hasEdited = false
+
+    this.visit( { currentStyle: Style?, string: String? ->
+        if (string?.contains(oldValue) == true && (!onlyReplaceFirst || !hasEdited)) {
+            val split = string.split(oldValue)
+            newComp.append(componentBuilder {
+                for ((index, str) in split.withIndex()) {
+                    append(Component.literal(str).withStyle(currentStyle))
+                    if (index < split.size - 1) {
+                        if (!onlyReplaceFirst || !hasEdited) {
+                            append(newValue)
+                            hasEdited = true
+                        } else {
+                            append(oldValue) {
+                                style = currentStyle
+                            }
+                        }
+                    }
+                }
+            })
+        } else {
+            newComp.append(Component.literal(string).withStyle(currentStyle))
+        }
+        Optional.empty<Component>()
+    }, Style.EMPTY)
+
+    if (!hasEdited) return null
+    return newComp
+}
+
 
 operator fun Component.plus(string: String): Component {
     return this.append(string)

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -382,7 +382,7 @@ private fun replace(component: Component, oldValue: Any, newValue: String): Muta
     val newComp = Component.empty()
     var hasEdited = false
 
-    component.visit( { style: Style?, string: String? ->
+    component.visit({ style: Style?, string: String? ->
         val edit: String?
         if (oldValue is String) {
             edit = string?.replace(oldValue, newValue)
@@ -405,23 +405,24 @@ fun Component.replace(oldValue: String, newValue: Component, onlyReplaceFirst: B
     val newComp = Component.empty()
     var hasEdited = false
 
-    this.visit( { currentStyle: Style?, string: String? ->
+    this.visit({ currentStyle: Style?, string: String? ->
         if (string?.contains(oldValue) == true && (!onlyReplaceFirst || !hasEdited)) {
             val split = string.split(oldValue)
-            newComp.append(componentBuilder {
-                for ((index, str) in split.withIndex()) {
-                    append(Component.literal(str).withStyle(currentStyle))
-                    if (index < split.size - 1) {
-                        if (!onlyReplaceFirst || !hasEdited) {
-                            append(newValue)
-                            hasEdited = true
-                        } else {
-                            append(oldValue) {
-                                style = currentStyle
+            newComp.append(
+                componentBuilder {
+                    for ((index, str) in split.withIndex()) {
+                        append(Component.literal(str).withStyle(currentStyle))
+                        if (index < split.size - 1) {
+                            if (!onlyReplaceFirst || !hasEdited) {
+                                append(newValue)
+                                hasEdited = true
+                            } else {
+                                append(oldValue) {
+                                    style = currentStyle
+                                }
                             }
                         }
                     }
-                }
             })
         } else {
             newComp.append(Component.literal(string).withStyle(currentStyle))


### PR DESCRIPTION
## What
Added a (proper) way to replace strings in components
You can only replace strings that are in the same component (so you can only replace things in the same colour and style)
also changed shorten coins to use this
which fixes the feature with the new da feature

## Changelog Fixes
+ Fixed Shorten Coins breaking formatting of other features. - nopo

## Changelog Technical Details
+ Added Component.replace(). - nopo

