### PR TITLE
Fix: Level Text Name Color Parsing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -168,9 +168,8 @@ object AdvancedPlayerList {
     }
 
     private fun createCustomName(data: PlayerData): Component {
-        val playerName = if (config.useLevelColorForName) {
-            val c = data.levelText[3]
-            "§$c" + data.name
+        val playerName = if (config.useLevelColorForName) data.levelText.getOrNull(3)?.let {
+            "§$it" + data.name
         } else if (config.hideRankColor) "§b" + data.name else data.coloredName
 
         val level = if (!config.hideLevel) {


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1000669238035497022/1484246325246558208

## Changelog Fixes
+ Fixed error when using level color for player name in tab. - Daveed

