### PR TITLE
Fix: Kuudra Chests Being instantly marked as Opened/Erroring

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -173,12 +173,16 @@ object CroesusChestTracker {
                 keyUsedPattern.anyMatches(lore) -> OpenedState.KEY_USED
                 openedPattern.anyMatches(lore) -> OpenedState.OPENED
                 unopenedPattern.anyMatches(lore) -> OpenedState.UNOPENED
-                else -> ErrorManager.logErrorStateWithData(
-                    "Croesus Chest couldn't be read correctly.",
-                    "Open state check failed for chest.",
-                    "run" to run,
-                    "lore" to lore,
-                ).run { null }
+                kuudraPattern.anyMatches(lore) -> OpenedState.UNOPENED
+                // Kuudra doesn't have an unopened, but it DOES have opened, this has to be after opened in when branch.
+                else -> {
+                    ErrorManager.logErrorStateWithData(
+                        "Croesus Chest couldn't be read correctly.",
+                        "Open state check failed for chest.",
+                        "run" to run,
+                        "lore" to lore,
+                    ).run { null }
+                }
             }
         }
     }
@@ -239,7 +243,7 @@ object CroesusChestTracker {
         if (!config.showUsedKismets) return
         if (!inCroesusInventory) return
         if (event.slot.containerSlot != event.slot.index) return
-        val run = croesusSlotMapToRun(event.slot.containerSlot) ?: return
+        croesusSlotMapToRun(event.slot.containerSlot) ?: return
         if (!kismetUsedInCroesusPattern.anyMatches(event.stack.getLore())) return
         event.offsetY = -1
         event.offsetX = -9

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -110,18 +110,25 @@ object CroesusChestTracker {
         if (!SkyHanniMod.feature.dungeon.croesusUnopenedChestTracker) return
 
         if (!inCroesusInventory || croesusEmpty) return
-        for ((run, slot) in InventoryUtils.getItemsInOpenChest()
-            .mapNotNull { slot -> runSlots(slot.containerSlot, slot) }) {
-
-            // If one chest is null every followup chest is null. Therefore, an early return is possible
-            if (run.floor == null) return
-
-            val state = run.openState ?: OpenedState.UNOPENED
-
-            if (state != OpenedState.KEY_USED) {
-                slot.highlight(if (state == OpenedState.OPENED) LorenzColor.DARK_AQUA else LorenzColor.DARK_PURPLE)
-            }
+        InventoryUtils.getItemsInOpenChest().forEach { slot ->
+            val state = getOpenState(slot.item.getLore()) ?: OpenedState.UNOPENED
+            val color = getColorForState(state) ?: return
+            slot.highlight(color)
         }
+
+        // Old Logic using the Run Storage, Hypixel Exposes enough info that this is unneeded now and is kinda bugged with multi-instance
+//         for ((run, slot) in InventoryUtils.getItemsInOpenChest()
+//             .mapNotNull { slot -> runSlots(slot.containerSlot, slot) }) {
+//
+//             // If one chest is null every followup chest is null. Therefore, an early return is possible
+//             if (run.floor == null) return
+//
+//             val state = run.openState ?: OpenedState.UNOPENED
+//
+//             if (state != OpenedState.KEY_USED) {
+//                 slot.highlight(if (state == OpenedState.OPENED) LorenzColor.DARK_AQUA else LorenzColor.DARK_PURPLE)
+//             }
+//         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -152,6 +159,31 @@ object CroesusChestTracker {
         kismetAmountCache = getKismetAmount()
     }
 
+    private fun getColorForState(state: OpenedState): LorenzColor? {
+        return when (state) {
+            OpenedState.OPENED -> LorenzColor.DARK_AQUA
+            OpenedState.UNOPENED -> LorenzColor.DARK_PURPLE
+            else -> null
+        }
+    }
+
+    private fun getOpenState(lore: List<String>): OpenedState? {
+        return when {
+            keyUsedPattern.anyMatches(lore) -> OpenedState.KEY_USED
+            openedPattern.anyMatches(lore) -> OpenedState.OPENED
+            unopenedPattern.anyMatches(lore) -> OpenedState.UNOPENED
+            kuudraPattern.anyMatches(lore) -> OpenedState.UNOPENED
+            // Kuudra doesn't have an unopened, but it DOES have opened, this has to be after opened in when branch.
+            else -> {
+                ErrorManager.logErrorStateWithData(
+                    "Croesus Chest couldn't be read correctly.",
+                    "Open state check failed for chest.",
+                    "lore" to lore,
+                ).run { null }
+            }
+        }
+    }
+
     private fun checkChests(inventory: Map<Int, ItemStack?>) {
         for ((run, item) in inventory.mapNotNull { (key, value) -> runSlots(key, value) }) {
             if (item == null) {
@@ -169,21 +201,7 @@ object CroesusChestTracker {
                     )
             if (run.floor == "F0" && kuudraPattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets())) run.floor =
                 ("T" + KuudraApi.getKuudraRunTierNumber(lore.firstNotNullOfOrNull { kuudraPattern.matchMatcher(it) { group("tier") } }))
-            run.openState = when {
-                keyUsedPattern.anyMatches(lore) -> OpenedState.KEY_USED
-                openedPattern.anyMatches(lore) -> OpenedState.OPENED
-                unopenedPattern.anyMatches(lore) -> OpenedState.UNOPENED
-                kuudraPattern.anyMatches(lore) -> OpenedState.UNOPENED
-                // Kuudra doesn't have an unopened, but it DOES have opened, this has to be after opened in when branch.
-                else -> {
-                    ErrorManager.logErrorStateWithData(
-                        "Croesus Chest couldn't be read correctly.",
-                        "Open state check failed for chest.",
-                        "run" to run,
-                        "lore" to lore,
-                    ).run { null }
-                }
-            }
+            run.openState = getOpenState(lore)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonCompleteEvent
 import at.hannibal2.skyhanni.events.kuudra.KuudraCompleteEvent
-import at.hannibal2.skyhanni.features.dungeon.CroesusChestTracker.OpenedState.Companion.getOpenState
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi.DungeonChest
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi.inDungeon
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
@@ -112,7 +111,7 @@ object CroesusChestTracker {
 
         if (!inCroesusInventory || croesusEmpty) return
         InventoryUtils.getItemsInOpenChest().forEach { slot ->
-            val color = (getOpenState(slot.item.getLore()) ?: return@forEach).color ?: return@forEach
+            val color = (OpenedState.getOpenState(slot.item.getLore()) ?: return@forEach).color ?: return@forEach
             slot.highlight(color)
         }
     }
@@ -162,7 +161,7 @@ object CroesusChestTracker {
                     )
             if (run.floor == "F0" && kuudraPattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets())) run.floor =
                 ("T" + KuudraApi.getKuudraRunTierNumber(lore.firstNotNullOfOrNull { kuudraPattern.matchMatcher(it) { group("tier") } }))
-            run.openState = getOpenState(lore)
+            run.openState = OpenedState.getOpenState(lore)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonCompleteEvent
 import at.hannibal2.skyhanni.events.kuudra.KuudraCompleteEvent
+import at.hannibal2.skyhanni.features.dungeon.CroesusChestTracker.OpenedState.Companion.getOpenState
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi.DungeonChest
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi.inDungeon
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
@@ -111,24 +112,9 @@ object CroesusChestTracker {
 
         if (!inCroesusInventory || croesusEmpty) return
         InventoryUtils.getItemsInOpenChest().forEach { slot ->
-            val state = getOpenState(slot.item.getLore()) ?: OpenedState.UNOPENED
-            val color = getColorForState(state) ?: return
+            val color = (getOpenState(slot.item.getLore()) ?: return@forEach).color ?: return@forEach
             slot.highlight(color)
         }
-
-        // Old Logic using the Run Storage, Hypixel Exposes enough info that this is unneeded now and is kinda bugged with multi-instance
-//         for ((run, slot) in InventoryUtils.getItemsInOpenChest()
-//             .mapNotNull { slot -> runSlots(slot.containerSlot, slot) }) {
-//
-//             // If one chest is null every followup chest is null. Therefore, an early return is possible
-//             if (run.floor == null) return
-//
-//             val state = run.openState ?: OpenedState.UNOPENED
-//
-//             if (state != OpenedState.KEY_USED) {
-//                 slot.highlight(if (state == OpenedState.OPENED) LorenzColor.DARK_AQUA else LorenzColor.DARK_PURPLE)
-//             }
-//         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -157,31 +143,6 @@ object CroesusChestTracker {
         if (!config.kismetStackSize) return
         chestInventory = DungeonChest.getByInventoryName(event.inventoryName) ?: return
         kismetAmountCache = getKismetAmount()
-    }
-
-    private fun getColorForState(state: OpenedState): LorenzColor? {
-        return when (state) {
-            OpenedState.OPENED -> LorenzColor.DARK_AQUA
-            OpenedState.UNOPENED -> LorenzColor.DARK_PURPLE
-            else -> null
-        }
-    }
-
-    private fun getOpenState(lore: List<String>): OpenedState? {
-        return when {
-            keyUsedPattern.anyMatches(lore) -> OpenedState.KEY_USED
-            openedPattern.anyMatches(lore) -> OpenedState.OPENED
-            unopenedPattern.anyMatches(lore) -> OpenedState.UNOPENED
-            kuudraPattern.anyMatches(lore) -> OpenedState.UNOPENED
-            // Kuudra doesn't have an unopened, but it DOES have opened, this has to be after opened in when branch.
-            else -> {
-                ErrorManager.logErrorStateWithData(
-                    "Croesus Chest couldn't be read correctly.",
-                    "Open state check failed for chest.",
-                    "lore" to lore,
-                ).run { null }
-            }
-        }
     }
 
     private fun checkChests(inventory: Map<Int, ItemStack?>) {
@@ -378,9 +339,30 @@ object CroesusChestTracker {
         } ?: -1
         ) + 1
 
-    enum class OpenedState {
-        UNOPENED,
-        OPENED,
-        KEY_USED,
+    enum class OpenedState(val color: LorenzColor?) {
+        UNOPENED(LorenzColor.DARK_PURPLE),
+        OPENED(LorenzColor.DARK_AQUA),
+        KEY_USED(null),
+        ;
+
+        companion object {
+            fun getOpenState(lore: List<String>): OpenedState? {
+                return when {
+                    keyUsedPattern.anyMatches(lore) -> KEY_USED
+                    openedPattern.anyMatches(lore) -> OPENED
+                    unopenedPattern.anyMatches(lore) -> UNOPENED
+                    kuudraPattern.anyMatches(lore) -> UNOPENED
+                    // Kuudra doesn't have an unopened line, but it DOES have opened line, this has to be after opened in when branch.
+                    else -> {
+                        ErrorManager.logErrorStateWithData(
+                            "Croesus Chest couldn't be read correctly.",
+                            "Open state check failed for chest.",
+                            "lore" to lore,
+                        )
+                        null
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What
Kuudra chests don't have opened text that we rely  on, this should fix it but ion have a 4 stack and PF is broken so I'm gonna PR this and hope ig

## Changelog Fixes
+ Fixed Kuudra Chests being incorrectly marked as fully opened when opening Croesus. - Fazfoxy
+ Fixed Croesus Highlight not working on chests made on a separate game instance. - Fazfoxy