### PR TITLE
Fix: Revert HypixelData Changes from 5270 due to event issues

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -45,6 +45,7 @@ import net.minecraft.client.Minecraft
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
+@Suppress("UnusedPrivateProperty")
 object HypixelData {
 
     private val patternGroup = RepoPattern.group("data.hypixeldata")
@@ -446,7 +447,8 @@ object HypixelData {
     fun onSkyBlockLeave(event: SkyBlockLeaveEvent) {
         val oldIsland = skyBlockIsland
         if (oldIsland != IslandType.NONE) {
-            IslandChangeEvent(IslandType.NONE, oldIsland)
+            skyBlockIsland = IslandType.NONE
+            IslandChangeEvent(skyBlockIsland, oldIsland)
         }
     }
 
@@ -553,7 +555,8 @@ object HypixelData {
             newIsland = getIslandType(foundIsland, guesting)
         }
 
-        if (skyBlockIsland != newIsland && !eitherIsNone(skyBlockIsland, newIsland)) {
+        // TODO Re-Add EitherIsNone, reverted alongside rest of changes from #5270 due to event firing issues
+        if (skyBlockIsland != newIsland) {
             val oldIsland = skyBlockIsland
             skyBlockIsland = newIsland
             IslandChangeEvent(newIsland, oldIsland).post()

--- a/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
@@ -6,4 +6,4 @@ import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
 @PrimaryFunction("onIslandChange")
 class IslandChangeEvent(val newIsland: IslandType, val oldIsland: IslandType) : SkyHanniEvent()
-//TODO: old Island never works due to being set to none in SkyblockLeaveEvent and Skyblock Leave Event firing every Island swap
+// TODO old Island never works due to being set to none in SkyblockLeaveEvent and Skyblock Leave Event firing every Island swap

--- a/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
@@ -6,3 +6,4 @@ import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
 @PrimaryFunction("onIslandChange")
 class IslandChangeEvent(val newIsland: IslandType, val oldIsland: IslandType) : SkyHanniEvent()
+//TODO: old Island never works due to being set to none in SkyblockLeaveEvent and Skyblock Leave Event firing every Island swap


### PR DESCRIPTION
## What
This seems better than slowly working out all the backend issues with a better solution

## Changelog Fixes
+ Fixed some island features not working after server swapping. - Fazfoxy
    * This is a temporary fix so SHO AutoLoad & Rift Motes session will not work again.