### PR TITLE
Fix: Add visibility check to Fishing Hook Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.deceased
@@ -22,6 +23,7 @@ object FishingHookDisplay {
     private var armorStand: ArmorStand? = null
     private val potentialArmorStands = mutableListOf<ArmorStand>()
     private val pattern = "§e§l(\\d+(\\.\\d+)?)".toPattern()
+    private var isRendering = false
 
     @HandleEvent
     fun onWorldChange() {
@@ -60,6 +62,7 @@ object FishingHookDisplay {
     fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!isEnabled()) return
         if (!config.hideArmorStand) return
+        if (!isRendering) return
 
         if (event.entity == armorStand) {
             event.cancel()
@@ -69,15 +72,17 @@ object FishingHookDisplay {
     @HandleEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
+        isRendering = false
 
         val armorStand = armorStand ?: return
         if (armorStand.deceased) {
             reset()
             return
         }
-        if (!armorStand.hasCustomName()) return
+        if (!armorStand.hasCustomName() || !armorStand.isCustomNameVisible || !armorStand.canBeSeen(50)) return
         val alertText = if (armorStand.name.string == "!!!") config.customAlertText.replace("&", "§") else armorStand.name.formattedTextCompatLessResets()
 
+        isRendering = true
         config.position.renderString(alertText, posLabel = "Fishing Hook Display")
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -79,7 +79,8 @@ object FishingHookDisplay {
             reset()
             return
         }
-        if (!armorStand.hasCustomName() || !armorStand.isCustomNameVisible || !armorStand.canBeSeen(50)) return
+        if (!armorStand.hasCustomName() || !armorStand.isCustomNameVisible) return
+        if (!armorStand.canBeSeen(50, ignoreFrustum = true)) return
         val alertText = if (armorStand.name.string == "!!!") config.customAlertText.replace("&", "§") else armorStand.name.formattedTextCompatLessResets()
 
         isRendering = true


### PR DESCRIPTION
## What
Not sure if this will actually fix it for the black magic Hypixel is doing [here](https://www.twitch.tv/kuehlpat/clip/BetterBenevolentCarabeefFutureMan-ej65Yc6vlULYGblj?filter=clips&range=all&sort=time), but we can hope.

## Changelog Fixes
+ Fixed Fishing Hook Display showing even when the Hypixel fishing timer is not visible to the player. - Luna
