### PR TITLE
Feature: Add Warty Drop Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
@@ -96,6 +96,11 @@ class GardenConfig {
     val armorDropTracker: ArmorDropTrackerConfig = ArmorDropTrackerConfig()
 
     @Expose
+    @ConfigOption(name = "Warty Crop Tracker", desc = "")
+    @Accordion
+    val wartyCropTracker: WartyCropTrackerConfig = WartyCropTrackerConfig()
+
+    @Expose
     @ConfigOption(name = "Crop Break Tracker", desc = "")
     @Accordion
     val gardenBpsTracker: GardenBpsTrackerConfig = GardenBpsTrackerConfig()

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/WartyCropTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/WartyCropTrackerConfig.kt
@@ -1,0 +1,34 @@
+package at.hannibal2.skyhanni.config.features.garden
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.misc.tracker.garden.GardenIndividualTrackerConfig
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class WartyCropTrackerConfig {
+
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Track §5Warty §7drops from the §dWart Eater Bonus§7.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enabled: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Hide Chat", desc = "Hide the chat message when receiving a Warty drop.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var hideChat: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Tracker Settings", desc = "")
+    @Accordion
+    val perTrackerConfig: GardenIndividualTrackerConfig = GardenIndividualTrackerConfig()
+
+    @Expose
+    @ConfigLink(owner = WartyCropTrackerConfig::class, field = "enabled")
+    val position: Position = Position(16, -260)
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -39,6 +39,7 @@ import at.hannibal2.skyhanni.features.garden.leaderboarddisplays.PestLeaderboard
 import at.hannibal2.skyhanni.features.garden.leaderboarddisplays.WeightLeaderboardStorage
 import at.hannibal2.skyhanni.features.garden.pests.stereo.VinylType
 import at.hannibal2.skyhanni.features.garden.tracker.ArmorDropTracker
+import at.hannibal2.skyhanni.features.garden.tracker.WartyCropTracker
 import at.hannibal2.skyhanni.features.garden.tracker.CropFeverTracker
 import at.hannibal2.skyhanni.features.garden.tracker.GardenBpsTracker
 import at.hannibal2.skyhanni.features.garden.tracker.PestProfitTracker
@@ -485,6 +486,9 @@ class ProfileSpecificStorage(
 
         @Expose
         var armorDropTracker: ArmorDropTracker.Data = ArmorDropTracker.Data()
+
+        @Expose
+        var wartyCropTracker: WartyCropTracker.Data = WartyCropTracker.Data()
 
         @Expose
         var composterUpgrades: MutableMap<ComposterUpgrade, Int> = enumMapOf()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/WartyCropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/WartyCropTracker.kt
@@ -1,0 +1,95 @@
+package at.hannibal2.skyhanni.features.garden.tracker
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.features.garden.CropType
+import at.hannibal2.skyhanni.features.garden.GardenApi
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
+import at.hannibal2.skyhanni.utils.renderables.Searchable
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.SessionUptime
+import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
+import at.hannibal2.skyhanni.utils.tracker.TrackerData
+import com.google.gson.annotations.Expose
+
+@SkyHanniModule
+object WartyCropTracker {
+
+    private val config get() = GardenApi.config.wartyCropTracker
+
+    private val patternGroup = RepoPattern.group("garden.warty")
+
+    /**
+     * REGEX-TEST: §6§lRARE CROP! §r§f§r§5Warty §r§b(Wart Eater Bonus)
+     */
+    private val wartyPattern by patternGroup.pattern(
+        "drop",
+        "§6§lRARE CROP! §r§f§r§5Warty §r§b\\(Wart Eater Bonus\\)",
+    )
+
+    val tracker = SkyHanniTracker(
+        "Warty Crop Tracker",
+        ::Data,
+        { it.garden.wartyCropTracker },
+        trackerConfig = { config.perTrackerConfig },
+        customUptimeControl = true,
+    ) {
+        drawDisplay(it)
+    }
+
+    data class Data(
+        @Expose
+        var wartyCount: Int = 0,
+    ) : TrackerData<SessionUptime.Garden>(SessionUptime.Garden::class)
+
+    @HandleEvent
+    fun onChat(event: SkyHanniChatEvent.Allow) {
+        if (!wartyPattern.matches(event.message)) return
+        tracker.modify { it.wartyCount++ }
+        if (config.hideChat) {
+            event.blockedReason = "warty_crop_drop"
+        }
+    }
+
+    private fun drawDisplay(data: Data): List<Searchable> = buildList {
+        addSearchString("§7Warty Crop Tracker:")
+        addSearchString(" §7- §e${data.wartyCount.addSeparators()}x §5Warty")
+    }
+
+    init {
+        tracker.initRenderer({ config.position }) { shouldShowDisplay() }
+    }
+
+    private fun shouldShowDisplay(): Boolean {
+        if (!config.enabled) return false
+        if (!GardenApi.inGarden()) return false
+        val crop = GardenApi.cropInHand ?: return false
+        if (crop != CropType.NETHER_WART) return false
+        return true
+    }
+
+    @HandleEvent
+    fun onIslandChange(event: IslandChangeEvent) {
+        if (event.newIsland == IslandType.GARDEN) {
+            tracker.firstUpdate()
+        }
+    }
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shresetwartycroptracker") {
+            description = "Resets the Warty Crop Tracker"
+            category = CommandCategory.USERS_RESET
+            simpleCallback { tracker.resetCommand() }
+        }
+    }
+}


### PR DESCRIPTION
## What
Added a Warty drop tracker feature heavily based on `ArmorDropTracker`.
* Tracks Warty drops from the Wart Eater Bonus.
* Only displays when holding a Nether Wart Hoe in the Garden.
*  Includes option to hide the drop chat message.

- Created `WartyCropTrackerConfig`, 
- Modified `GardenConfig` to include the new config file.
- Modified `ProfileSpecificStorage` to store the new configs.
- Created `WartyCropTracker` 

<details>
<summary>Images</summary>
<img width="177" height="58" alt="Warty_Display_Image1" src="https://github.com/user-attachments/assets/c9dd8fb3-de59-4be9-862c-f2361747afd2" />
<img width="182" height="65" alt="Warty_Display_Image2" src="https://github.com/user-attachments/assets/59c3b39c-cb6c-4809-bf6a-45016fc07bec" />
<img width="199" height="107" alt="Warty_Display_Image3" src="https://github.com/user-attachments/assets/3b880f5e-e2da-4a0b-bf87-e1989fab1ec5" />

</details>

## Changelog New Features
+ Added Warty Crop Tracker for Nether Wart farming. - Ambrosy