### PR TITLE
Fix: Don't notify for Hoppity eggs on Stranded

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -298,6 +298,7 @@ object HoppityEggsManager {
 
     private fun warn() {
         if (!unclaimedEggsConfig.warningsEnabled) return
+        if (SkyBlockUtils.isStrandedProfile) return
         if (ReminderUtils.isBusy() && !unclaimedEggsConfig.warnWhileBusy) return
         if (lastWarnTime.passedSince() < 1.minutes) return
 


### PR DESCRIPTION
## What
Disabled Hoppity egg notification on Stranded, since they can't collect eggs (except via Hitman, but that has cooldowns).

## Changelog Fixes
+ Fixed Stranded players being notified to collect Hoppity eggs. - Luna