### PR TITLE
Backend: raytrace -> raycast

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -79,7 +79,7 @@ class Mob(
     var armorStand: ArmorStand? = null,
     val name: String = "",
     additionalEntities: List<LivingEntity>? = null,
-    ownerName: String? = null,
+    var ownerName: String? = null,
     val hasStar: Boolean = false,
     val attribute: MobFilter.DungeonAttribute? = null,
     val levelOrTier: Int = -1,
@@ -89,7 +89,7 @@ class Mob(
     private val uniqueId: UUID = UUID.randomUUID()
     val id = baseEntity.id
 
-    val owner: MobUtils.OwnerShip?
+    val owner: MobUtils.Ownership?
 
     val ownerNameOrEmpty: String get() = owner?.ownerName.orEmpty()
 
@@ -196,11 +196,14 @@ class Mob(
         // Inlined updateBoundingBox()
         relativeBoundingBox = if (extraEntities.isNotEmpty()) makeRelativeBoundingBox() else null
 
-        owner = (
-            ownerName ?: if (category == MobCategory.SLAYER) hologram2?.let {
-                summonOwnerPattern.matchMatcher(it.cleanName()) { group("name") }
-            } else null
-            )?.let { MobUtils.OwnerShip(it) }
+        if (category == MobCategory.SLAYER) {
+            hologram2?.let {
+                summonOwnerPattern.matchMatcher(it.cleanName()) {
+                    ownerName = group("name")
+                }
+            }
+        }
+        ownerName?.let { owner = MobUtils.Ownership(it) }
     }
 
     private fun removeExtraEntitiesFromChecking() =

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -79,7 +79,7 @@ class Mob(
     var armorStand: ArmorStand? = null,
     val name: String = "",
     additionalEntities: List<LivingEntity>? = null,
-    var ownerName: String? = null,
+    private var ownerName: String? = null,
     val hasStar: Boolean = false,
     val attribute: MobFilter.DungeonAttribute? = null,
     val levelOrTier: Int = -1,

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -200,7 +200,7 @@ class Mob(
             ownerName ?: if (category == MobCategory.SLAYER) hologram2?.let {
                 summonOwnerPattern.matchMatcher(it.cleanName()) { group("name") }
             } else null
-        )?.let { MobUtils.OwnerShip(it) }
+            )?.let { MobUtils.OwnerShip(it) }
     }
 
     private fun removeExtraEntitiesFromChecking() =
@@ -217,7 +217,7 @@ class Mob(
             extraEntities.filter { it !is ArmorStand }
                 .mapNotNull { it.boundingBox },
         )
-    )?.move(-baseEntity.position().x, -baseEntity.position().y, -baseEntity.position().z)
+        )?.move(-baseEntity.position().x, -baseEntity.position().y, -baseEntity.position().z)
 
     fun fullEntityList() =
         baseEntity.toSingletonListOrEmpty() +

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -115,16 +115,21 @@ class Mob(
      */
     val isCorrupted get() = !RiftApi.inRift() && baseEntity.isCorrupted()
 
+    // TODO use component style
     /**
      * @property isRunic does not change.
      */
-    val isRunic = !RiftApi.inRift() && armorStand?.name.formattedTextCompatLessResets().startsWith("§5") && category == MobCategory.BASIC
+    val isRunic = !RiftApi.inRift() &&
+        armorStand?.name.formattedTextCompatLessResets().startsWith("§5") &&
+        category == MobCategory.BASIC
 
     fun isInRender() = baseEntity.distanceToPlayer() < MobData.ENTITY_RENDER_RANGE_IN_BLOCKS
 
     fun canBeSeen(viewDistance: Number = 150) = baseEntity.canBeSeen(viewDistance)
 
-    fun isInvisible() = baseEntity !is Zombie && baseEntity.isInvisible && baseEntity.getAllEquipment().isEmpty()
+    fun isInvisible() = baseEntity !is Zombie &&
+        baseEntity.isInvisible &&
+        baseEntity.getAllEquipment().isEmpty()
 
     private var highlightColor: Color? = null
     private var condition: () -> Boolean = { true }
@@ -141,13 +146,8 @@ class Mob(
 
     fun highlight(color: Color) {
         if (color == highlightColor) return
-        if (color == null) {
-            internalRemoveColor()
-            highlightColor = null
-        } else {
-            highlightColor = color.takeIf { it.alpha == 255 }?.addAlpha(127) ?: color
-            internalHighlight()
-        }
+        highlightColor = color.takeIf { it.alpha == 255 }?.addAlpha(127) ?: color
+        internalHighlight()
     }
 
     fun highlight(color: Property<ChromaColour>, condition: () -> Boolean) {
@@ -166,9 +166,9 @@ class Mob(
 
     private fun internalHighlight() {
         highlightColor?.let { color ->
-            RenderLivingEntityHelper.setEntityColor(baseEntity, color) { !this.isInvisible() && condition() }
+            RenderLivingEntityHelper.setEntityColor(baseEntity, color) { !isInvisible() && condition() }
             extraEntities.forEach {
-                RenderLivingEntityHelper.setEntityColor(it, color) { !this.isInvisible() && condition() }
+                RenderLivingEntityHelper.setEntityColor(it, color) { !isInvisible() && condition() }
             }
         }
     }
@@ -182,22 +182,25 @@ class Mob(
     }
 
     val boundingBox: AABB
-        get() = relativeBoundingBox?.move(baseEntity.position().x, baseEntity.position().y, baseEntity.position().z)
-            ?: baseEntity.boundingBox
+        get() = relativeBoundingBox?.move(
+            baseEntity.position().x,
+            baseEntity.position().y,
+            baseEntity.position().z,
+        ) ?: baseEntity.boundingBox
 
     val health: Float get() = baseEntity.findHealthReal()
     val maxHealth: Int get() = baseEntity.baseMaxHealth
 
     init {
         removeExtraEntitiesFromChecking()
-        relativeBoundingBox =
-            if (extraEntities.isNotEmpty()) makeRelativeBoundingBox() else null // Inlined updateBoundingBox()
+        // Inlined updateBoundingBox()
+        relativeBoundingBox = if (extraEntities.isNotEmpty()) makeRelativeBoundingBox() else null
 
         owner = (
             ownerName ?: if (category == MobCategory.SLAYER) hologram2?.let {
                 summonOwnerPattern.matchMatcher(it.cleanName()) { group("name") }
             } else null
-            )?.let { MobUtils.OwnerShip(it) }
+        )?.let { MobUtils.OwnerShip(it) }
     }
 
     private fun removeExtraEntitiesFromChecking() =
@@ -214,7 +217,7 @@ class Mob(
             extraEntities.filter { it !is ArmorStand }
                 .mapNotNull { it.boundingBox },
         )
-        )?.move(-baseEntity.position().x, -baseEntity.position().y, -baseEntity.position().z)
+    )?.move(-baseEntity.position().x, -baseEntity.position().y, -baseEntity.position().z)
 
     fun fullEntityList() =
         baseEntity.toSingletonListOrEmpty() +
@@ -251,15 +254,11 @@ class Mob(
     internal fun internalUpdateOfEntity(entity: LivingEntity) {
         internalRemoveColor()
         when (entity.id) {
-            baseEntity.id -> {
-                baseEntity = entity
-            }
-
+            baseEntity.id -> baseEntity = entity
             armorStand?.id ?: Int.MIN_VALUE -> armorStand = entity as ArmorStand
             else -> {
                 extraEntitiesList.remove(entity)
                 extraEntitiesList.add(entity)
-                Unit // To make return type of this branch Unit
             }
         }
         internalHighlight()
@@ -279,7 +278,12 @@ class Mob(
     }
 
     // TODO add max distance
-    fun lineToPlayer(color: ChromaColour, lineWidth: Int = 2, depth: Boolean = true, condition: () -> Boolean) =
+    fun lineToPlayer(
+        color: ChromaColour,
+        lineWidth: Int = 2,
+        depth: Boolean = true,
+        condition: () -> Boolean,
+    ) =
         LineToMobHandler.register(this, color, lineWidth, depth, condition)
 
     fun distanceToPlayer(): Double = baseEntity.distanceToPlayer()

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -196,7 +196,7 @@ class Mob(
         // Inlined updateBoundingBox()
         relativeBoundingBox = if (extraEntities.isNotEmpty()) makeRelativeBoundingBox() else null
 
-        if (category == MobCategory.SLAYER) {
+        if (ownerName == null && category == MobCategory.SLAYER) {
             hologram2?.let {
                 summonOwnerPattern.matchMatcher(it.cleanName()) {
                     ownerName = group("name")

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -203,7 +203,7 @@ class Mob(
                 }
             }
         }
-        ownerName?.let { owner = MobUtils.Ownership(it) }
+        owner = ownerName?.let { MobUtils.Ownership(it) }
     }
 
     private fun removeExtraEntitiesFromChecking() =

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -212,12 +212,10 @@ class Mob(
         relativeBoundingBox = if (extraEntities.isNotEmpty()) makeRelativeBoundingBox() else null
     }
 
-    private fun makeRelativeBoundingBox() = (
-        baseEntity.boundingBox.union(
-            extraEntities.filter { it !is ArmorStand }
-                .mapNotNull { it.boundingBox },
-        )
-        )?.move(-baseEntity.position().x, -baseEntity.position().y, -baseEntity.position().z)
+    private fun makeRelativeBoundingBox() = baseEntity.boundingBox.union(
+        extraEntities.filter { it !is ArmorStand }
+            .mapNotNull { it.boundingBox },
+    )?.move(-baseEntity.position().x, -baseEntity.position().y, -baseEntity.position().z)
 
     fun fullEntityList() =
         baseEntity.toSingletonListOrEmpty() +

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
@@ -50,7 +50,7 @@ object MobDebug {
     @HandleEvent
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (config.showRayHit || config.showInvisible) {
-            lastRayHit = MobUtils.rayTraceForMobs(MinecraftCompat.localPlayer, event.partialTicks)
+            lastRayHit = MobUtils.raycastForMobs(MinecraftCompat.localPlayer, event.partialTicks)
                 ?.firstOrNull { it.canBeSeen() && (!config.showInvisible || !it.isInvisible()) }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -89,7 +89,7 @@ object SkyHanniDebugsAndTests {
             add("[SkyHanni] Graph Area: ${SkyBlockUtils.graphArea}")
         }
 
-        registerDebugScreenEntry("raycasted_ore_block", SkyBlockUtils::inSkyBlock) {
+        registerDebugScreenEntry("targeted_oreblock", SkyBlockUtils::inSkyBlock) {
             BlockUtils.getTargetedBlockAtDistance(50.0)?.let { pos ->
                 OreBlock.getByStateOrNull(pos.getBlockStateAt())?.let { ore ->
                     add("[SkyHanni] Looking at: ${ore.name} (${pos.toCleanString()})")

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -89,7 +89,7 @@ object SkyHanniDebugsAndTests {
             add("[SkyHanni] Graph Area: ${SkyBlockUtils.graphArea}")
         }
 
-        registerDebugScreenEntry("ray_traced_ore_block", SkyBlockUtils::inSkyBlock) {
+        registerDebugScreenEntry("raycasted_ore_block", SkyBlockUtils::inSkyBlock) {
             BlockUtils.getTargetedBlockAtDistance(50.0)?.let { pos ->
                 OreBlock.getByStateOrNull(pos.getBlockStateAt())?.let { ore ->
                     add("[SkyHanni] Looking at: ${ore.name} (${pos.toCleanString()})")

--- a/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
@@ -36,15 +36,15 @@ object BlockUtils {
         return getValue(property) == 0
     }
 
-    private fun rayTrace(start: LorenzVec, direction: LorenzVec, distance: Double = 50.0): LorenzVec? {
+    private fun raycast(start: LorenzVec, direction: LorenzVec, distance: Double = 50.0): LorenzVec? {
         val target = start + direction.normalize() * distance
-        val result = rayTrace(start, target)
+        val result = raycast(start, target)
 
         return result?.location?.toLorenzVec()
     }
 
-    fun rayTrace(start: LorenzVec, end: LorenzVec): net.minecraft.world.phys.BlockHitResult? {
-        return world.clip(
+    fun raycast(start: LorenzVec, end: LorenzVec): net.minecraft.world.phys.BlockHitResult? =
+        world.clip(
             ClipContext(
                 start.toVec3(),
                 end.toVec3(),
@@ -53,15 +53,12 @@ object BlockUtils {
                 MinecraftCompat.localPlayer,
             ),
         )
-    }
 
-    fun getTargetedBlock(): LorenzVec? {
-        val mouseOverObject = Minecraft.getInstance().hitResult ?: return null
-        if (mouseOverObject.type != HitResult.Type.BLOCK) return null
-        return mouseOverObject.location.toLorenzVec().roundToBlock()
-    }
+    fun getTargetedBlock(): LorenzVec? =
+        Minecraft.getInstance().hitResult?.takeIf { it.type == HitResult.Type.BLOCK }
+            ?.location?.toLorenzVec()?.roundToBlock()
 
-    fun getTargetedBlockAtDistance(distance: Double) = rayTrace(
+    fun getTargetedBlockAtDistance(distance: Double) = raycast(
         LocationUtils.playerEyeLocation(),
         MinecraftCompat.localPlayer.lookAngle.toLorenzVec(),
         distance,
@@ -91,7 +88,8 @@ object BlockUtils {
         distance: Int,
         radius: Int = distance,
         filter: Block,
-    ): Map<LorenzVec, BlockState> = nearbyBlocks(center, distance, radius, condition = { it.block == filter })
+    ): Map<LorenzVec, BlockState> =
+        nearbyBlocks(center, distance, radius, condition = { it.block == filter })
 
     val redstoneOreBlocks = buildList { addRedstoneOres() }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/BlockUtils.kt
@@ -9,6 +9,7 @@ import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.entity.SkullBlockEntity
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.block.state.properties.IntegerProperty
+import net.minecraft.world.phys.BlockHitResult
 import net.minecraft.world.phys.HitResult
 
 object BlockUtils {
@@ -43,16 +44,15 @@ object BlockUtils {
         return result?.location?.toLorenzVec()
     }
 
-    fun raycast(start: LorenzVec, end: LorenzVec): net.minecraft.world.phys.BlockHitResult? =
-        world.clip(
-            ClipContext(
-                start.toVec3(),
-                end.toVec3(),
-                ClipContext.Block.COLLIDER,
-                ClipContext.Fluid.NONE,
-                MinecraftCompat.localPlayer,
-            ),
-        )
+    fun raycast(start: LorenzVec, end: LorenzVec): BlockHitResult? = world.clip(
+        ClipContext(
+            start.toVec3(),
+            end.toVec3(),
+            ClipContext.Block.COLLIDER,
+            ClipContext.Fluid.NONE,
+            MinecraftCompat.localPlayer,
+        ),
+    )
 
     fun getTargetedBlock(): LorenzVec? =
         Minecraft.getInstance().hitResult?.takeIf { it.type == HitResult.Type.BLOCK }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LocationUtils.kt
@@ -28,7 +28,7 @@ object LocationUtils {
         return canSee0(a, b) && offset?.let { canSee0(a.add(y = it), b.add(y = it)) } ?: true
     }
 
-    private fun canSee0(a: LorenzVec, b: LorenzVec): Boolean = BlockUtils.rayTrace(a, b)?.miss == true
+    private fun canSee0(a: LorenzVec, b: LorenzVec): Boolean = BlockUtils.raycast(a, b)?.miss == true
 
     fun playerLocation() = PlayerUtils.getLocation()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
@@ -43,7 +43,7 @@ object MobUtils {
 
     fun ArmorStand.isCompletelyDefault() = isDefaultValue() && hasEmptyInventory()
 
-    class OwnerShip(val ownerName: String) {
+    class Ownership(val ownerName: String) {
         val ownerPlayer = MobData.players.firstOrNull { it.name == ownerName }
         override fun equals(other: Any?): Boolean {
             if (other is Player) return ownerPlayer == other || ownerName == other.cleanName()

--- a/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
@@ -46,7 +46,7 @@ object MobUtils {
     class OwnerShip(val ownerName: String) {
         val ownerPlayer = MobData.players.firstOrNull { it.name == ownerName }
         override fun equals(other: Any?): Boolean {
-            if (other is Player) return ownerPlayer == other || ownerName == other.name.formattedTextCompatLessResets()
+            if (other is Player) return ownerPlayer == other || ownerName == other.cleanName()
             if (other is String) return ownerName == other
             return false
         }
@@ -56,25 +56,28 @@ object MobUtils {
         }
     }
 
-    fun rayTraceForMob(entity: Entity, distance: Double, partialTicks: Float, offset: LorenzVec = LorenzVec()) =
-        rayTraceForMob(entity, partialTicks, offset)?.takeIf {
-            it.baseEntity.distanceTo(entity.getLorenzVec()) <= distance
-        }
-
-    fun rayTraceForMobs(
+    fun raycastForMob(
         entity: Entity,
         distance: Double,
         partialTicks: Float,
         offset: LorenzVec = LorenzVec(),
-    ) =
-        rayTraceForMobs(entity, partialTicks, offset)?.filter {
-            it.baseEntity.distanceTo(entity.getLorenzVec()) <= distance
-        }.takeIf { it?.isNotEmpty() ?: false }
+    ) = raycastForMob(entity, partialTicks, offset)?.takeIf {
+        it.baseEntity.distanceTo(entity.getLorenzVec()) <= distance
+    }
 
-    fun rayTraceForMob(entity: Entity, partialTicks: Float, offset: LorenzVec = LorenzVec()) =
-        rayTraceForMobs(entity, partialTicks, offset)?.firstOrNull()
+    fun raycastForMobs(
+        entity: Entity,
+        distance: Double,
+        partialTicks: Float,
+        offset: LorenzVec = LorenzVec(),
+    ) = raycastForMobs(entity, partialTicks, offset)?.filter {
+        it.baseEntity.distanceTo(entity.getLorenzVec()) <= distance
+    }.takeIf { it?.isNotEmpty() ?: false }
 
-    fun rayTraceForMobs(entity: Entity, partialTicks: Float, offset: LorenzVec = LorenzVec()): List<Mob>? {
+    fun raycastForMob(entity: Entity, partialTicks: Float, offset: LorenzVec = LorenzVec()) =
+        raycastForMobs(entity, partialTicks, offset)?.firstOrNull()
+
+    fun raycastForMobs(entity: Entity, partialTicks: Float, offset: LorenzVec = LorenzVec()): List<Mob>? {
         val look = entity.lookAngle.toLorenzVec().normalize()
         val pos = entity.eyePosition.toLorenzVec() + offset
         val possibleEntities = MobData.entityToMob.filterKeys {


### PR DESCRIPTION
## What
Changed occurrences of "raytrace" to "raycast". The latter is a more accurate term for what we're doing – raytracing is generally used to refer to a more expensive operation that simulates light reflections and such. "Raycast" is also a term used in Minecraft source code as opposed to "raytrace", though the majority of the time they just call it "clip" or "pick" instead.

## Changelog Technical Details
+ Renamed BlockUtils.rayTrace to BlockUtils.raycast. - Luna
+ Renamed MobUtils.OwnerShip to MobUtils.Ownership. - Luna
+ Renamed MobUtils.rayTraceForMob to MobUtils.raycastForMob. - Luna
+ Renamed MobUtils.rayTraceForMobs to MobUtils.raycastForMobs. - Luna