### PR TITLE
Fix: Visual Words in chat on 1.21.11

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -70,7 +71,7 @@ open class VisualWordGui : SkyHanniBaseScreen() {
 
         @JvmStatic
         fun onCommand() {
-            if (!SkyBlockUtils.onHypixel) {
+            if (!SkyBlockUtils.onHypixel && !OutsideSBFeature.MODIFY_VISUAL_WORDS.isSelected()) {
                 ChatUtils.userError("You need to join Hypixel to use this feature!")
             } else {
                 if (sbeConfigPath.exists()) drawImport = true

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinTextHandler.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinTextHandler.java
@@ -17,27 +17,18 @@ import java.util.List;
 @Mixin(StringSplitter.class)
 public class MixinTextHandler {
 
-    @WrapMethod(
-        //? if < 1.21.11 {
-        method = "splitLines(Lnet/minecraft/network/chat/FormattedText;ILnet/minecraft/network/chat/Style;Lnet/minecraft/network/chat/FormattedText;)Ljava/util/List;"
-        //?} else
-        //method = "splitLines(Lnet/minecraft/network/chat/FormattedText;ILnet/minecraft/network/chat/Style;Ljava/util/function/BiConsumer;)V"
-    )
     //? if < 1.21.11 {
+    @WrapMethod(
+        method = "splitLines(Lnet/minecraft/network/chat/FormattedText;ILnet/minecraft/network/chat/Style;Lnet/minecraft/network/chat/FormattedText;)Ljava/util/List;"
+    )
     private List<FormattedText> dontWrapOtherLines(FormattedText text, int maxWidth, Style style, FormattedText wrappedLinePrefix, Operation<List<FormattedText>> original) {
-    //?} else
-    //private void dontWrapOtherLines(FormattedText text, int maxWidth, Style style, BiConsumer<FormattedText, Boolean> biConsumer, Operation<Void> original) {
         ModifyVisualWords.INSTANCE.setChangeWords(false);
 
-        //? if < 1.21.11 {
         List<FormattedText> lines = original.call(text, maxWidth, style, wrappedLinePrefix);
-        //?} else
-        //original.call(text, maxWidth, style, biConsumer);
-
         ModifyVisualWords.INSTANCE.setChangeWords(true);
-        //? if < 1.21.11
         return lines;
     }
+    //? }
 
     @WrapMethod(
         method = "splitLines(Lnet/minecraft/network/chat/FormattedText;ILnet/minecraft/network/chat/Style;)Ljava/util/List;"


### PR DESCRIPTION
## What
<img width="668" height="395" alt="image" src="https://github.com/user-attachments/assets/53cc53a2-07bb-4372-8398-92f71a77569a" />

## Changelog Fixes
+ Fixed Visual Words not working in chat on 1.21.11. - bloxigus
