### PR TITLE
Fix: Discord IPC Response Debug

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordIPC.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordIPC.kt
@@ -54,6 +54,9 @@ class DiscordIPC(
     var lastActivityJson: String? = null
         private set
 
+    var lastDiscordResponse: String? = null
+        private set
+
     /**
      * Updates the rich presence activity displayed on the user's Discord profile.
      *
@@ -144,7 +147,10 @@ class DiscordIPC(
                         _connected = false
                         ChatUtils.debug("Discord RPC CLOSE frame: $body")
                     }
-                    else -> ChatUtils.debug("Discord RPC frame ($opcode): $body")
+                    else -> {
+                        lastDiscordResponse = body
+                        ChatUtils.debug("Discord RPC frame ($opcode): $body")
+                    }
                 }
             }
         } catch (_: DiscordIPCException) {
@@ -163,16 +169,21 @@ class DiscordIPC(
     @Suppress("ThrowsCount")
     private fun readFrame(): Pair<Opcode, String> {
         val inp = pipe?.input ?: throw DiscordIPCException("readFrame called with no active connection")
-        val header = inp.readNBytes(8)
-        if (header.size < 8) {
+        try {
+            val header = inp.readNBytes(8)
+            if (header.size < 8) {
+                _connected = false
+                throw DiscordIPCException("Discord closed the IPC pipe unexpectedly (EOF in frame header)")
+            }
+            val buffer = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+            val opcodeId = buffer.int
+            val opcode = Opcode.fromId(opcodeId) ?: throw DiscordIPCException("Received unknown opcode: $opcodeId")
+            val length = buffer.int
+            return opcode to String(inp.readNBytes(length), Charsets.UTF_8)
+        } catch (e: IOException) {
             _connected = false
-            throw DiscordIPCException("Discord closed the IPC pipe unexpectedly (EOF in frame header)")
+            throw DiscordIPCException("IPC read failed: ${e.message}", e)
         }
-        val buffer = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
-        val opcodeId = buffer.int
-        val opcode = Opcode.fromId(opcodeId) ?: throw DiscordIPCException("Received unknown opcode: $opcodeId")
-        val length = buffer.int
-        return opcode to String(inp.readNBytes(length), Charsets.UTF_8)
     }
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -291,6 +291,7 @@ object DiscordRPCManager {
             add("no error detected.")
             add("status: $debugStatusMessage")
             add("lastActivityJson: ${client?.lastActivityJson ?: "none yet"}")
+            add("lastDiscordResponse: ${client?.lastDiscordResponse ?: "none yet"}")
             lastDebugInfo.forEach { (k, v) -> add("$k: $v") }
         }
     }


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1000669238035497022/1488223712762400808
Fixes a potential frame EOF error, and adds a response debug for the IPC client.
This is mainly just getting us more info. No user-facing changelog for now, since I'm almost certain this is not the root cause of the issues people are having.

exclude_from_changelog