### PR TITLE
Improvement: Show item name on Dark Auction items with no bids

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/DarkAuctionItemDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/DarkAuctionItemDisplay.kt
@@ -29,10 +29,11 @@ object DarkAuctionItemDisplay {
 
     /**
      * REGEX-TEST: [NPC] Sirius: The highest bidder was qtLuna with a bid of 25,950,000 Coins!
+     * REGEX-TEST: [NPC] Sirius: No one made any bids!
      */
     private val highestBidPattern by patternGroup.pattern(
         "highest-bid",
-        "\\[NPC] Sirius: The highest bidder was \\w+ with a bid of [\\d,]+ Coins!",
+        "\\[NPC] Sirius: (?:The highest bidder was \\w+ with a bid of [\\d,]+ Coins|No one made any bids)!",
     )
 
     private var lastItem: String? = null


### PR DESCRIPTION
## What
Added "No one made any bids" message to Dark Auction Item Display handling.

## Changelog Improvements
+ Dark Auction Item Display now also adds the item name when no one bid on the item. - Luna