### PR TITLE
Fix: Mute Banshee sound name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/MuteBanshee.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/MuteBanshee.kt
@@ -35,6 +35,6 @@ object MuteBanshee {
     @HandleEvent(onlyOnIsland = IslandType.BACKWATER_BAYOU)
     fun onSound(event: PlaySoundEvent) {
         if (!SkyHanniMod.feature.fishing.muteBanshee) return
-        if (event.pitch in bansheePitches && event.soundName == "entity.ghast.warn") event.cancel()
+        if (event.pitch in bansheePitches && event.soundName == "mob.ghast.affectionate_scream") event.cancel()
     }
 }


### PR DESCRIPTION
## What
Fixed the wrong sound name being used for Mute Banshee, causing it to not work. (Hypixel may have changed it at some point, since it used to be the wrong sound on modern, though I could have sworn it was changed *before* the feature was added.

## Changelog Fixes
+ Fixed Mute Banshee not working. - Luna
