### PR TITLE
Fix: Game crashes when clicking jump-to buttons in configuration

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
@@ -32,6 +32,8 @@ object ConfigUtils {
     }
 
     private fun KProperty0<*>.tryFindEditor(editor: MoulConfigEditor<*>): ProcessedOption? {
+        // Java reflection is used because MoulConfig is relocated at build time, causing Kotlin reflection
+        // (this.javaField) to fail to resolve property descriptors in the production build.
         val receiver = (this as? CallableReference)?.boundReceiver
             ?.takeIf { it !== CallableReference.NO_RECEIVER }
             ?: return null

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
@@ -13,8 +13,8 @@ import io.github.notenoughupdates.moulconfig.platform.MoulConfigScreenComponent
 import io.github.notenoughupdates.moulconfig.processor.ProcessedOption
 import net.minecraft.client.Minecraft
 import net.minecraft.network.chat.Component
+import kotlin.jvm.internal.CallableReference
 import kotlin.reflect.KProperty0
-import kotlin.reflect.jvm.javaField
 
 object ConfigUtils {
 
@@ -32,7 +32,14 @@ object ConfigUtils {
     }
 
     private fun KProperty0<*>.tryFindEditor(editor: MoulConfigEditor<*>): ProcessedOption? {
-        return editor.getOptionFromField(this.javaField ?: return null)
+        val receiver = (this as? CallableReference)?.boundReceiver
+            ?.takeIf { it !== CallableReference.NO_RECEIVER }
+            ?: return null
+        val field = generateSequence(receiver.javaClass as Class<*>?) { it.superclass }
+            .firstNotNullOfOrNull { clazz ->
+                runCatching { clazz.getDeclaredField(name) }.getOrNull()
+            } ?: return null
+        return editor.getOptionFromField(field)
     }
 
     fun KProperty0<*>.jumpToEditor() {


### PR DESCRIPTION
## What
When the user has Fabric Language Kotlin installed, SkyHanni crashes when clicking one of two buttons:
- Inventory > Enchant Parsing > Chroma Warning > Go
- Garden > Pests > Pest Trap > Display > Go

Tested on version 1.21.10, with Fabric Language Kotlin v1.13.7 and v1.13.9.

This PR fixes the issue by using Java reflection instead of Kotlin reflection.

Of note, I can't replicate this crash when using runClient from Gradle - it only crashes when creating a fresh install with SkyHanni + Fabric Language Kotlin + Fabric API, or when downloading an existing modpack. I don't know if this issue affects other parts of the mod or not - this issue is the one that I happened to run into.

`Dungeon > Instance Chest Profit > Go` does use the same class but works - I think this has something to do with the two instances of the crash using Property\<T>, while the one that works uses Boolean.

Logs:
- Minimal install: https://mclo.gs/Ad3AeZm
- Fresh install of the Skyblock Enhanced modpack: https://mclo.gs/73QVlSV

## Changelog Fixes
+ Fixed game crash when clicking some buttons in the configuration UI. - HyperKids