### PR TITLE
Improvement + Fix: Small TPS counter adjustments

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PartyChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PartyChatEvent.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.data.hypixel.chat.event
 
 import at.hannibal2.skyhanni.utils.ComponentSpan
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraft.network.chat.Component
 
 object PartyChatEvent {
@@ -12,7 +13,9 @@ object PartyChatEvent {
         chatComponent: Component,
         blockedReason: String? = null,
     ) : AbstractSourcedChatEvent.Allow(authorComponent, messageComponent, chatComponent, blockedReason) {
-        val cleanedAuthor = author.cleanPlayerName()
+        val authorName = author.cleanPlayerName()
+
+        override val cleanMessage: String = messageComponent.getText().removeColor()
     }
 
     class Modify(
@@ -21,6 +24,9 @@ object PartyChatEvent {
         chatComponent: Component,
         blockedReason: String? = null,
     ) : AbstractSourcedChatEvent.Modify(authorComponent, messageComponent, chatComponent, blockedReason) {
-        val cleanedAuthor = author.cleanPlayerName()
+        val authorName = author.cleanPlayerName()
+
+        override val cleanMessage: String
+            get() = messageComponent.getText().removeColor()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/SystemMessageEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/SystemMessageEvent.kt
@@ -15,8 +15,9 @@ object SystemMessageEvent {
         open val message: String,
         open val chatComponent: Component,
         open var blockedReason: String? = null,
-        open val cleanMessage: String = chatComponent.string.removeColor(),
-    ) : SkyHanniEvent()
+    ) : SkyHanniEvent() {
+        open val cleanMessage: String = chatComponent.string.removeColor()
+    }
 
     // TODO docs missing
     open class Modify(
@@ -24,8 +25,10 @@ object SystemMessageEvent {
         @set:Deprecated("Use replaceComponent() instead")
         open var chatComponent: Component,
         open val blockedReason: String? = null,
-        open val cleanMessage: String = chatComponent.string.removeColor(),
     ) : SkyHanniEvent() {
+        open val cleanMessage: String
+            get() = chatComponent.string.removeColor()
+
         fun replaceComponent(newComponent: Component, reason: String) {
             ChatManager.addReplacementContext(chatComponent, reason)
             @Suppress("DEPRECATION")

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
@@ -43,7 +43,7 @@ object PartyChatCommands {
             { config.transferCommand },
             triggerableBySelf = false,
             executable = {
-                HypixelCommands.partyTransfer(it.cleanedAuthor)
+                HypixelCommands.partyTransfer(it.authorName)
             },
         ),
         PartyChatCommand(
@@ -84,7 +84,7 @@ object PartyChatCommands {
             requiresPartyLead = false,
             executable = {
                 TpsCounter.tps?.let {
-                    HypixelCommands.partyChat("Current TPS: $it", prefix = true)
+                    HypixelCommands.partyChat("Current TPS: %.2f".format(it), prefix = true)
                 } ?: run {
                     ChatUtils.chat("Command sent too early to calculate TPS")
                 }
@@ -119,10 +119,10 @@ object PartyChatCommands {
 
     @HandleEvent
     fun onPartyCommand(event: PartyChatEvent.Allow) {
-        if (event.message.firstOrNull() !in commandPrefixes) return
-        val commandLabel = event.message.substring(1).substringBefore(' ')
+        if (event.cleanMessage.firstOrNull() !in commandPrefixes) return
+        val commandLabel = event.cleanMessage.substring(1).substringBefore(' ')
         val command = indexedPartyChatCommands[commandLabel.lowercase()] ?: return
-        val name = event.cleanedAuthor
+        val name = event.authorName
         if (name == PlayerUtils.getName() && (!command.triggerableBySelf || !config.selfTriggerCommands)) return
         if (!command.isEnabled()) return
         if (command.requiresPartyLead && PartyApi.partyLeader != PlayerUtils.getName()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PartyChatCommands.kt
@@ -83,8 +83,8 @@ object PartyChatCommands {
             { config.tpsCommand },
             requiresPartyLead = false,
             executable = {
-                TpsCounter.tps?.let {
-                    HypixelCommands.partyChat("Current TPS: %.2f".format(it), prefix = true)
+                TpsCounter.tps?.let { tps ->
+                    HypixelCommands.partyChat("Current TPS: %.2f".format(tps), prefix = true)
                 } ?: run {
                     ChatUtils.chat("Command sent too early to calculate TPS")
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
-import at.hannibal2.skyhanni.utils.collection.TimeAndSizeLimitedCache
+import at.hannibal2.skyhanni.utils.collection.SizeLimitedCache
 import at.hannibal2.skyhanni.utils.inPartialMilliseconds
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
@@ -31,11 +31,11 @@ object TpsCounter {
 
     private val config get() = SkyHanniMod.feature.gui
 
-    private val msPerTickList = TimeAndSizeLimitedCache<Long, Double>(100, 5.seconds)
+    private val msPerTickList = SizeLimitedCache<Long, Double>(100)
     val tps: Double?
         get() = when {
             timeSinceWorldSwitch < WORLD_SWITCH_DELAY -> null
-            msPerTickList.isEmpty() -> 0.0
+            msPerTickList.isEmpty() || lastServerTick.passedSince() >= 1.seconds -> 0.0
             else -> (1000.0 / msPerTickList.values.average()).coerceIn(0.0..20.0).also {
                 if (!it.isFinite()) printError(it)
             }
@@ -59,11 +59,6 @@ object TpsCounter {
 
     @HandleEvent
     fun onSecondPassed() {
-        if (lastServerTick.passedSince() >= 1.seconds && !msPerTickList.isEmpty()) {
-            ChatUtils.debug("No server ticks detected for 1 second, clearing TPS data")
-            msPerTickList.clear()
-        }
-
         display = Renderable.text(getTpsString(compact = true))
 
         if (pendingTpsCommand) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -173,16 +173,9 @@ object StringUtils {
         }.removeSuffix("'s")
     }
 
-    fun String.cleanPlayerName(displayName: Boolean = false): String {
-        return if (displayName) {
-            if (SkyHanniMod.feature.chat.playerMessage.playerRankHider) {
-                // TODO custom color
-                "§b" + internalCleanPlayerName()
-            } else this
-
-        } else {
-            internalCleanPlayerName()
-        }
+    fun String.cleanPlayerName(displayName: Boolean = false): String = internalCleanPlayerName().let { name ->
+        // TODO custom color
+        if (displayName && SkyHanniMod.feature.chat.playerMessage.playerRankHider) "§b$name" else name
     }
 
     fun String.isPlayerName() = UtilsPatterns.playerNamePattern.matches(this)

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -173,9 +173,16 @@ object StringUtils {
         }.removeSuffix("'s")
     }
 
-    fun String.cleanPlayerName(displayName: Boolean = false): String = internalCleanPlayerName().let { name ->
-        // TODO custom color
-        if (displayName && SkyHanniMod.feature.chat.playerMessage.playerRankHider) "§b$name" else name
+    fun String.cleanPlayerName(displayName: Boolean = false): String {
+        return if (displayName) {
+            if (SkyHanniMod.feature.chat.playerMessage.playerRankHider) {
+                // TODO custom color
+                "§b" + internalCleanPlayerName()
+            } else this
+
+        } else {
+            internalCleanPlayerName()
+        }
     }
 
     fun String.isPlayerName() = UtilsPatterns.playerNamePattern.matches(this)


### PR DESCRIPTION
## What
Small adjustments to the new TPS counter to hopefully make it a bit nicer.

## Changelog Improvements
+ TPS counter will now climb back up to 20 more gradually when the server was completely unresponsive for over a second. - Luna

## Changelog Fixes
+ Fixed `!tps` party command not rounding TPS to 2 decimal points. - Luna

## Changelog Technical Details
+ Fixed `cleanMessage` field in `PartyChatEvent.Allow` and `PartyChatEvent.Modify` being the whole message rather than just the actual message portion. - Luna
+ Renamed `cleanedAuthor` field in `PartyChatEvent.Allow` and `PartyChatEvent.Modify` to `authorName`. - Luna