### PR TITLE
Improvement: manual download from modrinth

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/About.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/About.kt
@@ -28,6 +28,7 @@ class About {
     @ConfigEditorBoolean
     var checkForUpdates: Boolean = true
 
+    // TODO change this somehow
     @ConfigOption(name = "Auto Updates", desc = "Automatically download new version on each startup")
     @Expose
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
@@ -26,7 +26,7 @@ class GuiOptionEditorUpdateCheck(option: ProcessedOption) : GuiOptionEditor(opti
         val nextVersion = UpdateManager.getNextVersion()
 
         button.text = when (UpdateManager.updateState) {
-            UpdateManager.UpdateState.AVAILABLE -> "Download update"
+            UpdateManager.UpdateState.AVAILABLE -> "Manually download"
             UpdateManager.UpdateState.QUEUED -> "Downloading..."
             UpdateManager.UpdateState.DOWNLOADED -> "Downloaded"
             UpdateManager.UpdateState.NONE -> if (nextVersion == null) "Check for Updates" else "Up to date"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.SkyHanniLogger
 import at.hannibal2.skyhanni.utils.api.ApiInternalUtils
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
@@ -57,8 +58,8 @@ object UpdateManager {
         return potentialUpdate?.update?.versionNumber?.asString
     }
 
-    @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    @HandleEvent(ConfigLoadEvent::class)
+    fun onConfigLoad() {
         SkyHanniMod.feature.about.updateStream.onToggle {
             reset()
         }
@@ -120,20 +121,18 @@ object UpdateManager {
                 potentialUpdate = it
                 if (it.isUpdateAvailable) {
                     updateState = UpdateState.AVAILABLE
-                    if (config.fullAutoUpdates || forceDownload) {
-                        ChatUtils.chat(
-                            componentBuilder {
-                                append("SkyHanni found a new update: ${it.update.versionName}, starting to download now.")
-                                withColor(ChatFormatting.GREEN)
-                            }
-                        )
-                        queueUpdate()
-                    } else if (config.checkForUpdates) {
-                        ChatUtils.chatAndOpenConfig(
-                            "§aSkyHanni found a new update: ${it.update.versionName}. " +
-                                "Check §b/sh download update §afor more info.",
-                            config::checkForUpdates,
-                        )
+//                     if (config.fullAutoUpdates || forceDownload) {
+//                         ChatUtils.chat(
+//                             componentBuilder {
+//                                 append("SkyHanni found a new update: ${it.update.versionName}, starting to download now.")
+//                                 withColor(ChatFormatting.GREEN)
+//                             }
+//                         )
+//                         queueUpdate()
+//                     } else
+                    if (config.checkForUpdates) {
+                        ChatUtils.chat("§aSkyHanni found a new update: ${it.update.versionName}.")
+                        suggestModrinth()
                         ChatUtils.clickableChat(
                             "§e§lCLICK HERE §r§eto view changes.",
                             onClick = {
@@ -146,7 +145,7 @@ object UpdateManager {
                         componentBuilder {
                             append("SkyHanni didn't find a new update.")
                             withColor(ChatFormatting.GREEN)
-                        }
+                        },
                     )
                 }
             },
@@ -155,23 +154,31 @@ object UpdateManager {
     }
 
     fun queueUpdate() {
-        if (updateState != UpdateState.AVAILABLE) {
-            logger.log("Trying to enqueue an update while another one is already downloaded or none is present")
-        }
-        updateState = UpdateState.QUEUED
-        activePromise = CompletableFuture.supplyAsync {
-            logger.log("Update download started")
-            potentialUpdate!!.prepareUpdate()
-        }.thenAcceptAsync(
-            {
-                logger.log("Update download completed, setting exit hook")
-                updateState = UpdateState.DOWNLOADED
-                potentialUpdate!!.executePreparedUpdate()
-                ChatUtils.chat("Download of update complete. ")
-                ChatUtils.chat("§aThe update will be installed after your next restart.")
-            },
-            Minecraft.getInstance(),
-        )
+        logger.log("auto updating is manually disabled for now.")
+        suggestModrinth()
+//         if (updateState != UpdateState.AVAILABLE) {
+//             logger.log("Trying to enqueue an update while another one is already downloaded or none is present")
+//         }
+//         updateState = UpdateState.QUEUED
+//         activePromise = CompletableFuture.supplyAsync {
+//             logger.log("Update download started")
+//             potentialUpdate!!.prepareUpdate()
+//         }.thenAcceptAsync(
+//             {
+//                 logger.log("Update download completed, setting exit hook")
+//                 updateState = UpdateState.DOWNLOADED
+//                 potentialUpdate!!.executePreparedUpdate()
+//                 ChatUtils.chat("Download of update complete. ")
+//                 ChatUtils.chat("§aThe update will be installed after your next restart.")
+//             },
+//             Minecraft.getInstance(),
+//         )
+    }
+
+    private fun suggestModrinth() {
+        ChatUtils.clickableChat("§eClick here to manually download the version from Modrinth.", onClick = {
+            OSUtils.openBrowser("https://modrinth.com/mod/skyhanni")
+        })
     }
 
     private val context = UpdateContext(


### PR DESCRIPTION
## What
changed the auto updater to only warn when an update is there, but no longer actually manually updates anything.
instead, we now suggest the user to manually update the mod from Modrinth.

This is not the final solution (see the commented out code), but a workaround for just now.

## Changelog Improvements
+ Changed the in-game auto-updater to not auto-update anything, rather suggest to manually update from Modrinth. - hannibal2