### PR TITLE
Improvement: Use ServerTime for LocalDifficulty mixin

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinDebugEntryLocalDifficulty.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinDebugEntryLocalDifficulty.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers;
-//? > 1.21.9 < 26.1 {
+//? < 26.1 {
+import at.hannibal2.skyhanni.utils.ServerTime;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
 import net.minecraft.client.gui.components.debug.DebugEntryLocalDifficulty;
@@ -19,7 +20,7 @@ public class MixinDebugEntryLocalDifficulty {
         Minecraft minecraftClient = Minecraft.getInstance();
         Entity entity = minecraftClient.getCameraEntity();
         if (entity != null && minecraftClient.level != null && (chunk == null || world == null)) {
-            long time = minecraftClient.level.getDayTime();
+            long time = ServerTime.getDayTime();
             lines.addLine("Local Difficulty: ?? (Day " + time / 24000L + ")");
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ServerTime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ServerTime.kt
@@ -7,11 +7,16 @@ import net.minecraft.network.protocol.game.ClientboundSetTimePacket
 
 @SkyHanniModule
 object ServerTime {
+    /**
+     * The current in-game day time reported by the server,
+     * unaffected by time-changing mods with invasive mixins.
+     */
+    @JvmStatic
     var dayTime: Long = 0L
         private set
 
     @HandleEvent
-    fun onPacketReceived(event: PacketReceivedEvent) {
+    internal fun onPacketReceived(event: PacketReceivedEvent) {
         val packet = event.packet as? ClientboundSetTimePacket ?: return
         dayTime = packet.dayTime
     }


### PR DESCRIPTION
## What
Migrated `MixinDebugEntryLocalDifficulty` to use `ServerTime` and added a quick KDoc to `ServerTime.dayTime`.

## Changelog Improvements
+ The day counter fix in the debug menu (F3) now works correctly when using a time changer mod. - Luna