### PR TITLE
Fix: Reindrake lootshare sphere off by default

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/SeaCreatureJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/SeaCreatureJson.kt
@@ -21,4 +21,5 @@ data class SeaCreatureInfo(
     @Expose @SerializedName("fishing_experience") val fishingExperience: Int,
     @Expose val rare: Boolean = false,
     @Expose val rarity: LorenzRarity,
+    @Expose val lootshareSphereOverride: Boolean?,
 )

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/SeaCreatureJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/SeaCreatureJson.kt
@@ -21,5 +21,5 @@ data class SeaCreatureInfo(
     @Expose @SerializedName("fishing_experience") val fishingExperience: Int,
     @Expose val rare: Boolean = false,
     @Expose val rarity: LorenzRarity,
-    @Expose val lootshareSphereOverride: Boolean?,
+    @Expose val lootshareSphereOverride: Boolean? = null,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreature.kt
@@ -8,6 +8,7 @@ data class SeaCreature(
     val chatColor: String,
     val rare: Boolean,
     val rarity: LorenzRarity,
+    val lootshareSphereOverride: Boolean?,
 ) {
 
     val displayName = chatColor + rare() + name

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -124,9 +124,9 @@ object SeaCreatureManager {
                 val fishingExperience = seaCreature.fishingExperience
                 val rarity = seaCreature.rarity
                 val rare = seaCreature.rare
-                val lootshare = seaCreature.lootshareSphereOverride
+                val lootshareSphere = seaCreature.lootshareSphereOverride
 
-                val creature = SeaCreature(name, fishingExperience, chatColor, rare, rarity, lootshare)
+                val creature = SeaCreature(name, fishingExperience, chatColor, rare, rarity, lootshareSphere)
                 seaCreatureMap[chatMessage] = creature
                 for (alternateMessage in seaCreature.alternateMessages.orEmpty()) {
                     seaCreatureMap[alternateMessage] = creature

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -124,8 +124,9 @@ object SeaCreatureManager {
                 val fishingExperience = seaCreature.fishingExperience
                 val rarity = seaCreature.rarity
                 val rare = seaCreature.rare
+                val lootshare = seaCreature.lootshareSphereOverride
 
-                val creature = SeaCreature(name, fishingExperience, chatColor, rare, rarity)
+                val creature = SeaCreature(name, fishingExperience, chatColor, rare, rarity, lootshare)
                 seaCreatureMap[chatMessage] = creature
                 for (alternateMessage in seaCreature.alternateMessages.orEmpty()) {
                     seaCreatureMap[alternateMessage] = creature

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/seaCreatureXMLGui/SpecificSeaCreatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/seaCreatureXMLGui/SpecificSeaCreatures.kt
@@ -63,7 +63,7 @@ class SpecificSeaCreatures(
                     SpecificSeaCreatureStorageXMLHelper(
                         SpecificSeaCreatureSettings(
                             name,
-                            shouldRenderLootshare = seaCreature.rare,
+                            shouldRenderLootshare = seaCreature.lootshareSphereOverride ?: seaCreature.rare,
                             shouldShowHealthOverlay = seaCreature.rare,
                             shouldShareInChat = seaCreature.rare,
                             shouldShowKillTime = seaCreature.rare,
@@ -88,7 +88,7 @@ class SpecificSeaCreatures(
                     SpecificSeaCreatureStorageXMLHelper(
                         SpecificSeaCreatureSettings(
                             name,
-                            shouldRenderLootshare = seaCreature.rare,
+                            shouldRenderLootshare = seaCreature.lootshareSphereOverride ?: seaCreature.rare,
                             shouldShowHealthOverlay = seaCreature.rare,
                             shouldShareInChat = seaCreature.rare,
                             shouldShowKillTime = seaCreature.rare,


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/658

## What
Yeah maybe we shouldn't show an LS sphere for the mob that can't be lootshared

## Changelog Fixes
+ Fixed Reindrake LS Sphere being on by default. - Fazfoxy