### PR TITLE
Fix: Custom item rendering causing high RAM and VRAM usage

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
@@ -57,7 +57,7 @@ internal object SkyHanniItemRenderCoordinator {
             }
 
             // Items that haven't moved in 4+ frames (or are static) use fallback (direct rendering)
-            if (settle.framesStable >= SETTLE_FRAMES || !state.isAnimated()) staticFallbackStates.add(state)
+            if (settle.framesStable >= SETTLE_FRAMES || !state.isAnimated()) animatedStates.add(state)
             else animatedStates.add(state)
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
@@ -57,8 +57,11 @@ internal object SkyHanniItemRenderCoordinator {
             }
 
             // Items that haven't moved in 4+ frames (or are static) use fallback (direct rendering)
-            if (settle.framesStable >= SETTLE_FRAMES || !state.isAnimated()) animatedStates.add(state)
-            else animatedStates.add(state)
+            // TODO: Revisit when a better solution for custom item rendering is implemented
+            // if (settle.framesStable >= SETTLE_FRAMES || !state.isAnimated()) staticFallbackStates.add(state)
+            // else animatedStates.add(state)
+
+            animatedStates.add(state)
         }
 
         SkyHanniItemRenderContext(

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
@@ -13,7 +13,7 @@ internal object SkyHanniItemRenderCoordinator {
 
     // items actively spinning re-render every frame, same as mojang's isAnimated path.
     // items that have been stable for this many frames are committed to the atlas.
-    private const val SETTLE_FRAMES = 4
+    // private const val SETTLE_FRAMES = 4
     private val projectionBuffer by lazy {
         CachedOrthoProjectionMatrixBuffer("SkyHanni items", -1000.0f, 1000.0f, true)
     }


### PR DESCRIPTION
## What
Makes 'static' custom rendered items use the 'animated' code path for rendering which utilises an atlas instead of continously creating a fallback renderer every frame with no clean up. (The whole idea of instantiating the fallback renderer is flawed, so correctly cleaning it up wouldn't solve the core issue anyway).

This is just a temporary fix until a better and more complete solution is made for the item renderer.

## Changelog Fixes
+ Fixed some item rendering causing extreme performance issues. - Vixid
