### PR TITLE
Fix + Backend: Update MoulConfig to 4.4.0-beta

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 libautoupdate = "1.3.1"
-moulconfig = "4.3.0-beta"
+moulconfig = "4.4.0-beta"
 jbAnnotations = "24.1.0"
 
 hypixelmodapi = "1.0.1"


### PR DESCRIPTION
## What
Updated MoulConfig to fix a macOS issue.

## Changelog Fixes
+ Fixed issues with clicking in the config on macOS with Retina display. - Luna

## Changelog Technical Details
+ Updated MoulConfig from 4.3.0-beta to 4.4.0-beta. - Luna