### PR TITLE
Fix: Wrong pathfinding on hub

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.data.jsonobjects.repo.IslandGraphSettingsJson
 import at.hannibal2.skyhanni.data.model.Graph
 import at.hannibal2.skyhanni.data.model.GraphNode
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.data.repo.SkyHanniRepoManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
@@ -519,7 +520,7 @@ object IslandGraphs {
     }
 
     /**
-     * Activates pathfinding to a location in the island.
+     * Activates pathfinding to a location on the current island.
      *
      * @param location The goal of the pathfinder.
      * @param label The name of the navigation goal in chat. Cannot be empty.
@@ -541,6 +542,9 @@ object IslandGraphs {
         shouldAllowRerouting = false
         pathFind0(location, label, color, onFound, onManualCancel, condition)
     }
+
+    fun node(nodeName: String, nodeTag: GraphNodeTag): GraphNode =
+        currentIslandGraph?.getClosestNode(nodeName, nodeTag) ?: error("node not found: name:$nodeName, tag: $nodeTag")
 
     private fun pathFind0(
         location: LorenzVec,

--- a/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.data.model
 
 import at.hannibal2.skyhanni.features.misc.pathfind.NavigationHelper
 import at.hannibal2.skyhanni.utils.GraphUtils
+import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.json.SkyHanniTypeAdapters.registerTypeAdapter
@@ -43,6 +44,10 @@ value class Graph(
 
     fun getNodesWithTags(vararg tag: GraphNodeTag): List<GraphNode> = nodes.filter { node -> tag.all { node.hasTag(it) } }
     fun getNodesWithName(name: String): List<GraphNode> = nodes.filter { it.name == name }
+    fun getNodesWithNameAndTags(name: String, tag: GraphNodeTag): List<GraphNode> = getNodesWithTags(tag).filter { it.name == name }
+
+    fun getClosestNode(nodeName: String, tag: GraphNodeTag): GraphNode? =
+        getNodesWithNameAndTags(nodeName, tag).minByOrNull { it.position.distanceToPlayer() }
 
     fun getNearestNode(
         location: LorenzVec = GraphUtils.playerPosition,

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalReminder.kt
@@ -4,9 +4,11 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -14,7 +16,6 @@ import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
@@ -99,7 +100,10 @@ object CarnivalReminder {
             action = {
                 HypixelCommands.warp("carnival")
                 EntityMovementData.onNextTeleport(IslandType.HUB) {
-                    IslandGraphs.pathFind(LorenzVec(-89.5, 71.0, -18.7), "§aCarnival Tickets", condition = { config.reminderDailyTickets })
+                    IslandGraphs.node("Carnival Leader", GraphNodeTag.NPC).pathFind(
+                        label = "§aCarnival Tickets",
+                        condition = { config.reminderDailyTickets },
+                    )
                 }
             },
         )

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityNpc.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityNpc.kt
@@ -3,7 +3,9 @@ package at.hannibal2.skyhanni.features.event.hoppity
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -17,7 +19,6 @@ import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
@@ -66,9 +67,8 @@ object HoppityNpc {
             action = {
                 HypixelCommands.warp("hub")
                 EntityMovementData.onNextTeleport(IslandType.HUB) {
-                    IslandGraphs.pathFind(
-                        LorenzVec(6.4, 70.0, 7.4),
-                        "§aHoppity's Shop",
+                    IslandGraphs.node("Hoppity", GraphNodeTag.NPC).pathFind(
+                        label = "§aHoppity's Shop",
                         condition = { config.hoppityShopReminder },
                     )
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -5,8 +5,10 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
@@ -22,7 +24,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -37,7 +38,6 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
@@ -91,9 +91,9 @@ object CityProjectFeatures {
             action = {
                 HypixelCommands.warp("elizabeth")
                 EntityMovementData.onNextTeleport(IslandType.HUB) {
-                    IslandGraphs.pathFind(
-                        LorenzVec(-1.7, 72.0, -102.0),
-                        "§aCity Project",
+
+                    IslandGraphs.node("City Project", GraphNodeTag.POI).pathFind(
+                        label = "§aCity Project",
                         condition = { config.dailyReminder },
                     )
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/CarrolynHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/CarrolynHelper.kt
@@ -3,7 +3,9 @@ package at.hannibal2.skyhanni.features.garden.inventory
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.events.minecraft.add
@@ -21,8 +23,6 @@ import net.minecraft.world.item.ItemStack
 @SkyHanniModule
 object CarrolynHelper {
     private val config get() = GardenApi.config
-
-    private val carrolynLocation = LorenzVec(0.5, 103.1, -803.7)
 
     private val patternGroup = RepoPattern.group("garden.carrolyn")
 
@@ -69,8 +69,7 @@ object CarrolynHelper {
     }
 
     private fun startPathfind() {
-
-        IslandGraphs.pathFind(carrolynLocation, "§5Carrolyn", condition = { isEnabled() })
+        IslandGraphs.node("Carrolyn", GraphNodeTag.NPC).pathFind("§5Carrolyn") { isEnabled() }
     }
 
     fun isEnabled() = SkyBlockUtils.inSkyBlock && config.helpCarrolyn

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/CarrolynHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/CarrolynHelper.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/CarrolynHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/CarrolynHelper.kt
@@ -69,6 +69,7 @@ object CarrolynHelper {
     }
 
     private fun startPathfind() {
+
         IslandGraphs.pathFind(carrolynLocation, "§5Carrolyn", condition = { isEnabled() })
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
@@ -4,9 +4,11 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
@@ -120,7 +122,7 @@ object CFBlockOpen {
                     action = {
                         HypixelCommands.warp("hub")
                         EntityMovementData.onNextTeleport(IslandType.HUB) {
-                            IslandGraphs.pathFind(LorenzVec(-32.5, 71.0, -76.5), "§aBazaar", condition = { true })
+                            IslandGraphs.node("Bazaar", GraphNodeTag.NPC).pathFind("§aBazaar", condition = { true })
                         }
                     },
                 )

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/RescueMissionWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/RescueMissionWaypoints.kt
@@ -3,8 +3,10 @@ package at.hannibal2.skyhanni.features.nether
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.RescueParkourJson
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -279,12 +281,12 @@ object RescueMissionWaypoints {
     private fun navigateToUndercoverAgent() {
         if (!config.agentPath) return
         val factionType = CrimsonIsleReputationHelper.factionType ?: return
-        val undercoverAgentLocation = when (factionType) {
-            FactionType.MAGE -> LorenzVec(-626.7, 119.0, -960.0)
-            FactionType.BARBARIAN -> LorenzVec(-15.5, 93.0, -843.7)
+        val undercoverAgentNode = when (factionType) {
+            FactionType.MAGE -> IslandGraphs.node("Undercover Agent (Mage)", GraphNodeTag.NPC)
+            FactionType.BARBARIAN -> IslandGraphs.node("Undercover Agent (Barbarian)", GraphNodeTag.NPC)
         }
-        IslandGraphs.pathFind(
-            undercoverAgentLocation,
+
+        undercoverAgentNode.pathFind(
             "§5${factionType.factionName} Undercover Agent",
             LorenzColor.DARK_PURPLE.toColor(),
             condition = { config.agentPath },


### PR DESCRIPTION
## What
Locations that are targets for pathfinding in specific features were hardcoded.
This PR fixes the locations by deleting the hard-coded location and instead looking for the correct node via the new `IslandGraphs.node(nodeName, nodeTag)` function.

This change impacts some features in Hub and Crimson Isle. Only the hub ones are invalid. Therefore, the changelog omits the Crimson Isle ones.

## Changelog Fixes
+ Fixed broken navigation in the Hub to the Carnival Shop, Hoppity Shop, and City Project. - hannibal2