### PR TITLE
Fix: 3d skin layers compat issue

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinHeadFeatureRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinHeadFeatureRenderer.java
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.mixins.hooks.HideArmorHookKt;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import net.minecraft.client.model.object.skull.SkullModelBase;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
+import net.minecraft.client.renderer.item.ItemStackRenderState;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.core.Direction;
 import org.spongepowered.asm.mixin.Mixin;
@@ -21,6 +22,14 @@ public class MixinHeadFeatureRenderer {
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/SkullBlockRenderer;submitSkull(Lnet/minecraft/core/Direction;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/model/object/skull/SkullModelBase;Lnet/minecraft/client/renderer/rendertype/RenderType;ILnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V")
     )
     private boolean onRenderArmor(Direction direction, float f, float g, PoseStack matrices, SubmitNodeCollector submitNodeCollector, int i, SkullModelBase skullModelBase, RenderType renderType, int j, ModelFeatureRenderer.CrumblingOverlay crumblingOverlay) {
+        return !HideArmorHookKt.shouldHideArmor();
+    }
+
+    @WrapWithCondition(
+        method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;FF)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/item/ItemStackRenderState;submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;III)V")
+    )
+    private boolean onRenderItemstackOnHead(ItemStackRenderState instance, PoseStack matrices, SubmitNodeCollector submitNodeCollector, int i, int j, int k) {
         return !HideArmorHookKt.shouldHideArmor();
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinHeadFeatureRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinHeadFeatureRenderer.java
@@ -1,24 +1,27 @@
 package at.hannibal2.skyhanni.mixins.transformers.renderer;
 
 import at.hannibal2.skyhanni.mixins.hooks.HideArmorHookKt;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import net.minecraft.client.model.object.skull.SkullModelBase;
+import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.core.Direction;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.renderer.entity.layers.CustomHeadLayer;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.entity.state.EntityRenderState;
 
 @Mixin(CustomHeadLayer.class)
 public class MixinHeadFeatureRenderer {
 
-    @Inject(method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/EntityRenderState;FF)V", at = @At("HEAD"), cancellable = true)
-    private void onRenderArmor(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int i, EntityRenderState entityRenderState, float f, float g, CallbackInfo ci) {
-        if (HideArmorHookKt.shouldHideArmor()) {
-            ci.cancel();
-        }
+    @WrapWithCondition(
+        method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;FF)V",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/SkullBlockRenderer;submitSkull(Lnet/minecraft/core/Direction;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/model/object/skull/SkullModelBase;Lnet/minecraft/client/renderer/rendertype/RenderType;ILnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V")
+    )
+    private boolean onRenderArmor(Direction direction, float f, float g, PoseStack matrices, SubmitNodeCollector submitNodeCollector, int i, SkullModelBase skullModelBase, RenderType renderType, int j, ModelFeatureRenderer.CrumblingOverlay crumblingOverlay) {
+        return !HideArmorHookKt.shouldHideArmor();
     }
 
 }


### PR DESCRIPTION
## What
Makes the injection point for removing armor skulls more specific to reduce the possibility of mod conflicts

Before:
<img width="130" height="115" alt="image" src="https://github.com/user-attachments/assets/ac018a24-8b93-47f9-bd63-e045b48f622b" />

After:
<img width="121" height="125" alt="image" src="https://github.com/user-attachments/assets/ad72bacf-1ddb-4d57-98d9-0f8aa920f1b6" />


## Changelog Fixes
+ Fixed Hide Armor hiding the outer layer of some skulls occasionally when using 3d skin layers. - bloxigus