### PR TITLE
Fix: Bingo NPC Handling

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -519,8 +519,11 @@ object IslandGraphs {
 
     private fun getGraph(): Graph = currentIslandGraph ?: error("current island graph is not loaded")
 
+    fun nodeOrNull(nodeName: String, nodeTag: GraphNodeTag): GraphNode? =
+        getGraph().getClosestNode(nodeName, nodeTag)
+
     fun node(nodeName: String, nodeTag: GraphNodeTag): GraphNode =
-        getGraph().getClosestNode(nodeName, nodeTag) ?: error("node not found: name: '$nodeName', tag: '$nodeTag'")
+        nodeOrNull(nodeName, nodeTag) ?: error("node not found: name: '$nodeName', tag: '$nodeTag'")
 
     fun nodes(nodeName: String, nodeTag: GraphNodeTag): List<GraphNode> =
         getGraph().getNodesWithNameAndTags(nodeName, nodeTag)

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
@@ -231,7 +231,7 @@ object BingoApi {
         val shouldHideBingoNpc = !isInBingoEventWindow()
         if (shouldHideBingoNpc != bingoNpcHidden) {
             bingoNpcHidden = shouldHideBingoNpc
-            IslandGraphs.node("Bingo", GraphNodeTag.NPC).enabled = !shouldHideBingoNpc
+            IslandGraphs.nodeOrNull("Bingo", GraphNodeTag.NPC)?.enabled = !shouldHideBingoNpc
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
@@ -225,7 +225,7 @@ object BingoApi {
         val shouldHideAlixer = !SkyBlockUtils.isBingoProfile
         if (shouldHideAlixer != alixerHidden) {
             alixerHidden = shouldHideAlixer
-            IslandGraphs.node("Alixer", GraphNodeTag.NPC).enabled = !shouldHideAlixer
+            IslandGraphs.nodeOrNull("Alixer", GraphNodeTag.NPC)?.enabled = !shouldHideAlixer
         }
 
         val shouldHideBingoNpc = !isInBingoEventWindow()


### PR DESCRIPTION

## What
Fixes `IllegalStateException` in `BingoApi.onIslandGraphReload()` when Bingo NPCs are not present

<errorlogs>
`SkyHanni 7.18.0 1.21.11: Caught a IllegalStateException in at.hannibal2.skyhanni.features.bingo.BingoApi.onIslandGraphReload() at IslandGraphReloadEvent: node not found: name: 'Alixer', tag: 'NPC'
 
Caused by java.lang.IllegalStateException: node not found: name: 'Alixer', tag: 'NPC'
    at SH.data.IslandGraphs.node(IslandGraphs.kt:523)
    at SH.features.bingo.BingoApi.checkBingoNpcs(BingoApi.kt:228)
    at SH.features.bingo.BingoApi.onIslandGraphReload(BingoApi.kt:186)
<Skyhanni event post>`
</errorlogs>


## Changelog Fixes
+ Fixed an error being thrown when Bingo NPCs aren't present on the island. - Rain
