### PR TITLE
Backend: ArmorStand Copy => Equipment Slot

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
@@ -5,11 +5,11 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.data.mob.Mob
+import at.hannibal2.skyhanni.data.mob.MobCategory
 import at.hannibal2.skyhanni.data.mob.MobData
 import at.hannibal2.skyhanni.data.mob.MobFilter.isDisplayNpc
 import at.hannibal2.skyhanni.data.mob.MobFilter.isRealPlayer
 import at.hannibal2.skyhanni.data.mob.MobFilter.isSkyBlockMob
-import at.hannibal2.skyhanni.data.mob.MobCategory
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.AllEntitiesGetter
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -30,7 +30,7 @@ import at.hannibal2.skyhanni.utils.compat.findHealthReal
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
-import at.hannibal2.skyhanni.utils.compat.getInventoryItems
+import at.hannibal2.skyhanni.utils.compat.getEquipmentSlots
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.Display
@@ -146,12 +146,17 @@ object CopyNearbyEntitiesCommand {
         add("-  headRotation: $headRotation")
         add("-  bodyRotation: $bodyRotation")
 
-        add("-  inventory:")
-        for ((id, stack) in entity.getInventoryItems().withIndex()) {
+        add("-  inventory equipment:")
+        for ((equipSlot, stack) in entity.getEquipmentSlots()) {
+            val adjustedStack = stack.orNull()
+            add("-     ${equipSlot.name} (id ${equipSlot.id}) ($adjustedStack)")
+            printItemStackData(adjustedStack)
+        }
+        /*for ((id, stack) in entity.getInventoryItems().withIndex()) {
             val adjustedStack = stack.orNull()
             add("-  id $id ($adjustedStack)")
             printItemStackData(adjustedStack)
-        }
+        }*/
     }
 
     private fun MutableList<String>.addEnderman(entity: EnderMan) {
@@ -268,7 +273,7 @@ object CopyNearbyEntitiesCommand {
 
     private fun MutableList<String>.printItemStackData(stack: ItemStack?) {
         if (stack != null) {
-            val skullTexture = stack.getSkullTexture()
+            val skullTexture = stack.getSkullTexture()?.trim()?.replace("\n", "")
             if (skullTexture != null) {
                 add("-     skullTexture:")
                 add("-     $skullTexture")

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
@@ -152,11 +152,6 @@ object CopyNearbyEntitiesCommand {
             add("-     ${equipSlot.name} (id ${equipSlot.id}) ($adjustedStack)")
             printItemStackData(adjustedStack)
         }
-        /*for ((id, stack) in entity.getInventoryItems().withIndex()) {
-            val adjustedStack = stack.orNull()
-            add("-  id $id ($adjustedStack)")
-            printItemStackData(adjustedStack)
-        }*/
     }
 
     private fun MutableList<String>.addEnderman(entity: EnderMan) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/EntityCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/EntityCompat.kt
@@ -31,6 +31,9 @@ fun ArmorStand.getInventoryItems(): Array<ItemStack> =
         getItemBySlot(EquipmentSlot.OFFHAND),
     )
 
+fun ArmorStand.getEquipmentSlots(): Map<EquipmentSlot, ItemStack?> =
+    EquipmentSlot.entries.associateWith { getItemBySlot(it) }
+
 fun Entity.getEntityLevel(): Level =
     this.level()
 


### PR DESCRIPTION
## What
Changed from index mapping the inventory slots, to mapping them to the actual `EquipmentSlot`, since the IDs we were printing had no value.

<details>
<summary>Images</summary>

Before
<img width="475" height="355" alt="image" src="https://github.com/user-attachments/assets/7733b2a4-a149-45c4-8e80-f22dfb9a1de4" />

After
<img width="460" height="389" alt="image" src="https://github.com/user-attachments/assets/c7a8eeeb-88a4-4233-a5a2-ba8331777200" />

</details>

## Changelog Technical Details
+ Changed ArmorStand entity copying to use EquipmentSlot. - Daveed



