### PR TITLE
Improvement: Ignore Totem of Corruption from other players

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/TotemOfCorruptionConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/TotemOfCorruptionConfig.kt
@@ -26,6 +26,15 @@ class TotemOfCorruptionConfig {
 
     @Expose
     @ConfigOption(
+        name = "Own Totem Only",
+        desc = "Ignore totems from other players, since they won't affect your sea creatures.\n" +
+            "§eMay break if you are nicked!"
+    )
+    @ConfigEditorBoolean
+    val ownTotemOnly: Boolean = true
+
+    @Expose
+    @ConfigOption(
         name = "Distance Threshold",
         desc = "The minimum distance to the Totem of Corruption for the overlay.\n" +
             "The effective distance of the totem is 16.\n" +

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/TotemOfCorruptionConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/TotemOfCorruptionConfig.kt
@@ -31,7 +31,7 @@ class TotemOfCorruptionConfig {
             "§eMay break if you are nicked!"
     )
     @ConfigEditorBoolean
-    val ownTotemOnly: Boolean = true
+    var ownTotemOnly: Boolean = true
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.fishing.TotemOfCorruptionConfig.OutlineType
 import at.hannibal2.skyhanni.data.title.TitleManager
-import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -13,22 +12,29 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playBeepSound
 import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.appendWithColor
+import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawSphereInWorld
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawSphereWireframeInWorld
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.ChatFormatting
 import net.minecraft.core.particles.ParticleTypes
+import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.decoration.ArmorStand
 import java.util.UUID
 import kotlin.time.Duration
@@ -40,28 +46,28 @@ object TotemOfCorruption {
 
     private val config get() = SkyHanniMod.feature.fishing.totemOfCorruption
 
-    private var display = emptyList<String>()
-    private var totems: List<Totem> = emptyList()
+    private var display = emptyList<Renderable>()
+    private var totems = emptyList<Totem>()
     private val warnedTotems = TimeLimitedSet<UUID>(2.minutes)
 
     private val patternGroup = RepoPattern.group("fishing.totemofcorruption")
     private val totemNamePattern by patternGroup.pattern(
-        "totemname",
-        "§5§lTotem of Corruption",
+        "totemname-nocolor",
+        "Totem of Corruption",
     )
     private val timeRemainingPattern by patternGroup.pattern(
-        "timeremaining",
-        "§7Remaining: §e(?:(?<min>\\d+)m )?(?<sec>\\d+)s"
+        "timeremaining-nocolor",
+        "Remaining: (?:(?<min>\\d+)m )?(?<sec>\\d+)s"
     )
     private val ownerPattern by patternGroup.pattern(
-        "owner",
-        "§7Owner: §e(?<owner>.+)"
+        "owner-nocolor",
+        "Owner: (?<owner>.+)"
     )
 
-    @HandleEvent
-    fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
+    fun onRenderOverlay() {
         if (!isOverlayEnabled() || display.isEmpty()) return
-        config.position.renderStrings(display, posLabel = "Totem of Corruption")
+        config.position.renderRenderables(display, posLabel = "Totem of Corruption")
     }
 
     @HandleEvent
@@ -109,7 +115,7 @@ object TotemOfCorruption {
     }
 
     @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    fun onConfigLoad() {
         config.showOverlay.onToggle {
             display = emptyList()
             totems = emptyList()
@@ -125,7 +131,7 @@ object TotemOfCorruption {
     private fun getTimeRemaining(totem: ArmorStand): Duration? =
         EntityUtils.getEntitiesNearby<ArmorStand>(totem.getLorenzVec(), 2.0)
             .firstNotNullOfOrNull { entity ->
-                timeRemainingPattern.matchMatcher(entity.name.formattedTextCompatLessResets()) {
+                timeRemainingPattern.matchMatcher(entity.cleanName()) {
                     val minutes = group("min")?.toIntOrNull() ?: 0
                     val seconds = group("sec")?.toInt() ?: 0
                     (minutes * 60 + seconds).seconds
@@ -135,27 +141,43 @@ object TotemOfCorruption {
     private fun getOwner(totem: ArmorStand): String? =
         EntityUtils.getEntitiesNearby<ArmorStand>(totem.getLorenzVec(), 2.0)
             .firstNotNullOfOrNull { entity ->
-                ownerPattern.matchMatcher(entity.name.formattedTextCompatLessResets()) {
+                ownerPattern.matchMatcher(entity.cleanName()) {
                     group("owner")
                 }
             }
 
-    private fun createDisplay() = buildList {
+    private fun createDisplay(): List<Renderable> = buildList {
         val totem = getTotemToShow() ?: return@buildList
-        add("§5§lTotem of Corruption")
-        add("§7Remaining: §e${totem.timeRemaining.format(TimeUnit.MINUTE)}")
-        add("§7Owner: §e${totem.ownerName}")
+        add(
+            Component.literal("Totem of Corruption").withStyle(ChatFormatting.DARK_PURPLE, ChatFormatting.BOLD)
+        )
+        add(
+            componentBuilder {
+                appendWithColor("Remaining: ", ChatFormatting.GRAY)
+                appendWithColor(totem.timeRemaining.format(TimeUnit.MINUTE), ChatFormatting.YELLOW)
+            }
+        )
+        add(
+            componentBuilder {
+                appendWithColor("Owner: ", ChatFormatting.GRAY)
+                appendWithColor(totem.ownerName, ChatFormatting.YELLOW)
+            }
+        )
+    }.map(Renderable::text)
+
+    private fun getTotemToShow(): Totem? {
+        val totems = totems.filter { it.distance < config.distanceThreshold }
+        totems.firstOrNull { it.ownerName == PlayerUtils.getName() }?.let { return it }
+        return totems.minByOrNull { it.distance }
     }
 
-    private fun getTotemToShow(): Totem? = totems
-        .filter { it.distance < config.distanceThreshold }
-        .maxByOrNull { it.timeRemaining }
-
     private fun getTotems(): List<Totem> = EntityUtils.getEntitiesNextToPlayer<ArmorStand>(100.0)
-        .filter { totemNamePattern.matches(it.name.formattedTextCompatLessResets()) }.toList()
+        .filter { totemNamePattern.matches(it.cleanName()) }.toList()
         .mapNotNull { totem ->
             val timeRemaining = getTimeRemaining(totem) ?: return@mapNotNull null
             val owner = getOwner(totem) ?: return@mapNotNull null
+
+            if (config.ownTotemOnly && (owner != PlayerUtils.getName())) return@mapNotNull null
 
             val timeToWarn = config.warnWhenAboutToExpire.seconds
             if (timeToWarn > 0.seconds && timeRemaining <= timeToWarn && totem.uuid !in warnedTotems) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -51,14 +51,24 @@ object TotemOfCorruption {
     private val warnedTotems = TimeLimitedSet<UUID>(2.minutes)
 
     private val patternGroup = RepoPattern.group("fishing.totemofcorruption")
+
     private val totemNamePattern by patternGroup.pattern(
         "totemname-nocolor",
         "Totem of Corruption",
     )
+
+    /**
+     * Remaining: 2m 30s
+     * Remaining: 5s
+     */
     private val timeRemainingPattern by patternGroup.pattern(
         "timeremaining-nocolor",
         "Remaining: (?:(?<min>\\d+)m )?(?<sec>\\d+)s"
     )
+
+    /**
+     * Owner: hannibal2
+     */
     private val ownerPattern by patternGroup.pattern(
         "owner-nocolor",
         "Owner: (?<owner>.+)"

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/TotemOfCorruption.kt
@@ -58,8 +58,8 @@ object TotemOfCorruption {
     )
 
     /**
-     * Remaining: 2m 30s
-     * Remaining: 5s
+     * REGEX-TEST: Remaining: 2m 30s
+     * REGEX-TEST: Remaining: 5s
      */
     private val timeRemainingPattern by patternGroup.pattern(
         "timeremaining-nocolor",
@@ -67,7 +67,7 @@ object TotemOfCorruption {
     )
 
     /**
-     * Owner: hannibal2
+     * REGEX-TEST: Owner: hannibal2
      */
     private val ownerPattern by patternGroup.pattern(
         "owner-nocolor",


### PR DESCRIPTION
## What
Updated Totem of Corruption Overlay to Hypixel changes that happened a few months ago, only showing own totems by default. Preserved the option to show all totems in case of nicked players or someone really wanting to be notified about others' totems in case of party fishing somehow, but now ordering by lowest distance rather than highest duration. Also cleaned up some code in the file.

## Changelog Improvements
+ Totem of Corruption Overlay now only shows your own totems by default. - Luna
    * This can be changed in the config if necessary, e.g. if you're nicked.
    * The totem priority was also changed from highest duration to lowest distance.