### PR TITLE
Backend: Fix VFE IDs on 1.21.11

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/render/SkyHanniVertexFormats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/SkyHanniVertexFormats.kt
@@ -13,21 +13,26 @@ internal typealias SHVFE = SkyHanniVertexFormats.SkyHanniVertexFormatElement
 
 object SkyHanniVertexFormats {
 
+    // 1.21.10, Minecraft registers 0-5, on 1.21.11 they register 0-6, so load the last registered ID dynamically.
+    val lastRegisteredId by lazy {
+        (0 until VertexFormatElement.MAX_COUNT).filter { VertexFormatElement.byId(it) != null }.max()
+    }
+
     internal enum class SkyHanniVertexFormatElement(
-        // The ID we use to register the format element with Minecraft.
-        // see safeRegister() for details on how this is used and determined at runtime.
-        private val registrationId: Int,
         private val index: Int = 0,
         private val type: VFEType = VFEType.FLOAT,
         private val usage: VFEUsage = VFEUsage.GENERIC,
         private val count: Int = 4,
     ) {
         // {radius, smoothness/borderThickness, adjustedHalfSizeX, adjustedHalfSizeY}
-        ROUNDED_PARAMS_0(6),
+        ROUNDED_PARAMS_0,
         // {adjustedCenterPosX, adjustedCenterPosY, borderBlur/0, 0}
-        ROUNDED_PARAMS_1(7),
+        ROUNDED_PARAMS_1,
         ;
 
+        // The ID we use to register the format element with Minecraft.
+        // see safeRegister() for details on how this is used and determined at runtime.
+        private val registrationId: Int by lazy { lastRegisteredId + (ordinal + 1) }
         val element by lazy { safeRegister(registrationId, index, type, usage, count) }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/SkyHanniVertexFormats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/SkyHanniVertexFormats.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.utils.render
 
 import at.hannibal2.skyhanni.mixins.transformers.renderer.MixinBufferBuilderAccessor
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import com.mojang.blaze3d.vertex.BufferBuilder
 import com.mojang.blaze3d.vertex.VertexFormat
 import com.mojang.blaze3d.vertex.VertexFormatElement
@@ -56,7 +57,7 @@ object SkyHanniVertexFormats {
         // Todo, it is exceptionally unlikely that a user will have enough mods to register 27 more vertex format elements,
         //  but, technically possible, and something we should account for eventually.
         val id = (desiredId until VertexFormatElement.MAX_COUNT).first { VertexFormatElement.byId(it) == null }
-        if (id != desiredId) ErrorManager.logErrorStateWithData(
+        if (id != desiredId && PlatformUtils.isDevEnvironment) ErrorManager.logErrorStateWithData(
             "VertexFormatElement ID $desiredId was already taken, using $id instead",
             "SkyHanni vertex format element ID conflict. Desired ID $desiredId was already registered",
         )


### PR DESCRIPTION
1.21.10, Minecraft registers 0-5, on 1.21.11 they register 0-6, so load the last registered ID dynamically.

exclude_from_changelog