### PR TITLE
Improvement: Copy amount for missing sack items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.isDouble
+import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.makePrimitiveStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher

--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
@@ -164,7 +164,11 @@ object GetFromSackApi {
 
     private fun bazaarMessage(item: String, amount: Int, isRemaining: Boolean = false) = ChatUtils.clickableChat(
         "§lCLICK §r§eto get the ${if (isRemaining) "remaining " else ""}§ax$amount §9$item §efrom bazaar",
-        onClick = { HypixelCommands.bazaar(item.removeColor()) }, "§eClick to find on the bazaar!",
+        onClick = {
+            OSUtils.copyToClipboard(amount.toString())
+            HypixelCommands.bazaar(item.removeColor())
+        },
+        "§eClick to find on the bazaar!",
     )
 
     private fun commandValidator(args: List<String>): Pair<CommandResult, PrimitiveItemStack?> {


### PR DESCRIPTION
## What
Adds a copy to the clipboard when trying to get missing items for /gfs from the bazaar.

## Changelog Improvements
+ Added a copy to clipboard for missing sack items. - ILike2WatchMemes

