### PR TITLE
Fix: Crash due to BackgroundDrawnEvent missing PrimaryFunction

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer
 import net.minecraft.client.gui.GuiGraphics
@@ -10,6 +11,7 @@ import net.minecraft.world.item.ItemStack
 
 abstract class GuiContainerEvent(open val gui: SkyHanniGuiContainer, open val container: AbstractContainerMenu) : SkyHanniEvent() {
 
+    @PrimaryFunction("onBackgroundDrawn")
     data class BackgroundDrawnEvent(
         override val context: GuiGraphics,
         override val gui: SkyHanniGuiContainer,


### PR DESCRIPTION
## What
I went overboard removing "unrelated changes" from #5530 and this didn't get caught at compile time. This needs a 7.16.1 release or whatever you want to call it ASAP.

## Changelog Fixes
+ Fixed game crashing on startup. - Luna