### PR TITLE
Fix: Death messages with Mark Own Name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -281,7 +281,7 @@ object MiningApi {
 
     @HandleEvent
     fun onPlayerDeath(event: PlayerDeathEvent) {
-        if (event.name == PlayerUtils.getName()) {
+        if (event.isSelf) {
             updateCold(0)
             updateHeat(0)
             lastColdReset = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -279,7 +279,7 @@ object MiningApi {
     }
 
     @HandleEvent
-    fun onPlayerDeath(event: PlayerDeathEvent) {
+    fun onPlayerDeath(event: PlayerDeathEvent.Allow) {
         if (event.isSelf) {
             updateCold(0)
             updateHeat(0)

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -21,7 +21,6 @@ import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
-import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher

--- a/src/main/java/at/hannibal2/skyhanni/data/PlayerDeathManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PlayerDeathManager.kt
@@ -14,6 +14,9 @@ object PlayerDeathManager {
 
     /**
      * WRAPPED-REGEX-TEST: " ☠ ZeroHazel was killed by Ashfang."
+     * WRAPPED-REGEX-TEST: " ☠ You fell into the void."
+     * WRAPPED-REGEX-TEST: " ☠ You burned to death."
+     * WRAPPED-REGEX-TEST: " ☠ You were killed by Bladesoul."
      */
     private val deathMessagePattern by RepoPattern.pattern(
         "chat.player.death-nocolor",

--- a/src/main/java/at/hannibal2/skyhanni/data/PlayerDeathManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PlayerDeathManager.kt
@@ -13,36 +13,30 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 object PlayerDeathManager {
 
     /**
-     * REGEX-TEST: §c ☠ §r§7§r§bZeroHazel§r§7 was killed by §r§8§lAshfang§r§7§r§7.
+     * WRAPPED-REGEX-TEST: " ☠ ZeroHazel was killed by Ashfang."
      */
     private val deathMessagePattern by RepoPattern.pattern(
-        "chat.player.death",
-        "§c ☠ §r§7§r§.(?<name>.+)§r§7 (?<reason>.+)",
+        "chat.player.death-nocolor",
+        " ☠ (?<name>\\w+) (?<reason>.+)",
     )
 
-    /**
-     * REGEX-TEST:  ☠ You fell into the void.
-     * REGEX-TEST:  ☠ You burned to death.
-     * REGEX-TEST:  ☠ You were killed by Bladesoul.
-     */
-    private val selfDeathMessagePattern by RepoPattern.pattern(
-        "chat.player.selfdeath",
-        " ☠ You (?<reason>.+)",
-    )
-
+    private fun handleDeath(message: String): Pair<String, String>? =
+        deathMessagePattern.matchMatcher(message) {
+            val name = group("name").takeUnless { it == "You" } ?: PlayerUtils.getName()
+            val reason = group("reason")
+            name to reason
+        }
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
-        deathMessagePattern.matchMatcher(event.message) {
-            val name = group("name")
-            val reason = group("reason").removeColor()
-            PlayerDeathEvent(name, reason, event).post()
-        }
+    fun onAllowChat(event: SkyHanniChatEvent.Allow) {
+        val (name, reason) = handleDeath(event.cleanMessage) ?: return
+        PlayerDeathEvent(name, reason).post()
+        PlayerDeathEvent.Allow(name, reason, event).post()
+    }
 
-        selfDeathMessagePattern.matchMatcher(event.cleanMessage) {
-            val name = PlayerUtils.getName()
-            val reason = group("reason")
-            PlayerDeathEvent(name, reason, event).post()
-        }
+    @HandleEvent
+    fun onModifyChat(event: SkyHanniChatEvent.Modify) {
+        val (name, reason) = handleDeath(event.cleanMessage) ?: return
+        PlayerDeathEvent.Modify(name, reason, event).post()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/PlayerDeathManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PlayerDeathManager.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.events.player.PlayerDeathEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/data/PlayerDeathManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PlayerDeathManager.kt
@@ -32,7 +32,6 @@ object PlayerDeathManager {
     @HandleEvent
     fun onAllowChat(event: SkyHanniChatEvent.Allow) {
         val (name, reason) = handleDeath(event.cleanMessage) ?: return
-        PlayerDeathEvent(name, reason).post()
         PlayerDeathEvent.Allow(name, reason, event).post()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/events/player/PlayerDeathEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/player/PlayerDeathEvent.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.utils.PlayerUtils
 
 abstract class AbstractPlayerDeathEvent(
     val name: String,
-    val reason: String
+    val reason: String,
 ) : SkyHanniEvent() {
     val isSelf: Boolean = name == PlayerUtils.getName()
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/player/PlayerDeathEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/player/PlayerDeathEvent.kt
@@ -4,18 +4,27 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.utils.PlayerUtils
 
-open class PlayerDeathEvent(val name: String, val reason: String) : SkyHanniEvent() {
-    val isSelf: Boolean = name == PlayerUtils.getName()
+abstract class AbstractPlayerDeathEvent(
+    override val name: String,
+    override val reason: String
+) : SkyHanniEvent(), PlayerDeathEvent {
+    override val isSelf: Boolean = name == PlayerUtils.getName()
+}
+
+sealed interface PlayerDeathEvent {
+    val name: String
+    val reason: String
+    val isSelf: Boolean
 
     class Allow(
         name: String,
         reason: String,
         val chatEvent: SkyHanniChatEvent.Allow,
-    ) : PlayerDeathEvent(name, reason)
+    ) : AbstractPlayerDeathEvent(name, reason)
 
     class Modify(
         name: String,
         reason: String,
         val chatEvent: SkyHanniChatEvent.Modify,
-    ) : PlayerDeathEvent(name, reason)
+    ) : AbstractPlayerDeathEvent(name, reason)
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/player/PlayerDeathEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/player/PlayerDeathEvent.kt
@@ -5,17 +5,13 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.utils.PlayerUtils
 
 abstract class AbstractPlayerDeathEvent(
-    override val name: String,
-    override val reason: String
-) : SkyHanniEvent(), PlayerDeathEvent {
-    override val isSelf: Boolean = name == PlayerUtils.getName()
+    val name: String,
+    val reason: String
+) : SkyHanniEvent() {
+    val isSelf: Boolean = name == PlayerUtils.getName()
 }
 
-sealed interface PlayerDeathEvent {
-    val name: String
-    val reason: String
-    val isSelf: Boolean
-
+object PlayerDeathEvent {
     class Allow(
         name: String,
         reason: String,

--- a/src/main/java/at/hannibal2/skyhanni/events/player/PlayerDeathEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/player/PlayerDeathEvent.kt
@@ -2,5 +2,20 @@ package at.hannibal2.skyhanni.events.player
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.utils.PlayerUtils
 
-class PlayerDeathEvent(val name: String, val reason: String, val chatEvent: SkyHanniChatEvent.Allow) : SkyHanniEvent()
+open class PlayerDeathEvent(val name: String, val reason: String) : SkyHanniEvent() {
+    val isSelf: Boolean = name == PlayerUtils.getName()
+
+    class Allow(
+        name: String,
+        reason: String,
+        val chatEvent: SkyHanniChatEvent.Allow,
+    ) : PlayerDeathEvent(name, reason)
+
+    class Modify(
+        name: String,
+        reason: String,
+        val chatEvent: SkyHanniChatEvent.Modify,
+    ) : PlayerDeathEvent(name, reason)
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PlayerDeathMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PlayerDeathMessages.kt
@@ -2,17 +2,18 @@ package at.hannibal2.skyhanni.features.chat
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.player.PlayerDeathEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.misc.MarkedPlayerManager
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.appendWithColor
+import at.hannibal2.skyhanni.utils.compat.componentBuilder
+import net.minecraft.ChatFormatting
 import net.minecraft.client.player.RemotePlayer
 import kotlin.time.Duration.Companion.seconds
 
@@ -22,44 +23,47 @@ object PlayerDeathMessages {
     private val lastTimePlayerSeen = mutableMapOf<String, SimpleTimeMark>()
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
-        if (!isHideFarDeathsEnabled()) return
+    fun onSecondPassed() {
+        if (!shouldHideFarDeaths()) return
 
-        checkOtherPlayers()
+        EntityUtils.getEntitiesNextToPlayer<RemotePlayer>(25.0).forEach { player ->
+            lastTimePlayerSeen[player.cleanName()] = SimpleTimeMark.now()
+        }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onPlayerDeath(event: PlayerDeathEvent) {
-
-        val name = event.name
-
-        if (MarkedPlayerManager.config.highlightInChat &&
-            !DungeonApi.inDungeon() &&
-            !KuudraApi.inKuudra &&
-            MarkedPlayerManager.isMarkedPlayer(name)
-        ) {
-            val reason = event.reason
-            val color = MarkedPlayerManager.config.chatColor.getChatColor()
-            ChatUtils.chat(" §c☠ $color$name §7$reason", false)
-            event.chatEvent.blockedReason = "marked_player_death"
-            return
-        }
-
-        val lastTime = lastTimePlayerSeen[name] ?: SimpleTimeMark.farPast()
+    fun onAllowPlayerDeath(event: PlayerDeathEvent.Allow) {
+        val lastTime = lastTimePlayerSeen[event.name] ?: SimpleTimeMark.farPast()
         val time = lastTime.passedSince() > 30.seconds
 
-        if (isHideFarDeathsEnabled() && time) {
+        if (shouldHideFarDeaths() && time) {
             event.chatEvent.blockedReason = "far_away_player_death"
         }
     }
 
-    private fun checkOtherPlayers() {
-        val entities = EntityUtils.getEntitiesNextToPlayer<RemotePlayer>(25.0)
-        for (otherPlayer in entities) {
-            lastTimePlayerSeen[otherPlayer.name.formattedTextCompatLessResets()] = SimpleTimeMark.now()
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onModifyPlayerDeath(event: PlayerDeathEvent.Modify) {
+        if (event.isSelf || DungeonApi.inDungeon() || KuudraApi.inKuudra) return
+
+        val name = event.name
+
+        if (MarkedPlayerManager.config.highlightInChat && MarkedPlayerManager.isMarkedPlayer(name)) {
+            val reason = event.reason
+            val color = MarkedPlayerManager.config.chatColor.toChatFormatting()
+            event.chatEvent.replaceComponent(
+                componentBuilder {
+                    appendWithColor(" ☠ ", ChatFormatting.RED)
+                    appendWithColor("$name ", color)
+                    appendWithColor(reason, ChatFormatting.GRAY)
+                },
+                "marked_player_death",
+            )
         }
     }
 
-    private fun isHideFarDeathsEnabled(): Boolean =
-        SkyBlockUtils.inSkyBlock && SkyHanniMod.feature.chat.hideFarDeathMessages && !DungeonApi.inDungeon() && !KuudraApi.inKuudra
+    private fun shouldHideFarDeaths(): Boolean =
+        SkyBlockUtils.inSkyBlock &&
+            SkyHanniMod.feature.chat.hideFarDeathMessages &&
+            !DungeonApi.inDungeon() &&
+            !KuudraApi.inKuudra
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -39,7 +39,7 @@ object PlayerUtils {
 
     fun getRawUuid(): UUID = MinecraftCompat.localPlayer.uuid
 
-    fun getName(): String = MinecraftCompat.localPlayer.name.string
+    fun getName(): String = MinecraftCompat.localPlayer.plainTextName
 
     fun inAir(): Boolean = !MinecraftCompat.localPlayer.onGround()
 


### PR DESCRIPTION
## What
Fixed own death messages being changed from "You" to the player name if Mark Own Name is enabled or the player marked themselves to /shmarkplayer, sometimes also leading to grammatically incorrect messages such as "mia_uw were killed by Empyrean Harpy."

Includes some cleanup of relevant files as well, and adding separate sub-events of PlayerDeathEvent for Allow and Modify, with the base event being there for consumers that do not care about the chat event.

## Changelog Fixes
+ Fixed own death messages being incorrectly modified with Mark Own Name enabled. - Luna

## Changelog Technical Details
+ Split `PlayerDeathEvent` into `PlayerDeathEvent.Allow` and `PlayerDeathEvent.Modify`. - Luna
+ Added `isSelf` convenience property to `PlayerDeathEvent`. - Luna
+ Made a small optimization to `PlayerUtils.getName` to avoid a round-trip from
  `String` to `Component` and back to `String`. - Luna
