### PR TITLE
Backend: Graph Editor show disabled nodes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
@@ -236,8 +236,10 @@ class GraphNode(val id: Int, override val position: LorenzVec, val name: String?
 
     var enabled = true
         set(value) {
+            if (value != field) {
+                GraphEditor.flagDisabledDirty()
+            }
             field = value
-            GraphEditor.flagDisabledDirty()
         }
 
     /** Keys are the neighbours and value the edge weight (e.g. Distance) */

--- a/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/Graph.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.data.model
 
 import at.hannibal2.skyhanni.features.misc.pathfind.NavigationHelper
+import at.hannibal2.skyhanni.test.graph.GraphEditor
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
@@ -234,6 +235,10 @@ class GraphNode(val id: Int, override val position: LorenzVec, val name: String?
     }
 
     var enabled = true
+        set(value) {
+            field = value
+            GraphEditor.flagDisabledDirty()
+        }
 
     /** Keys are the neighbours and value the edge weight (e.g. Distance) */
     lateinit var neighbours: Map<GraphNode, Double>

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
@@ -44,7 +44,6 @@ object GraphEditor {
         private set
 
     fun flagDisabledDirty() {
-        ChatUtils.debug("flagDisabledDirty")
         disabledDirty = true
     }
 
@@ -76,7 +75,6 @@ object GraphEditor {
 
     private fun handleDisabled() {
         if (!disabledDirty) return
-        ChatUtils.debug("handleDisabled 1")
         val graph = IslandGraphs.currentIslandGraph ?: return
         disabledDirty = false
         GraphNodeEditor.handleDisabled(graph)

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditor.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.features.dev.GraphConfig
+import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.events.entity.EntityMoveEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -30,6 +31,7 @@ object GraphEditor {
             field = value
             updateRender()
             GraphNodeEditor.updateNodeNames()
+            flagDisabledDirty()
         }
 
     fun isEnabled(): Boolean = config.enabled
@@ -37,6 +39,14 @@ object GraphEditor {
     private val nodes get() = state.nodes
     private val inTutorialMode get() = state.inTutorialMode
     private val inEditMode get() = state.inEditMode
+    private var disabledDirty = false
+    var hideDisabled = false
+        private set
+
+    fun flagDisabledDirty() {
+        ChatUtils.debug("flagDisabledDirty")
+        disabledDirty = true
+    }
 
     fun feedBackInTutorial(text: String) {
         if (inTutorialMode) {
@@ -47,6 +57,7 @@ object GraphEditor {
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {
         if (!isEnabled()) return
+        handleDisabled()
         GraphEditorInput.input()
         if (event.isMod(5)) {
             updateRender()
@@ -61,6 +72,14 @@ object GraphEditor {
         state.closestNode = state.cachedNearbyNodes.minByOrNull { it.distanceSqToPlayer() }
 
         GraphEditorNodeFinder.handleAllNodeFind()
+    }
+
+    private fun handleDisabled() {
+        if (!disabledDirty) return
+        ChatUtils.debug("handleDisabled 1")
+        val graph = IslandGraphs.currentIslandGraph ?: return
+        disabledDirty = false
+        GraphNodeEditor.handleDisabled(graph)
     }
 
     @HandleEvent
@@ -129,6 +148,19 @@ object GraphEditor {
                 GraphEditorNetworks.findNetworks()
             }
         }
+        event.registerBrigadier("shgraphtoggledisabled") {
+            description = "Show or hide disabled nodes."
+            category = CommandCategory.DEVELOPER_TEST
+            simpleCallback {
+                toggleDisabledVisibility()
+            }
+        }
+    }
+
+    fun toggleDisabledVisibility() {
+        hideDisabled = !hideDisabled
+        val label = if (hideDisabled) "hides" else "shows"
+        ChatUtils.chat("Graph Editor now $label disabled nodes")
     }
 
     var bypassTempRemoveTimer = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorRenderer.kt
@@ -64,6 +64,9 @@ object GraphEditorRenderer {
     }
 
     private fun buildDisplay(): List<Renderable> = buildList {
+        if (GraphEditor.hideDisabled) {
+            add("§cDisabled nodes are hidden!")
+        }
         add("§eExit: §6${KeyboardManager.getKeyName(config.exitKey)}")
         if (!inEditMode && !inTextMode) {
             add("§ePlace: §6${KeyboardManager.getKeyName(config.placeKey)}")
@@ -110,6 +113,7 @@ object GraphEditorRenderer {
 
     private fun SkyHanniRenderWorldEvent.drawNode(node: GraphingNode) {
         if (!node.rendering) return
+        if (GraphEditor.hideDisabled && !node.enabled) return
         this.drawWaypointFilled(
             node.position,
             node.getNodeColor(),
@@ -120,37 +124,36 @@ object GraphEditorRenderer {
 
         val showTextAlways = seeThroughBlocks || node.distanceSqToPlayer() < 100
 
+        fun draw(text: String, yOff: Float) {
+            this.drawDynamicText(
+                node.position,
+                text,
+                scaleMultiplier = 0.8,
+                seeThroughBlocks = showTextAlways,
+                smallestDistanceVew = 12.0,
+                ignoreY = true,
+                yOff = yOff,
+                maxDistance = 80,
+            )
+        }
+
+        if (!node.enabled) {
+            draw("§cDisabled", yOff = -30f)
+        }
+
         val nodeName = if (inTextMode && node == activeNode) {
             textBox.finalText().ifEmpty { null }
         } else {
             node.name
         }
         if (nodeName != null) {
-            this.drawDynamicText(
-                node.position,
-                nodeName,
-                0.8,
-                seeThroughBlocks = showTextAlways,
-                smallestDistanceVew = 12.0,
-                ignoreY = true,
-                yOff = -15f,
-                maxDistance = 80,
-            )
+            draw(nodeName, yOff = -15f)
         }
 
         val tags = node.tags
         if (tags.isEmpty()) return
         val tagText = tags.joinToString(" §f+ ") { it.displayName }
-        this.drawDynamicText(
-            node.position,
-            tagText,
-            0.8,
-            seeThroughBlocks = showTextAlways,
-            smallestDistanceVew = 12.0,
-            ignoreY = true,
-            yOff = 0f,
-            maxDistance = 80,
-        )
+        draw(tagText, yOff = 0f)
     }
 
     private fun SkyHanniRenderWorldEvent.drawEdge(edge: GraphingEdge) {

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
@@ -262,14 +262,12 @@ object GraphNodeEditor {
     private var disabledLocations = setOf<LorenzVec>()
 
     fun handleDisabled(graph: Graph) {
-        ChatUtils.debug("handleDisabled 2")
         val newDisabled = mutableSetOf<LorenzVec>()
         for (node in graph) {
             if (!node.enabled) {
                 newDisabled.add(node.position)
             }
         }
-        ChatUtils.debug("disabledLocations: ${disabledLocations.size}")
 
         disabledLocations = newDisabled
         updateDisabledNames()

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.data.model.Graph
 import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.GraphUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.LorenzVec

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphNodeEditor.kt
@@ -1,11 +1,14 @@
 package at.hannibal2.skyhanni.test.graph
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.model.Graph
 import at.hannibal2.skyhanni.data.model.GraphNodeTag
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.GraphUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.KeyboardManager
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -76,6 +79,7 @@ object GraphNodeEditor {
                 add(list.buildSearchableScrollable(height, textInput, scrollValueNodes, velocity = 10.0))
             }
         }
+        updateDisabledNames()
     }
 
     private fun updateToggleTags() {
@@ -255,7 +259,30 @@ object GraphNodeEditor {
         },
     ).toSearchable(name)
 
-    fun isEnabled() = GraphEditor.isEnabled()
+    private var disabledLocations = setOf<LorenzVec>()
+
+    fun handleDisabled(graph: Graph) {
+        ChatUtils.debug("handleDisabled 2")
+        val newDisabled = mutableSetOf<LorenzVec>()
+        for (node in graph) {
+            if (!node.enabled) {
+                newDisabled.add(node.position)
+            }
+        }
+        ChatUtils.debug("disabledLocations: ${disabledLocations.size}")
+
+        disabledLocations = newDisabled
+        updateDisabledNames()
+    }
+
+    private fun updateDisabledNames() {
+        for (node in state.nodes) {
+            node.enabled = node.position !in disabledLocations
+        }
+    }
+
+    private fun isEnabled() = GraphEditor.isEnabled()
+
     private val config get() = GraphEditor.config
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphingNode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphingNode.kt
@@ -13,6 +13,7 @@ class GraphingNode(
 ) : GraphUtils.GenericNode {
 
     var rendering = true
+    var enabled = true
 
     override fun hashCode(): Int {
         return id


### PR DESCRIPTION
## What
We already had support for hiding nodes in the IslandArea navigation. Now, these disabled states sync up (via location comparison) with the nodes in the graph editor, allowing us to show the label "disabled" over disabled nodes, or hide them entirely (`/shgraphtoggledisabled`). Edges always stay visible (see images).

Just to clarify: the disabled state of a node cannot be modified in the graph editor. This is done entirely dynamically in code by features (e.g., the carnival).

<details>
<summary>Images</summary>

<img width="1197" height="775" alt="image" src="https://github.com/user-attachments/assets/67417d8f-41ce-40cc-97fd-0f2998a12de0" />

<img width="1285" height="824" alt="image" src="https://github.com/user-attachments/assets/94107f49-9f23-449b-942a-bccc2d6fc782" />

<img width="1748" height="687" alt="image" src="https://github.com/user-attachments/assets/13b4978b-5573-4fbc-a567-9a0587b591dc" />

<img width="1700" height="697" alt="image" src="https://github.com/user-attachments/assets/0055939b-4028-48fd-8fa1-3ffb869864e1" />


</details>

## Changelog Technical Details
+ Added disabled nodes support to Graph Editor. - hannibal2