### PR TITLE
Fix: Kuudra key cost showing as 0

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/DiscountUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DiscountUtils.kt
@@ -36,7 +36,7 @@ object DiscountUtils {
         priceSource: ItemPriceSource = ItemPriceSource.BAZAAR_INSTANT_BUY,
         pastRecipes: List<PrimitiveRecipe> = emptyList(),
     ): Double {
-        val lowestNPCPrice = getRecipes(this).filter { it.recipeType != NeuRecipeType.NPC_SHOP && it !in pastRecipes }
+        val lowestNPCPrice = getRecipes(this).filter { it.recipeType == NeuRecipeType.NPC_SHOP && it !in pastRecipes }
             .map { it.getRecipePrice(priceSource, pastRecipes + it) }
             .filter { it > 0 }
             .minOrNull() ?: return 0.0


### PR DESCRIPTION
## What
Gotta love single character fixes.

Not tested, but this *should* fix it.

## Changelog Fixes
+ Fixed Kuudra Profit Tracker showing key cost as 0. - Luna