### PR TITLE
Fix: Not Clickable Items graying out composter items with overlay disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -162,7 +162,7 @@ object ComposterOverlay {
     }
 
     private fun update() {
-        if (!config.overlay) return
+        if (!isEnabled()) return
         val composterUpgrades = ComposterApi.composterUpgrades ?: return
         if (composterUpgrades.isEmpty()) {
             Renderable.text("§cOpen Composter Upgrades!").let {
@@ -669,9 +669,9 @@ object ComposterOverlay {
 
     @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class)
     fun onBackgroundDraw() {
+        if (!isEnabled() || !inInventory) return
         if (EstimatedItemValue.isCurrentlyShowing()) return
 
-        if (!inInventory || !config.overlay) return
         config.overlayOrganicMatterPos.renderRenderable(
             organicMatterDisplay,
             posLabel = "Composter Overlay Organic Matter",
@@ -738,4 +738,6 @@ object ComposterOverlay {
             }
         }
     }
+
+    fun isEnabled(): Boolean = config.overlay
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -211,7 +211,7 @@ object HideNotClickableItems {
             hidePrivateIslandChest(stack) -> true
             hideAttributeFusion(chestName, stack) -> true
             hideYourEquipment(chestName, stack) -> true
-            hideComposter(chestName, stack) -> true
+            hideComposter(stack) -> true
             hideRiftMotesGrubber(chestName, stack) -> true
             hideRiftTransferChest(chestName, stack) -> true
             hideFossilExcavator(stack) -> true
@@ -286,9 +286,8 @@ object HideNotClickableItems {
         return true
     }
 
-    @Suppress("UnusedParameter")
-    private fun hideComposter(chestName: String, stack: ItemStack): Boolean {
-        if (!ComposterOverlay.inInventory) return false
+    private fun hideComposter(stack: ItemStack): Boolean {
+        if (!ComposterOverlay.isEnabled() || !ComposterOverlay.inInventory) return false
 
         showGreenLine = true
 


### PR DESCRIPTION
## What
Fixed Not Clickable Items graying out items in Composter even if Composter Overlay is disabled.

## Changelog Fixes
+ Fixed "Only insert the selected items!" showing even when Composter Overlay is disabled. - Luna