### PR TITLE
Feature: Avorius Helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/CrimsonIsleConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/CrimsonIsleConfig.kt
@@ -68,6 +68,15 @@ class CrimsonIsleConfig {
     var sirihHelper: Boolean = true
 
     @Expose
+    @ConfigOption(
+        name = "Avorius NPC Helper",
+        desc = "Show a clickable message that grabs a cup of blood from your sacks.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var avoriusHelper: Boolean = true
+
+    @Expose
     @ConfigOption(name = "Volcano Explosivity", desc = "Show a HUD of the current volcano explosivity level.")
     @ConfigEditorBoolean
     var volcanoExplosivity: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
@@ -1,0 +1,63 @@
+package at.hannibal2.skyhanni.features.nether
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.GetFromSackApi
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.CrimsonIsleReputationApi
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.features.nether.reputationhelper.FactionType
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.makePrimitiveStack
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import kotlin.time.Duration.Companion.minutes
+
+// https://wiki.hypixel.net/Avorius
+@SkyHanniModule
+object AvoriusHelper {
+
+    private val config get() = SkyHanniMod.feature.crimsonIsle
+
+    private var lastSentMessage = SimpleTimeMark.farPast()
+
+    private val CUP_OF_BLOOD = "CUP_OF_BLOOD".toInternalName()
+
+    /**
+     * REGEX-TEST: §e[NPC] §cAvorius§f: §rI am quite thirsty all the time, it's a rare condition.
+     * REGEX-TEST: §e[NPC] §cAvorius§f: §rThere is no sunlight either, it would be quite accommodating for a Vampire.
+     * REGEX-TEST: §e[NPC] §cAvorius§f: §rWhy are you looking at me that way? I am not a Vampire, you are!
+     */
+    private val patterns by RepoPattern.list(
+        "crimson.avorius.helper",
+        "\\[NPC] Avorius: I am quite thirsty all the time, it's a rare condition\\.",
+        "\\[NPC] Avorius: There is no sunlight either, it would be quite accommodating for a Vampire\\.",
+        "\\[NPC] Avorius: Why are you looking at me that way\\? I am not a Vampire, you are!",
+    )
+
+    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
+    fun onChat(event: SkyHanniChatEvent.Allow) {
+        if (!isEnabled()) return
+        if (lastSentMessage.passedSince() < 5.minutes) return
+
+        patterns.matchMatchers(event.cleanMessage) {} ?: return
+
+        if (InventoryUtils.countItemsInLowerInventory { it.getInternalNameOrNull() == CUP_OF_BLOOD } > 0) return
+
+        DelayedRun.runNextTick {
+            GetFromSackApi.getFromChatMessageSackItems(
+                CUP_OF_BLOOD.makePrimitiveStack(),
+                "Click here to grab a Cup of Blood from sacks!",
+            )
+        }
+
+        lastSentMessage = SimpleTimeMark.now()
+    }
+
+    fun isEnabled() = config.avoriusHelper && CrimsonIsleReputationApi.factionType == FactionType.MAGE
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.makePrimitiveSta
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 // https://wiki.hypixel.net/Avorius
 @SkyHanniModule
@@ -28,12 +28,14 @@ object AvoriusHelper {
 
     private val CUP_OF_BLOOD = "CUP_OF_BLOOD".toInternalName()
 
+    private val cupOfBloodPrimitiveStack by lazy { CUP_OF_BLOOD.makePrimitiveStack() }
+
     /**
      * REGEX-TEST: §e[NPC] §cAvorius§f: §rI am quite thirsty all the time, it's a rare condition.
      * REGEX-TEST: §e[NPC] §cAvorius§f: §rThere is no sunlight either, it would be quite accommodating for a Vampire.
      * REGEX-TEST: §e[NPC] §cAvorius§f: §rWhy are you looking at me that way? I am not a Vampire, you are!
      */
-    private val patterns by RepoPattern.list(
+    private val avoriusLines by RepoPattern.list(
         "crimson.avorius.helper",
         "\\[NPC] Avorius: I am quite thirsty all the time, it's a rare condition\\.",
         "\\[NPC] Avorius: There is no sunlight either, it would be quite accommodating for a Vampire\\.",
@@ -43,15 +45,14 @@ object AvoriusHelper {
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
     fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
-        if (lastSentMessage.passedSince() < 5.minutes) return
+        if (lastSentMessage.passedSince() < 15.seconds) return
 
-        patterns.matchMatchers(event.cleanMessage) {} ?: return
-
+        if (!avoriusLines.matches(event.cleanMessage)) return;
         if (InventoryUtils.countItemsInLowerInventory { it.getInternalNameOrNull() == CUP_OF_BLOOD } > 0) return
 
         DelayedRun.runNextTick {
             GetFromSackApi.getFromChatMessageSackItems(
-                CUP_OF_BLOOD.makePrimitiveStack(),
+                cupOfBloodPrimitiveStack,
                 "Click here to grab a Cup of Blood from sacks!",
             )
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
@@ -47,7 +47,7 @@ object AvoriusHelper {
         if (!isEnabled()) return
         if (lastSentMessage.passedSince() < 15.seconds) return
 
-        if (!avoriusLines.matches(event.cleanMessage)) return;
+        if (!avoriusLines.matches(event.cleanMessage)) return
         if (InventoryUtils.countItemsInLowerInventory { it.getInternalNameOrNull() == CUP_OF_BLOOD } > 0) return
 
         DelayedRun.runNextTick {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
@@ -31,9 +31,9 @@ object AvoriusHelper {
     private val cupOfBloodPrimitiveStack by lazy { CUP_OF_BLOOD.makePrimitiveStack() }
 
     /**
-     * REGEX-TEST: §e[NPC] §cAvorius§f: §rI am quite thirsty all the time, it's a rare condition.
-     * REGEX-TEST: §e[NPC] §cAvorius§f: §rThere is no sunlight either, it would be quite accommodating for a Vampire.
-     * REGEX-TEST: §e[NPC] §cAvorius§f: §rWhy are you looking at me that way? I am not a Vampire, you are!
+     * REGEX-TEST: [NPC] Avorius: I am quite thirsty all the time, it's a rare condition.
+     * REGEX-TEST: [NPC] Avorius: There is no sunlight either, it would be quite accommodating for a Vampire.
+     * REGEX-TEST: [NPC] Avorius: Why are you looking at me that way? I am not a Vampire, you are!
      */
     private val avoriusLines by RepoPattern.list(
         "crimson.avorius.helper",

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/AvoriusHelper.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.makePrimitiveStack
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.seconds


### PR DESCRIPTION
## What
Adds a helper for the Avorius NPC on the Crimson Isle. When Avorius
sends one of his vampire-hinting dialogue lines, the mod will prompt
the player to grab a Cup of Blood from their sacks if they don't
already have one in their inventory. Only triggers for Mage faction
players.

## Changelog New Features
+ Added Avorius Helper for the Crimson Isle. - Destiny