### PR TITLE
Fix: Instance Chest Profit not Counting Stacked Items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -313,10 +313,6 @@ object InstanceChestProfit {
         count * getPrice(NeuInternalName.fromItemName(name))
     } ?: 0.0
 
-    private fun ItemStack.getPrice(item: ItemStack): Double {
-        return item.getInternalName().getPrice() * item.count
-    }
-
     private fun createDisplay(inventoryName: String, items: Map<Int, ItemStack>) {
         /**
          * Kuudra chests say "Free Chest Chest" and "Paid Chest Chest" due to Hypixel issue

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -313,6 +313,10 @@ object InstanceChestProfit {
         count * getPrice(NeuInternalName.fromItemName(name))
     } ?: 0.0
 
+    private fun ItemStack.getPrice(item: ItemStack): Double {
+        return item.getInternalName().getPrice() * item.count
+    }
+
     private fun createDisplay(inventoryName: String, items: Map<Int, ItemStack>) {
         /**
          * Kuudra chests say "Free Chest Chest" and "Paid Chest Chest" due to Hypixel issue
@@ -324,7 +328,7 @@ object InstanceChestProfit {
             if (fakeItemNamePattern.matches(it.value.hoverName.formattedTextCompatLeadingWhiteLessResets())) return@forEach
             if (it.value.getInternalNameOrNull() != null) {
                 val cost = EstimatedItemValueCalculator.getTotalPrice(it.value)
-                if (cost != null) itemsWithCost.addOrPut(it.value.getInternalName().repoItemName, cost)
+                if (cost != null) itemsWithCost.addOrPut(it.value.getInternalName().repoItemName, (cost * it.value.count))
             }
             val name = it.value.hoverName.formattedTextCompatLeadingWhiteLessResets()
             if (attributeShardPattern.matches(name)) {


### PR DESCRIPTION
## What
I don't have a Kuudra run to test on but this, probably? works?

## Changelog Fixes
+ Fixed Instance Chest Profit not Counting Stacked Items Properly. - Fazfoxy

