### PR TITLE
Fix: Custom Scoreboard Cache

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboard.kt
@@ -62,6 +62,8 @@ object CustomScoreboard {
 
     private var dirty = false
 
+    private var lastLines: List<ScoreboardLine> = emptyList()
+
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
@@ -111,9 +113,13 @@ object CustomScoreboard {
         if (dirty || nextScoreboardUpdate.isInPast()) {
             nextScoreboardUpdate = 250.milliseconds.fromNow()
             dirty = false
-            display = createLines().removeEmptyLinesFromEdges().createRenderable()
-            if (TabListData.fullyLoaded) {
-                cache = display
+            val newLines = createLines().removeEmptyLinesFromEdges()
+            if (newLines != lastLines) {
+                lastLines = newLines
+                display = newLines.createRenderable()
+                if (TabListData.fullyLoaded) {
+                    cache = display
+                }
             }
         }
 


### PR DESCRIPTION
## What
Currently, the custom scoreboard does two things every 250ms:
1. recalculating each line to a string
2. wrapping each string to a renderable

even though, most custom scoreboard elements only change once a second, many even updating way slower.

With this PR, we now cache the list of strings, and only run the "wrapping of strings to Renderables" if something changes.

to see this in action:

with the "show SkyBlock time" feature and its option "exact minutes" enabled, this updates around every 700ms.
with this patch,  there are two  cache hits per second.

without skyblcok time, without a timer active in the custom scoreboard, there is only one cache miss every 5ish seconds for my testings.

so overall, the amount of renderable creations saved is huge by this small change.

## Changelog Fixes
+ Improved Custom Scoreboard performance by caching rendered lines. - hannibal2