### PR TITLE
Fix + Backend: Include armor slots in item add detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
@@ -35,6 +35,7 @@ object OwnInventoryData {
 
     private var itemAmounts = mapOf<NeuInternalName, Int>()
     private var dirty = false
+    private var lastWardrobeClose = SimpleTimeMark.farPast()
 
     /**
      * REGEX-TEST: §aMoved §r§e10 Wheat§r§a from your Sacks to your inventory.
@@ -80,18 +81,33 @@ object OwnInventoryData {
         if (!dirty) return
         dirty = false
 
-        val map = getCurrentItems()
+
+        val armorInternalNames = InventoryUtils.getArmorInternalNames()
+
+        if (lastWardrobeClose.passedSince() < 2.seconds) {
+            lastWardrobeClose = SimpleTimeMark.farPast()
+            for (name in armorInternalNames) {
+                ignoreItem(1.seconds, name)
+            }
+        }
+
+        val map = getCurrentItems(armorInternalNames)
         for ((internalName, amount) in map) {
             calculateDifference(internalName, amount)
         }
         itemAmounts = map
     }
 
-    private fun getCurrentItems(): MutableMap<NeuInternalName, Int> {
+    private fun getCurrentItems(
+        armorInternalNames: Set<NeuInternalName> = InventoryUtils.getArmorInternalNames(),
+    ): MutableMap<NeuInternalName, Int> {
         val map = mutableMapOf<NeuInternalName, Int>()
         for (itemStack in InventoryUtils.getItemsInOwnInventory()) {
             val internalName = itemStack.getInternalNameOrNull() ?: continue
             map.addOrPut(internalName, itemStack.count)
+        }
+        for (name in armorInternalNames) {
+            map.addOrPut(name, 1)
         }
         return map
     }
@@ -110,8 +126,11 @@ object OwnInventoryData {
         }
     }
 
-    @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    @HandleEvent(InventoryCloseEvent::class)
+    fun onInventoryClose() {
+        if (InventoryUtils.openInventoryName().startsWith("Wardrobe")) {
+            lastWardrobeClose = SimpleTimeMark.now()
+        }
         val item = MinecraftCompat.localPlayer.getItemOnCursor() ?: return
         val internalNameOrNull = item.getInternalNameOrNull() ?: return
         ignoreItem(500.milliseconds, internalNameOrNull)

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -116,6 +116,7 @@ object InventoryUtils {
     fun getItemInHand(): ItemStack? = MinecraftCompat.localPlayerOrNull?.mainHandItem
 
     fun getArmor(): Array<ItemStack?> = MinecraftCompat.localPlayerOrNull?.getArmorInventory() ?: arrayOfNulls(4)
+    fun getArmorInternalNames(): Set<NeuInternalName> = getArmor().mapNotNull { it?.getInternalNameOrNull() }.toSet()
 
     fun getHelmet(): ItemStack? = getArmor()[3]
     fun getChestplate(): ItemStack? = getArmor()[2]


### PR DESCRIPTION
## What
`OwnInventoryData.getCurrentItems()` only counted items in the main inventory slots. Moving an armor piece from an armor slot to the inventory (or vice versa) was detected as a new item pickup. This caused issues like the Tiki Mask being added to the fishing profit tracker every time it was taken off the head.

The fix includes armor slots in the item count so that moving items between armor and inventory does not change the total. Additionally, closing the wardrobe now temporarily ignores armor items to prevent false detections from armor set swaps.

Supersedes #5273.

## Changelog Fixes
+ Fixed Tiki Mask being added to the Fishing Profit Tracker every time it was taken off the head. - hannibal2

## Changelog Technical Details
+ Added `InventoryUtils.getArmorInternalNames()` utility method. - hannibal2
+ Included armor slots in `OwnInventoryData.getCurrentItems()` item tracking. - hannibal2