### PR TITLE
Fix: Remove unnecessary cooldown on all burrows

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowApi.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.event.diana
 
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import kotlin.time.Duration.Companion.milliseconds
 
 object BurrowApi {
 
@@ -15,6 +14,5 @@ object BurrowApi {
             GriffinBurrowHelper.addDebug("set last interacted burrow to [${interacted.x}, ${interacted.y}, ${interacted.z}]")
         } else GriffinBurrowHelper.addDebug("set last interacted burrow to null")
         lastBurrowInteracted = interacted
-        BurrowWarpHelper.blockWarp(400.milliseconds)
     }
 }


### PR DESCRIPTION
## What
removes the warp delay for non spade guesses, the delay for spade is there to prevent you from warping while the spade particles are still being detected and was not removed, the delay for all guesses was added to prevent you from warping before the arrow particles themselves were detected but this simply doesnt happen as it waits for the chat message before removing the burrow (and triggering a target update allowing warp) which should arrive at the same time as particles and then you have to wait for the warp to actually be registered by the server before you get tped away

## Changelog Fixes
+ Fixed warping in diana having an unnecessary delay on non-spade guesses. - SidOfThe7Cs
