### PR TITLE
Backend: Fix Detekt Processing Regex

### DIFF
--- a/.github/scripts/gradlew-retry.kts
+++ b/.github/scripts/gradlew-retry.kts
@@ -28,7 +28,7 @@ val cmd = listOf("./gradlew") + gradleArgs
  */
 val retryableErrorRegex = Regex(
     // language=RegExp
-    "(?: *> )?(?:Could not (?:resolve|get|determine).+|(?:Caused by: )?[\\w.]+Exception.+)",
+    "(?: *> )?(?:Could not (?:resolve|get|determine).+|(?:Caused by: )?(?<!at)[\\w.]+(?<!TaskExecution|Verification)Exception:.+)",
     option = RegexOption.IGNORE_CASE,
 )
 

--- a/.github/scripts/gradlew-retry.kts
+++ b/.github/scripts/gradlew-retry.kts
@@ -25,6 +25,8 @@ val cmd = listOf("./gradlew") + gradleArgs
  * REGEX-TEST: Caused by: net.fabricmc.loom.util.download.DownloadException: Failed to download file
  * REGEX-TEST: > java.io.IOException: Server returned HTTP response code: 502 for URL: https://github.com/NotEnoughUpdates/NotEnoughUpdates-Repo/archive/refs/heads/master.zip
  * REGEX-TEST: Caused by: java.io.IOException: Server returned HTTP response code: 502 for URL: https://github.com/NotEnoughUpdates/NotEnoughUpdates-Repo/archive/refs/heads/master.zip
+ * REGEX-FAIL: org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':1.21.10:detektMain'.
+ * REGEX-FAIL: at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
  */
 val retryableErrorRegex = Regex(
     // language=RegExp

--- a/.github/scripts/process-detekt-output.kts
+++ b/.github/scripts/process-detekt-output.kts
@@ -19,8 +19,9 @@ val lines = detektOutput.split('\n')
  * REGEX-TEST: ::warning file=src/main/java/at/hannibal2/skyhanni/config/features/dev/NeuRepositoryConfig.kt,line=33,title=detekt.FormattingRules.StorageVarOrVal,col=9,endColumn=93::Runnable `resetRepoLocation` should be a val
  * REGEX-TEST: ::warning file=src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt,line=148,title=detekt.RepoRules.RepoPatternRegexTestFailed,col=28,endColumn=6::Repo pattern `hoverRewardPattern` failed regex test: `§2Forest Essence §8x4` pattern: `(?:§.)+(?<item>.*) (?:§.)+§8x(?<amount>[\d,-]+)`.
  * REGEX-TEST: ::warning file=src/common/main/kotlin/me/owdding/skyocean/features/mining/hollows/MetalDetectorSolver.kt,line=243,title=detekt.potential-bugs.UnsafeCallOnNullableType,col=41,endColumn=56::Calling !! on a nullable type will throw a NullPointerException at runtime in case the value is null. It should be avoided.
+ * REGEX-TEST: :: file=src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierBuilder.kt,line=68,title=detekt.ktlint.TrailingCommaOnDeclarationSite,col=45,endColumn=45::Missing trailing comma before ")"
  */
-val sarifRegex = Regex("^::warning file=(?<filePath>src\\/[^,]*\\/(?<file>[^,]+)),line=(?<line>\\d+),title=(?<wholeRule>(?<provider>[^.]+)\\.(?:(?:[\\w-]+)\\.)+(?<rule>[^.]+)),col=(?<col>\\d+),endColumn=(?<endcol>\\d+)::(?<message>(?:.|)*\\n*)\$")
+val sarifRegex = Regex("^::(?:(?:warning|error|notice)? )file=(?<filePath>src\\/[^,]*\\/(?<file>[^,]+)),line=(?<line>\\d+),title=(?<wholeRule>(?<provider>[^.]+)\\.(?:(?:[\\w-]+)\\.)+(?<rule>[^.]+)),col=(?<col>\\d+),endColumn=(?<endcol>\\d+)::(?<message>(?:.|)*\\n*)$")
 val sarifPattern = sarifRegex.toPattern()
 
 val urlBase = "https://github.com/$githubRepo/blob/$prSha/src/"

--- a/.github/scripts/process-detekt-output.kts
+++ b/.github/scripts/process-detekt-output.kts
@@ -94,23 +94,18 @@ val sb = StringBuilder().apply {
             else -> " (+ ${violatingFiles.size - ceilingedFiles.size} more)"
         }
         val fileViolationsFormat = ceilingedFiles.joinToString(", ") { (cleanedFilePath, _) ->
-            val url = flaggedFileUrls[cleanedFilePath]
             val fileName = pathToNameCache[cleanedFilePath] ?: cleanedFilePath.substringAfter("src/")
-            when (url) {
-                null -> "`$fileName`"
-                else -> "[$fileName]($url)"
-            }
+            flaggedFileUrls[cleanedFilePath]?.let { url ->
+                "[$fileName]($url)"
+            } ?: "`$fileName`"
         }
         append("**<ins>Files flagged</ins>** (${violatingFiles.size}): $fileViolationsFormat$xMoreFormat\n")
     }
 
     appendLine()
