### PR TITLE
Fix: OwnInventoryData NPE

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
@@ -131,7 +131,7 @@ object OwnInventoryData {
         if (InventoryUtils.openInventoryName().startsWith("Wardrobe")) {
             lastWardrobeClose = SimpleTimeMark.now()
         }
-        val item = MinecraftCompat.localPlayer.getItemOnCursor() ?: return
+        val item = MinecraftCompat.localPlayerOrNull?.getItemOnCursor() ?: return
         val internalNameOrNull = item.getInternalNameOrNull() ?: return
         ignoreItem(500.milliseconds, internalNameOrNull)
     }


### PR DESCRIPTION
## What
Fixed an unsafe access of `MinecraftCompat.localPlayer` in `OwnInventoryData.onInventoryClose` that occasionally caused an error when the player was null because of a world change.

## Changelog Fixes
+ Fixed error when closing inventory during world change. - Luna