### PR TITLE
Fix: Island Change Event not firing when it should've

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -135,6 +135,7 @@ object HypixelData {
     private var lastSuccessfulServerIdFetchTime = SimpleTimeMark.farPast()
     private var lastSuccessfulServerIdFetchType: String? = null
     private var failedServerIdFetchCounter = 0
+    private var hasPostedIslandChangeEvent = false
 
     // Ironman, Stranded and Bingo
     var noTrade = false
@@ -308,6 +309,7 @@ object HypixelData {
 
     @HandleEvent
     fun onWorldChange() {
+        hasPostedIslandChangeEvent = false
         locrawData = null
         skyBlock = false
         inLimbo = false
@@ -553,10 +555,11 @@ object HypixelData {
             newIsland = getIslandType(foundIsland, guesting)
         }
 
-        if (skyBlockIsland != newIsland && !eitherIsNone(skyBlockIsland, newIsland)) {
+        if (!hasPostedIslandChangeEvent && !eitherIsNone(skyBlockIsland, newIsland)) {
             val oldIsland = skyBlockIsland
             skyBlockIsland = newIsland
             IslandChangeEvent(newIsland, oldIsland).post()
+            hasPostedIslandChangeEvent = true
             HypixelLocationApi.checkEquals()
 
             if (newIsland == IslandType.UNKNOWN) {


### PR DESCRIPTION
## What
yeah I did expect that one to break stuff

## Changelog Fixes
+ Fixed some features not working when changing from 1 island to the same island type. (e.g. Hub -> Hub) . - Fazfoxy
