### PR TITLE
Fix: Fix Farming Fortune Display displaying incorrect values with Bonus Pest Chance disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -166,7 +166,6 @@ object FarmingFortuneDisplay {
                 pestBonusExpireTime = time
 
             }
-            update()
         }
     }
 
@@ -174,10 +173,7 @@ object FarmingFortuneDisplay {
         universalTabFortunePattern.firstMatcher(widget.lines.map { it.string }) {
             val fortune = group("fortune").toDouble()
             foundTabUniversalFortune = true
-            if (fortune != tabFortuneUniversal) {
-                tabFortuneUniversal = fortune
-                update()
-            }
+            tabFortuneUniversal = fortune
         }
         cropSpecificTabFortunePattern.firstMatcher(widget.lines.map { it.string }) {
             val crop = CropType.getByName(group("crop"))
@@ -185,10 +181,7 @@ object FarmingFortuneDisplay {
 
             currentCrop = crop
             foundTabCropFortune = true
-            if (cropFortune != tabFortuneCrop) {
-                tabFortuneCrop = cropFortune
-                update()
-            }
+            tabFortuneCrop = cropFortune
             if (GardenApi.cropInHand == crop) {
                 latestFF?.put(crop, getCurrentFarmingFortune())
             }
@@ -363,7 +356,8 @@ object FarmingFortuneDisplay {
     private fun isEnabled(): Boolean = GardenApi.inGarden() && config.display
 
     private fun getPestFFReduction(): Int {
-        val bpc = SkyblockStat.BONUS_PEST_CHANCE.lastKnownValue ?: 0.0
+        val bpcEnabled = PestApi.isBpcEnabled
+        val bpc = if (bpcEnabled) SkyblockStat.BONUS_PEST_CHANCE.lastKnownValue ?: 0.0 else 0.0
         val pests = (PestApi.scoreboardPests - floor(bpc / 100).toInt()).coerceAtLeast(0)
 
         return when (pests) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
@@ -9,27 +9,13 @@ import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConfigUtils
-import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderString
-import at.hannibal2.skyhanni.utils.compat.iterator
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
 object BonusPestChanceDisplay {
 
     private val config get() = PestApi.config
 
-    private val patternGroup = RepoPattern.group("garden.bonuspestchance")
-
-    /**
-     * REGEX-TEST:  Bonus Pest Chance: ൠ70
-     * REGEX-TEST:  Bonus Pest Chance: ൠ70
-     */
-    private val bonusPestChancePattern by patternGroup.pattern(
-        "widget-no-color",
-        "\\s+Bonus Pest Chance: ൠ(?<amount>[\\d,.]+)",
-    )
     private var display: String? = null
 
     @HandleEvent
@@ -40,26 +26,17 @@ object BonusPestChanceDisplay {
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.STATS)) return
-        val compact = config.pestChanceDisplay.get() == DisplayFormat.COMPACT
-        event.widget.lines.forEach { line ->
-            bonusPestChancePattern.matchMatcher(line) {
-                var disabled = false
-                for (component in line.iterator()) {
-                    if (component.style.isStrikethrough) {
-                        disabled = true
-                        break
-                    }
-                }
-                val amount = group("amount").formatInt()
+        PestApi.updateBpc(event)
 
-                display = buildString {
-                    if (compact) append("§2ൠ BPC ") else append("§2ൠ Bonus Pest Chance ")
-                    if (disabled) append("§c§m") else append("§f")
-                    append("$amount%")
-                    if (disabled && !compact) append("§r §cDISABLED")
-                }
-                return
-            }
+        val compact = config.pestChanceDisplay.get() == DisplayFormat.COMPACT
+        val disabled = !PestApi.isBpcEnabled
+        val amount = PestApi.latestBpc
+
+        display = buildString {
+            if (compact) append("§2ൠ BPC ") else append("§2ൠ Bonus Pest Chance ")
+            if (disabled) append("§c§m") else append("§f")
+            append("$amount%")
+            if (disabled && !compact) append("§r §cDISABLED")
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -47,6 +47,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+import at.hannibal2.skyhanni.utils.compat.iterator
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.decoration.ArmorStand
 import org.lwjgl.glfw.GLFW
@@ -73,6 +74,9 @@ object PestApi {
     var lastPestSpawnTime = SimpleTimeMark.farPast()
     var lastTimeVacuumHeld = SimpleTimeMark.farPast()
     var lastTimeLassoHeld = SimpleTimeMark.farPast()
+
+    var isBpcEnabled = false
+    var latestBpc = 0
 
     fun hasVacuumInHand() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.VACUUM
     fun hasLassoInHand() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.LASSO
@@ -176,6 +180,17 @@ object PestApi {
         "PLAYING",
     )
 
+    private val bpcPatternGroup = RepoPattern.group("garden.bonuspestchance")
+
+    /**
+     * REGEX-TEST:  Bonus Pest Chance: ൠ70
+     * REGEX-TEST:  Bonus Pest Chance: ൠ70
+     */
+    val bonusPestChancePattern by bpcPatternGroup.pattern(
+        "widget-no-color",
+        "\\s+Bonus Pest Chance: ൠ(?<amount>[\\d,.]+)",
+    )
+
     private var gardenJoinTime = SimpleTimeMark.farPast()
     private var firstScoreboardCheck = false
 
@@ -253,25 +268,43 @@ object PestApi {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
-        if (!event.isWidget(TabWidget.PESTS)) return
+        if (event.isWidget(TabWidget.PESTS)) {
+            infestedPlotsTabListPattern.firstMatcher(event.widget.lines.map { it.string }) {
+                val tabListPlots = group("plots").removeColor().split(", ").map { it.toInt() }.toSet()
+                val apiPlots = getInfestedPlots().map { it.id }.toSet()
 
-        infestedPlotsTabListPattern.firstMatcher(event.widget.lines.map { it.string }) {
-            val tabListPlots = group("plots").removeColor().split(", ").map { it.toInt() }.toSet()
-            val apiPlots = getInfestedPlots().map { it.id }.toSet()
+                if (tabListPlots == apiPlots) return
 
-            if (tabListPlots == apiPlots) return
-
-            for (plot in GardenPlotApi.plots) {
-                if (plot.id in tabListPlots) {
-                    if (!plot.isPestCountInaccurate && plot.pests == 0) {
-                        plot.isPestCountInaccurate = true
+                for (plot in GardenPlotApi.plots) {
+                    if (plot.id in tabListPlots) {
+                        if (!plot.isPestCountInaccurate && plot.pests == 0) {
+                            plot.isPestCountInaccurate = true
+                        }
+                    } else {
+                        plot.pests = 0
+                        plot.isPestCountInaccurate = false
                     }
-                } else {
-                    plot.pests = 0
-                    plot.isPestCountInaccurate = false
                 }
+                updatePests()
             }
-            updatePests()
+        } else if(event.isWidget(TabWidget.STATS)) {
+            updateBpc(event)
+        }
+    }
+
+    fun updateBpc(event: WidgetUpdateEvent) {
+        event.widget.lines.forEach { line ->
+            PestApi.bonusPestChancePattern.matchMatcher(line) {
+                latestBpc = group("amount").toInt()
+                for (component in line.iterator()) {
+                    if (component.style.isStrikethrough) {
+                        isBpcEnabled = false
+                        return
+                    }
+                }
+                isBpcEnabled = true
+                return
+            }
         }
     }
 


### PR DESCRIPTION
## What
The server's logic to increase the maximum number of pests before stat reduction by 1 for every 100 BPC you have only applies when BPC is enabled. The Farming Fortune Display now checks for BPC being enabled when calculating the FF reduction.

I've moved the Bonus Pest Chance Display's logic to the PestAPI so that it could be shared with the Farming Fortune Display.

## Changelog Fixes
+ Fixed Farming Fortune Display displaying incorrect values with Bonus Pest Chance disabled. - Nick-NCSU

