### PR TITLE
Backend: A singular line change

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
@@ -107,7 +107,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
     fun getGitHubRepoPath(): String = githubRepoLocation.location
 
     // Will be invoked by the implementation of this class
-    fun registerCommands(event: CommandRegistrationEvent) {
+    internal fun registerCommands(event: CommandRegistrationEvent) {
         event.registerBrigadier(updateCommand) {
             description = "Remove and re-download the $commonName repo"
             category = CommandCategory.USERS_BUG_FIX


### PR DESCRIPTION
Stops live plugin(s) from complaining about this.

<img width="1323" height="506" alt="image" src="https://github.com/user-attachments/assets/67a6313a-c381-4098-951a-b843e56562fe" />

exclude_from_changelog