### PR TITLE
Fix: Tracker uptime data not being saved between sessions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/TrackerData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/TrackerData.kt
@@ -14,13 +14,14 @@ abstract class TrackerData<T : SessionUptime>(
 ) : Resettable {
     @Expose
     private var migrated = false
+
+    @Expose
     @SerializedName("sessionUptime")
     private val sessionUptimeInternal: MutableMap<SessionUptime?, Stopwatch?> = mutableMapOf()
 
     @Suppress("UNCHECKED_CAST")
-    private val sessionUptime: MutableMap<SessionUptime, Stopwatch> get() {
-        return sessionUptimeInternal as MutableMap<SessionUptime, Stopwatch>
-    }
+    private val sessionUptime: MutableMap<SessionUptime, Stopwatch>
+        get() = sessionUptimeInternal as MutableMap<SessionUptime, Stopwatch>
 
 
     override fun reset() {


### PR DESCRIPTION
## What
got broken in #4702
got reported in https://discord.com/channels/997079228510117908/1000669238035497022/1482554970204016843

## Changelog Fixes
+ Fixed tracker uptime data not being saved between sessions. - hannibal2