### PR TITLE
Fix + Feature: Water highlighter in crop diagnostic tool

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
@@ -36,6 +36,15 @@ class GreenhouseConfig {
     var highlightHarvestableStatus: Boolean = true
 
     @Expose
+    @ConfigOption(
+        name = "Highlight Water Status",
+        desc = "Highlights the \"Water Status\" item green if the crop has enough water.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var highlightWaterStatus: Boolean = true
+
+    @Expose
     @ConfigLink(owner = GreenhouseConfig::class, field = "showDisplay")
     val position: Position = Position(180, 40)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/HarvestableHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/HarvestableHighlight.kt
@@ -17,7 +17,7 @@ object HarvestableHighlight {
     private val config get() = SkyHanniMod.feature.garden.greenhouse
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+    fun onGrowthStatusDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!config.highlightHarvestableStatus) return
         if (!GreenhouseUtils.cropDiagnosticInventory.isInside()) return
         val slot = InventoryUtils.getSlotAtIndex(24) ?: return
@@ -26,17 +26,32 @@ object HarvestableHighlight {
         var color = LorenzColor.RED
         for (component in beacon.getLoreComponent()) {
             val line = component.string
-            if (line.contains("Status: ")) {
-                if (line == "Status: Harvestable") {
-                    color = LorenzColor.GREEN
-                    continue
-                }
-                if (line.startsWith("Drops: ") || line.startsWith("Rewards: ")) {
-                    color = LorenzColor.YELLOW
-                    continue
-                }
+            if (line == "Status: Harvestable") {
+                color = LorenzColor.GREEN
+                continue
+            }
+            if (line.startsWith("Drops: ") || line.startsWith("Rewards: ")) {
+                color = LorenzColor.YELLOW
+                continue
             }
         }
         slot.highlight(color)
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onWaterLevelDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+        if (!config.highlightWaterStatus) return
+        if (!GreenhouseUtils.cropDiagnosticInventory.isInside()) return
+        val slot = InventoryUtils.getSlotAtIndex(21) ?: return
+        val water = slot.item ?: return
+        if (water.item != Items.WATER_BUCKET) return
+        for (component in water.getLoreComponent()) {
+            val line = component.string
+            if (line == "This crop has enough water to" || line == "This crop doesn't need water!") {
+                slot.highlight(LorenzColor.GREEN)
+                return
+            }
+
+        }
     }
 }


### PR DESCRIPTION
## What
highlights water bucket green if you dont need any more water

## Changelog New Features
+ Highlight Water Status green if the crop doesn't need more water. - nopo

## Changelog Fixes
+ Fixed Highlight Harvestable Status not highlighting multi drop crops yellow. - nopo
