### PR TITLE
Backend: ClientShutdownEvent & RenderShutdownEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -73,13 +73,6 @@ object SkyHanniMod {
         configManager.firstLoad()
         if (PlatformUtils.getRepoPatternDumpLocation() == null) EnoughUpdatesRepoManager.initRepo()
         MinecraftConsoleFilter.initLogging()
-        val runtime = Runtime.getRuntime()
-        runtime.addShutdownHook(
-            Thread { configManager.saveConfig(ConfigFileType.FEATURES, "shutdown-hook") },
-        )
-        runtime.addShutdownHook(
-            Thread { SkyHanniItemRenderCoordinator.closeAtlas() }
-        )
         try {
             if (PlatformUtils.getRepoPatternDumpLocation() == null) SkyHanniRepoManager.initRepo()
         } catch (e: Exception) {
@@ -102,6 +95,13 @@ object SkyHanniMod {
         Minecraft.getInstance().setScreen(screenToOpen)
         screenTicks = 0
         this.screenToOpen = null
+    }
+
+    @HandleEvent
+    fun onClientShutdown() {
+        configManager.saveConfig(ConfigFileType.FEATURES, "shutdown-hook")
+
+        SkyHanniItemRenderCoordinator.closeAtlas()
     }
 
     const val MODID: String = "skyhanni"

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -100,7 +100,10 @@ object SkyHanniMod {
     @HandleEvent
     fun onClientShutdown() {
         configManager.saveConfig(ConfigFileType.FEATURES, "shutdown-hook")
+    }
 
+    @HandleEvent
+    fun onRenderShutdown() {
         SkyHanniItemRenderCoordinator.closeAtlas()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.data.ActionBarData
 import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
+import at.hannibal2.skyhanni.events.minecraft.ClientShutdownEvent
 import at.hannibal2.skyhanni.events.minecraft.ResourcePackReloadEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
@@ -14,6 +15,7 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientWorldEvents
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents
@@ -88,6 +90,7 @@ object ClientEvents {
         ClientReceiveMessageEvents.MODIFY_GAME.register(::onModify)
         ClientReceiveMessageEvents.GAME_CANCELED.register(::onCanceled)
 
+        ClientLifecycleEvents.CLIENT_STOPPING.register { ClientShutdownEvent.post() }
     }
 
     var currentMessage: Component? = null

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/ClientShutdownEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/ClientShutdownEvent.kt
@@ -1,0 +1,7 @@
+package at.hannibal2.skyhanni.events.minecraft
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
+
+@PrimaryFunction("onClientShutdown")
+object ClientShutdownEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/RenderShutdownEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/RenderShutdownEvent.kt
@@ -1,0 +1,7 @@
+package at.hannibal2.skyhanni.events.minecraft
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
+
+@PrimaryFunction("onRenderShutdown")
+object RenderShutdownEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinWindow.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinWindow.java
@@ -1,0 +1,23 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.events.minecraft.RenderShutdownEvent;
+import com.mojang.blaze3d.platform.Window;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Window.class)
+public class MixinWindow {
+    @Inject(
+        method = "close",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/mojang/blaze3d/systems/RenderSystem;assertOnRenderThread()V",
+            shift = At.Shift.AFTER
+        )
+    )
+    private void onRenderShutdown(CallbackInfo ci) {
+        RenderShutdownEvent.INSTANCE.post();
+    }
+}


### PR DESCRIPTION
## What
Got rid of shutdown hooks, and instead created two new events:
* `ClientShutdownEvent`: gets fired on the `ClientLifecycleEvents.CLIENT_STOPPING` Fabric event
* `RenderShutdownEvent`: gets fired on `Window#close` with an assurance that we're on the render thread
  * `ClientShutdownEvent` would technically work for this right now, but with Mojang's plans to split the render thread from the main client thread in the future, we might as well separate it now.

This is meant to achieve two things:
* Fixes "Rendersystem called from wrong thread" error due to atlas closing whenever the game is closed.
* May or may not reduce instances of people's configs getting corrupted.

## Changelog Technical Details
+ Added `ClientShutdownEvent` and `RenderShutdownEvent` and migrated shutdown hooks to them as appropriate. - Luna
