### PR TITLE
Backend: Wiki npc location comparator

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
@@ -33,6 +33,18 @@ enum class IslandTypeTag(vararg types: SkyHanniIslandType) : SkyHanniIslandType 
 
     /** Busy islands are islands where a player is doing something considered 'important'. */
     BUSY(IslandType.DARK_AUCTION, IslandType.MINESHAFT, IslandType.THE_RIFT, IslandType.NONE, IslandType.UNKNOWN),
+
+    /** islands without npc locations that are fixed. */
+    NO_FIXED_NPC_LOCATIONS(
+        IslandType.PRIVATE_ISLAND, IslandType.PRIVATE_ISLAND_GUEST, IslandType.KUUDRA_ARENA,
+        IslandType.CATACOMBS,
+        IslandType.GARDEN,
+        IslandType.GARDEN_GUEST,
+        IslandType.MINESHAFT,
+        IslandType.NONE,
+        IslandType.ANY,
+        IslandType.UNKNOWN,
+    ),
     ;
 
     private val types: EnumSet<IslandType> = types.fold(
@@ -52,7 +64,9 @@ enum class IslandTypeTag(vararg types: SkyHanniIslandType) : SkyHanniIslandType 
         newValues.mapNotNullTo(types) { EnumUtils.enumValueOfOrNull<IslandType>(it.uppercase()) }
     }
 
