### PR TITLE
Improvement: Hide unnecessary duplicate markers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.events.entity.EntityTransparencyTickEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.CFApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
@@ -82,8 +83,13 @@ object HoppityEggDisplayManager {
             val totalEggs = HoppityEggLocations.islandLocations.size
             if (totalEggs > 0) {
                 val collectedEggs = HoppityEggLocations.islandCollectedLocations.size
-                val collectedFormat = formatEggsCollected(collectedEggs)
+                val percentage = collectedEggs.toDouble() / totalEggs.toDouble()
+                val collectedFormat = formatEggsCollected(percentage)
                 add("§7Locations: $collectedFormat$collectedEggs§7/§a$totalEggs")
+                if (percentage > 1) {
+                    ChatUtils.debug("removeInvalidCollectedEggs! $collectedEggs/$totalEggs in ${SkyBlockUtils.currentIsland}")
+                    HoppityEggLocations.removeInvalidCollectedEggs()
+                }
             }
         }.map { CFApi.partyModeReplace(it) }
 
@@ -110,11 +116,11 @@ object HoppityEggDisplayManager {
         )
     }
 
-    private fun formatEggsCollected(collectedEggs: Int): String =
-        when (collectedEggs) {
-            in 0 until 5 -> "§c"
-            in 5 until 10 -> "§6"
-            in 10 until 15 -> "§e"
+    private fun formatEggsCollected(collectedEggs: Double): String =
+        when {
+            collectedEggs < 0.3 -> "§c"
+            collectedEggs < 0.6 -> "§6"
+            collectedEggs < 0.9 -> "§e"
             else -> "§a"
         }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.entity.EntityTransparencyTickEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.CFApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
@@ -82,14 +81,10 @@ object HoppityEggDisplayManager {
 
             val totalEggs = HoppityEggLocations.islandLocations.size
             if (totalEggs > 0) {
-                val collectedEggs = HoppityEggLocations.islandCollectedLocations.size
+                val collectedEggs = HoppityEggLocations.islandCollectedLocations.count { it in HoppityEggLocations.islandLocations }
                 val percentage = collectedEggs.toDouble() / totalEggs.toDouble()
                 val collectedFormat = formatEggsCollected(percentage)
                 add("§7Locations: $collectedFormat$collectedEggs§7/§a$totalEggs")
-                if (percentage > 1) {
-                    ChatUtils.debug("removeInvalidCollectedEggs! $collectedEggs/$totalEggs in ${SkyBlockUtils.currentIsland}")
-                    HoppityEggLocations.removeInvalidCollectedEggs()
-                }
             }
         }.map { CFApi.partyModeReplace(it) }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggDisplayManager.kt
@@ -90,6 +90,9 @@ object HoppityEggDisplayManager {
                     ChatUtils.debug("removeInvalidCollectedEggs! $collectedEggs/$totalEggs in ${SkyBlockUtils.currentIsland}")
                     HoppityEggLocations.removeInvalidCollectedEggs()
                 }
+                if (percentage >= 1) {
+                    HoppityEggLocations.setFoundAll()
+                }
             }
         }.map { CFApi.partyModeReplace(it) }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -6,8 +6,8 @@ import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.HoppityEggLocationsJson
 import at.hannibal2.skyhanni.events.IslandChangeEvent
-import at.hannibal2.skyhanni.events.ProfileViewerDataLoadedEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
+import at.hannibal2.skyhanni.events.ProfileViewerDataLoadedEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.CFApi

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -69,6 +69,17 @@ object HoppityEggLocations {
         locations += location
     }
 
