### PR TITLE
Fix: FactionType NPE

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/HypixelPlayerApiJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/HypixelPlayerApiJson.kt
@@ -38,5 +38,5 @@ data class HypixelApiTrophyFish(
 data class HypixelApiFactionInfo(
     @Expose @SerializedName("barbarians_reputation") val barbarianReputation: Int,
     @Expose @SerializedName("mages_reputation") val mageReputation: Int,
-    @Expose @SerializedName("selected_faction") val currentFaction: String,
+    @Expose @SerializedName("selected_faction") val currentFaction: String?,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/FactionType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/FactionType.kt
@@ -17,6 +17,6 @@ enum class FactionType(val factionName: String, val apiName: String) {
 
     companion object {
         fun fromName(name: String): FactionType? = entries.firstOrNull { it.factionName.equals(name, ignoreCase = true) }
-        fun fromAPIName(name: String): FactionType? = entries.firstOrNull { it.apiName.equals(name, ignoreCase = true) }
+        fun fromAPIName(name: String?): FactionType? = entries.firstOrNull { it.apiName.equals(name, ignoreCase = true) }
     }
 }


### PR DESCRIPTION
## What
Fixes `FactionType.fromAPIName` expecting the argument to be non-nullable when it can be null.

## Changelog Fixes
+ Fixed error with SkyBlock Profile Viewer for players that have no selected Crimson Isle faction. - Luna

