### PR TITLE
Backend: Remove unused NoHurtTime logic

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -185,18 +185,18 @@ class Mob(
 
     private fun internalHighlight() {
         highlightColor?.let { color ->
-            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(baseEntity, color) { !this.isInvisible() && condition() }
+            RenderLivingEntityHelper.setEntityColor(baseEntity, color) { !this.isInvisible() && condition() }
             extraEntities.forEach {
-                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(it, color) { !this.isInvisible() && condition() }
+                RenderLivingEntityHelper.setEntityColor(it, color) { !this.isInvisible() && condition() }
             }
         }
     }
 
     private fun internalRemoveColor() {
         if (highlightColor == null) return
-        RenderLivingEntityHelper.removeCustomRender(baseEntity)
+        RenderLivingEntityHelper.removeEntityColor(baseEntity)
         extraEntities.forEach {
-            RenderLivingEntityHelper.removeCustomRender(it)
+            RenderLivingEntityHelper.removeEntityColor(it)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -52,7 +52,7 @@ object MobHighlight {
             else -> return
         }
 
-        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+        RenderLivingEntityHelper.setEntityColor(
             mob.baseEntity,
             color.toColor().addAlpha(127),
         ) { isEnabled() }
@@ -72,7 +72,7 @@ object MobHighlight {
         val entity = event.entity
         if (!entity.isCorrupted()) return
 
-        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+        RenderLivingEntityHelper.setEntityColor(
             entity,
             LorenzColor.DARK_PURPLE.toColor().addAlpha(127),
         ) { config.corruptedMobHighlight }
@@ -99,7 +99,7 @@ object MobHighlight {
             else -> return
         }
 
-        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+        RenderLivingEntityHelper.setEntityColor(
             entity,
             color.toColor().addAlpha(alpha),
         ) { isEnabled() }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
@@ -174,7 +174,7 @@ object DungeonHideItems {
 
         if (isSkeletonSkull(entity)) {
             movingSkeletonSkulls[entity] = SimpleTimeMark.now()
-            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+            RenderLivingEntityHelper.setEntityColor(
                 entity,
                 LorenzColor.GOLD.toColor().addAlpha(60),
             ) { shouldColorMovingSkull(entity) }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
@@ -251,13 +251,12 @@ object DungeonLividFinder {
     private fun RemotePlayer.highlight(color: LorenzColor?) {
         if (color == null) {
             RenderLivingEntityHelper.removeEntityColor(this)
-            RenderLivingEntityHelper.removeNoHurtTime(this)
             return
         }
 
         val newColor = if (config.colorOverride != LividColorHighlight.DEFAULT) config.colorOverride.color as LorenzColor else color
 
-        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+        RenderLivingEntityHelper.setEntityColor(
             entity = this,
             color = newColor.toColor(),
             condition = { this.isLividColor(newColor) },
@@ -278,14 +277,13 @@ object DungeonLividFinder {
             val newLivid = livid ?: return
             val newColor = color ?: return
 
-            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+            RenderLivingEntityHelper.setEntityColor(
                 entity = newLivid,
                 color = newColor.toColor(),
                 condition = { newLivid.isLividColor(newColor) },
             )
         } else {
             RenderLivingEntityHelper.removeEntityColor(livid ?: return)
-            RenderLivingEntityHelper.removeNoHurtTime(livid ?: return)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/HighlightRareDianaMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/HighlightRareDianaMob.kt
@@ -19,6 +19,6 @@ object HighlightRareDianaMob {
         val rareMob = event.entity
 
         val color = config.color.toColor()
-        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(rareMob, color) { config.highlightRareMobs }
+        RenderLivingEntityHelper.setEntityColor(rareMob, color) { config.highlightRareMobs }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
@@ -166,7 +166,7 @@ object GoldenFishTimer {
         if (weakPattern.matches(event.message)) {
             goldenFishDespawnTimer = DESPAWN_TIME.fromServerNow()
             val entity = confirmedGoldenFishEntity ?: return
-            if (config.highlight) RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+            if (config.highlight) RenderLivingEntityHelper.setEntityColor(
                 entity,
                 LorenzColor.GREEN.toColor().addAlpha(100),
             ) { true }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -61,7 +61,7 @@ object HighlightMiningCommissionMobs {
         val entities = EntityUtils.getEntities<LivingEntity>()
         for ((type, entity) in active.flatMap { type -> entities.map { type to it } }) {
             if (type.isMob(entity)) {
-                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                RenderLivingEntityHelper.setEntityColor(
                     entity,
                     LorenzColor.YELLOW.toColor().addAlpha(127),
                 ) { isEnabled() && type in active }
@@ -92,7 +92,7 @@ object HighlightMiningCommissionMobs {
         val entity = event.entity
         for (type in active) {
             if (type.isMob(entity)) {
-                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                RenderLivingEntityHelper.setEntityColor(
                     entity,
                     LorenzColor.YELLOW.toColor().addAlpha(127),
                 ) { isEnabled() && type in active }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -82,7 +82,7 @@ object MarkedPlayerManager {
         }
 
     private fun RemotePlayer.setColor() {
-        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+        RenderLivingEntityHelper.setEntityColor(
             this,
             config.entityColor.get().toColor().addAlpha(127),
             ::isEnabled,
@@ -197,7 +197,7 @@ object MarkedPlayerManager {
                     ChatUtils.chat("§aMarked §eplayer §b$displayName§e!")
                 } else {
                     playerNamesToMark.remove(name)
-                    markedPlayers[name]?.let { RenderLivingEntityHelper.removeCustomRender(it) }
+                    markedPlayers[name]?.let { RenderLivingEntityHelper.removeEntityColor(it) }
                     markedPlayers.remove(name)
                     ChatUtils.chat("§cUnmarked §eplayer §b$displayName§e!")
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -273,7 +273,7 @@ object TrevorFeatures {
             // Solve for the fact that Moby also has the same ID as the Trapper
             val entityMob = MobData.entityToMob[entityTrapper] ?: return
             if (entityMob.name == "Moby") return
-            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entityTrapper, currentStatus.color) {
+            RenderLivingEntityHelper.setEntityColor(entityTrapper, currentStatus.color) {
                 config.cooldown
             }
             entityTrapper.getLorenzVec().let {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BlobbercystsHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BlobbercystsHighlight.kt
@@ -26,7 +26,7 @@ object BlobbercystsHighlight {
         if (!isEnabled()) return
         val entity = event.entity
         if (entity.name.string != BLOBBER_NAME) return
-        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, Color.RED.addAlpha(80)) { isEnabled() }
+        RenderLivingEntityHelper.setEntityColor(entity, Color.RED.addAlpha(80)) { isEnabled() }
         entityList.add(entity)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
@@ -62,7 +62,7 @@ object VoltHighlighter {
         for (entity in EntityUtils.getEntities<LivingEntity>()) {
             val state = getVoltState(entity).takeIf { it != VoltState.NO_VOLT } ?: continue
 
-            if (config.voltMoodMeter) RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+            if (config.voltMoodMeter) RenderLivingEntityHelper.setEntityColor(
                 entity,
                 state.color.toColor()
             ) { config.voltMoodMeter }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
@@ -118,7 +118,7 @@ object LivingCaveDefenseBlocks {
             val entity = getNearestMovingDefenseBlock(location)?.entity ?: return
             staticBlocks = staticBlocks.editCopy {
                 add(DefenseBlock(entity, location))
-                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+                RenderLivingEntityHelper.setEntityColor(
                     entity,
                     color.addAlpha(50),
                 ) { isEnabled() && staticBlocks.any { it.entity == entity } }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
@@ -41,7 +41,7 @@ object VerminHighlighter {
     fun tryAdd(entity: LivingEntity) {
         if (!isVermin(entity)) return
         val color = config.color.get().toColor().addAlpha(60)
-        RenderLivingEntityHelper.setEntityColorWithNoHurtTime(entity, color) { isEnabled() }
+        RenderLivingEntityHelper.setEntityColor(entity, color) { isEnabled() }
     }
 
     // This only gets called on config change, so the performance impact is minimal

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -195,7 +195,7 @@ object VampireSlayerFeatures {
             }
 
             if (shouldRender) {
-                RenderLivingEntityHelper.setEntityColorWithNoHurtTime(this, color) { isEnabled() }
+                RenderLivingEntityHelper.setEntityColor(this, color) { isEnabled() }
                 entityList.add(this)
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/HellionShieldHelper.kt
@@ -58,13 +58,13 @@ object HellionShieldHelper {
     fun Mob.setHellionShield(shield: HellionShield?) {
         shield?.let {
             hellionShieldMobs[this] = it
-            RenderLivingEntityHelper.setEntityColorWithNoHurtTime(
+            RenderLivingEntityHelper.setEntityColor(
                 this,
                 it.color.toColor().addAlpha(80),
             ) { SkyBlockUtils.inSkyBlock && SlayerApi.config.blazes.hellion.coloredMobs }
         } ?: run {
             hellionShieldMobs.remove(this)
-            RenderLivingEntityHelper.removeCustomRender(this)
+            RenderLivingEntityHelper.removeEntityColor(this)
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -20,6 +20,7 @@ object RenderLivingEntityHelper {
 
     @JvmStatic
     var areMobsHighlighted = false
+        private set
 
     @JvmStatic
     var currentGlowEvent: RenderEntityOutlineEvent? = null

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -18,8 +18,6 @@ object RenderLivingEntityHelper {
     private val entityColorMap = mutableMapOf<LivingEntity, Color>()
     private val entityColorCondition = ConcurrentHashMap<LivingEntity, () -> Boolean>()
 
-    private val entityNoHurtTimeCondition = mutableMapOf<LivingEntity, () -> Boolean>()
-
     @JvmStatic
     var areMobsHighlighted = false
 
@@ -54,15 +52,12 @@ object RenderLivingEntityHelper {
     fun onWorldChange() {
         entityColorMap.clear()
         entityColorCondition.clear()
-
-        entityNoHurtTimeCondition.clear()
     }
 
     @HandleEvent(SkyHanniTickEvent::class)
     fun onTick() {
         entityColorMap.removeIfKey { it.deceased }
         entityColorCondition.removeIfKey { it.deceased }
-        entityNoHurtTimeCondition.removeIfKey { it.deceased }
     }
 
     fun <T : LivingEntity> removeEntityColor(entity: T) {
@@ -76,24 +71,6 @@ object RenderLivingEntityHelper {
         entityColorCondition[entity] = condition
     }
 
-    private fun <T : LivingEntity> setEntityNoHurtTime(entity: T, condition: () -> Boolean) {
-        entityNoHurtTimeCondition[entity] = condition
-    }
-
-    fun <T : LivingEntity> setEntityColorWithNoHurtTime(entity: T, color: Color, condition: () -> Boolean) {
-        setEntityColor(entity, color, condition)
-        setEntityNoHurtTime(entity, condition)
-    }
-
-    fun <T : LivingEntity> removeNoHurtTime(entity: T) {
-        entityNoHurtTimeCondition.remove(entity)
-    }
-
-    fun <T : LivingEntity> removeCustomRender(entity: T) {
-        removeEntityColor(entity)
-        removeNoHurtTime(entity)
-    }
-
     @JvmStatic
     fun <T : LivingEntity> internalSetColorMultiplier(entity: T, default: Int): Int {
         if (GlobalRender.renderDisabled) return default
@@ -104,17 +81,5 @@ object RenderLivingEntityHelper {
             }
         }
         return default
-    }
-
-    @JvmStatic
-    fun <T : LivingEntity> internalChangeHurtTime(entity: T): Int {
-        if (GlobalRender.renderDisabled) return entity.hurtTime
-        run {
-            val condition = entityNoHurtTimeCondition[entity] ?: return@run
-            if (condition.invoke()) {
-                return 0
-            }
-        }
-        return entity.hurtTime
     }
 }


### PR DESCRIPTION
## What
Removed NoHurtTime logic that is unused and irrelevant on modern Minecraft, since our entity highlighting is now glow-based, which doesn't interfere with hurt time.

## Changelog Technical Details
+ Removed `RenderLivingEntityHelper.setEntityColorWithNoHurtTime` in favor of `RenderLivingEntityHelper.setEntityColor`. - Luna
