### PR TITLE
Fix: Chroma preview text is always white

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.features.chroma
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.features.chroma.CHROMA_PREVIEW_COLOR_CODE
 import at.hannibal2.skyhanni.features.chroma.ChromaManager
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
@@ -12,7 +13,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
 
 class ChromaConfig {
-    @ConfigOption(name = "Chroma Preview", desc = "§\uE002Please star SkyHanni on GitHub!")
+    @ConfigOption(name = "Chroma Preview", desc = "§" + CHROMA_PREVIEW_COLOR_CODE + "Please star SkyHanni on GitHub!")
     @ConfigEditorInfoText(infoTitle = "Only in SkyBlock")
     var chromaPreview: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.kt
@@ -12,7 +12,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
 
 class ChromaConfig {
-    @ConfigOption(name = "Chroma Preview", desc = "§zPlease star SkyHanni on GitHub!")
+    @ConfigOption(name = "Chroma Preview", desc = "§\uE002Please star SkyHanni on GitHub!")
     @ConfigEditorInfoText(infoTitle = "Only in SkyBlock")
     var chromaPreview: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chroma/ChromaConfig.kt
@@ -12,7 +12,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
 
 class ChromaConfig {
-    @ConfigOption(name = "Chroma Preview", desc = "§fPlease star SkyHanni on GitHub!")
+    @ConfigOption(name = "Chroma Preview", desc = "§zPlease star SkyHanni on GitHub!")
     @ConfigEditorInfoText(infoTitle = "Only in SkyBlock")
     var chromaPreview: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chroma/ChromaFontManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chroma/ChromaFontManager.kt
@@ -19,7 +19,7 @@ fun checkIfGlyphIsChroma(drawnGlyph: GlyphInstance) {
 
 fun setChromaColorStyle(style: Style, text: String, colorCode: Char): Style {
     if (!SkyHanniMod.feature.gui.chroma.enabled.get()) return style
-    if (colorCode.lowercaseChar() == 'z') {
+    if (colorCode.lowercaseChar() == 'z' || colorCode == '\uE002') {
         return Style.EMPTY.withColor(textColor)
     }
     return style

--- a/src/main/java/at/hannibal2/skyhanni/features/chroma/ChromaFontManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chroma/ChromaFontManager.kt
@@ -9,6 +9,9 @@ var renderingChat: Boolean = false
 private val textColor = TextColor(0xFFFFFF, "chroma")
 private val textColorOffWhite = TextColor(0xFFFFFE, "chroma")
 var glyphIsChroma = false
+// Unicode private use area character used to preview SkyHanni's chroma,
+// avoids the 'z' color code to stop other mods styling our preview text.
+const val CHROMA_PREVIEW_COLOR_CODE = '\uE002'
 
 fun checkIfGlyphIsChroma(drawnGlyph: GlyphInstance) {
     if (!SkyHanniMod.feature.gui.chroma.enabled.get()) return
@@ -19,7 +22,7 @@ fun checkIfGlyphIsChroma(drawnGlyph: GlyphInstance) {
 
 fun setChromaColorStyle(style: Style, text: String, colorCode: Char): Style {
     if (!SkyHanniMod.feature.gui.chroma.enabled.get()) return style
-    if (colorCode.lowercaseChar() == 'z' || colorCode == '\uE002') {
+    if (colorCode.lowercaseChar() == 'z' || colorCode == CHROMA_PREVIEW_COLOR_CODE) {
         return Style.EMPTY.withColor(textColor)
     }
     return style


### PR DESCRIPTION
## What
The preview text previously showed as white at all times. It now shows as white when disabled and as chroma when enabled, which is consistent with the last time this issue was fixed in #2302.

I am aware that chroma will appear to "freeze" when in a singleplayer world or when accessing configuration from the main menu - this is because the [animation relies on ClientEvents.totalTicks](https://github.com/hannibal002/SkyHanni/blob/458bc04ecb6ed24466b2cde18bdc8e040b10aa7f/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiRendererHook.kt#L26) which seeming only increments when the game is not frozen (i.e. on a multiplayer server). This was previously resolved in #2302 by disabling the preview when outside of SkyBlock.

In my opinion, it's okay to leave this as-is given that (1) there is already a disclaimer in the menu ("Only on SkyBlock") and (2) this fix is much less complex than needing to conditionally enable/disable chroma. If you really want this fixed one way or another, there are two options:
1. Follow #2302 and display the preview text as white when not in SkyBlock
2. Modify how ticks are calculated, tying them to system time or some other external method

Tested on 1.21.10 and works fine. Let me know your thoughts about whether you want the "freezing in menu" fixed or if you're okay as it is.

## Changelog Fixes
+ Fixed Chroma preview text always displaying as white. - HyperKids


