### PR TITLE
Backend: Use PlayerDeathEvent for Crash on Death

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -203,7 +203,7 @@ class MiscConfig {
     var brewingStandOverlay: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Crash On Death", desc = "Crashes your game every time you die in Skyblock")
+    @ConfigOption(name = "Crash on Death", desc = "Crashes your game every time you die in SkyBlock")
     @ConfigEditorBoolean
     var crashOnDeath: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnDeath.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnDeath.kt
@@ -20,8 +20,9 @@ object CrashOnDeath {
             Minecraft.getInstance().delayCrash(
                 CrashReport(
                     "SkyHanni Crash on Death",
-                    Throwable("Disable Crash on Death in SkyHanni if you want to stop crashing")),
-                )
+                    Throwable("Disable Crash on Death in SkyHanni if you want to stop crashing")
+                ),
+            )
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnDeath.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnDeath.kt
@@ -18,8 +18,10 @@ object CrashOnDeath {
 
         if (event.isSelf) {
             Minecraft.getInstance().delayCrash(
-                CrashReport("Not Reading", Throwable("Don't toggle all the options")),
-            )
+                CrashReport(
+                    "SkyHanni Crash on Death",
+                    Throwable("Disable Crash on Death in SkyHanni if you want to stop crashing")),
+                )
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnDeath.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnDeath.kt
@@ -2,34 +2,24 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.player.PlayerDeathEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.CrashReport
 import net.minecraft.client.Minecraft
 
 @SkyHanniModule
 object CrashOnDeath {
+
     private val config get() = SkyHanniMod.feature.misc
 
-    /**
-     * REGEX-TEST: §c ☠ §r§7You were killed by §r§4§lMagma Boss§r§7§r§7.
-     */
-    private val pattern by RepoPattern.pattern(
-        "ownplayer.death.chat",
-        "§c ☠ §r§7You (?<reason>.+)",
-    )
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onPlayerDeath(event: PlayerDeathEvent.Allow) {
+        if (!config.crashOnDeath) return
 
-    @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
-        if (!isEnabled()) return
-
-        if (pattern.matches(event.message)) {
-            Minecraft.getInstance().delayCrash(CrashReport("Not Reading", Throwable("Don't toggle all the Options")))
+        if (event.isSelf) {
+            Minecraft.getInstance().delayCrash(
+                CrashReport("Not Reading", Throwable("Don't toggle all the options")),
+            )
         }
     }
-
-    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.crashOnDeath
 }


### PR DESCRIPTION
## What
Updated the Crash on Death feature to use PlayerDeathEvent and cleaned up the grammar.

## Changelog Technical Details
+ Updated Crash on Death to use PlayerDeathEvent. - Luna