### PR TITLE
Backend: Deleting PetChangeEvent.kt

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/CurrentPetApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/CurrentPetApi.kt
@@ -1,11 +1,11 @@
 package at.hannibal2.skyhanni.api.pet
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.PetData
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
-import at.hannibal2.skyhanni.events.pets.PetChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.LorenzRarity
@@ -17,6 +17,8 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.enumMapOf
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.seconds
+
+class PetChangeEvent(val pet: PetData) : SkyHanniEvent()
 
 @SkyHanniModule
 object CurrentPetApi {

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.data.hotx
+package at.hannibal2.skyhanni.data.hotxfeel
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.HotfApi

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.data.hotxfeel
+package at.hannibal2.skyhanni.data.hotx
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.HotfApi

--- a/src/main/java/at/hannibal2/skyhanni/events/pets/PetChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/pets/PetChangeEvent.kt
@@ -1,6 +1,0 @@
-package at.hannibal2.skyhanni.events.pets
-
-import at.hannibal2.skyhanni.api.event.SkyHanniEvent
-import at.hannibal2.skyhanni.data.PetData
-
-class PetChangeEvent(val pet: PetData) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.garden.farming
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.pet.CurrentPetApi
+import at.hannibal2.skyhanni.api.pet.PetChangeEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.garden.MoneyPerHourConfig.CustomFormatEntry
 import at.hannibal2.skyhanni.data.IslandType
@@ -12,7 +13,6 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.garden.GardenToolChangeEvent
-import at.hannibal2.skyhanni.events.pets.PetChangeEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.GardenNextJacobContest


### PR DESCRIPTION
## What
Proof of concept!

This is how we could delete all event files by moving the class into the same file that mainly fires the event. this will be a data/api clas in most cases. That way, we can free up a lot of files in the project, and in the end we even have one fewer root level package.

## Changelog Technical Details
+ Moved `PetChangeEvent` to `CurrentPetApi.kt`. - hannibal2