### PR TITLE
Fix: Remove FeatureToggle from Hide Vanilla Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.config.features.gui.customscoreboard
 
-import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.data.DateFormat
 import at.hannibal2.skyhanni.features.gui.customscoreboard.CustomScoreboardUtils.NumberDisplayFormat
 import at.hannibal2.skyhanni.utils.RenderUtils

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/DisplayConfig.kt
@@ -56,11 +56,10 @@ class DisplayConfig {
     @Expose
     @ConfigOption(
         name = "Hide Vanilla Scoreboard",
-        desc = "Hide the vanilla scoreboard.\n" +
+        desc = "Hide the vanilla scoreboard while the custom scoreboard is visible.\n" +
             "§cMods that add their own scoreboard will not be affected by this setting!",
     )
     @ConfigEditorBoolean
-    @FeatureToggle
     val hideVanillaScoreboard: Property<Boolean> = Property.of(true)
 
     @Expose


### PR DESCRIPTION
## What
Clarified the description of Hide Vanilla Scoreboard and removed `@FeatureToggle` from it (so that it doesn't get turned off when disabling all features and then the next time the player turns on Custom Scoreboard they get both scoreboards).

## Changelog Fixes
+ Fixed Custom Scoreboard not hiding vanilla scoreboard by default if you turned off all features in `/shdefaultoptions` and then turned it on manually. - Luna

