### PR TITLE
Feature: Prevent Block Break with Rod on Garden

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
@@ -54,6 +54,15 @@ class GardenConfig {
     val keyBind: KeyBindConfig = KeyBindConfig()
 
     @Expose
+    @ConfigOption(
+        name = "Prevent Breaking with Rod",
+        desc = "Stops you from breaking blocks while holding a fishing rod.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var noRodBreak: Boolean = true
+
+    @Expose
     @Category(name = "Optimal Speed", desc = "Optimal Speed Settings")
     val optimalSpeeds: OptimalSpeedConfig = OptimalSpeedConfig()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/NoRodBreak.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/NoRodBreak.kt
@@ -1,0 +1,26 @@
+package at.hannibal2.skyhanni.features.garden.farming
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.ClickType
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.BlockClickEvent
+import at.hannibal2.skyhanni.features.fishing.FishingApi.isFishingRod
+import at.hannibal2.skyhanni.features.garden.GardenApi
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils
+
+@SkyHanniModule
+object NoRodBreak {
+
+    private val config get() = GardenApi.config
+
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onBlockClick(event: BlockClickEvent) {
+        if (!config.noRodBreak) return
+        if (event.clickType != ClickType.LEFT_CLICK) return
+
+        if (InventoryUtils.getItemInHand()?.isFishingRod() == true) {
+            event.cancel()
+        }
+    }
+}


### PR DESCRIPTION
## What
Added an option to prevent breaking blocks on the Garden while holding a fishing rod.

This is commonly done by accident while pest farming, causing people to grief their farms.

## Changelog New Features
+ Added an option to prevent breaking crops on the Garden while holding a fishing rod. - Luna

