### PR TITLE
Fix: higher quantity crafts (e.g. bait)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftingInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftingInventory.kt
@@ -89,8 +89,9 @@ object SuperCraftingInventory {
         if (event.slotId != PICKAXE_SLOT) return
         val slots = InventoryUtils.getItemsInOpenChestWithNull()
         val craftingAmount = getSuperCraftingCount(slots) ?: return
-        val craftMultiplier = getResultItem(slots).amount
-        val profit = getProfit(slots, craftingAmount, craftMultiplier) ?: return
+        val result = getResultItem(slots)
+        val craftMultiplier = result.amount
+        val profit = getProfit(slots, craftingAmount, craftMultiplier, result) ?: return
         val maxCraftingAmount = getSuperCraftingMaxCount(slots, craftingAmount, craftMultiplier)
         if (!blockWasteClick(profit, craftingAmount, maxCraftingAmount)) return
         SoundUtils.playErrorSound()
@@ -126,18 +127,15 @@ object SuperCraftingInventory {
             owned / matsPerCraft
         }
 
-    private fun getProfit(slots: List<Slot>, craftingAmount: Long, craftMultiplier: Int): Double? {
+    private fun getProfit(slots: List<Slot>, craftingAmount: Long, craftMultiplier: Int, resultItem: PrimitiveItemStack): Double? {
         val materials = getRecipeMaterials(slots)
-
-        val recipeMultiplier = craftMultiplier
-        val resultItem = getResultItem(slots)
-        if (recipeMultiplier == 0) ErrorManager.skyHanniError(
+        if (craftMultiplier == 0) ErrorManager.skyHanniError(
             "Result item amount is 0",
             "item" to resultItem,
         )
 
         val itemsPrice = materials.sumOf { material ->
-            val totalAmount = material.amount * (craftingAmount / recipeMultiplier)
+            val totalAmount = material.amount * (craftingAmount / craftMultiplier)
             BazaarApi.calculatePriceOfAvailableOrders(
                 material.internalName, totalAmount, BazaarApi.SimpleTransactionType.BUY_ORDER,
             ) ?: return null

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftingInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftingInventory.kt
@@ -91,6 +91,10 @@ object SuperCraftingInventory {
         val craftingAmount = getSuperCraftingCount(slots) ?: return
         val result = getResultItem(slots)
         val craftMultiplier = result.amount
+        if (craftMultiplier == 0) ErrorManager.skyHanniError(
+            "Result item amount is 0",
+            "item" to result,
+        )
         val profit = getProfit(slots, craftingAmount, craftMultiplier, result) ?: return
         val maxCraftingAmount = getSuperCraftingMaxCount(slots, craftingAmount, craftMultiplier)
         if (!blockWasteClick(profit, craftingAmount, maxCraftingAmount)) return
@@ -129,10 +133,6 @@ object SuperCraftingInventory {
 
     private fun getProfit(slots: List<Slot>, craftingAmount: Long, craftMultiplier: Int, resultItem: PrimitiveItemStack): Double? {
         val materials = getRecipeMaterials(slots)
-        if (craftMultiplier == 0) ErrorManager.skyHanniError(
-            "Result item amount is 0",
-            "item" to resultItem,
-        )
 
         val itemsPrice = materials.sumOf { material ->
             val totalAmount = material.amount * (craftingAmount / craftMultiplier)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftingInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftingInventory.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getSingleLineLore
 import at.hannibal2.skyhanni.utils.KeyboardManager
+import at.hannibal2.skyhanni.utils.MobUtils.mob
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLongOrNull
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.toPrimitiveStackOrNull
@@ -25,6 +26,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPatternGroup
+import net.minecraft.client.Minecraft
 import net.minecraft.world.inventory.Slot
 import kotlin.time.Duration.Companion.seconds
 
@@ -89,8 +91,9 @@ object SuperCraftingInventory {
         if (event.slotId != PICKAXE_SLOT) return
         val slots = InventoryUtils.getItemsInOpenChestWithNull()
         val craftingAmount = getSuperCraftingCount(slots) ?: return
-        val profit = getProfit(slots, craftingAmount) ?: return
-        val maxCraftingAmount = getSuperCraftingMaxCount(slots, craftingAmount)
+        val craftMultiplier = getResultItem(slots).amount
+        val profit = getProfit(slots, craftingAmount, craftMultiplier) ?: return
+        val maxCraftingAmount = getSuperCraftingMaxCount(slots, craftingAmount, craftMultiplier)
         if (!blockWasteClick(profit, craftingAmount, maxCraftingAmount)) return
         SoundUtils.playErrorSound()
         val diff = (-profit).formatChatCoins()
@@ -108,27 +111,28 @@ object SuperCraftingInventory {
         event.cancel()
     }
 
-    private fun getSuperCraftingMaxCount(slots: List<Slot>, craftingAmount: Long) = slots[PICKAXE_SLOT].item.getLore()
-        .mapNotNull { calculateMaxPossible(it, craftingAmount) }
+    private fun getSuperCraftingMaxCount(slots: List<Slot>, craftingAmount: Long, craftMultiplier: Int) = slots[PICKAXE_SLOT].item.getLore()
+        .mapNotNull { calculateMaxPossible(it, craftingAmount, craftMultiplier) }
         .minOrNull() ?: ErrorManager.skyHanniError(
         "Super Crafting resource line not found",
         "lore" to slots.map { slot -> slot.item.getLore().map { line -> line.removeColor() } },
     )
 
-    private fun calculateMaxPossible(string: String, craftingAmount: Long) = craftingResourcePattern.matchMatcher(string.removeColor()) {
-        val owned = groupOrNull("owned")?.formatLongOrNull() ?: return null
-        val used = groupOrNull("used")?.formatLongOrNull() ?: return null
-        if (used == 0L || owned == 0L) return null
-        val matsPerCraft = used / craftingAmount
-        if (matsPerCraft == 0L) return null
-        owned / matsPerCraft
-    }
+    private fun calculateMaxPossible(string: String, craftingAmount: Long, craftMultiplier: Int) =
+        craftingResourcePattern.matchMatcher(string.removeColor()) {
+            val owned = groupOrNull("owned")?.formatLongOrNull() ?: return null
+            val used = groupOrNull("used")?.formatLongOrNull() ?: return null
+            if (used == 0L || owned == 0L) return null
+            val matsPerCraft = used / (craftingAmount / craftMultiplier)
+            if (matsPerCraft == 0L) return null
+            owned / matsPerCraft
+        }
 
-    private fun getProfit(slots: List<Slot>, craftingAmount: Long): Double? {
+    private fun getProfit(slots: List<Slot>, craftingAmount: Long, craftMultiplier: Int): Double? {
         val materials = getRecipeMaterials(slots)
-        val resultItem = getResultItem(slots)
 
-        val recipeMultiplier = resultItem.amount
+        val recipeMultiplier = craftMultiplier
+        val resultItem = getResultItem(slots)
         if (recipeMultiplier == 0) ErrorManager.skyHanniError(
             "Result item amount is 0",
             "item" to resultItem,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftingInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftingInventory.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getSingleLineLore
 import at.hannibal2.skyhanni.utils.KeyboardManager
-import at.hannibal2.skyhanni.utils.MobUtils.mob
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLongOrNull
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.toPrimitiveStackOrNull
@@ -26,7 +25,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPatternGroup
-import net.minecraft.client.Minecraft
 import net.minecraft.world.inventory.Slot
 import kotlin.time.Duration.Companion.seconds
 


### PR DESCRIPTION
## What
Fixed an exception for resource line not found if an item is crafted in single amounts with higher quantities. Essentially 16x Bait crafts like worm or hot bait.

## Changelog Fixes
+ Fixed Super Crafting Anti Waste not working for recipes that craft multiple items. - Hype_the_Time
    * Also covers coin waste for multi-craft recipes like 16x bait.