### PR TITLE
Fix: dungeonapi end event not firing.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -86,12 +86,11 @@ object DungeonApi {
     )
 
     /**
-     * REGEX-TEST: §f                §r§cMaster Mode The Catacombs §r§8- §r§eFloor VII
-     * REGEX-TEST: §f                         §r§cThe Catacombs §r§8- §r§eFloor V
+     * REGEX-TEST:                                  Master Mode The Catacombs - Floor V
      */
     private val dungeonComplete by patternGroup.pattern(
-        "complete",
-        "§.\\s+§.§.(?:Master Mode )?The Catacombs §.§.- §.§.(?:Floor )?(?<floor>M?[IV]{1,3}|Entrance)",
+        "completecolorless",
+        "\\s+(?:Master Mode )?The Catacombs - (?:Floor [IV]{1,3}|Entrance)",
     )
 
     /**
@@ -286,7 +285,7 @@ object DungeonApi {
             }
             return
         }
-        dungeonComplete.matchMatcher(event.message) {
+        dungeonComplete.matchMatcher(event.cleanMessage) {
             completed = true
             DungeonCompleteEvent(floor).post()
             return

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -38,7 +38,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.block.Blocks
 
-@Suppress("MemberVisibilityCanBePrivate")
+@Suppress("MemberVisibilityCanBePrivate", "UnusedPrivateProperty")
 @SkyHanniModule
 object DungeonApi {
 
@@ -91,6 +91,16 @@ object DungeonApi {
     private val dungeonComplete by patternGroup.pattern(
         "completecolorless",
         "\\s+(?:Master Mode )?The Catacombs - (?:Floor [IV]{1,3}|Entrance)",
+    )
+
+    /**
+     * REGEX-TEST: §f                §r§cMaster Mode The Catacombs §r§8- §r§eFloor VII
+     * REGEX-TEST: §f                         §r§cThe Catacombs §r§8- §r§eFloor V
+     */
+    private val dungeonCompleteOld by patternGroup.pattern(
+        // TODO: If It's April or Later and you're Reading This, remove this.
+        "complete",
+        "\\s+§.§.(?:Master Mode )?The Catacombs §.§.- §.§.(?:Floor )?(?<floor>M?[IV]{1,3}|Entrance)",
     )
 
     /**


### PR DESCRIPTION
## What
Fixed DungeonAPI not posting Run Ends because Hypixel removed a useless colour code, by removing all & simplifying the pattern (nothing ever used the groups so, I got rid of the useless ones..)

## Changelog Fixes
+ Fixed Croesus Chest Count/Highlight Not Working At All. - Fazfoxy

