### PR TITLE
Fix: Particle Offset for Freeze Particles

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
@@ -41,6 +41,8 @@ object FireFreezeFeatures {
 
     private val config get() = SkyHanniMod.feature.inventory.itemAbilities.fireFreeze
 
+    private const val PARTICLE_OFFSET  = 3.921568568330258E-4
+
     private data class FireFreezeArea(
         val center: LorenzVec,
         val lastPitch: Float,
@@ -116,7 +118,7 @@ object FireFreezeFeatures {
     private fun LorenzVec.isInAnyFireFreeze(): Boolean = fireFreezes.values.any { !it.hasFinished() && it.isInside(this) }
 
     private fun ReceiveParticleEvent.isFreezeParticle(): Boolean {
-        return offset.x == 3.921568568330258E-4 && offset.y == 3.921568568330258E-4 && offset.z == 3.921568568330258E-4
+        return offset.x == PARTICLE_OFFSET && offset.y == PARTICLE_OFFSET && offset.z == PARTICLE_OFFSET
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
@@ -40,8 +40,7 @@ import kotlin.time.Duration.Companion.seconds
 object FireFreezeFeatures {
 
     private val config get() = SkyHanniMod.feature.inventory.itemAbilities.fireFreeze
-
-    private const val PARTICLE_OFFSET  = 3.921568568330258E-4
+    private const val PARTICLE_OFFSET = 3.921568568330258E-4
 
     private data class FireFreezeArea(
         val center: LorenzVec,

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
@@ -117,7 +117,7 @@ object FireFreezeFeatures {
     private fun LorenzVec.isInAnyFireFreeze(): Boolean = fireFreezes.values.any { !it.hasFinished() && it.isInside(this) }
 
     private fun ReceiveParticleEvent.isFreezeParticle(): Boolean {
-        return abs(offset.x) < 0.001 && abs(offset.y) < 0.001 && offset.z < 0.001
+        return offset.x == 3.921568568330258E-4 && offset.y == 3.921568568330258E-4 && offset.z == 3.921568568330258E-4
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
@@ -33,7 +33,6 @@ import net.minecraft.core.Rotations
 import net.minecraft.core.particles.ParticleTypes
 import net.minecraft.world.entity.decoration.ArmorStand
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.math.abs
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 


### PR DESCRIPTION
## What
Fixed non Fire Freeze Particles being tracked https://discord.com/channels/997079228510117908/1476899381692338318

## Changelog Fixes
+ Fixed Fire Freeze Sphere incorrectly affecting Thunder Sparks. - Fazfoxy