### PR TITLE
Fix: Missing Farming Tool category

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
@@ -68,6 +68,7 @@ enum class ItemCategory {
     GARDEN_CHIP,
     MUTATION,
     WATERING_CAN,
+    FARMING_TOOL,
 
     NONE,
     ;


### PR DESCRIPTION
## What
Fixed item categories missing the new farming tool category

### While this is technically only on alpha i think we should still merge it before it releases, otherwise support will just be annoying.


## Changelog Fixes
+ Fixed error with new Farming Tool (Axes and Hoes) item category. - jani


