### PR TITLE
Fix: Composter Display Flag when Factors Update

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -630,7 +630,6 @@ object ComposterOverlay {
         }
     }
 
-    // TODO add neu repo reload support
     private fun updateOrganicMatterFactors() {
         try {
             organicMatterFactors = updateOrganicMatterFactors(organicMatter)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -634,6 +634,7 @@ object ComposterOverlay {
     private fun updateOrganicMatterFactors() {
         try {
             organicMatterFactors = updateOrganicMatterFactors(organicMatter)
+            displayDirty = true
         } catch (e: Exception) {
             ErrorManager.logErrorWithData(
                 e, "Failed to calculate composter overlay data",


### PR DESCRIPTION
## What
Flags the display as needing re-draw when factors are updated from repo.

https://discord.com/channels/997079228510117908/1094190239532208228/1479865683721584641

## Changelog Fixes
+ Fixed Composter Overlay not reloading when repo does. - Daveed

