### PR TITLE
Backend: Graph Editor Tags update around teleportation

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
@@ -15,13 +15,29 @@ enum class GraphNodeTag(
     DEV("dev", LorenzColor.WHITE, "Dev", "Intentionally marked as dev.", onlySkyblock = null), // E.g. Spawn points, todos, etc
 
     // Everywhere
-    NPC("npc", LorenzColor.YELLOW, "NPC", "A NPC to talk to.", onlySkyblock = null), // also take from neu repo
+    NPC("npc", LorenzColor.YELLOW, "NPC", "An NPC to talk to.", onlySkyblock = null),
     AREA("area", LorenzColor.DARK_GREEN, "Area", "A big SkyBlock area.", onlySkyblock = null),
     SMALL_AREA("small_area", LorenzColor.GREEN, "Small Area", "A small SkyBlock area, e.g. a house.", onlySkyblock = null),
     POI("poi", LorenzColor.WHITE, "Point of Interest", "A relevant spot or a landmark on the map.", onlySkyblock = null),
 
-    //     LAUNCH_PAD("launch", LorenzColor.WHITE, "Launch Pad", "Slime blocks sending you to another server."),
-    TELEPORT("teleport", LorenzColor.BLUE, "Teleport", "A spot from/to teleport.", onlySkyblock = null),
+    // TODO delete once no graph data contains this anymore
+    @Deprecated("gets split up into WARP, JUMP_PAD and TELEPORT_PAD")
+    TELEPORT(
+        "teleport",
+        LorenzColor.BLUE,
+        "Teleport",
+        "A teleportation spot. Deprecated, split into warp, jump pad, and teleport pad.",
+        onlySkyblock = null,
+    ),
+
+    // teleports from any island to this location on this island
+    WARP("warp", LorenzColor.BLUE, "Warp", "A warp command target.", onlySkyblock = null),
+
+    // stand there, jumps to another island, name is the other island (display name, not enum name)
+    JUMP_PAD("jump_pad", LorenzColor.BLUE, "Jump Pad", "A jump pad or portal to another island.", onlySkyblock = null),
+
+    // teleports around on the same island
+    TELEPORT_PAD("teleport_pad", LorenzColor.BLUE, "Teleport Pad", "A teleport pad inside the same island.", onlySkyblock = null),
 
     // on multiple islands
     ROMEO("romeo", LorenzColor.WHITE, "Romeo & Juliette Quest", "Spots related to the Romeo and Juliette/Ring of Love quest line."),
@@ -33,11 +49,6 @@ enum class GraphNodeTag(
     GRIND_CROPS("grind_crops", LorenzColor.DARK_GREEN, "Crop Area", "An area where crops grow that can be farmed."),
     // hoppity
 
-    // Hub
-    HUB_12_STARTER(
-        "starter_npc", LorenzColor.WHITE, "Starter NPC", "One of the 12 starter NPC's you need to talk to.",
-        onlyIsland = IslandType.HUB,
-    ),
     // diana
 
     // Farming Islands: Pelts
@@ -67,7 +78,7 @@ enum class GraphNodeTag(
         "SPIDER_RELIC",
         LorenzColor.DARK_PURPLE,
         "Spider's Relic",
-        "An relic in the Spider's Den.",
+        "A relic in the Spider's Den.",
         onlyIsland = IslandType.SPIDER_DEN,
     ),
 
@@ -80,7 +91,7 @@ enum class GraphNodeTag(
         "crimson_miniboss",
         LorenzColor.RED,
         "Crimson Miniboss",
-        "A Miniboss in the Crimson Isle.",
+        "A miniboss in the Crimson Isle.",
         onlyIsland = IslandType.CRIMSON_ISLE,
     ),
 
@@ -100,7 +111,7 @@ enum class GraphNodeTag(
         "fishing_hotspot",
         LorenzColor.AQUA,
         "Fishing Hotspot",
-        "A possible hotspot where you can fish",
+        "A possible hotspot where you can fish.",
         onlyIslands = setOf(IslandType.BACKWATER_BAYOU, IslandType.HUB, IslandType.CRIMSON_ISLE),
     ),
 

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
@@ -33,7 +33,7 @@ enum class GraphNodeTag(
     // teleports from any island to this location on this island
     WARP("warp", LorenzColor.BLUE, "Warp", "A warp command target.", onlySkyblock = null),
 
-    // stand there, jumps to another island, name is the other island (display name, not enum name)
+    // stand there, jumps to another island, name is the other island (enum name, not display name)
     JUMP_PAD("jump_pad", LorenzColor.BLUE, "Jump Pad", "A jump pad or portal to another island.", onlySkyblock = null),
 
     // teleports around on the same island

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
@@ -31,13 +31,25 @@ enum class GraphNodeTag(
     ),
 
     // teleports from any island to this location on this island
-    WARP("warp", LorenzColor.BLUE, "Warp", "A warp command target.", onlySkyblock = null),
+    WARP("warp", LorenzColor.BLUE, "Teleport Destination", "A teleport command destination.", onlySkyblock = null),
 
     // stand there, jumps to another island, name is the other island (enum name, not display name)
-    JUMP_PAD("jump_pad", LorenzColor.BLUE, "Jump Pad", "A jump pad or portal to another island.", onlySkyblock = null),
+    JUMP_PAD(
+        "jump_pad",
+        LorenzColor.BLUE,
+        "Teleport To Other Island",
+        "A jump pad, portal, or similar mechanic that teleports to another island.",
+        onlySkyblock = null,
+    ),
 
     // teleports around on the same island
-    TELEPORT_PAD("teleport_pad", LorenzColor.BLUE, "Teleport Pad", "A teleport pad inside the same island.", onlySkyblock = null),
+    TELEPORT_PAD(
+        "teleport_pad",
+        LorenzColor.BLUE,
+        "Teleport To Same Island",
+        "A teleport pad that teleports within the same island.",
+        onlySkyblock = null,
+    ),
 
     // on multiple islands
     ROMEO("romeo", LorenzColor.WHITE, "Romeo & Juliette Quest", "Spots related to the Romeo and Juliette/Ring of Love quest line."),
@@ -83,6 +95,7 @@ enum class GraphNodeTag(
     ),
 
     // Dwarven Mines
+    // always has to also have the npc tag added
     MINES_EMISSARY("mines_emissary", LorenzColor.GOLD, "Mines Emissary", "An Emissary to the king.", onlyIsland = IslandType.DWARVEN_MINES),
     // commission areas
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -37,7 +37,6 @@ object NavigationHelper {
         GraphNodeTag.GRIND_MOBS,
         GraphNodeTag.GRIND_ORES,
         GraphNodeTag.GRIND_CROPS,
-        GraphNodeTag.MINES_EMISSARY,
         GraphNodeTag.CRIMSON_MINIBOSS,
     )
 

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -4,8 +4,10 @@ import at.hannibal2.skyhanni.SkyHanniMod.launchCoroutine
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.graph.Graph
 import at.hannibal2.skyhanni.data.model.graph.GraphNode
+import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.misc.pathfind.IslandAreaBackend.getAreaTag
 import at.hannibal2.skyhanni.features.misc.pathfind.NavigationHelper
@@ -34,6 +36,8 @@ object GraphEditorBugFinder {
         checkConflictingTags(graph, errorsInWorld)
         checkConflictingAreas(graph, errorsInWorld)
         checkMissingData(graph, errorsInWorld)
+        checkDeprecatedTags(graph, errorsInWorld)
+        checkInvalidNames(graph, errorsInWorld)
 
         this.errorsInWorld = errorsInWorld
         errorsInWorld.keys.minByOrNull {
@@ -41,15 +45,46 @@ object GraphEditorBugFinder {
         }?.pathFind("Graph Editor Bug", Color.RED, condition = { isEnabled() })
     }
 
+    private fun checkDeprecatedTags(
+        graph: Graph,
+        errorsInWorld: MutableMap<GraphNode, String>,
+    ) {
+        for (node in graph) {
+            @Suppress("DEPRECATION")
+            if (node.hasTag(GraphNodeTag.TELEPORT)) {
+                errorsInWorld[node] = "deprecated teleport node"
+            }
+        }
+    }
+
+    private fun checkInvalidNames(
+        graph: Graph,
+        errorsInWorld: MutableMap<GraphNode, String>,
+    ) {
+        for (node in graph) {
+            val name = node.name ?: continue
+            if (node.hasTag(GraphNodeTag.WARP)) {
+                if (!name.startsWith("/")) {
+                    errorsInWorld[node] = "invalid warp name"
+                }
+            }
+            if (node.hasTag(GraphNodeTag.JUMP_PAD)) {
+                if (IslandType.entries.none { it.displayName == name }) {
+                    errorsInWorld[node] = "jump pad name is no known island name"
+                }
+            }
+        }
+    }
+
     private fun checkMissingData(graph: Graph, errorsInWorld: MutableMap<GraphNode, String>) {
         for (node in graph) {
             val nameNull = node.name.isNullOrBlank()
             val tagsEmpty = node.tags.isEmpty()
             if (nameNull > tagsEmpty) {
-                errorsInWorld[node] = "§cMissing name despite having tags"
+                errorsInWorld[node] = "Missing name despite having tags"
             }
             if (tagsEmpty > nameNull) {
-                errorsInWorld[node] = "§cMissing tags despite having name"
+                errorsInWorld[node] = "Missing tags despite having name"
             }
         }
     }
@@ -70,7 +105,7 @@ object GraphEditorBugFinder {
                 val neighboringAreaNode = nearestArea[neighbor]?.name ?: continue
                 if (neighboringAreaNode == areaNode) continue
                 if ((null == node.getAreaTag())) {
-                    errorsInWorld[node] = "§cConflicting areas $areaNode and $neighboringAreaNode"
+                    errorsInWorld[node] = "Conflicting areas $areaNode and $neighboringAreaNode"
                 }
             }
         }
@@ -81,7 +116,7 @@ object GraphEditorBugFinder {
             if (!node.tags.any { it in NavigationHelper.allowedTags }) continue
             val remainingTags = node.tags.filter { it in NavigationHelper.allowedTags }
             if (remainingTags.size != 1) {
-                errorsInWorld[node] = "§cConflicting tags: $remainingTags"
+                errorsInWorld[node] = "Conflicting tags: $remainingTags"
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.features.misc.pathfind.NavigationHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.GraphUtils.distanceSqToPlayer
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import java.awt.Color
@@ -69,8 +70,11 @@ object GraphEditorBugFinder {
                 }
             }
             if (node.hasTag(GraphNodeTag.JUMP_PAD)) {
-                if (IslandType.entries.none { it.displayName == name }) {
+                if (IslandType.entries.none { it.name == name }) {
                     errorsInWorld[node] = "jump pad name is no known island name"
+                }
+                if (name == SkyBlockUtils.currentIsland.name) {
+                    errorsInWorld[node] = "jump pad name is current island name"
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.misc.pathfind.IslandAreaBackend.getAreaTag
 import at.hannibal2.skyhanni.features.misc.pathfind.NavigationHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.GraphUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
@@ -39,6 +40,7 @@ object GraphEditorBugFinder {
         checkMissingData(graph, errorsInWorld)
         checkDeprecatedTags(graph, errorsInWorld)
         checkInvalidNames(graph, errorsInWorld)
+        checkHasSpawn(graph, errorsInWorld)
 
         this.errorsInWorld = errorsInWorld
         errorsInWorld.keys.minByOrNull {
@@ -77,6 +79,15 @@ object GraphEditorBugFinder {
                     errorsInWorld[node] = "jump pad name is current island name"
                 }
             }
+        }
+    }
+
+    private fun checkHasSpawn(
+        graph: Graph,
+        errorsInWorld: MutableMap<GraphNode, String>,
+    ) {
+        if (graph.none { it.hasTag(GraphNodeTag.POI) && it.name == "Spawn" }) {
+            ChatUtils.chat("§cGraph editor without spawn point!")
         }
     }
 
@@ -121,6 +132,11 @@ object GraphEditorBugFinder {
             val remainingTags = node.tags.filter { it in NavigationHelper.allowedTags }
             if (remainingTags.size != 1) {
                 errorsInWorld[node] = "Conflicting tags: $remainingTags"
+            }
+            if (node.hasTag(GraphNodeTag.MINES_EMISSARY)) {
+                if (!node.hasTag(GraphNodeTag.NPC)) {
+                    errorsInWorld[node] = "emissary without npc tag"
+                }
             }
         }
     }


### PR DESCRIPTION
## What
The old TELEPORT tag covered three fundamentally different mechanics: warp commands, cross-island jump pads, and same-island teleport pads. Splitting it allows the graph editor bug finder to validate each type specifically: WARP node names must start with /, and JUMP_PAD node names must match a known island enum name.

This change is also a precondition for future teleportation mechanic, e.g. supporting navigation from island to island, or better pathfind rendering around teleport pads, or generic warping support to navigation.

Additionally, the never used and now totally useless "12 hub villagers" tag got removed, and cleaned up typos in the file.

already filled the graph editor with the data, see https://github.com/hannibal002/SkyHanni-REPO/commit/52a244f486cbb89cd8053660e47ba37177334d1d

## Changelog Technical Details
+ Split deprecated `TELEPORT` graph node tag into `WARP`, `JUMP_PAD`, and `TELEPORT_PAD`. - hannibal2
+ Added graph editor validation for deprecated teleport nodes and invalid warp and jump pad names. - hannibal2