### PR TITLE
Fix: Only show HOTx UI element on Skyblock

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -30,7 +30,7 @@ object HotxFeatures {
 
     private val handlers = listOf(HotmData, HotfData)
 
-    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, onlyOnSkyblock = true)
     fun onRenderOverlay() {
         handlers.forEach { it.renderOverlay() }
     }


### PR DESCRIPTION
## What
When set to "Everywhere", HOTx UI elements (Sky Mall, Lottery) were visible outside of Skyblock.

This PR adds a check to ensure the feature is only enabled on Skyblock.

## Changelog Fixes
+ Fixed Sky Mall and Lottery HUD elements displaying outside of SkyBlock. - HyperKids
