### PR TITLE
Backend: More Reliable Build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -267,8 +267,11 @@ tasks.withType<KotlinCompile> {
         optIn.addAll(
             "kotlin.concurrent.atomics.ExperimentalAtomicApi",
         )
+        // 0 (all cores) triggers a race condition in JvmIrCodegenFactory's parallel codegen on Kotlin 2.3.x,
+        // leaving corrupt .class files that break subsequent incremental builds.
+        // see: https://youtrack.jetbrains.com/issue/KT-85498/
         freeCompilerArgs.addAll(
-            "-Xbackend-threads=0",
+            "-Xbackend-threads=1",
         )
     }
 }


### PR DESCRIPTION
## What
Kotlin `2.3.x` is bugged: [Race Condition in JvmIrCodegenFactory.invokeCodegen is Corrupting IBC](https://youtrack.jetbrains.com/issue/KT-85498)
Until they fix it, this fixes builds randomly dying sometimes.

## Changelog Technical Details
+ Added temporary workaround for Kotlin bug. - Daveed