### PR TITLE
Fix: No config write when on alpha

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.config.storage.AchievementStorage
 import at.hannibal2.skyhanni.config.storage.CustomTodosStorage
 import at.hannibal2.skyhanni.config.storage.OrderedWaypointsRoutes
 import at.hannibal2.skyhanni.config.storage.SpecificSeaCreatureStorage
+import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.PetDataStorage
 import at.hannibal2.skyhanni.data.jsonobjects.local.FriendsJson
 import at.hannibal2.skyhanni.data.jsonobjects.local.JacobContestsJson
@@ -207,6 +208,7 @@ class ConfigManager {
 
     private fun saveFile(file: File, fileName: String, data: Any, reason: String) {
         if (disableSaving) return
+        if (HypixelData.hypixelAlpha) return
         logger.log("saveConfig: $reason")
         try {
             logger.log("Saving $fileName file")

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -208,7 +208,7 @@ class ConfigManager {
 
     private fun saveFile(file: File, fileName: String, data: Any, reason: String) {
         if (disableSaving) return
-        if (HypixelData.hypixelAlpha) return
+        if (HypixelData.hypixelAlpha && !PlatformUtils.isDevEnvironment) return
         logger.log("saveConfig: $reason")
         try {
             logger.log("Saving $fileName file")


### PR DESCRIPTION

## What
Saving data to config now returns nothing if on alpha server.
This issue was causing data sync and overwriting errors when switching between the 2 servers.

## Changelog Fixes
+ Fixed config being written when on Alpha. - Rain
    * The mod won't write to config anymore when on Alpha, removing data sync/overwriting errors between Alpha and prod.
