### PR TITLE
Backend: Minor Cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
@@ -10,12 +10,14 @@ annotation class HandleEvent(
      * For cases where the event properties are themselves not needed, and solely a listener for an event fire suffices.
      * To specify multiple events, use [eventTypes] instead.
      */
+    @Deprecated("Use Primary Function Name, or explicit type parameter instead.")
     val eventType: KClass<out SkyHanniEvent> = SkyHanniEvent::class,
 
     /**
      * For cases where multiple events are listened to, and properties are unnecessary.
      * To specify only one event, use [eventType] instead.
      */
+    @Deprecated("Use Primary Function Name, or explicit type parameter instead.")
     val eventTypes: Array<KClass<out SkyHanniEvent>> = [],
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.LorenzLogger
 import at.hannibal2.skyhanni.utils.json.asIntOrNull
@@ -24,6 +25,7 @@ object ConfigUpdaterMigrator {
         return obj?.at(chain.drop(1), init)
     }
 
+    @PrimaryFunction("onConfigFix")
     data class ConfigFixEvent(
         val old: JsonObject,
         val new: JsonObject,

--- a/src/main/java/at/hannibal2/skyhanni/config/SkyHanniConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/SkyHanniConfig.kt
@@ -35,28 +35,23 @@ class SkyHanniConfig : Config() {
     private val discord = MyResourceLocation("skyhanni", "social/discord.png")
     private val github = MyResourceLocation("skyhanni", "social/github.png")
     private val patreon = MyResourceLocation("skyhanni", "social/patreon.png")
+    private val shSocials = listOf(
+        Social.forLink("Discord".asStructuredText(), discord, "https://discord.com/invite/skyhanni-997079228510117908"),
+        Social.forLink("GitHub".asStructuredText(), github, "https://github.com/hannibal002/SkyHanni"),
+        Social.forLink("Patreon".asStructuredText(), patreon, "https://www.patreon.com/hannibal2"),
+    )
 
     // in moulconfig, this value is currently bugged (version 3.5.0)
-    override fun shouldAutoFocusSearchbar(): Boolean {
-        return false
-    }
+    override fun shouldAutoFocusSearchbar(): Boolean = false
 
     override fun alignCategory(category: ProcessedCategory, isSelected: Boolean): HorizontalAlign {
         if (TimeUtils.isAprilFoolsDay) return HorizontalAlign.RIGHT
         return super.alignCategory(category, isSelected)
     }
 
-    override fun getSocials(): List<Social> {
-        return listOf(
-            Social.forLink("Discord".asStructuredText(), discord, "https://discord.com/invite/skyhanni-997079228510117908"),
-            Social.forLink("GitHub".asStructuredText(), github, "https://github.com/hannibal002/SkyHanni"),
-            Social.forLink("Patreon".asStructuredText(), patreon, "https://www.patreon.com/hannibal2"),
-        )
-    }
+    override fun getSocials(): List<Social> = shSocials
 
-    override fun saveNow() {
-        SkyHanniMod.configManager.saveConfig(ConfigFileType.FEATURES, "close-gui")
-    }
+    override fun saveNow() = SkyHanniMod.configManager.saveConfig(ConfigFileType.FEATURES, "close-gui")
 
     override fun getTitle(): StructuredText {
         val modName = if (TimeUtils.isAprilFoolsDay) "SkyHanni".reversed() else "SkyHanni"
@@ -71,85 +66,85 @@ class SkyHanniConfig : Config() {
     // Top
     @Expose
     @Category(name = "About", desc = "Information about SkyHanni and updates.")
-    var about: About = About()
+    val about: About = About()
 
     @JvmField
     @Expose
     @Category(name = "GUI", desc = "Change the locations of GUI elements (§e/sh gui§7).")
-    var gui: GuiConfig = GuiConfig()
+    val gui: GuiConfig = GuiConfig()
 
     // Islands
     @Expose
     @Category(name = "Garden", desc = "Features for the Garden island.")
-    var garden: GardenConfig = GardenConfig()
+    val garden: GardenConfig = GardenConfig()
 
     @Expose
     @Category(name = "Crimson Isle", desc = "Things to do on the Crimson Isle/Nether island.")
-    var crimsonIsle: CrimsonIsleConfig = CrimsonIsleConfig()
+    val crimsonIsle: CrimsonIsleConfig = CrimsonIsleConfig()
 
     @Expose
     @Category(name = "The Rift", desc = "Features for The Rift dimension.")
-    var rift: RiftConfig = RiftConfig()
+    val rift: RiftConfig = RiftConfig()
 
     // Skills
     @Expose
     @Category(name = "Fishing", desc = "Fishing stuff.")
-    var fishing: FishingConfig = FishingConfig()
+    val fishing: FishingConfig = FishingConfig()
 
     @Expose
     @Category(name = "Mining", desc = "Features that help you break blocks.")
-    var mining: MiningConfig = MiningConfig()
+    val mining: MiningConfig = MiningConfig()
 
     @Expose
     @Category(name = "Foraging", desc = "Features that help you cut down trees.")
-    var foraging: ForagingConfig = ForagingConfig()
+    val foraging: ForagingConfig = ForagingConfig()
 
     @Expose
     @Category(name = "Hunting", desc = "Features that help you hunt mobs for their shards.")
-    var hunting: HuntingConfig = HuntingConfig()
+    val hunting: HuntingConfig = HuntingConfig()
 
     // Combat like
     @Expose
     @Category(name = "Combat", desc = "Everything combat and PvE related.")
-    var combat: CombatConfig = CombatConfig()
+    val combat: CombatConfig = CombatConfig()
 
     @Expose
     @Category(name = "Slayer", desc = "Slayer features.")
-    var slayer: SlayerConfig = SlayerConfig()
+    val slayer: SlayerConfig = SlayerConfig()
 
     @Expose
     @Category(name = "Dungeon", desc = "Features that change the Dungeons experience in The Catacombs.")
-    var dungeon: DungeonConfig = DungeonConfig()
+    val dungeon: DungeonConfig = DungeonConfig()
 
     // Misc
     @Expose
     @Category(name = "Inventory", desc = "Change the behavior of items and the inventory.")
-    var inventory: InventoryConfig = InventoryConfig()
+    val inventory: InventoryConfig = InventoryConfig()
 
     @Expose
     @Category(name = "Events", desc = "Stuff that is not always available.")
-    var event: EventConfig = EventConfig()
+    val event: EventConfig = EventConfig()
 
     @Expose
     @Category(name = "Skill Progress", desc = "Skill Progress related config options.")
-    var skillProgress: SkillProgressConfig = SkillProgressConfig()
+    val skillProgress: SkillProgressConfig = SkillProgressConfig()
 
     @Expose
     @Category(name = "Chat", desc = "Change how the chat looks.")
-    var chat: ChatConfig = ChatConfig()
+    val chat: ChatConfig = ChatConfig()
 
     @JvmField
     @Expose
     @Category(name = "Misc", desc = "Settings without a category.")
-    var misc: MiscConfig = MiscConfig()
+    val misc: MiscConfig = MiscConfig()
 
     // Bottom
     @Expose
     @Category(name = "Dev", desc = "Debug and test stuff. Developers are cool.")
-    var dev: DevConfig = DevConfig()
+    val dev: DevConfig = DevConfig()
 
     @Expose
-    var storage: Storage = Storage()
+    val storage: Storage = Storage()
 
     @Expose
     @Suppress("unused")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
@@ -8,10 +8,6 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
-/**
- * Attention developers:
- * If your feature can only be used on the foraging islands please mark it with @[OnlyModern]
- */
 class ForagingConfig {
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/data/title/TitleManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/title/TitleManager.kt
@@ -343,7 +343,7 @@ object TitleManager {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!InventoryUtils.inInventory()) return
         val inventoryTitle = currentTitles[TitleLocation.INVENTORY] ?: return
         inventoryTitle.tryRenderInventoryTitle()

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiRenderEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiRenderEvent.kt
@@ -1,8 +1,10 @@
 package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.RenderingSkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.client.gui.GuiGraphics
 
+@PrimaryFunction("onGuiRender")
 sealed class GuiRenderEvent(context: GuiGraphics) : RenderingSkyHanniEvent(context) {
 
     /**
@@ -11,16 +13,21 @@ sealed class GuiRenderEvent(context: GuiGraphics) : RenderingSkyHanniEvent(conte
      * Use ScreenDrawnEvent instead.
      * Also, ensure you do not render with this event while in a sign, as it will override ScreenDrawnEvent.
      */
+    // TODO rename primary function to not be disambiguated with the event
+    //  rename to "onChestGuiRender" or similar
+    @PrimaryFunction("onBackgroundDraw")
     class ChestGuiOverlayRenderEvent(context: GuiGraphics) : GuiRenderEvent(context)
 
     /**
      * Renders always, and while in an inventory it renders a bit darker, gray
      */
+    @PrimaryFunction("onGuiRenderOverlay")
     class GuiOverlayRenderEvent(context: GuiGraphics) : GuiRenderEvent(context)
 
     /**
      * Renders as [GuiOverlayRenderEvent] if not inside an inventory and runs as [ChestGuiOverlayRenderEvent] when inside an inventory
      */
+    @PrimaryFunction("onGuiRenderTop")
     class GuiOnTopRenderEvent(context: GuiGraphics) : RenderingSkyHanniEvent(context)
     // This is intentional not an [GuiRenderEvent] since it will cause double renders
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiRenderEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiRenderEvent.kt
@@ -13,9 +13,7 @@ sealed class GuiRenderEvent(context: GuiGraphics) : RenderingSkyHanniEvent(conte
      * Use ScreenDrawnEvent instead.
      * Also, ensure you do not render with this event while in a sign, as it will override ScreenDrawnEvent.
      */
-    // TODO rename primary function to not be disambiguated with the event
-    //  rename to "onChestGuiRender" or similar
-    @PrimaryFunction("onBackgroundDraw")
+    @PrimaryFunction("onChestGuiRender")
     class ChestGuiOverlayRenderEvent(context: GuiGraphics) : GuiRenderEvent(context)
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/events/RenderItemTooltipEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RenderItemTooltipEvent.kt
@@ -1,7 +1,9 @@
 package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.RenderingSkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.world.item.ItemStack
 
+@PrimaryFunction("onRenderItemTooltip")
 class RenderItemTooltipEvent(context: GuiGraphics, val stack: ItemStack) : RenderingSkyHanniEvent(context)

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
@@ -1,10 +1,12 @@
 package at.hannibal2.skyhanni.events.minecraft
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import com.mojang.blaze3d.vertex.PoseStack
 import net.minecraft.client.Camera
 import net.minecraft.client.renderer.MultiBufferSource
 
+@PrimaryFunction("onRenderWorld")
 class SkyHanniRenderWorldEvent(
     val matrices: PoseStack,
     val camera: Camera,

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/packet/PacketSentEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/packet/PacketSentEvent.kt
@@ -1,8 +1,10 @@
 package at.hannibal2.skyhanni.events.minecraft.packet
 
 import at.hannibal2.skyhanni.api.event.CancellableSkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.network.protocol.Packet
 
+@PrimaryFunction("onPacketSent")
 class PacketSentEvent(val packet: Packet<*>) : CancellableSkyHanniEvent() {
 
     fun findOriginatingModCall(skipSkyhanni: Boolean = false): StackTraceElement? {

--- a/src/main/java/at/hannibal2/skyhanni/events/render/gui/DrawBackgroundEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/render/gui/DrawBackgroundEvent.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.events.render.gui
 
 import at.hannibal2.skyhanni.api.event.RenderingSkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.client.gui.GuiGraphics
 
+@PrimaryFunction("onBackgroundDraw")
 class DrawBackgroundEvent(context: GuiGraphics) : RenderingSkyHanniEvent(context)

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
@@ -92,7 +92,7 @@ object BestiaryData {
     ).flatten()
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (inInventory) {
             config.position.renderRenderables(

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -491,7 +491,7 @@ object HoppityCollectionStats {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!inInventory || !collectionConfig.enabled) return
 
         collectionConfig.position.renderRenderables(

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthewitch/StewHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthewitch/StewHelper.kt
@@ -118,8 +118,8 @@ object StewHelper {
         return container
     }
 
-    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class, onlyOnIsland = IslandType.HUB)
-    fun onRenderOverlay() {
+    @HandleEvent(onlyOnIsland = IslandType.HUB)
+    fun onChestGuiRender() {
         if (!config.stewHelper) return
         if (display.isEmpty()) return
         config.stewHelperPosition.renderRenderables(display, posLabel = "Witch Stew Helper")

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthewitch/StewHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthewitch/StewHelper.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacks
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryDetector

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -221,7 +221,7 @@ object CityProjectFeatures {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!config.showMaterials) return
         if (!inInventory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/AgathaCouponProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/AgathaCouponProfit.kt
@@ -164,7 +164,7 @@ object AgathaCouponProfit {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!inInventory) return
         config.agathaCouponProfitPos.renderRenderables(
             display,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/AnitaMedalProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/AnitaMedalProfit.kt
@@ -234,7 +234,7 @@ object AnitaMedalProfit {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!inInventory || VisitorApi.inInventory) return
         config.medalProfitPos.renderRenderables(
             display,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -452,7 +452,7 @@ object GardenNextJacobContest {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!config.display || !calendarDetector.isInside()) return
         val display = display ?: return
         config.inventoryPosition.renderRenderable(display, posLabel = "Load SkyBlock Calendar")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -672,8 +672,8 @@ object ComposterOverlay {
         return map
     }
 
-    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class)
-    fun onBackgroundDraw() {
+    @HandleEvent
+    fun onChestGuiRender() {
         if (!isEnabled() || !inInventory) return
         if (EstimatedItemValue.isCurrentlyShowing()) return
         if (displayDirty) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.data.model.ComposterUpgrade
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
@@ -142,7 +142,7 @@ object JacobContestFFNeededDisplay {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!config.ffForContest) return
         if (!FarmingContestApi.inInventory) return
         if (lastToolTipTime.passedSince() > 200.milliseconds) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestTimeNeeded.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestTimeNeeded.kt
@@ -195,7 +195,7 @@ object JacobContestTimeNeeded {
     } else getLatestBlocksPerSecond()
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!config.enabled) return
         if (!FarmingContestApi.inInventory) return
         config.position.renderRenderables(display, posLabel = "Jacob Contest Time Needed")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
@@ -94,7 +94,7 @@ object LogBookStats {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (IslandType.GARDEN_GUEST.isCurrent()) return
         if (inInventory && config.showLogBookStats) {
             config.logBookStatsPos.renderRenderables(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/SkyMartCopperPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/SkyMartCopperPrice.kt
@@ -108,7 +108,7 @@ object SkyMartCopperPrice {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (inInventory) {
             config.copperPricePos.renderRenderables(
                 display,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PesthunterProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PesthunterProfit.kt
@@ -132,7 +132,7 @@ object PesthunterProfit {
     } ?: 0
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!inInventory) return
         config.profitPosition.renderRenderables(
             display,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -51,8 +51,8 @@ object ChestValue {
     private var inOwnInventory = false
     private val scrollValue = ScrollValue()
 
-    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class)
-    fun onBackgroundDraw() {
+    @HandleEvent
+    fun onChestGuiRender() {
         if (!isEnabled()) return
         if (DungeonApi.inDungeon() && !config.enableInDungeons) return
         if (!inOwnInventory) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.inventory.ChestValueConfig.NumberFormatEntry
 import at.hannibal2.skyhanni.config.features.inventory.ChestValueConfig.SortingTypeEntry
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/DojoRankDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/DojoRankDisplay.kt
@@ -37,7 +37,7 @@ object DojoRankDisplay {
     private var belts = mapOf<String, Int>()
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         config.dojoRankDisplayPosition.renderStrings(display, posLabel = "Dojo Rank Display")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/MaxPurseItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/MaxPurseItems.kt
@@ -65,7 +65,7 @@ object MaxPurseItems {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (!BazaarApi.inBazaarInventory) return
         // I would use BazaarAPI for price info, but as soon as NEU's data goes out of date, it will be wrong

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
@@ -377,7 +377,7 @@ object ReforgeHelper {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         config.position.renderRenderables(display, posLabel = "Reforge Overlay")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/HuntingBoxValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/HuntingBoxValue.kt
@@ -118,8 +118,8 @@ object HuntingBoxValue {
         return modNine != 0 && modNine != 8
     }
 
-    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class, onlyOnSkyblock = true)
-    fun onRenderOverlay() {
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onChestGuiRender() {
         if (!config.huntingBoxValue) return
         if (!AttributeShardsData.huntingBoxInventory.isInside()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/HuntingBoxValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/HuntingBoxValue.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.inventory.attribute
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DisplayTableEntry
 import at.hannibal2.skyhanni.utils.InventoryUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarBestSellMethod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarBestSellMethod.kt
@@ -75,7 +75,7 @@ object BazaarBestSellMethod {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (display.isEmpty()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarLimitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarLimitTracker.kt
@@ -69,7 +69,7 @@ object BazaarLimitTracker {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!config.dailyLimitTracker) return
         if (!BazaarApi.inBazaarInventory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialCollector.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialCollector.kt
@@ -164,7 +164,7 @@ object CraftMaterialCollector {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (!inRecipeInventory && !purchasing) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
@@ -186,8 +186,8 @@ object CakeTracker {
         ) { invalidateCakeCache() }
     }
 
-    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class, onlyOnSkyblock = true)
-    fun onBackgroundDraw() {
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onChestGuiRender() {
         if (!config.enabled) return
 
         val inInvWithCakes = inCakeInventory && knownCakesInCurrentInventory.any()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.config.features.inventory.CakeTrackerConfig.CakeTra
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage.CakeData
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
@@ -132,7 +132,7 @@ object CFCustomReminder {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (!inChocolateMenu()) return
         if (ReminderUtils.isBusy()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShopPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFShopPrice.kt
@@ -187,7 +187,7 @@ object CFShopPrice {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (inInventory) {
             config.position.renderRenderables(
                 display,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFStats.kt
@@ -41,7 +41,7 @@ object CFStats {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!CFApi.inChocolateFactory && !CFApi.chocolateFactoryPaused) return
         if (!config.statsDisplay) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFTooltipCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFTooltipCompact.kt
@@ -41,7 +41,7 @@ object CFTooltipCompact {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!CFApi.inChocolateFactory) return
         if (config.tooltipMove) {
             if (lastHover.passedSince() < 1.seconds) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanSlots.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanSlots.kt
@@ -48,7 +48,7 @@ object HitmanSlots {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!config.hitmanCosts || slotPricesLeft.isEmpty()) return
         if (!inInventory) return
         config.hitmanCostsPosition.renderRenderable(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayTimer.kt
@@ -88,7 +88,7 @@ object CFStrayTimer {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         config.strayTimerPosition.renderRenderable(getTimerRenderable(), posLabel = "Stray Timer")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayWarning.kt
@@ -164,7 +164,7 @@ object CFStrayWarning {
     }
 
     @HandleEvent(priority = HandleEvent.HIGHEST)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!CFApi.inChocolateFactory) return
         if (!flashScreen && !config.partyMode.get()) return
         val alpha = ((2 + sin(SimpleTimeMark.now().toMillis() / 1000.0)) * 255 / 4).toInt().coerceIn(0..255)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/craft/CraftableItemList.kt
@@ -170,7 +170,7 @@ object CraftableItemList {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (!inInventory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
@@ -30,7 +30,7 @@ object ExperimentsDryStreakDisplay {
     private var ignoreNextFinish = false
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled() || !ExperimentationTableApi.inTable) return
 
         display = display.takeIfNotEmpty() ?: drawDisplay()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/SuperpairDataDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/SuperpairDataDisplay.kt
@@ -115,7 +115,7 @@ object SuperpairDataDisplay {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!config.superpairs.display || !ExperimentationTableApi.inTable) return
 
         display = display.takeIfNotEmpty()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
@@ -50,7 +50,7 @@ object UltraRareBookAlert {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (lastNotificationTime.passedSince() > 5.seconds) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -125,7 +125,7 @@ object CustomWardrobe {
 
     // Edit button in normal wardrobe while in edit mode
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (!editMode) return
         val gui = Minecraft.getInstance().screen as? SkyHanniGuiContainer ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ScrapGFS.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ScrapGFS.kt
@@ -96,8 +96,8 @@ object ScrapGFS {
         uiDirty = true
     }
 
-    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class, onlyOnIsland = IslandType.DWARVEN_MINES)
-    fun onBackgroundDraw() {
+    @HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES)
+    fun onChestGuiRender() {
         if (!enabled) return
         if (config.onlyIfNoScrap && susScrapInInventory > 0) return
         if (uiDirty) {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ScrapGFS.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ScrapGFS.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.SackApi
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
 import at.hannibal2.skyhanni.events.SackChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -23,9 +22,9 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.animated.AnimatedItemStackRenderable.Companion.animatedItemStack
 import at.hannibal2.skyhanni.utils.renderables.animated.framed.AnimatedFrameLocalStorage
 import at.hannibal2.skyhanni.utils.renderables.animated.framed.ItemStackAnimatedFrame
-import at.hannibal2.skyhanni.utils.renderables.animated.AnimatedItemStackRenderable.Companion.animatedItemStack
 import at.hannibal2.skyhanni.utils.renderables.animated.rotate.AnimatedRotationDefinition
 import at.hannibal2.skyhanni.utils.renderables.animated.rotate.AnimatedRotationPropertyStorage
 import at.hannibal2.skyhanni.utils.renderables.animated.rotate.AxisRotationDefinition

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/solver/FossilSolverDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/solver/FossilSolverDisplay.kt
@@ -187,7 +187,7 @@ object FossilSolverDisplay {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
 
         if (inExcavatorMenu) {

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -415,7 +415,7 @@ object MinionFeatures {
     private fun enableWithHub() = isEnabled() || IslandType.HUB.isCurrent()
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!minionInventoryOpen || !config.hopperProfitDisplay) return
 
         config.hopperProfitPos.renderRenderable(Renderable.text(coinsPerDay), posLabel = "Minion Coins Per Day")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CoralFishHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CoralFishHelper.kt
@@ -120,8 +120,8 @@ object CoralFishHelper {
         val searchable: Searchable,
     )
 
-    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class, onlyOnIsland = IslandType.GALATEA)
-    fun onRenderOverlay() {
+    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    fun onChestGuiRender() {
         if (!config.coralFishHelper) return
         if (display.isEmpty()) return
         config.coralFishHelperPosition.renderRenderables(display, posLabel = "Coral Fish Helper")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CoralFishHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CoralFishHelper.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.ItemBuyApi.buy
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryDetector

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CustomTextBox.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CustomTextBox.kt
@@ -29,7 +29,7 @@ object CustomTextBox {
     private fun String.format() = replace("&", "§").split("\\n").toList()
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!config.onlyInGui) return
         if (!isEnabled()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -118,7 +118,7 @@ object EstimatedItemValue {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         tryRendering()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/IslandAreaFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/IslandAreaFeatures.kt
@@ -116,8 +116,8 @@ object IslandAreaFeatures {
         }
     }
 
-    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class)
-    fun onBackgroundDraw() {
+    @HandleEvent
+    fun onChestGuiRender() {
         if (!isAreaListEnabled()) return
         val isInOwnInventory = Minecraft.getInstance().screen is InventoryScreen
         if (isInOwnInventory) {

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/GeorgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/GeorgeHelper.kt
@@ -134,8 +134,8 @@ object GeorgeHelper {
         var renderableInfo: HorizontalContainerRenderable,
     )
 
-    @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class, onlyOnIsland = IslandType.HUB)
-    fun onRenderOverlay() {
+    @HandleEvent(onlyOnIsland = IslandType.HUB)
+    fun onChestGuiRender() {
         if (!config.enabled) return
         if (display.isEmpty()) return
         config.position.renderRenderables(display, posLabel = "Taming 60 Helper")

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/GeorgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/GeorgeHelper.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.pets
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.features.commands.WikiManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/ShowMotesNpcSellPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/ShowMotesNpcSellPrice.kt
@@ -46,7 +46,7 @@ object ShowMotesNpcSellPrice {
     private val slotList = mutableListOf<Int>()
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isInventoryValueEnabled()) return
         if (inInventory) {
             config.inventoryValue.position.renderRenderables(

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -78,7 +78,7 @@ object SkillProgress {
     }
 
     @HandleEvent
-    fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isDisplayEnabled()) return
         if (display.isEmpty()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
@@ -49,7 +49,7 @@ class RenderDisplayHelper(
         }
 
         @HandleEvent
-        fun onBackgroundDraw(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+        fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
             val isInOwnInventory = Minecraft.getInstance().screen is InventoryScreen
             for (display in currentlyVisibleDisplays) {
                 if (display.renderIn(isInOwnInventory)) {


### PR DESCRIPTION
## What
In preparation for moving to the plugin and discontinuing use of the annotation param, deprecates them (I don't think it actually does anything but 🤷), and started the cleanup process around standardizing primary names for functions.

Config had some vars that really should not have been.

## Changelog Technical Details
+ Started defining `PrimaryFunctions` for events missing them. - Daveed
+ Migrated all top-level configs in `SkyHanniConfig` from `var` to `val`. - Daveed
+ Renamed all `ChestGuiOverlay` render handlers to `onChestGuiRender`. - Daveed