-    override fun isInIsland(): Boolean = SkyBlockUtils.inSkyBlock && SkyBlockUtils.currentIsland in types
+    override fun isInIsland(): Boolean = SkyBlockUtils.inSkyBlock && contains(SkyBlockUtils.currentIsland)
+
+    operator fun contains(type: IslandType) = type in types
 
     @SkyHanniModule
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -37,7 +37,6 @@ object NavigationHelper {
         GraphNodeTag.GRIND_MOBS,
         GraphNodeTag.GRIND_ORES,
         GraphNodeTag.GRIND_CROPS,
-        GraphNodeTag.MINES_EMISSARY,
         GraphNodeTag.CRIMSON_MINIBOSS,
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/test/WikiNpcComparator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/WikiNpcComparator.kt
@@ -28,7 +28,7 @@ object WikiNpcComparator {
             legacyCallbackArgs {
                 CoroutineSettings("compare wiki npc data").launchCoroutine {
                     val result = mutableListOf<String>()
-                    val wikiNpcs = loadWiki(result) ?: return@launchCoroutine
+                    val wikiNpcs = customRules(loadWiki(result)) ?: return@launchCoroutine
                     val shNpcs = loadShNpcs(result) ?: return@launchCoroutine
                     compare(result, shNpcs, wikiNpcs)
                 }
@@ -36,7 +36,22 @@ object WikiNpcComparator {
         }
     }
 
-    private fun loadWiki(result: MutableList<String>): Map<IslandType, Map<String, LorenzVec>>? {
+    private fun customRules(raw: MutableMap<IslandType, MutableMap<String, LorenzVec>>?): MutableMap<IslandType, MutableMap<String, LorenzVec>>? {
+        if (raw == null) return null
+        for ((island, names) in raw) {
+            for ((name, location) in names.toMutableMap()) {
+                if (name.contains(" (Dwarven)")) {
+                    val updatedName = name.removeSuffix(" (Dwarven)")
+                    names[updatedName] = location
+                    names.remove(name)
+                }
+            }
+        }
+
+        return raw
+    }
+
+    private fun loadWiki(result: MutableList<String>): MutableMap<IslandType, MutableMap<String, LorenzVec>>? {
         val clipboard = OSUtils.readFromClipboard() ?: run {
             ChatUtils.userError("clipboard does not contain a string")
             return null
@@ -57,28 +72,38 @@ object WikiNpcComparator {
     }
 
     // TODO do this once on skyblock join, then store until repo reload.
-    private suspend fun loadShNpcs(result: MutableList<String>): MutableMap<IslandType, Map<String, LorenzVec>>? {
-        val shNpcs = mutableMapOf<IslandType, Map<String, LorenzVec>>()
+    private suspend fun loadShNpcs(result: MutableList<String>): MutableMap<IslandType, MutableMap<String, LorenzVec>>? {
+        val shNpcs = mutableMapOf<IslandType, MutableMap<String, LorenzVec>>()
+
+        val islands = mutableMapOf<String, IslandType>()
         for (islandType in IslandType.entries) {
             if (islandType in IslandTypeTag.NO_FIXED_NPC_LOCATIONS) continue
+            islands[islandType.name] = islandType
+        }
+        islands["GLACITE_TUNNELS"] = IslandType.DWARVEN_MINES
+
+        for ((name, type) in islands) {
             val graph = runCatching {
                 SkyHanniRepoManager.getRepoDataAsync<Graph>(
-                    "constants/island_graphs", islandType.name, gson = Graph.gson,
+                    "constants/island_graphs", name, gson = Graph.gson,
                 )
             }.getOrElse {
-                result.add("failed to load island graph for island $islandType")
+                result.add("failed to load island graph for island $name")
                 continue
             }
 
             val npcs = mutableMapOf<String, LorenzVec>()
             for (node in graph) {
                 if (node.hasTag(GraphNodeTag.NPC)) {
-                    val name = node.name ?: error("name is null for npc node at ${node.position} in island $islandType")
+                    val name = node.name ?: error("name is null for npc node at ${node.position} in island $name")
                     npcs[name] = node.position
                 }
             }
-            if (npcs.isNotEmpty()) shNpcs[islandType] = npcs
+            if (npcs.isNotEmpty()) {
+                shNpcs.getOrPut(type) { mutableMapOf() }.putAll(npcs)
+            }
         }
+
         val total = shNpcs.values.sumOf { it.size }
         result.add("found in total $total npcs in sh repo")
         if (total == 0) {
@@ -121,10 +146,18 @@ object WikiNpcComparator {
 
                     shPos != null && wikiPos != null -> {
                         val dist = shPos.distance(wikiPos)
+                        /**
+                         * this cant be a precise check.
+                         * the wiki uses the block location the npc stands on,
+                         * and skyhanni uses the location of where the user should stand when talking to the npc
+                         * so this is almost never 0 block distance, and often even 2 blocks distance.
+                         */
                         if (dist > 3.0) {
-                            mismatch.add("$name: ${dist.roundTo(1)} blocks away\n" +
-                                "      sh: ${shPos.toChatFormat()}\n" +
-                                "      wiki: ${wikiPos.toChatFormat()}")
+                            mismatch.add(
+                                "$name: ${dist.roundTo(1)} blocks away\n" +
+                                    "      sh: ${shPos.toChatFormat()}\n" +
+                                    "      wiki: ${wikiPos.toChatFormat()}",
+                            )
                         } else {
                             allFine++
                         }

--- a/src/main/java/at/hannibal2/skyhanni/test/WikiNpcComparator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/WikiNpcComparator.kt
@@ -1,0 +1,163 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.SkyHanniMod.launchCoroutine
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.IslandTypeTag
+import at.hannibal2.skyhanni.data.model.graph.Graph
+import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
+import at.hannibal2.skyhanni.data.repo.SkyHanniRepoManager
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
+import at.hannibal2.skyhanni.utils.OSUtils
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
+import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
+
+@SkyHanniModule
+object WikiNpcComparator {
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shcomparewikinpc") {
+            description = "Compare NPC locations from wiki (clipboard) with SkyHanni graph data."
+            category = CommandCategory.DEVELOPER_TEST
+            legacyCallbackArgs {
+                CoroutineSettings("compare wiki npc data").launchCoroutine {
+                    val result = mutableListOf<String>()
+                    val wikiNpcs = loadWiki(result) ?: return@launchCoroutine
+                    val shNpcs = loadShNpcs(result) ?: return@launchCoroutine
+                    compare(result, shNpcs, wikiNpcs)
+                }
+            }
+        }
+    }
+
+    private fun loadWiki(result: MutableList<String>): Map<IslandType, Map<String, LorenzVec>>? {
+        val clipboard = OSUtils.readFromClipboard() ?: run {
+            ChatUtils.userError("clipboard does not contain a string")
+            return null
+        }
+        val wikiNpcs = WikiNpcParser.parse(clipboard)
+        val total = wikiNpcs.values.sumOf { it.size }
+        result.add("found in total $total npcs in wiki")
+        if (total == 0) {
+            ChatUtils.clickableChat(
+                "found no npc data in the html file, click here to copy.",
+                onClick = {
+                    OSUtils.openBrowser("https://hypixelskyblock.minecraft.wiki/w/NPC/List")
+                },
+            )
+            return null
+        }
+        return wikiNpcs
+    }
+
+    // TODO do this once on skyblock join, then store until repo reload.
+    private suspend fun loadShNpcs(result: MutableList<String>): MutableMap<IslandType, Map<String, LorenzVec>>? {
+        val shNpcs = mutableMapOf<IslandType, Map<String, LorenzVec>>()
+        for (islandType in IslandType.entries) {
+            if (islandType in IslandTypeTag.NO_FIXED_NPC_LOCATIONS) continue
+            val graph = runCatching {
+                SkyHanniRepoManager.getRepoDataAsync<Graph>(
+                    "constants/island_graphs", islandType.name, gson = Graph.gson,
+                )
+            }.getOrElse {
+                result.add("failed to load island graph for island $islandType")
+                continue
+            }
+
+            val npcs = mutableMapOf<String, LorenzVec>()
+            for (node in graph) {
+                if (node.hasTag(GraphNodeTag.NPC)) {
+                    val name = node.name ?: error("name is null for npc node at ${node.position} in island $islandType")
+                    npcs[name] = node.position
+                }
+            }
+            if (npcs.isNotEmpty()) shNpcs[islandType] = npcs
+        }
+        val total = shNpcs.values.sumOf { it.size }
+        result.add("found in total $total npcs in sh repo")
+        if (total == 0) {
+            ChatUtils.chat("no sh npcs loaded via local repo data!")
+            return null
+        }
+        return shNpcs
+    }
+
+    private fun compare(
+        result: MutableList<String>,
+        shNpcs: Map<IslandType, Map<String, LorenzVec>>,
+        wikiNpcs: Map<IslandType, Map<String, LorenzVec>>,
+    ) {
+        val allIslands = (shNpcs.keys + wikiNpcs.keys).sorted()
+
+        var allFine = 0
+        var issues = 0
+        for (island in allIslands) {
+            val sh = shNpcs[island].orEmpty()
+            val wiki = wikiNpcs[island].orEmpty()
+            val allNames = (sh.keys + wiki.keys).sorted()
+            val islandLines = mutableMapOf<String, List<String>>()
+
+            val onlyInSh = mutableListOf<String>()
+            islandLines["Only in skyhanni"] = onlyInSh
+            val onlyInWiki = mutableListOf<String>()
+            islandLines["Only in wiki"] = onlyInWiki
+            val mismatch = mutableListOf<String>()
+            islandLines["mismatch"] = mismatch
+
+            for (name in allNames) {
+                val shPos = sh[name]
+                val wikiPos = wiki[name]
+
+                when {
+                    shPos != null && wikiPos == null -> onlyInSh.add("$name: ${shPos.toChatFormat()}")
+
+                    shPos == null && wikiPos != null -> onlyInWiki.add("$name: ${wikiPos.toChatFormat()}")
+
+                    shPos != null && wikiPos != null -> {
+                        val dist = shPos.distance(wikiPos)
+                        if (dist > 3.0) {
+                            mismatch.add("$name: ${dist.roundTo(1)} blocks away\n" +
+                                "      sh: ${shPos.toChatFormat()}\n" +
+                                "      wiki: ${wikiPos.toChatFormat()}")
+                        } else {
+                            allFine++
+                        }
+                    }
+                }
+            }
+
+            islandLines.removeIf { it.value.isEmpty() }
+            if (islandLines.isNotEmpty()) {
+                result.add("=== $island (sh=${sh.size}, wiki=${wiki.size}) ===")
+                for ((type, list) in islandLines) {
+                    if (list.isEmpty()) continue
+                    result.add("  $type (${list.size})")
+                    list.forEach {
+                        result.add("    $it")
+                        issues++
+                    }
+                }
+            }
+        }
+        result.forEach { println(it) }
+        val total = allFine + issues
+        val percentageIdentical = (allFine.toDouble() / total) / 100
+        ChatUtils.clickableChat(
+            "comparison done: ${percentageIdentical.roundTo(1)}% identical.\n" +
+                "total: $total, all fine: $allFine, issues: $issues.\n" +
+                "see console for more infos or click here to copy to clipboard.",
+            onClick = {
+                CoroutineSettings("put wiki npc comparison data to clipboard").launchCoroutine {
+                    OSUtils.copyToClipboardAsync(result.joinToString("\n"))
+                }
+            },
+        )
+        ChatUtils.chat()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/WikiNpcParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/WikiNpcParser.kt
@@ -1,0 +1,89 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.utils.LorenzVec
+
+/**
+ * This parses the npc locations of the hypixel wiki.
+ *
+ * 1. open https://hypixelskyblock.minecraft.wiki/w/NPC/List
+ * 2. select all
+ * 3. copy
+ * 4. run the string through [parse]
+ */
+object WikiNpcParser {
+
+    private val sectionToIsland = mapOf(
+        "Hub Island" to IslandType.HUB,
+        "The Barn" to IslandType.THE_FARMING_ISLANDS,
+        "Mushroom Desert" to IslandType.THE_FARMING_ISLANDS,
+        "Gold Mine" to IslandType.GOLD_MINES,
+        "Deep Caverns" to IslandType.DEEP_CAVERNS,
+        "Dwarven Mines" to IslandType.DWARVEN_MINES,
+        "Crystal Hollows" to IslandType.CRYSTAL_HOLLOWS,
+        "Spider's Den" to IslandType.SPIDER_DEN,
+        "Spider\u2019s Den" to IslandType.SPIDER_DEN,
+        "Crimson Isle" to IslandType.CRIMSON_ISLE,
+        "Mushroom Desert" to IslandType.THE_FARMING_ISLANDS,
+        "The Park" to IslandType.THE_PARK,
+        "The End" to IslandType.THE_END,
+        "Dungeon Hub" to IslandType.DUNGEON_HUB,
+        "The Catacombs" to IslandType.CATACOMBS,
+        "Winter Island" to IslandType.WINTER,
+        "Rift Dimension" to IslandType.THE_RIFT,
+    )
+
+    fun parse(text: String): Map<IslandType, Map<String, LorenzVec>> {
+        val result = mutableMapOf<IslandType, MutableMap<String, LorenzVec>>()
+        var currentIsland: IslandType? = null
+
+        for (line in text.lines()) {
+            val trimmed = line.trim()
+            if (trimmed == "Removed NPCs") break
+
+            sectionToIsland[trimmed]?.let {
+                currentIsland = it
+                continue
+            }
+
+            if (trimmed.contains("⏣ Dwarven Mines") || trimmed.contains("\u23E3 Dwarven Mines")) {
+                currentIsland = IslandType.DWARVEN_MINES
+                continue
+            }
+
+            val island = currentIsland ?: continue
+
+            if (!line.startsWith("\t")) continue
+
+            val fields = line.split("\t").map { it.trim() }
+            if (fields.size < 5) continue
+
+            val name = fields.getOrNull(1)?.takeIf { it.isNotBlank() } ?: continue
+            if (name.toDoubleOrNull() != null) continue
+            if (name == "Name") continue
+
+            val coords = findCoordinateTriple(fields) ?: continue
+
+            result.getOrPut(island) { mutableMapOf() }[name] = coords
+        }
+
+        println("parsed ${result.values.sumOf { it.size }} npcs from ${result.size} islands")
+        return result
+    }
+
+    private fun findCoordinateTriple(fields: List<String>): LorenzVec? {
+        for (i in 2..fields.size - 3) {
+            val x = parseCoordinate(fields[i]) ?: continue
+            val y = parseCoordinate(fields[i + 1]) ?: continue
+            val z = parseCoordinate(fields[i + 2]) ?: continue
+            return LorenzVec(x, y, z)
+        }
+        return null
+    }
+
+    private fun parseCoordinate(field: String): Double? {
+        val first = field.lines().first().trim()
+        if (first.isBlank() || first.equals("Various", true) || first.equals("Varies", true)) return null
+        return first.toDoubleOrNull()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/WikiNpcParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/WikiNpcParser.kt
@@ -33,7 +33,7 @@ object WikiNpcParser {
         "Rift Dimension" to IslandType.THE_RIFT,
     )
 
-    fun parse(text: String): Map<IslandType, Map<String, LorenzVec>> {
+    fun parse(text: String): MutableMap<IslandType, MutableMap<String, LorenzVec>> {
         val result = mutableMapOf<IslandType, MutableMap<String, LorenzVec>>()
         var currentIsland: IslandType? = null
 


### PR DESCRIPTION
## What
The skyblock wiki has a list of npcs per island type and shows location data there: https://hypixelskyblock.minecraft.wiki/w/NPC/List. skyhanni also stores npc location data in the graph editor.
this pr adds a debug command that compares those two data.

for more info, see the convo in the wiki discord: https://discord.com/channels/651912910972649492/1495890663454277733

<details>
<summary>on first try, the result were those</summary>

```
found in total 244 npcs in wiki
failed to load island graph for island DARK_AUCTION
found in total 445 npcs in sh repo
=== CRIMSON_ISLE (sh=85, wiki=1) ===
  Only in skyhanni (85)
    Alchemage: x: -86, y: 119, z: -772
    Alwin: x: -85, y: 93, z: -735
    An: x: -621, y: 109, z: -742
    Aranya: x: -322, y: 153, z: -1010
    Arba: x: -4, y: 94, z: -822
    Arbadak: x: -2, y: 94, z: -825
    Arch: x: -361, y: 190, z: -552
    Auction House (Mage): x: -61, y: 109, z: -748
    Auction Master (Barbarian): x: -637, y: 103, z: -786
    Aviar: x: -362, y: 118, z: -972
    Avorius: x: -154, y: 129, z: -810
    Baar: x: -638, y: 124, z: -791
    Bank (Barbarian): x: -612, y: 101, z: -788
    Bank (Mage): x: -83, y: 109, z: -776
    Barbarian Emissary: x: -580, y: 100, z: -710
    Bazaar (Barbarian): x: -625, y: 101, z: -796
    Bazaar (Mage): x: -71, y: 108, z: -759
    Bruuh: x: -635, y: 125, z: -689
    Carrolyn: x: 0, y: 104, z: -804
    Chak: x: -603, y: 108, z: -868
    Chief Scorn: x: -583, y: 116, z: -688
    Chihai: x: -605, y: 108, z: -861
    Chuk: x: -606, y: 108, z: -870
    Colore: x: -130, y: 90, z: -712
    Corm: x: -669, y: 127, z: -926
    Crag: x: -372, y: 115, z: -1042
    Cyndarin: x: -205, y: 113, z: -956
    Dean: x: -16, y: 124, z: -883
    Deng: x: -686, y: 103, z: -766
    Desperate Engineer: x: -289, y: 128, z: -983
    Drakuu: x: -325, y: 192, z: -1017
    Edelis: x: -62, y: 108, z: -812
    Elle: x: -364, y: 81, z: -477
    Eludore: x: -102, y: 92, z: -872
    Etc: x: -606, y: 108, z: -868
    Ezekiel: x: -28, y: 108, z: -770
    Gnyl: x: -376, y: 118, z: -972
    Grelius: x: -133, y: 102, z: -753
    Gris: x: -687, y: 117, z: -832
    Grog: x: -664, y: 108, z: -738
    Igor: x: -551, y: 99, z: -707
    Igrupan: x: -31, y: 94, z: -825
    Kaus: x: -595, y: 114, z: -641
    Keran: x: -612, y: 109, z: -669
    Kheharad: x: -113, y: 100, z: -828
    Krevius: x: -133, y: 102, z: -756
    Kutral: x: -659, y: 108, z: -742
    Kuudra Archaeologist: x: -571, y: 112, z: -642
    Kuudra Believer: x: -392, y: 82, z: -702
    Kuudra Loremaster: x: -108, y: 127, z: -818
    Lasea: x: -566, y: 109, z: -658
    Lys: x: -110, y: 100, z: -804
    Mage Emissary: x: -130, y: 90, z: -725
    Marthos: x: -644, y: 102, z: -826
    Mazakala: x: -4, y: 94, z: -825
    Milda: x: -48, y: 108, z: -781
    Mollim: x: -132, y: 101, z: -790
    Nall: x: -659, y: 108, z: -739
    Odexar: x: -112, y: 100, z: -845
    Odger: x: -374, y: 208, z: -810
    Offea: x: -89, y: 94, z: -744
    Pablo: x: -131, y: 128, z: -817
    Pam: x: -598, y: 110, z: -666
    Plenk: x: -572, y: 119, z: -740
    Pomtair: x: -571, y: 121, z: -775
    Prie: x: -612, y: 109, z: -662
    Queen Nyx (Mage): x: -119, y: 105, z: -755
    Rhanora: x: -143, y: 101, z: -829
    Rollim: x: -148, y: 107, z: -854
    Rulenor: x: -28, y: 123, z: -770
    Scholar Alluin: x: -17, y: 115, z: -916
    Seffea: x: -139, y: 100, z: -817
    Sirih: x: -700, y: 132, z: -887
    Strux: x: -596, y: 124, z: -846
    Suus: x: -617, y: 116, z: -707
    Truu: x: -613, y: 123, z: -766
    Udel: x: -79, y: 108, z: -790
    Ulyn: x: -124, y: 100, z: -784
    Undercover Agent (Barbarian): x: -16, y: 94, z: -844
    Undercover Agent (Mage): x: -626, y: 120, z: -960
    Velyna: x: -86, y: 105, z: -821
    Vesuvius: x: -381, y: 116, z: -1031
    Vulcan: x: -364, y: 116, z: -1031
    Yoink: x: -613, y: 124, z: -788
    Ziri: x: -82, y: 115, z: -792
  Only in wiki (1)
    Elle of the Nether: x: -311, y: 96, z: -405
=== DWARVEN_MINES (sh=37, wiki=40) ===
  Only in skyhanni (12)
    Blacksmith: x: -7, y: 202, z: -154
    Block Guide: x: 87, y: 200, z: -108
    Brynmor: x: 32, y: 203, z: -154
    Don Expresso: x: 37, y: 203, z: -129
    Forge Foreman: x: -3, y: 150, z: -69
    Forger: x: 22, y: 152, z: -59
    Fragilis: x: 87, y: 200, z: -109
    Gemstone Grinder: x: 85, y: 200, z: -117
    Guard Gornum: x: -159, y: 150, z: -15
    Marigold: x: 179, y: 151, z: 60
    Rhys: x: -38, y: 201, z: -120
    Station Master: x: 39, y: 202, z: -87
  Only in wiki (15)
    Blacksmith (Dwarven): x: -6, y: 201, z: -154
    Cold Enjoyer: x: -15, y: 137, z: 217
    Dr. Stone: x: 28, y: 120, z: 238
    Emissary Braum: x: 89, y: 198, z: -92
    Emissary Carlton: x: -72, y: 153, z: -10
    Emissary Ceanna: x: 42, y: 134, z: 22
    Emissary Eliza: x: -37, y: 200, z: -131
    Emissary Fraiser: x: -132, y: 174, z: -50
    Emissary Lilith: x: 58, y: 198, z: -8
    Emissary Lissandra: x: 2, y: 121, z: 237
    Emissary Wilson: x: 171, y: 150, z: 31
    Fred: x: -2, y: 148, z: -68
    Plinius: x: 10, y: 121, z: 245
    Scardius: x: -16, y: 121, z: 232
    Sor'Hen: x: 0, y: 121, z: 225
  mismatch (4)
    Hornum: 3.3 blocks away
      sh: x: 34, y: 203, z: -149
      wiki: x: 35, y: 202, z: -146
    Lift Operator: 193.1 blocks away
      sh: x: -79, y: 201, z: -124
      wiki: x: 45, y: 150, z: 15
    Royal Resident: 105.2 blocks away
      sh: x: 62, y: 205, z: 199
      wiki: x: 165, y: 202, z: 178
    Tal Ker: 101.0 blocks away
      sh: x: 192, y: 197, z: 205
      wiki: x: 192, y: 196, z: 104
=== DUNGEON_HUB (sh=9, wiki=5) ===
  Only in skyhanni (4)
    Adventurer Saul: x: -54, y: 120, z: -3
    Crag: x: -47, y: 122, z: -24
    Croesus: x: -28, y: 121, z: 34
    Vulcan: x: -46, y: 122, z: -27
  mismatch (3)
    Malik: 146.4 blocks away
      sh: x: -49, y: 120, z: 9
      wiki: x: -80, y: 56, z: -119
    Mort: 147.4 blocks away
      sh: x: -61, y: 123, z: 0
      wiki: x: -88, y: 55, z: -128
    Ophelia: 149.7 blocks away
      sh: x: -49, y: 120, z: -9
      wiki: x: -85, y: 55, z: -139
=== HUB (sh=110, wiki=75) ===
  Only in skyhanni (58)
    Agnes: x: 11, y: 76, z: 0
    Alda: x: 70, y: 81, z: -59
    Alicina: x: 16, y: 76, z: 0
    Angler Angus: x: 125, y: 71, z: -67
    Auction Agent: x: -34, y: 73, z: -9
    Captain Baha: x: 161, y: 70, z: -66
    Carnival Cowboy: x: -104, y: 71, z: 38
    Carnival Fisherman: x: -81, y: 73, z: 29
    Carnival Leader: x: -89, y: 72, z: 10
    Carnival Pirateman: x: -107, y: 74, z: 28
    Carpenter Apprentice: x: -152, y: 64, z: -34
    Chantelle: x: -84, y: 72, z: 11
    Christopher: x: -14, y: 76, z: -76
    Clerk Seraphine: x: -2, y: 80, z: 10
    Coach Jackrabbit: x: 62, y: 69, z: 5
    Damia: x: -18, y: 56, z: -12
    Doug: x: -81, y: 71, z: 22
    Erihann: x: 43, y: 98, z: 94
    Fann: x: 10, y: 74, z: -63
    Farmer Rigby: x: 61, y: 73, z: -148
    Fear Mongorer: x: -31, y: 70, z: 6
    Fisherman Gerald: x: 119, y: 72, z: -32
    Fisherwoman Enid: x: 41, y: 71, z: -24
    Gavin: x: 146, y: 71, z: -60
    Gladiator: x: 123, y: 80, z: 166
    Grumblefoot: x: 43, y: 114, z: 99
    Hootie: x: 11, y: 74, z: -65
    Hoppity: x: 56, y: 71, z: -3
    Jax: x: -41, y: 70, z: -93
    Jerry: x: -33, y: 70, z: 6
    Karis: x: 65, y: 82, z: -60
    Liz: x: -36, y: 71, z: -80
    Ludleth: x: 82, y: 60, z: -114
    Mad Redstone Engineer: x: -9, y: 72, z: -58
    Malik Blacksmith: x: -81, y: 57, z: -121
    Mining Merchant: x: 12, y: 64, z: -114
    Mort: x: -88, y: 56, z: -129
    Ophelia: x: -86, y: 56, z: -137
    Oringo: x: -34, y: 70, z: 5
    Piggy: x: 14, y: 72, z: -9
    Rabbit Bro: x: 58, y: 71, z: 5
    Rabbit Cousin: x: 69, y: 69, z: 5
    Rabbit Daddy: x: 76, y: 66, z: 12
    Rabbit Dog: x: 62, y: 69, z: 9
    Rabbit Granny: x: 58, y: 69, z: 9
    Rabbit Sis: x: 68, y: 69, z: 11
    Rabbit Uncle: x: 77, y: 66, z: 10
    Richard: x: -33, y: 71, z: -81
    Salesman: x: -10, y: 72, z: -16
    Shania: x: 60, y: 73, z: -145
    Shen's Agent: x: 6, y: 54, z: -16
    Smithmonger: x: 16, y: 64, z: -135
    Taylor: x: 36, y: 75, z: -41
    The Handler: x: 39, y: 73, z: 1
    Tia The Fairy: x: 119, y: 66, z: 148
    Udium: x: 46, y: 102, z: 99
    Vincent: x: 79, y: 75, z: 53
    Zarina: x: -33, y: 71, z: -76
  Only in wiki (23)
    Andrew: x: 38, y: 68, z: -46
    Baker: x: 8, y: 71, z: -95
    Barry: x: 41, y: 122, z: 69
    Bazaar Agent: x: -39, y: 70, z: -78
    Duke: x: -6, y: 70, z: -89
    Farmer: x: 44, y: 72, z: -162
    Fear Mongerer: x: -2, y: 70, z: -43
    Felix: x: -25, y: 68, z: -103
    Fisherman: x: 155, y: 68, z: 47
    Jack: x: 0, y: 70, z: -54
    Jamie: x: -35, y: 70, z: -36
    Leo: x: -7, y: 70, z: -75
    Liam: x: -75, y: 70, z: -107
    Lynn: x: -21, y: 68, z: -124
    Mine Merchant: x: -9, y: 70, z: -124
    Oringo the Traveling Zookeeper: x: -3, y: 70, z: -43
    Ryu: x: -28, y: 70, z: -116
    Seraphine: x: 11, y: 71, z: -100
    Stella: x: -17, y: 70, z: -100
    Tia the Fairy: x: 129, y: 66, z: 137
    Tom: x: 28, y: 69, z: -57
    Tyashoi Alchemist: x: 41, y: 68, z: -55
    Vex: x: -16, y: 70, z: -81
  mismatch (48)
    Adventurer: 10.3 blocks away
      sh: x: -50, y: 70, z: -69
      wiki: x: -41, y: 70, z: -64
    Alchemist: 46.7 blocks away
      sh: x: 79, y: 72, z: -90
      wiki: x: 41, y: 70, z: -63
    Alixer: 97.5 blocks away
      sh: x: -3, y: 79, z: 4
      wiki: x: 0, y: 70, z: -93
    Amelia: 71.9 blocks away
      sh: x: -15, y: 75, z: -69
      wiki: x: -44, y: 85, z: -4
    Anita: 67.1 blocks away
      sh: x: 52, y: 74, z: -129
      wiki: x: 22, y: 77, z: -69
    Arthur: 23.2 blocks away
      sh: x: 53, y: 73, z: -113
      wiki: x: 51, y: 71, z: -136
    Auction Master: 77.3 blocks away
      sh: x: -39, y: 73, z: -13
      wiki: x: -46, y: 73, z: -90
    Banker: 20.7 blocks away
      sh: x: -29, y: 73, z: -38
      wiki: x: -24, y: 71, z: -58
    Bartender: 87.5 blocks away
      sh: x: -84, y: 75, z: -134
      wiki: x: -76, y: 70, z: -47
    Bazaar: 45.2 blocks away
      sh: x: -36, y: 73, z: -31
      wiki: x: -32, y: 71, z: -76
    Bea: 36.0 blocks away
      sh: x: 12, y: 73, z: -59
      wiki: x: 30, y: 70, z: -90
    Biblio: 105.4 blocks away
      sh: x: 7, y: 80, z: 10
      wiki: x: 8, y: 71, z: -95
    Bingo: 96.4 blocks away
      sh: x: 2, y: 79, z: 4
      wiki: x: 2, y: 70, z: -92
    Blacksmith: 38.4 blocks away
      sh: x: 10, y: 64, z: -127
      wiki: x: -28, y: 69, z: -125
    Builder: 53.3 blocks away
      sh: x: -10, y: 72, z: -61
      wiki: x: -51, y: 71, z: -27
    Carpenter: 108.1 blocks away
      sh: x: -138, y: 75, z: -41
      wiki: x: -30, y: 70, z: -43
    Curator: 102.9 blocks away
      sh: x: 27, y: 69, z: 33
      wiki: x: -62, y: 77, z: 84
    Dusk: 57.2 blocks away
      sh: x: 19, y: 64, z: -136
      wiki: x: -37, y: 68, z: -125
    Elise: 32.2 blocks away
      sh: x: 43, y: 78, z: 100
      wiki: x: 43, y: 82, z: 68
    Elizabeth: 118.5 blocks away
      sh: x: -6, y: 80, z: 17
      wiki: x: 0, y: 71, z: -101
    Farm Merchant: 63.1 blocks away
      sh: x: 62, y: 73, z: -113
      wiki: x: 15, y: 70, z: -71
    Fishing Merchant: 71.6 blocks away
      sh: x: 112, y: 72, z: -43
      wiki: x: 52, y: 70, z: -82
    George: 34.2 blocks away
      sh: x: 20, y: 75, z: -61
      wiki: x: 32, y: 77, z: -93
    Guy: 32.0 blocks away
      sh: x: 51, y: 79, z: 19
      wiki: x: 51, y: 79, z: -13
    Hub Selector: 44.1 blocks away
      sh: x: -6, y: 70, z: -23
      wiki: x: -9, y: 70, z: -67
    Jacob: 64.7 blocks away
      sh: x: 47, y: 74, z: -129
      wiki: x: 23, y: 71, z: -69
    Jacobus: 104.6 blocks away
      sh: x: -52, y: 71, z: -62
      wiki: x: 51, y: 69, z: -44
    Kat: 64.4 blocks away
      sh: x: 10, y: 73, z: -53
      wiki: x: -34, y: 71, z: -100
    Librarian: 47.4 blocks away
      sh: x: -69, y: 71, z: -79
      wiki: x: -35, y: 69, z: -112
    Lumber Jack: 13.4 blocks away
      sh: x: -124, y: 74, z: -30
      wiki: x: -112, y: 74, z: -36
    Lumber Merchant: 80.8 blocks away
      sh: x: -126, y: 74, z: -44
      wiki: x: -49, y: 70, z: -68
    Madame Eleanor Q. Goldsworth III: 103.3 blocks away
      sh: x: 32, y: 73, z: 11
      wiki: x: -49, y: 77, z: 75
    Maddox the Slayer: 76.5 blocks away
      sh: x: -83, y: 69, z: -131
      wiki: x: -75, y: 66, z: -55
    Marco: 116.8 blocks away
      sh: x: 59, y: 23, z: 69
      wiki: x: -9, y: 71, z: -13
    Maths Enjoyer: 130.9 blocks away
      sh: x: -73, y: 71, z: -62
      wiki: x: 56, y: 69, z: -40
    Maxwell: 116.1 blocks away
      sh: x: -65, y: 71, z: -67
      wiki: x: 46, y: 69, z: -33
    Nicole: 24.4 blocks away
      sh: x: 42, y: 94, z: 96
      wiki: x: 40, y: 90, z: 72
    Ozanne: 108.1 blocks away
      sh: x: -55, y: 71, z: -65
      wiki: x: 51, y: 69, z: -44
    Pat: 45.0 blocks away
      sh: x: -89, y: 74, z: -96
      wiki: x: -134, y: 73, z: -97
    Plumber Joe: 77.2 blocks away
      sh: x: 123, y: 75, z: -39
      wiki: x: 56, y: 70, z: -77
    Rosetta: 68.3 blocks away
      sh: x: -55, y: 70, z: -88
      wiki: x: -12, y: 68, z: -141
    Scoop: 30.0 blocks away
      sh: x: 3, y: 181, z: 56
      wiki: x: 4, y: 181, z: 26
    Security Sloth: 59.7 blocks away
      sh: x: 11, y: 72, z: -16
      wiki: x: 2, y: 70, z: -75
    Seymour: 5.1 blocks away
      sh: x: 28, y: 67, z: -40
      wiki: x: 24, y: 64, z: -41
    Weaponsmith: 69.8 blocks away
      sh: x: -52, y: 70, z: -85
      wiki: x: -9, y: 68, z: -140
    Wizard: 24.1 blocks away
      sh: x: 47, y: 120, z: 99
      wiki: x: 46, y: 122, z: 75
    Wool Weaver: 42.5 blocks away
      sh: x: -17, y: 72, z: -59
      wiki: x: -48, y: 74, z: -30
    Zog: 33.9 blocks away
      sh: x: 9, y: 70, z: -71
      wiki: x: 33, y: 70, z: -95
=== THE_FARMING_ISLANDS (sh=15, wiki=14) ===
  Only in skyhanni (1)
    Moby: x: 206, y: 44, z: -501
=== CRYSTAL_HOLLOWS (sh=3, wiki=3) ===
  Only in skyhanni (1)
    Chunk: x: 797, y: 129, z: 707
  Only in wiki (1)
    Emissary Sisko: x: 495, y: 106, z: 556
=== THE_PARK (sh=11, wiki=9) ===
  Only in skyhanni (4)
    Kelly: x: -351, y: 95, z: 32
    Molbert: x: -468, y: 121, z: -43
    Romeo & Juliette: x: -417, y: 131, z: -121
    Worker Xavier: x: -424, y: 111, z: -15
  Only in wiki (2)
    Charlie: x: -285, y: 82, z: -16
    Juliette: x: -476, y: 134, z: -116
  mismatch (7)
    Gustave: 25.1 blocks away
      sh: x: -363, y: 90, z: 43
      wiki: x: -385, y: 89, z: 55
    Master Tactician Funk: 45.1 blocks away
      sh: x: -452, y: 111, z: 29
      wiki: x: -462, y: 110, z: -15
    Melancholic Viking: 23.4 blocks away
      sh: x: -336, y: 93, z: 72
      wiki: x: -359, y: 91, z: 76
    Melody: 39.9 blocks away
      sh: x: -413, y: 110, z: 71
      wiki: x: -398, y: 110, z: 34
    Old Shaman Nyko: 103.4 blocks away
      sh: x: -371, y: 85, z: -64
      wiki: x: -379, y: 60, z: 36
    Ryan: 35.7 blocks away
      sh: x: -364, y: 103, z: -92
      wiki: x: -330, y: 103, z: -103
    Vanessa: 12.4 blocks away
      sh: x: -305, y: 77, z: -79
      wiki: x: -311, y: 83, z: -70
=== DEEP_CAVERNS (sh=5, wiki=3) ===
  Only in skyhanni (2)
    Lift Operator: x: 46, y: 14, z: 15
    Rhys: x: 32, y: 13, z: 14
=== GOLD_MINES (sh=5, wiki=3) ===
  Only in skyhanni (2)
    Blacksmith: x: -39, y: 78, z: -300
    Lazy Miner: x: -13, y: 79, z: -337
=== SPIDER_DEN (sh=9, wiki=7) ===
  Only in skyhanni (2)
    Ike: x: -261, y: 95, z: -284
    Michael: x: -265, y: 95, z: -284
  mismatch (3)
    Haymitch: 4.1 blocks away
      sh: x: -203, y: 84, z: -236
      wiki: x: -202, y: 84, z: -240
    Rick: 14.1 blocks away
      sh: x: -264, y: 72, z: -324
      wiki: x: -250, y: 70, z: -324
    Spider Tamer: 455.7 blocks away
      sh: x: -300, y: 63, z: -195
      wiki: x: 62, y: -194, z: -298
=== WINTER (sh=12, wiki=7) ===
  Only in skyhanni (6)
    Daan: x: 81, y: 80, z: 110
    Dirk: x: 79, y: 82, z: 55
    Einary: x: -16, y: 77, z: 63
    Frozen Alex: x: -74, y: 75, z: -7
    Helena: x: 37, y: 80, z: 75
    Maaike: x: 49, y: 82, z: 50
  Only in wiki (1)
    Terry: x: -92, y: 78, z: 25
  mismatch (1)
    Sherry: 6.5 blocks away
      sh: x: 5, y: 77, z: 94
      wiki: x: 9, y: 76, z: 99
=== THE_RIFT (sh=104, wiki=72) ===
  Only in skyhanni (41)
    Argofay Doorholder: x: -6, y: 181, z: 25
    Argofay Threebrother #1: x: -135, y: 76, z: 113
    Argofay Threebrother #2: x: -100, y: 77, z: 152
    Argofay Threebrother #3: x: -92, y: 77, z: 108
    Argofay Trafficker/Boots: x: -137, y: 89, z: 113
    Argofay Trafficker/Chestplate: x: -138, y: 98, z: 113
    Argofay Trafficker/Helmet: x: -151, y: 113, z: 114
    Argofay Trafficker/Leggings: x: -91, y: 91, z: 105
    Autonull: x: -223, y: 18, z: 4
    Blobbercyst: x: -223, y: 18, z: -12
    Button: x: -223, y: 20, z: -87
    Damia: x: 30, y: 73, z: -94
    Detective Amog: x: 25, y: 178, z: 42
    Dr Phear: x: -148, y: 37, z: 27
    Elise: x: 9, y: 56, z: 76
    Fairylosopher at the Bottom: x: 252, y: 107, z: 77
    Fairylosopher at the Top: x: 255, y: 131, z: 76
    Ikrus: x: 9, y: 158, z: 60
    Luverne: x: -18, y: 136, z: 42
    Madame Eleanor 2: x: -223, y: 18, z: -75
    Madame Eleanor Q. Goldsworth I: x: 0, y: 115, z: 36
    Madame Eleanor Q. Goldsworth IX: x: 36, y: 129, z: 40
    Madame Eleanor Q. Goldsworth V: x: 5, y: 151, z: 21
    Madame Eleanor Q. Goldsworth VII: x: 9, y: 180, z: 37
    Madame Eleanor Q. Goldsworth X: x: 23, y: 155, z: 41
    Madelia: x: -16, y: 136, z: 44
    Melrose: x: -17, y: 136, z: 43
    Mole: x: -160, y: 98, z: -75
    Motes Grubber: x: 164, y: 78, z: 125
    Noway: x: -224, y: 18, z: 42
    Obo: x: -228, y: 22, z: -63
    Old Timer: x: 17, y: 98, z: 18
    Oruo The Almighty: x: 38, y: 90, z: 17
    Roosterzilla: x: -224, y: 18, z: 97
    Sad Jacquelle: x: -122, y: 121, z: 135
    Shen Chaos: x: -260, y: 19, z: -68
    Spike: x: -223, y: 18, z: -50
    Transfigured Seraphine: x: -15, y: 72, z: -102
    Ubik Von Neumann (Free Will): x: 36, y: 133, z: 18
    Ubik Von Neumann (IQ Points): x: 20, y: 108, z: 53
    Ubik Von Neumann (Split or Steal): x: -20, y: 136, z: 42
  Only in wiki (9)
    Argofay Threebrother: x: -93, y: 76, z: 108
    Argofay Trafficker: x: -92, y: 90, z: 106
    Barry: x: -46, y: 54, z: -143
    Cowboy Nick: x: -13, y: 70, z: -7
    Damia (Rift): x: 31, y: 72, z: -95
    Detransfigured Seraphine: x: -17, y: 71, z: -101
    Dr. Phear: x: -146, y: 36, z: 27
    Jacquelle: x: -122, y: 120, z: 137
    Mole (NPC): x: -160, y: 97, z: -76
  mismatch (2)
    Kat: 30.9 blocks away
      sh: x: -34, y: 71, z: -91
      wiki: x: -62, y: 70, z: -78
    Sorcerer Okron: 24.6 blocks away
      sh: x: -52, y: 71, z: -99
      wiki: x: -71, y: 81, z: -111
=== BACKWATER_BAYOU (sh=4, wiki=0) ===
  Only in skyhanni (4)
    Captain Baha: x: -22, y: 76, z: -9
    Hattie: x: 16, y: 72, z: 14
    Junker Joel: x: 5, y: 73, z: 3
    Roddy: x: 21, y: 79, z: -24
=== GALATEA (sh=31, wiki=0) ===
  Only in skyhanni (31)
    Agatha: x: -649, y: 90, z: -4
    Alan: x: -626, y: 117, z: -37
    Albert: x: -593, y: 114, z: 8
    Amaury: x: -579, y: 115, z: 1
    Auryon: x: -558, y: 112, z: 48
    Banker Bonsai: x: -599, y: 117, z: -38
    Boris: x: -685, y: 130, z: 64
    Brian: x: -629, y: 118, z: 47
    Coral: x: -627, y: 100, z: -88
    David Hunterborough: x: -594, y: 115, z: -14
    Forest Essence Shop: x: -703, y: 163, z: 2
    Hina: x: -554, y: 111, z: -17
    Jaeger: x: -652, y: 90, z: -25
    Kiara: x: -654, y: 114, z: -70
    Kysha: x: -602, y: 116, z: -12
    Loras: x: -594, y: 119, z: 14
    Martin: x: -581, y: 94, z: 31
    Murkwater Loch: x: -706, y: 95, z: 33
    Nemo: x: -620, y: 88, z: -7
    Oden: x: -585, y: 114, z: -41
    Pounce: x: -599, y: 128, z: -21
    Rosemary: x: -704, y: 163, z: 3
    Salvage Old Attributes: x: -595, y: 115, z: -18
    Sawyer: x: -692, y: 122, z: 81
    Soul Campfire Adept: x: -626, y: 118, z: 50
    Soul Campfire Initiate: x: -629, y: 118, z: 51
    Swoop: x: -580, y: 115, z: -24
    Talia: x: -616, y: 109, z: 2
    Teddy: x: -657, y: 116, z: -40
    Tilus: x: -643, y: 56, z: 47
    Vaeri: x: -689, y: 117, z: -36
```

</details>

## Changelog Technical Details
+ Added debug command `/shcomparewikinpc` to compare wiki data with SkyHanni graph data. - hannibal2