### PR TITLE
Improvement: Better TPS Counter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MinecraftData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MinecraftData.kt
@@ -27,15 +27,12 @@ object MinecraftData {
 
     @HandleEvent(receiveCancelled = true)
     fun onPacket(event: PacketReceivedEvent) {
-        when (val packet = event.packet) {
-            is ClientboundPingPacket -> {
-                if (lastPingParameter == packet.id) return
-                lastPingParameter = packet.id
+        val packet = event.packet as? ClientboundPingPacket ?: return
 
-                totalServerTicks++
-                ServerTickEvent.post()
-            }
-        }
+        if (lastPingParameter == packet.id) return
+        lastPingParameter = packet.id
+
+        ServerTickEvent(++totalServerTicks).post()
     }
 
     private var lastPingParameter = 0

--- a/src/main/java/at/hannibal2/skyhanni/events/DebugDataCollectEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/DebugDataCollectEvent.kt
@@ -1,8 +1,10 @@
 package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.test.command.ErrorManager
 
+@PrimaryFunction("onDebugDataCollect")
 class DebugDataCollectEvent(private val list: MutableList<String>, private val search: String) : SkyHanniEvent() {
 
     var empty = true

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/ServerTickEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/ServerTickEvent.kt
@@ -1,5 +1,10 @@
 package at.hannibal2.skyhanni.events.minecraft
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
+import at.hannibal2.skyhanni.utils.ServerTimeMark
 
-object ServerTickEvent : SkyHanniEvent()
+@PrimaryFunction("onServerTick")
+class ServerTickEvent(val tick: Long) : SkyHanniEvent() {
+    val timeMark = ServerTimeMark(tick)
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
@@ -86,7 +86,7 @@ object PartyChatCommands {
                 TpsCounter.tps?.let {
                     HypixelCommands.partyChat("Current TPS: $it", prefix = true)
                 } ?: run {
-                    ChatUtils.chat("TPS Command Sent too early to calculate TPS")
+                    ChatUtils.chat("Command sent too early to calculate TPS")
                 }
             },
         ),

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -50,7 +50,7 @@ object TpsCounter {
     @HandleEvent
     fun onSecondPassed() {
         if (lastServerTick.passedSince() >= 1.seconds) {
-            ChatUtils.debug("No ping packets received for 1 second, clearing TPS data")
+            ChatUtils.debug("No server ticks detected for 1 second, clearing TPS data")
             tpsList.clear()
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -12,11 +12,17 @@ import at.hannibal2.skyhanni.events.minecraft.ServerTickEvent
 import at.hannibal2.skyhanni.features.misc.limbo.LimboTimeTracker
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.*
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.collection.TimeAndSizeLimitedCache
+import at.hannibal2.skyhanni.utils.inPartialMilliseconds
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import at.hannibal2.skyhanni.utils.roundedUpSeconds
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -70,7 +76,7 @@ object TpsCounter {
 
     private fun getTpsString(compact: Boolean = false): String = buildString {
         append("§eTPS: ")
-        val currentTps = tps
+        var currentTps = tps
         when {
             LimboTimeTracker.inLimbo -> {
                 append("§fN/A §7(Limbo)")
@@ -81,6 +87,7 @@ object TpsCounter {
                 append("§7(${remaining}s)")
             }
             else -> {
+                if (TimeUtils.isAprilFoolsDay) currentTps /= 2
                 append("%s%.1f".format(getColor(currentTps), currentTps))
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -134,7 +134,7 @@ object TpsCounter {
         ErrorManager.logErrorStateWithData(
             "TPS calculation got an error",
             "tps is $tps",
-            "tos" to tps,
+            "tps" to tps,
             "tpsList" to tpsList,
             "timeSinceWorldSwitch" to timeSinceWorldSwitch,
         )

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -7,18 +7,18 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
-import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
+import at.hannibal2.skyhanni.events.minecraft.ServerTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
-import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.ServerTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.TimeUtils
+import at.hannibal2.skyhanni.utils.collection.TimeAndSizeLimitedCache
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import at.hannibal2.skyhanni.utils.roundedUpSeconds
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -26,17 +26,12 @@ object TpsCounter {
 
     private val config get() = SkyHanniMod.feature.gui
 
-    private val ignorePacketDelay = 5.seconds
-    private val minimumSecondsDisplayDelay = 10.seconds
+    private val WORLD_SWITCH_DELAY = 5.seconds
 
-    private var packetsFromLastSecond = 0
-    private val tpsList = mutableListOf<Int>()
-    private var hasRemovedFirstSecond = false
-
-    private var hasReceivedPacket = false
-
-    var tps: Double? = null
-        private set
+    private var lastServerTick = ServerTimeMark.farPast()
+    private val tpsList = TimeAndSizeLimitedCache<Long, Long>(100, 5.seconds)
+    val tps: Double
+        get() = if (tpsList.isEmpty()) 0.0 else (1000.0 / tpsList.values.average()).coerceIn(0.0..20.0)
 
     private var display: Renderable? = null
 
@@ -44,19 +39,19 @@ object TpsCounter {
     private var pendingTpsCommand = false
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
-        if (shouldIgnore()) {
-            updateDisplay()
-            return
+    fun onServerTick(event: ServerTickEvent) {
+        val now = event.timeMark
+        if (!lastServerTick.isFarPast()) {
+            tpsList[event.tick] = (now - lastServerTick).inWholeMilliseconds
         }
+        lastServerTick = now
+    }
 
-        if (packetsFromLastSecond != 0) {
-            if (hasRemovedFirstSecond) tpsList.add(packetsFromLastSecond)
-            hasRemovedFirstSecond = true
+    @HandleEvent
+    fun onSecondPassed() {
+        if (lastServerTick.passedSince() >= 1.seconds) {
+            tpsList.clear()
         }
-        packetsFromLastSecond = 0
-
-        if (tpsList.size > 10) tpsList.removeAt(0)
 
         updateDisplay()
 
@@ -66,70 +61,41 @@ object TpsCounter {
         }
     }
 
-    private fun updateDisplay() {
-        val timeUntil = minimumSecondsDisplayDelay - timeSinceWorldSwitch
-        val text = if (timeUntil.isPositive()) {
-            "§f(${timeUntil.inWholeSeconds}s)"
+    private fun getTpsString(compact: Boolean = false): String =
+        "§eTPS: " + if (timeSinceWorldSwitch > WORLD_SWITCH_DELAY) {
+            format(tps)
         } else {
-            // when in limbo we don't receive any packets
-            if (tpsList.isEmpty()) {
-                "§70 (Limbo?)"
-            } else {
-                val newTps = tpsList.average().roundTo(1).coerceIn(0.0..20.0)
-                tps = newTps
-                val legacyColor = format(newTps)
-                "$legacyColor${fixTps(newTps)}"
-            }
+            val remaining = (WORLD_SWITCH_DELAY - timeSinceWorldSwitch).roundedUpSeconds
+            (if (compact) "" else "§fCalculating... ") + "§7(${remaining}s)"
         }
-        display = Renderable.text("§eTPS: $text")
-    }
 
-    private fun fixTps(tps: Double): Double {
-        return if (TimeUtils.isAprilFoolsDay) tps / 2 else tps
+    private fun updateDisplay() {
+        display = Renderable.text(getTpsString(compact = true))
     }
 
     private fun tpsCommand() {
-        val timeUntil = minimumSecondsDisplayDelay - timeSinceWorldSwitch
-        if (timeUntil.isPositive()) {
-            ChatUtils.chat("TPS: §fCalculating... §7(${timeUntil.inWholeSeconds}s)")
-            DelayedRun.runDelayed(timeUntil) {
+        val text = getTpsString()
+        ChatUtils.chat(text)
+
+        val remaining = (WORLD_SWITCH_DELAY - timeSinceWorldSwitch)
+        if (remaining.isPositive()) {
+            DelayedRun.runDelayed(remaining) {
                 pendingTpsCommand = true
             }
-        } else {
-            val tpsMessage = tps?.let { "${format(fixTps(it))}$it" } ?: "§70 (Limbo?)"
-            ChatUtils.chat("TPS: $tpsMessage")
-        }
-    }
-
-    @HandleEvent
-    fun onTick() {
-        if (hasReceivedPacket) {
-            packetsFromLastSecond++
-            hasReceivedPacket = false
         }
     }
 
     @HandleEvent
     fun onWorldChange() {
         tpsList.clear()
-        tps = null
-        packetsFromLastSecond = 0
         display = null
-        hasRemovedFirstSecond = false
+        lastServerTick = ServerTimeMark.farPast()
     }
 
-    @HandleEvent(priority = HandleEvent.HIGHEST, receiveCancelled = true)
-    fun onPacketReceive(event: PacketReceivedEvent) {
-        hasReceivedPacket = true
-    }
-
-    @HandleEvent
-    fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
+    fun onRenderOverlay() {
         if (!isEnabled()) return
-
-        display?.let {
-            config.tpsDisplayPosition.renderRenderable(it, posLabel = "Tps Display")
-        }
+        display?.let { config.tpsDisplayPosition.renderRenderable(it, posLabel = "TPS Display") }
     }
 
     @HandleEvent
@@ -140,8 +106,6 @@ object TpsCounter {
             simpleCallback { tpsCommand() }
         }
     }
-
-    private fun shouldIgnore() = timeSinceWorldSwitch < ignorePacketDelay
 
     private fun isEnabled() = SkyBlockUtils.onHypixel && config.tpsDisplay &&
         (SkyBlockUtils.inSkyBlock || OutsideSBFeature.TPS_DISPLAY.isSelected())
@@ -154,7 +118,7 @@ object TpsCounter {
 
     private fun format(tps: Double): String {
         if (!tps.isFinite()) printError(tps)
-        return getColor(tps)
+        return "%s%.1f§r".format(getColor(tps), tps)
     }
 
     private fun getColor(tps: Double) = when {
@@ -170,10 +134,7 @@ object TpsCounter {
         ErrorManager.logErrorStateWithData(
             "TPS calculation got an error",
             "tps is $tps",
-            "tps" to tps,
-            "packetsFromLastSecond" to packetsFromLastSecond,
-            "hasRemovedFirstSecond" to hasRemovedFirstSecond,
-            "hasReceivedPacket" to hasReceivedPacket,
+            "tos" to tps,
             "tpsList" to tpsList,
             "timeSinceWorldSwitch" to timeSinceWorldSwitch,
         )

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -6,51 +6,49 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.minecraft.ServerTickEvent
+import at.hannibal2.skyhanni.features.misc.limbo.LimboTimeTracker
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.*
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.ServerTimeMark
-import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.TimeAndSizeLimitedCache
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import at.hannibal2.skyhanni.utils.roundedUpSeconds
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object TpsCounter {
 
-    private val config get() = SkyHanniMod.feature.gui
-
     private val WORLD_SWITCH_DELAY = 5.seconds
 
-    private var lastServerTick = ServerTimeMark.farPast()
-    private var lastError = SimpleTimeMark.farPast()
-    private val tpsList = TimeAndSizeLimitedCache<Long, Long>(100, 5.seconds)
+    private val config get() = SkyHanniMod.feature.gui
+
+    // MSPT (Milliseconds Per Tick) = 1000 / TPS
+    private val msptList = TimeAndSizeLimitedCache<Long, Double>(100, 5.seconds)
     val tps: Double?
         get() = when {
             timeSinceWorldSwitch < WORLD_SWITCH_DELAY -> null
-            tpsList.isEmpty() -> 0.0
-            else -> (1000.0 / tpsList.values.average()).coerceIn(0.0..20.0).also {
+            msptList.isEmpty() -> 0.0
+            else -> (1000.0 / msptList.values.average()).coerceIn(0.0..20.0).also {
                 if (!it.isFinite()) printError(it)
             }
         }
 
-    private var display: Renderable? = null
-
     private val timeSinceWorldSwitch get() = SkyBlockUtils.lastWorldSwitch.passedSince()
+
+    private var display: Renderable? = null
+    private var lastServerTick = SimpleTimeMark.farPast()
+    private var lastError = SimpleTimeMark.farPast()
     private var pendingTpsCommand = false
 
     @HandleEvent
     fun onServerTick(event: ServerTickEvent) {
-        val now = event.timeMark
+        val now = SimpleTimeMark.now()
         if (!lastServerTick.isFarPast()) {
-            tpsList[event.tick] = (now - lastServerTick).inWholeMilliseconds
+            msptList[event.tick] = (now - lastServerTick).inPartialMilliseconds
         }
         lastServerTick = now
     }
@@ -59,7 +57,7 @@ object TpsCounter {
     fun onSecondPassed() {
         if (lastServerTick.passedSince() >= 1.seconds) {
             ChatUtils.debug("No server ticks detected for 1 second, clearing TPS data")
-            tpsList.clear()
+            msptList.clear()
         }
 
         updateDisplay()
@@ -72,8 +70,12 @@ object TpsCounter {
 
     private fun getTpsString(compact: Boolean = false): String = buildString {
         append("§eTPS: ")
-        when (val currentTps = tps) {
-            null -> {
+        val currentTps = tps
+        when {
+            LimboTimeTracker.inLimbo -> {
+                append("§fN/A §7(Limbo)")
+            }
+            currentTps == null -> {
                 val remaining = (WORLD_SWITCH_DELAY - timeSinceWorldSwitch).roundedUpSeconds
                 if (!compact) append("§fCalculating... ")
                 append("§7(${remaining}s)")
@@ -102,9 +104,9 @@ object TpsCounter {
 
     @HandleEvent
     fun onWorldChange() {
-        tpsList.clear()
+        msptList.clear()
         display = null
-        lastServerTick = ServerTimeMark.farPast()
+        lastServerTick = SimpleTimeMark.farPast()
     }
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
@@ -147,8 +149,18 @@ object TpsCounter {
             "TPS calculation got an error",
             "tps is $tps",
             "tps" to tps,
-            "tpsList" to tpsList,
+            "msptList" to msptList,
             "timeSinceWorldSwitch" to timeSinceWorldSwitch,
         )
+    }
+
+    @HandleEvent
+    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+        event.title("TPS Counter")
+        event.addIrrelevant {
+            add("TPS: %.1f".format(tps))
+            add("Milliseconds Per Tick: ${msptList.values.joinToString(", ") { "%.1f".format(it) }}")
+            add("Time Since World Switch: $timeSinceWorldSwitch")
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -79,7 +79,7 @@ object TpsCounter {
         var currentTps = tps
         when {
             LimboTimeTracker.inLimbo -> {
-                append("§fN/A §7(Limbo)")
+                append("§4N/A §7(Limbo)")
             }
             currentTps == null -> {
                 val remaining = (WORLD_SWITCH_DELAY - timeSinceWorldSwitch).roundedUpSeconds

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.ServerTimeMark
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.TimeAndSizeLimitedCache
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -29,9 +30,16 @@ object TpsCounter {
     private val WORLD_SWITCH_DELAY = 5.seconds
 
     private var lastServerTick = ServerTimeMark.farPast()
+    private var lastError = SimpleTimeMark.farPast()
     private val tpsList = TimeAndSizeLimitedCache<Long, Long>(100, 5.seconds)
-    val tps: Double
-        get() = if (tpsList.isEmpty()) 0.0 else (1000.0 / tpsList.values.average()).coerceIn(0.0..20.0)
+    val tps: Double?
+        get() = when {
+            timeSinceWorldSwitch < WORLD_SWITCH_DELAY -> null
+            tpsList.isEmpty() -> 0.0
+            else -> (1000.0 / tpsList.values.average()).coerceIn(0.0..20.0).also {
+                if (!it.isFinite()) printError(it)
+            }
+        }
 
     private var display: Renderable? = null
 
@@ -62,13 +70,19 @@ object TpsCounter {
         }
     }
 
-    private fun getTpsString(compact: Boolean = false): String =
-        "§eTPS: " + if (timeSinceWorldSwitch > WORLD_SWITCH_DELAY) {
-            format(tps)
-        } else {
-            val remaining = (WORLD_SWITCH_DELAY - timeSinceWorldSwitch).roundedUpSeconds
-            (if (compact) "" else "§fCalculating... ") + "§7(${remaining}s)"
+    private fun getTpsString(compact: Boolean = false): String = buildString {
+        append("§eTPS: ")
+        when (val currentTps = tps) {
+            null -> {
+                val remaining = (WORLD_SWITCH_DELAY - timeSinceWorldSwitch).roundedUpSeconds
+                if (!compact) append("§fCalculating... ")
+                append("§7(${remaining}s)")
+            }
+            else -> {
+                append("%s%.1f".format(getColor(currentTps), currentTps))
+            }
         }
+    }
 
     private fun updateDisplay() {
         display = Renderable.text(getTpsString(compact = true))
@@ -117,11 +131,6 @@ object TpsCounter {
         event.move(2, "misc.tpsDisplayPosition", "gui.tpsDisplayPosition")
     }
 
-    private fun format(tps: Double): String {
-        if (!tps.isFinite()) printError(tps)
-        return "%s%.1f§r".format(getColor(tps), tps)
-    }
-
     private fun getColor(tps: Double) = when {
         tps > 19.8 -> "§2"
         tps > 19 -> "§a"
@@ -132,6 +141,8 @@ object TpsCounter {
     }
 
     private fun printError(tps: Double) {
+        if (lastError.passedSince() < 5.seconds) return
+        lastError = SimpleTimeMark.now()
         ErrorManager.logErrorStateWithData(
             "TPS calculation got an error",
             "tps is $tps",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.minecraft.ServerTickEvent
 import at.hannibal2.skyhanni.features.misc.limbo.LimboTimeTracker
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -32,13 +31,12 @@ object TpsCounter {
 
     private val config get() = SkyHanniMod.feature.gui
 
-    // MSPT (Milliseconds Per Tick) = 1000 / TPS
-    private val msptList = TimeAndSizeLimitedCache<Long, Double>(100, 5.seconds)
+    private val msPerTickList = TimeAndSizeLimitedCache<Long, Double>(100, 5.seconds)
     val tps: Double?
         get() = when {
             timeSinceWorldSwitch < WORLD_SWITCH_DELAY -> null
-            msptList.isEmpty() -> 0.0
-            else -> (1000.0 / msptList.values.average()).coerceIn(0.0..20.0).also {
+            msPerTickList.isEmpty() -> 0.0
+            else -> (1000.0 / msPerTickList.values.average()).coerceIn(0.0..20.0).also {
                 if (!it.isFinite()) printError(it)
             }
         }
@@ -54,7 +52,7 @@ object TpsCounter {
     fun onServerTick(event: ServerTickEvent) {
         val now = SimpleTimeMark.now()
         if (!lastServerTick.isFarPast()) {
-            msptList[event.tick] = (now - lastServerTick).inPartialMilliseconds
+            msPerTickList[event.tick] = (now - lastServerTick).inPartialMilliseconds
         }
         lastServerTick = now
     }
@@ -63,10 +61,10 @@ object TpsCounter {
     fun onSecondPassed() {
         if (lastServerTick.passedSince() >= 1.seconds) {
             ChatUtils.debug("No server ticks detected for 1 second, clearing TPS data")
-            msptList.clear()
+            msPerTickList.clear()
         }
 
-        updateDisplay()
+        display = Renderable.text(getTpsString(compact = true))
 
         if (pendingTpsCommand) {
             pendingTpsCommand = false
@@ -93,10 +91,6 @@ object TpsCounter {
         }
     }
 
-    private fun updateDisplay() {
-        display = Renderable.text(getTpsString(compact = true))
-    }
-
     private fun tpsCommand() {
         val text = getTpsString()
         ChatUtils.chat(text)
@@ -111,13 +105,13 @@ object TpsCounter {
 
     @HandleEvent
     fun onWorldChange() {
-        msptList.clear()
+        msPerTickList.clear()
         display = null
         lastServerTick = SimpleTimeMark.farPast()
     }
 
-    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
-    fun onRenderOverlay() {
+    @HandleEvent
+    fun onGuiRenderOverlay() {
         if (!isEnabled()) return
         display?.let { config.tpsDisplayPosition.renderRenderable(it, posLabel = "TPS Display") }
     }
@@ -156,7 +150,7 @@ object TpsCounter {
             "TPS calculation got an error",
             "tps is $tps",
             "tps" to tps,
-            "msptList" to msptList,
+            "msptList" to msPerTickList,
             "timeSinceWorldSwitch" to timeSinceWorldSwitch,
         )
     }
@@ -166,7 +160,7 @@ object TpsCounter {
         event.title("TPS Counter")
         event.addIrrelevant {
             add("TPS: %.1f".format(tps))
-            add("Milliseconds Per Tick: ${msptList.values.joinToString(", ") { "%.1f".format(it) }}")
+            add("Milliseconds Per Tick: ${msPerTickList.values.joinToString(", ") { "%.1f".format(it) }}")
             add("Time Since World Switch: $timeSinceWorldSwitch")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -50,6 +50,7 @@ object TpsCounter {
     @HandleEvent
     fun onSecondPassed() {
         if (lastServerTick.passedSince() >= 1.seconds) {
+            ChatUtils.debug("No ping packets received for 1 second, clearing TPS data")
             tpsList.clear()
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ServerTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ServerTimeMark.kt
@@ -12,7 +12,7 @@ import kotlin.time.Duration
  * the server's tps instead of real time, and therefore are affected by server lag.
  */
 @JvmInline
-value class ServerTimeMark(val ticks: Long) : Comparable<ServerTimeMark> {
+value class ServerTimeMark internal constructor(val ticks: Long) : Comparable<ServerTimeMark> {
 
     operator fun minus(other: ServerTimeMark): Duration =
         (ticks - other.ticks).ticks

--- a/src/main/java/at/hannibal2/skyhanni/utils/ServerTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ServerTimeMark.kt
@@ -12,7 +12,7 @@ import kotlin.time.Duration
  * the server's tps instead of real time, and therefore are affected by server lag.
  */
 @JvmInline
-value class ServerTimeMark private constructor(val ticks: Long) : Comparable<ServerTimeMark> {
+value class ServerTimeMark(val ticks: Long) : Comparable<ServerTimeMark> {
 
     operator fun minus(other: ServerTimeMark): Duration =
         (ticks - other.ticks).ticks

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -19,6 +19,7 @@ import java.time.temporal.WeekFields
 import java.util.Locale
 import java.util.regex.Matcher
 import kotlin.math.absoluteValue
+import kotlin.math.ceil
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -319,5 +320,8 @@ val Duration.inPartialMinutes: Double get() = inPartialSeconds / 60
 val Duration.inPartialHours: Double get() = inPartialSeconds / 3600
 val Duration.inPartialDays: Double get() = inPartialSeconds / 86_400
 val Duration.inPartialYears: Double get() = inPartialSeconds / (86_400 * 365.25)
+
+val Duration.roundedUpSeconds: Int get() = ceil(inPartialSeconds).toInt()
+
 val Long.years: Duration get() = this.times(365.25).days
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -315,11 +315,11 @@ enum class TimeUnit(val factor: Long, private val shortName: String, private val
     }
 }
 
+val Duration.inPartialMilliseconds: Double get() = toDouble(DurationUnit.MILLISECONDS)
 val Duration.inPartialSeconds: Double get() = toDouble(DurationUnit.SECONDS)
-val Duration.inPartialMinutes: Double get() = inPartialSeconds / 60
-val Duration.inPartialHours: Double get() = inPartialSeconds / 3600
-val Duration.inPartialDays: Double get() = inPartialSeconds / 86_400
-val Duration.inPartialYears: Double get() = inPartialSeconds / (86_400 * 365.25)
+val Duration.inPartialMinutes: Double get() = toDouble(DurationUnit.MINUTES)
+val Duration.inPartialHours: Double get() = toDouble(DurationUnit.HOURS)
+val Duration.inPartialDays: Double get() = toDouble(DurationUnit.DAYS)
 
 val Duration.roundedUpSeconds: Int get() = ceil(inPartialSeconds).toInt()
 


### PR DESCRIPTION
## What
Significantly improved the TPS counter, meaning it should no longer show unrealistically high TPS values when the server is clearly lagging, and then sometimes show low values later when the server has already recovered.

Instead of looking for any and all packets received each tick, we now look specifically for ClientboundPingPacket (which fires our already existing ServerTickEvent). And instead of counting how many we get each second, we measure the average distance between those packets, resulting in a much more accurate measurement.

We take the average of the last 5 seconds, but if the server sends zero ping packets for a whole second, we reset the displayed TPS to 0.0, because otherwise it would take multiple seconds for the TPS display to change at all when the server is completely unresponsive.

Note that as of recently, Hypixel no longer delays sending ping packets until 10 seconds after a world switch, but rather starts sending them immediately. But I still kept a 5 second timer on world switch before showing the TPS to make sure we've gathered enough samples for accurate measurement and avoid displaying a low TPS value when the server is actually working fine.

I've been running this side by side with the old TPS counter implementation for the past few days and it seems pretty accurate.

Of course, if your connection to Hypixel is dying, this will show low TPS. There's not really anything we can do about that.

## Changelog Improvements
+ Significantly improved accuracy of server TPS measurement. - Luna

## Changelog Technical Details
+ Added `tick` and `timeMark` fields to `ServerTickEvent`. - Luna
+ Added `Duration.inPartialMilliseconds`. - Luna
+ Added `Duration.roundedUpSeconds`. - Luna
    * Useful for countdowns, because `inWholeSeconds` will round down, often leading to undesirable behavior where, for example, your 5-second countdown starts at 4 and shows 0 for a full second before finishing.
+ Removed unused `Duration.inPartialYears`. - Luna
    * The precise definition of a year is context-dependent anyway, so it's better not to have this.