### PR TITLE
Backend: KSerializable Cleanup + Unit Tests

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/KSerializable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KSerializable.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
 package at.hannibal2.skyhanni.utils
 
 import com.google.gson.Gson
@@ -12,6 +14,8 @@ import com.google.gson.stream.JsonWriter
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
+import kotlin.reflect.full.allSuperclasses
+import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.memberProperties
@@ -28,7 +32,7 @@ import com.google.gson.internal.`$Gson$Types` as InternalGsonTypes
 annotation class KSerializable
 
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.CLASS)
+@Target(AnnotationTarget.VALUE_PARAMETER)
 annotation class ExtraData
 
 class KotlinTypeAdapterFactory : TypeAdapterFactory {
@@ -40,40 +44,96 @@ class KotlinTypeAdapterFactory : TypeAdapterFactory {
         val field: KProperty1<Any, Any?>,
     )
 
+    /**
+     * Resolves the backing property for [param] in [kotlinClass].
+     *
+     * Tries [KClass.memberProperties] first (covers all visible inherited properties),
+     * then falls back to searching [KClass.allSuperclasses] declared properties to handle
+     * the case where the property is private in a superclass and therefore not visible
+     * from the child's [KClass.memberProperties].
+     *
+     * @param param The constructor parameter to resolve a backing property for.
+     * @param kotlinClass The data class being deserialized.
+     */
     @Suppress("UNCHECKED_CAST")
-    @OptIn(ExperimentalStdlibApi::class)
+    private fun resolveField(param: KParameter, kotlinClass: KClass<*>): KProperty1<Any, Any?>? {
+        val found = kotlinClass.memberProperties.singleOrNull { it.name == param.name }
+            ?: kotlinClass.allSuperclasses
+                .flatMap { it.declaredMemberProperties }
+                .find { it.name == param.name }
+        return found as? KProperty1<Any, Any?>
+    }
+
+    /**
+     * Finds the constructor parameter annotated with [ExtraData] and its corresponding property,
+     * if present. The parameter must be of type [MutableMap]<[String], [JsonElement]>.
+     *
+     * @param kotlinClass The data class being deserialized.
+     * @param primaryConstructorParams All parameters of the primary constructor.
+     */
+    private fun buildExtraDataParam(
+        kotlinClass: KClass<*>,
+        primaryConstructorParams: List<KParameter>,
+    ): Pair<KParameter, KProperty1<Any, Map<String, JsonElement>>>? {
+        val param = primaryConstructorParams.find {
+            it.findAnnotation<ExtraData>() != null &&
+                typeOf<MutableMap<String, JsonElement>>().isSubtypeOf(it.type)
+        } ?: return null
+        @Suppress("UNCHECKED_CAST")
+        val property = kotlinClass.memberProperties.find {
+            it.name == param.name && it.returnType.isSubtypeOf(typeOf<Map<String, JsonElement>>())
+        } as? KProperty1<Any, Map<String, JsonElement>> ?: return null
+        property.isAccessible = true
+        return param to property
+    }
+
+    /**
+     * Builds the map of JSON key to [ParameterInfo] used by both the reader and writer.
+     * Resolves each parameter's backing property via [resolveField], determines the JSON key
+     * from [SerializedName] (falling back to the parameter name), and selects the appropriate
+     * [TypeAdapter] from [gson].
+     *
+     * @param kotlinClass The data class being serialized/deserialized.
+     * @param gson The Gson instance to source type adapters from.
+     * @param type The [TypeToken] for [kotlinClass], used for generic type resolution.
+     * @param params The non-[ExtraData] primary constructor parameters to process.
+     */
+    private fun <T : Any> buildParameterInfos(
+        kotlinClass: KClass<T>,
+        gson: Gson,
+        type: TypeToken<T>,
+        params: List<KParameter>,
+    ): Map<String, ParameterInfo> = params.mapNotNull { param ->
+        val field = resolveField(param, kotlinClass) ?: return@mapNotNull null
+        runCatching { field.isAccessible = true }.getOrNull() ?: return@mapNotNull null
+        val kType = field.returnType
+        val name = param.findAnnotation<SerializedName>()?.value
+            ?: field.findAnnotation<SerializedName>()?.value
+            ?: field.javaField?.getAnnotation(SerializedName::class.java)?.value
+            ?: param.name!!
+        val javaTypeForAdapter = if (kType.jvmErasure.java.isAnnotationPresent(JvmInline::class.java)) {
+            kType.jvmErasure.java
+        } else {
+            InternalGsonTypes.resolve(type.type, type.rawType, kType.javaType)
+        }
+        @Suppress("UNCHECKED_CAST")
+        val adapter = gson.getAdapter(TypeToken.get(javaTypeForAdapter)) as TypeAdapter<Any?>
+        ParameterInfo(param, adapter, name, field)
+    }.associateBy { it.name }
+
+    @Suppress("UNCHECKED_CAST")
     override fun <T : Any> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T>? {
-        val kotlinClass = type.rawType.kotlin as KClass<T>
-        if (kotlinClass.findAnnotation<KSerializable>() == null) return null
-        if (!kotlinClass.isData) return null
-        val primaryConstructor = kotlinClass.primaryConstructor ?: return null
+        val kotlinClass = (type.rawType.kotlin as KClass<T>).takeIf {
+            it.findAnnotation<KSerializable>() != null && it.isData
+        } ?: return null
+
+        val primaryConstructor = kotlinClass.primaryConstructor?.apply {
+            isAccessible = true
+        } ?: return null
+
         val params = primaryConstructor.parameters.filter { it.findAnnotation<ExtraData>() == null }
-        val extraDataParam = primaryConstructor.parameters
-            .find { it.findAnnotation<ExtraData>() != null && typeOf<MutableMap<String, JsonElement>>().isSubtypeOf(it.type) }
-            ?.let { param ->
-                param to kotlinClass.memberProperties.find {
-                    it.name == param.name && it.returnType.isSubtypeOf(typeOf<Map<String, JsonElement>>())
-                } as KProperty1<Any, Map<String, JsonElement>>
-            }
-        val parameterInfos = params.mapNotNull { param ->
-            val field = kotlinClass.memberProperties.single { it.name == param.name } as KProperty1<Any, Any?>
-            kotlin.runCatching {
-                field.isAccessible = true
-            }.getOrNull() ?: return@mapNotNull null
-            val kType = field.returnType
-            val name = param.findAnnotation<SerializedName>()?.value
-                ?: field.findAnnotation<SerializedName>()?.value
-                ?: field.javaField?.getAnnotation(SerializedName::class.java)?.value
-                ?: param.name!!
-
-            val javaTypeForAdapter = if (kType.jvmErasure.java.isAnnotationPresent(JvmInline::class.java)) kType.jvmErasure.java
-            else InternalGsonTypes.resolve(type.type, type.rawType, kType.javaType)
-
-            val token = TypeToken.get(javaTypeForAdapter)
-            @Suppress("UNCHECKED_CAST")
-            val adapter = gson.getAdapter(token) as TypeAdapter<Any?>
-            ParameterInfo(param, adapter, name, field)
-        }.associateBy { it.name }
+        val extraDataParam = buildExtraDataParam(kotlinClass, primaryConstructor.parameters)
+        val parameterInfos = buildParameterInfos(kotlinClass, gson, type, params)
         val jsonElementAdapter = gson.getAdapter(JsonElement::class.java)
 
         return object : TypeAdapter<T>() {
@@ -82,19 +142,21 @@ class KotlinTypeAdapterFactory : TypeAdapterFactory {
                     out.nullValue()
                     return
                 }
+                val prevSerializeNulls = out.serializeNulls
+                out.serializeNulls = true
                 out.beginObject()
                 for ((name, paramInfo) in parameterInfos) {
                     out.name(name)
                     paramInfo.adapter.write(out, paramInfo.field.get(value))
                 }
                 if (extraDataParam != null) {
-                    val extraData = extraDataParam.second.get(value)
-                    for ((extraName, extraValue) in extraData) {
+                    for ((extraName, extraValue) in extraDataParam.second.get(value)) {
                         out.name(extraName)
                         jsonElementAdapter.write(out, extraValue)
                     }
                 }
                 out.endObject()
+                out.serializeNulls = prevSerializeNulls
             }
 
             override fun read(reader: JsonReader): T? {
@@ -112,8 +174,7 @@ class KotlinTypeAdapterFactory : TypeAdapterFactory {
                         extraData[name] = jsonElementAdapter.read(reader)
                         continue
                     }
-                    val value = paramData.adapter.read(reader)
-                    args[paramData.param] = value
+                    args[paramData.param] = paramData.adapter.read(reader)
                 }
                 reader.endObject()
                 if (extraDataParam != null) {
@@ -123,10 +184,10 @@ class KotlinTypeAdapterFactory : TypeAdapterFactory {
                     return primaryConstructor.callBy(args)
                 } catch (e: IllegalArgumentException) {
                     val errorString = buildString {
-                        appendLine("❗ Failed to invoke constructor for ${kotlinClass.simpleName}")
+                        appendLine("Failed to invoke constructor for ${kotlinClass.simpleName}")
                         appendLine("  Reason: ${e.message}")
                         args.forEach { (param, value) ->
-                            appendLine("  • ${param.name} : expected=${param.type}  value=$value  actualType=${value?.javaClass}")
+                            appendLine("  - ${param.name} : expected=${param.type} value=$value actualType=${value?.javaClass}")
                         }
                     }
                     System.err.println(errorString)

--- a/src/test/java/at/hannibal2/skyhanni/test/utils/KSerializableTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/utils/KSerializableTest.kt
@@ -1,0 +1,170 @@
+package at.hannibal2.skyhanni.test.utils
+
+import at.hannibal2.skyhanni.utils.ExtraData
+import at.hannibal2.skyhanni.utils.KSerializable
+import at.hannibal2.skyhanni.utils.KotlinTypeAdapterFactory
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonElement
+import com.google.gson.JsonParser
+import com.google.gson.JsonPrimitive
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class KSerializableTest {
+
+    private val gson = GsonBuilder()
+        .registerTypeAdapterFactory(KotlinTypeAdapterFactory())
+        .create()
+
+    @KSerializable
+    private data class Simple(val name: String, val count: Int)
+
+    @KSerializable
+    private data class WithRename(
+        @SerializedName("full_name") val name: String,
+        val age: Int,
+    )
+
+    @KSerializable
+    private data class WithDefault(val name: String, val count: Int = 42)
+
+    @KSerializable
+    private data class WithNullable(val value: String?)
+
+    @KSerializable
+    private data class Inner(val x: Int)
+
+    @KSerializable
+    private data class Outer(val inner: Inner, val label: String)
+
+    private abstract class LowestBase(lowest: Long, lowestVolume: Int) {
+        val combined: String = "$lowest/$lowestVolume"
+    }
+
+    @KSerializable
+    private data class WithInheritance(
+        val name: String,
+        val lowest: Long,
+        val lowestVolume: Int,
+    ) : LowestBase(lowest, lowestVolume)
+
+    @KSerializable
+    private data class WithExtra(
+        val known: String,
+        @ExtraData val extras: MutableMap<String, JsonElement> = mutableMapOf(),
+    )
+
+    private data class NotAnnotated(val x: Int)
+
+    @KSerializable
+    private class NotDataClass(val x: Int)
+
+    // Read
+
+    @Test
+    fun `basic deserialization reads all fields`() {
+        val result = gson.fromJson("""{"name":"hello","count":5}""", Simple::class.java)
+        assertEquals(Simple("hello", 5), result)
+    }
+
+    @Test
+    fun `SerializedName deserialization reads renamed key`() {
+        val result = gson.fromJson("""{"full_name":"Alice","age":30}""", WithRename::class.java)
+        assertEquals(WithRename("Alice", 30), result)
+    }
+
+    @Test
+    fun `missing optional field uses Kotlin default value`() {
+        val result = gson.fromJson("""{"name":"test"}""", WithDefault::class.java)
+        assertEquals(WithDefault("test", 42), result)
+    }
+
+    @Test
+    fun `null value deserializes to null`() {
+        val result = gson.fromJson("""{"value":null}""", WithNullable::class.java)
+        assertNull(result?.value)
+    }
+
+    @Test
+    fun `nested KSerializable type deserializes correctly`() {
+        val result = gson.fromJson("""{"inner":{"x":7},"label":"hi"}""", Outer::class.java)
+        assertEquals(Outer(Inner(7), "hi"), result)
+    }
+
+    @Test
+    fun `data class extending abstract base deserializes fields from superclass`() {
+        val result = gson.fromJson(
+            """{"name":"item","lowest":100,"lowestVolume":5}""",
+            WithInheritance::class.java,
+        )
+        assertEquals("item", result.name)
+        assertEquals("100/5", result.combined)
+    }
+
+    @Test
+    fun `ExtraData deserialization captures unknown fields`() {
+        val result = gson.fromJson("""{"known":"yes","extra1":"a","extra2":42}""", WithExtra::class.java)
+        assertEquals("yes", result.known)
+        assertEquals(2, result.extras.size)
+        assertEquals("a", result.extras["extra1"]?.asString)
+        assertEquals(42, result.extras["extra2"]?.asInt)
+    }
+
+    @Test
+    fun `non-annotated class returns null from factory`() {
+        val adapter = KotlinTypeAdapterFactory().create(gson, TypeToken.get(NotAnnotated::class.java))
+        assertNull(adapter)
+    }
+
+    @Test
+    fun `non-data class annotated with KSerializable returns null from factory`() {
+        val adapter = KotlinTypeAdapterFactory().create(gson, TypeToken.get(NotDataClass::class.java))
+        assertNull(adapter)
+    }
+
+    // Write
+
+    @Test
+    fun `basic serialization emits all fields`() {
+        val result = gson.toJson(Simple("hello", 5))
+        assertEquals("""{"name":"hello","count":5}""", result)
+    }
+
+    @Test
+    fun `SerializedName serialization uses annotation key`() {
+        val result = gson.toJson(WithRename("Alice", 30))
+        assertEquals("""{"full_name":"Alice","age":30}""", result)
+    }
+
+    @Test
+    fun `ExtraData serialization emits extra fields at top level`() {
+        val obj = WithExtra("yes", mutableMapOf("extra1" to JsonPrimitive("abc")))
+        val parsed = JsonParser.parseString(gson.toJson(obj)).asJsonObject
+        assertEquals("yes", parsed["known"]?.asString)
+        assertEquals("abc", parsed["extra1"]?.asString)
+    }
+
+    @Test
+    fun `null value serializes as JSON null`() {
+        val result = gson.toJson(WithNullable(null))
+        assertEquals("""{"value":null}""", result)
+    }
+
+    @Test
+    fun `nested KSerializable type serializes correctly`() {
+        val result = gson.toJson(Outer(Inner(7), "hi"))
+        assertEquals("""{"inner":{"x":7},"label":"hi"}""", result)
+    }
+
+    @Test
+    fun `inheritance serialization emits own and inherited constructor fields`() {
+        val obj = WithInheritance("item", 100L, 5)
+        val parsed = JsonParser.parseString(gson.toJson(obj)).asJsonObject
+        assertEquals("item", parsed["name"]?.asString)
+        assertEquals(100L, parsed["lowest"]?.asLong)
+        assertEquals(5, parsed["lowestVolume"]?.asInt)
+    }
+}


### PR DESCRIPTION
## What
(This was pulled out of #5532)
A little bit of cleanup to KSerializable, to allow it to properly serialize inherited fields.
Wrote unit tests to cover it.

## Changelog Technical Details
+ Fixed serialization of inherited fields in KSerializable. - Daveed
+ Added unit tests for KSerializable. - Daveed
