### PR TITLE
Backend: Support for other RNG Meters in Copy RNG Meter Feature

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.OSUtils
@@ -21,19 +21,14 @@ object TestCopyRngMeterValues {
     private val patternGroup = RepoPattern.group("test.dev.copyrng")
 
     /**
-     * REGEX-TEST: §7§7Slayer XP: §d20,625§5/§d7,917
+     * REGEX-TEST: Slayer XP: 20,625/7,917
+     * REGEX-TEST: Dungeon Score: 489,850/75,000
+     * REGEX-TEST: Frozen Corpse XP: 20,625/60,000
+     * REGEX-TEST: Experimental XP: 20,105/150,000
      */
-    private val slayerPattern by patternGroup.pattern(
-        "slayer",
-        "§7§7Slayer XP: §d.*§5/§d(?<xp>.*)"
-    )
-
-    /**
-     * REGEX-TEST: §7§7Dungeon Score: §d1,237§5/§d40,620
-     */
-    private val dungeonPattern by patternGroup.pattern(
-        "dungeon",
-        "§7§7Dungeon Score: §d.*§5/§d(?<xp>.*)"
+    private val rngScorePattern by patternGroup.pattern(
+        "rngscore",
+        "((?:Slayer|Experimental|Nucleus|Frozen Corpse) XP|Dungeon Score): .*/(?<xp>.*)",
     )
 
     @HandleEvent
@@ -42,11 +37,8 @@ object TestCopyRngMeterValues {
 
         val map = mutableMapOf<NeuInternalName, Long>()
         for (item in event.inventoryItems.values) {
-            for (line in item.getLore()) {
-                slayerPattern.matchMatcher(line) {
-                    map[item.getInternalName()] = group("xp").formatLong()
-                }
-                dungeonPattern.matchMatcher(line) {
+            for (line in item.getLoreComponent()) {
+                rngScorePattern.matchMatcher(line) {
                     map[item.getInternalName()] = group("xp").formatLong()
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
@@ -25,6 +25,7 @@ object TestCopyRngMeterValues {
      * REGEX-TEST: Dungeon Score: 489,850/75,000
      * REGEX-TEST: Frozen Corpse XP: 20,625/60,000
      * REGEX-TEST: Experimental XP: 20,105/150,000
+     * REGEX-TEST: Nucleus XP: 202,105/320,000
      */
     private val rngScorePattern by patternGroup.pattern(
         "rngscore",

--- a/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
@@ -28,7 +28,7 @@ object TestCopyRngMeterValues {
      */
     private val rngScorePattern by patternGroup.pattern(
         "rngscore",
-        "((?:Slayer|Experimental|Nucleus|Frozen Corpse) XP|Dungeon Score): .*/(?<xp>.*)",
+        "(?:(?:Slayer|Experimental|Nucleus|Frozen Corpse) XP|Dungeon Score): .*/(?<xp>.*)"
     )
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestCopyRngMeterValues.kt
@@ -29,7 +29,7 @@ object TestCopyRngMeterValues {
      */
     private val rngScorePattern by patternGroup.pattern(
         "rngscore",
-        "(?:(?:Slayer|Experimental|Nucleus|Frozen Corpse) XP|Dungeon Score): .*/(?<xp>.*)"
+        "(?:(?:Slayer|Experimental|Nucleus|Frozen Corpse) XP|Dungeon Score): [\\d,.kM]+/(?<xp>[\\d,.kM]+)"
     )
 
     @HandleEvent


### PR DESCRIPTION
## What
Hello everyone, and welcome to this amazing PR. In this PR, I wanted to work on a feature that has been around for about 85,622,400 seconds or in other numbers 85,622,400,000,000,000 nanoseconds (≈ 8.56224 × 10¹⁶ ns). It has been a great feature for all that time. Unfortunately, it has become somewhat outdated since the addition of the Experiments RNG Meter, the Nucleus RNG Meter, and a few days ago, the Frozen Corpse RNG Meter.

For that reason, I had the wonderful idea of updating this feature to add support for these very creative RNG meters.

_While you are reading this i would like to point out the small little fact that Octopuses have three hearts._

I hope you had a great time reading this very useful text, and I wish you a wonderful rest of your day.

Greetings,
Jani

## Changelog Technical Details
+ Added support for other RNG Meters in the Copy RNG Meter feature. - jani270

