### PR TITLE
Fix: TPS not being halved in party commands during April Fools

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -32,14 +32,15 @@ object TpsCounter {
     private val config get() = SkyHanniMod.feature.gui
 
     private val msPerTickList = SizeLimitedCache<Long, Double>(100)
-    val tps: Double?
+    val rawTps: Double?
         get() = when {
             timeSinceWorldSwitch < WORLD_SWITCH_DELAY -> null
             msPerTickList.isEmpty() || lastServerTick.passedSince() >= 1.seconds -> 0.0
             else -> (1000.0 / msPerTickList.values.average()).coerceIn(0.0..20.0).also {
                 if (!it.isFinite()) printError(it)
-            }.let { if (TimeUtils.isAprilFoolsDay) it / 2 else it }
+            }
         }
+    val tps get() = rawTps?.let { if (TimeUtils.isAprilFoolsDay) it / 2 else it }
 
     private val timeSinceWorldSwitch get() = SkyBlockUtils.lastWorldSwitch.passedSince()
 
@@ -74,11 +75,13 @@ object TpsCounter {
             LimboTimeTracker.inLimbo -> {
                 append("§4N/A §7(Limbo)")
             }
+
             currentTps == null -> {
                 val remaining = (WORLD_SWITCH_DELAY - timeSinceWorldSwitch).roundedUpSeconds
                 if (!compact) append("§fCalculating... ")
                 append("§7(${remaining}s)")
             }
+
             else -> {
                 append("%s%.1f".format(getColor(currentTps), currentTps))
             }
@@ -153,7 +156,7 @@ object TpsCounter {
     fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("TPS Counter")
         event.addIrrelevant {
-            add("TPS: %.1f".format(tps))
+            add("TPS: %.1f".format(rawTps))
             add("Milliseconds Per Tick: ${msPerTickList.values.joinToString(", ") { "%.1f".format(it) }}")
             add("Time Since World Switch: $timeSinceWorldSwitch")
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TpsCounter.kt
@@ -38,7 +38,7 @@ object TpsCounter {
             msPerTickList.isEmpty() || lastServerTick.passedSince() >= 1.seconds -> 0.0
             else -> (1000.0 / msPerTickList.values.average()).coerceIn(0.0..20.0).also {
                 if (!it.isFinite()) printError(it)
-            }
+            }.let { if (TimeUtils.isAprilFoolsDay) it / 2 else it }
         }
 
     private val timeSinceWorldSwitch get() = SkyBlockUtils.lastWorldSwitch.passedSince()
@@ -69,7 +69,7 @@ object TpsCounter {
 
     private fun getTpsString(compact: Boolean = false): String = buildString {
         append("§eTPS: ")
-        var currentTps = tps
+        val currentTps = tps
         when {
             LimboTimeTracker.inLimbo -> {
                 append("§4N/A §7(Limbo)")
@@ -80,7 +80,6 @@ object TpsCounter {
                 append("§7(${remaining}s)")
             }
             else -> {
-                if (TimeUtils.isAprilFoolsDay) currentTps /= 2
                 append("%s%.1f".format(getColor(currentTps), currentTps))
             }
         }
@@ -145,7 +144,7 @@ object TpsCounter {
             "TPS calculation got an error",
             "tps is $tps",
             "tps" to tps,
-            "msptList" to msPerTickList,
+            "msPerTickList" to msPerTickList,
             "timeSinceWorldSwitch" to timeSinceWorldSwitch,
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/DebugCommand.kt
@@ -207,7 +207,7 @@ object DebugCommand {
 
     private fun networkInfo(event: DebugDataCollectEvent) {
         event.title("Network Information")
-        val tps = TpsCounter.tps ?: 0.0
+        val tps = TpsCounter.rawTps ?: 0.0
         val pingEnabled = DevApi.mainToggles.pingApi
 
         val list = buildList {


### PR DESCRIPTION
## What
Makes `!tps` party command also show halved TPS during April Fools for consistency. (`!ping` already shows doubled ping with my previously merged PR.)

exclude_from_changelog