### PR TITLE
Fix: Croesus Overlay Errors from 5322 & Book Pattern error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -33,7 +33,6 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.NONE
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.PetUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
@@ -135,8 +134,13 @@ object InstanceChestProfit {
      * REGEX-TEST: Enchanted Book (§d§lCombo I§f)
      */
     private val bookColorFixer by patternGroup.pattern(
+        "bookcolorfixnew",
+        "(?<item>.+)(?:§.)+",
+    )
+
+    private val bookColorFixerold by patternGroup.pattern(
         "bookcolorfix",
-        "Enchanted Book \\((?<item>.+)(?:§.)+",
+        "Enchanted Book\\((?<item>.+)(?:§.)+\\)"
     )
 
     private val config get() = SkyHanniMod.feature.combat.instanceChestProfit
@@ -232,11 +236,10 @@ object InstanceChestProfit {
                 }
             } else {
                 var itemPrice: Double
-                var itemName = ItemUtils.readBookType(loreLine) ?: loreLine
-                var itemInternalName = NeuInternalName.fromItemNameOrNull(itemName)
-                bookColorFixer.matchMatcher(itemName) {
-                    itemName = ItemResolutionQuery.resolveEnchantmentByName(group("item"))?.repoItemName ?: itemName
-                    itemInternalName = itemName.toInternalName()
+                val bookCheckedLoreLine = ItemUtils.readBookType(loreLine) ?: loreLine
+                var itemInternalName = NeuInternalName.fromItemNameOrNull(bookCheckedLoreLine)
+                bookColorFixer.matchMatcher(bookCheckedLoreLine) {
+                    itemInternalName = ItemResolutionQuery.resolveEnchantmentByName(group("item")) ?: itemInternalName
                 }
                 val internalName = itemInternalName
                 var favorited = ""

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -130,14 +130,18 @@ object InstanceChestProfit {
     )
 
     /**
-     * REGEX-TEST: Enchanted Book (§d§lWisdom I§f)
-     * REGEX-TEST: Enchanted Book (§d§lCombo I§f)
+     * REGEX-TEST: §d§lWisdom I§f
+     * REGEX-TEST: §d§lCombo I§f
      */
     private val bookColorFixer by patternGroup.pattern(
         "bookcolorfixnew",
         "(?<item>.+)(?:§.)+",
     )
 
+    /**
+     * REGEX-TEST: Enchanted Book (§d§lWisdom I§f)
+     * REGEX-TEST: Enchanted Book (§d§lCombo I§f)
+     */
     private val bookColorFixerold by patternGroup.pattern(
         "bookcolorfix",
         "Enchanted Book\\((?<item>.+)(?:§.)+\\)"

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -142,6 +142,7 @@ object InstanceChestProfit {
      * REGEX-TEST: Enchanted Book (§d§lWisdom I§f)
      * REGEX-TEST: Enchanted Book (§d§lCombo I§f)
      */
+    @Suppress("UnusedPrivateProperty") // Remove after 7.6.0 is pushed
     private val bookColorFixerold by patternGroup.pattern(
         "bookcolorfix",
         "Enchanted Book\\((?<item>.+)(?:§.)+\\)"

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -131,12 +131,12 @@ object InstanceChestProfit {
     )
 
     /**
-     * REGEX-TEST: §d§lUltimate Wise I§f
-     * REGEX-TEST: §d§lCombo I§f
+     * REGEX-TEST: Enchanted Book (§d§lWisdom I§f)
+     * REGEX-TEST: Enchanted Book (§d§lCombo I§f)
      */
     private val bookColorFixer by patternGroup.pattern(
         "bookcolorfix",
-        "(?<item>.+)(?:§.)+",
+        "Enchanted Book \\((?<item>.+)(?:§.)+",
     )
 
     private val config get() = SkyHanniMod.feature.combat.instanceChestProfit

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -52,6 +52,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.item.ItemStack
 
 @SkyHanniModule
+@Suppress("UnusedPrivateProperty")
 object InstanceChestProfit {
     private val patternGroup = RepoPattern.group("combat.instance-chest-profit")
 
@@ -142,10 +143,9 @@ object InstanceChestProfit {
      * REGEX-TEST: Enchanted Book (§d§lWisdom I§f)
      * REGEX-TEST: Enchanted Book (§d§lCombo I§f)
      */
-    @Suppress("UnusedPrivateProperty") // Remove after 7.6.0 is pushed
-    private val bookColorFixerold by patternGroup.pattern(
+    private val bookColorFixerold by patternGroup.pattern( // Remove after 7.6.0 is pushed
         "bookcolorfix",
-        "Enchanted Book\\((?<item>.+)(?:§.)+\\)"
+        "Enchanted Book \\((?<item>.+)(?:§.)+\\)"
     )
 
     private val config get() = SkyHanniMod.feature.combat.instanceChestProfit

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -103,6 +103,13 @@ object CroesusChestTracker {
 
     private var display: List<Renderable>? = null
 
+    private val chestSlots = listOf(
+        10..16,
+        19..25,
+        28..34,
+        37..43,
+    )
+
     private val croesusChests get() = ProfileStorageData.profileSpecific?.dungeons?.runs
 
     @HandleEvent(GuiContainerEvent.BackgroundDrawnEvent::class, priority = HandleEvent.LOW, onlyOnSkyblock = true)
@@ -111,8 +118,10 @@ object CroesusChestTracker {
 
         if (!inCroesusInventory || croesusEmpty) return
         InventoryUtils.getItemsInOpenChest().forEach { slot ->
-            val color = (OpenedState.getOpenState(slot.item.getLore()) ?: return@forEach).color ?: return@forEach
-            slot.highlight(color)
+            if (chestSlots.any { it.contains(slot.containerSlot) }) {
+                val color = (OpenedState.getOpenState(slot.item.getLore()) ?: return@forEach).color ?: return@forEach
+                slot.highlight(color)
+            }
         }
     }
 


### PR DESCRIPTION
## What
I understand what was broken now
Splitting the pattern seems to fix it but also is duplicating the functionality of another pattern but seemed to fix it in my testing, worth trying for the sake of people who are on 7.5.0

## Changelog Fixes
+ Fixed Croesus Highlight errors. - Fazfoxy
+ Fixed Croesus Chest Overlay Profit. - Fazfoxy

