### PR TITLE
Backend: Remove outdated note from fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,6 +1,5 @@
 {
     "custom": {
-        "_note": "If you make changes here you must also make changes to all other fabric.mod.json files in other versions.",
         "modmenu": {
             "update_checker": true,
             "links": {


### PR DESCRIPTION
There are no longer multiple `fabric.mod.json` files that need to be edited, it's all handled by Stonecutter.

exclude_from_changelog