### PR TITLE
Backend: Don't run Detekt on all Types

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -2,6 +2,7 @@ name: Detekt
 
 on:
     pull_request_target:
+        types: [opened, synchronize, reopened]
         branches:
             - "*"
     workflow_dispatch:


### PR DESCRIPTION
## What
Changes the `detekt` workflow to only fire on `opened`, `reopened`, or `synchronize`. In practice, this will stop the job from starting to run on `/beta`, then cancelling, which marks it as a failure:

<img width="663" height="122" alt="image" src="https://github.com/user-attachments/assets/e32a86a2-37f1-437c-9b06-0ff43754f06f" />

exclude_from_changelog
