### PR TITLE
Backend: Copy Cosmetic Skull Data Dev Feature

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
@@ -75,7 +75,7 @@ class DebugConfig {
     var copyInternalName: Int = GLFW.GLFW_KEY_UNKNOWN
 
     @Expose
-    @ConfigOption(name = "Copy Cosmetics Data", desc = "Copies the cosmetic data for skins with different variants but no animations.")
+    @ConfigOption(name = "Copy Cosmetics Skull Data", desc = "Copies the cosmetic data for skins with different variants but no animations.")
     @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
     var copyCosmeticsSkullData: Int = GLFW.GLFW_KEY_UNKNOWN
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
@@ -75,6 +75,11 @@ class DebugConfig {
     var copyInternalName: Int = GLFW.GLFW_KEY_UNKNOWN
 
     @Expose
+    @ConfigOption(name = "Copy Cosmetics Data", desc = "Copies the cosmetic data for skins with different variants but no animations.")
+    @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
+    var copyCosmeticsSkullData: Int = GLFW.GLFW_KEY_UNKNOWN
+
+    @Expose
     @ConfigOption(name = "Show NPC Price", desc = "Show NPC price in item lore.")
     @ConfigEditorBoolean
     var showNpcPrice: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -55,6 +55,7 @@ import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.ReflectionUtils.makeAccessible
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
@@ -467,8 +468,8 @@ object SkyHanniDebugsAndTests {
         ChatUtils.debug("Mined: $originalOre(${extraBlocks.joinToString()})")
     }
 
-    @HandleEvent(GuiRenderEvent::class)
-    fun updateSkinId() {
+    @HandleEvent(GuiRenderEvent::class, onlyOnSkyblock = true)
+    fun onRenderUpdateSkinId() {
         val stack = stackUnderCursor() ?: return
         if (!stack.getLoreComponent().any { it.string.contains("Right-click to preview!") }) return
 
@@ -477,15 +478,15 @@ object SkyHanniDebugsAndTests {
         skinIdTime = SimpleTimeMark.now()
     }
 
-    @HandleEvent(GuiKeyPressEvent::class)
-    fun onCopyCosmeticsData() {
+    @HandleEvent(GuiKeyPressEvent::class, onlyOnSkyblock = true)
+    fun onKeyPressCopyCosmeticsData() {
         if (!debugConfig.copyCosmeticsSkullData.isKeyHeld()) return
         val stack = stackUnderCursor() ?: return
         if (stack.item != Items.PLAYER_HEAD) return
         if (skinId == null) return
         if (skinIdTime.passedSince() > 2.minutes) return
 
-        val skullTexture = stack.getSkullTexture()
+        val skullTexture = stack.getSkullTexture() ?: SkullTextureHolder.getTexture("ALEX_SKIN_TEXTURE")
         val skullOwner = stack.getSkullOwner()
         val skinColor = stack.cleanName().uppercase(Locale.getDefault()).replace(" ", "_")
         val formatted = "\"${skinId}_${skinColor}\": {\"ticks\": 1, \"textures\": [\"${skullOwner}:${skullTexture}\"]},"

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -33,11 +33,15 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getRawCraftCostOrNull
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.isAuctionHouseItem
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
 import at.hannibal2.skyhanni.utils.ItemUtils.getRawBaseStats
+import at.hannibal2.skyhanni.utils.ItemUtils.getSkullOwner
+import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LocationUtils
@@ -68,9 +72,12 @@ import net.minecraft.client.gui.components.debug.DebugScreenEntries
 import net.minecraft.client.gui.components.debug.DebugScreenEntry
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.resources.Identifier
+import net.minecraft.world.item.Items
 import net.minecraft.world.level.Level
 import net.minecraft.world.level.chunk.LevelChunk
 import java.io.File
+import java.util.Locale
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -336,6 +343,9 @@ object SkyHanniDebugsAndTests {
         )
     }
 
+    private var skinId: String? = null
+    private var skinIdTime: SimpleTimeMark = SimpleTimeMark.farPast()
+
     @HandleEvent(GuiKeyPressEvent::class)
     fun onKeybind() {
         if (!debugConfig.copyInternalName.isKeyHeld()) return
@@ -455,6 +465,33 @@ object SkyHanniDebugsAndTests {
         val originalOre = event.originalOre?.let { "$it " }.orEmpty()
         val extraBlocks = event.extraBlocks.map { "${it.key.name}: ${it.value}" }
         ChatUtils.debug("Mined: $originalOre(${extraBlocks.joinToString()})")
+    }
+
+    @HandleEvent(GuiRenderEvent::class)
+    fun updateSkinId() {
+        val stack = stackUnderCursor() ?: return
+        if (!stack.getLoreComponent().any { it.string.contains("Right-click to preview!") }) return
+
+        val internalName = stack.getInternalNameOrNull() ?: return
+        skinId = internalName.asString()
+        skinIdTime = SimpleTimeMark.now()
+    }
+
+    @HandleEvent(GuiKeyPressEvent::class)
+    fun onCopyCosmeticsData() {
+        if (!debugConfig.copyCosmeticsSkullData.isKeyHeld()) return
+        val stack = stackUnderCursor() ?: return
+        if (stack.item != Items.PLAYER_HEAD) return
+        if (skinId == null) return
+        if (skinIdTime.passedSince() > 2.minutes) return
+
+        val skullTexture = stack.getSkullTexture()
+        val skullOwner = stack.getSkullOwner()
+        val skinColor = stack.cleanName().uppercase(Locale.getDefault()).replace(" ", "_")
+        val formatted = "\"${skinId}_${skinColor}\": {\"ticks\": 1, \"textures\": [\"${skullOwner}:${skullTexture}\"]},"
+
+        OSUtils.copyToClipboard(formatted)
+        ChatUtils.chat("§eCopied cosmetic data to the clipboard!")
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/SkyHanniDebugsAndTests.kt
@@ -347,8 +347,13 @@ object SkyHanniDebugsAndTests {
     private var skinId: String? = null
     private var skinIdTime: SimpleTimeMark = SimpleTimeMark.farPast()
 
-    @HandleEvent(GuiKeyPressEvent::class)
-    fun onKeybind() {
+    @HandleEvent(GuiKeyPressEvent::class, onlyOnSkyblock = true)
+    fun onGuiKeyPress() {
+        onKeyPressCopyCosmeticsData()
+        onKeybind()
+    }
+
+    private fun onKeybind() {
         if (!debugConfig.copyInternalName.isKeyHeld()) return
         val stack = stackUnderCursor() ?: return
         val internalName = stack.getInternalNameOrNull() ?: return
@@ -469,7 +474,7 @@ object SkyHanniDebugsAndTests {
     }
 
     @HandleEvent(GuiRenderEvent::class, onlyOnSkyblock = true)
-    fun onRenderUpdateSkinId() {
+    fun onGuiRender() {
         val stack = stackUnderCursor() ?: return
         if (!stack.getLoreComponent().any { it.string.contains("Right-click to preview!") }) return
 
@@ -478,7 +483,6 @@ object SkyHanniDebugsAndTests {
         skinIdTime = SimpleTimeMark.now()
     }
 
-    @HandleEvent(GuiKeyPressEvent::class, onlyOnSkyblock = true)
     fun onKeyPressCopyCosmeticsData() {
         if (!debugConfig.copyCosmeticsSkullData.isKeyHeld()) return
         val stack = stackUnderCursor() ?: return


### PR DESCRIPTION
## What
Adds a keybind to copy cosmetic skull data from the skin swapper menu

Idk if we classify this as a Backend Feature or a normal feature, but its just a dev feature so idk

## Changelog Technical Details
+ Added Copy Cosmetic Skull Data feature. - jani




