### PR TITLE
Fix: Tasty cheese not having a price in the pest tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayType.kt
@@ -3,22 +3,31 @@ package at.hannibal2.skyhanni.features.garden.pests
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 
-enum class SprayType(val displayName: String) {
+enum class SprayType(val displayName: String, val internalName: NeuInternalName? = null) {
     COMPOST("Compost"),
     PLANT_MATTER("Plant Matter"),
     DUNG("Dung"),
     HONEY_JAR("Honey Jar"),
-    TASTY_CHEESE("Tasty Cheese"),
+    TASTY_CHEESE("Tasty Cheese", "CHEESE_FUEL".toInternalName()),
     FINE_FLOUR("Fine Flour"),
     JELLY("Jelly"),
     ;
 
-    fun toInternalName(): NeuInternalName = name.toInternalName()
+    fun toInternalName(): NeuInternalName {
+        if (internalName != null) return internalName
+        return name.toInternalName()
+    }
 
     companion object {
 
         fun getByNameOrNull(name: String) = entries.firstOrNull { it.displayName == name }
-        fun getByInternalName(internalName: NeuInternalName) = entries.firstOrNull { it.name == internalName.asString() }
+        fun getByInternalName(internalName: NeuInternalName): SprayType? {
+            for (spray in entries) {
+                if (spray.internalName == internalName) return spray
+                if (spray.name == internalName.asString()) return spray
+            }
+            return null
+        }
         fun getByPestTypeOrAll(pestType: PestType?) = entries.filter {
             it == pestType?.spray
         }.takeIf {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -30,7 +30,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ItemPriceSource
-import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -278,7 +278,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
             var sprayCosts = 0.0
             val hoverTips = if (sumSpraysUsed > 0) buildList {
                 applicableSpraysUsed.forEach { (spray, count) ->
-                    val sprayString = spray.toInternalName().getPriceOrNull()?.let { price ->
+                    val sprayString = getPricePerOrNull(spray.toInternalName())?.let { price ->
                         val sprayCost = price * count
                         sprayCosts += sprayCost
                         "§7${spray.displayName}: §a${count.shortFormat()} §7(§c-${sprayCost.shortFormat()}§7)"

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
@@ -82,6 +83,7 @@ open class SkyHanniTracker<Data : TrackerData, Config : GenericIndividualTracker
     }
 
     fun getPricePer(name: NeuInternalName) = name.getPrice(config.priceSource)
+    fun getPricePerOrNull(name: NeuInternalName) = name.getPriceOrNull(config.priceSource)
 
     fun isInventoryOpen() = inventoryOpen
 


### PR DESCRIPTION
## What
Fix tasty cheese having no price
Fix it not using npc prices

## Changelog Fixes
+ Fixed Pest Tracker counting Tasty Cheese as 0 coins. - nopo
+ Fixed Pest Tracker using bz prices for sprays when set to NPC. - nopo