### PR TITLE
Backend + Fix: Disable Custom Item Rendering

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
 import at.hannibal2.skyhanni.utils.compat.RenderCompat
-import at.hannibal2.skyhanni.utils.render.item.SkyHanniGuiItemRenderState
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
@@ -16,7 +15,6 @@ import com.mojang.blaze3d.platform.Lighting
 import com.mojang.blaze3d.systems.RenderSystem
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.Font
-import net.minecraft.client.gui.render.state.GuiItemRenderState
 import net.minecraft.network.chat.Component
 import net.minecraft.util.ARGB
 import net.minecraft.resources.Identifier
@@ -28,7 +26,6 @@ import kotlin.math.min
 import kotlin.math.sqrt
 import net.minecraft.client.renderer.item.TrackingItemStackRenderState
 import net.minecraft.world.item.ItemDisplayContext
-import org.joml.Matrix3x2f
 
 /**
  * Some functions taken from NotEnoughUpdates
@@ -360,7 +357,7 @@ object GuiRenderUtils {
 
         // Todo, uncomment when modern item rendering is fixed
         /* if (rotationVec == Vec3.ZERO && (totalItemScale <= 1 || !trackingState.usesBlockLight())) */
-            return item.normalRenderOnScreen(translateX, translateY, finalItemScale.toFloat())
+        return item.normalRenderOnScreen(translateX, translateY, finalItemScale.toFloat())
 
         /*
         /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/GuiRenderUtils.kt
@@ -358,9 +358,11 @@ object GuiRenderUtils {
         val trackingState = TrackingItemStackRenderState()
         Minecraft.getInstance().itemModelResolver.updateForTopItem(trackingState, item, ItemDisplayContext.GUI, null, null, 0)
 
-        if (rotationVec == Vec3.ZERO && (totalItemScale <= 1 || !trackingState.usesBlockLight()))
+        // Todo, uncomment when modern item rendering is fixed
+        /* if (rotationVec == Vec3.ZERO && (totalItemScale <= 1 || !trackingState.usesBlockLight())) */
             return item.normalRenderOnScreen(translateX, translateY, finalItemScale.toFloat())
 
+        /*
         /**
          * This is used to render items that fit these criteria:
          *  - Uses block light (mostly skulls)
@@ -390,6 +392,7 @@ object GuiRenderUtils {
         )
         Minecraft.getInstance().gameRenderer.guiRenderState.submitPicturesInPictureState(newRenderState)
         return newRenderState.stableId
+        */
     }
 
     private fun ItemStack.normalRenderOnScreen(


### PR DESCRIPTION
## What
Slew of issues causing weird scaling issues. Disabled until it can be fixed. Back to normal item rendering.

## Changelog Fixes
+ Fixed mis-scaled and improper items in displays. - Daveed