-    if (shouldCollapseComment) {
-        appendLine(buildCollapsedComment())
-    } else {
-        formatLines.forEach { (_, line) ->
-            appendLine(line)
-        }
+    if (shouldCollapseComment) appendLine(buildCollapsedComment())
+    else formatLines.forEach { (_, line) ->
+        appendLine(line)
     }
 
     appendLine()

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -200,14 +200,16 @@ object RenderUtils {
         if (renderables.isEmpty()) return
         var longestY = 0
         val longestX = renderables.maxOf { it.width }
-        for (line in renderables) DrawContextUtils.pushPop {
-            val (x, y) = transform()
-            DrawContextUtils.translate(0f, longestY.toFloat())
-            Renderable.withMousePosition(x, y) {
-                line.renderXAligned(0, longestY, longestX)
-            }
+        renderables.forEach { line ->
+            DrawContextUtils.pushPop {
+                val (x, y) = transform()
+                DrawContextUtils.translate(0f, longestY.toFloat())
+                Renderable.withMousePosition(x, y) {
+                    line.renderXAligned(0, longestY, longestX)
+                }
 
-            longestY += line.height + extraSpace + 2
+                longestY += line.height + extraSpace + 2
+            }
         }
         if (addToGuiManager) GuiEditManager.add(this, posLabel, longestX, longestY)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -200,16 +200,14 @@ object RenderUtils {
         if (renderables.isEmpty()) return
         var longestY = 0
         val longestX = renderables.maxOf { it.width }
-        renderables.forEach { line ->
-            DrawContextUtils.pushPop {
-                val (x, y) = transform()
-                DrawContextUtils.translate(0f, longestY.toFloat())
-                Renderable.withMousePosition(x, y) {
-                    line.renderXAligned(0, longestY, longestX)
-                }
-
-                longestY += line.height + extraSpace + 2
+        for (line in renderables) DrawContextUtils.pushPop {
+            val (x, y) = transform()
+            DrawContextUtils.translate(0f, longestY.toFloat())
+            Renderable.withMousePosition(x, y) {
+                line.renderXAligned(0, longestY, longestX)
             }
+
+            longestY += line.height + extraSpace + 2
         }
         if (addToGuiManager) GuiEditManager.add(this, posLabel, longestX, longestY)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/guide/GuideTab.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/guide/GuideTab.kt
@@ -14,7 +14,7 @@ class GuideTab(
     val tip: Renderable,
     val isVertical: Boolean = false,
     var lastTab: GuideGui.TabWrapper,
-    val onClick: (GuideTab) -> Unit
+    val onClick: (GuideTab) -> Unit,
 ) {
 
     fun fakeClick() = click()

--- a/src/main/java/at/hannibal2/skyhanni/utils/guide/GuideTab.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/guide/GuideTab.kt
@@ -14,7 +14,7 @@ class GuideTab(
     val tip: Renderable,
     val isVertical: Boolean = false,
     var lastTab: GuideGui.TabWrapper,
-    val onClick: (GuideTab) -> Unit,
+    val onClick: (GuideTab) -> Unit
 ) {
 
     fun fakeClick() = click()


### PR DESCRIPTION
## What
With 2.0, the `warning` is gone, so the processor regex needed updating.
This is why all PRs with detekt are getting "0 detekt failures".

exclude_from_changelog
