### PR TITLE
Fix: Shadow Warp Cooldown Detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -90,7 +90,7 @@ object ItemAbilityCooldown {
                 }
             }
 
-            event.soundName == "random.fizz" && event.pitch == 0.4920635f && event.volume == 1f -> {
+            event.soundName == "block.lava.extinguish" && event.pitch == 0.4920635f && event.volume == 1f -> {
                 val scrolls = ItemAbility.getAllAbilityScrolls(InventoryUtils.getItemInHand())
                 if (scrolls.contains(ItemAbility.SHADOW_WARP_SCROLL)) {
                     ItemAbility.SHADOW_WARP_SCROLL.sound()


### PR DESCRIPTION
## What
Fixed sound name for Shadow Warp ability. This wasn't in SoundCompat so it was already broken on modern for a while.

The correct sound name has been confirmed via having someone test it.

## Changelog Fixes
+ Fixed cooldown display for Shadow Warp ability not working. - Luna