### PR TITLE
Fix: ViewRecipe => Command ID

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
@@ -2,14 +2,12 @@ package at.hannibal2.skyhanni.features.commands
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.config.commands.brigadier.arguments.EnumArgumentType.Companion.lowercase
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.recipe.NeuRecipeType
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.commands
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.EnumArgumentType.Companion.lowercase
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.recipe.NeuRecipeType
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
@@ -66,7 +67,7 @@ object ViewRecipeCommand {
     fun onNeuRepoReload() {
         list = NeuItems.allNeuRepoItems().asSequence().filter { (_, json) ->
             json.recipe != null || json.recipes.any { it.type == NeuRecipeType.CRAFTING }
-        }.map { (key, _) -> key.repoItemName.lowercase() }.toList()
+        }.map { (key, _) -> key.skyblockCommandId }.toList()
     }
 
     fun customTabComplete(command: String): List<String>? {


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1000669238035497022/1483505144975855777
Changed `repoItemName` to `skyblockCommandId` so we are no longer sending color codes in autocompletes. 🥺 

## Changelog Fixes
+ Fixed colored item names in `/viewrecipe` autocomplete. - Daveed