### PR TITLE
Fix: Rei search bar focus check

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/compat/ReiCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/compat/ReiCompat.kt
@@ -18,8 +18,18 @@ object ReiCompat {
     @JvmStatic
     fun searchHasFocus(): Boolean {
         if (!isReiLoaded) return false
+        if (Minecraft.getInstance().screen == null) return false
         return try {
-            REIRuntime.getInstance().searchTextField?.isFocused == true
+            val searchBar = REIRuntime.getInstance().searchTextField
+            try {
+                searchBar?.isFocused == true
+            } catch (e: NoSuchMethodError) {
+                try {
+                    searchBar?.javaClass?.getMethod("method_25370")?.invoke(searchBar) as Boolean? == true
+                } catch (e: Throwable) {
+                    false
+                }
+            }
         } catch (e: Throwable) {
             false
         }

--- a/src/main/java/at/hannibal2/skyhanni/compat/ReiCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/compat/ReiCompat.kt
@@ -20,16 +20,7 @@ object ReiCompat {
         if (!isReiLoaded) return false
         if (Minecraft.getInstance().screen == null) return false
         return try {
-            val searchBar = REIRuntime.getInstance().searchTextField
-            try {
-                searchBar?.isFocused == true
-            } catch (e: NoSuchMethodError) {
-                try {
-                    searchBar?.javaClass?.getMethod("method_25370")?.invoke(searchBar) as Boolean? == true
-                } catch (e: Throwable) {
-                    false
-                }
-            }
+            (REIRuntime.getInstance().searchTextField as? GuiEventListener)?.isFocused == true
         } catch (e: Throwable) {
             false
         }


### PR DESCRIPTION
## What
Cast to the base mc class the required method is in so there arnt mapping issues
screen null check is because it seems to still return true if you esc out of the screen while the search bar is focused

## Changelog Fixes
+ Fixed GUI Editor opening while typing in REI search box. - SidOfThe7Cs

