### PR TITLE
Backend: Stop forcing Adoptium JDK

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,11 +30,6 @@ val target = ProjectTarget.entries.find { it.projectPath == project.path }!!
 // Toolchains:
 java {
     toolchain.languageVersion.set(target.minecraftVersion.javaLanguageVersion)
-    // We specifically request ADOPTIUM because if we do not restrict the vendor DCEVM is a
-    // possible candidate. Some DCEVMs are however incompatible with some things Gradle is doing,
-    // causing crashes during tests. You can still manually select DCEVM in the Minecraft Client
-    // IntelliJ run configuration.
-    toolchain.vendor.set(JvmVendorSpec.ADOPTIUM)
 }
 val runDirectory = rootProject.file("run")
 runDirectory.mkdirs()


### PR DESCRIPTION
## What
Removed the Adoptium JDK enforcement. It was always a bad hack, but nowadays we don't even really use DCEVM to my knowledge.

## Changelog Technical Details
+ The build script no longer requires specifically an Adoptium JDK. - Luna
