### PR TITLE
Backend: Mark as incompatible with clientspoofer

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -54,6 +54,7 @@
         "minecraft": "${minecraft}"
     },
     "breaks": {
+        "clientspoofer": "*",
         "exordium": "*"
     },
     "contact": {


### PR DESCRIPTION
## What
Per the [Modrinth page](https://modrinth.com/mod/clientspoofer):

> Blocks custom payload packets

This is going to silently break any Hypixel Mod API integrations. We may not be using much of those right now, but we definitely plan to in the near future.

exclude_from_changelog