### PR TITLE
fix: lazy-init currentMcVersion

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/system/MCVersion.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/system/MCVersion.kt
@@ -21,7 +21,7 @@ data class MCVersion(val epoch: Int, val major: Int, val minor: Int) : Comparabl
 
     companion object {
 
-        val currentMcVersion = fromString(PlatformUtils.MC_VERSION)
+        val currentMcVersion by lazy { fromString(PlatformUtils.MC_VERSION) })
 
         fun fromString(version: String): MCVersion {
             val parts = version.split('.')


### PR DESCRIPTION
## What
`MCVersion.currentMcVersion` was initialized early, causing `PlatformUtils` to call `SharedConstants.getCurrentVersion()` before Minecraft was set up in gradle tests, resulting in `IllegalStateException: Game version not set`.


<details>
[Logs](https://github.com/user-attachments/files/27027809/details.txt)

</details>

## Changelog Technical Details
+ Fixed `MCVersion.currentMcVersion` being called before Minecraft set-up in gradle test. - Rain

