### PR TITLE
Fix: Widget display lines having too much spacing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/TabWidgetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/TabWidgetDisplay.kt
@@ -82,6 +82,7 @@ enum class TabWidgetDisplay(
                         subWidget.lines.map { Renderable.text(it) }
                     },
                     posLabel = "Display Widget: ${widget.name}",
+                    extraSpace = -2
                 )
             }
         }


### PR DESCRIPTION
## What
who decided render renderables has 2 more spacing than render strings 

## Changelog Fixes
+ Fixed Widget display lines having too much spacing. - nopo

