### PR TITLE
Improvement: Use Time-based Visibility for Bingo NPC on Hub

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
@@ -3,12 +3,18 @@ package at.hannibal2.skyhanni.features.bingo
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.storage.PlayerSpecificStorage.BingoSession
 import at.hannibal2.skyhanni.data.HypixelData
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.BingoData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.BingoJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.BingoRanksJson
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.IslandGraphReloadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.features.bingo.card.goals.BingoGoal
 import at.hannibal2.skyhanni.features.bingo.card.goals.GoalType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -39,12 +45,12 @@ object BingoApi {
      */
     private val detectionPattern by RepoPattern.pattern(
         "bingo.detection.scoreboard",
-        " §.Ⓑ §.Bingo"
+        " §.Ⓑ §.Bingo",
     )
 
     private val titleDetectionPattern by RepoPattern.pattern(
         "bingo.detection.scoreboardtitle",
-        "SKYBLOCK Ⓑ"
+        "SKYBLOCK Ⓑ",
     )
 
     @HandleEvent
@@ -114,7 +120,7 @@ object BingoApi {
 
     private fun getStartOfMonthInMillis() = OffsetDateTime.of(
         TimeUtils.getCurrentLocalDate().plusDays(5).withDayOfMonth(1),
-        LocalTime.MIDNIGHT, ZoneOffset.UTC
+        LocalTime.MIDNIGHT, ZoneOffset.UTC,
     ).toEpochSecond()
 
     fun getCommunityPercentageColor(percentage: Double): String = when {
@@ -132,6 +138,38 @@ object BingoApi {
             "$rankIcon $rank"
         } else {
             rankIcon
+        }
+    }
+
+    private var bingoNpcsHidden = false
+
+    @HandleEvent(IslandGraphReloadEvent::class)
+    fun onIslandGraphReload() {
+        bingoNpcsHidden = false
+        checkBingoNpcs()
+    }
+
+    // Reset state on every island change in case IslandGraphReloadEvent does not fire for this island (private island, garden)
+    @HandleEvent(IslandChangeEvent::class)
+    fun onIslandChange() {
+        bingoNpcsHidden = false
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onSecondPassed(event: SecondPassedEvent) {
+        if (!event.repeatSeconds(10)) return
+        checkBingoNpcs()
+    }
+
+    private fun checkBingoNpcs() {
+        if (!IslandType.HUB.isCurrent()) return
+        val shouldHideBingoNpcs = !SkyBlockUtils.isBingoProfile
+        if (shouldHideBingoNpcs == bingoNpcsHidden) return
+
+        bingoNpcsHidden = shouldHideBingoNpcs
+        val npcs = setOf(IslandGraphs.node("Alixer", GraphNodeTag.NPC), IslandGraphs.node("Bingo", GraphNodeTag.NPC))
+        for (node in npcs) {
+            node.enabled = !shouldHideBingoNpcs
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
@@ -153,38 +153,6 @@ object BingoApi {
         }
     }
 
-    private var bingoNpcsHidden = false
-
-    @HandleEvent(IslandGraphReloadEvent::class)
-    fun onIslandGraphReload() {
-        bingoNpcsHidden = false
-        checkBingoNpcs()
-    }
-
-    // Reset state on every island change in case IslandGraphReloadEvent does not fire for this island (private island, garden)
-    @HandleEvent(IslandChangeEvent::class)
-    fun onIslandChange() {
-        bingoNpcsHidden = false
-    }
-
-    @HandleEvent(onlyOnSkyblock = true)
-    fun onSecondPassed(event: SecondPassedEvent) {
-        if (!event.repeatSeconds(10)) return
-        checkBingoNpcs()
-    }
-
-    private fun checkBingoNpcs() {
-        if (!IslandType.HUB.isCurrent()) return
-        val shouldHideBingoNpcs = !SkyBlockUtils.isBingoProfile
-        if (shouldHideBingoNpcs == bingoNpcsHidden) return
-
-        bingoNpcsHidden = shouldHideBingoNpcs
-        val npcs = setOf(IslandGraphs.node("Alixer", GraphNodeTag.NPC), IslandGraphs.node("Bingo", GraphNodeTag.NPC))
-        for (node in npcs) {
-            node.enabled = !shouldHideBingoNpcs
-        }
-    }
-
     @HandleEvent(IslandGraphReloadEvent::class)
     fun onIslandGraphReload() {
         bingoNpcHidden = false
@@ -203,14 +171,6 @@ object BingoApi {
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!event.repeatSeconds(10)) return
         checkBingoNpcs()
-    }
-
-    private fun isInBingoEventWindow(): Boolean {
-        val eventStart = getStartOfMonth()
-        val now = OffsetDateTime.now(ZoneOffset.UTC).asTimeMark()
-        val windowStart = eventStart - BINGO_NPC_OFFSET
-        val windowEnd = eventStart + BINGO_EVENT_DURATION + BINGO_NPC_OFFSET
-        return now in windowStart..windowEnd
     }
 
     private fun checkBingoNpcs() {
@@ -227,5 +187,13 @@ object BingoApi {
             bingoNpcHidden = shouldHideBingoNpc
             IslandGraphs.node("Bingo", GraphNodeTag.NPC).enabled = !shouldHideBingoNpc
         }
+    }
+
+    private fun isInBingoEventWindow(): Boolean {
+        val eventStart = getStartOfMonth()
+        val now = OffsetDateTime.now(ZoneOffset.UTC).asTimeMark()
+        val windowStart = eventStart - BINGO_NPC_OFFSET
+        val windowEnd = eventStart + BINGO_EVENT_DURATION + BINGO_NPC_OFFSET
+        return now in windowStart..windowEnd
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.asTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils
@@ -28,6 +29,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import kotlin.time.Duration.Companion.days
 
 @SkyHanniModule
 object BingoApi {
@@ -115,13 +117,16 @@ object BingoApi {
 
     val bingoStorage: BingoSession by lazy {
         val playerSpecific = ProfileStorageData.playerSpecific ?: error("playerSpecific is null")
-        playerSpecific.bingoSessions.getOrPut(getStartOfMonthInMillis()) { BingoSession() }
+        // we currently use seconds as key
+        // TODO change the seconds entry to SimpleTimeMark, use a config migration
+        val seconds = getStartOfMonth().toMillis() / 1000
+        playerSpecific.bingoSessions.getOrPut(seconds) { BingoSession() }
     }
 
-    private fun getStartOfMonthInMillis() = OffsetDateTime.of(
+    private fun getStartOfMonth() = OffsetDateTime.of(
         TimeUtils.getCurrentLocalDate().plusDays(5).withDayOfMonth(1),
         LocalTime.MIDNIGHT, ZoneOffset.UTC,
-    ).toEpochSecond()
+    ).asTimeMark()
 
     fun getCommunityPercentageColor(percentage: Double): String = when {
         percentage < 0.01 -> "§a"
@@ -141,18 +146,25 @@ object BingoApi {
         }
     }
 
-    private var bingoNpcsHidden = false
+    // TODO replace with dynamic detection once we have secret bingo detection (maybe via repo?)
+    private val BINGO_EVENT_DURATION = 7.days
+    private val BINGO_NPC_OFFSET = 3.days
+
+    private var bingoNpcHidden = false
+    private var alixerHidden = false
 
     @HandleEvent(IslandGraphReloadEvent::class)
     fun onIslandGraphReload() {
-        bingoNpcsHidden = false
+        bingoNpcHidden = false
+        alixerHidden = false
         checkBingoNpcs()
     }
 
     // Reset state on every island change in case IslandGraphReloadEvent does not fire for this island (private island, garden)
     @HandleEvent(IslandChangeEvent::class)
     fun onIslandChange() {
-        bingoNpcsHidden = false
+        bingoNpcHidden = false
+        alixerHidden = false
     }
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -161,15 +173,27 @@ object BingoApi {
         checkBingoNpcs()
     }
 
+    private fun isInBingoEventWindow(): Boolean {
+        val eventStart = getStartOfMonth()
+        val now = OffsetDateTime.now(ZoneOffset.UTC).asTimeMark()
+        val windowStart = eventStart - BINGO_NPC_OFFSET
+        val windowEnd = eventStart + BINGO_EVENT_DURATION + BINGO_NPC_OFFSET
+        return now in windowStart..windowEnd
+    }
+
     private fun checkBingoNpcs() {
         if (!IslandType.HUB.isCurrent()) return
-        val shouldHideBingoNpcs = !SkyBlockUtils.isBingoProfile
-        if (shouldHideBingoNpcs == bingoNpcsHidden) return
 
-        bingoNpcsHidden = shouldHideBingoNpcs
-        val npcs = setOf(IslandGraphs.node("Alixer", GraphNodeTag.NPC), IslandGraphs.node("Bingo", GraphNodeTag.NPC))
-        for (node in npcs) {
-            node.enabled = !shouldHideBingoNpcs
+        val shouldHideAlixer = !SkyBlockUtils.isBingoProfile
+        if (shouldHideAlixer != alixerHidden) {
+            alixerHidden = shouldHideAlixer
+            IslandGraphs.node("Alixer", GraphNodeTag.NPC).enabled = !shouldHideAlixer
+        }
+
+        val shouldHideBingoNpc = !isInBingoEventWindow()
+        if (shouldHideBingoNpc != bingoNpcHidden) {
+            bingoNpcHidden = shouldHideBingoNpc
+            IslandGraphs.node("Bingo", GraphNodeTag.NPC).enabled = !shouldHideBingoNpc
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
@@ -34,8 +34,15 @@ import kotlin.time.Duration.Companion.days
 @SkyHanniModule
 object BingoApi {
 
+    // TODO replace with dynamic detection once we have secret bingo detection (maybe via repo?)
+    private val BINGO_EVENT_DURATION = 7.days
+    private val BINGO_NPC_OFFSET = 3.days
+
     private var ranks = mapOf<String, Int>()
     private var data: Map<String, BingoData> = emptyMap()
+
+    private var bingoNpcHidden = false
+    private var alixerHidden = false
 
     val bingoGoals get() = bingoStorage.goals
     val personalGoals get() = bingoGoals.values.filter { it.type == GoalType.PERSONAL }
@@ -145,13 +152,6 @@ object BingoApi {
             rankIcon
         }
     }
-
-    // TODO replace with dynamic detection once we have secret bingo detection (maybe via repo?)
-    private val BINGO_EVENT_DURATION = 7.days
-    private val BINGO_NPC_OFFSET = 3.days
-
-    private var bingoNpcHidden = false
-    private var alixerHidden = false
 
     @HandleEvent(IslandGraphReloadEvent::class)
     fun onIslandGraphReload() {

--- a/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlin.math.abs
@@ -85,5 +86,6 @@ value class SimpleTimeMark(private val millis: Long) : Comparable<SimpleTimeMark
         fun Duration.fromNow() = now() + this
 
         fun Long.asTimeMark() = SimpleTimeMark(this)
+        fun OffsetDateTime.asTimeMark() = SimpleTimeMark(toInstant().toEpochMilli())
     }
 }


### PR DESCRIPTION
## Dependencies
- #5316

## What
Show Hoppity NPC always while the bingo shop is open. (7 days while bingo is active, plus 3 days offset at the beginning and end)


ignore_from_changelog