### PR TITLE
Fix: Composter display always showing in garden

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterDisplay.kt
@@ -174,7 +174,8 @@ object ComposterDisplay {
             } else "?"
         } ?: "§cJoin SkyBlock to show composter timer."
 
-        if (SkyBlockUtils.inSkyBlock && !GardenApi.inGarden() && !config.displayOutsideGarden) return
+        if (GardenApi.inGarden()) return
+        if (SkyBlockUtils.inSkyBlock && !config.displayOutsideGarden) return
         val outsideGardenDisplay = Renderable.horizontal {
             addItemStack(bucket)
             addString("§b$format")


### PR DESCRIPTION
## What
Fixes the outside garden composter display (bucket and time) always showing in the garden even with all toggles off.
Saying the outside garden composter display is kind of wordy and confusing, so I simplified it and sacrificed accuracy for the changelog.
https://discord.com/channels/997079228510117908/1000669238035497022/1492059464642203768
<details>
<summary>Images</summary>
<img width="427" height="115" alt="image" src="https://github.com/user-attachments/assets/8558e8ab-4d1b-41ee-beaa-2b5877dfd665" />
</details>


## Changelog Fixes
+ Fixed composter display always showing in the garden. - Obsidian