### PR TITLE
Fix: Chronomatron helper misses first note of sequence

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
@@ -51,7 +51,7 @@ object ExperimentsAddonsHelper {
     private val userUltrasequencerProgress: MutableList<Int> = mutableListOf()
     private val ultrasequencerDyeMap: MutableMap<Int, ItemStack> = mutableMapOf()
 
-    private var chronHasBeenEmpty: Boolean = false
+    private var chronHasBeenEmpty: Boolean = true
     private var lastChronomatronSound: SimpleTimeMark = SimpleTimeMark.farPast()
     private var currentAddonPhase: HelperPhase? = null
     private var chronomatronSequenceIndex: Int = 0
@@ -105,7 +105,7 @@ object ExperimentsAddonsHelper {
         chronomatronSequenceIndex = 0
         lastChronomatronSound = SimpleTimeMark.farPast()
         currentAddonPhase = null
-        chronHasBeenEmpty = false
+        chronHasBeenEmpty = true
     }
 
     private fun ItemStack.getLorenzColorOrNull(): LorenzColor? = when (hoverName.string.removeColor()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
@@ -342,6 +342,7 @@ object ExperimentsAddonsHelper {
                     if (ExperimentationTableApi.inChronomatron) {
                         addString("Current Round: $currentChronomatronRound")
                         addString("Current Sequence Index: $chronomatronSequenceIndex")
+                        addString("chronHasBeenEmpty: $chronHasBeenEmpty")
                         add(Renderable.emptyText())
                         addString("Hypixel Data:")
                         addString(formatColorSet(hypixelChronomatronData))


### PR DESCRIPTION
## What
The chronomatron experiment table helper occasionally misses the first note of the sequence.

This PR initializes the table with `chronHasBeenEmpty = true` to ensure the first note is always captured.

My theorized explanation for why this bug happens is that on the initial run, `InventoryUpdatedEvent` sometimes doesn't fire until `activeColors.isEmpty()` is already false, which incorrectly leaves `chronHasBeenEmpty` as false due to the initialized state, which then triggers the return statement on line 273.

Getting the bug to work is very, very inconsistent across machines / installations - I personally initially had this issue on a Lunar client install, and it seemingly happened out of the blue after it was working perfectly well for months. I cannot replicate this issue on a fresh Windows or Mac install via Modrinth, but can replicate it 100% of the time by running the Minecraft client on MacOS from inside the IDE.

## Changelog Fixes
+ Fixed Chronomatron experiment table helper missing the first note. - HyperKids