### PR TITLE
Fix: Update Diana perks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MayorData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorData.kt
@@ -30,7 +30,7 @@ enum class ElectionCandidate(
     DIANA(
         "Diana",
         "§2",
-        Perk.LUCKY,
+        Perk.HUNTRESS_INTUITION,
         Perk.MYTHOLOGICAL_RITUAL,
         Perk.PET_XP_BUFF,
         Perk.SHARING_IS_CARING,
@@ -171,7 +171,7 @@ enum class Perk(val perkName: String) {
     MOLTEN_FORGE("Molten Forge"),
 
     // Diana
-    LUCKY("Lucky!"),
+    HUNTRESS_INTUITION("Huntress' Intuition"),
     MYTHOLOGICAL_RITUAL("Mythological Ritual"),
     PET_XP_BUFF("Pet XP Buff"),
     SHARING_IS_CARING("Sharing is Caring"),


### PR DESCRIPTION
## What
Fixed Diana still having her old perks, causing it to not be detected from the calendar during Perkpocalypse.

## Changelog Fixes
+ Fixed Diana perks not being detected from calendar during Perkpocalypse. - Luna