+    fun removeInvalidCollectedEggs() {
+        val thisIsland = collectedEggStorage[SkyBlockUtils.currentIsland] ?: return
+
+        for (location in islandCollectedLocations) {
+            if (location !in islandLocations) {
+                ChatUtils.debug("removed $location")
+                thisIsland.remove(location)
+            }
+        }
+    }
+
     private var loadedNeuThisProfile = false
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.HoppityEggLocationsJson
+import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ProfileViewerDataLoadedEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
@@ -38,6 +39,18 @@ object HoppityEggLocations {
 
     fun getEggsIn(islandType: IslandType): Set<LorenzVec> {
         return collectedEggStorage[islandType].orEmpty()
+    }
+
+    var foundAllOnThisIsland = false
+        private set
+
+    fun setFoundAll() {
+        foundAllOnThisIsland = true
+    }
+
+    @HandleEvent
+    fun onWorldChange(event: IslandChangeEvent) {
+        foundAllOnThisIsland = false
     }
 
     fun hasCollectedEgg(location: LorenzVec): Boolean = islandCollectedLocations.contains(location)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocations.kt
@@ -69,17 +69,6 @@ object HoppityEggLocations {
         locations += location
     }
 
-    fun removeInvalidCollectedEggs() {
-        val thisIsland = collectedEggStorage[SkyBlockUtils.currentIsland] ?: return
-
-        for (location in islandCollectedLocations) {
-            if (location !in islandLocations) {
-                ChatUtils.debug("removed $location")
-                thisIsland.remove(location)
-            }
-        }
-    }
-
     private var loadedNeuThisProfile = false
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -130,6 +130,7 @@ object HoppityEggLocator {
                 // TODO add chroma color support via config
                 drawColor(eggLocation, LorenzColor.RED.toChromaColor(), false, alpha)
                 drawDynamicText(eggLocation.up(), "§cDuplicate Location!", 1.5)
+
             }
         }
     }
@@ -137,6 +138,7 @@ object HoppityEggLocator {
     private fun SkyHanniRenderWorldEvent.drawEggWaypoint(location: LorenzVec, label: String) {
         val shouldMarkDuplicate = waypointsConfig.highlightDuplicates && HoppityEggLocations.hasCollectedEgg(location)
         val possibleDuplicateLabel = if (shouldMarkDuplicate) "$label §c(Duplicate Location)" else label
+
         if (!shouldMarkDuplicate) {
             drawWaypointFilled(location, waypointsConfig.color.toColor(), seeThroughBlocks = true)
         } else {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -122,7 +122,10 @@ object HoppityEggLocator {
     }
 
     private fun SkyHanniRenderWorldEvent.drawDuplicateEggs(islandEggsLocations: Set<LorenzVec>) {
-        if (!waypointsConfig.highlightDuplicates || !waypointsConfig.showNearbyDuplicates) return
+        if (!waypointsConfig.highlightDuplicates) return
+        if (!waypointsConfig.showNearbyDuplicates) return
+        if (HoppityEggLocations.foundAllOnThisIsland) return
+
         for (eggLocation in islandEggsLocations) {
             val dist = eggLocation.distanceToPlayer()
             if (dist < 10 && HoppityEggLocations.hasCollectedEgg(eggLocation)) {
@@ -130,15 +133,17 @@ object HoppityEggLocator {
                 // TODO add chroma color support via config
                 drawColor(eggLocation, LorenzColor.RED.toChromaColor(), false, alpha)
                 drawDynamicText(eggLocation.up(), "§cDuplicate Location!", 1.5)
-
             }
         }
     }
 
     private fun SkyHanniRenderWorldEvent.drawEggWaypoint(location: LorenzVec, label: String) {
-        val shouldMarkDuplicate = waypointsConfig.highlightDuplicates && HoppityEggLocations.hasCollectedEgg(location)
-        val possibleDuplicateLabel = if (shouldMarkDuplicate) "$label §c(Duplicate Location)" else label
+        val shouldMarkDuplicate =
+            waypointsConfig.highlightDuplicates &&
+                HoppityEggLocations.hasCollectedEgg(location) &&
+                !HoppityEggLocations.foundAllOnThisIsland
 
+        val possibleDuplicateLabel = if (shouldMarkDuplicate) "$label §c(Duplicate Location)" else label
         if (!shouldMarkDuplicate) {
             drawWaypointFilled(location, waypointsConfig.color.toColor(), seeThroughBlocks = true)
         } else {


### PR DESCRIPTION
## Dependencies
- #5394

## What
the dupliate markers annoy me. tho, on new islands they are useful to have

## Changelog Improvements
+ Changed Duplicate Location Markers to no longer show after all Hoppity Egg locations on the island are found. - hannibal2