### PR TITLE
Fix: Shiny Shard -> Shiny Token

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
@@ -73,14 +73,14 @@ object PigFeaturesApi {
     )
 
     /**
-     * REGEX-TEST: SHINY! You extracted Shiny Shard and Blood God Crest from the piglet's orb!
-     * REGEX-TEST: SHINY! You extracted Shiny Shard and +1,185,000 Coins from the piglet's orb!
-     * REGEX-TEST: SHINY! You extracted Shiny Shard and +1,000 Foraging XP from the piglet's orb!
-     * REGEX-TEST: SHINY! You extracted Shiny Shard and 16x Enchanted Potato from the piglet's orb!
+     * REGEX-TEST: SHINY! You extracted Shiny Token and Blood God Crest from the piglet's orb!
+     * REGEX-TEST: SHINY! You extracted Shiny Token and +1,185,000 Coins from the piglet's orb!
+     * REGEX-TEST: SHINY! You extracted Shiny Token and +1,000 Foraging XP from the piglet's orb!
+     * REGEX-TEST: SHINY! You extracted Shiny Token and 16x Enchanted Potato from the piglet's orb!
      */
     private val orbLootedChatPattern by patternGroup.pattern(
         "chat.orb.looted",
-        "SHINY! You extracted Shiny Shard and (?<reward>.+) from the piglet's orb!",
+        "SHINY! You extracted Shiny Token and (?<reward>.+) from the piglet's orb!",
     )
 
     /**


### PR DESCRIPTION
## What
Just got renamed in the update that dropped today.

## Changelog Fixes
+ Updated Shiny Orb Tracker to work after Shiny Shard rename to Shiny Token. - Luna