### PR TITLE
Fix: Figh kill combo not getting filtered

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -112,10 +112,11 @@ object ChatFilter {
 
     // Kill Combo
     /**
+     * REGEX-TEST: §6§l+175 Kill Combo
      * REGEX-TEST: §a§l+5 Kill Combo §r§8+§r§b3% §r§b✯ Magic Find
      */
     private val killComboPatterns = listOf(
-        "§.§l\\+(.*) Kill Combo (.*)".toPattern(),
+        "§.§l\\+(.*) Kill Combo(.*)".toPattern(),
         "§cYour Kill Combo has expired! You reached a (.*) Kill Combo!".toPattern(),
     )
     private val killComboMessages = listOf(


### PR DESCRIPTION
## What

from https://discord.com/channels/997079228510117908/1479082784499961856

## Changelog Fixes
+ Fixed high kill combo chat messages not getting filtered. - hannibal2