### PR TITLE
Fix: Garden custom keybinds send inputs when being deactivated

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
@@ -5,6 +5,8 @@ import at.hannibal2.skyhanni.features.garden.farming.GardenCustomKeybinds;
 import at.hannibal2.skyhanni.test.graph.GraphEditor;
 import net.minecraft.client.KeyMapping;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -12,6 +14,10 @@ import net.minecraft.client.ToggleKeyMapping;
 
 @Mixin(KeyMapping.class)
 public class MixinKeyBinding {
+
+    @Mutable
+    @Shadow
+    private int clickCount;
 
     @Inject(method = "isDown", at = @At("HEAD"), cancellable = true)
     public void noIsKeyDown(CallbackInfoReturnable<Boolean> cir) {
@@ -30,6 +36,9 @@ public class MixinKeyBinding {
     public void noIsPressed(CallbackInfoReturnable<Boolean> cir) {
         KeyMapping keyBinding = (KeyMapping) (Object) this;
         GardenCustomKeybinds.isKeyPressed(keyBinding, cir);
+        if (cir.isCancelled()) {
+            this.clickCount = 0;
+        }
         if (keyBinding instanceof ToggleKeyMapping stickyKeyBinding) {
             if (stickyKeyBinding.needsToggle.getAsBoolean()) {
                 return;


### PR DESCRIPTION
## What
When garden custom keybinds are enabled, deactivating them in any way (such as opening inventory, opening chat, swapping tools) results in inputs being sent that were not initiated by the user.

This PR fixes this behavior by setting the accumulated clickCount to 0.

<details>
See Minecraft's KeyMapping.class, lines 39-41 and 125-137. It seems that click() (line 39) is still firing on the original key, which increments keyMapping.clickCount. But, we override consumeClick() (line 125) and therefore never decrement clickCount.

I fixed this by manually setting clickCount to 0 when we cancel the initial key press.

This fixes https://discord.com/channels/997079228510117908/1476326209636925571

Another approach is to cancel the click() event in the first place, but I'm slightly worried about side effects it could cause that I might not fully understand. Seems like it would cancel all KeyMapping bound to that key? Which is maybe a desired effect? But I didn't do that here to ensure underlying behavior stays the same for now.

### Full reproduction steps:
#### Version 1:
1. Enable garden custom keybinds with default keybinds
2. Press and release the left mouse button
3. Look at a block / crop, then open your inventory, open chat, or swap tools.

Expected behavior: Nothing happens
Actual behavior: Left click is sent

#### Version 2:
_(this verifies the underlying cause is what I identified it as & fixed)_
1. Enable garden custom keybinds, in those settings:
   - unbind "Attack"
   - bind "Use Item" to Button 1 (left click)
2. Press and release the left mouse button (nothing will happen)
3. Look at a block / crop, then open your inventory, open chat, or swap tools.

Expected behavior: Nothing happens
Actual behavior: Left click is sent

This demonstrates that it is the *original key* (i.e. left click) that is being detected and has an incremented clickCount.
</details>

## Changelog Fixes
+ Fixed key presses being sent when swapping off farming tools with Custom Garden Keybinds. - HyperKids