### PR TITLE
Backend: FF Recategorization

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -304,6 +304,7 @@ object GardenApi {
         }
         event.registerBrigadier("ff") {
             description = "Opens the Farming Fortune Guide"
+            category = CommandCategory.USERS_ACTIVE
             simpleCallback {
                 if (!SkyBlockUtils.inSkyBlock) {
                     ChatUtils.userError("Join SkyBlock to open the fortune guide!")


### PR DESCRIPTION
## What
Changed Farming Fortune Guide (/ff) from being a `MAIN` command to a `USERS_ACTIVE` command.

## Changelog Technical Details
+ Changed `/ff` category from main command to a normal command. - Ambrosy