### PR TITLE
Backend: Update Stonecutter to 0.9

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,7 +32,7 @@ plugins {
     // We can't use libs refs in settings, so these are not stored in `libs.versions.toml`
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
     id("at.skyhanni.shared-variables")
-    id("dev.kikugie.stonecutter") version "0.8.3"
+    id("dev.kikugie.stonecutter") version "0.9"
 }
 
 MultiVersionStage.initFrom(file(".gradle/private.properties"))

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
@@ -54,13 +54,8 @@ object CopyChat {
     private fun getChatLine(mouseX: Int, mouseY: Int): GuiMessage? {
         val mc = Minecraft.getInstance()
         val chatGui = mc.gui.chat ?: return null
-        //? if < 1.21.11 {
-        val chatLineY = chatGui.screenToChatY(mouseY.toDouble())
-        val chatLineX = chatGui.screenToChatX(mouseX.toDouble())
-        //?} else {
-        /*val chatLineY = screenToChatY(mouseY.toDouble())
+        val chatLineY = screenToChatY(mouseY.toDouble())
         val chatLineX = screenToChatX(mouseX.toDouble())
-        *///?}
         val lineIndex = (chatGui.chatScrollbarPos + chatLineY).toInt()
 
         if (chatLineX < -4.0 || chatLineX > Mth.floor(chatGui.width.toDouble() / chatGui.scale).toDouble()) return null
@@ -89,13 +84,20 @@ object CopyChat {
     fun screenToChatX(d: Double): Double {
         val mc = Minecraft.getInstance()
         val chatGui = mc.gui.chat ?: return 0.0
-        return d / chatGui.scale - 4.0
+        //? if < 1.21.11 {
+        return chatGui.screenToChatX(d)
+        //?} else
+        //return d / chatGui.scale - 4.0
     }
 
     fun screenToChatY(d: Double): Double {
         val mc = Minecraft.getInstance()
         val chatGui = mc.gui.chat ?: return 0.0
-        val e = mc.window.guiScaledHeight - d - 40.0
+        //? if < 1.21.11 {
+        return chatGui.screenToChatY(d)
+        //?} else {
+        /*val e = mc.window.guiScaledHeight - d - 40.0
         return e / (chatGui.scale * chatGui.lineHeight)
+        *///?}
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinEquipmentRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinEquipmentRenderer.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers.renderer;
 
+//~ if > 1.21.10 'RenderType' -> 'RenderTypes' {
 import at.hannibal2.skyhanni.data.entity.EntityTransparencyManager;
 import at.hannibal2.skyhanni.mixins.hooks.EntityRenderDispatcherHookKt;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -10,8 +11,6 @@ import net.minecraft.resources.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
-//? if > 1.21.10
-//import net.minecraft.client.renderer.rendertype.RenderTypes;
 
 @Mixin(EquipmentLayerRenderer.class)
 public class MixinEquipmentRenderer {
@@ -22,12 +21,9 @@ public class MixinEquipmentRenderer {
              Integer entityAlpha = EntityTransparencyManager.getEntityTransparency(livingEntity);
              if (entityAlpha == null) return original;
 
-             //? if < 1.21.11 {
              return RenderType.armorTranslucent(identifier);
-             //?} else
-             //return RenderTypes.armorTranslucent(identifier);
          }
          return original;
      }
-
 }
+//~}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinEquipmentRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinEquipmentRenderer.java
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.mixins.transformers.renderer;
 
-
 import at.hannibal2.skyhanni.data.entity.EntityTransparencyManager;
 import at.hannibal2.skyhanni.mixins.hooks.EntityRenderDispatcherHookKt;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -29,4 +28,3 @@ public class MixinEquipmentRenderer {
          return original;
      }
 }
-//~}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinEquipmentRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinEquipmentRenderer.java
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers.renderer;
 
-//~ if > 1.21.10 'RenderType' -> 'RenderTypes' {
+
 import at.hannibal2.skyhanni.data.entity.EntityTransparencyManager;
 import at.hannibal2.skyhanni.mixins.hooks.EntityRenderDispatcherHookKt;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -11,6 +11,8 @@ import net.minecraft.resources.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+//? if > 1.21.10
+//import net.minecraft.client.renderer.rendertype.RenderTypes;
 
 @Mixin(EquipmentLayerRenderer.class)
 public class MixinEquipmentRenderer {
@@ -21,6 +23,7 @@ public class MixinEquipmentRenderer {
              Integer entityAlpha = EntityTransparencyManager.getEntityTransparency(livingEntity);
              if (entityAlpha == null) return original;
 
+             //~ if > 1.21.10 'RenderType' -> 'RenderTypes'
              return RenderType.armorTranslucent(identifier);
          }
          return original;

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -57,7 +57,7 @@ object SoundUtils {
         //? if < 1.21.11 {
         Minecraft.getInstance().soundManager.setVolume(this, level)
     //?} else
-    //Minecraft.getInstance().soundManager.updateCategoryVolume(this.source, level)
+    //Minecraft.getInstance().soundManager.updateCategoryVolume(source, level)
 
     fun createSound(name: String, pitch: Float, volume: Float = 50f): SoundInstance {
         val newSound = SoundCompat.getModernSoundName(name)

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
@@ -22,6 +22,6 @@ object MinecraftCompat {
 
     val localWorldExists get(): Boolean = localWorldOrNull != null
 
-    //~ if >=1.21.11 'isF3Visible' -> 'isOverlayVisible'
+    //~ if > 1.21.10 'isF3Visible' -> 'isOverlayVisible'
     val showDebugHud get(): Boolean = Minecraft.getInstance().debugEntries.isF3Visible
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
@@ -22,9 +22,6 @@ object MinecraftCompat {
 
     val localWorldExists get(): Boolean = localWorldOrNull != null
 
-    //? if < 1.21.11 {
+    //~ if >=1.21.11 'isF3Visible' -> 'isOverlayVisible'
     val showDebugHud get(): Boolean = Minecraft.getInstance().debugEntries.isF3Visible
-    //? } else {
-    /*val showDebugHud get(): Boolean = Minecraft.getInstance().debugEntries.isOverlayVisible
-    *///?}
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniRealtimeItemSlot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniRealtimeItemSlot.kt
@@ -8,7 +8,7 @@ import net.minecraft.client.gui.render.state.GuiRenderState
 import net.minecraft.client.renderer.CachedOrthoProjectionMatrixBuffer
 import net.minecraft.client.renderer.RenderPipelines
 //? if > 1.21.10
-// import com.mojang.blaze3d.textures.FilterMode
+//import com.mojang.blaze3d.textures.FilterMode
 
 internal class SkyHanniRealtimeItemSlot(val slotSize: Int) : SkyHanniAbstractItemTexture() {
 
@@ -64,7 +64,7 @@ internal class SkyHanniRealtimeItemSlot(val slotSize: Int) : SkyHanniAbstractIte
                 //? if < 1.21.11 {
                 TextureSetup.singleTexture(textureView),
                 //?} else
-                // TextureSetup.singleTexture(textureView, RenderSystem.getSamplerCache().getRepeat(FilterMode.NEAREST)),
+                //TextureSetup.singleTexture(textureView, RenderSystem.getSamplerCache().getRepeat(FilterMode.NEAREST)),
                 state.pose(),
                 state.x0(), state.y0(), state.x1(), state.y1(),
                 0f,

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/atlas/SkyHanniItemAtlasRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/atlas/SkyHanniItemAtlasRenderer.kt
@@ -13,7 +13,7 @@ import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.RenderPipelines
 import net.minecraft.client.renderer.feature.FeatureRenderDispatcher
 //? if > 1.21.10
-// import com.mojang.blaze3d.textures.FilterMode
+//import com.mojang.blaze3d.textures.FilterMode
 
 internal class SkyHanniItemAtlasRenderer(
     private val sizePixels: Int,
@@ -76,7 +76,7 @@ internal class SkyHanniItemAtlasRenderer(
                 //? if < 1.21.11 {
                 TextureSetup.singleTexture(textureView),
                 //?} else
-                // TextureSetup.singleTexture(textureView, RenderSystem.getSamplerCache().getRepeat(FilterMode.NEAREST)),
+                //TextureSetup.singleTexture(textureView, RenderSystem.getSamplerCache().getRepeat(FilterMode.NEAREST)),
                 shState.pose(),
                 shState.x0(), shState.y0(), shState.x1(), shState.y1(),
                 u, u1, v, v1,


### PR DESCRIPTION
## What
Updated the Stonecutter version we use to [0.9](https://stonecutter.kikugie.dev/blog/changes/0.9), allowing us to use the new local replacement syntax.

## Changelog Technical Details
+ Updated Stonecutter to version 0.9. - Luna

