### PR TITLE
Backend: Removed duplicate code around location parsing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -741,7 +741,7 @@ object IslandGraphs {
 
         data["generic data"] = "below"
         data["island"] = island
-        data["reported location"] = with(location.roundTo(1)) { "/shtestwaypoint $x $y $z pathfind" }
+        data["reported location"] = "/shtestwaypoint ${location.toLocalFormat()} pathfind"
         if (graphArea != scoreboardArea) {
             data["area graph"] = graphArea.orEmpty()
             data["area scoreboard"] = scoreboardArea

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -125,9 +125,7 @@ object SlayerApi {
             if (!isInCorrectArea) {
                 add("currentAreaType: $currentAreaType")
                 add(" graph area: ${SkyBlockUtils.graphArea}")
-                with(PlayerUtils.blockPosition()) {
-                    add(" /shtestwaypoint $x $y $z pathfind")
-                }
+                add(" /shtestwaypoint ${PlayerUtils.blockPosition().toLocalFormat()} pathfind")
             }
             add("isInAnyArea: $isInAnyArea")
             add("latestProgress: '${latestProgress.removeColor()}'")

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/SendCoordinatedCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/SendCoordinatedCommand.kt
@@ -25,11 +25,5 @@ object SendCoordinatedCommand {
         }
     }
 
-    private fun getCoordinates(): String {
-        val location = LocationUtils.playerLocation()
-        val x = location.x.toInt()
-        val y = location.y.toInt()
-        val z = location.z.toInt()
-        return "x: $x, y: $y, z: $z"
-    }
+    private fun getCoordinates(): String = LocationUtils.playerLocation().toChatFormat()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
@@ -22,6 +22,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.hasGroup
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RegexUtils.toLorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
@@ -228,13 +229,10 @@ object RareMobWaypointShare {
             ChatUtils.chat("§cRare Mob is dead")
             return
         }
-        val location = rareMob.getLorenzVec()
-        val x = location.x.toInt()
-        val y = location.y.toInt()
-        val z = location.z.toInt()
+        val location = rareMob.getLorenzVec().toChatFormat()
         val mobName = rareMob.name.string.orEmpty()
         val name = if (mobName.isEmpty()) "" else "| $mobName"
-        HypixelCommands.partyChat("x: $x, y: $y, z: $z $name")
+        HypixelCommands.partyChat("$location $name")
     }
 
     private fun Matcher.block(): Boolean = !hasGroup("party") && !config.globalChat
@@ -242,10 +240,7 @@ object RareMobWaypointShare {
     private fun Matcher.detectFromChat(): Boolean {
         if (block()) return false
         val rawPlayerName = group("playerName")
-        val x = group("x").trim().toDoubleOrNull() ?: return false
-        val y = group("y").trim().toDoubleOrNull() ?: return false
-        val z = group("z").trim().toDoubleOrNull() ?: return false
-        val location = LorenzVec(x, y, z)
+        val location = toLorenzVec() ?: return false
 
         val rawMobName = if (hasGroup("mobName")) group("mobName").replace(" | ", "").trim().lowercase() else "Rare Mob"
         var mobName = "Rare Mob"
@@ -260,7 +255,7 @@ object RareMobWaypointShare {
         val name = rawPlayerName.cleanPlayerName()
         val playerDisplayName = rawPlayerName.cleanPlayerName(displayName = true)
         if (!waypoints.containsKey(name)) {
-            ChatUtils.chat("$playerDisplayName §l§efound $optionalAn $mobName at §l§c${x.toInt()} ${y.toInt()} ${z.toInt()}!")
+            ChatUtils.chat("$playerDisplayName §l§efound $optionalAn $mobName at §l§c${location.toLocalFormat()}!")
             if (name != PlayerUtils.getName()) {
                 TitleManager.sendTitle("§d$mobName §efrom §b$playerDisplayName")
                 playUserSound()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsShared.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsShared.kt
@@ -7,9 +7,9 @@ import at.hannibal2.skyhanni.features.inventory.chocolatefactory.CFApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.toLorenzVec
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 
@@ -32,8 +32,7 @@ object HoppityEggsShared {
         if (!isEnabled()) return
 
         sharedEggPattern.matchMatcher(event.message.removeColor()) {
-            val (x, y, z) = listOf(group("x"), group("y"), group("z")).map { it.formatInt() }
-            val eggLocation = LorenzVec(x, y, z)
+            val eggLocation = toLorenzVec() ?: return
 
             val meal = getEggType(event)
             val note = groupOrNull("note")
@@ -52,11 +51,9 @@ object HoppityEggsShared {
         val islandEggsLocations = HoppityEggLocations.islandLocations
         val closestEgg = islandEggsLocations.minByOrNull { it.distance(playerLocation) } ?: return
 
-        val x = closestEgg.x.toInt()
-        val y = closestEgg.y.toInt()
-        val z = closestEgg.z.toInt()
+        val location = closestEgg.toChatFormat()
 
-        HypixelCommands.allChat("[SkyHanni] ${meal.mealName} Chocolate Egg located at x: $x, y: $y, z: $z ($note)")
+        HypixelCommands.allChat("[SkyHanni] ${meal.mealName} Chocolate Egg located at $location ($note)")
     }
 
     fun isEnabled() = SkyBlockUtils.inSkyBlock && waypointsConfig.enabled && waypointsConfig.shared

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/MetalDetectorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/MetalDetectorSolver.kt
@@ -23,6 +23,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NumberUtil.formatDoubleOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -111,7 +112,7 @@ object MetalDetectorSolver {
         }
 
         metalDetectorDistancePattern.matchMatcher(event.actionBar) {
-            val distance = group("distance").toDoubleOrNull() ?: return
+            val distance = group("distance").formatDoubleOrNull() ?: return
 
             if (baseCoordinates == null) findBaseCoordinates()
             val baseCoordinatesNonNull = baseCoordinates ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseLocator.kt
@@ -16,9 +16,9 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LocationUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.toLorenzVec
 import at.hannibal2.skyhanni.utils.compat.getStandHelmet
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -77,10 +77,10 @@ object CorpseLocator {
             .filter { it.location.distanceToPlayer() <= 5 }
             .minByOrNull { it.location.distanceToPlayer() } ?: return
 
-        val (x, y, z) = closestCorpse.location.toDoubleArray().map { it.toInt() }
+        val location = closestCorpse.location.toChatFormat()
         val type = closestCorpse.waypointType.displayText
 
-        HypixelCommands.partyChat("x: $x, y: $y, z: $z | ($type)")
+        HypixelCommands.partyChat("$location | ($type)")
         closestCorpse.shared = true
     }
 
@@ -117,8 +117,7 @@ object CorpseLocator {
         if (PlayerUtils.getName() in author) return
 
         mineshaftCoordsPattern.matchMatcher(message) {
-            val (x, y, z) = listOf(group("x"), group("y"), group("z")).map { it.formatInt() }
-            val location = LorenzVec(x, y, z)
+            val location = toLorenzVec() ?: return
 
             // Return if someone had already sent a location nearby
             if (sharedWaypoints.any { it.distance(location) <= 5 }) return

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/MineshaftWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/MineshaftWaypoints.kt
@@ -66,11 +66,9 @@ object MineshaftWaypoints {
             .minByOrNull { it.location.distanceToPlayer() } ?: return
 
         timeLastShared = SimpleTimeMark.now()
-        val location = closestWaypoint.location
-        val (x, y, z) = location.toDoubleArray().map { it.toInt() }
+        val location = closestWaypoint.location.toChatFormat()
         val type = closestWaypoint.waypointType.displayText
-
-        val message = "x: $x, y: $y, z: $z | ($type)"
+        val message = "$location | ($type)"
 
         if (PartyApi.partyMembers.isNotEmpty()) {
             HypixelCommands.partyChat(message)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatDoubleOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -136,7 +137,7 @@ object LimboPlaytime {
             modifiedList = modifiedList.sortedByDescending {
                 val matcher = hoursPattern.matcher(it.string)
                 if (matcher.find()) {
-                    matcher.group("hours").replace(",", "").toDoubleOrNull() ?: 0.0
+                    matcher.group("hours").formatDoubleOrNull() ?: 0.0
                 } else 0.0
             }.toMutableList()
             setMinutes = false

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -131,9 +131,7 @@ object NavigationHelper {
             aliases = listOf("shnav")
             argCallback("coords", LorenzVecArgumentType.double()) { location ->
                 pathFind(location.add(-1, -1, -1), "Custom Goal", condition = { true })
-                with(location) {
-                    ChatUtils.chat("Started Navigating to custom goal at §f$x $y $z", messageId = messageId)
-                }
+                ChatUtils.chat("Started Navigating to custom goal at §f${location.toLocalFormat()}", messageId = messageId)
             }
             argCallback("search", BrigadierArguments.greedyString(), BrigadierUtils.dynamicSuggestionProvider { getNames() }) {
                 SkyHanniMod.launchCoroutine("shnavigate command") {

--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -145,9 +145,8 @@ object DebugCommand {
             add("skyBlockArea:")
             add("  scoreboard: '${SkyBlockUtils.scoreboardArea}'")
             add("  graph network: '${SkyBlockUtils.graphArea}'")
-            with(PlayerUtils.blockPosition()) {
-                add(" /shtestwaypoint $x $y $z pathfind")
-            }
+            val location = PlayerUtils.blockPosition().toLocalFormat()
+            add(" /shtestwaypoint $location pathfind")
             add("isOnAlphaServer: '${SkyBlockUtils.isOnAlphaServer}'")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -314,20 +314,20 @@ object SkyHanniDebugsAndTests {
     }
 
     private fun copyLocation(parameter: String? = null) {
-        val location = LocationUtils.playerLocation()
-        val x = (location.x + 0.001).roundTo(1)
-        val y = (location.y + 0.001).roundTo(1)
-        val z = (location.z + 0.001).roundTo(1)
-        val (clipboard, format) = formatLocation(x, y, z, parameter)
+        val location = LocationUtils.playerLocation().roundTo(1)
+        val (clipboard, format) = formatLocation(location, parameter)
         OSUtils.copyToClipboard(clipboard)
         ChatUtils.chat("Copied the current location to clipboard ($format format)!", replaceSameMessage = true)
     }
 
-    private fun formatLocation(x: Double, y: Double, z: Double, parameter: String?): Pair<String, String> = when (parameter) {
-        "json" -> "$x:$y:$z" to "json"
-        "pathfind" -> "`/shtestwaypoint $x $y $z pathfind`" to "pathfind"
-        "navigate" -> "`/shnavigate $x $y $z`" to "navigate"
-        else -> "LorenzVec($x, $y, $z)" to "LorenzVec"
+    private fun formatLocation(location: LorenzVec, parameter: String?): Pair<String, String> {
+        val localFormat = location.toLocalFormat()
+        return when (parameter) {
+            "json" -> location.asStoredString() to "json"
+            "pathfind" -> "`/shtestwaypoint $localFormat pathfind`" to "pathfind"
+            "navigate" -> "`/shnavigate $localFormat`" to "navigate"
+            else -> "LorenzVec(${location.x}, ${location.y}, ${location.z})" to "LorenzVec"
+        }
     }
 
     private fun registerDebugScreenEntry(
@@ -350,7 +350,7 @@ object SkyHanniDebugsAndTests {
                 }
 
                 override fun isAllowed(reducedDebugInfo: Boolean) = true
-            }
+            },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -314,7 +314,7 @@ object SkyHanniDebugsAndTests {
     }
 
     private fun copyLocation(parameter: String? = null) {
-        val location = LocationUtils.playerLocation().roundTo(1)
+        val location = LocationUtils.playerLocation().add(0.001, 0.001, 0.001).roundTo(1)
         val (clipboard, format) = formatLocation(location, parameter)
         OSUtils.copyToClipboard(clipboard)
         ChatUtils.chat("Copied the current location to clipboard ($format format)!", replaceSameMessage = true)

--- a/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
@@ -225,6 +225,12 @@ data class LorenzVec(
 
     private operator fun div(i: Number): LorenzVec = LorenzVec(x / i.toDouble(), y / i.toDouble(), z / i.toDouble())
 
+    // format we use to send to all/party chat
+    fun toChatFormat(): String = "x: ${x.toInt()}, y: ${y.toInt()}, z: ${z.toInt()}"
+
+    // format we show in local chat or for local commands
+    fun toLocalFormat(): String = "${x.toInt()} ${y.toInt()} ${z.toInt()}"
+
     /**
      * Kotlin compiles the default equals method of data classes for doubles by comparing them, like
      * ```kt

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -101,6 +101,17 @@ object RegexUtils {
 
     fun Matcher.hasGroup(groupName: String): Boolean = groupOrNull(groupName) != null
 
+    fun Matcher.toLorenzVec(
+        xGroup: String = "x",
+        yGroup: String = "y",
+        zGroup: String = "z",
+    ): LorenzVec? {
+        val x = groupOrNull(xGroup)?.trim()?.toDoubleOrNull() ?: return null
+        val y = groupOrNull(yGroup)?.trim()?.toDoubleOrNull() ?: return null
+        val z = groupOrNull(zGroup)?.trim()?.toDoubleOrNull() ?: return null
+        return LorenzVec(x, y, z)
+    }
+
     fun Pattern.indexOfFirstMatch(list: List<String>): Int? {
         for ((index, line) in list.withIndex()) {
             matcher(line).let { if (it.matches()) return index }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.utils.NumberUtil.formatDoubleOrNull
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import net.minecraft.network.chat.Component
 import java.util.regex.Matcher
@@ -106,9 +107,9 @@ object RegexUtils {
         yGroup: String = "y",
         zGroup: String = "z",
     ): LorenzVec? {
-        val x = groupOrNull(xGroup)?.trim()?.toDoubleOrNull() ?: return null
-        val y = groupOrNull(yGroup)?.trim()?.toDoubleOrNull() ?: return null
-        val z = groupOrNull(zGroup)?.trim()?.toDoubleOrNull() ?: return null
+        val x = groupOrNull(xGroup)?.trim()?.formatDoubleOrNull() ?: return null
+        val y = groupOrNull(yGroup)?.trim()?.formatDoubleOrNull() ?: return null
+        val z = groupOrNull(zGroup)?.trim()?.formatDoubleOrNull() ?: return null
         return LorenzVec(x, y, z)
     }
 


### PR DESCRIPTION
## What
removed dupliate code  when searching for stuff like
`x: $x, y: $y, z: $z `
or
`$x $y $z`
or
`group("x")`

this all is now handled via functions in `LorenzVec` or `RegexUtils`.

## Changelog Technical Details
+ Cleaned up code duplications around location to string or string to location parsing. - hannibal2