### PR TITLE
Fix: Force Entity rendering over background in Wardrobe

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -362,7 +362,12 @@ object CustomWardrobe {
 
                 val playerRenderable = createFakePlayerRenderable(slot, playerWidth, containerHeight, containerWidth)
 
-                Renderable.doubleLayered(playerBackground, playerRenderable, false)
+                Renderable.doubleLayered(
+                    playerBackground,
+                    playerRenderable,
+                    blockBottomHover = false,
+                    forceBottomRenderFirst = true
+                )
             }
             Renderable.horizontal(slotsRenderables, horizontalSpacing)
         }


### PR DESCRIPTION
## What
Fixes the Wardrobe entity rendering not on the top layer

<details>
<summary>Images</summary>

<img width="569" height="339" alt="image" src="https://github.com/user-attachments/assets/d082bb97-f547-46f8-a625-a33171b8df13" />

</details>

## Changelog Fixes
+ Fixed Wardrobe background rendering over entities. - FabiHBBBT
