### PR TITLE
Fix: More consistently mute pest spawn sounds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnSound.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnSound.kt
@@ -79,5 +79,5 @@ object PestSpawnSound {
     }
 
     private fun PlaySoundEvent.isPestSpawnSound(): Boolean =
-        soundName == "note.bassattack" && distanceToPlayer < 2.0 && volume == 1.0f && pitch == 1.4920635f
+        soundName == "note.bassattack" && distanceToPlayer < 15.0 && volume == 1.0f && pitch == 1.4920635f
 }


### PR DESCRIPTION
## What
When using the option to mute pest spawn sounds, the sounds are inconsistently muted when moving, which is more noticeable at high speeds.

This is fixed by significantly increasing the radius in which pest spawn sounds are detected around the player.

<details>
The server plays all three bass notes of the pest spawn sound at your location the moment it was spawned in, but when moving, it is easy to escape the 2-block radius which results in one or two bass notes being not detected and thereby not muted.

This doesn't affect anything other than pest sounds being muted, given that the rest of the file is only concerned with detecting the first sound and explicitly ignores all other sound-based triggers within 5 seconds of the first.

I chose a distance of 15 given that the three sounds are played at around 0ms, 150ms, and 300ms, and the fastest speed achieved by the player while sprinting at 500 speed is around 28 m/s. So a distance of 15 will give up to 200ms of leniency - let me know if we should increase the distance further (or just make the edit yourself).

Another potential approach is to detect the first sound within <2 blocks, and then mute all identical sounds that are played within 0-1000ms after the first. It'd probably be higher accuracy, with the same issue around high client ping, i.e. if the user escapes the 2-block check before it's played due to high ping / lag spike, they will hear all three sounds still. I think this approach is the simplest approach, and we can always increase the radius if it's causing issues on laggy clients.

I'm tempted to completely remove the distance check to improve consistency, especially on clients with high ping, as I suspect there is nothing else on the garden that uses the precise sound and pitch that we detect. However, I don't have the ability to 100% verify this. If we're okay with removing the distance check completely, the one edge case to check is if co-op members spawning in pests would be categorized as a pest spawn sound (I suspect that sounds are sent directly to the receiving client as opposed to broadcast).
</details>

## Changelog Fixes
+ Fixed pest spawn sounds sometimes not being muted. - HyperKids