### PR TITLE
dont error coroutines timing out

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -205,12 +205,12 @@ object SkyHanniMod {
                 function()
             }
         } catch (e: TimeoutCancellationException) {
-            ErrorManager.logErrorWithData(
+            /*ErrorManager.logErrorWithData(
                 e,
                 "Coroutine $name timed out after $timeout",
                 "coroutine name" to name,
                 "timeout" to timeout,
-            )
+            )*/
             throw e
         } catch (e: CancellationException) {
             // Don't notify the user about cancellation exceptions - these are to be expected at times


### PR DESCRIPTION
this errors like useless like 9.99999.99.99.9.9.9.99999.9% of the time

exclude_from_changelog