### PR TITLE
Backend: Add ItemStack.asTextComponent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -51,6 +51,7 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.NbtCompat
+import at.hannibal2.skyhanni.utils.compat.append
 import at.hannibal2.skyhanni.utils.compat.appendWithColor
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
@@ -60,6 +61,7 @@ import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
 import at.hannibal2.skyhanni.utils.compat.getStringOrDefault
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
 import at.hannibal2.skyhanni.utils.compat.stackHover
+import at.hannibal2.skyhanni.utils.compat.withColor
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineConfig
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
@@ -75,6 +77,7 @@ import net.minecraft.core.component.DataComponents
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.contents.objects.PlayerSprite
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
@@ -940,5 +943,17 @@ object ItemUtils {
         val identifier = this.get(DataComponents.ITEM_MODEL)
         val itemModel = BuiltInRegistries.ITEM.getValue(identifier)
         return if (itemModel == Items.AIR || itemModel == this.item) null else itemModel
+    }
+
+    fun ItemStack.asTextComponent(): Component? {
+        val stack = this
+        if (this.item == Items.PLAYER_HEAD) {
+            return componentBuilder {
+                append(Component.`object`(PlayerSprite(stack.get(DataComponents.PROFILE), true))) {
+                    withColor(ChatFormatting.WHITE)
+                }
+            }
+        }
+        return null
     }
 }


### PR DESCRIPTION
## What
why? idk got distracted
will anyone ever use this? maybe 
only works on skulls

<details>
<summary>Images</summary>

<img width="64" height="37" alt="image" src="https://github.com/user-attachments/assets/610a0325-5b92-4d90-aba0-ae119d4af373" />
<img width="211" height="709" alt="image" src="https://github.com/user-attachments/assets/b5fd9ad4-f08a-4b30-b3ad-3f5b59789785" />


</details>

## Changelog Technical Details
+ Added ItemStack.asTextComponent. - nopo
