### PR TITLE
Backend: Check against clean message for Sea Creature catch

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -60,7 +60,7 @@ object SeaCreatureManager {
             PetStorageApi.isAutopetMessage(event.message)
         ) return
 
-        getSeaCreatureFromMessage(event.message)?.let {
+        getSeaCreatureFromMessage(event.cleanMessage)?.let {
             SeaCreatureFishEvent(it, doubleHook).post()
             if (config.seaCreatureTracker.hideChat) {
                 event.blockedReason = "sea_creature_tracker"
@@ -83,7 +83,7 @@ object SeaCreatureManager {
             PetStorageApi.isAutopetMessage(event.message)
         ) return
 
-        getSeaCreatureFromMessage(event.message)?.let {
+        getSeaCreatureFromMessage(event.cleanMessage)?.let {
             val original = event.chatComponent.copy()
             var edited = original
 


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/650

## What
Changed sea creature catch detection to use `event.cleanMessage`. See repo PR for details.

## Changelog Technical Details
+ Changed sea creature catch detection to use the message without color codes. - Luna
    * The version with color codes should still be added as `alternate_messages` to the repo to not break older mod versions until Hypixel drops 1.21.11 support.
