### PR TITLE
Backend: Slight Repo Cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt
@@ -10,7 +10,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
-class NeuRepositoryConfig : AbstractRepoConfig<NeuRepositoryConfig.NeuRepositoryLocation>() {
+class NeuRepositoryConfig : AbstractRepoConfig {
 
     @Expose
     @ConfigOption(
@@ -30,7 +30,7 @@ class NeuRepositoryConfig : AbstractRepoConfig<NeuRepositoryConfig.NeuRepository
     @Accordion
     override val location: NeuRepositoryLocation = NeuRepositoryLocation()
 
-    class NeuRepositoryLocation : AbstractRepoLocationConfig() {
+    class NeuRepositoryLocation : AbstractRepoLocationConfig {
         @ConfigOption(name = "Reset Repository Location", desc = "Reset your NEU repository location to the default.")
         @ConfigEditorButton(buttonText = "Reset")
         val resetRepoLocation: Runnable = Runnable { reset() }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/RepositoryConfig.kt
@@ -10,7 +10,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorText
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
-class RepositoryConfig : AbstractRepoConfig<RepositoryConfig.RepositoryLocation>() {
+class RepositoryConfig : AbstractRepoConfig {
     @Expose
     @ConfigOption(
         name = "Repo Auto Update",
@@ -29,7 +29,7 @@ class RepositoryConfig : AbstractRepoConfig<RepositoryConfig.RepositoryLocation>
     @Accordion
     override val location: RepositoryLocation = RepositoryLocation()
 
-    class RepositoryLocation : AbstractRepoLocationConfig() {
+    class RepositoryLocation : AbstractRepoLocationConfig {
         @ConfigOption(name = "Reset Repository Location", desc = "Reset your repository location to the default.")
         @ConfigEditorButton(buttonText = "Reset")
         val resetRepoLocation: Runnable = Runnable { reset() }

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoConfig.kt
@@ -1,8 +1,8 @@
 package at.hannibal2.skyhanni.data.repo
 
-abstract class AbstractRepoConfig<RLC : AbstractRepoLocationConfig> {
-    abstract var repoAutoUpdate: Boolean
-    abstract val updateRepo: Runnable
-    abstract val location: RLC
-    abstract var unzipToMemory: Boolean
+interface AbstractRepoConfig {
+    var repoAutoUpdate: Boolean
+    val updateRepo: Runnable
+    val location: AbstractRepoLocationConfig
+    var unzipToMemory: Boolean
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoLocationConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoLocationConfig.kt
@@ -1,19 +1,19 @@
 package at.hannibal2.skyhanni.data.repo
 
-abstract class AbstractRepoLocationConfig {
-    abstract var user: String
-    abstract var repoName: String
-    abstract var branch: String
+interface AbstractRepoLocationConfig {
+    var user: String
+    var repoName: String
+    var branch: String
 
     val valid get() = user.isNotEmpty() && repoName.isNotEmpty() && branch.isNotEmpty()
 
-    abstract val defaultUser: String
-    abstract val defaultRepoName: String
-    abstract val defaultBranch: String
+    val defaultUser: String
+    val defaultRepoName: String
+    val defaultBranch: String
 
-    private fun hasDefaultUser() = user.lowercase() == defaultUser.lowercase()
-    private fun hasDefaultRepoName() = repoName.lowercase() == defaultRepoName.lowercase()
-    private fun hasDefaultBranch() = branch.lowercase() == defaultBranch.lowercase()
+    private fun hasDefaultUser() = user.equals(defaultUser, ignoreCase = true)
+    private fun hasDefaultRepoName() = repoName.equals(defaultRepoName, ignoreCase = true)
+    private fun hasDefaultBranch() = branch.equals(defaultBranch, ignoreCase = true)
 
     fun hasDefaultSettings() = hasDefaultUser() && hasDefaultRepoName() && hasDefaultBranch()
     fun reset() {

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
@@ -65,7 +65,7 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
     open val backupRepoResourcePath: String? = null
 
     private val debugConfig get() = SkyHanniMod.feature.dev.debug
-    abstract val config: AbstractRepoConfig<*>
+    abstract val config: AbstractRepoConfig
     abstract val configDirectory: File
 
     val logger by lazy { RepoLogger("[Repo - $commonName]") }


### PR DESCRIPTION
## What
Semantic, but there was no reason for the repo configs to be classes. Structurally, they were always interfaces. Also removed typing from the config, since it, just, was not being used for anything.

exclude_from_changelog
