### PR TITLE
Fix: Rendering in Non-Render Events in Composter Overlay

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -21,8 +21,6 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.TabListUpdateComponentEvent
-import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -20,6 +20,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.TabListUpdateComponentEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
@@ -77,6 +78,7 @@ import kotlin.time.Duration.Companion.milliseconds
 @SkyHanniModule
 object ComposterOverlay {
 
+    private var displayDirty = false
     private var organicMatterFactors: Map<NeuInternalName, Double> = emptyMap()
     private var fuelFactors: Map<NeuInternalName, Double> = emptyMap()
     private var organicMatter: Map<NeuInternalName, Double> = emptyMap()
@@ -119,26 +121,22 @@ object ComposterOverlay {
     private val VOLTA = "VOLTA".toInternalName()
     private val OIL_BARREL = "OIL_BARREL".toInternalName()
 
-    @HandleEvent(TabListUpdateEvent::class, priority = HandleEvent.LOW)
+    @HandleEvent(TabListUpdateComponentEvent::class, priority = HandleEvent.LOW)
     fun onTabListUpdate() {
-        if (inInventory) {
-            update()
-        }
+        if (inInventory) displayDirty = true
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onTick() {
         if (composterUpgradesInventory.isInside() && extraComposterUpgrade != null && lastHovered.passedSince() > 200.milliseconds) {
             extraComposterUpgrade = null
-            update()
+            displayDirty = true
         }
     }
 
     @HandleEvent(InventoryFullyOpenedEvent::class, onlyOnIsland = IslandType.GARDEN)
     fun onInventoryFullyOpened() {
-        if (inInventory) {
-            update()
-        }
+        if (inInventory) displayDirty = true
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
@@ -151,7 +149,7 @@ object ComposterOverlay {
                     group("level")?.romanToDecimalIfNecessary() ?: 0
                 } == 25
                 extraComposterUpgrade = upgrade
-                update()
+                displayDirty = true
                 return
             }
         }
@@ -159,7 +157,7 @@ object ComposterOverlay {
             extraComposterUpgrade = null
             maxLevel = false
         }
-        update()
+        displayDirty = true
     }
 
     private fun update() {
@@ -276,11 +274,11 @@ object ComposterOverlay {
             addString("§7Items needed to fill §eOrganic Matter")
             val fillList = fillList(organicMatterFactors, missingOrganicMatter, testOffset) {
                 currentOrganicMatterItem = it
-                update()
+                displayDirty = true
             }
             if (currentOrganicMatterItem == NONE) {
                 currentOrganicMatterItem = fillList
-                update()
+                displayDirty = true
             }
         }
     }
@@ -294,11 +292,11 @@ object ComposterOverlay {
         val missingFuel = (maxFuel - currentFuel).toDouble()
         val fillList = fillList(fuelFactors, missingFuel) {
             currentFuelItem = it
-            update()
+            displayDirty = true
         }
         if (currentFuelItem == NONE) {
             currentFuelItem = fillList
-            update()
+            displayDirty = true
         }
     }
 
@@ -368,7 +366,7 @@ object ComposterOverlay {
                 current = currentTimeType,
                 onChange = {
                     currentTimeType = it
-                    update()
+                    displayDirty = true
                 },
             )
 
@@ -429,7 +427,7 @@ object ComposterOverlay {
 
         val testOffset = if (testOffsetRec > map.size) {
             ChatUtils.userError("Invalid Composter Overlay Offset! $testOffset cannot be greater than ${map.size}!")
-            ComposterOverlay.testOffset = 0
+            testOffset = 0
             0
         } else testOffsetRec
 
@@ -438,7 +436,7 @@ object ComposterOverlay {
             add(
                 Renderable.link("testOffset = $testOffset") {
                     ComposterOverlay.testOffset = 0
-                    update()
+                    displayDirty = true
                 },
             )
         }
@@ -679,6 +677,7 @@ object ComposterOverlay {
     fun onBackgroundDraw() {
         if (!isEnabled() || !inInventory) return
         if (EstimatedItemValue.isCurrentlyShowing()) return
+        if (displayDirty) update()
 
         config.overlayOrganicMatterPos.renderRenderable(
             organicMatterDisplay,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -78,7 +78,6 @@ import kotlin.time.Duration.Companion.milliseconds
 @SkyHanniModule
 object ComposterOverlay {
 
-    private var lastWidgetHash: Int = 0
     private var displayDirty = false
     private var organicMatterFactors: Map<NeuInternalName, Double> = emptyMap()
     private var fuelFactors: Map<NeuInternalName, Double> = emptyMap()
@@ -125,11 +124,7 @@ object ComposterOverlay {
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!isEnabled() || !event.isWidget(TabWidget.COMPOSTER)) return
-        val newComposterHash = event.widget.hashCode()
-        if (newComposterHash != lastWidgetHash) {
-            lastWidgetHash = newComposterHash
-            displayDirty = true
-        }
+        displayDirty = true
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -677,7 +677,10 @@ object ComposterOverlay {
     fun onBackgroundDraw() {
         if (!isEnabled() || !inInventory) return
         if (EstimatedItemValue.isCurrentlyShowing()) return
-        if (displayDirty) update()
+        if (displayDirty) {
+            update()
+            displayDirty = false
+        }
 
         config.overlayOrganicMatterPos.renderRenderable(
             organicMatterDisplay,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.data.SackApi.getAmountInSacksOrNull
 import at.hannibal2.skyhanni.data.SackApi.isMissingSackItem
 import at.hannibal2.skyhanni.data.jsonobjects.repo.GardenJson
 import at.hannibal2.skyhanni.data.model.ComposterUpgrade
+import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -22,6 +23,7 @@ import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.TabListUpdateComponentEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
+import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.composter.ComposterApi.getLevel
@@ -78,6 +80,7 @@ import kotlin.time.Duration.Companion.milliseconds
 @SkyHanniModule
 object ComposterOverlay {
 
+    private var lastWidgetHash: Int = 0
     private var displayDirty = false
     private var organicMatterFactors: Map<NeuInternalName, Double> = emptyMap()
     private var fuelFactors: Map<NeuInternalName, Double> = emptyMap()
@@ -121,9 +124,14 @@ object ComposterOverlay {
     private val VOLTA = "VOLTA".toInternalName()
     private val OIL_BARREL = "OIL_BARREL".toInternalName()
 
-    @HandleEvent(TabListUpdateComponentEvent::class, priority = HandleEvent.LOW)
-    fun onTabListUpdate() {
-        if (inInventory) displayDirty = true
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+        if (!isEnabled() || !event.isWidget(TabWidget.COMPOSTER)) return
+        val newComposterHash = event.widget.hashCode()
+        if (newComposterHash != lastWidgetHash) {
+            lastWidgetHash = newComposterHash
+            displayDirty = true
+        }
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)


### PR DESCRIPTION
Replaced calls to `update()` (which was causing rendering on non-render threads) with a dirty flag, that will cause it to be re-calced when needed.

## Changelog Fixes
+ Fixed error when first opening Composter with overlay enabled. - Daveed