### PR TITLE
Improvement: Rename EliteBot to EliteSkyBlock

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,7 +336,7 @@ SkyHanni uses **[MoulConfig](https://github.com/NotEnoughUpdates/MoulConfig)**, 
 
 ### Elite Farmers API
 
-SkyHanni utilizes the [Elite API](https://api.elitebot.dev/) (view the [public site here](https://elitebot.dev)) for
+SkyHanni utilizes the [Elite API](https://api.eliteskyblock.com/) (view the [public site here](https://eliteskyblock.com)) for
 some farming features.
 
 This includes features relating to Farming Weight, as well as syncing jacob contests amongst players for convenience.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -808,8 +808,8 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
     + Default: #10k
 + Sync Jacob Contests - Kaeso + CalMWolfs
     + No need to open the calendar every SkyBlock year again.
-    + Grab Jacob Contest data from the elitebot.dev website.
-    + Option to send local contest data to elitebot.dev at the start of the new SkyBlock year.
+    + Grab Jacob Contest data from the eliteskyblock.com website.
+    + Option to send local contest data to eliteskyblock.com at the start of the new SkyBlock year.
 + **Visual garden plot borders** - VixidDev
     + Press F3 + G to enable/disable the view.
 + /shmouselock command to lock mouse rotation for farming. - Cad
@@ -844,11 +844,11 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
 + Added crop collection leaderboard display. - Chissl (https://github.com/hannibal002/SkyHanni/pull/4665)
   + For each crop, show your all-time and monthly collection, leaderboard position, and players ahead/behind you.
   + Swap between crops and leaderboard modes by clicking on the display switcher button while in an inventory.
-  + Data sourced from the Elitebot.dev API.
+  + Data sourced from the eliteskyblock.com API.
 + Added pest kills leaderboard display. - Chissl (https://github.com/hannibal002/SkyHanni/pull/4665)
   + For each pest, show your all-time kills, leaderboard position, and players ahead/behind you.
   + Swap between pests by clicking on the display switcher button while in an inventory.
-  + Data sourced from the Elitebot.dev API.
+  + Data sourced from the eliteskyblock.com API.
 + Highlight Harvestability status in the Greenhouse. - nopo (https://github.com/hannibal002/SkyHanni/pull/5136)
 + Highlight Water Status green if the crop doesn't need more water. - nopo (https://github.com/hannibal002/SkyHanni/pull/5168)
 + Added command `/shgardenuptime`. - Chissl (https://github.com/hannibal002/SkyHanni/pull/4703)
@@ -903,7 +903,7 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
     + Option to change the number of seconds until the waypoint will disappear.
 + Pest Profit Tracker. - Empa (https://github.com/hannibal002/SkyHanni/pull/1321)
 + Open On Elite. - Obsidian (https://github.com/hannibal002/SkyHanni/pull/1185)
-    + Allow opening farming contest stats on elitebot.dev by pressing a keybind + mouse click onto a contest item.
+    + Allow opening farming contest stats on eliteskyblock.com by pressing a keybind + mouse click onto a contest item.
     + Works inside the menus Jacob's Farming Contest, Your Contests, and SkyBlock Calendar.
 + Visitor's Logbook Stats. - HiZe (https://github.com/hannibal002/SkyHanni/pull/1287)
     + Show all your visited/accepted/denied visitors stats in a display.
@@ -1379,7 +1379,7 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
 + `/pt <player>` as alias for `/party transfer <player>`
     + SkyBlock Command `/tp` to check the play time still works
 + **/shfarmingprofile [player name]**
-    + Opens the elitebot.dev website in your web browser to show your Farming Weight profile.
+    + Opens the eliteskyblock.com website in your web browser to show your Farming Weight profile.
 + Tab Complete support to sacks command /gfs and /getfromsacks. - J10a1n15
 + /shcalccrop. - CalMWolfs
     + Calculate how many crops need to be farmed between different crop milestones.

--- a/src/main/java/at/hannibal2/skyhanni/api/EliteDevApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/EliteDevApi.kt
@@ -54,7 +54,7 @@ object EliteDevApi {
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shfetcheliteresource") {
-            description = "Fetches the specified Elite resource from elitebot.dev"
+            description = "Fetches the specified Elite resource from eliteskyblock.com"
             category = CommandCategory.DEVELOPER_DEBUG
             argCallback("resource", EnumArgumentType.lowercase<EliteResourceType>()) { resource ->
                 SkyHanniMod.launchIOCoroutine("shfetcheliteresource command") {
@@ -116,25 +116,25 @@ object EliteDevApi {
         ChatUtils.chat("Failed to fetch $resourceType resources!")
     }
 
-    private const val ELITEBOT_API_URL = "https://api.elitebot.dev"
-    private const val FARMING_WEIGHT_API_NAME = "Elitebot Farming Weight"
-    private const val FARMING_WEIGHT_URL = "$ELITEBOT_API_URL/weight"
+    private const val ELITE_SKYBLOCK_API_URL = "https://api.eliteskyblock.com"
+    private const val FARMING_WEIGHT_API_NAME = "EliteSkyBlock Farming Weight"
+    private const val FARMING_WEIGHT_URL = "$ELITE_SKYBLOCK_API_URL/weight"
 
     private val contestStatic = ApiStaticPostPath(
-        "$ELITEBOT_API_URL/contests/at/now",
-        "Elitebot Farming Contests",
+        "$ELITE_SKYBLOCK_API_URL/contests/at/now",
+        "EliteSkyBlock Farming Contests",
     )
 
     private val apiWeightsStatic = ApiStaticPath(
-        "$ELITEBOT_API_URL/weights/all",
+        "$ELITE_SKYBLOCK_API_URL/weights/all",
         FARMING_WEIGHT_API_NAME,
     )
 
-    private const val LEADERBOARD_URL = "$ELITEBOT_API_URL/leaderboard/"
-    private const val LEADERBOARD_API_NAME = "Elitebot Leaderboard"
+    private const val LEADERBOARD_URL = "$ELITE_SKYBLOCK_API_URL/leaderboard/"
+    private const val LEADERBOARD_API_NAME = "EliteSkyBlock Leaderboard"
 
-    private const val RESOURCE_API_NAME = "Elitebot Resources"
-    private const val RESOURCE_API_URL = "$ELITEBOT_API_URL/resources"
+    private const val RESOURCE_API_NAME = "EliteSkyBlock Resources"
+    private const val RESOURCE_API_URL = "$ELITE_SKYBLOCK_API_URL/resources"
 
     // <editor-fold desc="Upcoming Contests">
     suspend fun fetchUpcomingContests(): List<EliteFarmingContest> {
@@ -185,7 +185,7 @@ object EliteDevApi {
         ErrorManager.logErrorWithData(
             e,
             "Error loading user farming weight\n" +
-                "§eLoading the farming weight data from elitebot.dev failed!\n" +
+                "§eLoading the farming weight data from eliteskyblock.com failed!\n" +
                 "§eYou can re-enter the garden to try to fix the problem.\n" +
                 "§cIf this message repeats, please report it on Discord",
             "weightUrl" to weightUrl,
@@ -198,7 +198,7 @@ object EliteDevApi {
     suspend fun fetchApiWeights(): EliteWeightsJson {
         val apiWeightsResponse = ApiUtils.getTypedJsonResponse<JsonObject>(apiWeightsStatic.toGet())
         val (_, apiData) = apiWeightsResponse.assertSuccessWithData() ?: ErrorManager.skyHanniError(
-            "Error getting crop weights from elitebot.dev",
+            "Error getting crop weights from eliteskyblock.com",
             "apiWeightsResponse" to apiWeightsResponse,
         )
         return ConfigManager.gson.fromJson<EliteWeightsJson>(apiData)
@@ -243,7 +243,7 @@ object EliteDevApi {
         val resourceUrl = "$RESOURCE_API_URL/$subUrl"
         val resourceApiResponse = ApiUtils.getTypedJsonResponse<JsonObject>(resourceUrl, apiName = RESOURCE_API_NAME)
         val (_, apiData) = resourceApiResponse.assertSuccessWithData() ?: ErrorManager.skyHanniError(
-            "Error getting resources from elitebot.dev",
+            "Error getting resources from eliteskyblock.com",
             "resourceUrl" to resourceUrl,
             "resourceApiResponse" to resourceApiResponse,
         )

--- a/src/main/java/at/hannibal2/skyhanni/api/EliteDevApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/EliteDevApi.kt
@@ -54,7 +54,7 @@ object EliteDevApi {
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shfetcheliteresource") {
-            description = "Fetches the specified Elite resource from eliteskyblock.com"
+            description = "Fetches the specified Elite resource from $ELITE_DOMAIN"
             category = CommandCategory.DEVELOPER_DEBUG
             argCallback("resource", EnumArgumentType.lowercase<EliteResourceType>()) { resource ->
                 SkyHanniMod.launchIOCoroutine("shfetcheliteresource command") {
@@ -116,25 +116,28 @@ object EliteDevApi {
         ChatUtils.chat("Failed to fetch $resourceType resources!")
     }
 
-    private const val ELITE_SKYBLOCK_API_URL = "https://api.eliteskyblock.com"
-    private const val FARMING_WEIGHT_API_NAME = "EliteSkyBlock Farming Weight"
-    private const val FARMING_WEIGHT_URL = "$ELITE_SKYBLOCK_API_URL/weight"
+    const val ELITE_DOMAIN = "eliteskyblock.com"
+
+    const val ELITE_URL = "https://$ELITE_DOMAIN"
+    const val ELITE_API_URL = "https://api.$ELITE_DOMAIN"
+    const val FARMING_WEIGHT_API_NAME = "EliteSkyBlock Farming Weight"
+    private const val FARMING_WEIGHT_URL = "$ELITE_API_URL/weight"
 
     private val contestStatic = ApiStaticPostPath(
-        "$ELITE_SKYBLOCK_API_URL/contests/at/now",
+        "$ELITE_API_URL/contests/at/now",
         "EliteSkyBlock Farming Contests",
     )
 
-    private val apiWeightsStatic = ApiStaticPath(
-        "$ELITE_SKYBLOCK_API_URL/weights/all",
+    val apiWeightsStatic = ApiStaticPath(
+        "$ELITE_API_URL/weights/all",
         FARMING_WEIGHT_API_NAME,
     )
 
-    private const val LEADERBOARD_URL = "$ELITE_SKYBLOCK_API_URL/leaderboard/"
+    private const val LEADERBOARD_URL = "$ELITE_API_URL/leaderboard/"
     private const val LEADERBOARD_API_NAME = "EliteSkyBlock Leaderboard"
 
     private const val RESOURCE_API_NAME = "EliteSkyBlock Resources"
-    private const val RESOURCE_API_URL = "$ELITE_SKYBLOCK_API_URL/resources"
+    private const val RESOURCE_API_URL = "$ELITE_API_URL/resources"
 
     // <editor-fold desc="Upcoming Contests">
     suspend fun fetchUpcomingContests(): List<EliteFarmingContest> {
@@ -185,7 +188,7 @@ object EliteDevApi {
         ErrorManager.logErrorWithData(
             e,
             "Error loading user farming weight\n" +
-                "§eLoading the farming weight data from eliteskyblock.com failed!\n" +
+                "§eLoading the farming weight data from $ELITE_DOMAIN failed!\n" +
                 "§eYou can re-enter the garden to try to fix the problem.\n" +
                 "§cIf this message repeats, please report it on Discord",
             "weightUrl" to weightUrl,
@@ -198,7 +201,7 @@ object EliteDevApi {
     suspend fun fetchApiWeights(): EliteWeightsJson {
         val apiWeightsResponse = ApiUtils.getTypedJsonResponse<JsonObject>(apiWeightsStatic.toGet())
         val (_, apiData) = apiWeightsResponse.assertSuccessWithData() ?: ErrorManager.skyHanniError(
-            "Error getting crop weights from eliteskyblock.com",
+            "Error getting crop weights from $ELITE_DOMAIN",
             "apiWeightsResponse" to apiWeightsResponse,
         )
         return ConfigManager.gson.fromJson<EliteWeightsJson>(apiData)
@@ -211,7 +214,7 @@ object EliteDevApi {
         lbType: EliteLeaderboardType,
         upcomingCount: Int? = null,
         atRank: Int? = null,
-        mode: String? = null
+        mode: String? = null,
     ): EliteLeaderboard {
         require(profileId.isNotBlank()) { "Profile ID cannot be blank" }
         val uuid = if (spoofProfile) playerUuid else PlayerUtils.getUuid()
@@ -243,7 +246,7 @@ object EliteDevApi {
         val resourceUrl = "$RESOURCE_API_URL/$subUrl"
         val resourceApiResponse = ApiUtils.getTypedJsonResponse<JsonObject>(resourceUrl, apiName = RESOURCE_API_NAME)
         val (_, apiData) = resourceApiResponse.assertSuccessWithData() ?: ErrorManager.skyHanniError(
-            "Error getting resources from eliteskyblock.com",
+            "Error getting resources from $ELITE_DOMAIN",
             "resourceUrl" to resourceUrl,
             "resourceApiResponse" to resourceApiResponse,
         )

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/NextJacobContestConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/NextJacobContestConfig.kt
@@ -39,7 +39,7 @@ class NextJacobContestConfig {
     @Expose
     @ConfigOption(
         name = "Fetch Contests",
-        desc = "Automatically fetch Contests from elitebot.dev for the current year if they're uploaded already.",
+        desc = "Automatically fetch Contests from eliteskyblock.com for the current year if they're uploaded already.",
     )
     @ConfigEditorBoolean
     var fetchAutomatically: Boolean = true
@@ -63,7 +63,7 @@ class NextJacobContestConfig {
     @Expose
     @ConfigOption(
         name = "Share Contests",
-        desc = "Share the list of upcoming Contests to elitebot.dev for everyone else to then fetch automatically.",
+        desc = "Share the list of upcoming Contests to eliteskyblock.com for everyone else to then fetch automatically.",
     )
     @ConfigEditorDropdown
     var shareAutomatically: ShareContestsEntry = ShareContestsEntry.ASK

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
@@ -24,7 +24,7 @@ class EliteFarmersLeaderboardsConfig {
         name = "Leaderboards",
         desc = "Choose what leaderboards to enable.\n" +
             "Per-leaderboard settings below.\n" +
-            "Leaderboards provided by §eelitebot.dev"
+            "Leaderboards provided by §eeliteskyblock.com"
     )
     @ConfigEditorDraggableList
     val display: Property<MutableList<EliteLeaderboards>> = Property.of(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/JacobFarmingContestConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/JacobFarmingContestConfig.kt
@@ -26,7 +26,7 @@ class JacobFarmingContestConfig {
     @Expose
     @ConfigOption(
         name = "Open On Elite",
-        desc = "Open the contest on §eelitebot.dev§7 when pressing this key in Jacob's menu or the calendar."
+        desc = "Open the contest on §eeliteskyblock.com§7 when pressing this key in Jacob's menu or the calendar."
     )
     @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
     var openOnElite: Int = GLFW.GLFW_KEY_UNKNOWN

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/DiscordRPCConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/DiscordRPCConfig.kt
@@ -72,8 +72,9 @@ class DiscordRPCConfig {
     @ConfigEditorBoolean
     val showSkyCryptButton: Property<Boolean> = Property.of(true)
 
+    // TODO rename to showEliteSkyBlockButton
     @Expose
-    @ConfigOption(name = "Show Button for EliteBot", desc = "Add a button to the RPC that opens your EliteBot profile.")
+    @ConfigOption(name = "Show Button for EliteSkyBlock", desc = "Add a button to the RPC that opens your EliteSkyBlock profile.")
     @ConfigEditorBoolean
     val showEliteBotButton: Property<Boolean> = Property.of(true)
 

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -493,7 +493,7 @@ object EliteFarmersLeaderboard {
             message,
             listOf(
                 "§eClick to open your Farming Weight",
-                "§eprofile on §celiteskyblock.com",
+                "§eprofile on §c${EliteDevApi.ELITE_DOMAIN}",
             ),
             "/shfarmingprofile ${PlayerUtils.getName()}",
         )

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -493,7 +493,7 @@ object EliteFarmersLeaderboard {
             message,
             listOf(
                 "§eClick to open your Farming Weight",
-                "§eprofile on §celitebot.dev",
+                "§eprofile on §celiteskyblock.com",
             ),
             "/shfarmingprofile ${PlayerUtils.getName()}",
         )

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -244,8 +244,8 @@ object FarmingWeightData {
     )
 
     private val weightStatic = ApiStaticGetPath(
-        "https://api.elitebot.dev/weights/all",
-        "Elitebot Farming Weights",
+        "https://api.eliteskyblock.com/weights/all",
+        "EliteSkyBlock Farming Weights",
     )
 
     private suspend fun getCropWeights() {
@@ -264,7 +264,7 @@ object FarmingWeightData {
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shfarmingprofile") {
-            description = "Look up the farming profile from yourself or another player on elitebot.dev"
+            description = "Look up the farming profile from yourself or another player on eliteskyblock.com"
             category = CommandCategory.USERS_ACTIVE
             argCallback("name", BrigadierArguments.string()) { name ->
                 openWebsite(name, ignoreCooldown = true)
@@ -283,7 +283,7 @@ object FarmingWeightData {
         lastOpenWebsite = SimpleTimeMark.now()
         lastName = name
 
-        OSUtils.openBrowser("https://elitebot.dev/@$name".addSkyHanniUtm())
+        OSUtils.openBrowser("https://eliteskyblock.com/@$name".addSkyHanniUtm())
         ChatUtils.chat("Opening Farming Profile of player §b$name")
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -244,7 +244,7 @@ object FarmingWeightData {
     )
 
     private val weightStatic = ApiStaticGetPath(
-        "https://api.eliteskyblock.com/weights/all",
+        "${EliteDevApi.ELITE_API_URL}/weights/all",
         "EliteSkyBlock Farming Weights",
     )
 
@@ -264,7 +264,7 @@ object FarmingWeightData {
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shfarmingprofile") {
-            description = "Look up the farming profile from yourself or another player on eliteskyblock.com"
+            description = "Look up the farming profile from yourself or another player on ${EliteDevApi.ELITE_DOMAIN}"
             category = CommandCategory.USERS_ACTIVE
             argCallback("name", BrigadierArguments.string()) { name ->
                 openWebsite(name, ignoreCooldown = true)
@@ -283,7 +283,7 @@ object FarmingWeightData {
         lastOpenWebsite = SimpleTimeMark.now()
         lastName = name
 
-        OSUtils.openBrowser("https://eliteskyblock.com/@$name".addSkyHanniUtm())
+        OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/@$name".addSkyHanniUtm())
         ChatUtils.chat("Opening Farming Profile of player §b$name")
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.garden
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.EliteDevApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.pet.CurrentPetApi
 import at.hannibal2.skyhanni.config.commands.CommandCategory
@@ -312,8 +313,8 @@ object GardenApi {
                     if (profile.isNotEmpty()) profile += "/"
                     ChatUtils.clickableLinkChat(
                         "§cSkyHannis /ff display is no longer being developed! " +
-                            "§6Click §bhere §6to see your updated fortune progress and cheapest upgrades on eliteskyblock.com instead!",
-                        "https://eliteskyblock.com/@$name/${profile}fortune".addSkyHanniUtm() + "#fortune",
+                            "§6Click §bhere §6to see your updated fortune progress and cheapest upgrades on ${EliteDevApi.ELITE_DOMAIN} instead!",
+                        "${EliteDevApi.ELITE_URL}/@$name/${profile}fortune".addSkyHanniUtm() + "#fortune",
                     )
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -312,8 +312,8 @@ object GardenApi {
                     if (profile.isNotEmpty()) profile += "/"
                     ChatUtils.clickableLinkChat(
                         "§cSkyHannis /ff display is no longer being developed! " +
-                            "§6Click §bhere §6to see your updated fortune progress and cheapest upgrades on elitebot.dev instead!",
-                        "https://elitebot.dev/@$name/${profile}fortune".addSkyHanniUtm() + "#fortune",
+                            "§6Click §bhere §6to see your updated fortune progress and cheapest upgrades on eliteskyblock.com instead!",
+                        "https://eliteskyblock.com/@$name/${profile}fortune".addSkyHanniUtm() + "#fortune",
                     )
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -479,7 +479,7 @@ object GardenNextJacobContest {
 
     private fun handleFetchedContests() {
         if (haveAllContests) {
-            ChatUtils.chat("Successfully loaded this year's contests from elitebot.dev automatically!")
+            ChatUtils.chat("Successfully loaded this year's contests from eliteskyblock.com automatically!")
             fetchedFromElite = true
             nextContestsAvailableAt = SkyBlockTime(SkyBlockTime.now().year + 1, 1, 2).toTimeMark()
             loadedContestsYear = SkyBlockTime.now().year

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -479,7 +479,7 @@ object GardenNextJacobContest {
 
     private fun handleFetchedContests() {
         if (haveAllContests) {
-            ChatUtils.chat("Successfully loaded this year's contests from eliteskyblock.com automatically!")
+            ChatUtils.chat("Successfully loaded this year's contests from ${EliteDevApi.ELITE_DOMAIN} automatically!")
             fetchedFromElite = true
             nextContestsAvailableAt = SkyBlockTime(SkyBlockTime.now().year + 1, 1, 2).toTimeMark()
             loadedContestsYear = SkyBlockTime.now().year

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -117,29 +117,33 @@ object JacobFarmingContestsInventory {
 
     private fun openContest(year: String, month: String, day: String) {
         val date = "$year/${SkyBlockTime.getSBMonthByName(month)}/$day"
-        OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/contests/$date".addSkyHanniUtm())
+        openElite("contests/$date".addSkyHanniUtm())
         ChatUtils.chat("Opening contest in ${EliteDevApi.ELITE_DOMAIN}")
     }
 
     private fun openFromJacobMenu(itemName: String) {
         when (itemName) {
             "§6Upcoming Contests" -> {
-                OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/contests/upcoming".addSkyHanniUtm())
+                openElite("contests/upcoming".addSkyHanniUtm())
                 ChatUtils.chat("Opening upcoming contests in ${EliteDevApi.ELITE_DOMAIN}")
             }
 
             "§bClaim your rewards!" -> {
-                OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/@${PlayerUtils.getName()}/${HypixelData.profileName}/contests".addSkyHanniUtm())
+                openElite("@${PlayerUtils.getName()}/${HypixelData.profileName}/contests".addSkyHanniUtm())
                 ChatUtils.chat("Opening your contests in ${EliteDevApi.ELITE_DOMAIN}")
             }
 
             "§aWhat is this?" -> {
-                OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/contests".addSkyHanniUtm())
+                openElite("contests".addSkyHanniUtm())
                 ChatUtils.chat("Opening contest page in ${EliteDevApi.ELITE_DOMAIN}")
             }
 
             else -> return
         }
+    }
+
+    private fun openElite(url: String) {
+        OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/$url")
     }
 
     private fun openFromCalendar(
@@ -159,7 +163,7 @@ object JacobFarmingContestsInventory {
                 openContest(year, month, day)
             } else {
                 val timestamp = time / 1000
-                OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/contests/upcoming".addSkyHanniUtm() + "#$timestamp")
+                openElite("contests/upcoming".addSkyHanniUtm() + "#$timestamp")
                 ChatUtils.chat("Opening upcoming contests in ${EliteDevApi.ELITE_DOMAIN}")
             }
             event.cancel()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.garden.contest
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.EliteDevApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.HypixelData
@@ -116,25 +117,25 @@ object JacobFarmingContestsInventory {
 
     private fun openContest(year: String, month: String, day: String) {
         val date = "$year/${SkyBlockTime.getSBMonthByName(month)}/$day"
-        OSUtils.openBrowser("https://eliteskyblock.com/contests/$date".addSkyHanniUtm())
-        ChatUtils.chat("Opening contest in eliteskyblock.com")
+        OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/contests/$date".addSkyHanniUtm())
+        ChatUtils.chat("Opening contest in ${EliteDevApi.ELITE_DOMAIN}")
     }
 
     private fun openFromJacobMenu(itemName: String) {
         when (itemName) {
             "§6Upcoming Contests" -> {
-                OSUtils.openBrowser("https://eliteskyblock.com/contests/upcoming".addSkyHanniUtm())
-                ChatUtils.chat("Opening upcoming contests in eliteskyblock.com")
+                OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/contests/upcoming".addSkyHanniUtm())
+                ChatUtils.chat("Opening upcoming contests in ${EliteDevApi.ELITE_DOMAIN}")
             }
 
             "§bClaim your rewards!" -> {
-                OSUtils.openBrowser("https://eliteskyblock.com/@${PlayerUtils.getName()}/${HypixelData.profileName}/contests".addSkyHanniUtm())
-                ChatUtils.chat("Opening your contests in eliteskyblock.com")
+                OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/@${PlayerUtils.getName()}/${HypixelData.profileName}/contests".addSkyHanniUtm())
+                ChatUtils.chat("Opening your contests in ${EliteDevApi.ELITE_DOMAIN}")
             }
 
             "§aWhat is this?" -> {
-                OSUtils.openBrowser("https://eliteskyblock.com/contests".addSkyHanniUtm())
-                ChatUtils.chat("Opening contest page in eliteskyblock.com")
+                OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/contests".addSkyHanniUtm())
+                ChatUtils.chat("Opening contest page in ${EliteDevApi.ELITE_DOMAIN}")
             }
 
             else -> return
@@ -158,8 +159,8 @@ object JacobFarmingContestsInventory {
                 openContest(year, month, day)
             } else {
                 val timestamp = time / 1000
-                OSUtils.openBrowser("https://eliteskyblock.com/contests/upcoming".addSkyHanniUtm() + "#$timestamp")
-                ChatUtils.chat("Opening upcoming contests in eliteskyblock.com")
+                OSUtils.openBrowser("${EliteDevApi.ELITE_URL}/contests/upcoming".addSkyHanniUtm() + "#$timestamp")
+                ChatUtils.chat("Opening upcoming contests in ${EliteDevApi.ELITE_DOMAIN}")
             }
             event.cancel()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -116,25 +116,25 @@ object JacobFarmingContestsInventory {
 
     private fun openContest(year: String, month: String, day: String) {
         val date = "$year/${SkyBlockTime.getSBMonthByName(month)}/$day"
-        OSUtils.openBrowser("https://elitebot.dev/contests/$date".addSkyHanniUtm())
-        ChatUtils.chat("Opening contest in elitebot.dev")
+        OSUtils.openBrowser("https://eliteskyblock.com/contests/$date".addSkyHanniUtm())
+        ChatUtils.chat("Opening contest in eliteskyblock.com")
     }
 
     private fun openFromJacobMenu(itemName: String) {
         when (itemName) {
             "§6Upcoming Contests" -> {
-                OSUtils.openBrowser("https://elitebot.dev/contests/upcoming".addSkyHanniUtm())
-                ChatUtils.chat("Opening upcoming contests in elitebot.dev")
+                OSUtils.openBrowser("https://eliteskyblock.com/contests/upcoming".addSkyHanniUtm())
+                ChatUtils.chat("Opening upcoming contests in eliteskyblock.com")
             }
 
             "§bClaim your rewards!" -> {
-                OSUtils.openBrowser("https://elitebot.dev/@${PlayerUtils.getName()}/${HypixelData.profileName}/contests".addSkyHanniUtm())
-                ChatUtils.chat("Opening your contests in elitebot.dev")
+                OSUtils.openBrowser("https://eliteskyblock.com/@${PlayerUtils.getName()}/${HypixelData.profileName}/contests".addSkyHanniUtm())
+                ChatUtils.chat("Opening your contests in eliteskyblock.com")
             }
 
             "§aWhat is this?" -> {
-                OSUtils.openBrowser("https://elitebot.dev/contests".addSkyHanniUtm())
-                ChatUtils.chat("Opening contest page in elitebot.dev")
+                OSUtils.openBrowser("https://eliteskyblock.com/contests".addSkyHanniUtm())
+                ChatUtils.chat("Opening contest page in eliteskyblock.com")
             }
 
             else -> return
@@ -158,8 +158,8 @@ object JacobFarmingContestsInventory {
                 openContest(year, month, day)
             } else {
                 val timestamp = time / 1000
-                OSUtils.openBrowser("https://elitebot.dev/contests/upcoming".addSkyHanniUtm() + "#$timestamp")
-                ChatUtils.chat("Opening upcoming contests in elitebot.dev")
+                OSUtils.openBrowser("https://eliteskyblock.com/contests/upcoming".addSkyHanniUtm() + "#$timestamp")
+                ChatUtils.chat("Opening upcoming contests in eliteskyblock.com")
             }
             event.cancel()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
@@ -195,7 +195,7 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
             return Renderable.hoverTips(
                 content = "§7Waiting for update...",
                 tips = listOf(
-                    "§celitebot.dev is currently overloaded or unavailable.",
+                    "§celiteskyblock.com is currently overloaded or unavailable.",
                     "§7Leaderboard data will update when the service recovers.",
                 ),
             )

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.leaderboarddisplays
 
+import at.hannibal2.skyhanni.api.EliteDevApi
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboardConfigApi
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboardConfigApi.getConfigFromClass
@@ -195,7 +196,7 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
             return Renderable.hoverTips(
                 content = "§7Waiting for update...",
                 tips = listOf(
-                    "§celiteskyblock.com is currently overloaded or unavailable.",
+                    "§c${EliteDevApi.ELITE_DOMAIN} is currently overloaded or unavailable.",
                     "§7Leaderboard data will update when the service recovers.",
                 ),
             )

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -182,8 +182,8 @@ object DiscordRPCManager {
         if (config.showEliteBotButton.get()) {
             buttons.add(
                 Activity.Button(
-                    label = "Open EliteBot",
-                    url = "https://elitebot.dev/@${PlayerUtils.getName()}/${HypixelData.profileName}".addSkyHanniUtm(),
+                    label = "Open EliteSkyBlock",
+                    url = "https://eliteskyblock.com/@${PlayerUtils.getName()}/${HypixelData.profileName}".addSkyHanniUtm(),
                 ),
             )
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -4,6 +4,7 @@ package at.hannibal2.skyhanni.features.misc.discordrpc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.SkyHanniMod.feature
+import at.hannibal2.skyhanni.api.EliteDevApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.commands.CommandCategory
@@ -183,7 +184,7 @@ object DiscordRPCManager {
             buttons.add(
                 Activity.Button(
                     label = "Open EliteSkyBlock",
-                    url = "https://eliteskyblock.com/@${PlayerUtils.getName()}/${HypixelData.profileName}".addSkyHanniUtm(),
+                    url = "${EliteDevApi.ELITE_URL}/@${PlayerUtils.getName()}/${HypixelData.profileName}".addSkyHanniUtm(),
                 ),
             )
         }


### PR DESCRIPTION
## What

https://eliteskyblock.com/articles/blog-new-domain-name

not sure if the visual name shoud be `EliteSkyBlock` or `Elite SkyBlock`.

## Changelog Improvements
+ Renamed Farming Weight's EliteBot display name to Elite SkyBlock. - hannibal2