### PR TITLE
Fix: Tiki mask getting added to the tracker every time u take it off your head

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
@@ -30,7 +30,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeModifier
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getTimestamp
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
@@ -45,6 +45,7 @@ import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import com.google.gson.annotations.Expose
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 typealias CategoryName = String
@@ -68,11 +69,11 @@ object FishingProfitTracker {
         "Fishing Profit Tracker",
         ::Data,
         { it.fishing.fishingProfitTracker },
-        trackerConfig = { config.perTrackerConfig }
+        trackerConfig = { config.perTrackerConfig },
     ) { drawDisplay(it) }
 
     data class Data(
-        @Expose var totalCatchAmount: Long = 0L
+        @Expose var totalCatchAmount: Long = 0L,
     ) : ItemTrackerData<SessionUptime.Normal>(SessionUptime.Normal::class) {
         override fun getDescription(timesGained: Long): List<String> {
             val percentage = timesGained.toDouble() / totalCatchAmount
@@ -255,16 +256,11 @@ object FishingProfitTracker {
             return
         }
         if (internalName == TIKI_MASK) {
-            var foundCleanTikiMask = false
-            for (stack in InventoryUtils.getItemsInOwnInventory()) {
-                if (stack.getInternalName() == TIKI_MASK) {
-                    if (stack.getReforgeModifier().isNullOrBlank()) {
-                        foundCleanTikiMask = true
-                        break
-                    }
-                }
+            val isOld = InventoryUtils.getItemsInOwnInventory().any {
+                it.getInternalName() == TIKI_MASK &&
+                    it.getTimestamp()?.passedSince()?.let { age -> age > 2.minutes } == true
             }
-            if (!foundCleanTikiMask) return
+            if (isOld) return
         }
 
         tracker.addItem(internalName, amount, command)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
@@ -18,7 +18,9 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemCategory
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -28,6 +30,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getReforgeModifier
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
@@ -243,11 +246,25 @@ object FishingProfitTracker {
         lastCatchTime = SimpleTimeMark.farPast()
     }
 
+    private val TIKI_MASK = "TIKI_MASK".toInternalName()
+
     private fun tryAddItem(internalName: NeuInternalName, amount: Int, command: Boolean) {
         if (!FishingApi.isFishing(checkRodInHand = false)) return
         if (!isAllowedItem(internalName)) {
             ChatUtils.debug("Ignored non-fishing item pickup: $internalName'")
             return
+        }
+        if (internalName == TIKI_MASK) {
+            var foundCleanTikiMask = false
+            for (stack in InventoryUtils.getItemsInOwnInventory()) {
+                if (stack.getInternalName() == TIKI_MASK) {
+                    if (stack.getReforgeModifier().isNullOrBlank()) {
+                        foundCleanTikiMask = true
+                        break
+                    }
+                }
+            }
+            if (!foundCleanTikiMask) return
         }
 
         tracker.addItem(internalName, amount, command)

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -448,4 +448,7 @@ object SkyBlockItemModifierUtils {
             fun getColorCode(name: String) = getByName(name).colorCode
         }
     }
+
+    fun ItemStack.getTimestamp(): SimpleTimeMark? =
+        getAttributeLong("timestamp")?.let { SimpleTimeMark(it) }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -449,6 +449,9 @@ object SkyBlockItemModifierUtils {
         }
     }
 
+    /**
+     * returns null for older items.
+     */
     fun ItemStack.getTimestamp(): SimpleTimeMark? =
         getAttributeLong("timestamp")?.let { SimpleTimeMark(it) }
 }


### PR DESCRIPTION
## What
the code isnt ideal because the itemstack isnt passed through the events
also untested cus i dont got one 

## Changelog Fixes
+ Fixed Tiki Mask being added to the fishing profit tracker every time it was taken off your head. - nopo
