### PR TITLE
Fix: Hide Far Deaths hiding own deaths

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PlayerDeathMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PlayerDeathMessages.kt
@@ -33,6 +33,8 @@ object PlayerDeathMessages {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onAllowPlayerDeath(event: PlayerDeathEvent.Allow) {
+        if (event.isSelf) return
+
         val lastTime = lastTimePlayerSeen[event.name] ?: SimpleTimeMark.farPast()
         val time = lastTime.passedSince() > 30.seconds
 


### PR DESCRIPTION
## What
Fixed a missing `isSelf` check in Hide Far Deaths after a recent refactor fixed the event not firing on own deaths.

## Changelog Fixes
+ Fixed Hide Far Deaths incorrectly hiding the player's own deaths. - Luna