### PR TITLE
Fix: Reindrakes not counting as double hook

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/WinterApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/WinterApi.kt
@@ -3,11 +3,26 @@ package at.hannibal2.skyhanni.data
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.TimeUtils
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import java.time.Month
 
 @SkyHanniModule
 object WinterApi {
+
+    private val patternGroup = RepoPattern.group("event.winter")
+
+    /**
+     * REGEX-TEST: WOAH! [VIP] Georeek summoned a Reindrake from the depths!
+     * REGEX-TEST: WOAH! [MVP+] DulceLyncis summoned TWO Reindrakes from the depths!
+     */
+    private val reindrakeSpawnPattern by patternGroup.pattern(
+        "reindrake.spawn_message",
+        "WOAH! .+ summoned (?:a Reindrake|TWO Reindrakes) from the depths!",
+    )
+
+    fun isReindrakeSpawnMessage(message: String) = reindrakeSpawnPattern.matches(message)
 
     private var inArea = false
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/ReindrakeWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/ReindrakeWarpHelper.kt
@@ -3,38 +3,26 @@ package at.hannibal2.skyhanni.features.event.winter
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.WinterApi
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
 object ReindrakeWarpHelper {
 
     private val config get() = SkyHanniMod.feature.event.winter
 
-    private val patternGroup = RepoPattern.group("event.winter.reindrakewarphelper")
-
-    /**
-     * REGEX-TEST: WOAH! [VIP] Georeek summoned a Reindrake from the depths!
-     * REGEX-TEST: WOAH! [MVP+] DulceLyncis summoned TWO Reindrakes from the depths!
-     */
-    val spawnPattern by patternGroup.pattern(
-        "spawn.message",
-        "WOAH! .+ summoned (?:a Reindrake|TWO Reindrakes) from the depths!",
-    )
-
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
-        if (!spawnPattern.matches(event.cleanMessage)) return
+        if (!WinterApi.isReindrakeSpawnMessage(event.cleanMessage)) return
         ChatUtils.clickToActionOrDisable(
             "A Reindrake was detected. Click to warp to the Winter Island spawn!",
             config::reindrakeWarpHelper,
             actionName = "warp to winter island spawn",
-            action = { HypixelCommands.warp("winter") }
+            action = { HypixelCommands.warp("winter") },
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/winter/ReindrakeWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/winter/ReindrakeWarpHelper.kt
@@ -21,7 +21,7 @@ object ReindrakeWarpHelper {
      * REGEX-TEST: WOAH! [VIP] Georeek summoned a Reindrake from the depths!
      * REGEX-TEST: WOAH! [MVP+] DulceLyncis summoned TWO Reindrakes from the depths!
      */
-    private val spawnPattern by patternGroup.pattern(
+    val spawnPattern by patternGroup.pattern(
         "spawn.message",
         "WOAH! .+ summoned (?:a Reindrake|TWO Reindrakes) from the depths!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -102,7 +102,6 @@ object SeaCreatureManager {
         doubleHook = false
     }
 
-
     /**
      * Autopet can be triggered via Sinkers as rod parts (Sponge, Prismarine, Icy) to trigger collection gain which goes between Double Hook! and the Catch message.
      * The Thunder sea Creature gives charge when hooked, which can cause thunder bottles to charge and send the full charge message between Double Hook! and Catch message.
@@ -110,8 +109,7 @@ object SeaCreatureManager {
     private fun isInterceptingColorCodeMessage(message: String): Boolean =
         (PetStorageApi.isAutopetMessage(message) || thunderBottleChargedPattern.matches(message))
 
-
-    // TODO Unify when both Clean. (I do not wanna touch that Pet Storage Autopet Regex, I will horrifically break something)
+    // TODO Unify when both use CleanMessage.
 
     /**
      * Reindrakes Send an empty line, the global message & another empty line Double Hook! and Catch message.

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -3,11 +3,11 @@ package at.hannibal2.skyhanni.features.fishing
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.pet.PetStorageApi
+import at.hannibal2.skyhanni.data.WinterApi
 import at.hannibal2.skyhanni.data.jsonobjects.repo.SeaCreatureJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.fishing.SeaCreatureFishEvent
-import at.hannibal2.skyhanni.features.event.winter.ReindrakeWarpHelper
 import at.hannibal2.skyhanni.features.fishing.seaCreatureXMLGui.SpecificSeaCreatures
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -112,10 +112,10 @@ object SeaCreatureManager {
     // TODO Unify when both use CleanMessage.
 
     /**
-     * Reindrakes Send an empty line, the global message & another empty line Double Hook! and Catch message.
+     * Reindrakes send an empty line, the global message & another empty line between Double Hook! and Catch message.
      */
     private fun isInterceptingCleanMessage(message: String): Boolean =
-        (ReindrakeWarpHelper.spawnPattern.matches(message) || message.isEmpty())
+        (WinterApi.isReindrakeSpawnMessage(message) || message.isEmpty())
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -58,9 +58,6 @@ object SeaCreatureManager {
         }
         if (isInterceptingColorCodeMessage(event.message)) return
         if (isInterceptingCleanMessage(event.cleanMessage)) return
-        /*
-        These
-         */
 
         getSeaCreatureFromMessage(event.message)?.let {
             SeaCreatureFishEvent(it, doubleHook).post()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -108,11 +108,11 @@ object SeaCreatureManager {
     private fun isInterceptingColorCodeMessage(message: String): Boolean {
         var shouldIgnore = false
         if (PetStorageApi.isAutopetMessage(message)) shouldIgnore = true
-        /**
+        /*
          * Icy, Sponge and Prismarine Sinkers can cause an autopet message between the double Hook & Catch Message.
          */
         if (thunderBottleChargedPattern.matches(message)) shouldIgnore = true
-        /**
+        /*
          * Thunder Sea Creature gives an immediate amount of charge This also lands between Double Hook & Catch Message.
          */
         return shouldIgnore
@@ -124,7 +124,7 @@ object SeaCreatureManager {
         var shouldIgnore = false
         if (ReindrakeWarpHelper.spawnPattern.matches(message)) shouldIgnore = true
         if (message.isEmpty()) shouldIgnore = true
-        /**
+        /*
          * Reindrakes Send an empty line, the global message & another empty line between double hook & Catch message.
          */
         return shouldIgnore

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -107,7 +107,7 @@ object SeaCreatureManager {
             thunderBottleChargedPattern.matches(message)
         )
         // TODO Unify when both are Color Code-less (I do not wanna touch that Pet Storage Autopet Regex, I will horrifically break something)
-    private fun isInterceptingCleanMessage(message: String): Boolean = (ReindrakeWarpHelper.spawnPattern.matches(message))
+    private fun isInterceptingCleanMessage(message: String): Boolean = (ReindrakeWarpHelper.spawnPattern.matches(message) || message.isEmpty())
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -58,7 +58,9 @@ object SeaCreatureManager {
         }
         if (isInterceptingColorCodeMessage(event.message)) return
         if (isInterceptingCleanMessage(event.cleanMessage)) return
-        // I have no idea if this is the bug or if it's Hypixel, but we, might... Be able to fix this.
+        /*
+        These
+         */
 
         getSeaCreatureFromMessage(event.message)?.let {
             SeaCreatureFishEvent(it, doubleHook).post()
@@ -103,13 +105,30 @@ object SeaCreatureManager {
         doubleHook = false
     }
 
-    private fun isInterceptingColorCodeMessage(message: String): Boolean = (PetStorageApi.isAutopetMessage(message) ||
-        thunderBottleChargedPattern.matches(message)
-        )
+    private fun isInterceptingColorCodeMessage(message: String): Boolean {
+        var shouldIgnore = false
+        if (PetStorageApi.isAutopetMessage(message)) shouldIgnore = true
+        /**
+         * Icy, Sponge and Prismarine Sinkers can cause an autopet message between the double Hook & Catch Message.
+         */
+        if (thunderBottleChargedPattern.matches(message)) shouldIgnore = true
+        /**
+         * Thunder Sea Creature gives an immediate amount of charge This also lands between Double Hook & Catch Message.
+         */
+        return shouldIgnore
+    }
+
 
     // TODO Unify when both Clean. (I do not wanna touch that Pet Storage Autopet Regex, I will horrifically break something)
-    private fun isInterceptingCleanMessage(message: String): Boolean =
-        (ReindrakeWarpHelper.spawnPattern.matches(message) || message.isEmpty())
+    private fun isInterceptingCleanMessage(message: String): Boolean {
+        var shouldIgnore = false
+        if (ReindrakeWarpHelper.spawnPattern.matches(message)) shouldIgnore = true
+        if (message.isEmpty()) shouldIgnore = true
+        /**
+         * Reindrakes Send an empty line, the global message & another empty line between double hook & Catch message.
+         */
+        return shouldIgnore
+    }
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.SeaCreatureJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.fishing.SeaCreatureFishEvent
+import at.hannibal2.skyhanni.features.event.winter.ReindrakeWarpHelper
 import at.hannibal2.skyhanni.features.fishing.seaCreatureXMLGui.SpecificSeaCreatures
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -55,10 +56,9 @@ object SeaCreatureManager {
             doubleHook = true
             return
         }
-
-        if (thunderBottleChargedPattern.matches(event.message) ||
-            PetStorageApi.isAutopetMessage(event.message)
-        ) return
+        if (isInterceptingColorCodeMessage(event.message)) return
+        if (isInterceptingCleanMessage(event.cleanMessage)) return
+        // I have no idea if this is the bug or if it's Hypixel, but we, might... Be able to fix this.
 
         getSeaCreatureFromMessage(event.message)?.let {
             SeaCreatureFishEvent(it, doubleHook).post()
@@ -79,9 +79,8 @@ object SeaCreatureManager {
             return
         }
 
-        if (thunderBottleChargedPattern.matches(event.message) ||
-            PetStorageApi.isAutopetMessage(event.message)
-        ) return
+        if (isInterceptingColorCodeMessage(event.message)) return
+        if (isInterceptingCleanMessage(event.cleanMessage)) return
 
         getSeaCreatureFromMessage(event.message)?.let {
             val original = event.chatComponent.copy()
@@ -103,6 +102,12 @@ object SeaCreatureManager {
 
         doubleHook = false
     }
+
+    private fun isInterceptingColorCodeMessage(message: String): Boolean = (PetStorageApi.isAutopetMessage(message) ||
+            thunderBottleChargedPattern.matches(message)
+        )
+        // TODO Unify when both are Color Code-less (I do not wanna touch that Pet Storage Autopet Regex, I will horrifically break something)
+    private fun isInterceptingCleanMessage(message: String): Boolean = (ReindrakeWarpHelper.spawnPattern.matches(message))
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -104,10 +104,12 @@ object SeaCreatureManager {
     }
 
     private fun isInterceptingColorCodeMessage(message: String): Boolean = (PetStorageApi.isAutopetMessage(message) ||
-            thunderBottleChargedPattern.matches(message)
+        thunderBottleChargedPattern.matches(message)
         )
-        // TODO Unify when both are Color Code-less (I do not wanna touch that Pet Storage Autopet Regex, I will horrifically break something)
-    private fun isInterceptingCleanMessage(message: String): Boolean = (ReindrakeWarpHelper.spawnPattern.matches(message) || message.isEmpty())
+
+    // TODO Unify when both Clean. (I do not wanna touch that Pet Storage Autopet Regex, I will horrifically break something)
+    private fun isInterceptingCleanMessage(message: String): Boolean =
+        (ReindrakeWarpHelper.spawnPattern.matches(message) || message.isEmpty())
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -105,30 +105,22 @@ object SeaCreatureManager {
         doubleHook = false
     }
 
-    private fun isInterceptingColorCodeMessage(message: String): Boolean {
-        var shouldIgnore = false
-        if (PetStorageApi.isAutopetMessage(message)) shouldIgnore = true
-        /*
-         * Icy, Sponge and Prismarine Sinkers can cause an autopet message between the double Hook & Catch Message.
-         */
-        if (thunderBottleChargedPattern.matches(message)) shouldIgnore = true
-        /*
-         * Thunder Sea Creature gives an immediate amount of charge This also lands between Double Hook & Catch Message.
-         */
-        return shouldIgnore
-    }
+
+    /**
+     * Autopet can be triggered via Sinkers as rod parts (Sponge, Prismarine, Icy) to trigger collection gain which goes between Double Hook! and the Catch message.
+     * The Thunder sea Creature gives charge when hooked, which can cause thunder bottles to charge and send the full charge message between Double Hook! and Catch message.
+     */
+    private fun isInterceptingColorCodeMessage(message: String): Boolean =
+        (PetStorageApi.isAutopetMessage(message) || thunderBottleChargedPattern.matches(message))
 
 
     // TODO Unify when both Clean. (I do not wanna touch that Pet Storage Autopet Regex, I will horrifically break something)
-    private fun isInterceptingCleanMessage(message: String): Boolean {
-        var shouldIgnore = false
-        if (ReindrakeWarpHelper.spawnPattern.matches(message)) shouldIgnore = true
-        if (message.isEmpty()) shouldIgnore = true
-        /*
-         * Reindrakes Send an empty line, the global message & another empty line between double hook & Catch message.
-         */
-        return shouldIgnore
-    }
+
+    /**
+     * Reindrakes Send an empty line, the global message & another empty line Double Hook! and Catch message.
+     */
+    private fun isInterceptingCleanMessage(message: String): Boolean =
+        (ReindrakeWarpHelper.spawnPattern.matches(message) || message.isEmpty())
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {


### PR DESCRIPTION
## What
This is entirely based on 1 screnshot and pure guesswork that we're hiding the double hook message but being blocked from detection by the Reindrake hook message

<img width="940" height="115" alt="image" src="https://github.com/user-attachments/assets/1ada4e19-5e64-4e99-bbdd-3397b822099c" />

ok got a new screenshot while making this PR, this is 100% fixable and exactly the bug I thought it was.

Untested Because Jerry just ended but, I think we ball

## Changelog Fixes
+ Fixed Double Hook Reindrakes not being picked up by SH. - Fazfoxy
    * This also fixes the Double Hook message being incorrectly removed without appending.
    * Also Sea Creature Tracker only tracking 1 Reindrake for double hooks.