### PR TITLE
Backend: hide last 0 in version string

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/Features.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/Features.kt
@@ -60,7 +60,8 @@ class Features : Config() {
 
     override fun getTitle(): StructuredText {
         val modName = if (TimeUtils.isAprilFoolsDay) "SkyHanni".reversed() else "SkyHanni"
-        return "$modName ${SkyHanniMod.VERSION} by §channibal2§r, config by §5Moulberry §rand §5nea89".asStructuredText()
+        val version = SkyHanniMod.VERSION.removeSuffix(".0")
+        return "$modName $version by §channibal2§r, config by §5Moulberry §rand §5nea89".asStructuredText()
     }
 
     /*


### PR DESCRIPTION
## What
remove the last `.0` from the version string in the main config GUI title.
old: `7.7.0`
new: `7.7`

does not change the version string for the internal logic, the debug commands or error messaging

why? because we dont use the last digit practially, and this is the first step in getting users to know that there is no 0.1

https://github.com/SkyHanniStudios/SkyHanniChangelogBuilder/commit/2d3eebb0d89ff30dc2192e6397ca268ec9b412e1

next steps are the chagnelog builder to change the discord/github release messages (already done, see link above), and the final build jar file name (and in changelog builder!).

internally, id like to keep the three digits, maybe later also update the error messages? like, everything user facing? not sure.

## Changelog Technical Details
+ Removed the third digit from user facing version string if zero. - hannibal2