### PR TITLE
Backend: Fixed Custom Scoreboard using old data after repo reload

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import java.util.regex.Pattern
 
 @SkyHanniModule
 object ScoreboardPattern {
@@ -12,10 +13,13 @@ object ScoreboardPattern {
     // Lines from the scoreboard
     private val scoreboardGroup by group.exclusiveGroup("scoreboard")
 
-    @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
-        UnknownLinesHandler.remoteOnlyPatterns = scoreboardGroup.getUnusedPatterns().toTypedArray()
+    @HandleEvent(RepositoryReloadEvent::class)
+    fun onRepoReload() {
+        UnknownLinesHandler.invalidateRemoteOnlyPatterns()
     }
+
+    internal fun computeRemoteOnlyPatterns(): Array<Pattern> =
+        scoreboardGroup.getUnusedPatterns().toTypedArray()
 
     // Main scoreboard
     private val mainSB = scoreboardGroup.group("main")

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -28,7 +28,11 @@ internal class UnknownLine(val line: String) {
 
 object UnknownLinesHandler {
 
-    internal lateinit var remoteOnlyPatterns: Array<Pattern>
+    private var remoteOnlyPatterns: Array<Pattern>? = null
+
+    internal fun invalidateRemoteOnlyPatterns() {
+        remoteOnlyPatterns = null
+    }
 
     /**
      * Remove known lines with patterns
@@ -40,9 +44,10 @@ object UnknownLinesHandler {
 
         val patternsToExclude = CustomScoreboard.activePatterns.toMutableList()
 
-        if (::remoteOnlyPatterns.isInitialized) {
-            patternsToExclude.addAll(remoteOnlyPatterns)
-        }
+        val remotePatterns = remoteOnlyPatterns
+            ?: SBPattern.computeRemoteOnlyPatterns().also { remoteOnlyPatterns = it }
+        patternsToExclude.addAll(remotePatterns)
+
         unknownLines = unknownLines.filterNot { line ->
             patternsToExclude.any { pattern -> pattern.matches(line) }
         }


### PR DESCRIPTION
## What
`ScoreboardPattern.onRepoReload` uses `remoteOnlyPatterns` during `RepositoryReloadEvent`, before `RepoPatternManager.onRepoReload` had loaded the new data.

The cache is now invalidated on reload and recomputed lazily.

## Changelog Technical Details
+ Fixed Custom Scoreboard using old repo data after a reload. - hannibal2