### PR TITLE
Fix: Overclocker Pattern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactJacobClaim.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactJacobClaim.kt
@@ -153,7 +153,7 @@ object CompactJacobClaim {
         }
 
         overclockerPattern.matchMatcher(message) {
-            rewardSet.overclockers += groupOrNull("overclockers")?.formatInt() ?: 1
+            rewardSet.overclockers += groupOrNull("count")?.formatInt() ?: 1
         }
 
         bookPattern.matchMatcher(message) {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactJacobClaim.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactJacobClaim.kt
@@ -95,10 +95,11 @@ object CompactJacobClaim {
 
     /**
      * REGEX-TEST:     Overclocker 3000
+     * REGEX-TEST:     Overclocker 3000 x4
      */
     private val overclockerPattern by patternGroup.pattern(
         "overclocker",
-        " {4}Overclocker 3000",
+        " {4}Overclocker 3000(?: x(?<count>\\d+))?",
     )
     // </editor-fold>
 
@@ -152,7 +153,7 @@ object CompactJacobClaim {
         }
 
         overclockerPattern.matchMatcher(message) {
-            rewardSet.overclockers++
+            rewardSet.overclockers += groupOrNull("overclockers")?.formatInt() ?: 1
         }
 
         bookPattern.matchMatcher(message) {


### PR DESCRIPTION
## What
Evidently when bulk-claiming 60+ contests at a time, it can produce more than 1 overclocker.

<details>
<summary>Images</summary>

<img width="1034" height="499" alt="image" src="https://github.com/user-attachments/assets/b763ea66-edb6-4b8b-a6c4-ad8231aee2c9" />

</details>

## Changelog Fixes
+ Fixed multiple overclockers not being detected by Jacob bulk-claim. - Daveed