### PR TITLE
Feature: Draw Talbot's Theodolite radius

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrevorTheTrapperConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/TrevorTheTrapperConfig.kt
@@ -81,6 +81,16 @@ class TrevorTheTrapperConfig {
     var solver: Boolean = true
 
     @Expose
+    @ConfigOption(
+        name = "Theodolite Visualizer",
+        desc = "Draw the radius given by Talbot's Theodolite.\n" +
+            "The larger the height difference, the more accurate it will be."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var talbotCircles: Boolean = true
+
+    @Expose
     @ConfigOption(name = "Mob Dead Warning", desc = "Show a message when Trevor's mob dies.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
@@ -1,0 +1,37 @@
+package at.hannibal2.skyhanni.features.misc.trevor
+
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.utils.LocationUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawCircleWireframe
+import java.awt.Color
+import kotlin.math.absoluteValue
+import kotlin.math.tan
+
+object TalbotCircles {
+
+    private const val MAXIMUM_RADIUS = 500.0
+
+    private data class Circle(val center: LorenzVec, val radius: Double)
+
+    private val circles = mutableListOf<Circle>()
+
+    fun drawCircles(event: SkyHanniRenderWorldEvent) {
+        for (circle in circles) {
+            event.drawCircleWireframe(circle.center, circle.radius, Color.ORANGE)
+        }
+    }
+
+    fun addResult(dY: Int, angle: Int) {
+        val radius = tan(Math.toRadians(90.0 - angle)) * dY.absoluteValue
+        if (radius in 0.0..MAXIMUM_RADIUS) {
+            val playerPosition = LocationUtils.playerLocation().roundTo(2)
+            val center = LorenzVec(playerPosition.x, playerPosition.y + dY, playerPosition.z)
+            circles.add(Circle(center, radius))
+        }
+    }
+
+    fun resetCircles() {
+        circles.clear()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -380,7 +380,7 @@ object TrevorFeatures {
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shcleartalbotcircles") {
-            description = "Clears talbot circles"
+            description = "Clears Talbot circles"
             category = CommandCategory.USERS_RESET
             simpleCallback { TalbotCircles.resetCircles() }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -3,6 +3,8 @@ package at.hannibal2.skyhanni.features.misc.trevor
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.mob.MobData
@@ -134,6 +136,7 @@ object TrevorFeatures {
 
         mobDiedPattern.matchMatcher(event.message) {
             TrevorSolver.resetLocation()
+            TalbotCircles.resetCircles()
             if (config.mobDiedMessage) {
                 lastTitle?.stop()
                 lastTitle = TitleManager.sendTitle("§2Mob Died")
@@ -163,11 +166,15 @@ object TrevorFeatures {
 
         talbotPatternAbove.matchMatcher(formattedMessage) {
             val height = group("height").toInt()
+            val angle = group("angle").toInt()
             TrevorSolver.findMobHeight(height, true)
+            TalbotCircles.addResult(height, angle)
         }
         talbotPatternBelow.matchMatcher(formattedMessage) {
             val height = group("height").toInt()
+            val angle = group("angle").toInt()
             TrevorSolver.findMobHeight(height, false)
+            TalbotCircles.addResult(-height, angle)
         }
         talbotPatternAt.matchMatcher(formattedMessage) {
             TrevorSolver.averageHeight = LocationUtils.playerLocation().y
@@ -275,6 +282,8 @@ object TrevorFeatures {
             }
         }
 
+        var mobFound = false
+
         if (config.solver) {
             var location = TrevorSolver.mobLocation.coordinates
             if (TrevorSolver.mobLocation == TrapperMobArea.NONE) return
@@ -282,6 +291,7 @@ object TrevorFeatures {
                 location = LorenzVec(location.x, TrevorSolver.averageHeight, location.z)
             }
             if (TrevorSolver.mobLocation == TrapperMobArea.FOUND) {
+                mobFound = true
                 val displayName = TrevorSolver.currentMob?.mobName ?: "Mob Location"
                 location = TrevorSolver.mobCoordinates
                 event.drawWaypointFilled(location.down(2), LorenzColor.GREEN.toColor(), seeThroughBlocks = true, beacon = true)
@@ -290,6 +300,10 @@ object TrevorFeatures {
                 event.drawWaypointFilled(location, LorenzColor.GOLD.toColor(), seeThroughBlocks = true, beacon = true)
                 event.drawDynamicText(location.up(), TrevorSolver.mobLocation.location, 1.5)
             }
+        }
+
+        if (config.talbotCircles && !mobFound) {
+            TalbotCircles.drawCircles(event)
         }
     }
 
@@ -324,6 +338,7 @@ object TrevorFeatures {
 
     private fun resetTrapper() {
         TrevorSolver.resetLocation()
+        TalbotCircles.resetCircles()
         currentStatus = TrapperStatus.READY
         currentLabel = "§2Ready"
         questActive = false
@@ -360,5 +375,14 @@ object TrevorFeatures {
         event.move(95, "$base.trapperReadyTitle", "$base.readyTitle")
         event.move(95, "$base.trapperCooldownGui", "$base.cooldownGui")
         event.move(95, "$base.trapperCooldownGuiPosition", "$base.cooldownGuiPosition")
+    }
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shcleartalbotcircles") {
+            description = "Clears talbot circles"
+            category = CommandCategory.USERS_RESET
+            simpleCallback { TalbotCircles.resetCircles() }
+        }
     }
 }


### PR DESCRIPTION
## What
Add a setting to enable drawing circles to estimate the radius of a trapper mob based on the output of Talbot's Theodolite. This helps narrow down the search space when pelt farming.

<details>
<summary>Images</summary>

<img width="3840" height="2010" alt="2026-02-27_23 30 28" src="https://github.com/user-attachments/assets/c3030955-1402-4d92-af99-64eea7d37be6" />

</details>

## Changelog New Features
+ Added ability to show the radius given by Talbot's Theodolite. - Maxwell Zhao
