### PR TITLE
Fix: Pest waypoint is inaccurate when used in rapid succession

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.garden.GardenPlotApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
+import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayerIgnoreY
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
@@ -70,6 +71,7 @@ object PestParticleWaypoint {
         val pos = event.location
 
         if (bezierFitter.isEmpty()) {
+            if (pos.distance(LocationUtils.playerLocation()) > 5) return
             bezierFitter.addPoint(pos)
             return
         }


### PR DESCRIPTION
## What
When using the pest tracker feature on a vacuum in rapid succession, the code makes an inaccurate waypoint prediction based on residual particles from the previous vacuum use.

The likelihood of this issue happening is reduced by ensuring the first particle is less than 5 blocks from the player.

## Changelog Fixes
+ Fixed Pest Prediction Waypoint inaccuracy when used too rapidly. - HyperKids