### PR TITLE
Feature: Quantity preset overlay for supercrafting menu

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
@@ -19,7 +19,7 @@ class SuperCraftPresetsConfig {
     var enabled: Boolean = false
 
     @Expose
-    var presets: MutableList<Int> = mutableListOf(4, 8, 16, 32, 64, 128, 256, 512)
+    val presets: MutableList<Int> = mutableListOf(4, 8, 16, 32, 64, 128, 256, 512)
 
     @Expose
     @ConfigLink(owner = SuperCraftPresetsConfig::class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.config.features.inventory
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class SuperCraftPresetsConfig {
+
+    @Expose
+    @ConfigOption(
+        name = "Enabled",
+        desc = "Show preset craft amounts in the Supercrafting sign menu."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enabled: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Preset Values",
+        desc = "Comma-separated list of supercraft amounts to display."
+    )
+    @ConfigEditorText
+    var presets: String = "4,8,16,32,64,128,256,512"
+
+    @Expose
+    @ConfigLink(owner = SuperCraftPresetsConfig::class, field = "enabled")
+    val signPosition: Position = Position(100, 100, false, true)
+}
+
+

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
-import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
@@ -13,19 +12,14 @@ class SuperCraftPresetsConfig {
     @Expose
     @ConfigOption(
         name = "Enabled",
-        desc = "Show preset craft amounts in the Supercrafting sign menu."
+        desc = "Show preset craft amounts in the Supercrafting sign menu (edit with /shsupercraftpreset <number>)."
     )
     @ConfigEditorBoolean
     @FeatureToggle
     var enabled: Boolean = false
 
     @Expose
-    @ConfigOption(
-        name = "Preset Values",
-        desc = "Comma-separated list of supercraft amounts to display."
-    )
-    @ConfigEditorText
-    var presets: String = "4,8,16,32,64,128,256,512"
+    var presets: MutableList<Int> = mutableListOf(4, 8, 16, 32, 64, 128, 256, 512)
 
     @Expose
     @ConfigLink(owner = SuperCraftPresetsConfig::class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
@@ -12,7 +12,7 @@ class SuperCraftPresetsConfig {
     @Expose
     @ConfigOption(
         name = "Enabled",
-        desc = "Show preset craft amounts in the Supercrafting sign menu (edit with /shsupercraftpreset <number>)."
+        desc = "Show preset craft amounts in the Supercrafting sign menu (edit with /shsupercraftpreset <number>).",
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftPresetsConfig.kt
@@ -29,7 +29,5 @@ class SuperCraftPresetsConfig {
 
     @Expose
     @ConfigLink(owner = SuperCraftPresetsConfig::class, field = "enabled")
-    val signPosition: Position = Position(100, 100, false, true)
+    val signPosition: Position = Position(100, 100)
 }
-
-

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/SuperCraftingConfig.kt
@@ -8,6 +8,11 @@ class SuperCraftingConfig {
 
     @Expose
     @Accordion
+    @ConfigOption(name = "Presets", desc = "")
+    var presets = SuperCraftPresetsConfig()
+
+    @Expose
+    @Accordion
     @ConfigOption(name = "Waste Warning", desc = "")
     var waste = SuperCraftingWasteConfig()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftPresets.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftPresets.kt
@@ -60,8 +60,8 @@ object SuperCraftPresets {
 
     private fun commandHelp() {
         ChatUtils.chat(
-            "§6/shsupercraftpreset <number> §7 - Add or remove a preset amount.",
-            prefix = false
+            "§6/shsupercraftpreset <number> §7- Add or remove a preset amount.",
+            prefix = false,
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftPresets.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftPresets.kt
@@ -2,9 +2,13 @@ package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.events.render.gui.GuiScreenOpenEvent
 import at.hannibal2.skyhanni.events.render.gui.ScreenDrawnEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
@@ -26,6 +30,50 @@ object SuperCraftPresets {
 
     private const val BUTTONS_PER_ROW = 4
 
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shsupercraftpreset") {
+            description = "Add or remove supercraft preset amounts"
+            category = CommandCategory.USERS_ACTIVE
+            argCallback("number", BrigadierArguments.integer(min = 1)) { number ->
+                togglePreset(number)
+            }
+            simpleCallback {
+                showCurrentPresets()
+                commandHelp()
+            }
+        }
+    }
+
+    private fun togglePreset(number: Int) {
+        val presets = config.presets
+        if (number in presets) {
+            presets.remove(number)
+            ChatUtils.chat("§cRemoved §e${number.addSeparators()} §cfrom supercraft presets.")
+        } else {
+            presets.add(number)
+            ChatUtils.chat("§aAdded §e${number.addSeparators()} §ato supercraft presets.")
+        }
+        presets.sort()
+        showCurrentPresets()
+    }
+
+    private fun commandHelp() {
+        ChatUtils.chat(
+            "§6/shsupercraftpreset <number> §7 - Add or remove a preset amount.",
+            prefix = false
+        )
+    }
+
+    private fun showCurrentPresets() {
+        val presets = config.presets
+        if (presets.isEmpty()) {
+            ChatUtils.chat("§7Current presets: §cnone")
+        } else {
+            ChatUtils.chat("§7Current presets: §e${presets.joinToString("§7, §e") { it.addSeparators() }}")
+        }
+    }
+
     @HandleEvent(onlyOnSkyblock = true)
     fun onGuiOpen(event: GuiScreenOpenEvent) {
         display = null
@@ -33,7 +81,7 @@ object SuperCraftPresets {
         val gui = event.gui as? SignEditScreen ?: return
         if (!gui.isSupercraftAmountSetSign()) return
 
-        val presets = parsePresets()
+        val presets = config.presets
         if (presets.isEmpty()) return
 
         val title = Renderable.text(
@@ -97,10 +145,4 @@ object SuperCraftPresets {
     private fun setPresetAmount(amount: Int) {
         SignUtils.setTextIntoSign("$amount", 0)
     }
-
-    private fun parsePresets(): List<Int> = config.presets
-        .split(",")
-        .mapNotNull { it.trim().toIntOrNull() }
-        .filter { it > 0 }
-        .distinct()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftPresets.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftPresets.kt
@@ -104,7 +104,3 @@ object SuperCraftPresets {
         .filter { it > 0 }
         .distinct()
 }
-
-
-
-

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftPresets.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SuperCraftPresets.kt
@@ -1,0 +1,110 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.render.gui.GuiScreenOpenEvent
+import at.hannibal2.skyhanni.events.render.gui.ScreenDrawnEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SignUtils
+import at.hannibal2.skyhanni.utils.SignUtils.isSupercraftAmountSetSign
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
+import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import net.minecraft.client.gui.screens.inventory.SignEditScreen
+import java.awt.Color
+
+@SkyHanniModule
+object SuperCraftPresets {
+
+    private val config get() = SkyHanniMod.feature.inventory.superCrafting.presets
+
+    private var display: Renderable? = null
+
+    private const val BUTTONS_PER_ROW = 4
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onGuiOpen(event: GuiScreenOpenEvent) {
+        display = null
+        if (!config.enabled) return
+        val gui = event.gui as? SignEditScreen ?: return
+        if (!gui.isSupercraftAmountSetSign()) return
+
+        val presets = parsePresets()
+        if (presets.isEmpty()) return
+
+        val title = Renderable.text(
+            "§7Supercraft Presets",
+            horizontalAlign = HorizontalAlignment.CENTER,
+        )
+        val buttonRows = presets.chunked(BUTTONS_PER_ROW).map { row ->
+            Renderable.horizontal(
+                row.map { amount -> createButton(amount) },
+                spacing = 3,
+                horizontalAlign = HorizontalAlignment.CENTER,
+            )
+        }
+
+        display = Renderable.drawInsideRoundedRect(
+            Renderable.vertical(
+                listOf(title) + buttonRows,
+                spacing = 3,
+                horizontalAlign = HorizontalAlignment.CENTER,
+            ),
+            color = Color(32, 32, 32, 128),
+            padding = 5,
+            radius = 6,
+        )
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onScreenDrawn(event: ScreenDrawnEvent) {
+        if (!config.enabled) return
+        val gui = event.gui as? SignEditScreen ?: return
+        if (!gui.isSupercraftAmountSetSign()) return
+        config.signPosition.renderRenderable(
+            display,
+            posLabel = "Supercraft Presets",
+        )
+    }
+
+    private fun createButton(amount: Int): Renderable {
+        val label = Renderable.text(
+            " §e${amount.addSeparators()} ",
+            horizontalAlign = HorizontalAlignment.CENTER,
+        )
+        val button = Renderable.drawInsideRoundedRect(
+            label,
+            color = Color(255, 255, 255, 0),
+            padding = 4,
+            radius = 4,
+        )
+        val hoverButton = Renderable.drawInsideRoundedRect(
+            label,
+            color = Color(255, 255, 255, 255),
+            padding = 4,
+            radius = 4,
+        )
+        return Renderable.clickable(
+            Renderable.hoverable(hoverButton, button),
+            onLeftClick = { setPresetAmount(amount) },
+        )
+    }
+
+    private fun setPresetAmount(amount: Int) {
+        SignUtils.setTextIntoSign("$amount", 0)
+    }
+
+    private fun parsePresets(): List<Int> = config.presets
+        .split(",")
+        .mapNotNull { it.trim().toIntOrNull() }
+        .filter { it > 0 }
+        .distinct()
+}
+
+
+
+


### PR DESCRIPTION
## What
Adds an quantity preset overlay to the supercrafting GUI. Default preset quantities can be changed in configuration, which accepts a comma-separated list of integers. Similar code to the optimal angles overlay / rancher boots overlay.
<details>
<summary>Images</summary>
<img width="911" height="666" alt="image" src="https://github.com/user-attachments/assets/2f38fda3-c210-4ff6-be50-b0869a10d2d0" />
</details>

## Changelog New Features
+ Added Supercrafting menu quantity preset overlay. - HyperKids

