### PR TITLE
Fix: Less Elite Api Calls

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 122
+    const val CONFIG_VERSION = 123
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
@@ -28,7 +28,7 @@ class EliteFarmersLeaderboardsConfig {
     )
     @ConfigEditorDraggableList
     val display: Property<MutableList<EliteLeaderboards>> = Property.of(
-        mutableListOf(EliteLeaderboards.CROP, EliteLeaderboards.PEST, EliteLeaderboards.WEIGHT)
+        mutableListOf()
     )
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/Storage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/Storage.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.storage
 
 import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.features.garden.leaderboarddisplays.EliteLeaderboards
 import at.hannibal2.skyhanni.features.misc.reminders.Reminder
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
@@ -34,4 +35,7 @@ class Storage {
 
     @Expose
     var testRenderablePositions: MutableMap<String, Position> = mutableMapOf()
+
+    @Expose
+    var oldLeaderboardDisplaySettings: MutableList<EliteLeaderboards> = mutableListOf()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/CropDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/CropDisplay.kt
@@ -31,7 +31,7 @@ class CropDisplay : EliteLeaderboardDisplayBase<CropType, EliteLeaderboardType.C
 
     override fun getDefaultEnum(): CropType? {
         return if (!config.display.hideWhenNotFarming) {
-            CropCollectionApi.lastGainedCrop ?: getCurrentlyFarmedCrop()
+            getCurrentlyFarmedCrop() ?: CropCollectionApi.lastGainedCrop
         } else {
             getCurrentlyFarmedCrop()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
@@ -145,9 +145,9 @@ enum class EliteLeaderboards(
         private fun sendConfigChangedMessage(config: MutableList<EliteLeaderboards>) {
             val displayConfig: EliteFarmersLeaderboardsConfig = GardenApi.config.eliteFarmersLeaderboards
             ChatUtils.clickableChat(
-                "Due to excessive requests, Elite Leaderboards have been disabled by default. " +
+                "Due to excessive requests, Elite Leaderboards have been disabled by default.\n" +
                 "Click here to restore your settings!",
-                hover = "Click here to restore your settings! Shift + click to open config.",
+                hover = "Click to restore your settings! Shift + click to open config.",
                 onClick = {
                     if (KeyboardManager.isShiftKeyDown()) {
                         run { displayConfig::display.jumpToEditor() }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
@@ -1,23 +1,30 @@
 package at.hannibal2.skyhanni.features.garden.leaderboarddisplays
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.core.config.PositionList
+import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteFarmersLeaderboardsConfig
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboardConfigApi.getLeaderboardRankConfig
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.garden.EliteFarmersLeaderboard.clearCategories
 import at.hannibal2.skyhanni.data.garden.EliteFarmersLeaderboard.clearEntries
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteLeaderboardMode
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteLeaderboardType
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.pests.PestType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
+import at.hannibal2.skyhanni.utils.ConfigUtils.jumpToEditor
+import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.json.fromJson
 import kotlin.reflect.KClass
@@ -126,6 +133,31 @@ enum class EliteLeaderboards(
             }
         }
 
+        @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+        fun onGardenJoin(event: WorldChangeEvent) {
+            val oldLeaderboardSettings = SkyHanniMod.feature.storage.oldLeaderboardDisplaySettings
+            if (oldLeaderboardSettings.isNotEmpty()) {
+                sendConfigChangedMessage(oldLeaderboardSettings)
+                SkyHanniMod.feature.storage.oldLeaderboardDisplaySettings = mutableListOf()
+            }
+        }
+
+        private fun sendConfigChangedMessage(config: MutableList<EliteLeaderboards>) {
+            val displayConfig: EliteFarmersLeaderboardsConfig = GardenApi.config.eliteFarmersLeaderboards
+            ChatUtils.clickableChat(
+                "Due to excessive requests, Elite Leaderboards have been disabled by default. " +
+                "Click here to restore your settings!",
+                hover = "Click here to restore your settings! Shift + click to open config.",
+                onClick = {
+                    if (KeyboardManager.isShiftKeyDown()) {
+                        run { displayConfig::display.jumpToEditor() }
+                    } else {
+                        displayConfig.display.get().addAll(config)
+                    }
+                }
+            )
+        }
+
         @HandleEvent
         fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
             event.transform(1, "garden.eliteFarmingWeightoffScreenDropMessage")
@@ -197,6 +229,13 @@ enum class EliteLeaderboards(
                 ConfigManager.gson.toJsonTree(entry.asString != "10000")
             }
             event.move(120, "$oldConfig.ignoreLow", "$display.ignoreLow")
+
+            var leaderboardList: MutableList<EliteLeaderboards>
+            event.transform(123, "garden.eliteFarmersLeaderboards.display") { entry ->
+                leaderboardList = ConfigManager.gson.fromJson<MutableList<EliteLeaderboards>>(entry)
+                SkyHanniMod.feature.storage.oldLeaderboardDisplaySettings = leaderboardList
+                ConfigManager.gson.toJsonTree(emptyList<EliteLeaderboards>())
+            }
         }
 
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
@@ -32,7 +32,7 @@ import kotlin.reflect.KClass
 enum class EliteLeaderboards(
     private val displayName: String,
     val display: EliteLeaderboardDisplayBase<*, *>,
-    val leaderboardType: KClass<out EliteLeaderboardType>
+    val leaderboardType: KClass<out EliteLeaderboardType>,
 ) {
     WEIGHT("Farming Weight", WeightDisplay(), EliteLeaderboardType.Weight::class),
     CROP("Crop Collection", CropDisplay(), EliteLeaderboardType.Crop::class),
@@ -93,7 +93,7 @@ enum class EliteLeaderboards(
             val pestConfigs = listOf(
                 pestConfig.rankGoals.useRankGoal,
                 pestConfig.rankGoals.rankGoalTypes,
-                pestConfig.gamemode
+                pestConfig.gamemode,
             )
 
             weightConfigs.forEach {
@@ -146,7 +146,7 @@ enum class EliteLeaderboards(
             val displayConfig: EliteFarmersLeaderboardsConfig = GardenApi.config.eliteFarmersLeaderboards
             ChatUtils.clickableChat(
                 "Due to excessive requests, Elite Leaderboards have been disabled by default.\n" +
-                "Click here to restore your settings!",
+                    "Click here to restore your settings!",
                 hover = "Click to restore your settings! Shift + click to open config.",
                 onClick = {
                     if (KeyboardManager.isShiftKeyDown()) {
@@ -154,7 +154,7 @@ enum class EliteLeaderboards(
                     } else {
                         displayConfig.display.get().addAll(config)
                     }
-                }
+                },
             )
         }
 


### PR DESCRIPTION
## What
Stopped switching crop collection leaderboard on pest kills, and retroactively turned off leaderboards, with a chat message notifying affected users on garden join. Hasn't been tested. 

## Changelog Improvements
+ Retroactively turned off all elite leaderboard displays in config. - Chissl
    *  These displays were accidentally enabled by default, overloading the elite api.
    *  The first time you join garden, a message will pop up prompting you to restore your old settings. 

## Changelog Fixes
+ Fixed crop collection leaderboard changing selected crop when killing a pest. - Chissl
    * This was causing excessive calls to the elite api. 

