### PR TITLE
Backend: SkyHanniTickEvent Improvements + ClientEvents Refactor

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -21,17 +21,14 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientWorldEvents
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents
-import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener
-import net.fabricmc.fabric.api.resource.ResourceManagerHelper
+import net.fabricmc.fabric.api.resource.v1.ResourceLoader
 import net.minecraft.client.GuiMessage
 import net.minecraft.client.GuiMessageTag
 import net.minecraft.client.Minecraft
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
 import net.minecraft.server.packs.PackType
-import net.minecraft.server.packs.resources.PreparableReloadListener
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executor
 
 @SkyHanniModule
 object ClientEvents {
@@ -41,58 +38,38 @@ object ClientEvents {
     init {
 
         // Tick event
-        ClientTickEvents.START_WORLD_TICK.register(
-            ClientTickEvents.StartWorldTick {
-                if (!MinecraftCompat.localPlayerExists) return@StartWorldTick
-                if (!MinecraftCompat.localWorldExists) return@StartWorldTick
+        ClientTickEvents.END_CLIENT_TICK.register {
+            if (!MinecraftCompat.localPlayerExists) return@register
+            if (!MinecraftCompat.localWorldExists) return@register
 
-                DelayedRun.checkRuns()
-                totalTicks++
-                SkyHanniTickEvent(totalTicks).post()
-            },
-        )
+            SkyHanniTickEvent(++totalTicks).post()
+
+            DelayedRun.checkRuns()
+        }
 
         // Disconnect event
-        ClientPlayConnectionEvents.DISCONNECT.register(
-            ClientPlayConnectionEvents.Disconnect { _, _ ->
-                ClientDisconnectEvent.post()
-            },
-        )
+        ClientPlayConnectionEvents.DISCONNECT.register { _, _ ->
+            ClientDisconnectEvent.post()
+        }
 
         // Connect event
-        ClientPlayConnectionEvents.JOIN.register(
-            ClientPlayConnectionEvents.Join { _, _, _ ->
-                ClientConnectEvent.post()
-            },
-        )
+        ClientPlayConnectionEvents.JOIN.register { _, _, _ ->
+            ClientConnectEvent.post()
+        }
 
         // World change event
-        ClientWorldEvents.AFTER_CLIENT_WORLD_CHANGE.register(
-            ClientWorldEvents.AfterClientWorldChange { client, world ->
-                WorldChangeEvent().post()
-            },
-        )
+        ClientWorldEvents.AFTER_CLIENT_WORLD_CHANGE.register { _, _ ->
+            WorldChangeEvent.post()
+        }
 
-        ResourceManagerHelper.get(PackType.CLIENT_RESOURCES).registerReloadListener(
-            object : IdentifiableResourceReloadListener {
-
-                override fun getFabricId(): Identifier =
-                    Identifier.fromNamespaceAndPath("skyhanni", "resources")
-
-                @Suppress("ForbiddenVoid")
-                override fun reload(
-                    store: PreparableReloadListener.SharedState,
-                    prepareExecutor: Executor,
-                    reloadSynchronizer: PreparableReloadListener.PreparationBarrier,
-                    applyExecutor: Executor,
-                ): CompletableFuture<Void> {
-                    return CompletableFuture.runAsync(
-                        { ResourcePackReloadEvent(store.resourceManager()).post() },
-                        applyExecutor,
-                    ).thenCompose(reloadSynchronizer::wait)
-                }
-            },
-        )
+        ResourceLoader.get(PackType.CLIENT_RESOURCES).registerReloader(
+            Identifier.fromNamespaceAndPath("skyhanni", "resources"),
+        ) { currentReload, _, preparationBarrier, reloadExecutor ->
+            CompletableFuture.runAsync(
+                { ResourcePackReloadEvent(currentReload.resourceManager()).post() },
+                reloadExecutor,
+            ).thenCompose(preparationBarrier::wait)
+        }
 
         ClientReceiveMessageEvents.ALLOW_GAME.register(::onAllow)
         ClientReceiveMessageEvents.MODIFY_GAME.register(::onModify)

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.data.SkyHanniNotification
 import at.hannibal2.skyhanni.data.jsonobjects.repo.EnforcedConfigValuesJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.EnforcedValueData
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.render.gui.GuiScreenOpenEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -45,7 +44,7 @@ object EnforcedConfigValues {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTick(tickEvent: SkyHanniTickEvent) {
+    fun onTick() {
         if (hasSentPSAsOnce) return
         hasSentPSAsOnce = true
         sendPSAs()

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniTickEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniTickEvent.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.events.minecraft
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
 @PrimaryFunction("onTick")
@@ -10,7 +11,7 @@ class SkyHanniTickEvent(private val tick: Int) : SkyHanniEvent() {
 
     /**
      * Use of this method is discouraged, use [SecondPassedEvent] instead.
-     * Only use if very needed.
+     * Only use if absolutely necessary.
      */
     fun repeatSeconds(i: Int, offset: Int = 0) = isMod(i * 20, offset)
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/WorldChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/WorldChangeEvent.kt
@@ -4,4 +4,4 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
 @PrimaryFunction("onWorldChange")
-class WorldChangeEvent : SkyHanniEvent()
+object WorldChangeEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -389,7 +389,7 @@ object DamageIndicatorManager {
     }
 
     @HandleEvent
-    fun onSkyHanniTick(event: SkyHanniTickEvent) {
+    fun onTick() {
         if (!isEnabled()) return
         data.values.forEach(::update)
         // TODO config to define between 100ms and 5 sec

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -18,7 +18,6 @@ import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.ServerTickEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.combat.end.DragonFightAPI
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.rift.RiftApi

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.combat.end
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.AllEntitiesGetter
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -136,7 +135,7 @@ object ProfitPerDragon {
     private var lastScanned = SimpleTimeMark.farPast()
 
     @HandleEvent(onlyOnIsland = IslandType.THE_END)
-    fun onTick(event: SkyHanniTickEvent) {
+    fun onTick() {
         if (lastScanned.passedSince() >= 1.seconds && !DragonFeatures.eggSpawned && !finishedLoot) {
             scanForLoot()
             lastScanned = SimpleTimeMark.now()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -82,7 +82,7 @@ object CarnivalZombieShootout {
 
     @HandleEvent
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
-        if (!isEnabled() || (!config.coloredHitboxes && !config.coloredLines && !config.zombieTimer)) return
+        if (!isEnabled()) return
 
         if (config.zombieTimer) event.renderZombieTimer()
         if (config.coloredHitboxes) event.renderHitBoxes()
@@ -188,7 +188,7 @@ object CarnivalZombieShootout {
 
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {
-        if (!isEnabled() || (!config.coloredHitboxes && !config.zombieTimer && !config.lampTimer) || !event.isMod(2)) return
+        if (!isEnabled() || !event.isMod(2)) return
 
         if (config.coloredHitboxes || config.zombieTimer) {
             updateZombies()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/PageScrolling.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/PageScrolling.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ToolTipData
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
@@ -58,7 +57,7 @@ object PageScrolling {
     private var cooldown = SimpleTimeMark.farPast()
 
     @HandleEvent
-    fun onTick(event: SkyHanniTickEvent) {
+    fun onTick() {
         if (!isEnabled()) return
         if (!currentlyScrollable && cooldown.isInFuture()) return
         if (!scroll.isMouseEventValid()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.events.bazaar.BazaarOpenedProductEvent
 import at.hannibal2.skyhanni.events.bazaar.BazaarTransactionEvent
 import at.hannibal2.skyhanni.events.bazaar.BazaarTransactionEvent.TransactionType
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -215,7 +214,7 @@ object BazaarApi {
     }
 
     @HandleEvent
-    fun onTick(event: SkyHanniTickEvent) {
+    fun onTick() {
         if (ApiUtils.isHypixelItemsDisabled()) return
 
         if (!loadedNpcPriceData) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayTimer.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.hoppity.EggFoundEvent
 import at.hannibal2.skyhanni.events.inventory.AttemptedInventoryCloseEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
@@ -74,7 +73,7 @@ object CFStrayTimer {
     }
 
     @HandleEvent
-    fun onTick(event: SkyHanniTickEvent) {
+    fun onTick() {
         if (!isEnabled()) return
         lastTimerSubtraction = lastTimerSubtraction?.takeIfInitialized()?.let {
             timer -= it.passedSince()

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/MetalDetectorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/MetalDetectorSolver.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.ActionBarUpdateEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
@@ -209,7 +208,7 @@ object MetalDetectorSolver {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.CRYSTAL_HOLLOWS)
-    fun onTick(event: SkyHanniTickEvent) {
+    fun onTick() {
         if (!isEnabled()) return
         if (predictedChestLocations.size == 1) {
             val distanceSq = predictedChestLocations[0].distanceSqToPlayer()

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.data.model.graph.GraphNode
 import at.hannibal2.skyhanni.events.IslandGraphReloadEvent
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.CopyNearbyEntitiesCommand.getMobInfo
@@ -100,7 +99,7 @@ object MatriarchHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onTick(event: SkyHanniTickEvent) {
+    fun onTick() {
         if (SkyBlockUtils.graphArea != AREA_NAME) return
         path.clear()
         path.addAll(accessPearls())


### PR DESCRIPTION
## What
Adjusted `SkyHanniTickEvent` so that instead of `START_WORLD_TICK`, it now fires on `END_CLIENT_TICK`. Using client ticks rather than firing specifically around entity ticking is better (we check if player and world are non-null anyway). Plus, perhaps counterintuitively, but firing on the start of a tick results in us being a tick behind and the event handlers operating on stale data from the previous tick.

I also made it so that `DelayedRun.checkRuns` runs *after* we post `SkyHanniTickEvent`, because it is a blocking call and otherwise may cause the event post to be significantly delayed.

Also done some refactoring in `ClientEvents`, simplifying Fabric event registrations and updating deprecated code to the new API.

## Changelog Technical Details
+ `SkyHanniTickEvent` now fires at `END_CLIENT_TICK` instead of `START_WORLD_TICK`. - Luna
    * This avoids event handlers operating on stale data that is a tick behind.
+ Fixed `SkyHanniTickEvent` post being delayed by DelayedRun calls. - Luna
