### PR TITLE
Fix: Enchanted Book Name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -94,8 +94,18 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
+// TODO refactor
 @Suppress("LargeClass")
 object ItemUtils {
+
+    private val patternGroup = RepoPattern.group("utils.item")
+
+    // <editor-fold desc="Patterns">
+    private val anvilCombinablePattern by patternGroup.pattern(
+        "anvil-combinable",
+        "Combinable in Anvil",
+    )
+    // </editor-fold>
 
     private val itemNameCache = mutableMapOf<NeuInternalName, String>() // internal name -> item name
     private val compactItemNameCache = mutableMapOf<NeuInternalName, String>() // internal name -> compact item name
@@ -678,7 +688,15 @@ object ItemUtils {
 
         // show enchanted book name
         if (itemStack.getItemCategoryOrNull() == ItemCategory.ENCHANTED_BOOK) {
-            return ReplaceRomanNumerals.replaceLine(itemStack.getLore()[0])
+            val enchantName = itemStack.getLore().firstOrNull {
+                val clean = it.removeColor()
+                clean.isNotBlank() && !anvilCombinablePattern.matches(clean)
+            } ?: run {
+                val name = toString()
+                addMissingRepoItem(name, "Could not find enchanted book name for $name")
+                return "§c$name"
+            }
+            return ReplaceRomanNumerals.replaceLine(enchantName)
         }
         if (name.endsWith("Enchanted Book Bundle")) {
             return name.replace("Enchanted Book", ReplaceRomanNumerals.replaceLine(itemStack.getLore()[0]).removeColor())

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -93,8 +93,8 @@ import kotlin.time.Duration.Companion.INFINITE
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-@SkyHanniModule
 // TODO refactor
+@SkyHanniModule
 @Suppress("LargeClass")
 object ItemUtils {
 


### PR DESCRIPTION
## What
Hypixel changed the lore of enchanted books so that there is now a "Combinable in Anvil" line and a blank line before the enchantment name. This PR fixes parsing of the enchant name for lores obtained from the NEU repo. A good test case right now is Habanero Tactics, as that was already updated to the new format and is currently recognized as "Combinable in Anvil" rather than "Habanero Tactics IV/V".

I kept the deprecated `getLore()` function here since we need to return the string with color codes and I don't want to scope creep this to refactor the whole item name cache and everything to use components.

## Changelog Fixes
+ Fixed some enchantments being named Combinable in the Anvil instead of their actual name in Estimated Item Value. - Luna