### PR TITLE
Fix: Easter Egg and Lumber Jack NPC coordinates

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/lobby/waypoints/easter/EasterEggWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/lobby/waypoints/easter/EasterEggWaypoints.kt
@@ -64,6 +64,7 @@ object EasterEggWaypoints {
         val notFoundEggs = EasterEgg.entries.filter { !it.found }
         if (notFoundEggs.isEmpty()) return
         val nextEgg = notFoundEggs.minByOrNull { it.waypoint.distanceSqToPlayer() } ?: error("next easter egg is null")
+        if (IslandGraphs.currentIslandGraph == null) return
         closest = nextEgg
 
         IslandGraphs.pathFind(

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTutorialQuest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTutorialQuest.kt
@@ -24,7 +24,7 @@ object ForagingTutorialQuest {
     private var lastSuggestion = SimpleTimeMark.farPast()
 
     private enum class Quest(val questName: String, val npcName: String, val npcLocation: LorenzVec) {
-        FIRST("Foraging Tutorial", "Lumber Jack", LorenzVec(-112.2, 73.0, -36.9)),
+        FIRST("Foraging Tutorial", "Lumber Jack", LorenzVec(-123.5, 74.0, -30.0)),
         SECOND("Into the Woods", "Charlie", LorenzVec(-275.9, 80.0, -17.1)),
         THIRD("A Helping Hand", "Kelly", LorenzVec(-350.8, 94.0, 31.7)),
         FOURTH("The Campfire Cult", "Ryan", LorenzVec(-362.7, 102.0, -90.5)),


### PR DESCRIPTION
## What
- Fixed `EasterEggWaypoints` Not work.
- Updated Lumber Jack NPC coordinates in `ForagingTutorialQuest`.

## Changelog Fixes
+ Fixed Easter Egg waypoint not working. - LegentPc
+ Fixed Lumber Jack NPC coordinates in Foraging Tutorial Quest. - LegentPc