### PR TITLE
Backend: Bump Moul to 4.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 libautoupdate = "1.3.1"
-moulconfig = "4.5.0"
+moulconfig = "4.6.0"
 jbAnnotations = "24.1.0"
 hypixelmodapi = "1.0.2"
 hypixelmodapi-fabric = "1.0.1+build.1+mc1.21"


### PR DESCRIPTION
## What
Bumps moul to 4.6.0, which brings the inheritance annotations that I designed, so we can finally have true config inheriting 🙏

## Changelog Technical Details
+ Bumped MoulConfig to 4.6.0. - Daveed
    * Configs can now inherit and override config definitions.

