### PR TITLE
Fix: Greenhouse Growth Stage alert sending multiple times

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
@@ -70,17 +70,17 @@ object GrowthCycle {
         updateDisplay()
 
         val nextCycle = storage?.nextCycle ?: return
-        if (nextCycle.isInPast() && !hasNotified) {
-            hasNotified = true
-            SoundUtils.playPlingSound()
-            ChatUtils.chat(
-                componentBuilder {
-                    append("Greenhouse Growth Stage is ready in the Garden") {
-                        withColor(ChatFormatting.GREEN)
-                    }
-                },
-            )
-        }
+        if (!nextCycle.isInPast() || hasNotified) return
+
+        hasNotified = true
+        SoundUtils.playPlingSound()
+        ChatUtils.chat(
+            componentBuilder {
+                append("Greenhouse Growth Stage is ready in the Garden") {
+                    withColor(ChatFormatting.GREEN)
+                }
+            },
+        )
     }
 
     private fun updateDisplay() {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/GrowthCycle.kt
@@ -47,7 +47,7 @@ object GrowthCycle {
     )
 
     private var display: Renderable? = null
-    private var beep = true
+    private var hasNotified = true
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
@@ -59,23 +59,36 @@ object GrowthCycle {
             val timeString = group("time")
             val duration = TimeUtils.getDurationOrNull(timeString) ?: return
             storage?.nextCycle = duration.fromNow()
-            beep = false
+            hasNotified = false
             updateDisplay()
         }
     }
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    fun onSecondPassed() {
         if (!config.showDisplay) return
 
         updateDisplay()
+
+        val nextCycle = storage?.nextCycle ?: return
+        if (nextCycle.isInPast() && !hasNotified) {
+            hasNotified = true
+            SoundUtils.playPlingSound()
+            ChatUtils.chat(
+                componentBuilder {
+                    append("Greenhouse Growth Stage is ready in the Garden") {
+                        withColor(ChatFormatting.GREEN)
+                    }
+                },
+            )
+        }
     }
 
     private fun updateDisplay() {
         val nextCycle = storage?.nextCycle ?: return
         if (nextCycle.isFarPast() || nextCycle.passedSince() > 60.minutes) {
             display = null
-            beep = false
+            hasNotified = false
             return
         }
         display = drawDisplay(nextCycle)
@@ -85,17 +98,6 @@ object GrowthCycle {
         val timeUntil = nextCycle.timeUntil()
         val color = timeUntil.timerColor("§a")
         val formatted = if (nextCycle.isInPast()) {
-            if (!beep) {
-                SoundUtils.playPlingSound()
-                ChatUtils.chat(
-                    componentBuilder {
-                        append("Greenhouse Growth Stage is ready in the Garden") {
-                            withColor(ChatFormatting.GREEN)
-                        }
-                    },
-                )
-                beep = true
-            }
             "§cOVERDUE"
         } else {
             if (config.onlyShowWhenOverdue) return null


### PR DESCRIPTION
## What
Fixed Greenhouse Growth Stage alert sometimes sending multiple times due to a race condition by setting `hasNotified` (renamed from `beep`) to `true` *before* sending the notification. Also while I'm at it, refactored the code so that we aren't sending notifications in render code.

## Changelog Fixes
+ Fixed Greenhouse Growth Stage alert sometimes sending multiple times. - Luna