### PR TITLE
Backend: Refactor Eye Height/Position Handling

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/LineToMobHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/LineToMobHandler.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import io.github.notenoughupdates.moulconfig.ChromaColour
 
 @SkyHanniModule
@@ -44,7 +44,7 @@ object LineToMobHandler {
 
         for ((mob, settings) in lines) {
             if (!settings.condition() || !mob.canBeSeen()) continue
-            event.drawLineToEye(
+            event.drawLineToCrosshair(
                 mob.centerCords,
                 settings.color,
                 settings.width,

--- a/src/main/java/at/hannibal2/skyhanni/data/navigation/PathRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/navigation/PathRenderer.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
 import at.hannibal2.skyhanni.utils.GraphUtils.playerPosition
 import at.hannibal2.skyhanni.utils.LocationUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.PlayerUtils.STANDING_EYE_HEIGHT
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.addWaters
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils
@@ -45,8 +46,6 @@ private const val TANGENT_LOOKAHEAD = 1.5
 
 private const val NEAR_LINE_WIDTH = 6
 private const val FAR_LINE_WIDTH = 4
-
-private const val STANDING_EYE_HEIGHT = 1.62
 
 // distance in blocks above/below a water surface crossing where depth testing is disabled
 private const val PEEK_DISTANCE = 4.0

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.EntityUtils.getBlockInHand
 import at.hannibal2.skyhanni.utils.EntityUtils.isCorrupted
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.monster.EnderMan
 import net.minecraft.world.level.block.Blocks
@@ -113,7 +113,7 @@ object MobHighlight {
 
         if (!arachne.canBeSeen(10)) return
 
-        event.drawLineToEye(
+        event.drawLineToCrosshair(
             arachne.centerCords,
             LorenzColor.RED.toChromaColor(),
             config.lineToArachneWidth,

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
@@ -39,7 +39,7 @@ import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactBoundingBox
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactLocation
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -243,7 +243,7 @@ object DungeonLividFinder {
 
         val color = lorenzColor.toChromaColor()
         event.drawFilledBoundingBox(boundingBox, color, 0.5f)
-        event.drawLineToEye(location.add(x = 0.5, z = 0.5), color, 3, true)
+        event.drawLineToCrosshair(location.add(x = 0.5, z = 0.5), color, 3, true)
     }
 
     private fun inLividBossRoom() = DungeonApi.inBossRoom && DungeonApi.getCurrentBoss() == DungeonFloor.F5

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
@@ -6,8 +6,8 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.mob.Mob
-import at.hannibal2.skyhanni.data.mob.MobData
 import at.hannibal2.skyhanni.data.mob.MobCategory
+import at.hannibal2.skyhanni.data.mob.MobData
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.entity.EntityMoveEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.ColorUtils.toColor
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.MobUtils.mob
 import at.hannibal2.skyhanni.utils.getLorenzVec
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import net.minecraft.world.entity.LivingEntity
@@ -87,7 +87,7 @@ object DungeonMobManager {
         if (fel.line) {
             val color = getFelColor()
             felOnTheGround.filter { it.canBeSeen(30) }.forEach {
-                event.drawLineToEye(
+                event.drawLineToCrosshair(
                     it.baseEntity.getLorenzVec().add(y = 0.15),
                     color,
                     3,

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -21,7 +21,7 @@ import at.hannibal2.skyhanni.utils.compat.getEntityHelmet
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawHitbox
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
@@ -141,7 +141,7 @@ object CarnivalZombieShootout {
     }
 
     private fun SkyHanniRenderWorldEvent.renderLines() = lamp?.let {
-        drawLineToEye(
+        drawLineToCrosshair(
             it.pos.add(0.5, 0.5, 0.5),
             Color.RED,
             3,

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -47,7 +47,7 @@ import at.hannibal2.skyhanni.utils.compat.addTallGrass
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import io.github.notenoughupdates.moulconfig.ChromaColour
@@ -469,7 +469,7 @@ object GriffinBurrowHelper {
                 3
             } else 2
             if (currentWarp == null) {
-                event.drawLineToEye(renderLocation, color, lineWidth, false)
+                event.drawLineToCrosshair(renderLocation, color, lineWidth, false)
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -29,7 +29,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import net.minecraft.core.particles.ParticleTypes
 import net.minecraft.world.entity.projectile.FishingHook
@@ -116,7 +116,7 @@ object HoppityEggLocator {
             } else "§aGuess #${index + 1}"
             drawEggWaypoint(eggLocation, name)
             if (waypointsConfig.showLine) {
-                drawLineToEye(eggLocation.blockCenter(), LorenzColor.GREEN.toChromaColor(), 2, false)
+                drawLineToCrosshair(eggLocation.blockCenter(), LorenzColor.GREEN.toChromaColor(), 2, false)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeatures.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.utils.ColorUtils.toChromaColor
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import java.awt.Color
 
 @SkyHanniModule
@@ -34,7 +34,7 @@ object PigFeatures {
         if (!lineToPigEnabled) return
 
         val pigEntityLocation = WorldRenderUtils.exactLocation(pigEntity, partialTicks)
-        drawLineToEye(
+        drawLineToCrosshair(
             pigEntityLocation.up(0.54),
             Color.PINK.toChromaColor(),
             3,

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHotspotRadar.kt
@@ -21,7 +21,7 @@ import at.hannibal2.skyhanni.utils.ParticlePathBezierFitter
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactPlayerEyeLocation
 import net.minecraft.core.particles.ParticleTypes
 import kotlin.time.Duration.Companion.seconds
@@ -116,7 +116,7 @@ object FishingHotspotRadar {
         val location = hotspotLocation ?: return
         val distance = location.distance(event.exactPlayerEyeLocation())
         if (config.lineToHotspot) {
-            event.drawLineToEye(location, LorenzColor.LIGHT_PURPLE.toChromaColor(), lineWidth = 3, depth = false)
+            event.drawLineToCrosshair(location, LorenzColor.LIGHT_PURPLE.toChromaColor(), lineWidth = 3, depth = false)
         }
         if (distance > 10) {
             val formattedDistance = distance.toInt().addSeparators()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestParticleWaypoint.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.ParticlePathBezierFitter
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactPlayerEyeLocation
 import com.google.gson.JsonPrimitive
@@ -123,7 +123,7 @@ object PestParticleWaypoint {
         event.drawWaypointFilled(waypoint, color.toColor(), beacon = true)
         event.drawDynamicText(waypoint, "§aPest Guess", 1.3)
         if (config.drawLine) {
-            event.drawLineToEye(
+            event.drawLineToCrosshair(
                 waypoint.add(0.5, 0.5, 0.5),
                 color,
                 3,

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OrderedWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OrderedWaypoints.kt
@@ -26,10 +26,12 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
+import at.hannibal2.skyhanni.utils.PlayerUtils.SNEAKING_EYE_HEIGHT
+import at.hannibal2.skyhanni.utils.PlayerUtils.STANDING_EYE_HEIGHT
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawEdges
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import kotlinx.coroutines.Job
@@ -118,7 +120,7 @@ object OrderedWaypoints {
         else orderedWaypointsList[renderWaypoints[2]]
         val traceLineColor = config.traceLineColor
         if (config.traceLine && !config.showAll && !config.setupMode) {
-            event.drawLineToEye(
+            event.drawLineToCrosshair(
                 traceWP.location.add(0.5, 0.25, 0.5),
                 traceLineColor,
                 config.traceLineThickness.toInt(),
@@ -129,10 +131,9 @@ object OrderedWaypoints {
         val currentWP = orderedWaypointsList[renderWaypoints[1]]
         val setupModeLineColor = config.setupModeLineColor
         if (config.setupMode && !config.showAll) {
-            val eyePos = if (config.sneakingDuringRoute) 1.54
-            else 1.62
+            val eyeHeight = if (config.sneakingDuringRoute) SNEAKING_EYE_HEIGHT else STANDING_EYE_HEIGHT
             event.draw3DLine(
-                currentWP.location.add(0.5, 1.0 + eyePos, 0.5),
+                currentWP.location.add(0.5, 1.0 + eyeHeight, 0.5),
                 traceWP.location.add(0.5, 0.5, 0.5),
                 setupModeLineColor,
                 config.setupModeLineThickness.toInt(),

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsWalls.kt
@@ -70,7 +70,7 @@ object CrystalHollowsWalls {
     @HandleEvent
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
-        val position = WorldRenderUtils.getViewerPos(event.partialTicks)
+        val position = WorldRenderUtils.getViewerPos()
         when {
             position.y < HEAT_HEIGHT + yViewOffset -> drawHeat(event)
             nucleusBBOffsetY.contains(position.toVec3()) -> {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/MetalDetectorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/MetalDetectorSolver.kt
@@ -34,7 +34,7 @@ import at.hannibal2.skyhanni.utils.compat.appendWithColor
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.compat.withColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -191,7 +191,7 @@ object MetalDetectorSolver {
         predictedChestLocations.forEach {
             // TODO add chroma color support via config
             event.drawColor(it, LorenzColor.GOLD.toChromaColor())
-            event.drawLineToEye(it.add(0.5, 0.5, 0.5), LorenzColor.WHITE.toChromaColor(), 3, false)
+            event.drawLineToCrosshair(it.add(0.5, 0.5, 0.5), LorenzColor.WHITE.toChromaColor(), 3, false)
             event.drawWaypointFilled(it, LorenzColor.RED.toColor(), seeThroughBlocks = true, beacon = true)
             event.drawString(it, "Treasure: §e${it.distanceToPlayer().roundTo(1)}m", true)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/powdertracker/PowderChestTimer.kt
@@ -29,7 +29,7 @@ import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import net.minecraft.world.level.block.Blocks
@@ -153,7 +153,7 @@ object PowderChestTimer {
     private fun SkyHanniRenderWorldEvent.drawFirstLine(list: List<Map.Entry<LorenzVec, SimpleTimeMark>>) {
         val (firstPos, firstTime) = list.first()
 
-        drawLineToEye(
+        drawLineToCrosshair(
             firstPos.blockCenter(),
             firstTime.timeUntil().getColorBasedOnTime(),
             lineWidth = 3,

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactLocation
 import net.minecraft.client.player.RemotePlayer
@@ -148,7 +148,7 @@ object LivingCaveDefenseBlocks {
             if (time > System.currentTimeMillis()) {
                 val location = block.location
                 event.drawWaypointFilled(location, color)
-                event.drawLineToEye(
+                event.drawLineToCrosshair(
                     location.blockCenter(),
                     color,
                     1,

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.getLorenzVec
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import net.minecraft.world.entity.Entity
 
 @SkyHanniModule
@@ -58,7 +58,7 @@ object SlayerMiniBossFeatures {
         if (!config.slayerMinibossLine) return
         for (mob in miniBosses) {
             if (!mob.baseEntity.canBeSeen(10)) continue
-            event.drawLineToEye(
+            event.drawLineToCrosshair(
                 mob.baseEntity.getLorenzVec().up(),
                 LorenzColor.AQUA.toChromaColor(),
                 config.slayerMinibossLineWidth,
@@ -67,7 +67,7 @@ object SlayerMiniBossFeatures {
         }
         for (mob in cocoons) {
             if (!mob.canBeSeen(10)) continue
-            event.drawLineToEye(
+            event.drawLineToCrosshair(
                 mob.getLorenzVec().up(),
                 LorenzColor.AQUA.toChromaColor(),
                 config.slayerMinibossLineWidth,

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -31,6 +31,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.PlayerUtils.SNEAKING_EYE_HEIGHT
 import at.hannibal2.skyhanni.utils.ServerTimeMark
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
@@ -41,7 +42,7 @@ import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactLocation
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactPlayerEyeLocation
@@ -252,8 +253,8 @@ object VampireSlayerFeatures {
                 if (!it.isHighlighted()) continue
                 if (!it.canBeSeen(15)) continue
                 val vec = event.exactLocation(it)
-                event.drawLineToEye(
-                    vec.up(1.54),
+                event.drawLineToCrosshair(
+                    vec.up(SNEAKING_EYE_HEIGHT),
                     config.lineColor,
                     config.lineWidth,
                     true,

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -25,12 +25,11 @@ import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.compat.deceased
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.getStandHelmet
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
-import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToEye
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactLocation
 import net.minecraft.world.entity.Entity
@@ -131,7 +130,7 @@ object EndermanSlayerFeatures {
                 val skullLocation = event.exactLocation(skull)
                 // TODO remove visibility check once the skull stops moving
                 if (!skull.canBeSeen(viewDistance = 20)) continue
-                event.drawLineToEye(
+                event.drawLineToCrosshair(
                     skullLocation.up(),
                     LorenzColor.GOLD.toChromaColor(),
                     3,
@@ -151,7 +150,7 @@ object EndermanSlayerFeatures {
 
             if (beaconConfig.showLine) {
                 val beaconLocation = event.exactLocation(beacon)
-                event.drawLineToEye(
+                event.drawLineToCrosshair(
                     beaconLocation.add(0.5, 1.0, 0.5),
                     beaconConfig.lineColor,
                     beaconConfig.lineWidth,
@@ -165,7 +164,7 @@ object EndermanSlayerFeatures {
         for ((location, time) in sittingBeacon) {
             if (location.distanceToPlayer() > 20) continue
             if (beaconConfig.showLine) {
-                event.drawLineToEye(
+                event.drawLineToCrosshair(
                     location.add(0.5, 1.0, 0.5),
                     beaconConfig.lineColor,
                     beaconConfig.lineWidth,

--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -4,10 +4,15 @@ import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.StringUtils.toUnDashedUUID
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.client.Minecraft
+import net.minecraft.world.entity.Avatar
+import net.minecraft.world.entity.Pose
 import net.minecraft.world.entity.ai.attributes.Attributes
 import java.util.UUID
 
 object PlayerUtils {
+
+    val STANDING_EYE_HEIGHT = Avatar.POSES.getValue(Pose.STANDING).eyeHeight
+    val SNEAKING_EYE_HEIGHT = Avatar.POSES.getValue(Pose.CROUCHING).eyeHeight
 
     // thirdPersonView on 1.8.9
     // 0 == normal

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -147,10 +147,9 @@ object WorldRenderUtils {
          * If set to `false`, will be relativized to [WorldRenderUtils.getViewerPos].
          */
         renderRelativeToCamera: Boolean = false,
-        drawVerticalBarriers: Boolean = true,
         seeThroughBlocks: Boolean = false,
     ) {
-        drawFilledBoundingBox(aabb, c.toColor(), alphaMultiplier, renderRelativeToCamera, drawVerticalBarriers, seeThroughBlocks)
+        drawFilledBoundingBox(aabb, c.toColor(), alphaMultiplier, renderRelativeToCamera, seeThroughBlocks)
     }
 
     // TODO make deprecated
@@ -163,7 +162,6 @@ object WorldRenderUtils {
          * If set to `false`, will be relativized to [WorldRenderUtils.getViewerPos].
          */
         renderRelativeToCamera: Boolean = false,
-        drawVerticalBarriers: Boolean = true,
         seeThroughBlocks: Boolean = false,
     ) {
         val effectiveAABB = if (!renderRelativeToCamera) {
@@ -816,13 +814,13 @@ object WorldRenderUtils {
         }
     }
 
-    fun SkyHanniRenderWorldEvent.drawLineToEye(location: LorenzVec, color: ChromaColour, lineWidth: Int, depth: Boolean) {
-        drawLineToEye(location, color.toColor(), lineWidth, depth)
+    fun SkyHanniRenderWorldEvent.drawLineToCrosshair(location: LorenzVec, color: ChromaColour, lineWidth: Int, depth: Boolean) {
+        drawLineToCrosshair(location, color.toColor(), lineWidth, depth)
     }
 
-    fun SkyHanniRenderWorldEvent.drawLineToEye(location: LorenzVec, color: Color, lineWidth: Int, depth: Boolean) {
+    fun SkyHanniRenderWorldEvent.drawLineToCrosshair(location: LorenzVec, color: Color, lineWidth: Int, depth: Boolean) {
         draw3DLine(
-            exactPlayerEyeLocation() + MinecraftCompat.localPlayer.lookAngle.toLorenzVec().times(2),
+            exactPlayerCrosshairLocation(),
             location,
             color,
             lineWidth,
@@ -952,8 +950,6 @@ object WorldRenderUtils {
         )
     }
 
-    fun getViewerPos(ignored: Float) = getViewerPos()
-
     fun getViewerPos() =
         Minecraft.getInstance().gameRenderer.mainCamera?.let { exactLocation(it) } ?: LorenzVec()
 
@@ -984,6 +980,9 @@ object WorldRenderUtils {
         return exactLocation(player).add(y = eyeHeight)
     }
 
+    fun SkyHanniRenderWorldEvent.exactPlayerCrosshairLocation(): LorenzVec =
+        exactPlayerEyeLocation() + MinecraftCompat.localPlayer.lookAngle.toLorenzVec().times(2)
+
     fun SkyHanniRenderWorldEvent.exactBoundingBox(entity: Entity): AABB {
         if (entity.deceased) return entity.boundingBox
         val offset = exactLocation(entity) - entity.getLorenzVec()
@@ -997,10 +996,12 @@ object WorldRenderUtils {
         ) ?: aabb
     }
 
-    fun SkyHanniRenderWorldEvent.exactPlayerEyeLocation(player: Entity): LorenzVec {
-        val add = if (player.isShiftKeyDown) LorenzVec(0.0, 1.54, 0.0) else LorenzVec(0.0, 1.62, 0.0)
-        return exactLocation(player) + add
-    }
+    fun SkyHanniRenderWorldEvent.exactPlayerEyeLocation(player: Entity): LorenzVec =
+        exactLocation(player) + LorenzVec(
+            0.0,
+            if (player.isShiftKeyDown) SNEAKING_EYE_HEIGHT else STANDING_EYE_HEIGHT,
+            0.0,
+        )
 
     private fun addChainedFilledBoxVertices(
         matrices: PoseStack,

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -14,6 +14,8 @@ import at.hannibal2.skyhanni.utils.LocationUtils.union
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.PlayerUtils.SNEAKING_EYE_HEIGHT
+import at.hannibal2.skyhanni.utils.PlayerUtils.STANDING_EYE_HEIGHT
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.createResourceLocation
 import at.hannibal2.skyhanni.utils.compat.deceased
@@ -999,7 +1001,7 @@ object WorldRenderUtils {
     fun SkyHanniRenderWorldEvent.exactPlayerEyeLocation(player: Entity): LorenzVec =
         exactLocation(player) + LorenzVec(
             0.0,
-            if (player.isShiftKeyDown) SNEAKING_EYE_HEIGHT else STANDING_EYE_HEIGHT,
+            (if (player.isShiftKeyDown) SNEAKING_EYE_HEIGHT else STANDING_EYE_HEIGHT).toDouble(),
             0.0,
         )
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -14,8 +14,6 @@ import at.hannibal2.skyhanni.utils.LocationUtils.union
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.PlayerUtils.SNEAKING_EYE_HEIGHT
-import at.hannibal2.skyhanni.utils.PlayerUtils.STANDING_EYE_HEIGHT
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.createResourceLocation
 import at.hannibal2.skyhanni.utils.compat.deceased
@@ -999,11 +997,7 @@ object WorldRenderUtils {
     }
 
     fun SkyHanniRenderWorldEvent.exactPlayerEyeLocation(player: Entity): LorenzVec =
-        exactLocation(player) + LorenzVec(
-            0.0,
-            (if (player.isShiftKeyDown) SNEAKING_EYE_HEIGHT else STANDING_EYE_HEIGHT).toDouble(),
-            0.0,
-        )
+        exactLocation(player).up(player.getEyeHeight(player.pose))
 
     private fun addChainedFilledBoxVertices(
         matrices: PoseStack,

--- a/src/main/resources/skyhanni.classtweaker
+++ b/src/main/resources/skyhanni.classtweaker
@@ -47,6 +47,7 @@ accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScr
 accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen imageHeight I
 accessible field net/minecraft/client/multiplayer/MultiPlayerGameMode destroyBlockPos Lnet/minecraft/core/BlockPos;
 accessible field net/minecraft/client/renderer/GameRenderer guiRenderState Lnet/minecraft/client/gui/render/state/GuiRenderState;
+accessible field net/minecraft/world/entity/Avatar POSES Ljava/util/Map;
 
 #? < 1.21.11 {
 accessible field net/minecraft/client/renderer/rendertype/RenderType$CompositeRenderType state Lnet/minecraft/client/renderer/rendertype/RenderType$CompositeState;


### PR DESCRIPTION
## What
Refactored eye height and position handling for cleaner code, fixing outdated sneaking eye height assumption, and removed some dead code.

## Changelog Technical Details
+ Added `SkyHanniRenderWorldEvent.exactPlayerCrosshairLocation`. - Luna
+ Renamed `WorldRenderUtils.drawLineToEye` to `WorldRenderUtils.drawLineToCrosshair` to more accurately represent its function. - Luna
+ Added `PlayerUtils.STANDING_EYE_HEIGHT` and `PlayerUtils.SNEAKING_EYE_HEIGHT` in place of. of previous hardcoded magic numbers. - Luna
    * This also updates our outdated assumption of sneaking eye height being 1.54, which was true in Minecraft 1.8.9, but nowadays it is more like 1.27.

