### PR TITLE
Fix: Remove canBeSeen check from Fishing Hook Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.deceased
@@ -80,7 +79,6 @@ object FishingHookDisplay {
             return
         }
         if (!armorStand.hasCustomName() || !armorStand.isCustomNameVisible) return
-        if (!armorStand.canBeSeen(50, ignoreFrustum = true)) return
         val alertText = if (armorStand.name.string == "!!!") config.customAlertText.replace("&", "§") else armorStand.name.formattedTextCompatLessResets()
 
         isRendering = true


### PR DESCRIPTION
## What
Just removing it for now because it's breaking legitimate use cases where the original armor stand is actually clearly visible to the player due to how visible modern vanilla clients make armor stand name tags through walls, and it likely didn't address the original macro check issue it was added in response to anyway. Kept the `isCustomNameVisible` check because that should be harmless, at worst it does nothing to help.

https://discord.com/channels/997079228510117908/1117409804382642296/1471338356972720260

## Changelog Fixes
+ Fixed a recent change causing Fishing Hook Display to sometimes not show when it should. - Luna