### PR TITLE
Backend: Upload Jar Artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,16 +33,17 @@ jobs:
                 uses: hannibal002/SkyHanni/.github/actions/gradle-retry@beta
                 with:
                     gradle-command: assemble -x test --stacktrace -PskipDetekt=true
-            -   uses: actions/upload-artifact@v4
+            -   uses: actions/upload-artifact@v7
                 name: Upload development build
                 with:
                     name: "Development Build"
                     path: build/libs/*.jar
+                    archive: false
             -   name: Test with Gradle w/retry
                 uses: hannibal002/SkyHanni/.github/actions/gradle-retry@beta
                 with:
                     gradle-command: test
-            -   uses: actions/upload-artifact@v4
+            -   uses: actions/upload-artifact@v7
                 name: "Upload test report"
                 if: ${{ !cancelled() }}
                 with:
@@ -84,8 +85,9 @@ jobs:
                     labels: 'Fails Multi-Version'
 
             -   name: Upload multi-version build
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v7
                 if: ${{ !cancelled() }}
                 with:
                     name: "Multi-version Development Build"
                     path: build/libs/*.jar
+                    archive: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,36 @@ jobs:
                     github_token: ${{ secrets.GITHUB_TOKEN }}
                     labels: 'Fails Multi-Version'
 
-            -   name: Upload multi-version build
-                uses: actions/upload-artifact@v7
+            -   name: Stage JARs as transfer artifact
                 if: ${{ !cancelled() }}
+                uses: actions/upload-artifact@v4
                 with:
-                    name: "Multi-version Development Build"
+                    name: jars-transfer
                     path: build/libs/*.jar
+
+            -   name: List JARs for matrix
+                if: ${{ !cancelled() }}
+                id: list-jars
+                run: |
+                    matrix=$(ls build/libs/*.jar | xargs -I{} basename {} | jq -R . | jq -sc '{"jar": .}')
+                    echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+    upload-jars:
+        name: "Upload ${{ matrix.jar }}"
+        needs: preprocess
+        if: ${{ !cancelled() && needs.preprocess.outputs.jar-matrix != '' }}
+        runs-on: ubuntu-latest
+        strategy:
+            matrix: ${{ fromJson(needs.preprocess.outputs.jar-matrix) }}
+        steps:
+            -   name: Download staged JARs
+                uses: actions/download-artifact@v4
+                with:
+                    name: jars-transfer
+
+            -   name: Upload ${{ matrix.jar }} unarchived
+                uses: actions/upload-artifact@v7
+                with:
+                    name: "Multi-version Development Build - ${{ matrix.jar }}"
+                    path: ${{ matrix.jar }}
                     archive: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         if: ${{ !cancelled() && needs.preprocess.outputs.jar-matrix != '' }}
         runs-on: ubuntu-latest
         strategy:
-            matrix: ${{ fromJson(needs.preprocess.outputs.jar-matrix) }}
+            matrix: ${{ fromJSON(needs.preprocess.outputs.jar-matrix) }}
         steps:
             -   name: Download staged JARs
                 uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
         if: ${{ !cancelled() && needs.preprocess.outputs.jar-matrix != '' }}
         runs-on: ubuntu-latest
         strategy:
+            fail-fast: false
             matrix: ${{ fromJSON(needs.preprocess.outputs.jar-matrix) }}
         steps:
             -   name: Download staged JARs
@@ -118,6 +119,7 @@ jobs:
                 with:
                     path: ${{ matrix.jar }}
                     archive: false
+                    overwrite: true
 
     cleanup:
         name: "Delete transfer artifact"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
                     name: jars-transfer
 
             -   name: Upload ${{ matrix.jar }} unarchived
+                continue-on-error: true
                 uses: actions/upload-artifact@v7
                 with:
                     path: ${{ matrix.jar }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,8 @@ jobs:
     preprocess:
         runs-on: ubuntu-latest
         name: "Build multi version"
+        outputs:
+            jar-matrix: ${{ steps.list-jars.outputs.matrix }}
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4
@@ -114,6 +116,19 @@ jobs:
             -   name: Upload ${{ matrix.jar }} unarchived
                 uses: actions/upload-artifact@v7
                 with:
-                    name: "Multi-version Development Build - ${{ matrix.jar }}"
                     path: ${{ matrix.jar }}
                     archive: false
+
+    cleanup:
+        name: "Delete transfer artifact"
+        needs: upload-jars
+        if: ${{ always() }}
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Delete jars-transfer
+                env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                run: |
+                    gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+                        --jq '.artifacts[] | select(.name=="jars-transfer") | .id' \
+                    | xargs -I{} gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/{}

--- a/.github/workflows/generate-constants.yaml
+++ b/.github/workflows/generate-constants.yaml
@@ -34,11 +34,12 @@ jobs:
                 uses: ./.github/actions/gradle-retry
                 with:
                     gradle-command: generateRepoPatterns --stacktrace
-            -   uses: actions/upload-artifact@v4
+            -   uses: actions/upload-artifact@v7
                 name: Upload generated repo regexes
                 with:
                     name: Repo Regexes
                     path: versions/1.21.10/build/regexes/constants.json
+                    archive: false
     publish-regexes:
         runs-on: ubuntu-latest
         needs: regexes


### PR DESCRIPTION
Changes `upload-artifact` to `v7`, and changes all artifact uploads to be `archive: false`, so it uploads `.jar` and `.json` files now.

exclude_from_changelog