### PR TITLE
Fix: CME in GardenCropBreakTracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/GardenCropBreakTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/GardenCropBreakTracker.kt
@@ -93,9 +93,11 @@ object GardenCropBreakTracker {
         if (!event.isMod(5)) return
         if (cropMap.isEmpty()) return
 
-        for (crop in cropMap) {
-            val amount = cropMap.remove(crop.key)
-            crop.key.addCollectionCounter(CropCollectionType.BREAKING_CROPS, amount?.toLong() ?: 0)
+        val iterator = cropMap.entries.iterator()
+        while (iterator.hasNext()) {
+            val (crop, amount) = iterator.next()
+            iterator.remove()
+            crop.addCollectionCounter(CropCollectionType.BREAKING_CROPS, amount.toLong())
         }
 
         if (mooshroomCowCrops > 0) {


### PR DESCRIPTION
## What
Fixes a ConcurrentModificationException in GardenCropBreakTracker when you rapidly switch from farming one crop to another.

## Changelog Fixes
+ Fixed error when quickly switching between crops while farming. - Luna