### PR TITLE
Fix: Pest Cooldown timer saying Unknown

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -229,8 +229,9 @@ object PestSpawnTimer {
         } else {
             val cooldownValue = when {
                 maxPests -> "§cMax Pests!"
+                ready -> "§aReady!"
                 pestCooldownEndTime.isFarPast() -> "§cUnknown"
-                ready || pestCooldownEndTime.isInPast() -> "§aReady!"
+                pestCooldownEndTime.isInPast() -> "§aReady!"
                 else -> pestCooldownEndTime.timeUntil().format()
             }
             "§ePest Cooldown: §b$cooldownValue"


### PR DESCRIPTION
## What
Fixed Pest Cooldown timer always saying Unknown! 

## Changelog Fixes
+ Fixed Pest Cooldown Timer saying Unknown when the timer was ready. - FabiHBBBT