### PR TITLE
Improvement: Stop calling updateCollections so much

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/EliteDevApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/EliteDevApi.kt
@@ -92,7 +92,7 @@ object EliteDevApi {
     }
 
     private fun resetLeaderboardData() {
-        updateCollections()
+        updateCollections(ignoreCooldown = true)
         FarmingWeightData.reset()
         EliteFarmersLeaderboard.reset()
         EliteLeaderboards.resetDisplays()

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -61,7 +61,6 @@ object EliteFarmersLeaderboard {
     private var hasWarned = false
     private var fetchAttempts = 0
     private var lastFetchAttempt = SimpleTimeMark.farPast()
-    private var lastTimeoutMessage = SimpleTimeMark.farPast()
 
     fun clearEntries(leaderboardType: EliteLeaderboardType) {
         leaderboardPosMap?.remove(leaderboardType)
@@ -251,10 +250,6 @@ object EliteFarmersLeaderboard {
                 }
             } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
                 apiUnavailable = true
-                if (lastTimeoutMessage.passedSince() > 5.minutes) {
-                    lastTimeoutMessage = SimpleTimeMark.now()
-                    ChatUtils.userError("elitebot.dev is currently overloaded. Leaderboards won't update until it recovers, sorry!")
-                }
                 throw e
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -57,9 +57,11 @@ object EliteFarmersLeaderboard {
     private val eliteLeaderboardData: MutableMap<EliteLeaderboardType, EliteLeaderboardData> = mutableMapOf()
 
     var apiError = false
+    var apiUnavailable = false
     private var hasWarned = false
     private var fetchAttempts = 0
     private var lastFetchAttempt = SimpleTimeMark.farPast()
+    private var lastTimeoutMessage = SimpleTimeMark.farPast()
 
     fun clearEntries(leaderboardType: EliteLeaderboardType) {
         leaderboardPosMap?.remove(leaderboardType)
@@ -232,19 +234,28 @@ object EliteFarmersLeaderboard {
 
         val category = leaderboardType::class
 
-        SkyHanniMod.launchIOCoroutine("load elite lb") {
-            loadingLeaderboardMutex[leaderboardType::class]?.withLock {
-                val oldPos = leaderboardPosMap?.get(leaderboardType)
-                val lbPos = loadLeaderboardPosition(leaderboardType)
-                lbPos?.let {
-                    leaderboardPosMap?.set(leaderboardType, lbPos)
-                    // warn for the load of each mode in each enabled display
-                    if (category !in loadedLeaderboardCategories) {
-                        checkOffScreenLeaderboardChanges(oldPos, leaderboardType)
-                        loadedLeaderboardCategories.add(category)
+        SkyHanniMod.launchIOCoroutine("load elite lb", timeout = 15.seconds) {
+            try {
+                loadingLeaderboardMutex[leaderboardType::class]?.withLock {
+                    val oldPos = leaderboardPosMap?.get(leaderboardType)
+                    val lbPos = loadLeaderboardPosition(leaderboardType)
+                    lbPos?.let {
+                        leaderboardPosMap?.set(leaderboardType, lbPos)
+                        // warn for the load of each mode in each enabled display
+                        if (category !in loadedLeaderboardCategories) {
+                            checkOffScreenLeaderboardChanges(oldPos, leaderboardType)
+                            loadedLeaderboardCategories.add(category)
+                        }
+                        eliteLeaderboardData.getOrPut(leaderboardType) { EliteLeaderboardData() }.lastUpdate = SimpleTimeMark.now()
                     }
-                    eliteLeaderboardData.getOrPut(leaderboardType) { EliteLeaderboardData() }.lastUpdate = SimpleTimeMark.now()
                 }
+            } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+                apiUnavailable = true
+                if (lastTimeoutMessage.passedSince() > 5.minutes) {
+                    lastTimeoutMessage = SimpleTimeMark.now()
+                    ChatUtils.userError("elitebot.dev is currently overloaded. Leaderboards won't update until it recovers, sorry!")
+                }
+                throw e
             }
         }
         return leaderboardPosMap?.get(leaderboardType)
@@ -293,6 +304,14 @@ object EliteFarmersLeaderboard {
         lbData.lastUpdate = SimpleTimeMark.now()
         lbData.shouldRefresh = false
         apiError = false
+
+        if (apiData.disabled) {
+            apiUnavailable = true
+            return leaderboardPosMap?.get(leaderboardType)
+        }
+
+        apiUnavailable = false
+
         if (apiData.rank <= 0) { // api returns -1 for unranked players
             lbData.isUnranked = true
             // correct wrong data
@@ -305,7 +324,7 @@ object EliteFarmersLeaderboard {
 
             return null
         }
-        lbData.isUnranked = true
+        lbData.isUnranked = false
         if (shouldUpdateData) handleDiff(leaderboardType, apiData)
         handleUpcomingPlayers(leaderboardType, apiData)
         // prefer our lb pos
@@ -449,6 +468,7 @@ object EliteFarmersLeaderboard {
         leaderboardAmountMap?.clear()
         eliteLeaderboardData.clear()
         apiError = false
+        apiUnavailable = false
         hasWarned = false
         fetchAttempts = 0
         lastFetchAttempt = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.data.garden.FarmingWeightData.getFactor
 import at.hannibal2.skyhanni.data.garden.FarmingWeightData.getWeight
 import at.hannibal2.skyhanni.data.garden.FarmingWeightData.profileId
 import at.hannibal2.skyhanni.data.garden.FarmingWeightData.setWeight
-import at.hannibal2.skyhanni.data.garden.FarmingWeightData.updateCollections
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteLeaderboard
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteLeaderboardMode
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteLeaderboardPlayer
@@ -230,7 +229,6 @@ object EliteFarmersLeaderboard {
 
     private fun loadLeaderboardIfAble(leaderboardType: EliteLeaderboardType): Int? {
         if (loadingLeaderboardMutex[leaderboardType::class]?.isLocked == true) return null
-        if (profileId == "") updateCollections()
 
         val category = leaderboardType::class
 
@@ -367,7 +365,10 @@ object EliteFarmersLeaderboard {
     ) {
         if (diff >= 0.5 || abs(diff) >= 100) {
             when (leaderboardType.mode) {
-                EliteLeaderboardMode.ALL_TIME -> updateCollections() // we handle all-time weight in the farmingweight class
+                EliteLeaderboardMode.ALL_TIME -> {
+                    // we handle all-time weight in the farmingweight class
+                    // we only update collections on garden join
+                }
                 EliteLeaderboardMode.MONTHLY -> setWeight(leaderboardType.mode, apiData.amount)
             }
         }
@@ -382,7 +383,10 @@ object EliteFarmersLeaderboard {
         val diffWeight = diff / crop.getFactor()
         if (diffWeight >= 0.5 || abs(diffWeight) >= 100) {
             when (leaderboardType.mode) {
-                EliteLeaderboardMode.ALL_TIME -> updateCollections() // we handle all-time collections in the farming weight class
+                EliteLeaderboardMode.ALL_TIME -> {
+                    // we handle all-time collections in the farming weight class
+                    // we only update collections on garden join
+                }
                 EliteLeaderboardMode.MONTHLY ->
                     leaderboardAmountMap?.set(leaderboardType, apiData.amount)
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -65,13 +65,6 @@ object FarmingWeightData {
         updateCollections()
     }
 
-    // We need profile id for leaderboard api
-    // This should only fetch once
-    @HandleEvent(onlyOnSkyblock = true)
-    fun onSecondPassed(event: SecondPassedEvent) {
-        if (profileId.isBlank()) updateCollections()
-    }
-
     @HandleEvent
     fun onCollectionUpdate(event: CropCollectionAddEvent) {
         if (event.cropCollectionType == CropCollectionType.MOOSHROOM_COW) {
@@ -101,7 +94,9 @@ object FarmingWeightData {
     fun getWeight(leaderboardMode: EliteLeaderboardMode, override: Boolean = false, cropWeightOnly: Boolean = false): Double? {
         if (weightMap[leaderboardMode] == null || override) {
             when (leaderboardMode) {
-                EliteLeaderboardMode.ALL_TIME -> updateCollections()
+                EliteLeaderboardMode.ALL_TIME -> {
+                    // we only update collections on garden join
+                }
                 EliteLeaderboardMode.MONTHLY ->
                     getLeaderboardPosition(EliteLeaderboardType.Weight(FarmingWeight.FARMING_WEIGHT, leaderboardMode))
             }
@@ -127,8 +122,8 @@ object FarmingWeightData {
         weightGain += amount
     }
 
-    fun updateCollections() {
-        if (lastFetchAttempt.passedSince() <= 30.seconds || lastPlayerWeightFetch.passedSince() <= 15.minutes) return
+    fun updateCollections(ignoreCooldown: Boolean = false) {
+        if (!ignoreCooldown && (lastFetchAttempt.passedSince() <= 30.seconds || lastPlayerWeightFetch.passedSince() <= 15.minutes)) return
         if (HypixelData.profileName.isEmpty()) return
         if (collectionMutex.isLocked) return
         lastFetchAttempt = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -19,11 +19,12 @@ import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteWeightsJson
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.FarmingWeight
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.garden.farming.CropCollectionAddEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.garden.CropCollectionType
 import at.hannibal2.skyhanni.features.garden.CropType
+import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.EnumUtils.isAnyOf
@@ -62,6 +63,12 @@ object FarmingWeightData {
     @HandleEvent
     fun onWorldChange(event: IslandChangeEvent) {
         if (event.newIsland != IslandType.GARDEN) return
+        updateCollections()
+    }
+
+    @HandleEvent
+    fun onProfileJoin(event: ProfileJoinEvent) {
+        if (!GardenApi.inGarden()) return
         updateCollections()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteWeightJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteWeightJson.kt
@@ -45,7 +45,8 @@ data class EliteLeaderboard(
     @Expose val initialAmount: Double,
     @Expose val upcomingRank: Int,
     @Expose val upcomingPlayers: List<EliteLeaderboardPlayer>,
-    @Expose val previous: List<EliteLeaderboardPlayer>?
+    @Expose val previous: List<EliteLeaderboardPlayer>?,
+    @Expose val disabled: Boolean = false,
 )
 
 data class EliteLeaderboardPlayer(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/CropType.kt
@@ -100,8 +100,15 @@ enum class CropType(
         replenish = true,
     ),
     WILD_ROSE(
-        "Wild Rose", "THEORETICAL_HOE_WILD_ROSE", "HELIANTHUS", 2.0,
-        { ItemStack(Items.ROSE_BUSH).overrideId("WILD_ROSE") }, "rose", FarmingItemType.WILD_ROSE, replenish = true,
+        "Wild Rose",
+        "THEORETICAL_HOE_WILD_ROSE",
+        "HELIANTHUS",
+        2.0,
+        { ItemStack(Items.ROSE_BUSH).overrideId("WILD_ROSE") },
+        "rose",
+        FarmingItemType.WILD_ROSE,
+        replenish = true,
+        eliteLbName = "wildrose"
     ),
     ;
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
@@ -161,6 +161,15 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
     }
 
     private fun nullNextPlayerRenderable(leaderboardType: EliteLeaderboardType): Renderable {
+        if (EliteFarmersLeaderboard.apiUnavailable) {
+            return Renderable.hoverTips(
+                content = "§7Waiting for update...",
+                tips = listOf(
+                    "§celitebot.dev is currently overloaded or unavailable.",
+                    "§7Leaderboard data will update when the service recovers.",
+                ),
+            )
+        }
         return if (isUnranked(leaderboardType)) {
             val minAmount = leaderboardMinAmount(leaderboardType) ?: 0.0
             // the amount eligible to enter every other leaderboard is the all-time amount for that lb, except for the monthly weight lb


### PR DESCRIPTION
## What
Removes additional calls to updateCollections() which I believe chissl only included to spam my API (not actually). But they aren't needed. We revert to just fetching that endpoint on garden load.

Also adds an error state to fetching leaderboards so users see a nicer message if the endpoint is disabled temporarily.

<img width="1190" height="112" alt="image" src="https://github.com/user-attachments/assets/78227e0a-d2c2-48b8-a7d7-ecc55366ebb2" />

## Changelog Improvements
+ Improved error handling for elite leaderboards. - Ke5o

