### PR TITLE
Backend: Only clear TPS data on stall if we had some

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -59,7 +59,7 @@ object TpsCounter {
 
     @HandleEvent
     fun onSecondPassed() {
-        if (lastServerTick.passedSince() >= 1.seconds) {
+        if (lastServerTick.passedSince() >= 1.seconds && !msPerTickList.isEmpty()) {
             ChatUtils.debug("No server ticks detected for 1 second, clearing TPS data")
             msPerTickList.clear()
         }


### PR DESCRIPTION
## What
Currently, we send a debug log every second if the player is in limbo or the server is otherwise stalled for an extended period of time, even if we haven't detected any server ticks since the last clear. Not a thing most users will see so backend it is.

## Changelog Technical Details
+ Fixed unnecessary debug logging in TpsCounter if player is in limbo or server is stalled for an extended period of time. - Luna