### PR TITLE
Backend: Crimson Faction Quests Graph Editor usage

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/nether/RescueMissionWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/RescueMissionWaypoints.kt
@@ -281,10 +281,7 @@ object RescueMissionWaypoints {
     private fun navigateToUndercoverAgent() {
         if (!config.agentPath) return
         val factionType = CrimsonIsleReputationApi.factionType ?: return
-        val undercoverAgentNode = when (factionType) {
-            FactionType.MAGE -> IslandGraphs.node("Undercover Agent (Mage)", GraphNodeTag.NPC)
-            FactionType.BARBARIAN -> IslandGraphs.node("Undercover Agent (Barbarian)", GraphNodeTag.NPC)
-        }
+        val undercoverAgentNode = factionType.getUndercoverAgentNode()
 
         undercoverAgentNode.pathFind(
             "§5${factionType.factionName} Undercover Agent",
@@ -295,8 +292,7 @@ object RescueMissionWaypoints {
 
     private fun navigateToQuestBoard(reason: String) {
         val location = DailyQuestHelper.getQuestBoardLocation()
-        IslandGraphs.pathFind(
-            location,
+        location.pathFind(
             "Head back to Quest board, $reason",
             LorenzColor.WHITE.toColor(),
             condition = { (config.agentPath || config.hostagePath) },

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/FactionType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/FactionType.kt
@@ -1,9 +1,19 @@
 package at.hannibal2.skyhanni.features.nether.reputationhelper
 
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.model.GraphNode
+import at.hannibal2.skyhanni.data.model.GraphNodeTag
+
 enum class FactionType(val factionName: String, val apiName: String) {
     BARBARIAN("Barbarian", "barbarians"),
     MAGE("Mage", "mages"),
     ;
+
+    private val nodeSuffix = "($factionName)"
+
+    fun getUndercoverAgentNode(): GraphNode = IslandGraphs.node("Undercover Agent $nodeSuffix", GraphNodeTag.NPC)
+
+    fun getQuestBoardNode(): GraphNode = IslandGraphs.node("Quest Board $nodeSuffix", GraphNodeTag.POI)
 
     companion object {
         fun fromName(name: String): FactionType? = entries.firstOrNull { it.factionName.equals(name, ignoreCase = true) }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage
 import at.hannibal2.skyhanni.data.CrimsonIsleReputationApi
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacksOrNull
+import at.hannibal2.skyhanni.data.model.GraphNode
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
@@ -60,10 +61,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object DailyQuestHelper {
-
-    private val questBoardMage = LorenzVec(-138, 92, -755)
-    private val questBoardBarbarian = LorenzVec(-572, 100, -687)
-
     val quests = mutableListOf<Quest>()
 
     val patternGroup = RepoPattern.group("crimson.reputationhelper.quest")
@@ -235,12 +232,10 @@ object DailyQuestHelper {
         renderTownBoard(event)
     }
 
-    fun getQuestBoardLocation(): LorenzVec {
+    fun getQuestBoardLocation(): GraphNode {
         val factionType = CrimsonIsleReputationApi.factionType ?: ErrorManager.skyHanniError("faction type is unknown")
-        return when (factionType) {
-            FactionType.BARBARIAN -> questBoardBarbarian
-            FactionType.MAGE -> questBoardMage
-        }
+
+        return factionType.getQuestBoardNode()
     }
 
     private fun renderTownBoard(event: SkyHanniRenderWorldEvent) {
@@ -248,7 +243,7 @@ object DailyQuestHelper {
 
         // we do not call getQuestBoardLocation in the first few seconds when faction type is null, since this will show an error
         if (CrimsonIsleReputationApi.factionType == null && SkyBlockUtils.lastWorldSwitch.passedSince() < 5.seconds) return
-        val location = getQuestBoardLocation()
+        val location = getQuestBoardLocation().position
         event.drawWaypointFilled(location, LorenzColor.WHITE.toColor())
         event.drawDynamicText(location, "Town Board", 1.5)
     }


### PR DESCRIPTION
## What
removes existing hard-coded locations and instead uses the graph data for this navigation target.

Cleaned up existing code and moved get node logic into fraction type enum.

## Changelog Technical Details
+ Changed Crimson Isle Faction Quests to use the Graph Editor more. - hannibal2