### PR TITLE
Fix: Custom Keybinds not properly cancelling Attack/Destroy input

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -55,6 +55,17 @@ object GardenCustomKeybinds {
         return handled
     }
 
+    @JvmStatic
+    fun shouldCancelKeyClick(key: InputConstants.Key): Boolean {
+        if (!isActive()) return false
+        for ((keyBinding, override) in map) {
+            if (override == keyBinding.key.value) continue
+            if (key.value == keyBinding.key.value) return true
+            if (override != GLFW.GLFW_KEY_UNKNOWN && key.value == override) return true
+        }
+        return false
+    }
+
     @HandleEvent
     fun onTick() {
         if (!isEnabled()) return

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
@@ -28,6 +28,13 @@ public class MixinKeyBinding {
         }
     }
 
+    @Inject(method = "click", at = @At("HEAD"), cancellable = true)
+    private static void noClick(InputConstants.Key key, CallbackInfo ci) {
+        if (GardenCustomKeybinds.shouldCancelKeyClick(key)) {
+            ci.cancel();
+        }
+    }
+
     @Inject(method = "consumeClick", at = @At("HEAD"), cancellable = true)
     public void noIsPressed(CallbackInfoReturnable<Boolean> cir) {
         KeyMapping keyBinding = (KeyMapping) (Object) this;


### PR DESCRIPTION
## What
Fixes a long-standing issue with Custom Keybinds where pressing your normal Attack/Destroy key would still send a one-off input while holding a farming tool even if it is set to something else in SkyHanni.

## Changelog Fixes
+ Fixed normal Attack/Destroy key still triggering inputs with Garden Custom Keybinds active. - Luna