### PR TITLE
Fix: correct inventory GUI scale overlay rendering

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
@@ -55,7 +55,7 @@ object BurrowWarpHelper {
         }
     }
 
-    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, onlyOnIsland = IslandType.HUB)
+    @HandleEvent(onlyOnIsland = IslandType.HUB)
     fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.burrowNearestWarp) return
         if (!DianaApi.isDoingDiana()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
@@ -55,8 +55,8 @@ object BurrowWarpHelper {
         }
     }
 
-    @HandleEvent(GuiRenderEvent::class, onlyOnIsland = IslandType.HUB)
-    fun onRenderOverlay() {
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, onlyOnIsland = IslandType.HUB)
+    fun onRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.burrowNearestWarp) return
         if (!DianaApi.isDoingDiana()) return
         val warp = currentWarp ?: return

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 
@@ -53,7 +54,13 @@ class RenderDisplayHelper(
             val isInOwnInventory = Minecraft.getInstance().screen is InventoryScreen
             for (display in currentlyVisibleDisplays) {
                 if (display.renderIn(isInOwnInventory)) {
-                    display.render()
+                    if (display.outsideInventory && isInOwnInventory) {
+                        InventoryGuiScaleCompat.withOriginalHudScale {
+                            display.render()
+                        }
+                    } else {
+                        display.render()
+                    }
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/GuiScreenUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/GuiScreenUtils.kt
@@ -5,12 +5,19 @@ import net.minecraft.client.Minecraft
 object GuiScreenUtils {
 
     private val mc get() = Minecraft.getInstance()
+    private var screenMetricsOverride: ScreenMetricsOverride? = null
+
+    private data class ScreenMetricsOverride(
+        val scaledWindowWidth: Int,
+        val scaledWindowHeight: Int,
+        val scaleFactor: Int,
+    )
 
     val scaledWindowHeight: Int
-        get() = mc.window.guiScaledHeight
+        get() = screenMetricsOverride?.scaledWindowHeight ?: mc.window.guiScaledHeight
 
     val scaledWindowWidth: Int
-        get() = mc.window.guiScaledWidth
+        get() = screenMetricsOverride?.scaledWindowWidth ?: mc.window.guiScaledWidth
 
     val displayWidth: Int
         get() = mc.window.width
@@ -19,7 +26,7 @@ object GuiScreenUtils {
         get() = mc.window.height
 
     val scaleFactor: Int
-        get() = mc.window.guiScale.toInt()
+        get() = screenMetricsOverride?.scaleFactor ?: mc.window.guiScale.toInt()
 
     private val globalMouseX get() = MouseCompat.getX()
     private val globalMouseY get() = MouseCompat.getY()
@@ -40,4 +47,19 @@ object GuiScreenUtils {
         }
 
     val mousePos: Pair<Int, Int> get() = mouseX to mouseY
+
+    fun <T> withScreenMetricsOverride(
+        scaledWindowWidth: Int,
+        scaledWindowHeight: Int,
+        scaleFactor: Int,
+        action: () -> T,
+    ): T {
+        val previousOverride = screenMetricsOverride
+        screenMetricsOverride = ScreenMetricsOverride(scaledWindowWidth, scaledWindowHeight, scaleFactor)
+        return try {
+            action()
+        } finally {
+            screenMetricsOverride = previousOverride
+        }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryGuiScaleCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryGuiScaleCompat.kt
@@ -8,7 +8,7 @@ object InventoryGuiScaleCompat {
 
     fun <T> withOriginalHudScale(action: () -> T): T {
         val window = mc.window
-        val currentScale = window.guiScale.toInt()
+        val currentScale = window.guiScale
         val originalScale = window.calculateScale(mc.options.guiScale().get(), mc.isEnforceUnicode)
 
         if (currentScale == originalScale) return action()

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryGuiScaleCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryGuiScaleCompat.kt
@@ -1,0 +1,29 @@
+package at.hannibal2.skyhanni.utils.compat
+
+import net.minecraft.client.Minecraft
+
+object InventoryGuiScaleCompat {
+
+    private val mc get() = Minecraft.getInstance()
+
+    fun <T> withOriginalHudScale(action: () -> T): T {
+        val window = mc.window
+        val currentScale = window.guiScale.toInt()
+        val originalScale = window.calculateScale(mc.options.guiScale().get(), mc.isEnforceUnicode)
+
+        if (currentScale == originalScale) return action()
+
+        val correctionScale = originalScale.toFloat() / currentScale.toFloat()
+        val originalScaledWidth = ceilDiv(window.width, originalScale)
+        val originalScaledHeight = ceilDiv(window.height, originalScale)
+
+        return GuiScreenUtils.withScreenMetricsOverride(originalScaledWidth, originalScaledHeight, originalScale) {
+            DrawContextUtils.pushPopResult {
+                DrawContextUtils.scale(correctionScale, correctionScale)
+                action()
+            }
+        }
+    }
+
+    private fun ceilDiv(value: Int, divisor: Int): Int = (value + divisor - 1) / divisor
+}


### PR DESCRIPTION
## What
Fixes SkyHanni overlays rendering incorrectly when another mod uses a different GUI scale for inventory screens. For example Profit overlays would resize when opening the inventory with a different GUI scale for inventory.

This keeps HUD-style overlays at the normal HUD scale while the player's inventory is open, and fixes Diana's nearest warp helper rendering a second oversized copy over the inventory.

Tested locally with Aaron Mod using a separate inventory GUI scale.

<img width="1519" height="851" alt="image" src="https://github.com/user-attachments/assets/f92bb964-0071-497f-91d6-ca8638c7ff9d" />
<img width="1519" height="853" alt="image" src="https://github.com/user-attachments/assets/67d641f4-287f-4a58-b567-5ff2b93edf0e" />


## Changelog Fixes
+ Fixed some overlays rendering at the wrong size with separate inventory GUI scales, and fixed Diana's nearest warp helper rendering twice over inventory. - akinsoft
