### PR TITLE
Improvement: Add gamemode selected for Elite Api displays

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/EliteDevApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/EliteDevApi.kt
@@ -211,6 +211,7 @@ object EliteDevApi {
         lbType: EliteLeaderboardType,
         upcomingCount: Int? = null,
         atRank: Int? = null,
+        mode: String? = null
     ): EliteLeaderboard {
         require(profileId.isNotBlank()) { "Profile ID cannot be blank" }
         val uuid = if (spoofProfile) playerUuid else PlayerUtils.getUuid()
@@ -218,7 +219,8 @@ object EliteDevApi {
         val upcomingPlayersParam = upcomingCount?.let { "upcoming=$it" }
         val atRankParam = atRank?.let { "atRank=$it" }
         val previousPlayersParam = "previous=1"
-        val params = listOfNotNull(upcomingPlayersParam, atRankParam, previousPlayersParam)
+        val modeParam = mode?.let { "mode=$it" }
+        val params = listOfNotNull(upcomingPlayersParam, atRankParam, previousPlayersParam, modeParam)
         val paramString = if (params.isEmpty()) "" else {
             "?" + params.joinToString("&")
         }

--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
@@ -33,7 +33,6 @@ import net.minecraft.world.inventory.ChestMenu
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
-import java.util.regex.Matcher
 
 // Code taken from NotEnoughUpdates
 class ItemResolutionQuery {
@@ -55,7 +54,7 @@ class ItemResolutionQuery {
          */
         private val petPattern by patternGroup.pattern(
             "pet",
-            "(?:§.)*\\[Lvl (?<level>\\d+)] (?:§.)*§(?<rarity>.)(?<name>[^§]+)(?:(§.)* ✦)?",
+            "(?:§.)*\\[Lvl (?<level>\\d+)] (?:§.)*§(?<rarity>.)(?<name>[^§]+)(?:(?:§.)* ✦)?",
         )
 
         /**

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
@@ -17,7 +17,7 @@ class EliteFarmersLeaderboardsConfig {
     @ConfigOption(name = "Enabled", desc = "Enable leaderboard features.")
     @ConfigEditorBoolean
     @FeatureToggle
-    val enabled: Boolean = true
+    var enabled: Boolean = true
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
@@ -1,9 +1,11 @@
 package at.hannibal2.skyhanni.config.features.garden.leaderboards
 
+import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.PositionList
 import at.hannibal2.skyhanni.features.garden.leaderboarddisplays.EliteLeaderboards
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
@@ -12,11 +14,17 @@ import io.github.notenoughupdates.moulconfig.observer.Property
 class EliteFarmersLeaderboardsConfig {
 
     @Expose
+    @ConfigOption(name = "Enabled", desc = "Enable leaderboard features.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    val enabled: Boolean = true
+
+    @Expose
     @ConfigOption(
         name = "Leaderboards",
-        desc = "Choose what leaderboards to enable." +
-            "Per-leaderboard settings below." +
-            "Leaderboards provided by elitebot.dev"
+        desc = "Choose what leaderboards to enable.\n" +
+            "Per-leaderboard settings below.\n" +
+            "Leaderboards provided by §eelitebot.dev"
     )
     @ConfigEditorDraggableList
     val display: Property<MutableList<EliteLeaderboards>> = Property.of(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/generics/EliteLeaderboardGenericConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/generics/EliteLeaderboardGenericConfig.kt
@@ -3,7 +3,9 @@ package at.hannibal2.skyhanni.config.features.garden.leaderboards.generics
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
 
 open class EliteLeaderboardGenericConfig<RankGoal : RankGoalGenericConfig, Display : EliteDisplayGenericConfig>(
     rankGoalConfig: () -> RankGoal,
@@ -35,4 +37,23 @@ open class EliteLeaderboardGenericConfig<RankGoal : RankGoalGenericConfig, Displ
     )
     @ConfigEditorBoolean
     var offlineLbChange: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Gamemode",
+        desc = "Which game mode to show on the leaderboard.",
+    )
+    @ConfigEditorDropdown
+    var gamemode: Property<Gamemode> = Property.of(Gamemode.ALL)
+}
+
+enum class Gamemode(val apiMode: String?, val displayName: String, val renderableName: String) {
+    ALL(null, "All", ""),
+    IRONMAN("ironman", "Ironman", " Ironman"),
+    STRANDED("island", "Stranded", " Stranded")
+    ;
+
+    override fun toString(): String {
+        return this.displayName
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/generics/EliteLeaderboardGenericConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/generics/EliteLeaderboardGenericConfig.kt
@@ -44,7 +44,7 @@ open class EliteLeaderboardGenericConfig<RankGoal : RankGoalGenericConfig, Displ
         desc = "Which game mode to show on the leaderboard.",
     )
     @ConfigEditorDropdown
-    var gamemode: Property<Gamemode> = Property.of(Gamemode.ALL)
+    val gamemode: Property<Gamemode> = Property.of(Gamemode.ALL)
 }
 
 enum class Gamemode(val apiMode: String?, val displayName: String, val renderableName: String) {

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -286,6 +286,7 @@ object EliteFarmersLeaderboard {
             lbType = leaderboardType,
             upcomingCount = upcomingPlayers,
             atRank = atRank,
+            getLeaderboardConfig(leaderboardType).gamemode.get().apiMode
         )
         // elite only updates player profiles once an hour, so assume it's wrong if it's the same as last fetch
         val shouldUpdateData = shouldUpdateData(leaderboardType, apiData)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.garden.leaderboarddisplays
 
 import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboardConfigApi
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboardConfigApi.getConfigFromClass
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.generics.EliteDisplayGenericConfig.LeaderboardTextEntry
 import at.hannibal2.skyhanni.data.garden.EliteFarmersLeaderboard
@@ -123,8 +124,9 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
         }
 
         val leaderboardPos = getLeaderboardFormat(leaderboardType)
+        val mode = EliteLeaderboardConfigApi.getLeaderboardConfig(leaderboardType).gamemode.get().renderableName
         return Renderable.clickable(
-            "§6$leaderboardType§7: §e$amountText$leaderboardPos",
+            "§6$leaderboardType$mode§7: §e$amountText$leaderboardPos",
             tips = listOf("§eClick to open your Farming Profile."),
             onLeftClick = { openWebsite(PlayerUtils.getName()) },
         )

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
@@ -32,7 +32,7 @@ enum class EliteLeaderboards(
     PEST("Pest Kills", PestDisplay(), EliteLeaderboardType.Pest::class)
     ;
 
-    val isEnabled get() = this in config.display.get()
+    val isEnabled get() = config.enabled && this in config.display.get()
     val position get() = config.displayPositions[ordinal]
     override fun toString() = displayName
 
@@ -56,6 +56,7 @@ enum class EliteLeaderboards(
         @HandleEvent
         fun onRenderOverlay(event: GuiRenderEvent) {
             if (config.displayPositions.isEmpty()) return
+            if (!config.enabled) return
             config.display.get().forEach { leaderboard ->
                 leaderboard.display.renderDisplay(leaderboard.position)
             }
@@ -72,17 +73,20 @@ enum class EliteLeaderboards(
             val weightConfigs = listOf(
                 weightConfig.rankGoals.useRankGoal,
                 weightConfig.rankGoals.monthlyRankGoal,
-                weightConfig.rankGoals.rankGoal
+                weightConfig.rankGoals.rankGoal,
+                weightConfig.gamemode,
             )
 
             val cropConfigs = listOf(
                 cropConfig.rankGoals.useRankGoal,
                 cropConfig.rankGoals.rankGoalTypes,
+                cropConfig.gamemode,
             )
 
             val pestConfigs = listOf(
                 pestConfig.rankGoals.useRankGoal,
                 pestConfig.rankGoals.rankGoalTypes,
+                pestConfig.gamemode
             )
 
             weightConfigs.forEach {


### PR DESCRIPTION
## What
game mode selector so u can see lb for just ur game mode
if ur normal dont set it to ironman idk skill issue if it bugs out
also added an enable for the whole thing

## Changelog Improvements
+ Added gamemode selector to the Elite Leaderboard Features. - nopo
