### PR TITLE
Fix: YouTuber Tab Matching

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -13,8 +13,8 @@ import at.hannibal2.skyhanni.features.misc.ContributorManager
 import at.hannibal2.skyhanni.features.misc.MarkedPlayerManager
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
+import at.hannibal2.skyhanni.utils.NumberUtil.formatIntOrNull
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -78,18 +78,8 @@ object AdvancedPlayerList {
             val playerData: PlayerData? = levelPattern.matchMatcher(line) {
                 val levelText = group("level")
                 val removeColor = levelText.removeColor()
-                try {
-                    val sbLevel = removeColor.toIntOrNull() ?: return@matchMatcher null
-                    readPlayerData(sbLevel, levelText, line)
-                } catch (e: NumberFormatException) {
-                    ErrorManager.logErrorWithData(
-                        e, "Advanced Player List failed to parse username",
-                        "line" to line,
-                        "i" to i,
-                        "original" to original,
-                    )
-                    null
-                }
+                val sbLevel = removeColor.formatIntOrNull() ?: return@matchMatcher null
+                readPlayerData(sbLevel, levelText, line)
             }
             playerData?.let {
                 val name = it.name

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -38,10 +38,11 @@ object AdvancedPlayerList {
      * REGEX-TEST: [290] Skirtwearer ꀾ♲
      * REGEX-TEST: [14] ColombianoGood Ⓑ
      * REGEX-TEST: [218] nightdives
+     * REGEX-TEST: [281] [YOUTUBE] Remittal
      */
     private val levelPattern by RepoPattern.pattern(
         "misc.compacttablist.advanced.level.colorless",
-        ".*\\[(?<level>.*)] (?<name>.*)",
+        ".*\\[(?<level>[\\d,]+)](?: \\[\\w+\\])? (?<name>.*)",
     )
 
     private var playerData = mutableMapOf<Component, PlayerData>()
@@ -78,7 +79,7 @@ object AdvancedPlayerList {
                 val levelText = group("level")
                 val removeColor = levelText.removeColor()
                 try {
-                    val sbLevel = removeColor.toInt()
+                    val sbLevel = removeColor.toIntOrNull() ?: return@matchMatcher null
                     readPlayerData(sbLevel, levelText, line)
                 } catch (e: NumberFormatException) {
                     ErrorManager.logErrorWithData(


### PR DESCRIPTION
## What
Changelog says it all.

## Changelog Fixes
+ Fixed Advanced Player List parsing YouTubers as numbers. - Daveed



exclude_from_changelog
reverted by https://github.com/hannibal002/SkyHanni/pull/5372