### PR TITLE
Fix: Shiny Orb Tracker for new Year of the Pig

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/yearofthepig/ShinyOrbChargedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/yearofthepig/ShinyOrbChargedEvent.kt
@@ -1,7 +1,9 @@
 package at.hannibal2.skyhanni.events.yearofthepig
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
+@PrimaryFunction("onShinyOrbCharged")
 class ShinyOrbChargedEvent(
     val orbEntityId: Int? = null,
 ) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/yearofthepig/ShinyOrbLootedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/yearofthepig/ShinyOrbLootedEvent.kt
@@ -2,8 +2,10 @@ package at.hannibal2.skyhanni.events.yearofthepig
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.features.skillprogress.SkillType
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.NeuInternalName
 
+@PrimaryFunction("onShinyOrbLooted")
 class ShinyOrbLootedEvent(
     val loot: Pair<NeuInternalName, Int>? = null,
     val coins: Int? = null,

--- a/src/main/java/at/hannibal2/skyhanni/events/yearofthepig/ShinyOrbUsedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/yearofthepig/ShinyOrbUsedEvent.kt
@@ -1,5 +1,7 @@
 package at.hannibal2.skyhanni.events.yearofthepig
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
+@PrimaryFunction("onShinyOrbUsed")
 class ShinyOrbUsedEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeatures.kt
@@ -16,13 +16,12 @@ import java.awt.Color
 object PigFeatures {
 
     private val config get() = SkyHanniMod.feature.event.yearOfThePig
-    private val dataSetList get() = PigFeaturesApi.dataSetList
 
     @HandleEvent
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!config.linesToDraw.any()) return
 
-        dataSetList.forEach { dataSet ->
+        PigFeaturesApi.dataSetList.forEach { dataSet ->
             event.tryRenderLineToPig(dataSet)
             event.tryRenderLinePigToOrb(dataSet)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
@@ -76,6 +76,7 @@ object PigFeaturesApi {
      * REGEX-TEST: SHINY! You extracted Shiny Shard and Blood God Crest from the piglet's orb!
      * REGEX-TEST: SHINY! You extracted Shiny Shard and +1,185,000 Coins from the piglet's orb!
      * REGEX-TEST: SHINY! You extracted Shiny Shard and +1,000 Foraging XP from the piglet's orb!
+     * REGEX-TEST: SHINY! You extracted Shiny Shard and 16x Enchanted Potato from the piglet's orb!
      */
     private val orbLootedChatPattern by patternGroup.pattern(
         "chat.orb.looted.colorless",

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.EntityClickEvent
-import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.events.yearofthepig.ShinyOrbChargedEvent
 import at.hannibal2.skyhanni.events.yearofthepig.ShinyOrbLootedEvent
 import at.hannibal2.skyhanni.events.yearofthepig.ShinyOrbUsedEvent
@@ -51,11 +50,11 @@ object PigFeaturesApi {
     private val SHINY_ORB_ITEM = "SHINY_ORB".toInternalName()
 
     private val data: MutableList<ShinyOrbData> = mutableListOf()
-    val dataSetList get() = data
+    val dataSetList get(): List<ShinyOrbData> = data
 
     private fun tryToRemoveOrb() {
         DelayedRun.runDelayed(1.seconds) {
-            dataSetList.removeIf { dataSet ->
+            data.removeIf { dataSet ->
                 val pigId = dataSet.pigEntityId
                 EntityUtils.getEntityByID(pigId) == null && dataSet.spawnTime.passedSince() > 2.seconds
             }
@@ -64,28 +63,23 @@ object PigFeaturesApi {
 
     // <editor-fold desc="Patterns">
     private val orbChargedChatPattern by patternGroup.pattern(
-        "chat.orb.charged",
-        "§6§lSHINY! §r§eThe orb is charged! Click on it for loot!",
+        "chat.orb.charged.colorless",
+        "SHINY! The orb is charged! Click on it for loot!",
     )
 
     private val orbExpiredChatPattern by patternGroup.pattern(
-        "chat.orb.expired",
-        "§cYour Shiny Orb and associated pig expired and disappeared\\.",
+        "chat.orb.expired.colorless",
+        "Your Shiny Orb and associated pig expired and disappeared\\.",
     )
 
     /**
-     * REGEX-TEST: §6§lSHINY! §r§eYou extracted §r§3+1,000 Mining XP §r§efrom the piglet's orb!
-     * REGEX-TEST: §6§lSHINY! §r§eYou extracted §r§5Potato Spreading §r§efrom the piglet's orb!
-     * REGEX-TEST: §6§lSHINY! §r§eYou extracted §r§b3x §r§aGrand Experience Bottle §r§efrom the piglet's orb!
-     * REGEX-TEST: §6§lSHINY! §r§eYou extracted §r§6+9,721 Coins §r§efrom the piglet's orb!
-     * REGEX-TEST: §6§lSHINY! §r§eYou extracted §r§5Farming for Dummies §r§efrom the piglet's orb!
-     * REGEX-TEST: §6§lSHINY! §r§eYou extracted §r§3+1,000 Alchemy XP §r§efrom the piglet's orb!
-     * REGEX-TEST: §6§lSHINY! §r§eYou extracted §r§9Harvesting VI §r§efrom the piglet's orb!
-     * REGEX-TEST: §6§lSHINY! §r§eYou extracted §r§a8x Enchanted Pork §r§efrom the piglet's orb!
+     * REGEX-TEST: SHINY! You extracted Shiny Shard and Blood God Crest from the piglet's orb!
+     * REGEX-TEST: SHINY! You extracted Shiny Shard and +1,185,000 Coins from the piglet's orb!
+     * REGEX-TEST: SHINY! You extracted Shiny Shard and +1,000 Foraging XP from the piglet's orb!
      */
     private val orbLootedChatPattern by patternGroup.pattern(
-        "chat.orb.looted",
-        "§6§lSHINY! §r§eYou extracted (?:§.)+(?<reward>.*) §r§efrom the piglet's orb!",
+        "chat.orb.looted.colorless",
+        "SHINY! You extracted Shiny Shard and (?<reward>.+) from the piglet's orb!",
     )
 
     /**
@@ -116,14 +110,14 @@ object PigFeaturesApi {
     }
 
     @HandleEvent
-    fun onWorldChange(event: WorldChangeEvent) {
+    fun onWorldChange() {
         data.clear()
     }
 
     @HandleEvent(onlyOnIsland = IslandType.HUB)
     fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isYearOfThePig()) return
-        val message = event.message
+        val message = event.cleanMessage
 
         orbChargedChatPattern.matchMatcher(message) {
             val orbEntity = tryFindOrb(LocationUtils.playerLocation())

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
@@ -79,7 +79,7 @@ object PigFeaturesApi {
      * REGEX-TEST: SHINY! You extracted Shiny Shard and 16x Enchanted Potato from the piglet's orb!
      */
     private val orbLootedChatPattern by patternGroup.pattern(
-        "chat.orb.looted.colorless",
+        "chat.orb.looted",
         "SHINY! You extracted Shiny Shard and (?<reward>.+) from the piglet's orb!",
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/ShinyOrbTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/ShinyOrbTracker.kt
@@ -36,7 +36,6 @@ object ShinyOrbTracker {
         ::ShinyOrbData,
         { it.shinyOrbTracker },
         trackerConfig = { config.perTrackerConfig },
-        customUptimeControl = true,
     ) { drawDisplay(it) }
 
     private fun passesHoldingItem() = !config.holdingItems || InventoryUtils.getItemInHand()?.let {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/ShinyOrbTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/ShinyOrbTracker.kt
@@ -2,10 +2,10 @@ package at.hannibal2.skyhanni.features.event.yearofthepig
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.events.yearofthepig.ShinyOrbChargedEvent
 import at.hannibal2.skyhanni.events.yearofthepig.ShinyOrbLootedEvent
-import at.hannibal2.skyhanni.events.yearofthepig.ShinyOrbUsedEvent
 import at.hannibal2.skyhanni.features.skillprogress.SkillType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -30,11 +30,13 @@ object ShinyOrbTracker {
     private val config get() = SkyHanniMod.feature.event.yearOfThePig.shinyOrbTracker
     private val SHINY_ORB_ITEM = "SHINY_ORB".toInternalName()
     private val SHINY_ROD_ITEM = "SHINY_ROD".toInternalName()
+    private val SHINY_SHARD_ITEM = "SHINY_SHARD".toInternalName()
     private val tracker = SkyHanniItemTracker(
         "Shiny Orb Tracker",
         ::ShinyOrbData,
         { it.shinyOrbTracker },
-        trackerConfig = { config.perTrackerConfig }
+        trackerConfig = { config.perTrackerConfig },
+        customUptimeControl = true,
     ) { drawDisplay(it) }
 
     private fun passesHoldingItem() = !config.holdingItems || InventoryUtils.getItemInHand()?.let {
@@ -74,17 +76,18 @@ object ShinyOrbTracker {
     }
 
     @HandleEvent
-    fun onShinyOrbUsed(event: ShinyOrbUsedEvent) {
+    fun onShinyOrbUsed() {
         tracker.modify { it.orbsUsed++ }
     }
 
     @HandleEvent
-    fun onShinyOrbCharged(event: ShinyOrbChargedEvent) {
+    fun onShinyOrbCharged() {
         tracker.modify { it.orbsCompleted++ }
     }
 
     @HandleEvent
     fun onShinyOrbLooted(event: ShinyOrbLootedEvent) {
+        tracker.addItem(SHINY_SHARD_ITEM, 1, command = false)
         when {
             event.loot != null -> {
                 val (internalName, amount) = event.loot.first to event.loot.second
@@ -114,5 +117,14 @@ object ShinyOrbTracker {
 
         val duration = data.getTotalUptime()
         addAll(tracker.addTotalProfit(profit, data.orbsCompleted, "orb used", duration, "Orbs used"))
+    }
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shresetshinyorbtracker") {
+            description = "Resets the Shiny Orb Tracker"
+            category = CommandCategory.USERS_RESET
+            simpleCallback { tracker.resetCommand() }
+        }
     }
 }


### PR DESCRIPTION
## What
Updated Shiny Orb Tracker for new Year of the Pig event and added a reset command.

## Changelog Improvements
+ Added `/shresetshinyorbtracker` command to reset Shiny Orb Tracker. - Luna

## Changelog Fixes
+ Fixed Shiny Orb Tracker not working with revamped Year of the Pig event. - Luna