### PR TITLE
Fix: Praying mantis leaderboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -48,6 +48,12 @@ object EliteFarmersLeaderboard {
         EliteLeaderboardType.Pest::class to Mutex()
     )
     private val storage get() = GardenApi.storage?.farmingWeight
+
+    data class LeaderboardPlayerInfo(
+        val name: String,
+        val amountDifference: Double,
+        val rank: Int?
+    )
     private val leaderboardPosMap: MutableMap<EliteLeaderboardType, Int>? get() = storage?.lastLeaderboardPosMap
     private val leaderboardAmountMap: MutableMap<EliteLeaderboardType, Double>? get() = storage?.leaderboardAmountMap
     private val minAmount: MutableMap<EliteLeaderboardType, Double>? get() = storage?.minAmountMap
@@ -155,7 +161,7 @@ object EliteFarmersLeaderboard {
         return pos
     }
 
-    fun getNextPlayer(leaderboardType: EliteLeaderboardType): Pair<String, Double>? {
+    fun getNextPlayer(leaderboardType: EliteLeaderboardType): LeaderboardPlayerInfo? {
         val lbData = eliteLeaderboardData.getOrPut(leaderboardType) { EliteLeaderboardData() }
         val amount = getAmount(leaderboardType) ?: return null
         var nextPlayer = lbData.nextPlayers.firstOrNull() ?: return null
@@ -168,15 +174,15 @@ object EliteFarmersLeaderboard {
             lbData.shouldRefresh = true
             return null
         }
-        return Pair(nextPlayer.name, amountBehind)
+        return LeaderboardPlayerInfo(nextPlayer.name, amountBehind, nextPlayer.rank)
     }
 
-    fun getLastPlayer(leaderboardType: EliteLeaderboardType): Pair<String, Double>? {
+    fun getLastPlayer(leaderboardType: EliteLeaderboardType): LeaderboardPlayerInfo? {
         val lbData = eliteLeaderboardData.getOrPut(leaderboardType) { EliteLeaderboardData() }
         val amount = getAmount(leaderboardType) ?: return null
         val lastPlayer = lbData.lastPlayer ?: return null
         val amountAhead = amount - lastPlayer.amount
-        return if (amountAhead < 0) null else Pair(lastPlayer.name, amountAhead)
+        return if (amountAhead < 0) null else LeaderboardPlayerInfo(lastPlayer.name, amountAhead, lastPlayer.rank)
     }
 
     fun getAmount(leaderboardType: EliteLeaderboardType): Double? {
@@ -224,7 +230,15 @@ object EliteFarmersLeaderboard {
             return null
         }
         val rankGoal = getRankGoal(leaderboardType) // getRankGoal returns null if we're at or in front of it
-        leaderboardPosMap?.set(leaderboardType, rankGoal ?: (currentRank - 1)) // player we passed should be at rank goal if not null
+
+        // Use the rank from the player if available, otherwise decrement
+        val newRank = if (nextPlayer.rank != null && nextPlayer.rank > 0) {
+            nextPlayer.rank
+        } else {
+            rankGoal ?: (currentRank - 1)
+        }
+
+        leaderboardPosMap?.set(leaderboardType, newRank)
         return lbData.nextPlayers.firstOrNull()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -51,7 +51,7 @@ object EliteFarmersLeaderboard {
 
     data class LeaderboardPlayerInfo(
         val name: String,
-        val amountDifference: Double,
+        val amountUntil: Double,
         val rank: Int?,
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -45,15 +45,16 @@ object EliteFarmersLeaderboard {
     val loadingLeaderboardMutex = mutableMapOf<KClass<out EliteLeaderboardType>, Mutex>(
         EliteLeaderboardType.Crop::class to Mutex(),
         EliteLeaderboardType.Weight::class to Mutex(),
-        EliteLeaderboardType.Pest::class to Mutex()
+        EliteLeaderboardType.Pest::class to Mutex(),
     )
     private val storage get() = GardenApi.storage?.farmingWeight
 
     data class LeaderboardPlayerInfo(
         val name: String,
         val amountDifference: Double,
-        val rank: Int?
+        val rank: Int?,
     )
+
     private val leaderboardPosMap: MutableMap<EliteLeaderboardType, Int>? get() = storage?.lastLeaderboardPosMap
     private val leaderboardAmountMap: MutableMap<EliteLeaderboardType, Double>? get() = storage?.leaderboardAmountMap
     private val minAmount: MutableMap<EliteLeaderboardType, Double>? get() = storage?.minAmountMap
@@ -196,13 +197,15 @@ object EliteFarmersLeaderboard {
     fun getAmount(leaderboardType: EliteLeaderboardType, eliteLeaderboardMode: EliteLeaderboardMode): Double? {
         return when (leaderboardType) {
             is EliteLeaderboardType.Weight -> getAmount(
-                leaderboardType.copy(mode = eliteLeaderboardMode)
+                leaderboardType.copy(mode = eliteLeaderboardMode),
             )
+
             is EliteLeaderboardType.Crop -> getAmount(
-                leaderboardType.copy(mode = eliteLeaderboardMode)
+                leaderboardType.copy(mode = eliteLeaderboardMode),
             )
+
             is EliteLeaderboardType.Pest -> getAmount(
-                leaderboardType.copy(mode = eliteLeaderboardMode)
+                leaderboardType.copy(mode = eliteLeaderboardMode),
             )
         }
     }
@@ -304,7 +307,7 @@ object EliteFarmersLeaderboard {
             lbType = leaderboardType,
             upcomingCount = upcomingPlayers,
             atRank = atRank,
-            getLeaderboardConfig(leaderboardType).gamemode.get().apiMode
+            getLeaderboardConfig(leaderboardType).gamemode.get().apiMode,
         )
         // elite only updates player profiles once an hour, so assume it's wrong if it's the same as last fetch
         val shouldUpdateData = shouldUpdateData(leaderboardType, apiData)
@@ -389,7 +392,7 @@ object EliteFarmersLeaderboard {
     private fun handleWeightDiff(
         leaderboardType: EliteLeaderboardType,
         apiData: EliteLeaderboard,
-        diff: Double
+        diff: Double,
     ) {
         if (diff >= 0.5 || abs(diff) >= 100) {
             when (leaderboardType.mode) {
@@ -397,6 +400,7 @@ object EliteFarmersLeaderboard {
                     // we handle all-time weight in the farmingweight class
                     // we only update collections on garden join
                 }
+
                 EliteLeaderboardMode.MONTHLY -> setWeight(leaderboardType.mode, apiData.amount)
             }
         }
@@ -405,7 +409,7 @@ object EliteFarmersLeaderboard {
     private fun handleCollectionDiff(
         leaderboardType: EliteLeaderboardType,
         apiData: EliteLeaderboard,
-        diff: Double
+        diff: Double,
     ) {
         val crop = leaderboardType.crop ?: return
         val diffWeight = diff / crop.getFactor()
@@ -415,6 +419,7 @@ object EliteFarmersLeaderboard {
                     // we handle all-time collections in the farming weight class
                     // we only update collections on garden join
                 }
+
                 EliteLeaderboardMode.MONTHLY ->
                     leaderboardAmountMap?.set(leaderboardType, apiData.amount)
             }
@@ -424,7 +429,7 @@ object EliteFarmersLeaderboard {
     private fun handlePestDiff(
         leaderboardType: EliteLeaderboardType,
         apiData: EliteLeaderboard,
-        diff: Double
+        diff: Double,
     ) {
         if (diff >= 1 || abs(diff) >= 150) {
             leaderboardAmountMap?.set(leaderboardType, apiData.amount)

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteWeightJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteWeightJson.kt
@@ -78,7 +78,7 @@ sealed class EliteLeaderboardType {
 
     data class Weight(
         @Expose val weight: FarmingWeight,
-        @Expose override val mode: EliteLeaderboardMode
+        @Expose override val mode: EliteLeaderboardMode,
     ) : EliteLeaderboardType(),
         WithEnum<FarmingWeight> {
         override val enumValue: FarmingWeight = weight
@@ -87,7 +87,7 @@ sealed class EliteLeaderboardType {
 
     data class Crop(
         @Expose val crop: CropType,
-        @Expose override val mode: EliteLeaderboardMode
+        @Expose override val mode: EliteLeaderboardMode,
     ) : EliteLeaderboardType(), WithEnum<CropType> {
         override val enumValue: CropType = crop
         override fun toString() = "${crop.cropName} Collection${mode.displaySuffix}"
@@ -95,7 +95,7 @@ sealed class EliteLeaderboardType {
 
     data class Pest(
         @Expose val pest: PestType?,
-        @Expose override val mode: EliteLeaderboardMode
+        @Expose override val mode: EliteLeaderboardMode,
     ) : EliteLeaderboardType(), WithEnum<PestType> {
         override val enumValue: PestType? = pest
         override fun toString() = "${pest?.displayName ?: "Pest"} Kills${mode.displaySuffix}"
@@ -125,7 +125,7 @@ val EliteLeaderboardType.crop: CropType?
 enum class EliteLeaderboardMode(
     val displayName: String,
     val lbSuffix: String = "",
-    val displaySuffix: String = ""
+    val displaySuffix: String = "",
 ) {
     ALL_TIME("All-Time"),
     MONTHLY("Monthly", "-monthly", " Monthly"),
@@ -150,11 +150,13 @@ class EliteLeaderboardTypeAdapter : TypeAdapter<EliteLeaderboardType>() {
                 out.name("weight").value(value.weight.name)
                 out.name("mode").value(value.mode.name)
             }
+
             is Crop -> {
                 out.name("type").value("crop")
                 out.name("crop").value(value.crop.name)
                 out.name("mode").value(value.mode.name)
             }
+
             is Pest -> {
                 out.name("type").value("pest")
                 out.name("pest")
@@ -191,6 +193,7 @@ class EliteLeaderboardTypeAdapter : TypeAdapter<EliteLeaderboardType>() {
                         pest = PestType.valueOf(reader.nextString())
                     }
                 }
+
                 else -> reader.skipValue()
             }
         }
@@ -203,18 +206,21 @@ class EliteLeaderboardTypeAdapter : TypeAdapter<EliteLeaderboardType>() {
                 }
                 Weight(weight, mode)
             }
+
             "crop" -> {
                 if (crop == null || mode == null) {
                     throw JsonParseException("Missing required fields for Crop")
                 }
                 Crop(crop, mode)
             }
+
             "pest" -> {
                 if (mode == null) {
                     throw JsonParseException("Missing required fields for Pest")
                 }
                 Pest(pest, mode)
             }
+
             else -> throw JsonParseException("Unknown type: $type")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteWeightJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteWeightJson.kt
@@ -54,6 +54,7 @@ data class EliteLeaderboardPlayer(
     @Expose val profile: String,
     @Expose val uuid: UUID,
     @Expose val amount: Double,
+    @Expose val rank: Int? = null,
     @Expose val mode: String? = null,
     @Expose val meta: JsonObject? = null,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
@@ -40,10 +40,11 @@ import kotlin.time.Duration.Companion.seconds
 abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType.WithEnum<E>>(
     private val typeClass: KClass<out T>,
     private val createType: (E, EliteLeaderboardMode) -> EliteLeaderboardType,
-    private val name: String
+    private val name: String,
 ) {
     protected val configBase get() = GardenApi.config.eliteFarmersLeaderboards
     private val config get() = baseClass?.let { getConfigFromClass(it) }
+
     @Suppress("Unchecked_cast")
     private val baseClass: KClass<out EliteLeaderboardType>?
         get() = typeClass as? KClass<out EliteLeaderboardType>
@@ -164,9 +165,9 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
         val currentRank = leaderboardPos
         val shouldShowRank = playerRank != null && currentRank != null && (
             useRankGoal || // Always show when using rank goal
-            (!getLastPlayer && playerRank != currentRank - 1) || // Show for next player if non-sequential
-            (getLastPlayer && playerRank != currentRank + 1) // Show for last player if non-sequential
-        )
+                (!getLastPlayer && playerRank != currentRank - 1) || // Show for next player if non-sequential
+                (getLastPlayer && playerRank != currentRank + 1) // Show for last player if non-sequential
+            )
 
         if (useRankGoal && rankGoal != null) {
             nextName += " §7[§b#${rankGoal.addSeparators()}§7]"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
@@ -82,13 +82,11 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
     open val currentLeaderboardType: EliteLeaderboardType?
         get() {
             val enum = currentEnum ?: run {
-                // Apply debounce when auto-switching (currentEnum is null)
+                // Debounce leaderboard when auto switching
                 val now = SimpleTimeMark.now()
                 if (lastEnumSwitchTime.passedSince() < 5.seconds) {
-                    // Use cached value during debounce period
                     lastAutoSelectedEnum
                 } else {
-                    // Update cache after debounce period
                     val newDefault = getDefaultEnum()
                     if (newDefault != lastAutoSelectedEnum) {
                         lastEnumSwitchTime = now
@@ -163,19 +161,17 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
         val (playerName, amountUntil, playerRank) = playerInfo ?: return nullNextPlayerRenderable(leaderboardType)
         var nextName = playerName
 
-        // Display rank if we have it and it provides useful non-sequential information
-        @Suppress("KotlinConstantConditions")
-        val shouldShowRank = when {
-            useRankGoal && rankGoal != null -> true
-            playerRank == null || leaderboardPos == null -> false
-            getLastPlayer -> playerRank != leaderboardPos + 1
-            else -> playerRank != leaderboardPos - 1
-        }
+        val currentRank = leaderboardPos
+        val shouldShowRank = playerRank != null && currentRank != null && (
+            useRankGoal || // Always show when using rank goal
+            (!getLastPlayer && playerRank != currentRank - 1) || // Show for next player if non-sequential
+            (getLastPlayer && playerRank != currentRank + 1) // Show for last player if non-sequential
+        )
 
         if (useRankGoal && rankGoal != null) {
             nextName += " §7[§b#${rankGoal.addSeparators()}§7]"
-        } else if (shouldShowRank && playerRank != null) {
-            nextName += " §7[§b#${playerRank.addSeparators()}§7]"
+        } else if (shouldShowRank) {
+            nextName += " §7[#${playerRank?.addSeparators()}]"
         }
 
         val behindOrAhead = if (getLastPlayer) "ahead of" else "behind"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboar
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboardConfigApi.getConfigFromClass
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.generics.EliteDisplayGenericConfig.LeaderboardTextEntry
 import at.hannibal2.skyhanni.data.garden.EliteFarmersLeaderboard
+import at.hannibal2.skyhanni.data.garden.EliteFarmersLeaderboard.LeaderboardPlayerInfo
 import at.hannibal2.skyhanni.data.garden.EliteFarmersLeaderboard.clearCategories
 import at.hannibal2.skyhanni.data.garden.EliteFarmersLeaderboard.getAmount
 import at.hannibal2.skyhanni.data.garden.EliteFarmersLeaderboard.getLastPlayer
@@ -54,7 +55,9 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
     protected var apiError = false
     protected var amount: Double? = null
     private var leaderboardPos: Int? = null
-    private var nextPlayer: Pair<String, Double>? = null
+    private var nextPlayer: LeaderboardPlayerInfo? = null
+    private var lastEnumSwitchTime = SimpleTimeMark.farPast()
+    private var lastAutoSelectedEnum: E? = null
 
     protected abstract var currentMode: EliteLeaderboardMode
     protected abstract var currentEnum: E?
@@ -77,7 +80,25 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
     }
 
     open val currentLeaderboardType: EliteLeaderboardType?
-        get() = (currentEnum ?: getDefaultEnum())?.let { createType(it, currentMode) }
+        get() {
+            val enum = currentEnum ?: run {
+                // Apply debounce when auto-switching (currentEnum is null)
+                val now = SimpleTimeMark.now()
+                if (lastEnumSwitchTime.passedSince() < 5.seconds) {
+                    // Use cached value during debounce period
+                    lastAutoSelectedEnum
+                } else {
+                    // Update cache after debounce period
+                    val newDefault = getDefaultEnum()
+                    if (newDefault != lastAutoSelectedEnum) {
+                        lastEnumSwitchTime = now
+                        lastAutoSelectedEnum = newDefault
+                    }
+                    newDefault
+                }
+            }
+            return enum?.let { createType(it, currentMode) }
+        }
 
     fun update(overrideCooldown: Boolean = false) {
         // we want to avoid unnecessarily calling the api as much as possible
@@ -133,15 +154,28 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
     }
 
     private fun overtakeRenderable(leaderboardType: EliteLeaderboardType, getLastPlayer: Boolean = false): Renderable {
-        val next: Pair<String, Double>? = if (getLastPlayer) getLastPlayer(leaderboardType) else getNextPlayer(leaderboardType)
+        val playerInfo: LeaderboardPlayerInfo? = if (getLastPlayer) getLastPlayer(leaderboardType) else getNextPlayer(leaderboardType)
 
         val rankGoal = getRankGoal(leaderboardType)
         val useRankGoal = useEtaGoalRank() && rankGoal != null
         if (useRankGoal && getLastPlayer) return Renderable.empty()
 
-        var (nextName, amountUntil) = next ?: return nullNextPlayerRenderable(leaderboardType)
-        if (useRankGoal) {
-            nextName += " §7[§b#${rankGoal?.addSeparators()}§7]"
+        val (playerName, amountUntil, playerRank) = playerInfo ?: return nullNextPlayerRenderable(leaderboardType)
+        var nextName = playerName
+
+        // Display rank if we have it and it provides useful non-sequential information
+        @Suppress("KotlinConstantConditions")
+        val shouldShowRank = when {
+            useRankGoal && rankGoal != null -> true
+            playerRank == null || leaderboardPos == null -> false
+            getLastPlayer -> playerRank != leaderboardPos + 1
+            else -> playerRank != leaderboardPos - 1
+        }
+
+        if (useRankGoal && rankGoal != null) {
+            nextName += " §7[§b#${rankGoal.addSeparators()}§7]"
+        } else if (shouldShowRank && playerRank != null) {
+            nextName += " §7[§b#${playerRank.addSeparators()}§7]"
         }
 
         val behindOrAhead = if (getLastPlayer) "ahead of" else "behind"
@@ -149,8 +183,8 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
         val text = "§e${amountUntil.roundTo(2).addSeparators()}$overtakeETA §7$behindOrAhead §b$nextName"
         return Renderable.clickable(
             text,
-            tips = listOf("§eClick to open the Farming Profile of §b$nextName."),
-            onLeftClick = { openWebsite(nextName) },
+            tips = listOf("§eClick to open the Farming Profile of §b$playerName."),
+            onLeftClick = { openWebsite(playerName) },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
@@ -80,29 +80,28 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
         }
     }
 
-    open val currentLeaderboardType: EliteLeaderboardType?
-        get() {
-            val enum = currentEnum ?: run {
-                // Debounce leaderboard when auto switching
-                val now = SimpleTimeMark.now()
-                if (lastEnumSwitchTime.passedSince() < 5.seconds) {
-                    lastAutoSelectedEnum
-                } else {
-                    val newDefault = getDefaultEnum()
-                    if (newDefault != lastAutoSelectedEnum) {
-                        lastEnumSwitchTime = now
-                        lastAutoSelectedEnum = newDefault
-                    }
-                    newDefault
+    open fun currentLeaderboardType(): EliteLeaderboardType? {
+        val enum = currentEnum ?: run {
+            // Debounce leaderboard when auto switching
+            val now = SimpleTimeMark.now()
+            if (lastEnumSwitchTime.passedSince() < 5.seconds) {
+                lastAutoSelectedEnum
+            } else {
+                val newDefault = getDefaultEnum()
+                if (newDefault != lastAutoSelectedEnum) {
+                    lastEnumSwitchTime = now
+                    lastAutoSelectedEnum = newDefault
                 }
+                newDefault
             }
-            return enum?.let { createType(it, currentMode) }
         }
+        return enum?.let { createType(it, currentMode) }
+    }
 
     fun update(overrideCooldown: Boolean = false) {
         // we want to avoid unnecessarily calling the api as much as possible
         if (!isEnabled()) return
-        val type = currentLeaderboardType ?: return
+        val type = currentLeaderboardType() ?: return
         leaderboardPos = getLeaderboardPosition(type, overrideCooldown)
         amount = getAmount(type)
         nextPlayer = getNextPlayer(type)
@@ -169,10 +168,10 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
                 (getLastPlayer && playerRank != currentRank + 1) // Show for last player if non-sequential
             )
 
-        if (useRankGoal && rankGoal != null) {
+        if (useRankGoal) {
             nextName += " §7[§b#${rankGoal.addSeparators()}§7]"
         } else if (shouldShowRank) {
-            nextName += " §7[#${playerRank?.addSeparators()}]"
+            nextName += " §7[#${playerRank.addSeparators()}]"
         }
 
         val behindOrAhead = if (getLastPlayer) "ahead of" else "behind"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/PestDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/PestDisplay.kt
@@ -31,8 +31,9 @@ class PestDisplay : EliteLeaderboardDisplayBase<PestType, EliteLeaderboardType.P
         return null
     }
 
-    override val currentLeaderboardType: EliteLeaderboardType
-        get() = EliteLeaderboardType.Pest(currentEnum, currentMode)
+    override fun currentLeaderboardType(): EliteLeaderboardType {
+        return EliteLeaderboardType.Pest(currentEnum, currentMode)
+    }
 
     // We don't track pest kills over a time period so we can't support this right now
     override fun overtakeEta(amountUntil: Double): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -116,6 +116,7 @@ enum class PestType(
         VinylType.PRAY_FOR_ME,
         "PEST_PRAYING_MANTIS_MONSTER".toInternalName(),
         CropType.WILD_ROSE,
+        eliteLbName = "mantis"
     ),
     FIREFLY(
         "Firefly",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -116,7 +116,6 @@ enum class PestType(
         VinylType.PRAY_FOR_ME,
         "PEST_PRAYING_MANTIS_MONSTER".toInternalName(),
         CropType.WILD_ROSE,
-        eliteLbName = "mantis"
     ),
     FIREFLY(
         "Firefly",


### PR DESCRIPTION
## What

Praying mantis leaderboard was using the id of "praying mantis" directly in the URL, which was erroring out because there's a space in the URL. The proper url is just `mantis`. 

Also adds support for if I change the backend api at some point to return non-sequential upcoming players which may be necessary if SkyHanni is hammering the API too much. Kinda impossible to test right now, but it seems to work.

A non sequential response might include upcoming players at ranks like: 
`49998, 49997, 49996, 49995, 49994, 49500, 49000, 48500`
Such that there will likely be *some* player in the request immediately to use rather than loop with requests, we'll see if it's needed though.

<details>
<summary>Images</summary>

If the upcoming player isn't the next one a grayed out rank shows here:
<img width="525" height="96" alt="image" src="https://github.com/user-attachments/assets/122dd772-0965-48fd-b0d2-4975bf491092" />

</details>

## Changelog Fixes
+ Fixed praying mantis leaderboard erroring out. - Ke5o

## Changelog Technical Details
+ Added support for non-sequential upcoming player lists in leaderboards. - Ke5o