### PR TITLE
Improvement: Add wrong crop warning to Hoe Levels Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
@@ -60,39 +60,43 @@ object HoeLevelDisplay {
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onTick() {
         if (!isEnabled()) return
-        display = null
-        val list = mutableListOf<Renderable>()
-        list.add(Renderable.text("§6Hoe Levels"))
-        val heldItem = InventoryUtils.getItemInHand()
-        val hoeExp = heldItem?.getHoeExp() ?: return
-        var hoeLevel = heldItem.getHoeLevel() ?: return
-        var next = hoeOverflow
-        val hoeLevels = hoeLevels ?: return
+        display = buildList {
+            add(Renderable.text("§6Hoe Levels"))
+            val heldItem = InventoryUtils.getItemInHand()
+            val hoeExp = heldItem?.getHoeExp() ?: return
+            var hoeLevel = heldItem.getHoeLevel() ?: return
+            var next = hoeOverflow
+            val hoeLevels = hoeLevels ?: return
 
-        if (hoeLevel <= hoeLevels.size) {
-            next = hoeLevels.let { it[hoeLevel - 1] }
-        }
+            if (hoeLevel <= hoeLevels.size) {
+                next = hoeLevels.let { it[hoeLevel - 1] }
+            }
 
-        if (hoeLevel > hoeLevels.size && config.overflow) {
-            val uuid = heldItem.getItemUuid()
-            val overflowLevel = getOverflowHoeLevel(uuid)
-            if (overflowLevel != null) {
-                hoeLevel += overflowLevel
+            if (hoeLevel > hoeLevels.size && config.overflow) {
+                val uuid = heldItem.getItemUuid()
+                val overflowLevel = getOverflowHoeLevel(uuid)
+                if (overflowLevel != null) {
+                    hoeLevel += overflowLevel
+                }
+            }
+            add(Renderable.text("§7Level §8$hoeLevel➜§3${hoeLevel + 1}"))
+
+            var colorPrefix = "§e"
+            if (hoeExp > next) {
+                colorPrefix = "§c§l"
+                if (hoeLevel >= OVERCLOCK_THRESHOLD) add(Renderable.text("§3§lOVERCLOCK REQUIRED!"))
+                else add(Renderable.text("§c§lUPGRADE REQUIRED!"))
+            }
+            val formattedXp = hoeExp.addSeparators()
+            val formattedXpToNext = next.addSeparators()
+            add(Renderable.text("$colorPrefix$formattedXp§8/§e$formattedXpToNext"))
+
+            GardenApi.lastBrokenCropType?.let { lastCrop ->
+                if (lastCrop != GardenApi.cropInHand) {
+                    add(Renderable.text("§cNot gaining XP! (Wrong crop)"))
+                }
             }
         }
-        list.add(Renderable.text("§7Level §8$hoeLevel➜§3${hoeLevel + 1}"))
-
-        var colorPrefix = "§e"
-        if (hoeExp > next) {
-            colorPrefix = "§c§l"
-            if (hoeLevel >= OVERCLOCK_THRESHOLD) list.add(Renderable.text("§3§lOVERCLOCK REQUIRED!"))
-            else list.add(Renderable.text("§c§lUPGRADE REQUIRED!"))
-        }
-        val formattedXp = hoeExp.addSeparators()
-        val formattedXpToNext = next.addSeparators()
-        list.add(Renderable.text("$colorPrefix$formattedXp§8/§e$formattedXpToNext"))
-
-        display = list
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
@@ -77,11 +77,11 @@ object HoeLevelDisplay {
             }
             add("§7Level §8$hoeLevel➜§3${hoeLevel + 1}")
 
-            val colorPrefix = if (hoeExp <= next) "§e"
-            else {
+            var colorPrefix = "§e"
+            if (hoeExp > next) {
+                colorPrefix = "§c§l"
                 if (hoeLevel >= OVERCLOCK_THRESHOLD) add("§3§lOVERCLOCK REQUIRED!")
                 else add("§c§lUPGRADE REQUIRED!")
-                "§c§l"
             }
             val formattedXp = hoeExp.addSeparators()
             val formattedXpToNext = next.addSeparators()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
@@ -65,12 +65,8 @@ object HoeLevelDisplay {
             val heldItem = InventoryUtils.getItemInHand()
             val hoeExp = heldItem?.getHoeExp() ?: return
             var hoeLevel = heldItem.getHoeLevel() ?: return
-            var next = hoeOverflow
             val hoeLevels = hoeLevels ?: return
-
-            if (hoeLevel <= hoeLevels.size) {
-                next = hoeLevels.let { it[hoeLevel - 1] }
-            }
+            val next = if (hoeLevel <= hoeLevels.size) hoeLevels[hoeLevel - 1] else hoeOverflow
 
             if (hoeLevel > hoeLevels.size && config.overflow) {
                 val uuid = heldItem.getItemUuid()
@@ -81,20 +77,18 @@ object HoeLevelDisplay {
             }
             add("§7Level §8$hoeLevel➜§3${hoeLevel + 1}")
 
-            var colorPrefix = "§e"
-            if (hoeExp > next) {
-                colorPrefix = "§c§l"
+            val colorPrefix = if (hoeExp <= next) "§e"
+            else {
                 if (hoeLevel >= OVERCLOCK_THRESHOLD) add("§3§lOVERCLOCK REQUIRED!")
                 else add("§c§lUPGRADE REQUIRED!")
+                "§c§l"
             }
             val formattedXp = hoeExp.addSeparators()
             val formattedXpToNext = next.addSeparators()
             add("$colorPrefix$formattedXp§8/§e$formattedXpToNext")
 
-            GardenApi.lastBrokenCropType?.let { lastCrop ->
-                if (lastCrop != GardenApi.cropInHand) {
-                    add("§cNot gaining XP! (Wrong crop)")
-                }
+            GardenApi.lastBrokenCropType?.takeIf { it != GardenApi.cropInHand }?.let {
+                add("§cNot gaining XP! (Wrong crop)")
             }
         }.map(Renderable::text)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
@@ -61,7 +61,7 @@ object HoeLevelDisplay {
     fun onTick() {
         if (!isEnabled()) return
         display = buildList {
-            add(Renderable.text("§6Hoe Levels"))
+            add("§6Hoe Levels")
             val heldItem = InventoryUtils.getItemInHand()
             val hoeExp = heldItem?.getHoeExp() ?: return
             var hoeLevel = heldItem.getHoeLevel() ?: return
@@ -79,24 +79,24 @@ object HoeLevelDisplay {
                     hoeLevel += overflowLevel
                 }
             }
-            add(Renderable.text("§7Level §8$hoeLevel➜§3${hoeLevel + 1}"))
+            add("§7Level §8$hoeLevel➜§3${hoeLevel + 1}")
 
             var colorPrefix = "§e"
             if (hoeExp > next) {
                 colorPrefix = "§c§l"
-                if (hoeLevel >= OVERCLOCK_THRESHOLD) add(Renderable.text("§3§lOVERCLOCK REQUIRED!"))
-                else add(Renderable.text("§c§lUPGRADE REQUIRED!"))
+                if (hoeLevel >= OVERCLOCK_THRESHOLD) add("§3§lOVERCLOCK REQUIRED!")
+                else add("§c§lUPGRADE REQUIRED!")
             }
             val formattedXp = hoeExp.addSeparators()
             val formattedXpToNext = next.addSeparators()
-            add(Renderable.text("$colorPrefix$formattedXp§8/§e$formattedXpToNext"))
+            add("$colorPrefix$formattedXp§8/§e$formattedXpToNext")
 
             GardenApi.lastBrokenCropType?.let { lastCrop ->
                 if (lastCrop != GardenApi.cropInHand) {
-                    add(Renderable.text("§cNot gaining XP! (Wrong crop)"))
+                    add("§cNot gaining XP! (Wrong crop)")
                 }
             }
-        }
+        }.map(Renderable::text)
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)


### PR DESCRIPTION
> [!NOTE]
> Make sure to turn on "Hide whitespace" (`?w=1`) when reviewing the PR to easily see the actual changes.

## What
You don't gain tool exp on specialized farming tools if you're not farming the crop matching the type of tool you're using. This PR adds a line to Hoe Levels Display warning you about this case.

This is just an info line, not an alert or anything, so it won't aid in detecting macro checks or anything like that.

## Changelog Improvements
+ Hoe Levels Display now warns you if your tool is not gaining XP because you're farming the wrong crop. - Luna

