### PR TITLE
Fix: Fix BeachBallCatchHelper bounce values

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
@@ -97,7 +97,7 @@ object BeachBallCatchHelper {
     private fun SkyHanniRenderWorldEvent.renderString(predictor: Predictor, location: LorenzVec) {
         val counter = predictor.bounceCounter
         val (qualityColor, quality) = when {
-            counter <= 1 -> "§c" to null
+            counter <= 1 -> "§c" to null // aww man
             counter <= 5 -> "§f" to "DECENT"
             counter <= 15 -> "§a" to "GOOD"
             counter <= 25 -> "§5" to "AMAZING"

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
@@ -101,7 +101,7 @@ object BeachBallCatchHelper {
             counter < 8 -> "§f" to "DECENT"
             counter < 18 -> "§a" to "GOOD"
             counter < 32 -> "§5" to "AMAZING"
-            counter < 51 -> "§6" to "IMPRESSIVE"
+            counter < 41 -> "§6" to "IMPRESSIVE"
             else -> "§d" to "INSANE"
         }
         val qualityString = quality?.let { " §8- $qualityColor§l$it!" }.orEmpty()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
@@ -97,11 +97,11 @@ object BeachBallCatchHelper {
     private fun SkyHanniRenderWorldEvent.renderString(predictor: Predictor, location: LorenzVec) {
         val counter = predictor.bounceCounter
         val (qualityColor, quality) = when {
-            counter < 2 -> "§c" to null // aww man
-            counter < 8 -> "§f" to "DECENT"
-            counter < 18 -> "§a" to "GOOD"
-            counter < 32 -> "§5" to "AMAZING"
-            counter < 41 -> "§6" to "IMPRESSIVE"
+            counter <= 1 -> "§c" to null
+            counter <= 5 -> "§f" to "DECENT"
+            counter <= 15 -> "§a" to "GOOD"
+            counter <= 25 -> "§5" to "AMAZING"
+            counter <= 39 -> "§6" to "IMPRESSIVE"
             else -> "§d" to "INSANE"
         }
         val qualityString = quality?.let { " §8- $qualityColor§l$it!" }.orEmpty()


### PR DESCRIPTION
## What
Fixes an incorrect value thresholds in BeachBallCatchHelper scoring logic.

## Changelog Fixes
- Fixed the Bouncy Ball thresholds not matching the updated values. - AverageUser125