### PR TITLE
Backend: Make validateAccessWidener explicitly depend on stonecutterPrepare

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -399,9 +399,7 @@ tasks.withType<DetektCreateBaselineTask>().configureEach {
 }
 
 tasks.withType<ValidateAccessWidenerTask>().configureEach {
-    notCompatibleWithConfigurationCache(
-        "Access widener validation fails with configuration cache enabled",
-    )
+    notCompatibleWithConfigurationCache("Access wideners need to be pre-processed by Stonecutter")
 }
 
 tasks.withType<RemapSourcesJarTask>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import at.skyhanni.sharedvariables.MultiVersionStage
 import at.skyhanni.sharedvariables.ProjectTarget
 import at.skyhanni.sharedvariables.SHVersionInfo
 import dev.kikugie.stonecutter.StonecutterExperimentalAPI
+import dev.kikugie.stonecutter.build.task.StonecutterPrepareTask
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import net.fabricmc.loom.task.RemapSourcesJarTask
@@ -398,16 +399,17 @@ tasks.withType<DetektCreateBaselineTask>().configureEach {
     baseline.set(file(rootProject.layout.projectDirectory.file("detekt/$outputFileName.xml")))
 }
 
-tasks.withType<ValidateAccessWidenerTask>().configureEach {
-    notCompatibleWithConfigurationCache("Access wideners need to be pre-processed by Stonecutter")
-}
-
 tasks.withType<RemapSourcesJarTask>().configureEach {
     enabled = false
 }
 
 tasks.matching { it.name == "kspTestKotlin" || it.name == "kspTestJava" }.configureEach {
     enabled = false
+}
+
+tasks.withType<ValidateAccessWidenerTask>().configureEach {
+    // This must be explicitly declared because of configuration cache shenanigans
+    dependsOn("stonecutterPrepare")
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import at.skyhanni.sharedvariables.MultiVersionStage
 import at.skyhanni.sharedvariables.ProjectTarget
 import at.skyhanni.sharedvariables.SHVersionInfo
 import dev.kikugie.stonecutter.StonecutterExperimentalAPI
-import dev.kikugie.stonecutter.build.task.StonecutterPrepareTask
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import net.fabricmc.loom.task.RemapSourcesJarTask

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import dev.kikugie.stonecutter.StonecutterExperimentalAPI
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import net.fabricmc.loom.task.RemapSourcesJarTask
+import net.fabricmc.loom.task.ValidateAccessWidenerTask
 import net.fabricmc.loom.task.prod.ClientProductionRunTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -395,6 +396,12 @@ tasks.withType<DetektCreateBaselineTask>().configureEach {
     val isMainBaseline = name == "detektBaselineMain"
     val outputFileName = if (isMainBaseline) "baseline-main" else "baseline"
     baseline.set(file(rootProject.layout.projectDirectory.file("detekt/$outputFileName.xml")))
+}
+
+tasks.withType<ValidateAccessWidenerTask>().configureEach {
+    notCompatibleWithConfigurationCache(
+        "Access widener validation fails with configuration cache enabled",
+    )
 }
 
 tasks.withType<RemapSourcesJarTask>().configureEach {


### PR DESCRIPTION
## What
Fixes validateAccessWidener tasks occasionally failing due to configuration cache:

```
FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':1.21.10:validateAccessWidener'.
> Failed to read access widener

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights from a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':1.21.11:validateAccessWidener'.
> Failed to read access widener

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights from a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.
==============================================================================

BUILD FAILED in 1m 2s
```

## Changelog Technical Details
+ Made `validateAccessWidener` Gradle task explicitly depend on `stonecutterPrepare` to fix occasional build failures. - Luna
