### PR TITLE
Backend:  discord roles explanation

### DIFF
--- a/docs/discord_roles.md
+++ b/docs/discord_roles.md
@@ -11,15 +11,16 @@ If those users talk to you, their word is law.
 - **Admin**
     - Only the most trusted members.
     - Full control over the Discord server, manages role assignments.
-- **Staff**
-    - Legacy role with broad permissions. May be merged into Admin in the future.
-
-[//]: # (This is a hidden comment: Clarify why Staff role even exists: can this get merged with Admin eventually? Jani, can this go?)
 
 ## Core Team Roles
 
-Hand-picked by **Admins** from members who have already held the **Contributor** or **Community Helper** role for some time.
+Hand-picked by **Admins** from members who have already held the **Contributor** or **Community Helper** role for some time.  
 If those users talk to you, you better pay attention.
+
+- **Staff**
+    - Legacy role with many permissions. May be merged into Admin in the future.
+
+[//]: # (This is a hidden comment: Clarify why Staff role even exists: can this get merged with Admin eventually? Jani, can this go?)
 
 - **Moderator**
     - This role has moderation permissions (warn, mute, ban).
@@ -35,7 +36,7 @@ If those users talk to you, you better pay attention.
 
 ## Helper Roles
 
-People who help the mod.
+People who help the mod.  
 If those users talk to you, they probably know what they're talking about.
 
 - **Contributor**
@@ -47,7 +48,7 @@ If those users talk to you, they probably know what they're talking about.
 
 ## Fancy Roles
 
-These roles are purely cosmetic and exist to recognize specific community contributions or partnerships.
+These roles are purely cosmetic and exist to recognize specific community contributions or partnerships.  
 If those users talk to you, you read their name in cool colors.
 
 - **Bug Hunter**
@@ -55,12 +56,12 @@ If those users talk to you, you read their name in cool colors.
       issues.
 - **Makes Good Suggestions**
     - Awarded to members who suggest well-thought-out ideas for new or improved features.
-- **Cool Person**
-    - Friends of **Admins**.
 - **Cool Developer**
     - Developer or contributor of another SkyBlock-related resource: Third-party mods, websites, tools, etc.
 - **Cool Content Creator**
     - YouTuber, streamer, or admin of a third-party Discord server who helps spread the word about SkyHanni.
+- **Cool Person**
+    - Friends of **Admins**.
 - **Patreon Supporter**
     - Pay to win role.
 - **Server Booster**
@@ -76,7 +77,7 @@ If those users talk to you, congratulations, you found the chat.
 
 ## Ping Roles
 
-All those roles are self-selectable for all members.
+All those roles are self-selectable for all members.  
 If those users talk to you, you are yapping with a nerd.
 
 - **Announcements**
@@ -95,7 +96,7 @@ If those users talk to you, you are yapping with a nerd.
 
 ## Bot Roles
 
-Only for bots, with different levels of permissions.
+Only for bots, with different levels of permissions.  
 If those users talk to you, you know they aren't human.
 
 - **Bot**
@@ -127,7 +128,7 @@ If those users talk to you, you know they aren't human.
 
 ## Special Roles
 
-Hopefully you don't encounter such users in the wild.
+Hopefully you don't encounter such users in the wild.  
 If those users talk to you, you can ignore them.
 
 - **Muted**

--- a/docs/discord_roles.md
+++ b/docs/discord_roles.md
@@ -51,7 +51,7 @@ If those users talk to you, you know they aren't human.
 ## Core Team Roles
 
 Hand-picked by **Admins** from members who have already held the **Contributor** or **Community Helper** role for some time.
-If those users talk to you, don't ignore them.
+If those users talk to you, you better pay attention.
 
 - **Moderator**
     - This role has moderation permissions (warn, mute, ban).
@@ -68,7 +68,7 @@ If those users talk to you, don't ignore them.
 ## Helper Roles
 
 People who help the mod.
-If those users talk to you, better listen.
+If those users talk to you, they probably know what they're talking about.
 
 - **Contributor**
     - The role for everyone who makes meaningful code contributions to the mod on GitHub.

--- a/docs/discord_roles.md
+++ b/docs/discord_roles.md
@@ -10,7 +10,7 @@ If those users talk to you, their word is law.
 
 - **Admin**
     - Only the most trusted members.
-    - Full control over the discord server, manages role assignments.
+    - Full control over the Discord server, manages role assignments.
 - **Staff**
     - Legacy role with broad permissions. May be merged into Admin in the future.
 
@@ -26,26 +26,26 @@ If those users talk to you, you know they aren't human.
     - For all bots on the server.
     - This doesn't mean they have rights or something, we just want them to show up high in the member list.
 - **SH Bot**
-    - The SkyHanni bot does SkyHanni-specific stuff.
+    - SkyHanni bot does SkyHanni-specific stuff.
     - Mainly auto-tags and Pull Request linking.
 - **Elite**
-    - The elite farming bot offers /weight and other farming-related utility commands.
+    - Elite Farming bot offers /weight and other farming-related utility commands.
 - **SkyHelper**
-    - The SkyHelper bot is the go-to SkyBlock utility command bot.
+    - SkyHelper bot is the go-to SkyBlock utility command bot.
 
 [//]: # (This is a hidden comment: top 3 most used/most important commands that the bot can offer)
 
 - **Kuudra Gang**
-    - The Kuudra Gang bot helps you if you need help doing math around Kuudra runs or Kuudra items.
+    - Kuudra Gang bot helps with math around Kuudra runs or Kuudra items
 - **Tanzanite**
-    - Tanzanite Bot does generic Discord utility stuff like logging, banning, or setting reminders.
+    - Tanzanite bot does generic Discord utility stuff like logging, banning, or setting reminders.
 - **Carl Bot**
-    - The Carl bot does more Discord utility stuff, like logging.
+    - Carl bot also does Discord utility stuff.
 
 [//]: # (This is a hidden comment: Does Carl Bot actually only do logging? What else?)
 
 - **Fire**
-    - The fire bot reacts to links of Discord messages with said Discord message.
+    - Fire bot reacts to links of Discord messages with said Discord message.
 
 ## High-end Roles
 
@@ -57,7 +57,7 @@ If those users talk to you, don't ignore them.
     - Independent of coding/contributing.
     - Gets selected from **Community Helper** or higher roles.
 - **Mod Maintainer**
-    - Most trusted code guys without full access.
+    - Most trusted coders without full access.
     - They know SkyHanni very well.
     - If you have coding questions, ask them.
 - **Main Contributor**
@@ -116,7 +116,9 @@ If those users talk to you, you are yapping with a nerd.
     - When the mod updates to a shiny new release.
 - **Beta Ping**
     - When a new beta version is available for testing.
-    - This role may be renamed to Beta Tester in the future.
+
+[//]: # (This is a hidden comment: This role may be renamed to Beta Tester in the future.)
+
 - **Leaks Ping**
     - When a **Main Contributor** or higher decides to show off something new and cool.
 - **Stream Ping**

--- a/docs/discord_roles.md
+++ b/docs/discord_roles.md
@@ -1,0 +1,133 @@
+# SkyHanni Server Roles
+
+This is a list of all server roles on the SkyHanni Discord server.
+This explains why the roles exist and how to get them.
+**You can NOT apply to any of those roles directly.** (except ping roles)
+
+## Full Perm Roles
+
+If those users talk to you, their word is law.
+
+- **Admin**
+    - Only the most trusted members.
+    - Full control over the discord server, manages role assignments.
+- **Staff**
+    - Legacy role with broad permissions. May be merged into Admin in the future.
+
+[//]: # (This is a hidden comment: Clarify why Staff role even exists: can this get merged with Admin eventually? Jani, can this go?)
+
+## Bot Roles
+
+Only for bots, with different levels of permissions.
+If those users talk to you, you know they aren't human.
+
+- **Bot**
+    - Generic "this is a bot" role.
+    - For all bots on the server.
+    - This doesn't mean they have rights or something, we just want them to show up high in the member list.
+- **SH Bot**
+    - The SkyHanni bot does SkyHanni-specific stuff.
+    - Mainly auto-tags and Pull Request linking.
+- **Elite**
+    - The elite farming bot offers /weight and other farming-related utility commands.
+- **SkyHelper**
+    - The SkyHelper bot is the go-to SkyBlock utility command bot.
+
+[//]: # (This is a hidden comment: top 3 most used/most important commands that the bot can offer)
+
+- **Kuudra Gang**
+    - The Kuudra Gang bot helps you if you need help doing math around Kuudra runs or Kuudra items.
+- **Tanzanite**
+    - Tanzanite Bot does generic Discord utility stuff like logging, banning, or setting reminders.
+- **Carl Bot**
+    - The Carl bot does more Discord utility stuff, like logging.
+
+[//]: # (This is a hidden comment: Does Carl Bot actually only do logging? What else?)
+
+- **Fire**
+    - The fire bot reacts to links of Discord messages with said Discord message.
+
+## High-end Roles
+
+Hand-picked by **Admins** from members who have already held the **Contributor** or **Community Helper** role for some time.
+If those users talk to you, don't ignore them.
+
+- **Moderator**
+    - This role has moderation permissions (warn, mute, ban).
+    - Independent of coding/contributing.
+    - Gets selected from **Community Helper** or higher roles.
+- **Mod Maintainer**
+    - Most trusted code guys without full access.
+    - They know SkyHanni very well.
+    - If you have coding questions, ask them.
+- **Main Contributor**
+    - Developers who help the project a lot over a long time.
+    - A cosmetic role between **Contributor** and **Mod Maintainer**.
+
+## Main Roles
+
+People who help the mod.
+If those users talk to you, better listen.
+
+- **Contributor**
+    - The role for everyone who makes meaningful code contributions to the mod on GitHub.
+    - Requires one or more merged PRs on GitHub, not just suggestions or bug reports.
+- **Community Helper**
+    - Someone who helps others in the Discord a lot around SkyHanni.
+    - Selected by Admins and Main Contributors from active community members.
+
+## Fancy Roles
+
+These roles are purely cosmetic and exist to recognize specific community contributions or partnerships.
+If those users talk to you, you read their name in cool colors.
+
+- **Bug Hunter**
+    - Awarded to members who report important or hard-to-find bugs, or who go out of their way to test features and track down
+      issues.
+- **Makes Good Suggestions**
+    - Awarded to members who suggest well-thought-out ideas for new or improved features.
+- **Cool Person**
+    - Friends of **Admins**.
+- **Cool Developer**
+    - Developer or contributor of another SkyBlock-related resource: Third-party mods, websites, tools, etc.
+- **Cool Content Creator**
+    - YouTuber, streamer, or admin of a third-party Discord server who helps spread the word about SkyHanni.
+- **Patreon Supporter**
+    - Pay to win role.
+- **Server Booster**
+    - Automatically assigned by Discord to members who actively boost the server.
+    - Unlocks Discord-native visual perks.
+
+## Normal Roles
+
+If those users talk to you, congratulations, you found the chat.
+
+- **Member**
+    - Lucky users who found the invite link.
+
+## Ping Roles
+
+All those roles are self-selectable for all members.
+If those users talk to you, you are yapping with a nerd.
+
+- **Announcements**
+    - When something big happens.
+- **Update Ping**
+    - When the mod updates to a shiny new release.
+- **Beta Ping**
+    - When a new beta version is available for testing.
+    - This role may be renamed to Beta Tester in the future.
+- **Leaks Ping**
+    - When a **Main Contributor** or higher decides to show off something new and cool.
+- **Stream Ping**
+    - When someone actually streams while coding. It happens. Sometimes.
+
+## Special Roles
+
+Hopefully you don't encounter such users in the wild.
+If those users talk to you, you can ignore them.
+
+- **Muted**
+    - You shall not write.
+- **No Reaction**
+    - No more pleading reactions for you.

--- a/docs/discord_roles.md
+++ b/docs/discord_roles.md
@@ -29,7 +29,7 @@ If those users talk to you, you know they aren't human.
     - SkyHanni bot does SkyHanni-specific stuff.
     - Mainly auto-tags and Pull Request linking.
 - **Elite**
-    - Elite Farming bot offers /weight and other farming-related utility commands.
+    - Elite Farming bot offers `/weight` and other farming-related utility commands.
 - **SkyHelper**
     - SkyHelper is the go-to SkyBlock bot.
     - `/networth`: Total worth of a player's or guild's items.

--- a/docs/discord_roles.md
+++ b/docs/discord_roles.md
@@ -31,9 +31,10 @@ If those users talk to you, you know they aren't human.
 - **Elite**
     - Elite Farming bot offers /weight and other farming-related utility commands.
 - **SkyHelper**
-    - SkyHelper bot is the go-to SkyBlock utility command bot.
-
-[//]: # (This is a hidden comment: top 3 most used/most important commands that the bot can offer)
+    - SkyHelper is the go-to SkyBlock bot.
+    - `/networth`: Total worth of a player's or guild's items.
+    - `/missing`: Missing accessories with prices.
+    - `/leaderboard`: Player or guild leaderboards.
 
 - **Kuudra Gang**
     - Kuudra Gang bot helps with math around Kuudra runs or Kuudra items.

--- a/docs/discord_roles.md
+++ b/docs/discord_roles.md
@@ -4,7 +4,7 @@ This is a list of all server roles on the SkyHanni Discord server.
 This explains why the roles exist and how to get them.
 **You can NOT apply to any of those roles directly.** (except ping roles)
 
-## Full Perm Roles
+## Full Permissions Roles
 
 If those users talk to you, their word is law.
 
@@ -36,7 +36,7 @@ If those users talk to you, you know they aren't human.
 [//]: # (This is a hidden comment: top 3 most used/most important commands that the bot can offer)
 
 - **Kuudra Gang**
-    - Kuudra Gang bot helps with math around Kuudra runs or Kuudra items
+    - Kuudra Gang bot helps with math around Kuudra runs or Kuudra items.
 - **Tanzanite**
     - Tanzanite bot does generic Discord utility stuff like logging, banning, or setting reminders.
 - **Carl Bot**
@@ -47,7 +47,7 @@ If those users talk to you, you know they aren't human.
 - **Fire**
     - Fire bot reacts to links of Discord messages with said Discord message.
 
-## High-end Roles
+## Core Team Roles
 
 Hand-picked by **Admins** from members who have already held the **Contributor** or **Community Helper** role for some time.
 If those users talk to you, don't ignore them.
@@ -64,7 +64,7 @@ If those users talk to you, don't ignore them.
     - Developers who help the project a lot over a long time.
     - A cosmetic role between **Contributor** and **Mod Maintainer**.
 
-## Main Roles
+## Helper Roles
 
 People who help the mod.
 If those users talk to you, better listen.

--- a/docs/discord_roles.md
+++ b/docs/discord_roles.md
@@ -16,38 +16,6 @@ If those users talk to you, their word is law.
 
 [//]: # (This is a hidden comment: Clarify why Staff role even exists: can this get merged with Admin eventually? Jani, can this go?)
 
-## Bot Roles
-
-Only for bots, with different levels of permissions.
-If those users talk to you, you know they aren't human.
-
-- **Bot**
-    - Generic "this is a bot" role.
-    - For all bots on the server.
-    - This doesn't mean they have rights or something, we just want them to show up high in the member list.
-- **SH Bot**
-    - SkyHanni bot does SkyHanni-specific stuff.
-    - Mainly auto-tags and Pull Request linking.
-- **Elite**
-    - Elite Farming bot offers `/weight` and other farming-related utility commands.
-- **SkyHelper**
-    - SkyHelper is the go-to SkyBlock bot.
-    - `/networth`: Total worth of a player's or guild's items.
-    - `/missing`: Missing accessories with prices.
-    - `/leaderboard`: Player or guild leaderboards.
-
-- **Kuudra Gang**
-    - Kuudra Gang bot helps with math around Kuudra runs or Kuudra items.
-- **Tanzanite**
-    - Tanzanite bot does generic Discord utility stuff like logging, banning, or setting reminders.
-- **Carl Bot**
-    - Carl bot also does Discord utility stuff.
-
-[//]: # (This is a hidden comment: Does Carl Bot actually only do logging? What else?)
-
-- **Fire**
-    - Fire bot reacts to links of Discord messages with said Discord message.
-
 ## Core Team Roles
 
 Hand-picked by **Admins** from members who have already held the **Contributor** or **Community Helper** role for some time.
@@ -124,6 +92,38 @@ If those users talk to you, you are yapping with a nerd.
     - When a **Main Contributor** or higher decides to show off something new and cool.
 - **Stream Ping**
     - When someone actually streams while coding. It happens. Sometimes.
+
+## Bot Roles
+
+Only for bots, with different levels of permissions.
+If those users talk to you, you know they aren't human.
+
+- **Bot**
+    - Generic "this is a bot" role.
+    - For all bots on the server.
+    - This doesn't mean they have rights or something, we just want them to show up high in the member list.
+- **SH Bot**
+    - SkyHanni bot does SkyHanni-specific stuff.
+    - Mainly auto-tags and Pull Request linking.
+- **Elite**
+    - Elite Farming bot offers `/weight` and other farming-related utility commands.
+- **SkyHelper**
+    - SkyHelper is the go-to SkyBlock bot.
+    - `/networth`: Total worth of a player's or guild's items.
+    - `/missing`: Missing accessories with prices.
+    - `/leaderboard`: Player or guild leaderboards.
+
+- **Kuudra Gang**
+    - Kuudra Gang bot helps with math around Kuudra runs or Kuudra items.
+- **Tanzanite**
+    - Tanzanite bot does generic Discord utility stuff like logging, banning, or setting reminders.
+- **Carl Bot**
+    - Carl bot also does Discord utility stuff.
+
+[//]: # (This is a hidden comment: Does Carl Bot actually only do logging? What else?)
+
+- **Fire**
+    - Fire bot reacts to links of Discord messages with said Discord message.
 
 ## Special Roles
 


### PR DESCRIPTION
added discord roles explanation to docs

Click [here](https://github.com/hannibal002/SkyHanni/blob/docs/discord-roles/docs/discord_roles.md) for a preview

ignore_from_changelog