### PR TITLE
Fix: Discord Rich Presence logging error again

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -67,7 +67,6 @@ object DiscordRPCManager {
         try {
             progress.update("calling setup")
             setup(progress, fromCommand)
-            progress.end("setup done successfully")
         } catch (e: Throwable) {
             progress.end("error: ${e.message}")
             updateDebugStatus("Unexpected error: ${e.message}", error = true)


### PR DESCRIPTION
## What
Removes second progress.end() message added as part of my previous PR. The only progress.end() that should run is now on line 94.

## Changelog Fixes
+ Fixed Discord Rich Presence Logging. - NetheriteMiner
