### PR TITLE
Fix: NeuInternalName not being safe as a key in maps

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -3,15 +3,55 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import net.minecraft.world.item.Items
 import kotlin.time.Duration.Companion.minutes
 
-class NeuInternalName private constructor(private val internalName: String) {
+@JvmInline
+value class NeuInternalName private constructor(private val internalName: String) {
+
+    fun asString() = internalName
+
+    override fun toString(): String = "internalName:$internalName"
+
+    fun contains(other: String) = internalName.contains(other)
+
+    fun startsWith(other: String) = internalName.startsWith(other)
+
+    fun endsWith(other: String) = internalName.endsWith(other)
+
+    fun replace(oldValue: String, newValue: String): NeuInternalName =
+        internalName.replace(oldValue, newValue, ignoreCase = true).toInternalName()
+
+    fun isKnownItem(): Boolean = getItemStackOrNull() != null || this == SKYBLOCK_COIN
+
+    fun getItemCategoryOrNull(): ItemCategory? =
+        categoryCache.getOrPut(this) { getItemStackOrNull()?.getItemCategoryOrNull() }
+
+    /**
+     * This is because skyblock has special ids in commands such as /viewrecipe for items like enchanted books and pets
+     */
+    val skyblockCommandId: String
+        get() = when {
+            isPet -> internalName.split(";").first()
+            isEnchantedBook && internalName.contains(";") -> {
+                val (name, level) = internalName.split(";", limit = 2)
+                "ENCHANTED_BOOK_${name}_$level"
+            }
+            else -> internalName
+        }
+
+    val isPet: Boolean
+        get() = petCache.getOrPut(this) {
+            PetUtils.isKnownPetInternalName(this) || (getItemCategoryOrNull() == ItemCategory.PET)
+        }
+
+    private val isEnchantedBook: Boolean
+        get() = getItemStackOrNull()?.item == Items.ENCHANTED_BOOK
+
 
     companion object {
-
-        private val internalNameMap = mutableMapOf<String, NeuInternalName>()
 
         val NONE = "NONE".toInternalName()
         val MISSING_ITEM = "MISSING_ITEM".toInternalName()
@@ -24,14 +64,15 @@ class NeuInternalName private constructor(private val internalName: String) {
         val ENCHANTED_HAY_BLOCK = "ENCHANTED_HAY_BLOCK".toInternalName()
         val TIGHTLY_TIED_HAY_BALE = "TIGHTLY_TIED_HAY_BALE".toInternalName()
 
-        fun String.toInternalName(): NeuInternalName = uppercase().replace(" ", "_").let {
-            if (it.contains("§") || it.contains("&") || it.contains("'")) {
+        fun String.toInternalName(): NeuInternalName {
+            val formatted = uppercase().replace(" ", "_")
+            if (formatted.any { it.equalsOneOf('§', '&', '\'') }) {
                 ErrorManager.skyHanniError(
                     "Internal name found with color codes",
-                    "Internal Name" to it, "Original String" to this,
+                    "Internal Name" to formatted, "Original String" to this,
                 )
             }
-            internalNameMap.getOrPut(it) { NeuInternalName(it) }
+            return NeuInternalName(formatted)
         }
 
         fun Set<String>.toInternalNames(): Set<NeuInternalName> = mapTo(mutableSetOf()) { it.toInternalName() }
@@ -44,6 +85,10 @@ class NeuInternalName private constructor(private val internalName: String) {
         }
 
         fun fromItemNameOrInternalName(itemName: String): NeuInternalName = fromItemNameOrNull(itemName) ?: itemName.toInternalName()
+
+        private val categoryCache = mutableMapOf<NeuInternalName, ItemCategory?>()
+
+        private val petCache: TimeLimitedCache<NeuInternalName, Boolean> = TimeLimitedCache(10.minutes)
 
         private fun getCoins(itemName: String): NeuInternalName? = when {
             isCoins(itemName) -> SKYBLOCK_COIN
@@ -64,57 +109,4 @@ class NeuInternalName private constructor(private val internalName: String) {
             MISSING_ITEM
         }
     }
-
-    fun asString() = internalName
-
-    override fun equals(other: Any?) = this === other
-
-    override fun toString(): String = "internalName:$internalName"
-
-    override fun hashCode(): Int = internalName.hashCode()
-
-    fun contains(other: String) = internalName.contains(other)
-
-    fun startsWith(other: String) = internalName.startsWith(other)
-
-    fun endsWith(other: String) = internalName.endsWith(other)
-
-    fun replace(oldValue: String, newValue: String): NeuInternalName =
-        internalName.replace(oldValue, newValue, ignoreCase = true).toInternalName()
-
-    fun isKnownItem(): Boolean = getItemStackOrNull() != null || this == SKYBLOCK_COIN
-
-    private val categoryCache = mutableMapOf<NeuInternalName, ItemCategory?>()
-
-    fun getItemCategoryOrNull(): ItemCategory? {
-        return categoryCache.getOrPut(this) {
-            getItemStackOrNull()?.getItemCategoryOrNull()
-        }
-    }
-
-    /**
-     * This is because skyblock has special ids in commands such as /viewrecipe for items like enchanted books and pets
-     */
-    val skyblockCommandId: String
-        get() = when {
-            isPet -> internalName.split(";").first()
-            isEnchantedBook -> {
-                if (internalName.contains(";")) {
-                    val (name, level) = internalName.split(";", limit = 2)
-                    "ENCHANTED_BOOK_${name}_$level"
-                } else internalName
-            }
-
-            else -> internalName
-        }
-
-    private val petCache: TimeLimitedCache<NeuInternalName, Boolean> = TimeLimitedCache(10.minutes)
-
-    val isPet: Boolean
-        get() = petCache.getOrPut(this) {
-            PetUtils.isKnownPetInternalName(this) || (getItemStackOrNull()?.getItemCategoryOrNull() == ItemCategory.PET)
-        }
-
-    private val isEnchantedBook: Boolean
-        get() = getItemStackOrNull()?.item == Items.ENCHANTED_BOOK
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -27,7 +27,7 @@ value class NeuInternalName private constructor(private val internalName: String
     fun isKnownItem(): Boolean = getItemStackOrNull() != null || this == SKYBLOCK_COIN
 
     fun getItemCategoryOrNull(): ItemCategory? =
-        categoryCache.getOrPut(this) { getItemStackOrNull()?.getItemCategoryOrNull() }
+        categoryCache.getOrPut(this) { getItemStackOrNull()?.getItemCategoryOrNull() ?: return null }
 
     /**
      * This is because skyblock has special ids in commands such as /viewrecipe for items like enchanted books and pets
@@ -86,7 +86,7 @@ value class NeuInternalName private constructor(private val internalName: String
 
         fun fromItemNameOrInternalName(itemName: String): NeuInternalName = fromItemNameOrNull(itemName) ?: itemName.toInternalName()
 
-        private val categoryCache = mutableMapOf<NeuInternalName, ItemCategory?>()
+        private val categoryCache = TimeLimitedCache<NeuInternalName, ItemCategory>(10.minutes)
 
         private val petCache: TimeLimitedCache<NeuInternalName, Boolean> = TimeLimitedCache(10.minutes)
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RecalculatingValue.kt
@@ -55,8 +55,6 @@ class ResettableValue<T>(private val calculation: () -> T) : ReadOnlyProperty<An
 
 class AutoUpdatingItemStack(internalName: NeuInternalName) : ReadOnlyProperty<Any?, ItemStack> {
 
-    constructor(rawInternalName: String) : this(rawInternalName.toInternalName())
-
     private val value: ResettableValue<ItemStack> = ResettableValue {
         internalName.getItemStack()
     }.also { list.add(it) }
@@ -65,6 +63,11 @@ class AutoUpdatingItemStack(internalName: NeuInternalName) : ReadOnlyProperty<An
 
     @SkyHanniModule
     companion object {
+        // We cant have a real constructor that uses a string, as NeuInternalName is a string on runtime, and they would have
+        // the same jvm signature. Using an invoke operator makes it look like a fake constructor
+        fun of(internalName: String) = AutoUpdatingItemStack(internalName.toInternalName())
+        operator fun invoke(internalName: String) = of(internalName)
+
         val list = mutableListOf<ResettableValue<ItemStack>>()
 
         @HandleEvent(RepositoryReloadEvent::class)

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SimpleStringTypeAdapter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SimpleStringTypeAdapter.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.utils.json
 
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken
 import com.google.gson.stream.JsonWriter
 
 class SimpleStringTypeAdapter<T>(
@@ -9,11 +10,16 @@ class SimpleStringTypeAdapter<T>(
     val deserializer: String.() -> T,
 ) : TypeAdapter<T>() {
 
-    override fun write(writer: JsonWriter, value: T) {
-        writer.value(serializer(value))
+    override fun write(writer: JsonWriter, value: T?) {
+        if (value == null) writer.nullValue()
+        else writer.value(serializer(value))
     }
 
-    override fun read(reader: JsonReader): T {
+    override fun read(reader: JsonReader): T? {
+        if (reader.peek() == JsonToken.NULL) {
+            reader.nextNull()
+            return null
+        }
         return deserializer(reader.nextString())
     }
 
@@ -37,7 +43,7 @@ class SimpleStringTypeAdapter<T>(
                 deserializer = {
                     try {
                         enumValueOf(this.replace(" ", "_").uppercase())
-                    } catch (e: IllegalArgumentException) {
+                    } catch (_: IllegalArgumentException) {
                         enumReplacementMap[defaultValue] = this
                         defaultValue
                     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SkyHanniTypeAdapters.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SkyHanniTypeAdapters.kt
@@ -24,6 +24,7 @@ import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import com.google.gson.GsonBuilder
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken
 import com.google.gson.stream.JsonWriter
 import net.minecraft.world.item.ItemStack
 import java.time.LocalDate
@@ -44,10 +45,19 @@ object SkyHanniTypeAdapters {
         { NbtBoolean.fromString(this) },
     )
 
-    val INTERNAL_NAME: TypeAdapter<NeuInternalName> = SimpleStringTypeAdapter(
-        { this.asString() },
-        { this.toInternalName() },
-    )
+    val INTERNAL_NAME: TypeAdapter<NeuInternalName> = object : TypeAdapter<NeuInternalName>() {
+        override fun write(writer: JsonWriter, value: NeuInternalName?) {
+            if (value == null) writer.nullValue() else writer.value(value.asString())
+        }
+
+        override fun read(reader: JsonReader): NeuInternalName? {
+            if (reader.peek() == JsonToken.NULL) {
+                reader.nextNull()
+                return null
+            }
+            return reader.nextString().toInternalName()
+        }
+    }
 
     val VEC_STRING: TypeAdapter<LorenzVec> = SimpleStringTypeAdapter(
         LorenzVec::asStoredString,


### PR DESCRIPTION
## What
This PR fixes internal name not actually being safe to use as a key in maps, by making it a value class instead.

Multiple instances of the same internal name could exist at the same time, for example if 2 threads tried to create an internal name at the same time there could be a race condition. Because neuinternalname used reference equality, this would cause issues. The easiest and safest way to solve this issue is just by just making it be a value class instead.

This also fixes the categoryCache and petCache not only not working at all, but also being straight up detrimental towards performance, as they were just creating a new one for every single neu internal name created, because someone forgot to put them in the companion object???

All of this could cause things like this to happen
<img width="621" height="595" alt="imagen" src="https://github.com/user-attachments/assets/4353c6e1-25f8-4f27-9c80-56c146425dbc" />
<img width="424" height="85" alt="imagen" src="https://github.com/user-attachments/assets/9dc1dd2d-738f-4c06-b10d-2eea88fa8c73" />

Also since they are now value classes, the cache for internal names is useless, so i removed it.

## Changelog Fixes
+ Fixed item trackers sometimes showing the same item separately multiple times. - Empa
    * This would also cause the trackers to lose information on the next restart.