### PR TITLE
Fix: Hide with Item Value and Hide outside Inventory tracker options

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniItemTracker.kt
@@ -383,4 +383,12 @@ SkyHanniItemTracker<Data : ItemTrackerData>(
             )
         }
     }
+
+    override fun hideInEstimatedItemValue(): Boolean {
+        return config.itemTracker.hideInEstimatedItemValue
+    }
+
+    override fun hideOutsideInventory(): Boolean {
+        return config.itemTracker.hideOutsideInventory
+    }
 }


### PR DESCRIPTION
## What
these were forgotten to be hooked back up

## Changelog Fixes
+ Fixed Hide with Item Value tracker setting not working. - nopo
+ Fixed Hide outside Inventory tracker setting not working. - nopo
