### PR TITLE
Backend: Use MutableComponent factory method instead of casting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -30,6 +30,7 @@ import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import com.mojang.blaze3d.systems.RenderSystem
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.HoverEvent
+import net.minecraft.network.chat.MutableComponent
 import net.minecraft.network.chat.contents.PlainTextContents
 import net.minecraft.world.item.ItemStack
 import java.util.TreeSet
@@ -478,8 +479,7 @@ object EnchantParser {
     }
 
     private fun editChatComponent(chatComponent: Component, loreList: MutableList<Component>) {
-        val newComponent = Component.literal((chatComponent.contents as PlainTextContents.LiteralContents).text)
-            .setStyle(chatComponent.style)
+        val newComponent = MutableComponent.create(chatComponent.contents).setStyle(chatComponent.style)
         loreList.forEach { newComponent.append(it) }
         GuiChatHook.replaceHoverEventComponent(newComponent)
     }


### PR DESCRIPTION
## What
Instead of using `Component.literal()` and trying to cast the original component's contents to `PlainTextContents.LiteralContents` (which can fail), just use MutableComponents factory method which takes in `ComponentContents` instead.

## Changelog Technical Details
+ Use MutableComponent factory method instead of casting and using `Component.literal()`. - Vixid

