### PR TITLE
Backend: Fix ComputerEnvDebug NPE

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/LaunchersJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/LaunchersJson.kt
@@ -10,7 +10,7 @@ data class LaunchersJson(
 data class LauncherEntry(
     @Expose val name: String,
     @Expose val firstStacks: List<String>,
-    @Expose val brand: String = "",
+    @Expose val brand: String? = null,
     @Expose val flagged: Boolean = false,
 ) {
     fun getIdPair() = name to flagged

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
@@ -129,8 +129,8 @@ object ComputerEnvDebug {
         text.add("Minecraft Allocated: $allocatedPercentage% ${totalMemoryGB.formatGB()} GB")
 
         // Get total system memory using OS-specific APIs
-        val osBean = ManagementFactory.getOperatingSystemMXBean()
-        val totalPhysicalMemory = (osBean as com.sun.management.OperatingSystemMXBean).totalMemorySize
+        val osBean = ManagementFactory.getOperatingSystemMXBean() as com.sun.management.OperatingSystemMXBean
+        val totalPhysicalMemory = osBean.totalMemorySize
         val freePhysicalMemory = osBean.freeMemorySize
         val usedPhysicalMemory = totalPhysicalMemory - freePhysicalMemory
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
@@ -70,7 +70,7 @@ object ComputerEnvDebug {
         val isGeneric = genericStacks.any { firstStack.contains(it) }
         val matchingLaunchers = launchers.filter { launcher ->
             val firstStackMatch = launcher.firstStacks.any { firstStack.contains(it) }
-            val brandMatch = launcher.brand.isEmpty() || launcher.brand.equals(launcherBrand, ignoreCase = true)
+            val brandMatch = launcher.brand.isNullOrBlank() || launcher.brand.equals(launcherBrand, ignoreCase = true)
             (isGeneric || firstStackMatch) && brandMatch
         }
         val fallbackPair = null to true
@@ -130,8 +130,8 @@ object ComputerEnvDebug {
 
         // Get total system memory using OS-specific APIs
         val osBean = ManagementFactory.getOperatingSystemMXBean()
-        val totalPhysicalMemory = (osBean as com.sun.management.OperatingSystemMXBean).totalPhysicalMemorySize
-        val freePhysicalMemory = osBean.freePhysicalMemorySize
+        val totalPhysicalMemory = (osBean as com.sun.management.OperatingSystemMXBean).totalMemorySize
+        val freePhysicalMemory = osBean.freeMemorySize
         val usedPhysicalMemory = totalPhysicalMemory - freePhysicalMemory
 
         // Convert system memory to GB


### PR DESCRIPTION
## What
Fixed NPE in ComputerEnvDebug causing errors whenever `/shdebug` was used. Turns out, GSON does not respect Kotlin default values and uses its own defaults (`null`, `0`, `false`, etc.)

Also replaced uses of some deprecated fields with non-deprecated equivalents.

## Changelog Technical Details
+ Fixed errors in chat when using `/shdebug`. - Luna

