### PR TITLE
Fix: some skyhanni hover events saying null

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -305,7 +305,10 @@ object ChatUtils {
                 else withColor(color)
             }
             this.url = url
-            this.hover = "$prefixColor$hover".asComponent()
+            this.hover = hover.asComponent {
+                if (color != null) withColor(color)
+                else withColor(ChatFormatting.YELLOW)
+            }
         }
 
         if (replaceSameMessage) text.send(message.getUniqueMessageIdForString())


### PR DESCRIPTION
## What
"null" is not a valid colour code

## Changelog Fixes
+ Fixed some skyhanni hover events saying null. - nopo
