### PR TITLE
Fix: Hoppity Call Tracking

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -68,10 +68,11 @@ object HoppityEggsManager {
     /**
      * REGEX-TEST: §aYou bought §r§9Casanova §r§afor §r§6970,000 Coins§r§a!
      * REGEX-TEST: §aYou bought §r§fHeidie §r§afor §r§6194,000 Coins§r§a!
+     * REGEX-TEST: §aYou bought §r§aBubbles§r§a!
      */
     val eggBoughtPattern by CFApi.patternGroup.pattern(
         "egg.bought",
-        "§aYou bought §r(?<rabbitname>.*?) §r§afor §r§6(?<cost>[\\d,]*) Coins§r§a!",
+        "§aYou bought §r(?<rabbitname>.*?)(?: §r§afor §r§6(?<cost>[\\d,]*) Coins)?§r§a!",
     )
 
     /**


### PR DESCRIPTION
## What
Hypixel seems to have removed the coin cost from the message sent when you buy a rabbit from Hoppity via abiphone.

<details>
<summary>Images</summary>

<img width="1010" height="156" alt="image" src="https://github.com/user-attachments/assets/7c647f2d-bd4a-43d5-933d-726a3a01a31c" />

</details>

## Changelog Fixes
+ Fixed rabbits bought from Hoppity via Abiphone not compacting/tracking. - Daveed