### PR TITLE
Fix: the config having a forehead on 1.21.5

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorDeprecatedVersion.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorDeprecatedVersion.kt
@@ -11,7 +11,7 @@ class GuiOptionEditorDeprecatedVersion(option: ProcessedOption) : GuiOptionEdito
 
     override fun render(context: RenderContext, x: Int, y: Int, width: Int) {
         if (!isDiscontinued()) return
-        val versionData = UpdateManager.discontinuedVersions.get(PlatformUtils.MC_VERSION)?.configInfo ?: return
+        val versionData = UpdateManager.discontinuedVersions[PlatformUtils.MC_VERSION]?.configInfo ?: return
         val fr = context.minecraft.defaultFontRenderer
         context.drawColoredRect(x.toFloat(), y.toFloat(), (x + width).toFloat(), y + 2f, Color.RED.rgb)
         context.drawColoredRect(x.toFloat(), y + 55f - 2, (x + width).toFloat(), y + 55f, Color.RED.rgb)
@@ -33,6 +33,6 @@ class GuiOptionEditorDeprecatedVersion(option: ProcessedOption) : GuiOptionEdito
     }
 
     private fun isDiscontinued(): Boolean {
-        return UpdateManager.discontinuedVersions.containsKey(PlatformUtils.MC_VERSION)
+        return UpdateManager.discontinuedVersions[PlatformUtils.MC_VERSION]?.configInfo != null
     }
 }


### PR DESCRIPTION
## What
might have negative user luck but no yap in the config yet

## Changelog Fixes
+ Fixed the About page in the config having a forehead on 1.21.5. - nopo
