### PR TITLE
Fix: Dungeon Chest Profit counting dungeon chest keys incorrectly

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -153,7 +153,6 @@ object InstanceChestProfit {
      * REGEX-TEST: §eRequires a Dungeon Chest Key
      */
     private val requiresDungeonChestKeyPattern by patternGroup.pattern(
-        // Remove after 7.6.0 is pushed
         "requiresadungeonchestkey",
         "§eRequires a Dungeon Chest Key",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -149,6 +149,15 @@ object InstanceChestProfit {
         "Enchanted Book \\((?<item>.+)(?:§.)+\\)",
     )
 
+    /**
+     * REGEX-TEST: §eRequires a Dungeon Chest Key
+     */
+    private val requiresDungeonChestKeyPattern by patternGroup.pattern(
+        // Remove after 7.6.0 is pushed
+        "requiresadungeonchestkey",
+        "§eRequires a Dungeon Chest Key",
+    )
+
     private val config get() = SkyHanniMod.feature.combat.instanceChestProfit
 
     private var croesusDisplay: Renderable? = null
@@ -258,6 +267,9 @@ object InstanceChestProfit {
                     itemPrice = getPrice(internalName)
                     essencePattern.matchMatcher(loreLine) {
                         itemPrice = getEssence(group("name"), group("count").toInt())
+                    }
+                    if (requiresDungeonChestKeyPattern.matches(loreLine) || loreLine.isEmpty()) {
+                        itemPrice = -1.0
                     }
                     if (dungeonChestKey.matches(loreLine)) {
                         cost += getPrice(internalName).times(-1)


### PR DESCRIPTION
## What
Fixed dungeon chest profit calculation by removing the extra dungeon key that was incorrectly included in the profit, and cleaned up the displayed items by removing empty ones.

## Changelog Fixes
+ Fixed instance profit calculation. - Tommo
    * Removed the dungeon key counting as profit.
    * Removed empty items from display.

