### PR TITLE
Improvement: Ubik's Cube Quick Close

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/mountaintop/MountaintopConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/rift/area/mountaintop/MountaintopConfig.kt
@@ -7,6 +7,7 @@ import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class MountaintopConfig {
 
@@ -33,18 +34,30 @@ class MountaintopConfig {
     @ConfigOption(name = "Ubik's Cube Reminder", desc = "Reminder when the 2 hour cooldown is over for Ubik's Cube in the Rift.")
     @ConfigEditorBoolean
     @FeatureToggle
+    @SearchTag("split or steal")
     var ubikReminder: Boolean = false
 
     @Expose
     @ConfigOption(name = "Ubik's Cube GUI", desc = "GUI that shows how long until Ubik's Cube is ready.")
     @ConfigEditorBoolean
     @FeatureToggle
+    @SearchTag("split or steal")
     var ubikGui: Boolean = false
 
     @Expose
     @ConfigOption(name = "Only Show When Ready", desc = "Only show the Ubik's Cube GUI when it is ready.")
     @ConfigEditorBoolean
+    @SearchTag("split or steal")
     var ubikOnlyWhenReady: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Ubik's Cube Quick Close",
+        desc = "Close the Split or Steal minigame by clicking anywhere after it ends.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var ubikQuickClose: Boolean = true
 
     @Expose
     @ConfigLink(owner = MountaintopConfig::class, field = "ubikGui")

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/UbikQuickClose.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/UbikQuickClose.kt
@@ -1,0 +1,36 @@
+package at.hannibal2.skyhanni.features.rift.area.mountaintop
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.features.rift.RiftApi
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryDetector
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.world.item.Items
+
+@SkyHanniModule
+object UbikQuickClose {
+
+    private val config get() = RiftApi.config.area.mountaintop
+
+    private val patternGroup = RepoPattern.group("rift.ubik")
+
+    private val inventoryNamePattern by patternGroup.pattern(
+        "inventory-name",
+        "Split or Steal",
+    )
+
+    private val inventory = InventoryDetector { name -> inventoryNamePattern.matches(name) }
+
+    @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!config.ubikQuickClose) return
+        if (!inventory.isInside()) return
+
+        if (!event.container.slots[4].item.`is`(Items.CLOCK)) {
+            event.gui.onClose()
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/UbikReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mountaintop/UbikReminder.kt
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.features.rift.everywhere
+package at.hannibal2.skyhanni.features.rift.area.mountaintop
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType


### PR DESCRIPTION
## What
Added a quick close option for Split or Steal games, and moved UbikReminder to the `mountaintop` package per discussion on Discord.

## Changelog Improvements
+ Added the ability to quickly close Ubik's Cube (Split or Steal) games by clicking anywhere after the last round. - Luna