### PR TITLE
Improvement: Convert colourful item stats to use components

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 121
+    const val CONFIG_VERSION = 122
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/ColorfulItemTooltips.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/ColorfulItemTooltips.kt
@@ -9,20 +9,12 @@ class ColorfulItemTooltips {
 
     @Expose
     @ConfigOption(
-        name = "Color Item Stat Numbers",
-        desc = "Changes the color of the numbers in item lore to the color they are in the SkyBlock stats menu.",
-    )
-    @ConfigEditorBoolean
-    @FeatureToggle
-    var enabled: Boolean = false
-
-    @Expose
-    @ConfigOption(
         name = "Add Stat Icons",
         desc = "Adds in the stat icons after the stat number.",
     )
     @ConfigEditorBoolean
-    var statIcons: Boolean = true
+    @FeatureToggle
+    var statIcons: Boolean = false
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -368,21 +368,37 @@ val ALWAYS get(): (Style?) -> Boolean = { true }
  * The strings have to exist within 1 sibling
  * AKA they have to have the same Style
  */
-fun Component.replace(oldValue: String, newValue: String, predicate: (Style?) -> Boolean = ALWAYS): MutableComponent? {
-    return replace(this, oldValue, newValue, predicate)
+fun Component.replace(
+    oldValue: String,
+    newValue: String,
+    onlyReplaceFirst: Boolean = false,
+    predicate: (Style?) -> Boolean = ALWAYS
+): MutableComponent? {
+    return replace(this, oldValue, newValue, onlyReplaceFirst, predicate)
 }
 
-fun Component.replace(oldValue: Regex, newValue: String, predicate: (Style?) -> Boolean = ALWAYS): MutableComponent? {
-    return replace(this, oldValue, newValue, predicate)
+fun Component.replace(
+    oldValue: Regex,
+    newValue: String,
+    onlyReplaceFirst: Boolean = false,
+    predicate: (Style?) -> Boolean = ALWAYS
+): MutableComponent? {
+    return replace(this, oldValue, newValue, onlyReplaceFirst, predicate)
 }
 
-private fun replace(component: Component, oldValue: Any, newValue: String, predicate: (Style?) -> Boolean = ALWAYS): MutableComponent? {
+private fun replace(
+    component: Component,
+    oldValue: Any,
+    newValue: String,
+    onlyReplaceFirst: Boolean,
+    predicate: (Style?) -> Boolean = ALWAYS
+): MutableComponent? {
     val newComp = Component.empty()
     var hasEdited = false
 
     component.visit({ style: Style?, string: String? ->
         var edit = string
-        if (predicate(style)) {
+        if ((!onlyReplaceFirst || !hasEdited) && predicate(style)) {
             if (oldValue is String) {
                 edit = string?.replace(oldValue, newValue)
             } else if (oldValue is Regex) {


### PR DESCRIPTION
## What
use tooltiptext event 

<details>
<summary>Images</summary>

<img width="802" height="342" alt="image" src="https://github.com/user-attachments/assets/3924daea-0015-49c7-b98a-8b94bdcb6c19" />

</details>


## Changelog Improvements
+ Improved Item Stat Icon compatibility with other mods. - nopo

