### PR TITLE
Fix: Hoppity display more than 100%

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/DisabledApiJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/DisabledApiJson.kt
@@ -10,4 +10,5 @@ data class DisabledApiJson(
     @Expose @SerializedName("disabled_elite_ah") val disabledEliteAh: Boolean,
     @Expose @SerializedName("disabled_elite_bz") val disabledEliteBz: Boolean,
     @Expose @SerializedName("disabled_elite_items") val disabledEliteItems: Boolean,
+    @Expose @SerializedName("disabled_counting_legacy_hoppity_locations") val disabledCountingLegacyHoppityLocations: Boolean,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.events.entity.EntityTransparencyTickEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.CFApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
@@ -82,8 +83,13 @@ object HoppityEggDisplayManager {
             val totalEggs = HoppityEggLocations.islandLocations.size
             if (totalEggs > 0) {
                 val collectedEggs = HoppityEggLocations.islandCollectedLocations.size
-                val collectedFormat = formatEggsCollected(collectedEggs)
+                val percentage = collectedEggs.toDouble() / totalEggs.toDouble()
+                val collectedFormat = formatEggsCollected(percentage)
                 add("§7Locations: $collectedFormat$collectedEggs§7/§a$totalEggs")
+                if (percentage > 1) {
+                    ChatUtils.debug("removeInvalidCollectedEggs! $collectedEggs/$totalEggs in ${SkyBlockUtils.currentIsland}")
+                    HoppityEggLocations.removeInvalidCollectedEggs()
+                }
             }
         }.map { CFApi.partyModeReplace(it) }
 
@@ -110,11 +116,11 @@ object HoppityEggDisplayManager {
         )
     }
 
-    private fun formatEggsCollected(collectedEggs: Int): String =
-        when (collectedEggs) {
-            in 0 until 5 -> "§c"
-            in 5 until 10 -> "§6"
-            in 10 until 15 -> "§e"
+    private fun formatEggsCollected(collectedEggs: Double): String =
+        when {
+            collectedEggs < 0.3 -> "§c"
+            collectedEggs < 0.6 -> "§6"
+            collectedEggs < 0.9 -> "§e"
             else -> "§a"
         }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.entity.EntityTransparencyTickEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.CFApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
@@ -82,14 +81,10 @@ object HoppityEggDisplayManager {
 
             val totalEggs = HoppityEggLocations.islandLocations.size
             if (totalEggs > 0) {
-                val collectedEggs = HoppityEggLocations.islandCollectedLocations.size
+                val collectedEggs = HoppityEggLocations.islandCollectedLocations.count { it in HoppityEggLocations.islandLocations }
                 val percentage = collectedEggs.toDouble() / totalEggs.toDouble()
                 val collectedFormat = formatEggsCollected(percentage)
                 add("§7Locations: $collectedFormat$collectedEggs§7/§a$totalEggs")
-                if (percentage > 1) {
-                    ChatUtils.debug("removeInvalidCollectedEggs! $collectedEggs/$totalEggs in ${SkyBlockUtils.currentIsland}")
-                    HoppityEggLocations.removeInvalidCollectedEggs()
-                }
             }
         }.map { CFApi.partyModeReplace(it) }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.api.ApiUtils
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
@@ -81,7 +82,11 @@ object HoppityEggDisplayManager {
 
             val totalEggs = HoppityEggLocations.islandLocations.size
             if (totalEggs > 0) {
-                val collectedEggs = HoppityEggLocations.islandCollectedLocations.count { it in HoppityEggLocations.islandLocations }
+                val collectedEggs = if (ApiUtils.isLegacyHoppityLocationCountingDisabled()) {
+                    HoppityEggLocations.islandCollectedLocations.count { it in HoppityEggLocations.islandLocations }
+                } else {
+                    HoppityEggLocations.islandCollectedLocations.size.coerceAtMost(HoppityEggLocations.islandLocations.size)
+                }
                 val percentage = collectedEggs.toDouble() / totalEggs.toDouble()
                 val collectedFormat = formatEggsCollected(percentage)
                 add("§7Locations: $collectedFormat$collectedEggs§7/§a$totalEggs")

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -69,6 +69,17 @@ object HoppityEggLocations {
         locations += location
     }
 
+    fun removeInvalidCollectedEggs() {
+        val thisIsland = collectedEggStorage[SkyBlockUtils.currentIsland] ?: return
+
+        for (location in islandCollectedLocations) {
+            if (location !in islandLocations) {
+                ChatUtils.debug("removed $location")
+                thisIsland.remove(location)
+            }
+        }
+    }
+
     private var loadedNeuThisProfile = false
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -69,17 +69,6 @@ object HoppityEggLocations {
         locations += location
     }
 
-    fun removeInvalidCollectedEggs() {
-        val thisIsland = collectedEggStorage[SkyBlockUtils.currentIsland] ?: return
-
-        for (location in islandCollectedLocations) {
-            if (location !in islandLocations) {
-                ChatUtils.debug("removed $location")
-                thisIsland.remove(location)
-            }
-        }
-    }
-
     private var loadedNeuThisProfile = false
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -130,6 +130,7 @@ object HoppityEggLocator {
                 // TODO add chroma color support via config
                 drawColor(eggLocation, LorenzColor.RED.toChromaColor(), false, alpha)
                 drawDynamicText(eggLocation.up(), "§cDuplicate Location!", 1.5)
+
             }
         }
     }
@@ -137,6 +138,7 @@ object HoppityEggLocator {
     private fun SkyHanniRenderWorldEvent.drawEggWaypoint(location: LorenzVec, label: String) {
         val shouldMarkDuplicate = waypointsConfig.highlightDuplicates && HoppityEggLocations.hasCollectedEgg(location)
         val possibleDuplicateLabel = if (shouldMarkDuplicate) "$label §c(Duplicate Location)" else label
+
         if (!shouldMarkDuplicate) {
             drawWaypointFilled(location, waypointsConfig.color.toColor(), seeThroughBlocks = true)
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/utils/api/ApiUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/api/ApiUtils.kt
@@ -129,4 +129,13 @@ object ApiUtils {
     fun isMoulberryLowestBinDisabled() = disabledApis?.disabledMoulberryLowestBin == true
     fun isHypixelItemsDisabled() = disabledApis?.disableHypixelItems == true
     fun isBazaarDisabled() = disabledApis?.disabledBazaar == true
+
+    /**
+     * Hypixel counts all hoppity locations ever found per island, not only the live ones. meaning, when an island changes big time,
+     * and the hoppity locations change, hypixel does not remove the legacy information from the player data.
+     * For fairy souls, hypixel properly moves the pointer/raw data for changed locations, for hoppity not. This toggle exists so we
+     * can change when hypixel decides to do the right thing and properly clears out invalid data from their user data.
+     * While this is not the case yet, we need to support invalid data to not show the user wrong data. thanks hypixel.
+     */
+    fun isLegacyHoppityLocationCountingDisabled() = disabledApis?.disabledCountingLegacyHoppityLocations == true
 }


### PR DESCRIPTION
## What
With the changed hub island, the hoppity locations have changed. this means, there were two invalid locations stored in the data for me, and with the other 15 locations, my display told me 17/15.

This PR now compares the numbes, and when more than 100% are found, removes all invalid ones.
as alternative, this should only check once on repo data load and not only when more than 100% are found, but thats for another time. the current pr works, thats whats important for me now.

## Changelog Fixes
+ Fixed showing more than 100% of found Hoppity locations on the island because of outdated config data. - hannibal2