### PR TITLE
Fix + Backend: Island Detect

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -450,6 +450,13 @@ object HypixelData {
         }
     }
 
+    fun workaroundChangeTo(new: IslandType) {
+        ChatUtils.debug("workaroundChangeTo $new")
+        val old = skyBlockIsland
+        IslandChangeEvent(new, old).post()
+        skyBlockIsland = new
+    }
+
     @HandleEvent
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         when (event.widget) {

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -1,15 +1,15 @@
 package at.hannibal2.skyhanni.data
 
-import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.SkyHanniMod.launchCoroutine
 import at.hannibal2.skyhanni.api.enoughupdates.EnoughUpdatesRepoManager
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.hypixelapi.HypixelLocationApi
 import at.hannibal2.skyhanni.config.ConfigManager.Companion.gson
+import at.hannibal2.skyhanni.data.hypixel.SkyBlockLocationData
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.repo.ChatProgressUpdates
 import at.hannibal2.skyhanni.data.repo.SkyHanniRepoManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
@@ -19,18 +19,16 @@ import at.hannibal2.skyhanni.events.hypixel.HypixelLeaveEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
-import at.hannibal2.skyhanni.events.skyblock.SkyBlockLeaveEvent
+import at.hannibal2.skyhanni.events.skyblock.SkyBlockJoinEvent
 import at.hannibal2.skyhanni.features.bingo.BingoApi
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.RegexUtils.allMatchesComponent
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -38,11 +36,16 @@ import at.hannibal2.skyhanni.utils.TabListData
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getSidebarObjective
+import at.hannibal2.skyhanni.utils.coroutines.CoroutineConfig
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonObject
 import net.minecraft.client.Minecraft
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * This class handles "am I on hypixel", and similar states.
+ * For "am I in SkyBlock" and "what SkyBlock island am I on" checks see [SkyBlockLocationData].
+ */
 @SkyHanniModule
 object HypixelData {
 
@@ -92,24 +95,6 @@ object HypixelData {
         "scoreboard.visiting.amount",
         "\\s+§.✌ §.\\(§.(?<currentamount>\\d+)(?:§.)?/(?<maxamount>\\d+)(?:§.)?\\)",
     )
-    private val guestPattern by patternGroup.pattern(
-        "guesting.scoreboard",
-        "SKYBLOCK GUEST",
-    )
-
-    /**
-     * REGEX-TEST: SKYBLOCK
-     * REGEX-TEST: SKYBLOCK GUEST
-     * REGEX-TEST: SKYBLOCK CO-OP
-     * REGEX-TEST: SKYBLOCK ♲
-     * REGEX-TEST: SKYBLOCK ☀
-     * REGEX-TEST: SKYBLOCK Ⓑ
-     *
-     */
-    private val scoreboardTitlePattern by patternGroup.pattern(
-        "scoreboard.title",
-        "SK[YI]BLOCK(?: CO-OP| GUEST)?(?: [♲☀Ⓑ])?",
-    )
 
     /**
      * REGEX-TEST:  §7⏣ §bVillage
@@ -128,13 +113,15 @@ object HypixelData {
     var hypixelAlpha = false
     var inLobby = false
     var inLimbo = false
-    var skyBlock = false
-    var skyBlockIsland = IslandType.UNKNOWN
+
+    // TODO remove eventually
+    val skyBlock get() = SkyBlockLocationData.inSkyBlock
+    val skyBlockIsland get() = SkyBlockLocationData.currentIsland
+
     var serverId: String? = null
     private var lastSuccessfulServerIdFetchTime = SimpleTimeMark.farPast()
     private var lastSuccessfulServerIdFetchType: String? = null
     private var failedServerIdFetchCounter = 0
-    private var hasPostedIslandChangeEvent = false
 
     // Ironman, Stranded and Bingo
     var noTrade = false
@@ -269,7 +256,7 @@ object HypixelData {
         if (serverId?.startsWith("mega") == true) {
             return IslandType.maxPlayersMega
         }
-        return skyBlockIsland.islandData?.maxPlayers ?: IslandType.maxPlayers
+        return SkyBlockLocationData.currentIsland.islandData?.maxPlayers ?: IslandType.maxPlayers
     }
 
     // This code is modified from NEU, and depends on NEU (or another mod) sending /locraw.
@@ -305,9 +292,7 @@ object HypixelData {
 
     @HandleEvent
     fun onWorldChange() {
-        hasPostedIslandChangeEvent = false
         locrawData = null
-        skyBlock = false
         inLimbo = false
         inLobby = false
         locraw.forEach { locraw[it.key] = "" }
@@ -317,11 +302,10 @@ object HypixelData {
         skyBlockAreaWithSymbol = null
     }
 
-    @HandleEvent
-    fun onDisconnect(event: ClientDisconnectEvent) {
+    @HandleEvent(ClientDisconnectEvent::class)
+    fun onDisconnect() {
         hypixelLive = false
         hypixelAlpha = false
-        skyBlock = false
         inLobby = false
         locraw.forEach { locraw[it.key] = "" }
         locrawData = null
@@ -330,8 +314,8 @@ object HypixelData {
         hasScoreboardUpdated = false
     }
 
-    @HandleEvent
-    fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
+    @HandleEvent(ScoreboardUpdateEvent::class)
+    fun onScoreboardUpdate() {
         hasScoreboardUpdated = true
     }
 
@@ -377,7 +361,7 @@ object HypixelData {
             loop@ for (line in ScoreboardData.sidebarLinesFormatted) {
                 skyblockAreaPattern.matchMatcher(line) {
                     val originalLocation = group("area").removeColor()
-                    val area = LocationFixData.fixLocation(skyBlockIsland) ?: originalLocation
+                    val area = LocationFixData.fixLocation(SkyBlockLocationData.currentIsland) ?: originalLocation
                     skyBlockAreaWithSymbol = line.trim()
                     if (area != skyBlockArea) {
                         val previousArea = skyBlockArea
@@ -397,7 +381,7 @@ object HypixelData {
         when {
             !wasOnHypixel && nowOnHypixel -> {
                 HypixelJoinEvent.post()
-                SkyHanniMod.launchIOCoroutine("hypixel join repo update") {
+                CoroutineConfig("hypixel join repo update").launchCoroutine {
                     val progress = progressCategory.start("hypixel join repo update check")
                     SkyHanniRepoManager.displayRepoStatus(progress, joinEvent = true)
                     EnoughUpdatesRepoManager.displayRepoStatus(progress, joinEvent = true)
@@ -406,10 +390,6 @@ object HypixelData {
             }
 
             wasOnHypixel && !nowOnHypixel -> {
-                if (skyBlock) {
-                    skyBlock = false
-                    SkyBlockLeaveEvent.post()
-                }
                 HypixelLeaveEvent.post()
             }
         }
@@ -418,19 +398,10 @@ object HypixelData {
 
         if (!event.isMod(5)) return
 
-        val inSkyBlock = checkScoreboard()
-        if (inSkyBlock) {
+        if (SkyBlockLocationData.inSkyBlock) {
             checkSpecialModes()
             checkCurrentServerId()
-        } else {
-            if (skyBlock) {
-                SkyBlockLeaveEvent.post()
-            }
         }
-
-        if (inSkyBlock == skyBlock) return
-        skyBlock = inSkyBlock
-        HypixelLocationApi.checkEquals()
     }
 
     private fun sendLocraw() {
@@ -438,23 +409,6 @@ object HypixelData {
             lastLocRaw = SimpleTimeMark.now()
             HypixelCommands.locraw()
         }
-    }
-
-    @HandleEvent
-    fun onSkyBlockLeave(event: SkyBlockLeaveEvent) {
-        val oldIsland = skyBlockIsland
-        if (oldIsland != IslandType.NONE && oldIsland != IslandType.UNKNOWN) {
-            skyBlockIsland = IslandType.NONE
-            ChatUtils.debug("onSkyBlockLeave firing: $oldIsland → NONE (hasPostedIslandChangeEvent=$hasPostedIslandChangeEvent)")
-            IslandChangeEvent(IslandType.NONE, oldIsland).post()
-        }
-    }
-
-    fun workaroundChangeTo(new: IslandType) {
-        ChatUtils.debug("workaroundChangeTo $new")
-        val old = skyBlockIsland
-        skyBlockIsland = new
-        IslandChangeEvent(new, old).post()
     }
 
     @HandleEvent
@@ -543,41 +497,23 @@ object HypixelData {
         noTrade = ironman || stranded || bingo
     }
 
+    private var tabListDataDirty = false
+
+    @HandleEvent(SkyBlockJoinEvent::class)
+    fun onSkyBlockJoin() {
+        tabListDataDirty = true
+    }
+
     private fun checkIsland(event: WidgetUpdateEvent) {
-        val newIsland = if (event.isClear()) {
-            TabListData.fullyLoaded = false
-            IslandType.NONE
+        TabListData.fullyLoaded = !event.isClear()
 
-        } else {
-            TabListData.fullyLoaded = true
-            fetchTabListType()
-        }
-
-        if (!hasPostedIslandChangeEvent && newIsland != IslandType.NONE) {
-            val oldIsland = skyBlockIsland
-            ChatUtils.debug("checkIsland firing: $oldIsland → $newIsland")
-            skyBlockIsland = newIsland
-            IslandChangeEvent(newIsland, oldIsland).post()
-            hasPostedIslandChangeEvent = true
-            HypixelLocationApi.checkEquals()
-
+        if (SkyBlockLocationData.inSkyBlock && tabListDataDirty) {
+            tabListDataDirty = false
             if (TabListData.fullyLoaded) {
                 TabWidget.reSendEvents()
             }
         }
     }
-
-    // Can not use color coding, because of the color effect (§f§lSKYB§6§lL§e§lOCK§A§L GUEST)
-    fun fetchTabListType(): IslandType {
-        val guesting = guestPattern.matches(ScoreboardData.objectiveTitle.removeColor())
-        val islandType = IslandType.getByNameOrUnknown(rawTabListIslandName())
-        if (guesting) {
-            return islandType.guestVariant()
-        }
-        return islandType
-    }
-
-    fun rawTabListIslandName(): String = TabWidget.AREA.matchMatcherFirstLine { group("island").removeColor() }.orEmpty()
 
     fun getScoreboardTitle(): String? {
         val world = MinecraftCompat.localWorldOrNull ?: return null
@@ -585,12 +521,6 @@ object HypixelData {
         val objective = world.scoreboard.getSidebarObjective() ?: return null
         val displayName = objective.displayName.formattedTextCompat()
         return displayName
-    }
-
-    private fun checkScoreboard(): Boolean {
-        val displayName = getScoreboardTitle() ?: return false
-        val scoreboardTitle = displayName.removeColor()
-        return scoreboardTitlePattern.matches(scoreboardTitle)
     }
 
     private fun countPlayersOnIsland(event: WidgetUpdateEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -92,7 +92,7 @@ object HypixelData {
         "scoreboard.visiting.amount",
         "\\s+§.✌ §.\\(§.(?<currentamount>\\d+)(?:§.)?/(?<maxamount>\\d+)(?:§.)?\\)",
     )
-    val guestPattern by patternGroup.pattern(
+    private val guestPattern by patternGroup.pattern(
         "guesting.scoreboard",
         "SKYBLOCK GUEST",
     )
@@ -453,8 +453,8 @@ object HypixelData {
     fun workaroundChangeTo(new: IslandType) {
         ChatUtils.debug("workaroundChangeTo $new")
         val old = skyBlockIsland
-        IslandChangeEvent(new, old).post()
         skyBlockIsland = new
+        IslandChangeEvent(new, old).post()
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -423,7 +423,7 @@ object HypixelData {
             checkSpecialModes()
             checkCurrentServerId()
         } else {
-            if (!skyBlock) {
+            if (skyBlock) {
                 SkyBlockLeaveEvent.post()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -93,7 +93,7 @@ object HypixelData {
         "scoreboard.visiting.amount",
         "\\s+§.✌ §.\\(§.(?<currentamount>\\d+)(?:§.)?/(?<maxamount>\\d+)(?:§.)?\\)",
     )
-    private val guestPattern by patternGroup.pattern(
+    val guestPattern by patternGroup.pattern(
         "guesting.scoreboard",
         "SKYBLOCK GUEST",
     )
@@ -303,8 +303,6 @@ object HypixelData {
             }
         }
     }
-
-    private val loggerIslandChange = LorenzLogger("debug/island_change")
 
     @HandleEvent
     fun onWorldChange() {
@@ -566,9 +564,6 @@ object HypixelData {
 
             if (newIsland == IslandType.UNKNOWN) {
                 ChatUtils.debug("Unknown island detected: '$foundIsland'")
-                loggerIslandChange.log("Unknown: '$foundIsland'")
-            } else {
-                loggerIslandChange.log(newIsland.name)
             }
             if (TabListData.fullyLoaded) {
                 TabWidget.reSendEvents()
@@ -576,7 +571,7 @@ object HypixelData {
         }
     }
 
-    private fun getIslandType(name: String, guesting: Boolean): IslandType {
+    fun getIslandType(name: String, guesting: Boolean): IslandType {
         val islandType = IslandType.getByNameOrUnknown(name)
         if (guesting) {
             return islandType.guestVariant()

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -27,7 +27,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.RegexUtils.allMatchesComponent
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.repo.ChatProgressUpdates
 import at.hannibal2.skyhanni.data.repo.SkyHanniRepoManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
@@ -19,7 +20,6 @@ import at.hannibal2.skyhanni.events.hypixel.HypixelLeaveEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.skyblock.ScoreboardAreaChangeEvent
-import at.hannibal2.skyhanni.events.skyblock.SkyBlockJoinEvent
 import at.hannibal2.skyhanni.features.bingo.BingoApi
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.rift.RiftApi
@@ -499,8 +499,8 @@ object HypixelData {
 
     private var tabListDataDirty = false
 
-    @HandleEvent(SkyBlockJoinEvent::class)
-    fun onSkyBlockJoin() {
+    @HandleEvent(IslandJoinEvent::class)
+    fun onIslandJoin() {
         tabListDataDirty = true
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -544,20 +544,13 @@ object HypixelData {
     }
 
     private fun checkIsland(event: WidgetUpdateEvent) {
-        val newIsland: IslandType
-        val foundIsland: String
-        if (event.isClear()) {
-
+        val newIsland = if (event.isClear()) {
             TabListData.fullyLoaded = false
-            newIsland = IslandType.NONE
-            foundIsland = ""
+            IslandType.NONE
 
         } else {
             TabListData.fullyLoaded = true
-            // Can not use color coding, because of the color effect (§f§lSKYB§6§lL§e§lOCK§A§L GUEST)
-            val guesting = guestPattern.matches(ScoreboardData.objectiveTitle.removeColor())
-            foundIsland = TabWidget.AREA.matchMatcherFirstLine { group("island").removeColor() }.orEmpty()
-            newIsland = getIslandType(foundIsland, guesting)
+            fetchTabListType()
         }
 
         if (!hasPostedIslandChangeEvent && newIsland != IslandType.NONE) {
@@ -568,22 +561,23 @@ object HypixelData {
             hasPostedIslandChangeEvent = true
             HypixelLocationApi.checkEquals()
 
-            if (newIsland == IslandType.UNKNOWN) {
-                ChatUtils.debug("Unknown island detected: '$foundIsland'")
-            }
             if (TabListData.fullyLoaded) {
                 TabWidget.reSendEvents()
             }
         }
     }
 
-    fun getIslandType(name: String, guesting: Boolean): IslandType {
-        val islandType = IslandType.getByNameOrUnknown(name)
+    // Can not use color coding, because of the color effect (§f§lSKYB§6§lL§e§lOCK§A§L GUEST)
+    fun fetchTabListType(): IslandType {
+        val guesting = guestPattern.matches(ScoreboardData.objectiveTitle.removeColor())
+        val islandType = IslandType.getByNameOrUnknown(rawTabListIslandName())
         if (guesting) {
             return islandType.guestVariant()
         }
         return islandType
     }
+
+    fun rawTabListIslandName(): String = TabWidget.AREA.matchMatcherFirstLine { group("island").removeColor() }.orEmpty()
 
     fun getScoreboardTitle(): String? {
         val world = MinecraftCompat.localWorldOrNull ?: return null

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.allIdentical
 import at.hannibal2.skyhanni.utils.collection.SizeLimitedSet
 import kotlin.time.Duration.Companion.seconds
@@ -123,9 +124,9 @@ object IslandDetectionWatcher {
         ChatUtils.chat("Changed island type to ${type.displayName} as a workaround")
     }
 
-    private fun buildLog(): List<String> = action.map { data ->
+    private fun buildLog(): List<String> = action.sortedBy { it.time }.map { data ->
         val time = data.time
-        "${data.text} (${time.passedSince()} ago, $time)"
+        "${data.text} ${time.passedSince().format()} ago ($time)"
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -1,0 +1,139 @@
+package at.hannibal2.skyhanni.data.hypixel
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.HypixelData
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.ScoreboardData
+import at.hannibal2.skyhanni.data.model.TabWidget
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import at.hannibal2.skyhanni.events.skyblock.SkyBlockLeaveEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.LorenzLogger
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.allIdentical
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Sends errors when the island state is different between tab list and infos from IslandChangeEvent
+ */
+@SkyHanniModule
+object IslandDetectionWatcher {
+
+    private val action = mutableMapOf<String, SimpleTimeMark>()
+
+    private var latestEventType = IslandType.NONE
+    private var lastWorldChange = SimpleTimeMark.farFuture()
+    private var showedError = false
+    private var lastActionLog = listOf<String>()
+
+    private val logger = LorenzLogger("debug/island_change")
+
+    @HandleEvent
+    fun onIslandChange(event: IslandChangeEvent) {
+        val old = event.oldIsland
+        val new = event.newIsland
+        log("IslandChangeEvent $old -> $new")
+
+        latestEventType = new
+    }
+
+    @HandleEvent(SkyBlockLeaveEvent::class)
+    fun onSkyBlockLeave() {
+        log("SkyBlockLeaveEvent")
+    }
+
+    @HandleEvent(WorldChangeEvent::class)
+    fun onWorldChange() {
+        log("WorldChangeEvent")
+        lastWorldChange = SimpleTimeMark.now()
+        showedError = false
+    }
+
+    fun log(text: String) {
+        action[text] = SimpleTimeMark.now()
+        logger.log(text)
+    }
+
+    @HandleEvent(SecondPassedEvent::class)
+    fun onSecondPassed() {
+        if (lastWorldChange.passedSince() > 10.seconds) {
+            lastWorldChange = SimpleTimeMark.farFuture()
+            checkIslandConsistency()
+        }
+    }
+
+    private fun checkIslandConsistency() {
+        if (!SkyBlockUtils.inSkyBlock) return
+
+        val tabListType = fetchTabListType()
+        val latestEventType = latestEventType
+        val internalType = SkyBlockUtils.currentIsland
+
+        if (listOf(tabListType, latestEventType, internalType).allIdentical()) return
+
+        ErrorManager.logErrorStateWithData(
+            userMessage = "Error loading island type",
+            internalMessage = "invalid island state",
+            "tab list" to tabListType,
+            "latest event" to latestEventType,
+            "internal" to internalType,
+            "log" to buildAndClearLog(),
+        )
+        showedError = true
+    }
+
+    private fun fetchTabListType(): IslandType {
+        val guesting = HypixelData.guestPattern.matches(ScoreboardData.objectiveTitle.removeColor())
+        val foundIsland = TabWidget.AREA.matchMatcherFirstLine { group("island").removeColor() }.orEmpty()
+        return HypixelData.getIslandType(foundIsland, guesting)
+    }
+
+    private fun buildAndClearLog(): List<String> {
+        val result = mutableListOf<String>()
+        for ((text, time) in action) {
+            if (time.passedSince() > 5.minutes) continue
+
+            result.add("$text (${time.passedSince()} ago, $time)")
+        }
+        action.clear()
+
+        lastActionLog = result
+        return result
+    }
+
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("Island Detection Watcher")
+
+        val tabListType = fetchTabListType()
+        val latestEventType = latestEventType
+        val internalType = SkyBlockUtils.currentIsland
+
+        val list = buildList {
+            add("showedError: $showedError")
+            add(" ")
+            add("tabListType: $tabListType")
+            add("latestEventType: $latestEventType")
+            add("internalType: $internalType")
+            add(" ")
+            add("log: ")
+            for (line in lastActionLog) {
+                add(" - $line")
+            }
+        }
+
+        if (showedError) {
+            event.addData(list)
+        } else {
+            event.addIrrelevant(list)
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.SkyBlockLeaveEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -88,6 +89,25 @@ object IslandDetectionWatcher {
             "log" to buildAndClearLog(),
         )
         showedError = true
+        suggestWorkaround(tabListType)
+    }
+
+    private fun suggestWorkaround(type: IslandType) {
+        ChatUtils.clickableChat(
+            "Wanna have a one time workaround for now? Click here!",
+            onClick = { doWorkaround(type) },
+            hover = "Click to change the internal island type to ${type.displayName}",
+        )
+    }
+
+    private fun doWorkaround(type: IslandType) {
+        if (!SkyBlockUtils.inSkyBlock) {
+            ChatUtils.userError("this only works while on SkyBlock!")
+            return
+        }
+        log("workaround to $type")
+        HypixelData.workaroundChangeTo(type)
+        ChatUtils.chat("Changed island type to ${type.displayName} as a workaround")
     }
 
     private fun fetchTabListType(): IslandType {

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -9,8 +9,6 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
-import at.hannibal2.skyhanni.events.skyblock.SkyBlockJoinEvent
-import at.hannibal2.skyhanni.events.skyblock.SkyBlockLeaveEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -53,16 +51,6 @@ object IslandDetectionWatcher {
     @HandleEvent
     fun onIslandLeave(event: IslandLeaveEvent) {
         log("IslandLeaveEvent ${event.island}")
-    }
-
-    @HandleEvent(SkyBlockJoinEvent::class)
-    fun onSkyBlockJoin() {
-        log("SkyBlockJoinEvent")
-    }
-
-    @HandleEvent(SkyBlockLeaveEvent::class)
-    fun onSkyBlockLeave() {
-        log("SkyBlockLeaveEvent")
     }
 
     @HandleEvent(WorldChangeEvent::class)

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -21,7 +21,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.allIdentical
-import kotlin.time.Duration.Companion.minutes
+import at.hannibal2.skyhanni.utils.collection.SizeLimitedCache
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -30,12 +30,11 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object IslandDetectionWatcher {
 
-    private val action = mutableMapOf<String, SimpleTimeMark>()
+    private val action = SizeLimitedCache<String, SimpleTimeMark>(20)
 
     private var latestEventType = IslandType.NONE
     private var lastWorldChange = SimpleTimeMark.farFuture()
     private var showedError = false
-    private var lastActionLog = listOf<String>()
 
     private val logger = LorenzLogger("debug/island_change")
 
@@ -98,7 +97,7 @@ object IslandDetectionWatcher {
             "tab list" to tabListType,
             "latest event" to latestEventType,
             "internal" to internalType,
-            "log" to buildAndClearLog(),
+            "log" to buildLog(),
         )
         showedError = true
         suggestWorkaround(tabListType)
@@ -128,16 +127,11 @@ object IslandDetectionWatcher {
         return HypixelData.getIslandType(foundIsland, guesting)
     }
 
-    private fun buildAndClearLog(): List<String> {
+    private fun buildLog(): List<String> {
         val result = mutableListOf<String>()
         for ((text, time) in action) {
-            if (time.passedSince() > 5.minutes) continue
-
             result.add("$text (${time.passedSince()} ago, $time)")
         }
-        action.clear()
-
-        lastActionLog = result
         return result
     }
 
@@ -157,7 +151,7 @@ object IslandDetectionWatcher {
             add("internalType: $internalType")
             add(" ")
             add("log: ")
-            for (line in lastActionLog) {
+            for (line in buildLog()) {
                 add(" - $line")
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -26,7 +26,7 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object IslandDetectionWatcher {
 
-    private val action = SizeLimitedCache<String, SimpleTimeMark>(20)
+    private val action = SizeLimitedCache<SimpleTimeMark, String>(20)
 
     private var latestEventType = IslandType.NONE
     private var lastWorldChange = SimpleTimeMark.farFuture()
@@ -70,7 +70,7 @@ object IslandDetectionWatcher {
     }
 
     fun log(text: String) {
-        action[text] = SimpleTimeMark.now()
+        action[SimpleTimeMark.now()] = text
         logger.log(text)
         // TODO add ChatUtils.debug here once DevApi is advanced enough
     }
@@ -124,7 +124,7 @@ object IslandDetectionWatcher {
 
     private fun buildLog(): List<String> {
         val result = mutableListOf<String>()
-        for ((text, time) in action) {
+        for ((time, text) in action) {
             result.add("$text (${time.passedSince()} ago, $time)")
         }
         return result

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -69,7 +69,7 @@ object IslandDetectionWatcher {
         log("HypixelJoinEvent")
     }
 
-    fun log(text: String) {
+    private fun log(text: String) {
         action[SimpleTimeMark.now()] = text
         logger.log(text)
         // TODO add ChatUtils.debug here once DevApi is advanced enough
@@ -114,7 +114,7 @@ object IslandDetectionWatcher {
 
     private fun doWorkaround(type: IslandType) {
         if (!SkyBlockUtils.inSkyBlock) {
-            ChatUtils.userError("this only works while on SkyBlock!")
+            ChatUtils.userError("This only works while on SkyBlock!")
             return
         }
         log("workaround to $type")
@@ -139,7 +139,7 @@ object IslandDetectionWatcher {
         val internalType = SkyBlockUtils.currentIsland
 
         val isCurrentlyValid = listOf(tabListType, latestEventType, internalType).allIdentical()
-        val isRelevant = isCurrentlyValid || showedError
+        val isRelevant = !isCurrentlyValid || showedError
 
         val list = buildList {
             add("isCurrentlyValid: $isCurrentlyValid")

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -7,7 +7,9 @@ import at.hannibal2.skyhanni.data.ScoreboardData
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.events.skyblock.SkyBlockLeaveEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -56,6 +58,16 @@ object IslandDetectionWatcher {
         log("WorldChangeEvent")
         lastWorldChange = SimpleTimeMark.now()
         showedError = false
+    }
+
+    @HandleEvent(ProfileJoinEvent::class)
+    fun onProfileJoin() {
+        log("ProfileJoinEvent")
+    }
+
+    @HandleEvent(HypixelJoinEvent::class)
+    fun onHypixelJoin() {
+        log("HypixelJoinEvent")
     }
 
     fun log(text: String) {

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -27,13 +27,13 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object IslandDetectionWatcher {
 
+    private data class Action(val text: String, val time: SimpleTimeMark)
+
     private val action = SizeLimitedSet<Action>(20)
 
     private var latestEventType = IslandType.NONE
     private var lastWorldChange = SimpleTimeMark.farFuture()
     private var showedError = false
-
-    private data class Action(val text: String, val time: SimpleTimeMark)
 
     private val logger = LorenzLogger("debug/island_change")
 
@@ -108,7 +108,7 @@ object IslandDetectionWatcher {
 
     private fun suggestWorkaround(type: IslandType) {
         ChatUtils.clickableChat(
-            "Wanna have a one time workaround for now? Click here!",
+            "Wanna have a one-time workaround for now? Click here!",
             onClick = { doWorkaround(type) },
             hover = "Click to change the internal island type to ${type.displayName}",
         )
@@ -124,9 +124,8 @@ object IslandDetectionWatcher {
         ChatUtils.chat("Changed island type to ${type.displayName} as a workaround")
     }
 
-    private fun buildLog(): List<String> = action.sortedBy { it.time }.map { data ->
-        val time = data.time
-        "${data.text} ${time.passedSince().format()} ago ($time)"
+    private fun buildLog(): List<String> = action.sortedBy { it.time }.map { (text, time) ->
+        "$text ${time.passedSince().format()} ago($time)"
     }
 
     @HandleEvent
@@ -143,11 +142,11 @@ object IslandDetectionWatcher {
         val list = buildList {
             add("isCurrentlyValid: $isCurrentlyValid")
             add("error got shown: $showedError")
-            add(" ")
+            add("")
             add("tabListType: $tabListType")
             add("currentEventType: $currentEventType")
             add("internalType: $internalType")
-            add(" ")
+            add("")
             add("log: ")
             for (line in buildLog()) {
                 add(" - $line")

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -138,8 +138,12 @@ object IslandDetectionWatcher {
         val latestEventType = latestEventType
         val internalType = SkyBlockUtils.currentIsland
 
+        val isCurrentlyValid = listOf(tabListType, latestEventType, internalType).allIdentical()
+        val isRelevant = isCurrentlyValid || showedError
+
         val list = buildList {
-            add("showedError: $showedError")
+            add("isCurrentlyValid: $isCurrentlyValid")
+            add("error got shown: $showedError")
             add(" ")
             add("tabListType: $tabListType")
             add("latestEventType: $latestEventType")
@@ -151,7 +155,7 @@ object IslandDetectionWatcher {
             }
         }
 
-        if (showedError) {
+        if (isRelevant) {
             event.addData(list)
         } else {
             event.addIrrelevant(list)

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -72,6 +72,7 @@ object IslandDetectionWatcher {
     fun log(text: String) {
         action[text] = SimpleTimeMark.now()
         logger.log(text)
+        // TODO add ChatUtils.debug here once DevApi is advanced enough
     }
 
     @HandleEvent(SecondPassedEvent::class)

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -122,12 +122,8 @@ object IslandDetectionWatcher {
         ChatUtils.chat("Changed island type to ${type.displayName} as a workaround")
     }
 
-    private fun buildLog(): List<String> {
-        val result = mutableListOf<String>()
-        for ((time, text) in action) {
-            result.add("$text (${time.passedSince()} ago, $time)")
-        }
-        return result
+    private fun buildLog(): List<String> = action.map { (time, text) ->
+        "$text (${time.passedSince()} ago, $time)"
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.data.hypixel
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.IslandJoinEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.allIdentical
 import at.hannibal2.skyhanni.utils.collection.SizeLimitedCache
+import at.hannibal2.skyhanni.utils.collection.SizeLimitedSet
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -26,11 +27,13 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object IslandDetectionWatcher {
 
-    private val action = SizeLimitedCache<SimpleTimeMark, String>(20)
+    private val action = SizeLimitedSet<Data>(20)
 
     private var latestEventType = IslandType.NONE
     private var lastWorldChange = SimpleTimeMark.farFuture()
     private var showedError = false
+
+    data class Data(val text: String, val time: SimpleTimeMark)
 
     private val logger = LorenzLogger("debug/island_change")
 
@@ -43,7 +46,6 @@ object IslandDetectionWatcher {
             ChatUtils.debug("Unknown island detected: '$foundIsland'")
         }
         log("IslandChangeEvent $oldIsland -> $newIsland")
-
         latestEventType = newIsland
     }
 
@@ -70,7 +72,7 @@ object IslandDetectionWatcher {
     }
 
     private fun log(text: String) {
-        action[SimpleTimeMark.now()] = text
+        action.add(Data(text, SimpleTimeMark.now()))
         logger.log(text)
         // TODO add ChatUtils.debug here once DevApi is advanced enough
     }
@@ -87,16 +89,16 @@ object IslandDetectionWatcher {
         if (!SkyBlockUtils.inSkyBlock) return
 
         val tabListType = HypixelData.fetchTabListType()
-        val latestEventType = latestEventType
+        val currentEventType = latestEventType
         val internalType = SkyBlockUtils.currentIsland
 
-        if (listOf(tabListType, latestEventType, internalType).allIdentical()) return
+        if (listOf(tabListType, currentEventType, internalType).allIdentical()) return
 
         ErrorManager.logErrorStateWithData(
             userMessage = "Error loading island type",
             internalMessage = "invalid island state",
             "tab list" to tabListType,
-            "latest event" to latestEventType,
+            "latest event" to currentEventType,
             "internal" to internalType,
             "log" to buildLog(),
         )
@@ -122,8 +124,9 @@ object IslandDetectionWatcher {
         ChatUtils.chat("Changed island type to ${type.displayName} as a workaround")
     }
 
-    private fun buildLog(): List<String> = action.map { (time, text) ->
-        "$text (${time.passedSince()} ago, $time)"
+    private fun buildLog(): List<String> = action.map { data ->
+        val time = data.time
+        "${data.text} (${time.passedSince()} ago, $time)"
     }
 
     @HandleEvent
@@ -131,10 +134,10 @@ object IslandDetectionWatcher {
         event.title("Island Detection Watcher")
 
         val tabListType = HypixelData.fetchTabListType()
-        val latestEventType = latestEventType
+        val currentEventType = latestEventType
         val internalType = SkyBlockUtils.currentIsland
 
-        val isCurrentlyValid = listOf(tabListType, latestEventType, internalType).allIdentical()
+        val isCurrentlyValid = listOf(tabListType, currentEventType, internalType).allIdentical()
         val isRelevant = !isCurrentlyValid || showedError
 
         val list = buildList {
@@ -142,7 +145,7 @@ object IslandDetectionWatcher {
             add("error got shown: $showedError")
             add(" ")
             add("tabListType: $tabListType")
-            add("latestEventType: $latestEventType")
+            add("currentEventType: $currentEventType")
             add("internalType: $internalType")
             add(" ")
             add("log: ")

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -4,11 +4,13 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.IslandJoinEvent
+import at.hannibal2.skyhanni.events.IslandLeaveEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import at.hannibal2.skyhanni.events.skyblock.SkyBlockJoinEvent
 import at.hannibal2.skyhanni.events.skyblock.SkyBlockLeaveEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -31,22 +33,32 @@ object IslandDetectionWatcher {
 
     private val action = SizeLimitedSet<Action>(20)
 
-    private var latestEventType = IslandType.NONE
+    private var latestEventType = IslandType.UNKNOWN
     private var lastWorldChange = SimpleTimeMark.farFuture()
     private var showedError = false
 
     private val logger = LorenzLogger("debug/island_change")
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
-        val oldIsland = event.oldIsland
-        val newIsland = event.newIsland
+    fun onIslandJoin(event: IslandJoinEvent) {
+        val newIsland = event.island
+        val oldIsland = event.previousIsland
         if (newIsland == IslandType.UNKNOWN) {
-            val foundIsland = HypixelData.rawTabListIslandName()
+            val foundIsland = SkyBlockLocationData.rawTabListIslandName()
             ChatUtils.debug("Unknown island detected: '$foundIsland'")
         }
-        log("IslandChangeEvent $oldIsland -> $newIsland")
+        log("IslandJoinEvent $oldIsland -> $newIsland")
         latestEventType = newIsland
+    }
+
+    @HandleEvent
+    fun onIslandLeave(event: IslandLeaveEvent) {
+        log("IslandLeaveEvent ${event.island}")
+    }
+
+    @HandleEvent(SkyBlockJoinEvent::class)
+    fun onSkyBlockJoin() {
+        log("SkyBlockJoinEvent")
     }
 
     @HandleEvent(SkyBlockLeaveEvent::class)
@@ -88,7 +100,7 @@ object IslandDetectionWatcher {
     private fun checkIslandConsistency() {
         if (!SkyBlockUtils.inSkyBlock) return
 
-        val tabListType = HypixelData.fetchTabListType()
+        val tabListType = SkyBlockLocationData.fetchTabListType()
         val currentEventType = latestEventType
         val internalType = SkyBlockUtils.currentIsland
 
@@ -120,7 +132,7 @@ object IslandDetectionWatcher {
             return
         }
         log("workaround to $type")
-        HypixelData.workaroundChangeTo(type)
+        SkyBlockLocationData.workaroundChangeTo(type)
         ChatUtils.chat("Changed island type to ${type.displayName} as a workaround")
     }
 
@@ -132,15 +144,15 @@ object IslandDetectionWatcher {
     fun onDebug(event: DebugDataCollectEvent) {
         event.title("Island Detection Watcher")
 
-        val tabListType = HypixelData.fetchTabListType()
+        val tabListType = SkyBlockLocationData.fetchTabListType()
         val currentEventType = latestEventType
         val internalType = SkyBlockUtils.currentIsland
 
-        val isCurrentlyValid = listOf(tabListType, currentEventType, internalType).allIdentical()
-        val isRelevant = !isCurrentlyValid || showedError
+        val isIncorrect = !listOf(tabListType, currentEventType, internalType).allIdentical()
+        val isRelevant = isIncorrect || showedError
 
         val list = buildList {
-            add("isCurrentlyValid: $isCurrentlyValid")
+            add("isWrong: $isIncorrect")
             add("error got shown: $showedError")
             add("")
             add("tabListType: $tabListType")

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -3,8 +3,6 @@ package at.hannibal2.skyhanni.data.hypixel
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.ScoreboardData
-import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
@@ -16,10 +14,8 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzLogger
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.allIdentical
 import at.hannibal2.skyhanni.utils.collection.SizeLimitedCache
 import kotlin.time.Duration.Companion.seconds
@@ -40,11 +36,15 @@ object IslandDetectionWatcher {
 
     @HandleEvent
     fun onIslandChange(event: IslandChangeEvent) {
-        val old = event.oldIsland
-        val new = event.newIsland
-        log("IslandChangeEvent $old -> $new")
+        val oldIsland = event.oldIsland
+        val newIsland = event.newIsland
+        if (newIsland == IslandType.UNKNOWN) {
+            val foundIsland = HypixelData.rawTabListIslandName()
+            ChatUtils.debug("Unknown island detected: '$foundIsland'")
+        }
+        log("IslandChangeEvent $oldIsland -> $newIsland")
 
-        latestEventType = new
+        latestEventType = newIsland
     }
 
     @HandleEvent(SkyBlockLeaveEvent::class)
@@ -85,7 +85,7 @@ object IslandDetectionWatcher {
     private fun checkIslandConsistency() {
         if (!SkyBlockUtils.inSkyBlock) return
 
-        val tabListType = fetchTabListType()
+        val tabListType = HypixelData.fetchTabListType()
         val latestEventType = latestEventType
         val internalType = SkyBlockUtils.currentIsland
 
@@ -121,12 +121,6 @@ object IslandDetectionWatcher {
         ChatUtils.chat("Changed island type to ${type.displayName} as a workaround")
     }
 
-    private fun fetchTabListType(): IslandType {
-        val guesting = HypixelData.guestPattern.matches(ScoreboardData.objectiveTitle.removeColor())
-        val foundIsland = TabWidget.AREA.matchMatcherFirstLine { group("island").removeColor() }.orEmpty()
-        return HypixelData.getIslandType(foundIsland, guesting)
-    }
-
     private fun buildLog(): List<String> {
         val result = mutableListOf<String>()
         for ((text, time) in action) {
@@ -139,7 +133,7 @@ object IslandDetectionWatcher {
     fun onDebug(event: DebugDataCollectEvent) {
         event.title("Island Detection Watcher")
 
-        val tabListType = fetchTabListType()
+        val tabListType = HypixelData.fetchTabListType()
         val latestEventType = latestEventType
         val internalType = SkyBlockUtils.currentIsland
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/IslandDetectionWatcher.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.allIdentical
-import at.hannibal2.skyhanni.utils.collection.SizeLimitedCache
 import at.hannibal2.skyhanni.utils.collection.SizeLimitedSet
 import kotlin.time.Duration.Companion.seconds
 
@@ -27,13 +26,13 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object IslandDetectionWatcher {
 
-    private val action = SizeLimitedSet<Data>(20)
+    private val action = SizeLimitedSet<Action>(20)
 
     private var latestEventType = IslandType.NONE
     private var lastWorldChange = SimpleTimeMark.farFuture()
     private var showedError = false
 
-    data class Data(val text: String, val time: SimpleTimeMark)
+    private data class Action(val text: String, val time: SimpleTimeMark)
 
     private val logger = LorenzLogger("debug/island_change")
 
@@ -72,7 +71,7 @@ object IslandDetectionWatcher {
     }
 
     private fun log(text: String) {
-        action.add(Data(text, SimpleTimeMark.now()))
+        action.add(Action(text, SimpleTimeMark.now()))
         logger.log(text)
         // TODO add ChatUtils.debug here once DevApi is advanced enough
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/SkyBlockLocationData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/SkyBlockLocationData.kt
@@ -1,0 +1,163 @@
+package at.hannibal2.skyhanni.data.hypixel
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.HypixelData
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.model.TabWidget
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.IslandJoinEvent
+import at.hannibal2.skyhanni.events.IslandLeaveEvent
+import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
+import at.hannibal2.skyhanni.events.WidgetUpdateEvent
+import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
+import at.hannibal2.skyhanni.events.skyblock.SkyBlockJoinEvent
+import at.hannibal2.skyhanni.events.skyblock.SkyBlockLeaveEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+/**
+ * This class handles the "am I in SkyBlock" and "what SkyBlock island am I on" checks.
+ * For "Am i on hypixel" see [HypixelData].
+ */
+@SkyHanniModule
+object SkyBlockLocationData {
+
+    private val patternGroup = RepoPattern.group("data.skyblockstate")
+
+    /**
+     * REGEX-TEST: SKYBLOCK
+     * REGEX-TEST: SKYBLOCK GUEST
+     * REGEX-TEST: SKYBLOCK CO-OP
+     * REGEX-TEST: SKYBLOCK ♲
+     * REGEX-TEST: SKYBLOCK ☀
+     * REGEX-TEST: SKYBLOCK Ⓑ
+     */
+    private val scoreboardTitlePattern by patternGroup.pattern(
+        "scoreboard.title",
+        "SK[YI]BLOCK(?: CO-OP| GUEST)?(?: [♲☀Ⓑ])?",
+    )
+
+    private val guestPattern by patternGroup.pattern(
+        "scoreboard.guest",
+        "SKYBLOCK GUEST",
+    )
+
+    val inSkyBlock: Boolean get() = SkyBlockUtils.onHypixel && scoreboardShowsSkyBlock
+    val currentIsland: IslandType get() = confirmedIsland
+
+    private var scoreboardShowsSkyBlock = false
+    private var tabListIsland = IslandType.NONE
+    private var confirmedIsland = IslandType.NONE
+    private var previousIsland = IslandType.NONE
+    private var scoreboardTitle: String? = null
+
+    @HandleEvent
+    fun onWorldChange() {
+        scoreboardTitle = null
+        scoreboardShowsSkyBlock = false
+        tabListIsland = IslandType.NONE
+        handleStateChange()
+    }
+
+    @HandleEvent(ClientDisconnectEvent::class)
+    fun onDisconnect() {
+        scoreboardTitle = null
+        scoreboardShowsSkyBlock = false
+        tabListIsland = IslandType.NONE
+        if (confirmedIsland != IslandType.NONE) {
+            changeTo(IslandType.NONE)
+        }
+    }
+
+    @HandleEvent(ScoreboardUpdateEvent::class)
+    fun onScoreboardUpdate() {
+        scoreboardTitle = HypixelData.getScoreboardTitle()?.removeColor()
+        scoreboardShowsSkyBlock = scoreboardTitle?.let { scoreboardTitlePattern.matches(it) } ?: false
+        if (scoreboardShowsSkyBlock && tabListIsland == IslandType.NONE) {
+            val island = fetchTabListType()
+            if (island != IslandType.NONE) tabListIsland = island
+        }
+        handleStateChange()
+    }
+
+    @HandleEvent
+    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+        if (event.widget != TabWidget.AREA) return
+
+        tabListIsland = if (event.isClear()) IslandType.NONE else fetchTabListType()
+        handleStateChange()
+    }
+
+    // Can not use color coding, because of the color effect (§f§lSKYB§6§lL§e§lOCK§A§L GUEST)
+    fun fetchTabListType(): IslandType {
+        val isGuest = scoreboardTitle?.let { guestPattern.matches(it) } ?: false
+        val islandName = rawTabListIslandName()
+        val islandType = IslandType.getByNameOrUnknown(islandName)
+        return if (isGuest) islandType.guestVariant() else islandType
+    }
+
+    fun rawTabListIslandName(): String = TabWidget.AREA.matchMatcherFirstLine { group("island").removeColor() }.orEmpty()
+
+    fun workaroundChangeTo(newIsland: IslandType) {
+        ChatUtils.debug("workaroundChangeTo $newIsland")
+        if (confirmedIsland != IslandType.NONE) {
+            changeTo(IslandType.NONE)
+        }
+        tabListIsland = newIsland
+        changeTo(newIsland)
+    }
+
+    private fun handleStateChange() {
+        val newIsland = if (inSkyBlock) tabListIsland else IslandType.NONE
+        if (newIsland == confirmedIsland) return
+
+        changeTo(newIsland)
+    }
+
+    private fun changeTo(newIsland: IslandType) {
+        val oldIsland = confirmedIsland
+        confirmedIsland = newIsland
+
+        if (oldIsland != IslandType.NONE && newIsland == IslandType.NONE) {
+            SkyBlockLeaveEvent.post()
+        }
+        if (oldIsland == IslandType.NONE && newIsland != IslandType.NONE) {
+            SkyBlockJoinEvent.post()
+        }
+        if (newIsland == IslandType.NONE) {
+            IslandLeaveEvent(oldIsland).post()
+        }
+        if (oldIsland == IslandType.NONE) {
+            IslandJoinEvent(island = newIsland, previousIsland = previousIsland).post()
+            previousIsland = newIsland
+        }
+
+        // TODO delete this event eventually
+        IslandChangeEvent(newIsland, oldIsland).post()
+    }
+
+    @HandleEvent
+    fun onDebug(event: DebugDataCollectEvent) {
+        event.title("SkyBlock Location Data")
+        val list = listOf(
+            "onHypixel: ${SkyBlockUtils.onHypixel}",
+            "scoreboardShowsSkyBlock: $scoreboardShowsSkyBlock",
+            "scoreboardTitle: $scoreboardTitle",
+            "tabListIsland: $tabListIsland",
+            "tab widget AREA lines: ${TabWidget.AREA.lines}",
+            "confirmedIsland: $confirmedIsland",
+            "inSkyBlock: $inSkyBlock",
+            "fetchTabListType: ${fetchTabListType()}",
+        )
+        if (inSkyBlock) {
+            event.addIrrelevant(list)
+        } else {
+            event.addData(list)
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/SkyBlockLocationData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/SkyBlockLocationData.kt
@@ -11,9 +11,8 @@ import at.hannibal2.skyhanni.events.IslandLeaveEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
-import at.hannibal2.skyhanni.events.skyblock.SkyBlockJoinEvent
-import at.hannibal2.skyhanni.events.skyblock.SkyBlockLeaveEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
@@ -78,10 +77,6 @@ object SkyBlockLocationData {
     fun onScoreboardUpdate() {
         scoreboardTitle = HypixelData.getScoreboardTitle()?.removeColor()
         scoreboardShowsSkyBlock = scoreboardTitle?.let { scoreboardTitlePattern.matches(it) } ?: false
-        if (scoreboardShowsSkyBlock && tabListIsland == IslandType.NONE) {
-            val island = fetchTabListType()
-            if (island != IslandType.NONE) tabListIsland = island
-        }
         handleStateChange()
     }
 
@@ -120,15 +115,17 @@ object SkyBlockLocationData {
     }
 
     private fun changeTo(newIsland: IslandType) {
+        if (confirmedIsland == newIsland) {
+            ErrorManager.logErrorStateWithData(
+                "Invalid island type change detected",
+                "old and new island are identical, this should never happen!",
+                "newIsland" to newIsland,
+            )
+            return
+        }
         val oldIsland = confirmedIsland
         confirmedIsland = newIsland
 
-        if (oldIsland != IslandType.NONE && newIsland == IslandType.NONE) {
-            SkyBlockLeaveEvent.post()
-        }
-        if (oldIsland == IslandType.NONE && newIsland != IslandType.NONE) {
-            SkyBlockJoinEvent.post()
-        }
         if (newIsland == IslandType.NONE) {
             IslandLeaveEvent(oldIsland).post()
         }

--- a/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
@@ -4,9 +4,6 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
-
-// TODO to support checking "switched from island X to island Y" where both are specific islands,
-//  expand this event with a "last valid island" field that holds the last non-[IslandType.NONE] island.
 /**
  * Fired when the current island state changes.
  *
@@ -17,5 +14,9 @@ import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
  * When switching islands, the event fires twice: first with [newIsland] =[IslandType.NONE]
  * (leaving the old island), then with [oldIsland] = [IslandType.NONE] (entering the new one).
  */
+@Deprecated("use IslandJoinEvent or IslandLeaveEvent instead")
 @PrimaryFunction("onIslandChange")
 class IslandChangeEvent(val newIsland: IslandType, val oldIsland: IslandType) : SkyHanniEvent()
+
+class IslandJoinEvent(val island: IslandType, val previousIsland: IslandType) : SkyHanniEvent()
+class IslandLeaveEvent(val island: IslandType) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/skyblock/SkyBlockJoinLeaveEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/skyblock/SkyBlockJoinLeaveEvent.kt
@@ -2,4 +2,5 @@ package at.hannibal2.skyhanni.events.skyblock
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
+object SkyBlockJoinEvent : SkyHanniEvent()
 object SkyBlockLeaveEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/skyblock/SkyBlockJoinLeaveEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/skyblock/SkyBlockJoinLeaveEvent.kt
@@ -1,6 +1,0 @@
-package at.hannibal2.skyhanni.events.skyblock
-
-import at.hannibal2.skyhanni.api.event.SkyHanniEvent
-
-object SkyBlockJoinEvent : SkyHanniEvent()
-object SkyBlockLeaveEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.hotx.HotmData
 import at.hannibal2.skyhanni.data.hotx.HotmReward
 import at.hannibal2.skyhanni.data.model.TabWidget
-import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.IslandLeaveEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -11,6 +11,8 @@ import at.hannibal2.skyhanni.data.hotx.HotmData
 import at.hannibal2.skyhanni.data.hotx.HotmReward
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.IslandJoinEvent
+import at.hannibal2.skyhanni.events.IslandLeaveEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -322,8 +324,15 @@ object MineshaftPityDisplay {
     }
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
-        if (event.newIsland == IslandType.MINESHAFT || event.oldIsland == IslandType.MINESHAFT) {
+    fun onIslandChange(event: IslandJoinEvent) {
+        if (event.island == IslandType.MINESHAFT) {
+            resetCounter()
+        }
+    }
+
+    @HandleEvent
+    fun onIslandLeave(event: IslandLeaveEvent) {
+        if (event.island == IslandType.MINESHAFT) {
             resetCounter()
         }
     }
@@ -362,6 +371,7 @@ object MineshaftPityDisplay {
             2,
             ColoredBlockCompat.LIGHT_BLUE.createWoolStack(),
         ),
+
         // cant rename enum because config explodes
         GEMSTONE(
             "Low Tier Gemstone",

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.TabWidget
-import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.IslandLeaveEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.IslandLeaveEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -51,8 +52,8 @@ object MotesSession {
     }
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
-        if (event.oldIsland == IslandType.THE_RIFT) {
+    fun onIslandLeave(event: IslandLeaveEvent) {
+        if (event.island == IslandType.THE_RIFT) {
             sendMotesInfo()
             initialMotes = null
             currentMotes = null

--- a/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
@@ -109,7 +109,7 @@ object CollectionUtils {
      */
     inline fun <K, V : Number, R> Map<K, V>.subtract(
         other: Map<K, V>,
-        transform: (Double) -> R
+        transform: (Double) -> R,
     ): Map<K, R> = (keys + other.keys).associateWith { k ->
         val diff = (this[k]?.toDouble() ?: 0.0) - (other[k]?.toDouble() ?: 0.0)
         transform(diff)
@@ -122,7 +122,7 @@ object CollectionUtils {
         map { it.value }.runningFold(initial, operation).zip(map { it.index }) { value, index -> IndexedValue(index, value) }
 
     suspend inline fun <T, R> Iterable<T>.mapAsync(
-        crossinline transform: (T) -> R
+        crossinline transform: (T) -> R,
     ): List<R> = coroutineScope {
         map {
             async { transform(it) }
@@ -130,7 +130,7 @@ object CollectionUtils {
     }
 
     suspend inline fun <T, R> Iterable<T>.mapNotNullAsync(
-        crossinline transform: (T) -> R?
+        crossinline transform: (T) -> R?,
     ): List<R> = coroutineScope {
         mapNotNull {
             async { transform(it) }
@@ -563,7 +563,7 @@ object CollectionUtils {
 
     @Deprecated(
         "Use the built-in ifEmpty function with emptySet() instead",
-        ReplaceWith("this.ifEmpty { emptySet() }")
+        ReplaceWith("this.ifEmpty { emptySet() }"),
     )
     fun <T> Set<T>.optionalEmpty(): Set<T> = ifEmpty { emptySet() }
 
@@ -574,4 +574,10 @@ object CollectionUtils {
 
     @Suppress("UNCHECKED_CAST")
     fun <K, V> Map<K, V?>.filterValuesNotNull(): Map<K, V> = filterValues { it != null } as Map<K, V>
+
+    fun <T> List<T>.allIdentical(): Boolean {
+        if (isEmpty()) return true
+        val first = first()
+        return all { it == first }
+    }
 }


### PR DESCRIPTION
## What
since we had multiple prs trying to fix a bug around island type detection, i think a proper error logger is in order here.

Also, this PR rewrote the entire island type and in SkyBlock check logic into a new file.
Also, added new events for island join and island leave, marking the island change event deprecated.

## Changelog Fixes
+ Fixed multiple different errors all related to island type detection, this time for real. - hannibal2

## Changelog Technical Details
+ Added error logging and showing of island detection issues. - hannibal2