### PR TITLE
Improvement: Sky Mall and Lottery displays outside of mining/foraging islands

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = LorenzLogger("ConfigMigration")
-    const val CONFIG_VERSION = 124
+    const val CONFIG_VERSION = 125
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/HotfConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/HotfConfig.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features.foraging
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.data.hotx.CurrencyPerHotxPerk.CurrencySpentDesign
+import at.hannibal2.skyhanni.features.mining.HotxFeatures.LotteryDisplayVisibility
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
@@ -21,9 +22,8 @@ class HotfConfig {
 
     @Expose
     @ConfigOption(name = "Lottery Display", desc = "Display your current Lottery perk in a GUI element.")
-    @ConfigEditorBoolean
-    @FeatureToggle
-    var lotteryDisplay: Boolean = false
+    @ConfigEditorDropdown
+    var lotteryDisplay: LotteryDisplayVisibility = LotteryDisplayVisibility.OFF
 
     @Expose
     @ConfigLink(owner = HotfConfig::class, field = "lotteryDisplay")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/HotfConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/HotfConfig.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.config.features.foraging
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.data.hotx.CurrencyPerHotxPerk.CurrencySpentDesign
-import at.hannibal2.skyhanni.features.mining.HotxFeatures.LotteryDisplayVisibility
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
@@ -27,7 +26,7 @@ class HotfConfig {
 
     @Expose
     @ConfigLink(owner = HotfConfig::class, field = "lotteryDisplay")
-    val lotteryPosition: Position = Position(100, 100)
+    val lotteryPosition: Position = Position(100, 120)
 
     @Expose
     @ConfigOption(name = "Level Stack", desc = "Show the level of a perk as item stacks.")
@@ -69,4 +68,12 @@ class HotfConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var currentWhispers: Boolean = true
+
+    enum class LotteryDisplayVisibility(val display: String) {
+        OFF("Off"),
+        FORAGING_ONLY("Foraging Islands Only"),
+        EVERYWHERE("Everywhere");
+
+        override fun toString() = display
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/HotmConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/HotmConfig.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.config.features.mining
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.data.hotx.CurrencyPerHotxPerk.CurrencySpentDesign
-import at.hannibal2.skyhanni.features.mining.HotxFeatures.SkyMallDisplayVisibility
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
@@ -71,4 +70,12 @@ class HotmConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var currentPowder: Boolean = true
+
+    enum class SkyMallDisplayVisibility(val display: String) {
+        OFF("Off"),
+        MINING_ONLY("Mining Islands Only"),
+        EVERYWHERE("Everywhere");
+
+        override fun toString() = display
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/HotmConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/HotmConfig.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features.mining
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.data.hotx.CurrencyPerHotxPerk.CurrencySpentDesign
+import at.hannibal2.skyhanni.features.mining.HotxFeatures.SkyMallDisplayVisibility
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
@@ -22,10 +23,9 @@ class HotmConfig {
 
     @Expose
     @ConfigOption(name = "Sky Mall Display", desc = "Display your current Sky Mall perk in a GUI element.")
-    @ConfigEditorBoolean
-    @FeatureToggle
+    @ConfigEditorDropdown
     @SearchTag("skymall")
-    var skyMallDisplay: Boolean = false
+    var skyMallDisplay: SkyMallDisplayVisibility = SkyMallDisplayVisibility.OFF
 
     @Expose
     @ConfigLink(owner = HotmConfig::class, field = "skyMallDisplay")

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -3,6 +3,8 @@ package at.hannibal2.skyhanni.data.hotx
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.HotfApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.foraging.HotfConfig.LotteryDisplayVisibility
 import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
@@ -268,6 +270,16 @@ enum class HotfData(
         override val rotatingPerkEntry = LOTTERY
         override var currentRotPerk = HotfApi.lottery
         override val applicableIslandType = IslandTypeTags.FORAGING
+        private val config get() = SkyHanniMod.feature.foraging.hotf
+
+        override val position: Position get() = config.lotteryPosition
+
+        override val shouldShowDisplay
+            get() = when (config.lotteryDisplay) {
+                LotteryDisplayVisibility.OFF -> false
+                LotteryDisplayVisibility.FORAGING_ONLY -> inApplicableIsland
+                LotteryDisplayVisibility.EVERYWHERE -> true
+            }
 
         override var tokens: Int
             get() = ProfileStorageData.profileSpecific?.foraging?.tokens ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -5,6 +5,8 @@ import at.hannibal2.skyhanni.api.HotmApi
 import at.hannibal2.skyhanni.api.HotmApi.MayhemPerk
 import at.hannibal2.skyhanni.api.HotmApi.SkymallPerk
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.mining.HotmConfig.SkyMallDisplayVisibility
 import at.hannibal2.skyhanni.data.IslandTypeTags
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.local.HotxTree
@@ -427,6 +429,16 @@ enum class HotmData(
         override val rotatingPerkEntry: HotmData = SKY_MALL
         override var currentRotPerk = HotmApi.skymall
         override val applicableIslandType = IslandTypeTags.MINING
+
+        private val config get() = SkyHanniMod.feature.mining.hotm
+        override val position: Position get() = config.skyMallPosition
+
+        override val shouldShowDisplay
+            get() = when (config.skyMallDisplay) {
+                SkyMallDisplayVisibility.OFF -> false
+                SkyMallDisplayVisibility.MINING_ONLY -> inApplicableIsland
+                SkyMallDisplayVisibility.EVERYWHERE -> true
+            }
 
         val storage get() = ProfileStorageData.profileSpecific?.mining?.hotmTree
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.data.hotx
 
+import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -37,6 +38,8 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
     protected abstract val notUnlockedPattern: Pattern
     protected abstract val heartItemPattern: Pattern
     protected abstract val resetItemPattern: Pattern
+    abstract val position: Position
+    abstract val shouldShowDisplay: Boolean
 
     /**
      * Needs a group "token" (only digits)

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.mining
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.hotx.HotfData
 import at.hannibal2.skyhanni.data.hotx.HotmData
 import at.hannibal2.skyhanni.data.hotx.HotxHandler
@@ -11,6 +12,7 @@ import at.hannibal2.skyhanni.events.RenderItemTipEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
@@ -26,7 +28,9 @@ object HotxFeatures {
     @HandleEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         val (handler, configPos) = when {
-            HotmData.inApplicableIsland && configHotm.skyMallDisplay -> Pair(HotmData, configHotm.skyMallPosition)
+            configHotm.skyMallDisplay.let { vis ->
+                vis != SkyMallDisplayVisibility.OFF && (vis == SkyMallDisplayVisibility.EVERYWHERE || HotmData.inApplicableIsland)
+            } -> Pair(HotmData, configHotm.skyMallPosition)
             HotfData.inApplicableIsland && configHotf.lotteryDisplay -> Pair(HotfData, configHotf.lotteryPosition)
             else -> return
         }
@@ -108,4 +112,18 @@ object HotxFeatures {
         event.stackTip = handler.availableTokens.takeIf { it != 0 }?.let { "§b$it" }.orEmpty()
     }
 
+    @HandleEvent
+    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+        event.transform(125, "mining.hotm.skyMallDisplay") {
+            ConfigUtils.migrateBooleanToEnum(it, SkyMallDisplayVisibility.MINING_ONLY, SkyMallDisplayVisibility.OFF)
+        }
+    }
+
+    enum class SkyMallDisplayVisibility(val display: String) {
+        OFF("Off"),
+        MINING_ONLY("Mining Islands Only"),
+        EVERYWHERE("Everywhere");
+
+        override fun toString() = display
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -3,6 +3,9 @@ package at.hannibal2.skyhanni.features.mining
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.foraging.HotfConfig.LotteryDisplayVisibility
+import at.hannibal2.skyhanni.config.features.mining.HotmConfig.SkyMallDisplayVisibility
 import at.hannibal2.skyhanni.data.hotx.HotfData
 import at.hannibal2.skyhanni.data.hotx.HotmData
 import at.hannibal2.skyhanni.data.hotx.HotxHandler
@@ -27,15 +30,16 @@ object HotxFeatures {
 
     @HandleEvent
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        val (handler, configPos) = when {
-            configHotm.skyMallDisplay.let { vis ->
-                vis != SkyMallDisplayVisibility.OFF && (vis == SkyMallDisplayVisibility.EVERYWHERE || HotmData.inApplicableIsland)
-            } -> Pair(HotmData, configHotm.skyMallPosition)
-            configHotf.lotteryDisplay.let { vis ->
-                vis != LotteryDisplayVisibility.OFF && (vis == LotteryDisplayVisibility.EVERYWHERE || HotfData.inApplicableIsland)
-            } -> Pair(HotfData, configHotf.lotteryPosition)
-            else -> return
-        }
+        if (configHotm.skyMallDisplay != SkyMallDisplayVisibility.OFF &&
+            (configHotm.skyMallDisplay == SkyMallDisplayVisibility.EVERYWHERE || HotmData.inApplicableIsland)
+        ) renderOverlay(HotmData, configHotm.skyMallPosition)
+
+        if (configHotf.lotteryDisplay != LotteryDisplayVisibility.OFF &&
+            (configHotf.lotteryDisplay == LotteryDisplayVisibility.EVERYWHERE || HotfData.inApplicableIsland)
+        ) renderOverlay(HotfData, configHotf.lotteryPosition)
+    }
+
+    private fun renderOverlay(handler: HotxHandler<*, *, *>, configPos: Position) {
         val rotatingPerkEntry = handler.rotatingPerkEntry
         if (!rotatingPerkEntry.isUnlocked || !rotatingPerkEntry.enabled) return
         val currentPerk = handler.currentRotPerk
@@ -122,21 +126,5 @@ object HotxFeatures {
         event.transform(125, "foraging.hotf.lotteryDisplay") {
             ConfigUtils.migrateBooleanToEnum(it, LotteryDisplayVisibility.FORAGING_ONLY, LotteryDisplayVisibility.OFF)
         }
-    }
-
-    enum class SkyMallDisplayVisibility(val display: String) {
-        OFF("Off"),
-        MINING_ONLY("Mining Islands Only"),
-        EVERYWHERE("Everywhere");
-
-        override fun toString() = display
-    }
-
-    enum class LotteryDisplayVisibility(val display: String) {
-        OFF("Off"),
-        FORAGING_ONLY("Foraging Islands Only"),
-        EVERYWHERE("Everywhere");
-
-        override fun toString() = display
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -28,15 +28,22 @@ object HotxFeatures {
     private val configHotm get() = SkyHanniMod.feature.mining.hotm
     private val configHotf get() = SkyHanniMod.feature.foraging.hotf
 
-    @HandleEvent
-    fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (configHotm.skyMallDisplay != SkyMallDisplayVisibility.OFF &&
-            (configHotm.skyMallDisplay == SkyMallDisplayVisibility.EVERYWHERE || HotmData.inApplicableIsland)
-        ) renderOverlay(HotmData, configHotm.skyMallPosition)
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
+    fun onRenderOverlay() {
+        if (configHotm.skyMallDisplay.isActive()) renderOverlay(HotmData, configHotm.skyMallPosition)
+        if (configHotf.lotteryDisplay.isActive()) renderOverlay(HotfData, configHotf.lotteryPosition)
+    }
 
-        if (configHotf.lotteryDisplay != LotteryDisplayVisibility.OFF &&
-            (configHotf.lotteryDisplay == LotteryDisplayVisibility.EVERYWHERE || HotfData.inApplicableIsland)
-        ) renderOverlay(HotfData, configHotf.lotteryPosition)
+    private fun SkyMallDisplayVisibility.isActive() = when (this) {
+        SkyMallDisplayVisibility.OFF -> false
+        SkyMallDisplayVisibility.MINING_ONLY -> HotmData.inApplicableIsland
+        SkyMallDisplayVisibility.EVERYWHERE -> true
+    }
+
+    private fun LotteryDisplayVisibility.isActive() = when (this) {
+        LotteryDisplayVisibility.OFF -> false
+        LotteryDisplayVisibility.FORAGING_ONLY -> HotfData.inApplicableIsland
+        LotteryDisplayVisibility.EVERYWHERE -> true
     }
 
     private fun renderOverlay(handler: HotxHandler<*, *, *>, configPos: Position) {
@@ -69,13 +76,13 @@ object HotxFeatures {
 
         ErrorManager.logErrorStateWithData(
             "Could not read the rotating effect from chat",
-            "no hotxhandler claimed the event",
-            "chat" to event.message,
+            "no HotxHandler claimed the event",
+            "chat" to event.cleanMessage,
         )
     }
 
-    @HandleEvent(onlyOnSkyblock = true)
-    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+    @HandleEvent(GuiContainerEvent.BackgroundDrawnEvent::class, onlyOnSkyblock = true)
+    fun onBackgroundDrawn() {
         val handler: HotxHandler<*, *, *> = when {
             HotmData.inInventory && configHotm.highlightEnabledPerks -> HotmData
             HotfData.inInventory && configHotf.highlightEnabledPerks -> HotfData

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -28,34 +28,24 @@ object HotxFeatures {
     private val configHotm get() = SkyHanniMod.feature.mining.hotm
     private val configHotf get() = SkyHanniMod.feature.foraging.hotf
 
+    private val handlers = listOf(HotmData, HotfData)
+
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
     fun onRenderOverlay() {
-        if (configHotm.skyMallDisplay.isActive()) renderOverlay(HotmData, configHotm.skyMallPosition)
-        if (configHotf.lotteryDisplay.isActive()) renderOverlay(HotfData, configHotf.lotteryPosition)
+        handlers.forEach { it.renderOverlay() }
     }
 
-    private fun SkyMallDisplayVisibility.isActive() = when (this) {
-        SkyMallDisplayVisibility.OFF -> false
-        SkyMallDisplayVisibility.MINING_ONLY -> HotmData.inApplicableIsland
-        SkyMallDisplayVisibility.EVERYWHERE -> true
-    }
-
-    private fun LotteryDisplayVisibility.isActive() = when (this) {
-        LotteryDisplayVisibility.OFF -> false
-        LotteryDisplayVisibility.FORAGING_ONLY -> HotfData.inApplicableIsland
-        LotteryDisplayVisibility.EVERYWHERE -> true
-    }
-
-    private fun renderOverlay(handler: HotxHandler<*, *, *>, configPos: Position) {
-        val rotatingPerkEntry = handler.rotatingPerkEntry
+    private fun HotxHandler<*, *, *>.renderOverlay() {
+        if (!shouldShowDisplay) return
+        val rotatingPerkEntry = rotatingPerkEntry
         if (!rotatingPerkEntry.isUnlocked || !rotatingPerkEntry.enabled) return
-        val currentPerk = handler.currentRotPerk
+        val currentPerk = currentRotPerk
 
         val perkDescriptionFormat = currentPerk?.perkDescription
-            ?: "§cUnknown! Run ${"§b/${handler.name.lowercase()}"} §cto fix this."
+            ?: "§cUnknown! Run ${"§b/${name.lowercase()}"} §cto fix this."
         val finalFormat = "§b${rotatingPerkEntry.guiName}§8: $perkDescriptionFormat"
 
-        configPos.renderRenderable(
+        position.renderRenderable(
             Renderable.text(finalFormat),
             posLabel = "${rotatingPerkEntry.guiName} Display",
         )

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -31,7 +31,9 @@ object HotxFeatures {
             configHotm.skyMallDisplay.let { vis ->
                 vis != SkyMallDisplayVisibility.OFF && (vis == SkyMallDisplayVisibility.EVERYWHERE || HotmData.inApplicableIsland)
             } -> Pair(HotmData, configHotm.skyMallPosition)
-            HotfData.inApplicableIsland && configHotf.lotteryDisplay -> Pair(HotfData, configHotf.lotteryPosition)
+            configHotf.lotteryDisplay.let { vis ->
+                vis != LotteryDisplayVisibility.OFF && (vis == LotteryDisplayVisibility.EVERYWHERE || HotfData.inApplicableIsland)
+            } -> Pair(HotfData, configHotf.lotteryPosition)
             else -> return
         }
         val rotatingPerkEntry = handler.rotatingPerkEntry
@@ -117,11 +119,22 @@ object HotxFeatures {
         event.transform(125, "mining.hotm.skyMallDisplay") {
             ConfigUtils.migrateBooleanToEnum(it, SkyMallDisplayVisibility.MINING_ONLY, SkyMallDisplayVisibility.OFF)
         }
+        event.transform(125, "foraging.hotf.lotteryDisplay") {
+            ConfigUtils.migrateBooleanToEnum(it, LotteryDisplayVisibility.FORAGING_ONLY, LotteryDisplayVisibility.OFF)
+        }
     }
 
     enum class SkyMallDisplayVisibility(val display: String) {
         OFF("Off"),
         MINING_ONLY("Mining Islands Only"),
+        EVERYWHERE("Everywhere");
+
+        override fun toString() = display
+    }
+
+    enum class LotteryDisplayVisibility(val display: String) {
+        OFF("Off"),
+        FORAGING_ONLY("Foraging Islands Only"),
         EVERYWHERE("Everywhere");
 
         override fun toString() = display


### PR DESCRIPTION
## What
Modified configuration option for Sky Mall (mining) and Lottery (foraging) HUD, which allows them to be shown outside of mining/foraging islands. Config bumped to version 125.

Resolves https://discord.com/channels/997079228510117908/1474911522810757302

## Changelog Improvements
+ Added option to show Sky Mall and Lottery HUD outside of mining/foraging islands. - HyperKids