### PR TITLE
Backend: Disable Spirit Scepter Bat mob detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -258,9 +258,10 @@ object MobDetection {
     @HandleEvent
     fun onEntityHealthUpdateEvent(event: EntityHealthUpdateEvent) {
         when {
-            event.entity is Bat && event.health == 6 -> {
+            // Very high false positive rate
+            /*event.entity is Bat && event.health == 6 -> {
                 entityFromPacket.add(EntityPacketType.SPIRIT_BAT to event.entity.id)
-            }
+            }*/
 
             event.entity is Villager && event.health != 20 -> {
                 entityFromPacket.add(EntityPacketType.VILLAGER to event.entity.id)


### PR DESCRIPTION
## What
This has a really high false positive rate (everything from pests to random Rift mobs triggers it), and serves literally no purpose right now other than wasting cycles on needlessly raycasting.

## Changelog Technical Details
+ Disabled Spirit Scepter Bat mob detection rule because it is unused and has a very high false-positive rate. - Luna