### PR TITLE
Fix: Ultrasequencer misses first round

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -430,7 +430,7 @@ object ExperimentationTableApi {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
+    @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND, priority = HandleEvent.HIGH)
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!inTable) return
         event.tryFireRareBookUncovered()


### PR DESCRIPTION
## What
When left or middle clicking to start the ultrasequencer experiment, the first round was not registered.

The handler in ExperimentationTableApi needs to set the experiment type prior to the handler in ExperimentsAddonsHelper firing. So, this issue is fixed by increasing the priority of the handler in ExperimentationTableApi.

## Changelog Fixes
+ Fixed Ultrasequencer Helper missing first round. - HyperKids