### PR TITLE
Fix: Skip unnecessary expensive raycasts in canBeSeen

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -237,9 +237,7 @@ object LocationUtils {
     fun LorenzVec.canBeSeen(viewDistance: Number = 150.0, offset: Double? = null): Boolean {
         val a = playerEyeLocation()
         val b = this
-        val noBlocks = canSee(a, b, offset)
-        val notTooFar = a.distance(b) < viewDistance.toDouble()
-        return noBlocks && notTooFar
+        return a.distance(b) < viewDistance.toDouble() && canSee(a, b, offset)
     }
 
     fun LorenzVec.canBeSeen(yOffsetRange: IntRange, radius: Double = 150.0): Boolean =


### PR DESCRIPTION
## What
Fixed `LorenzVec.canBeSeen` to check for view distance first and short-circuit to skip a potentially exclusive raycast.

This usually hasn't resulted in noticeable performance issues, but it turns out, there is one particular area in the Rift where Hypixel *loves* sending Scribe entities over a million blocks lower than where the player is standing, and when you raycast over a distance of million blocks every tick... not fun.

## Changelog Fixes
+ Fixed occasional performance issues with Mob Detection. - Luna
