### PR TITLE
Fix: Composter Display Showing When Disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -174,7 +174,7 @@ object ComposterDisplay {
             } else "?"
         } ?: "§cJoin SkyBlock to show composter timer."
 
-        if (SkyBlockUtils.inSkyBlock && !GardenApi.inGarden() && !config.displayOutsideGarden) return
+        if (GardenApi.inGarden() || SkyBlockUtils.inSkyBlock && !config.displayOutsideGarden) return
         val outsideGardenDisplay = Renderable.horizontal {
             addItemStack(bucket)
             addString("§b$format")


### PR DESCRIPTION
## What
Fixes the "Outside of Garden" version showing in the Garden and when disabled.
[Bug Report Thread](https://canary.discord.com/channels/997079228510117908/1491877136712339697/1491877136712339697)

## Changelog Fixes
+ Fixed the Composter Display showing when disabled. - Alex