### PR TITLE
Feature: Dungeon Profit Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonConfig.kt
@@ -14,6 +14,12 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class DungeonConfig {
+
+    @Expose
+    @ConfigOption(name = "Dungeon Profit Tracker", desc = "")
+    @Accordion
+    val profitTracker: DungeonProfitTrackerConfig = DungeonProfitTrackerConfig()
+
     @Expose
     @ConfigOption(
         name = "Clicked Blocks",

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonProfitTrackerConfig.kt
@@ -23,7 +23,7 @@ class DungeonProfitTrackerConfig {
     @Expose
     @ConfigOption(
         name = "Show Always",
-        desc = "Always show the profit tracker while in a dungeon run.",
+        desc = "Always show the profit tracker while in a Dungeon or in the Dungeon Hub.",
     )
     @ConfigEditorBoolean
     var showAlways: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dungeon/DungeonProfitTrackerConfig.kt
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.features.fishing
+package at.hannibal2.skyhanni.config.features.dungeon
 
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
@@ -9,30 +9,29 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
-class FishingProfitTrackerConfig {
+class DungeonProfitTrackerConfig {
     @Expose
-    @ConfigOption(name = "Enabled", desc = "Count all items you pick up while fishing.")
+    @ConfigOption(name = "Enabled", desc = "Count chest rewards you gain at the end of a dungeon run.")
     @ConfigEditorBoolean
     @FeatureToggle
     var enabled: Boolean = false
 
     @Expose
-    @ConfigLink(owner = FishingProfitTrackerConfig::class, field = "enabled")
+    @ConfigLink(owner = DungeonProfitTrackerConfig::class, field = "enabled")
     val position: Position = Position(20, 20)
 
     @Expose
     @ConfigOption(
-        name = "Show When Pickup",
-        desc = "Show the fishing tracker for a couple of seconds after catching something even while moving."
+        name = "Show Always",
+        desc = "Always show the profit tracker while in a dungeon run.",
     )
     @ConfigEditorBoolean
-    var showWhenPickup: Boolean = true
+    var showAlways: Boolean = false
 
-    // TODO remove suffix config
     @Expose
     @ConfigOption(
         name = "Tracker Settings",
-        desc = ""
+        desc = "",
     )
     @Accordion
     val perTrackerConfig: IndividualItemTrackerConfig = IndividualItemTrackerConfig()

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
@@ -52,6 +52,7 @@ class FishingConfig {
     @Accordion
     val rareCatches: RareCatchesConfig = RareCatchesConfig()
 
+    // TODO remove prefix fishing
     @Expose
     @ConfigOption(name = "Fishing Profit Tracker", desc = "")
     @Accordion

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -140,7 +140,7 @@ class ProfileSpecificStorage(
 
         // we can not reuse runs data because it is inaccurate and gets autocorrected via opening the chest.
         @Expose
-        var availableCroesus: MutableMap<DungeonFloor, CroesusStorage> = mutableMapOf()
+        var availableCroesus: MutableMap<DungeonFloor, CroesusStorage> = enumMapOf()
 
         @Expose
         var profitTracker: DungeonProfitTracker.BucketData = DungeonProfitTracker.BucketData()

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -160,6 +160,7 @@ class ProfileSpecificStorage(
             @Expose
             var runTime: SimpleTimeMark? = null
 
+            // TODO change to DungeonFloor
             @Expose
             var floor: String? = null
 

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -17,7 +17,10 @@ import at.hannibal2.skyhanni.features.combat.ghosttracker.GhostTracker
 import at.hannibal2.skyhanni.features.commands.OpenLastStorage
 import at.hannibal2.skyhanni.features.dungeon.CroesusChestTracker.OpenedState
 import at.hannibal2.skyhanni.features.dungeon.CroesusChestTracker.generateMaxChestAsList
+import at.hannibal2.skyhanni.features.dungeon.CroesusStorage
+import at.hannibal2.skyhanni.features.dungeon.DungeonBoss
 import at.hannibal2.skyhanni.features.dungeon.DungeonFloor
+import at.hannibal2.skyhanni.features.dungeon.DungeonProfitTracker
 import at.hannibal2.skyhanni.features.event.carnival.CarnivalGoal
 import at.hannibal2.skyhanni.features.event.diana.DianaProfitTracker
 import at.hannibal2.skyhanni.features.event.diana.MythologicalCreatureTracker
@@ -133,7 +136,14 @@ class ProfileSpecificStorage(
 
     class DungeonStorage {
         @Expose
-        var bosses: MutableMap<DungeonFloor, Int> = enumMapOf()
+        var bosses: MutableMap<DungeonBoss, Int> = enumMapOf()
+
+        // we can not reuse runs data because it is inaccurate and gets autocorrected via opening the chest.
+        @Expose
+        var availableCroesus: MutableMap<DungeonFloor, CroesusStorage> = mutableMapOf()
+
+        @Expose
+        var profitTracker: DungeonProfitTracker.BucketData = DungeonProfitTracker.BucketData()
 
         @Expose
         var runs: MutableList<DungeonRunInfo> = generateMaxChestAsList()
@@ -421,6 +431,7 @@ class ProfileSpecificStorage(
     var fishing: FishingStorage = FishingStorage()
 
     class FishingStorage {
+        // TODO remove prefix fishing
         @Expose
         var fishingProfitTracker: FishingProfitTracker.Data = FishingProfitTracker.Data()
 

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -520,7 +520,7 @@ object IslandGraphs {
     private fun getGraph(): Graph = currentIslandGraph ?: error("current island graph is not loaded")
 
     fun nodeOrNull(nodeName: String, nodeTag: GraphNodeTag): GraphNode? =
-        getGraph().getClosestNode(nodeName, nodeTag)
+        currentIslandGraph?.getClosestNode(nodeName, nodeTag)
 
     fun node(nodeName: String, nodeTag: GraphNodeTag): GraphNode =
         nodeOrNull(nodeName, nodeTag) ?: error("node not found: name: '$nodeName', tag: '$nodeTag'")

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
@@ -27,6 +27,8 @@ enum class IslandTypeTag(vararg types: SkyHanniIslandType) : SkyHanniIslandType 
     FORAGING(IslandType.THE_PARK, IslandType.GALATEA),
     FORAGING_CUSTOM_TREES(IslandType.GALATEA),
 
+    DUNGEON_ISLANDS(IslandType.DUNGEON_HUB, IslandType.CATACOMBS),
+
     HOPPITY_DISALLOWED(IslandType.THE_RIFT, IslandType.KUUDRA_ARENA, IslandType.CATACOMBS, IslandType.MINESHAFT),
     HAS_SHOWCASES(PRIVATE_ISLAND, IslandType.HUB, IslandType.CRIMSON_ISLE),
     CONTESTS_SHOWN(IslandType.GARDEN, IslandType.HUB, IslandType.THE_FARMING_ISLANDS),

--- a/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonCompleteEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonCompleteEvent.kt
@@ -1,5 +1,13 @@
 package at.hannibal2.skyhanni.events.dungeon
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonFloor
+import kotlin.time.Duration
 
-class DungeonCompleteEvent(val floor: String) : SkyHanniEvent()
+/**
+ * gets fired when the dungeon is done. either a death or the final boss is killed.
+ *  @param dungeonFloor the floor of the dungeon, e.g. F1
+ *  @param time the time it took to close the dungeon, taken from the scoreboard.
+ */
+class DungeonCompleteEvent(val dungeonFloor: DungeonFloor, @Deprecated("use dungeonFloor") val floor: String, val time: Duration) :
+    SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonEnterEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonEnterEvent.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.events.dungeon
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonFloor
 
-class DungeonEnterEvent(val dungeonFloor: String) : SkyHanniEvent()
+class DungeonEnterEvent(val dungeonFloor: DungeonFloor) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonLootApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonLootApi.kt
@@ -1,0 +1,78 @@
+package at.hannibal2.skyhanni.events.dungeon
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonApi
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.costs
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+
+@SkyHanniModule
+object DungeonLootApi {
+
+    private val DUNGEON_CHEST_KEY = "DUNGEON_CHEST_KEY".toInternalName()
+
+    // infos about the current process of buying a chest
+    private var cost = 0
+    private var usedKey = false
+    private var chestType: String? = null
+    private var loot = mutableListOf<Pair<String, Int>>()
+
+
+    @HandleEvent
+    fun onChat(event: SkyHanniChatEvent.Allow) {
+        val message = event.cleanMessage
+        val patterns = " {2}(?<type>.*) CHEST REWARDS".toPattern()
+        patterns.matchMatcher(message) {
+            val type = group("type")
+            chestType = type
+            return
+        }
+
+        val chestType = chestType ?: return
+
+        if (message == "") {
+            if (loot.isEmpty()) error("loot is empty!")
+            DungeonLootEvent(cost, usedKey, chestType, loot).post()
+            cost = 0
+            usedKey = false
+            this.chestType = null
+            loot = mutableListOf()
+            return
+        }
+
+        println("message: $message")
+        ItemUtils.readItemStackFromChat(event.message)?.let {
+            loot.add(it)
+        }
+    }
+
+    @HandleEvent
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (DungeonApi.isInCroesus || IslandType.CATACOMBS.isInIsland()) {
+            val stack = event.item ?: return
+            val costs = stack.costs()
+            println("costs: ${costs.size}")
+            for ((internalName, amount) in costs) {
+                println("internalName: $internalName ($amount)")
+                when (internalName) {
+                    NeuInternalName.SKYBLOCK_COIN -> {
+                        cost = amount
+                    }
+
+                    DUNGEON_CHEST_KEY -> {
+                        usedKey = true
+                    }
+
+                    else -> error("unknown cost of dungeon chest: $internalName (x$amount)")
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonLootEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonLootEvent.kt
@@ -1,0 +1,13 @@
+package at.hannibal2.skyhanni.events.dungeon
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+
+/**
+ * Gets fired when the player opens a reward chest in Dungeons or in Croesus
+ */
+class DungeonLootEvent(
+    val cost: Int,
+    val usedKey: Boolean,
+    val chestType: String,
+    val loot: List<Pair<String, Int>>,
+) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonStartEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonStartEvent.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.events.dungeon
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonFloor
 
-class DungeonStartEvent(val dungeonFloor: String) : SkyHanniEvent()
+class DungeonStartEvent(val dungeonFloor: DungeonFloor) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -672,6 +672,7 @@ object ChatFilter {
     private fun powderMiningBlock(event: SkyHanniChatEvent.Modify) {
         val powderMiningMatchResult = PowderMiningChatFilter.block(event.message)
         if (powderMiningMatchResult == "no_filter") {
+            // TODO find out if we can replace this with ItemUtils.readItemStackFromChat
             genericMiningRewardMessage.matchMatcher(event.message) {
                 val reward = groupOrEmpty("reward")
                 val amountFormat = groupOrNull("amount")?.let {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -350,6 +350,7 @@ object InstanceChestProfit {
 
         // Slot 31 has the cost information for the chest
         items[31]?.getLore()?.forEach {
+            // TODO use ItemUtiils.readFromLore
             coinsPattern.matchMatcher(it) {
                 val amount = group("amount").formatInt()
                 itemsWithCost.put(it, -amount.toDouble())

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -244,7 +244,7 @@ object CroesusChestTracker {
 
     @HandleEvent
     fun onDungeonComplete(event: DungeonCompleteEvent) {
-        if (event.floor == "E") return
+        if (event.dungeonFloor == DungeonFloor.E) return
         addCroesusChest(event.floor)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -56,12 +56,6 @@ object CroesusChestTracker {
     private val kismetUsedInChestPattern by patternGroup.pattern("kismet.used", "§aYou already rerolled a chest!")
 
     /**
-     * REGEX-TEST: §eFloor V
-     */
-    private val floorPattern by patternGroup.pattern("chest.floor", "§eFloor (?<floor>[IV]+)")
-    private val masterPattern by patternGroup.pattern("chest.master", ".*Master.*")
-
-    /**
      * REGEX-TEST: §eInfernal Tier
      */
     private val kuudraPattern by patternGroup.pattern("chest.kuudra", "§e(?<tier>Basic|Hot|Burning|Fiery|Infernal) Tier")
@@ -162,14 +156,16 @@ object CroesusChestTracker {
 
             val lore = item.getLore()
 
-            if (run.floor == null || run.floor == "F0") run.floor =
-                (if (masterPattern.matches(item.hoverName)) "M" else "F") + (
-                    lore.firstNotNullOfOrNull {
-                        floorPattern.matchMatcher(it) { group("floor").romanToDecimal() }
-                    } ?: "0"
-                    )
-            if (run.floor == "F0" && kuudraPattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets())) run.floor =
-                ("T" + KuudraApi.getKuudraRunTierNumber(lore.firstNotNullOfOrNull { kuudraPattern.matchMatcher(it) { group("tier") } }))
+            if (run.floor == null || run.floor == "F0") {
+                val floor = DungeonApi.getFloorByItemStack(item)
+                run.floor = floor?.name ?: "F0"
+            }
+            val cleanName = item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            if (run.floor == "F0" && kuudraPattern.matches(cleanName)) {
+                val rawTier = lore.firstNotNullOfOrNull { kuudraPattern.matchMatcher(it) { group("tier") } }
+                val kuudraTier = KuudraApi.getKuudraRunTierNumber(rawTier)
+                run.floor = "T$kuudraTier"
+            }
             run.openState = OpenedState.getOpenState(lore)
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -245,7 +245,7 @@ object CroesusChestTracker {
     @HandleEvent
     fun onDungeonComplete(event: DungeonCompleteEvent) {
         if (event.dungeonFloor == DungeonFloor.E) return
-        addCroesusChest(event.floor)
+        addCroesusChest(event.dungeonFloor.name)
     }
 
     // TODO Replace y > 103 check with a better "is actively playing Cata/Kuudra" heuristic

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.events.dungeon.DungeonStartEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
@@ -78,7 +77,7 @@ object DungeonApi {
         private set
     var roomId: String? = null
         private set
-    var time: Duration? = null
+    private var time: Duration? = null
     val active get() = started && !completed
 
     val bossStorage: MutableMap<DungeonBoss, Int>? get() = ProfileStorageData.profileSpecific?.dungeons?.bosses
@@ -182,10 +181,7 @@ object DungeonApi {
         return bossName.endsWith(correctBoss)
     }
 
-    fun getCurrentBoss(): DungeonBoss? {
-        val floor = dungeonFloor ?: return null
-        return DungeonBoss.valueOf(floor.replace("M", "F"))
-    }
+    fun getCurrentBoss(): DungeonBoss? = dungeonFloorEnum?.boss
 
     private const val WATER_ROOM_ID = "-60,-60"
     val inWaterRoom: Boolean get() = roomId == WATER_ROOM_ID

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -7,6 +7,8 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
@@ -20,6 +22,8 @@ import at.hannibal2.skyhanni.events.dungeon.DungeonStartEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
@@ -79,6 +83,12 @@ object DungeonApi {
         private set
     private var time: Duration? = null
     val active get() = started && !completed
+
+    // floor type of the last viewed dungeon run in croesus
+    var lastCroesusFloor: DungeonFloor? = null
+        private set
+    var isInCroesus = false
+        private set
 
     val bossStorage: MutableMap<DungeonBoss, Int>? get() = ProfileStorageData.profileSpecific?.dungeons?.bosses
 
@@ -512,5 +522,30 @@ object DungeonApi {
         } ?: return null
         val boss = DungeonBoss.byFloorNumber(number)
         return DungeonFloor.getByBoss(boss, masterMode)
+    }
+
+    @HandleEvent
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (IslandType.DUNGEON_HUB.isInIsland()) {
+            if (InventoryUtils.openInventoryName() == "Croesus") {
+                if (!isInCroesus) {
+                    ChatUtils.chat("opened Croesus")
+                    isInCroesus = true
+                }
+                val stack = event.item ?: return
+                val floor = getFloorByItemStack(stack)
+                lastCroesusFloor = floor
+            }
+        }
+    }
+
+    // WHY DOES THIS EVENT GET FIRED wrongly????
+    @HandleEvent
+    fun onInventoryClose(event: InventoryCloseEvent) {
+        if (isInCroesus) {
+            ////isInCroesus = false
+            ChatUtils.chat("closed Croesus")
+            ChatUtils.chat("reopenSameName: ${event.reopenSameName}")
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -20,6 +20,7 @@ import at.hannibal2.skyhanni.events.dungeon.DungeonStartEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
@@ -32,12 +33,15 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.block.Blocks
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 @Suppress("MemberVisibilityCanBePrivate")
 @SkyHanniModule
@@ -52,7 +56,11 @@ object DungeonApi {
     private val killPattern = " +☠ Defeated (?<boss>\\w+).*".toPattern()
     private val totalKillsPattern = "§7Total Kills: §e(?<kills>.*)".toPattern()
 
+    // TODO change to DungeonFloor
+    @Deprecated("use dungeonFloorEnum")
     var dungeonFloor: String? = null
+        private set
+    var dungeonFloorEnum: DungeonFloor? = null
         private set
     var started = false
         private set
@@ -66,13 +74,14 @@ object DungeonApi {
         private set
     var isUniqueClass = false
         private set
-    var time: String = ""
+    var timeDisplay: String = ""
         private set
     var roomId: String? = null
         private set
+    var time: Duration? = null
     val active get() = started && !completed
 
-    val bossStorage: MutableMap<DungeonFloor, Int>? get() = ProfileStorageData.profileSpecific?.dungeons?.bosses
+    val bossStorage: MutableMap<DungeonBoss, Int>? get() = ProfileStorageData.profileSpecific?.dungeons?.bosses
 
     private val patternGroup = RepoPattern.group("dungeon")
     private val WITHER_ESSENCE_TEXTURE by lazy { SkullTextureHolder.getTexture("WITHER_ESSENCE") }
@@ -173,9 +182,9 @@ object DungeonApi {
         return bossName.endsWith(correctBoss)
     }
 
-    fun getCurrentBoss(): DungeonFloor? {
+    fun getCurrentBoss(): DungeonBoss? {
         val floor = dungeonFloor ?: return null
-        return DungeonFloor.valueOf(floor.replace("M", "F"))
+        return DungeonBoss.valueOf(floor.replace("M", "F"))
     }
 
     private const val WATER_ROOM_ID = "-60,-60"
@@ -202,7 +211,9 @@ object DungeonApi {
             val floor = group("floor")
             if (dungeonFloor == floor) return
             dungeonFloor = floor
-            DungeonEnterEvent(floor).post()
+            val dungeonFloor = DungeonFloor.getByName(floor) ?: error("unknown dungeon floor: '$floor'")
+            dungeonFloorEnum = dungeonFloor
+            DungeonEnterEvent(dungeonFloor).post()
             return
         }
         if (!inDungeon()) return
@@ -211,7 +222,12 @@ object DungeonApi {
             return
         }
         timePattern.firstMatcher(event.added) {
-            time = "${groupOrNull("minutes") ?: "00"}:${group("seconds")}"
+            val minutes = groupOrNull("minutes")
+            val seconds = group("seconds")
+            timeDisplay = "${minutes ?: "00"}:$seconds"
+            val m = minutes?.formatInt() ?: 0
+            val s = seconds.formatInt()
+            time = (m * 60 + s).seconds
             return
         }
     }
@@ -256,6 +272,7 @@ object DungeonApi {
     @HandleEvent
     fun onWorldChange() {
         dungeonFloor = null
+        dungeonFloorEnum = null
         started = false
         inBossRoom = false
         isUniqueClass = false
@@ -263,17 +280,19 @@ object DungeonApi {
         playerClassLevel = -1
         completed = false
         playerTeamClasses.clear()
-        time = ""
+        timeDisplay = ""
         roomId = null
+        time = null
         DungeonBlessings.reset()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onChat(event: SkyHanniChatEvent.Allow) {
         val floor = dungeonFloor ?: return
+        val floorEnum = dungeonFloorEnum ?: return
         if (event.message == "§e[NPC] §bMort§f: §rHere, I found this map when I first entered the dungeon.") {
             started = true
-            DungeonStartEvent(floor).post()
+            DungeonStartEvent(floorEnum).post()
         }
         if (event.cleanMessage.matches(uniqueClassBonus)) {
             isUniqueClass = true
@@ -281,7 +300,7 @@ object DungeonApi {
 
         killPattern.matchMatcher(event.cleanMessage) {
             val bossCollections = bossStorage ?: return
-            val boss = DungeonFloor.byBossName(group("boss"))
+            val boss = DungeonBoss.byBossName(group("boss"))
             if (matches() && boss != null && boss !in bossCollections) {
                 bossCollections.addOrPut(boss, 1)
             }
@@ -289,7 +308,9 @@ object DungeonApi {
         }
         dungeonComplete.matchMatcher(event.cleanMessage) {
             completed = true
-            DungeonCompleteEvent(floor).post()
+            val time = time ?: error("time is null")
+            DungeonCompleteEvent(floorEnum, floor, time).post()
+
             return
         }
     }
@@ -307,7 +328,7 @@ object DungeonApi {
     }
 
     private fun readOneMaxCollection(
-        bossCollections: MutableMap<DungeonFloor, Int>,
+        bossCollections: MutableMap<DungeonBoss, Int>,
         inventoryItems: Map<Int, ItemStack>,
         inventoryName: String,
     ) {
@@ -316,7 +337,7 @@ object DungeonApi {
                 item.getLore().getOrNull(0)?.let { firstLine ->
                     if (firstLine == "§7To Boss Collections") {
                         val name = inventoryName.split(" ").dropLast(1).joinToString(" ")
-                        val floor = DungeonFloor.byBossName(name) ?: return
+                        val floor = DungeonBoss.byBossName(name) ?: return
                         val lore = inventoryItems[4]?.getLore() ?: return
                         val line = lore.find { it.contains("Total Kills:") } ?: return
                         val kills = totalKillsPattern.matchMatcher(line) {
@@ -330,7 +351,7 @@ object DungeonApi {
     }
 
     private fun readAllCollections(
-        bossCollections: MutableMap<DungeonFloor, Int>,
+        bossCollections: MutableMap<DungeonBoss, Int>,
         inventoryItems: Map<Int, ItemStack>,
     ) {
         nextItem@ for (stack in inventoryItems.values) {
@@ -350,7 +371,7 @@ object DungeonApi {
                     }
                 }
             }
-            val floor = DungeonFloor.byBossName(name) ?: continue
+            val floor = DungeonBoss.byBossName(name) ?: continue
             bossCollections[floor] = kills
         }
     }
@@ -368,7 +389,7 @@ object DungeonApi {
             add("dungeonFloor: $dungeonFloor")
             add("started: $started")
             add("getRoomID: $roomId")
-            add("time: $time")
+            add("time: $timeDisplay")
             add("inBossRoom: $inBossRoom")
             add("")
             add("playerClass: $playerClass")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -22,6 +22,7 @@ import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
+import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
@@ -32,7 +33,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
@@ -133,6 +133,14 @@ object DungeonApi {
         "tablist.playerteam.colorless",
         "^(?<sbLevel>\\[\\d+]) (?<rank>\\[[^]]+])? ?(?<playerName>\\S+)\\s?(?<symbols>[^(]*) \\((?:(?<className>\\S+) (?<classLevel>[CLXVI0]+)|(?<playerDead>DEAD))\\)\$",
     )
+
+    /**
+     * REGEX-TEST: §eFloor V
+     */
+    private val croesusFloorPattern by patternGroup.pattern("croesus.chest.floor", "§eFloor (?<floor>[IV]+)")
+
+    // TODO regex text
+    private val croesusMasterPattern by patternGroup.pattern("croesus.chest.master", ".*Master.*")
 
     enum class DungeonBlessings(var power: Int) {
         LIFE(0),
@@ -494,5 +502,15 @@ object DungeonApi {
                 )
             }
         }
+    }
+
+    fun getFloorByItemStack(stack: ItemStack): DungeonFloor? {
+        val lore = stack.getLore()
+        val masterMode = croesusMasterPattern.matches(stack.hoverName)
+        val number = lore.firstNotNullOfOrNull {
+            croesusFloorPattern.matchMatcher(it) { group("floor").romanToDecimal() }
+        } ?: return null
+        val boss = DungeonBoss.byFloorNumber(number)
+        return DungeonFloor.getByBoss(boss, masterMode)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
@@ -95,7 +95,7 @@ object DungeonCopilot {
         if (message == "§c[BOSS] The Watcher§r§f: That will be enough for now.") changeNextStep("Clear Blood Room")
 
         if (message == "§c[BOSS] The Watcher§r§f: You have proven yourself. You may pass.") {
-            if (DungeonApi.getCurrentBoss() == DungeonFloor.E) {
+            if (DungeonApi.getCurrentBoss() == DungeonBoss.E) {
                 changeNextStep()
             } else {
                 changeNextStep("Enter Boss Room")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFloor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFloor.kt
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.features.dungeon
 
-enum class DungeonFloor(val floor: DungeonBoss, val masterMode: Boolean) {
+enum class DungeonFloor(val boss: DungeonBoss, val masterMode: Boolean) {
     E(DungeonBoss.E, false),
 
     F1(DungeonBoss.F1, false),
@@ -39,6 +39,6 @@ enum class DungeonBoss(private val bossName: String) {
 
     companion object {
 
-        fun byBossName(bossName: String) = DungeonBoss.entries.firstOrNull { it.bossName == bossName }
+        fun byBossName(bossName: String): DungeonBoss? = entries.firstOrNull { it.bossName == bossName }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFloor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFloor.kt
@@ -1,6 +1,33 @@
 package at.hannibal2.skyhanni.features.dungeon
 
-enum class DungeonFloor(private val bossName: String) {
+enum class DungeonFloor(val floor: DungeonBoss, val masterMode: Boolean) {
+    E(DungeonBoss.E, false),
+
+    F1(DungeonBoss.F1, false),
+    F2(DungeonBoss.F2, false),
+    F3(DungeonBoss.F3, false),
+    F4(DungeonBoss.F4, false),
+    F5(DungeonBoss.F5, false),
+    F6(DungeonBoss.F6, false),
+    F7(DungeonBoss.F7, false),
+
+    M1(DungeonBoss.F1, true),
+    M2(DungeonBoss.F2, true),
+    M3(DungeonBoss.F3, true),
+    M4(DungeonBoss.F4, true),
+    M5(DungeonBoss.F5, true),
+    M6(DungeonBoss.F6, true),
+    M7(DungeonBoss.F7, true),
+    ;
+
+    fun asString() = name
+
+    companion object {
+        fun getByName(name: String): DungeonFloor? = entries.find { it.name == name }
+    }
+}
+
+enum class DungeonBoss(private val bossName: String) {
     E("The Watcher"),
     F1("Bonzo"),
     F2("Scarf"),
@@ -12,6 +39,6 @@ enum class DungeonFloor(private val bossName: String) {
 
     companion object {
 
-        fun byBossName(bossName: String) = DungeonFloor.entries.firstOrNull { it.bossName == bossName }
+        fun byBossName(bossName: String) = DungeonBoss.entries.firstOrNull { it.bossName == bossName }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFloor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFloor.kt
@@ -24,21 +24,24 @@ enum class DungeonFloor(val boss: DungeonBoss, val masterMode: Boolean) {
 
     companion object {
         fun getByName(name: String): DungeonFloor? = entries.find { it.name == name }
+        fun getByBoss(boss: DungeonBoss, masterMode: Boolean): DungeonFloor? =
+            entries.find { it.boss == boss && it.masterMode == masterMode }
     }
 }
 
-enum class DungeonBoss(private val bossName: String) {
-    E("The Watcher"),
-    F1("Bonzo"),
-    F2("Scarf"),
-    F3("The Professor"),
-    F4("Thorn"),
-    F5("Livid"),
-    F6("Sadan"),
-    F7("Necron");
+enum class DungeonBoss(private val bossName: String, private val floor: Int) {
+    E("The Watcher", 0),
+    F1("Bonzo", 1),
+    F2("Scarf", 2),
+    F3("The Professor", 3),
+    F4("Thorn", 4),
+    F5("Livid", 5),
+    F6("Sadan", 6),
+    F7("Necron", 7);
 
     companion object {
 
         fun byBossName(bossName: String): DungeonBoss? = entries.firstOrNull { it.bossName == bossName }
+        fun byFloorNumber(floor: Int): DungeonBoss = entries.firstOrNull { it.floor == floor } ?: error("unknown floor number: $floor")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
@@ -183,7 +183,7 @@ object DungeonLividFinder {
 
     @HandleEvent(DungeonBossRoomEnterEvent::class)
     fun onBossStart() {
-        if (DungeonApi.getCurrentBoss() != DungeonFloor.F5) return
+        if (DungeonApi.getCurrentBoss() != DungeonBoss.F5) return
         color = LorenzColor.RED
     }
 
@@ -246,7 +246,7 @@ object DungeonLividFinder {
         event.drawLineToCrosshair(location.add(x = 0.5, z = 0.5), color, 3, true)
     }
 
-    private fun inLividBossRoom() = DungeonApi.inBossRoom && DungeonApi.getCurrentBoss() == DungeonFloor.F5
+    private fun inLividBossRoom() = DungeonApi.inBossRoom && DungeonApi.getCurrentBoss() == DungeonBoss.F5
 
     private fun RemotePlayer.highlight(color: LorenzColor?) {
         if (color == null) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
@@ -10,15 +10,19 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
 import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonCompleteEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonProfitTracker.drawDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumAllValues
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.Searchable
@@ -42,11 +46,11 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
 ) {
     val config get() = SkyHanniMod.feature.dungeon.profitTracker
 
-    // thius only exists to ignore croesuses openings for floors the player did prior to this feature being implemented.
+    // this only exists to ignore croesus openings for floors the player did prior to this feature being implemented.
     val availableCroesus: MutableMap<DungeonFloor, CroesusStorage>? get() = ProfileStorageData.profileSpecific?.dungeons?.availableCroesus
 
     var hasOpened = false
-    var hasUSedKey = false
+    var hasUsedKey = false
 
     var lastChangeTime = SimpleTimeMark.farPast()
 
@@ -61,10 +65,11 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
         }
     }
 
-    // TODO show while holding kismet or dungoen key in hand always
+    // TODO show while holding kismet or dungeon key in hand always
     private fun shouldShowDisplay(): Boolean {
         if (!config.enabled) return false
         if (!IslandTypeTag.DUNGEON_ISLANDS.isInIsland()) return false
+        if (DungeonApi.dungeonFloorEnum == DungeonFloor.E) return false
         if (lastChangeTime.passedSince() < 30.seconds) return true
 
         if (config.showAlways && IslandType.CATACOMBS.isInIsland()) {
@@ -84,7 +89,6 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
     }
 
     data class BucketData(
-        @Expose var totalFloorParticipated: Long = 0L,
         @Expose var runsParticipated: MutableMap<DungeonFloor, Long> = EnumMap(DungeonFloor::class.java),
         @Expose var coinsSpent: MutableMap<DungeonFloor, Long> = EnumMap(DungeonFloor::class.java),
         @Expose var chestsOpened: MutableMap<DungeonFloor, Long> = EnumMap(DungeonFloor::class.java),
@@ -100,6 +104,9 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
                 "§7Your drop rate: §c$dropRate.",
             )
         }
+
+        val totalFloorParticipated get() = runsParticipated.sumAllValues().toLong()
+        val totalKismetsUsed get() = kismetsUsed.sumAllValues().toLong()
 
         override fun getCoinName(bucket: DungeonFloor?, item: TrackedItem) = "§6Dungeon Chest Coins"
 
@@ -119,8 +126,21 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
     }
 
     @HandleEvent
-    fun onDungeonComplete(event: DungeonCompleteEvent) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
+        if (event.cleanMessage == "You used a Kismet Feather!") {
+            modify {
+                val floor = DungeonApi.dungeonFloorEnum
+                if (floor != null) {
+                    it.kismetsUsed.addOrPut(floor, 1)
+                }
 
+            }
+        }
+    }
+
+    @HandleEvent
+    fun onDungeonComplete(event: DungeonCompleteEvent) {
+        if (event.dungeonFloor == DungeonFloor.E) return
         val dungeonFloor = event.dungeonFloor
         availableCroesus?.let {
             val floor = it[dungeonFloor] ?: run {
@@ -131,7 +151,6 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
             floor.keys++
             floor.chests++
             modify {
-                it.totalFloorParticipated++
                 it.runsParticipated.addOrPut(event.dungeonFloor, 1)
             }
         }
@@ -202,8 +221,15 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
              **/
         }
 
+        val kismetsUsed = selectedBucket?.let { bucketData.kismetsUsed[it] ?: 0 } ?: bucketData.totalKismetsUsed
+        val kismetPrice = "KISMET_FEATHER".toInternalName().getPrice()
+        val totalKismetPrice = kismetPrice * kismetsUsed
+        val kismetPriceDisplay = if (kismetsUsed != 0L) " §7(§c-${totalKismetPrice.shortFormat()}§7)" else ""
+        profit -= totalKismetPrice
+        add(Renderable.text("§7Kismets used: §e$kismetsUsed$kismetPriceDisplay").toSearchable("kismet"))
+
         val duration = bucketData.getTotalUptime()
-        addAll(addTotalProfit(profit, bucketData.totalFloorParticipated, "kill", duration, "Kills"))
+        addAll(addTotalProfit(profit, bucketData.totalFloorParticipated, "run", duration, "runs"))
 
         addPriceFromButton(this)
     }
@@ -213,5 +239,7 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
 class CroesusStorage {
     @Expose
     var chests = 0
+
+    @Expose
     var keys = 0
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
@@ -8,22 +8,25 @@ import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
-import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonCompleteEvent
+import at.hannibal2.skyhanni.events.dungeon.DungeonLootEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonProfitTracker.drawDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
+import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
+import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumAllValues
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
@@ -55,11 +58,9 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
     private val KISMET_FEATHER = "KISMET_FEATHER".toInternalName()
     private val DUNGEON_CHEST_KEY = "DUNGEON_CHEST_KEY".toInternalName()
 
+    // infos about the c urrent dungeon run lobby
     var hasOpened = false
     var hasUsedKey = false
-
-    // floor type of the last viewed dungeon run in croesus
-    var lastCroesusFloor: DungeonFloor? = null
 
     var lastChangeTime = SimpleTimeMark.farPast()
 
@@ -136,13 +137,30 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
 
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent.Allow) {
-        if (event.cleanMessage == "You used a Kismet Feather!") {
+        // TODO use repo patterns
+        val message = event.cleanMessage
+        if (message == "You used a Kismet Feather!") {
             modify {
-                val floor = DungeonApi.dungeonFloorEnum ?: lastCroesusFloor
+                val floor = DungeonApi.dungeonFloorEnum ?: DungeonApi.lastCroesusFloor
                 if (floor != null) {
                     it.kismetsUsed.addOrPut(floor, 1)
                 }
             }
+        }
+    }
+
+    @HandleEvent
+    fun onDungeonLoot(event: DungeonLootEvent) {
+        val chestType = event.chestType
+        val cost = event.cost
+        val usedKey = event.usedKey
+        ChatUtils.chat("opened dungeon chest: $chestType")
+        ChatUtils.chat("cost: $cost")
+        ChatUtils.chat("used key: $usedKey")
+        ChatUtils.chat("loot: ${event.loot.size}")
+        for ((itemName, amount) in event.loot) {
+            val internalName = NeuInternalName.fromItemName(itemName)
+            ChatUtils.chat(" - loot: $itemName/${internalName.repoItemName} §8x$amount")
         }
     }
 
@@ -169,15 +187,6 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
         if (shouldShowDisplay() && event.source == ItemAddManager.Source.COMMAND) {
             event.addItemFromEvent()
         }
-    }
-
-    @HandleEvent(onlyOnIsland = IslandType.DUNGEON_HUB)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        if (InventoryUtils.openInventoryName() != "Croesus") return
-        val stack = event.item ?: return
-        val floor = DungeonApi.getFloorByItemStack(stack)
-        lastCroesusFloor = floor
-        ChatUtils.chat("Floor: $floor")
     }
 
     private fun drawDisplay(bucketData: BucketData): List<Searchable> = buildList {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonCompleteEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonProfitTracker.drawDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
@@ -50,6 +51,7 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
     val availableCroesus: MutableMap<DungeonFloor, CroesusStorage>? get() = ProfileStorageData.profileSpecific?.dungeons?.availableCroesus
 
     private val KISMET_FEATHER = "KISMET_FEATHER".toInternalName()
+    private val DUNGEON_CHEST_KEY = "DUNGEON_CHEST_KEY".toInternalName()
 
     var hasOpened = false
     var hasUsedKey = false
@@ -67,16 +69,14 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
         }
     }
 
-    // TODO show while holding kismet or dungeon key in hand always
     private fun shouldShowDisplay(): Boolean {
         if (!config.enabled) return false
-        if (!IslandTypeTag.DUNGEON_ISLANDS.isInIsland()) return false
         if (DungeonApi.dungeonFloorEnum == DungeonFloor.E) return false
-        if (lastChangeTime.passedSince() < 30.seconds) return true
+        if (hasItemInHand()) return true
+        if (!IslandTypeTag.DUNGEON_ISLANDS.isInIsland()) return false
 
-        if (config.showAlways && IslandType.CATACOMBS.isInIsland()) {
-            return true
-        }
+        if (config.showAlways) return true
+        if (lastChangeTime.passedSince() < 30.seconds) return true
 
         if (IslandType.DUNGEON_HUB.isInIsland()) {
             IslandGraphs.nodeOrNull("Croesus", GraphNodeTag.NPC)?.let {
@@ -89,6 +89,8 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
 
         return false
     }
+
+    private fun hasItemInHand() = InventoryUtils.itemInHandId == KISMET_FEATHER || InventoryUtils.itemInHandId == DUNGEON_CHEST_KEY
 
     data class BucketData(
         @Expose var runsParticipated: MutableMap<DungeonFloor, Long> = EnumMap(DungeonFloor::class.java),

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
@@ -8,12 +8,14 @@ import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
+import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonCompleteEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonProfitTracker.drawDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
@@ -55,6 +57,9 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
 
     var hasOpened = false
     var hasUsedKey = false
+
+    // floor type of the last viewed dungeon run in croesus
+    var lastCroesusFloor: DungeonFloor? = null
 
     var lastChangeTime = SimpleTimeMark.farPast()
 
@@ -133,11 +138,10 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
     fun onChat(event: SkyHanniChatEvent.Allow) {
         if (event.cleanMessage == "You used a Kismet Feather!") {
             modify {
-                val floor = DungeonApi.dungeonFloorEnum
+                val floor = DungeonApi.dungeonFloorEnum ?: lastCroesusFloor
                 if (floor != null) {
                     it.kismetsUsed.addOrPut(floor, 1)
                 }
-
             }
         }
     }
@@ -165,6 +169,15 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
         if (shouldShowDisplay() && event.source == ItemAddManager.Source.COMMAND) {
             event.addItemFromEvent()
         }
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.DUNGEON_HUB)
+    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (InventoryUtils.openInventoryName() != "Croesus") return
+        val stack = event.item ?: return
+        val floor = DungeonApi.getFloorByItemStack(stack)
+        lastCroesusFloor = floor
+        ChatUtils.chat("Floor: $floor")
     }
 
     private fun drawDisplay(bucketData: BucketData): List<Searchable> = buildList {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
@@ -1,0 +1,217 @@
+package at.hannibal2.skyhanni.features.dungeon
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.IslandTypeTag
+import at.hannibal2.skyhanni.data.ItemAddManager
+import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
+import at.hannibal2.skyhanni.events.IslandJoinEvent
+import at.hannibal2.skyhanni.events.ItemAddEvent
+import at.hannibal2.skyhanni.events.dungeon.DungeonCompleteEvent
+import at.hannibal2.skyhanni.features.dungeon.DungeonProfitTracker.drawDisplay
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
+import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.Searchable
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import at.hannibal2.skyhanni.utils.renderables.toSearchable
+import at.hannibal2.skyhanni.utils.tracker.BucketedItemTrackerData
+import at.hannibal2.skyhanni.utils.tracker.SessionUptime
+import at.hannibal2.skyhanni.utils.tracker.SkyHanniBucketedItemTracker
+import com.google.gson.annotations.Expose
+import java.util.EnumMap
+import kotlin.time.Duration.Companion.seconds
+
+@SkyHanniModule
+object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonProfitTracker.BucketData>(
+    "Dungeon Profit Tracker",
+    ::BucketData,
+    { it.dungeons.profitTracker },
+    { drawDisplay(it) },
+    trackerConfig = { SkyHanniMod.feature.dungeon.profitTracker.perTrackerConfig },
+    customUptimeControl = true,
+) {
+    val config get() = SkyHanniMod.feature.dungeon.profitTracker
+
+    // thius only exists to ignore croesuses openings for floors the player did prior to this feature being implemented.
+    val availableCroesus: MutableMap<DungeonFloor, CroesusStorage>? get() = ProfileStorageData.profileSpecific?.dungeons?.availableCroesus
+
+    var hasOpened = false
+    var hasUSedKey = false
+
+    var lastChangeTime = SimpleTimeMark.farPast()
+
+    init {
+        initRenderer({ config.position }) { shouldShowDisplay() }
+    }
+
+    @HandleEvent
+    fun onIslandJoin(event: IslandJoinEvent) {
+        if (event.island == IslandType.DUNGEON_HUB) {
+            firstUpdate()
+        }
+    }
+
+    // TODO show while holding kismet or dungoen key in hand always
+    private fun shouldShowDisplay(): Boolean {
+        if (!config.enabled) return false
+        if (!IslandTypeTag.DUNGEON_ISLANDS.isInIsland()) return false
+        if (lastChangeTime.passedSince() < 30.seconds) return true
+
+        if (config.showAlways && IslandType.CATACOMBS.isInIsland()) {
+            return true
+        }
+
+        if (IslandType.DUNGEON_HUB.isInIsland()) {
+            IslandGraphs.nodeOrNull("Croesus", GraphNodeTag.NPC)?.let {
+                if (it.position.distanceSqToPlayer() < 100) {
+                    return true
+                }
+            }
+        }
+
+
+        return false
+    }
+
+    data class BucketData(
+        @Expose var totalFloorParticipated: Long = 0L,
+        @Expose var runsParticipated: MutableMap<DungeonFloor, Long> = EnumMap(DungeonFloor::class.java),
+        @Expose var coinsSpent: MutableMap<DungeonFloor, Long> = EnumMap(DungeonFloor::class.java),
+        @Expose var chestsOpened: MutableMap<DungeonFloor, Long> = EnumMap(DungeonFloor::class.java),
+        @Expose var kismetsUsed: MutableMap<DungeonFloor, Long> = EnumMap(DungeonFloor::class.java),
+        @Expose var keysUsed: MutableMap<DungeonFloor, Long> = EnumMap(DungeonFloor::class.java),
+    ) : BucketedItemTrackerData<DungeonFloor, SessionUptime.Normal>(DungeonFloor::class, SessionUptime.Normal::class) {
+        override fun getDescription(bucket: DungeonFloor?, timesGained: Long): List<String> {
+            val participated = runsParticipated[bucket]
+            val percentage = participated?.let { timesGained.toDouble() / it } ?: 1.0
+            val dropRate = percentage.coerceAtMost(1.0).formatPercentage()
+            return listOf(
+                "§7Dropped §e${timesGained.addSeparators()} §7times.",
+                "§7Your drop rate: §c$dropRate.",
+            )
+        }
+
+        override fun getCoinName(bucket: DungeonFloor?, item: TrackedItem) = "§6Dungeon Chest Coins"
+
+        override fun getCoinDescription(bucket: DungeonFloor?, item: TrackedItem): List<String> {
+            val pestsCoinsFormat = item.totalAmount.shortFormat()
+            return listOf(
+                "§7Dungeon chests never give you coins.",
+                "§7You got §6$pestsCoinsFormat coins §7that way.",
+            )
+        }
+
+        override fun DungeonFloor.isBucketSelectable() = this != DungeonFloor.E
+
+        override fun bucketName(): String {
+            return "Floor"
+        }
+    }
+
+    @HandleEvent
+    fun onDungeonComplete(event: DungeonCompleteEvent) {
+
+        val dungeonFloor = event.dungeonFloor
+        availableCroesus?.let {
+            val floor = it[dungeonFloor] ?: run {
+                val croesusStorage = CroesusStorage()
+                it[dungeonFloor] = croesusStorage
+                croesusStorage
+            }
+            floor.keys++
+            floor.chests++
+            modify {
+                it.totalFloorParticipated++
+                it.runsParticipated.addOrPut(event.dungeonFloor, 1)
+            }
+        }
+    }
+
+    @HandleEvent
+    fun onItemAdd(event: ItemAddEvent) {
+        if (shouldShowDisplay() && event.source == ItemAddManager.Source.COMMAND) {
+            event.addItemFromEvent()
+        }
+    }
+
+    private fun drawDisplay(bucketData: BucketData): List<Searchable> = buildList {
+        addSearchString("§e§lDungeon Profit Tracker")
+        addBucketSelector(this, bucketData, "Floor Type")
+
+        var profit = drawItems(bucketData, { true }, this)
+
+        val selectedBucket = bucketData.selectedBucket
+        val pestCount = selectedBucket?.let { bucketData.runsParticipated[it] ?: 0 } ?: bucketData.totalFloorParticipated
+
+
+        val pestCountFormat = "§7${selectedBucket ?: "Floors"} done: §e${pestCount.addSeparators()}"
+
+        add(
+            when {
+                selectedBucket != null -> Renderable.text(pestCountFormat).toSearchable()
+                else -> Renderable.hoverTips(
+                    pestCountFormat,
+                    buildList {
+                        // Sort by A-Z in displaying real types
+                        bucketData.runsParticipated.toList()
+                            .forEach { (type, count) ->
+                                add("§7$type: §e${count.addSeparators()}")
+                            }
+                    },
+                ).toSearchable()
+            },
+        )
+
+        if (selectedBucket == null) {
+            var sprayCosts = 0.0
+
+            /**
+            val hoverTips = if (sumSpraysUsed > 0) buildList {
+            applicableSpraysUsed.forEach { (spray, count) ->
+            val sprayString = getPricePerOrNull(spray.toInternalName())?.let { price ->
+            val sprayCost = price * count
+            sprayCosts += sprayCost
+            "§7${spray.displayName}: §a${count.shortFormat()} §7(§c-${sprayCost.shortFormat()}§7)"
+            } ?: add("§7${spray.displayName}: §a${count.addSeparators()}")
+            add(sprayString)
+            }
+            add("")
+            add("§7Total spray cost: §6${sprayCosts.addSeparators()} coins")
+            } else emptyList()
+             **/
+            profit -= sprayCosts
+
+            /**
+            val sprayCostString = if (sumSpraysUsed > 0) " §7(§c-${sprayCosts.shortFormat()}§7)" else ""
+            add(
+            Renderable.hoverTips(
+            "§aSprays used: §a$sumSpraysUsed$sprayCostString",
+            hoverTips,
+            ).toSearchable(),
+            )
+             **/
+        }
+
+        val duration = bucketData.getTotalUptime()
+        addAll(addTotalProfit(profit, bucketData.totalFloorParticipated, "kill", duration, "Kills"))
+
+        addPriceFromButton(this)
+    }
+}
+
+
+class CroesusStorage {
+    @Expose
+    var chests = 0
+    var keys = 0
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonProfitTracker.kt
@@ -49,6 +49,8 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
     // this only exists to ignore croesus openings for floors the player did prior to this feature being implemented.
     val availableCroesus: MutableMap<DungeonFloor, CroesusStorage>? get() = ProfileStorageData.profileSpecific?.dungeons?.availableCroesus
 
+    private val KISMET_FEATHER = "KISMET_FEATHER".toInternalName()
+
     var hasOpened = false
     var hasUsedKey = false
 
@@ -191,47 +193,23 @@ object DungeonProfitTracker : SkyHanniBucketedItemTracker<DungeonFloor, DungeonP
             },
         )
 
-        if (selectedBucket == null) {
-            var sprayCosts = 0.0
-
-            /**
-            val hoverTips = if (sumSpraysUsed > 0) buildList {
-            applicableSpraysUsed.forEach { (spray, count) ->
-            val sprayString = getPricePerOrNull(spray.toInternalName())?.let { price ->
-            val sprayCost = price * count
-            sprayCosts += sprayCost
-            "§7${spray.displayName}: §a${count.shortFormat()} §7(§c-${sprayCost.shortFormat()}§7)"
-            } ?: add("§7${spray.displayName}: §a${count.addSeparators()}")
-            add(sprayString)
-            }
-            add("")
-            add("§7Total spray cost: §6${sprayCosts.addSeparators()} coins")
-            } else emptyList()
-             **/
-            profit -= sprayCosts
-
-            /**
-            val sprayCostString = if (sumSpraysUsed > 0) " §7(§c-${sprayCosts.shortFormat()}§7)" else ""
-            add(
-            Renderable.hoverTips(
-            "§aSprays used: §a$sumSpraysUsed$sprayCostString",
-            hoverTips,
-            ).toSearchable(),
-            )
-             **/
-        }
-
-        val kismetsUsed = selectedBucket?.let { bucketData.kismetsUsed[it] ?: 0 } ?: bucketData.totalKismetsUsed
-        val kismetPrice = "KISMET_FEATHER".toInternalName().getPrice()
-        val totalKismetPrice = kismetPrice * kismetsUsed
-        val kismetPriceDisplay = if (kismetsUsed != 0L) " §7(§c-${totalKismetPrice.shortFormat()}§7)" else ""
-        profit -= totalKismetPrice
-        add(Renderable.text("§7Kismets used: §e$kismetsUsed$kismetPriceDisplay").toSearchable("kismet"))
+        profit -= calculateKismet(selectedBucket, bucketData)
 
         val duration = bucketData.getTotalUptime()
         addAll(addTotalProfit(profit, bucketData.totalFloorParticipated, "run", duration, "runs"))
 
         addPriceFromButton(this)
+    }
+
+    private fun MutableList<Searchable>.calculateKismet(
+        selectedBucket: DungeonFloor?,
+        bucketData: BucketData,
+    ): Double {
+        val amount = selectedBucket?.let { bucketData.kismetsUsed[it] ?: 0 } ?: bucketData.totalKismetsUsed
+        val price = KISMET_FEATHER.getPrice() * amount
+        val priceDisplay = if (amount != 0L) " §7(§c-${price.shortFormat()}§7)" else ""
+        add(Renderable.text("§7Kismets used: §e$amount$priceDisplay").toSearchable("kismet"))
+        return price
     }
 }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/TerracottaPhase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/TerracottaPhase.kt
@@ -53,5 +53,5 @@ object TerracottaPhase {
 
     private fun isActive() = inTerracottaPhase && isEnabled()
 
-    private fun isEnabled() = DungeonApi.inBossRoom && DungeonApi.getCurrentBoss() == DungeonFloor.F6
+    private fun isEnabled() = DungeonApi.inBossRoom && DungeonApi.getCurrentBoss() == DungeonBoss.F6
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearofthepig/PigFeaturesApi.kt
@@ -150,6 +150,7 @@ object PigFeaturesApi {
     }
 
     private fun handleLootedOrb(reward: String) {
+        // TODO use ItemUtiils.readFromLore
         coinsRewardPattern.matchMatcher(reward) {
             val amount = group("amount").formatIntOrNull() ?: return@matchMatcher
             ShinyOrbLootedEvent(coins = amount).post()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
@@ -162,6 +162,7 @@ object FishyTreatProfit {
     private fun getAdditionalMaterials(requiredItems: Map<String, Int>): Map<NeuInternalName, Int> {
         val additionalMaterials = mutableMapOf<NeuInternalName, Int>()
         for ((name, amount) in requiredItems) {
+            // TODO use ItemUtiils.readFromLore
             coinsPattern.matchMatcher(name) {
                 additionalMaterials[NeuInternalName.SKYBLOCK_COIN] = group("coins").formatInt()
             } ?: run {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
@@ -82,6 +82,7 @@ object StockOfStonkFeature {
                 stonksReward = group("amount").toInt()
                 continue@loop
             }
+            // TODO use ItemUtiils.readFromLore
             bidPattern.matchMatcher(line) {
                 val cost = group("amount").formatLong().coerceAtLeast(2000000) // minimum bid is 2,000,000
                 val ratio = cost / stonksReward.transformIf({ this == 0 }, { 1 })

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorApi.kt
@@ -31,11 +31,6 @@ object FossilExcavatorApi {
     private val endPattern by chatPatternGroup.pattern("end", "§a§l▬{64}")
 
     /**
-     * REGEX-TEST:     §r§6Tusk Fossil
-     */
-    private val itemPattern by chatPatternGroup.pattern("item", " {4}§r(?<item>.+)")
-
-    /**
      * REGEX-TEST: §cYou didn't find anything. Maybe next time!
      */
     private val emptyPattern by chatPatternGroup.pattern("empty", "§cYou didn't find anything. Maybe next time!")
@@ -49,7 +44,7 @@ object FossilExcavatorApi {
 
     val excavatorInventory = InventoryDetector(
         checkInventoryName = { it == "Fossil Excavator" },
-        onCloseInventory = { inExcavatorMenu = false }
+        onCloseInventory = { inExcavatorMenu = false },
     )
 
     @HandleEvent
@@ -83,20 +78,8 @@ object FossilExcavatorApi {
             inLoot = false
             return
         }
-        var pair = itemPattern.matchMatcher(message) {
-            /**
-             * TODO fix the bug that readItemAmount produces two different outputs:
-             * §r§fEnchanted Book -> §fEnchanted
-             * §fEnchanted Book §r§8x -> §fEnchanted Book
-             *
-             * also maybe this is no bug, as enchanted book is no real item?
-             */
-            ItemUtils.readItemAmount(group("item"))
-        } ?: return
-
-        ItemUtils.readBookTypeStrippedColor(pair.first)?.let {
-            pair = it to pair.second
+        ItemUtils.readItemStackFromChat(message)?.let {
+            loot.add(it)
         }
-        loot.add(pair)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
@@ -32,12 +32,6 @@ object CorpseApi {
      */
     private val endPattern by chatPatternGroup.pattern("end", "§a§l▬{64}")
 
-    /**
-     * REGEX-TEST:     §r§9☠ Fine Onyx Gemstone §r§8x2
-     * REGEX-TEST:     §r§fEnchanted Book (Ice Cold I§r§f)
-     */
-    private val itemPattern by chatPatternGroup.pattern("item", " {4}§r(?<item>.+)")
-
     private var inLoot = false
     private val loot = mutableListOf<Pair<String, Int>>()
 
@@ -65,21 +59,9 @@ object CorpseApi {
             inLoot = false
             return
         }
-        var pair = itemPattern.matchMatcher(message) {
-            /**
-             * TODO fix the bug that readItemAmount produces two different outputs:
-             * §r§fEnchanted Book -> §fEnchanted
-             * §fEnchanted Book §r§8x -> §fEnchanted Book
-             *
-             * also maybe this is no bug, as enchanted book is no real item?
-             */
-            ItemUtils.readItemAmount(group("item"))
-        } ?: return
 
-        if (pair.first.startsWith("§fEnchanted Book (")) {
-            val book = ItemUtils.readBookTypeStrippedColor(pair.first) ?: return
-            pair = book to pair.second
+        ItemUtils.readItemStackFromChat(message)?.let {
+            loot.add(it)
         }
-        loot.add(pair)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
@@ -302,7 +302,7 @@ enum class DiscordStatus(private val displayMessageSupplier: DiscordStatus.() ->
                 } else {
                     val floor = DungeonApi.dungeonFloor ?: AutoStatus.DUNGEONS.placeholderText
                     val amountKills = DungeonApi.bossStorage?.get(boss)?.addSeparators() ?: "Unknown"
-                    val time = DungeonApi.time
+                    val time = DungeonApi.timeDisplay
                     "$floor Kills: $amountKills ($time)"
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.features.event.yearofthepig.PigFeaturesApi
 import at.hannibal2.skyhanni.features.misc.ReplaceRomanNumerals
 import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator.getAttributeName
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -26,6 +27,7 @@ import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PetUtils.getMaxLevel
@@ -46,8 +48,10 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.onClick
 import at.hannibal2.skyhanni.utils.chat.TextHelper.onHover
 import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIfKey
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sublistAfter
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.NbtCompat
@@ -104,6 +108,18 @@ object ItemUtils {
     private val anvilCombinablePattern by patternGroup.pattern(
         "anvil-combinable",
         "Combinable in Anvil",
+    )
+
+    /**
+     * REGEX-TEST:     §r§6Tusk Fossil
+     * REGEX-TEST:     §r§9☠ Fine Onyx Gemstone §r§8x2
+     * REGEX-TEST:     §r§fEnchanted Book (Ice Cold I§r§f)
+     */
+    private val chatStackPatterns by patternGroup.pattern("chat.stack", " {4}§r(?<item>.+)")
+
+    private val itemLoreNamePatterns by patternGroup.pattern(
+        "item.lore.name",
+        "\\+(?<amount>[\\d,]+) Coins",
     )
     // </editor-fold>
 
@@ -173,6 +189,9 @@ object ItemUtils {
     fun ItemStack.cleanName() = hoverName.string.removeColor()
 
     fun isSack(stack: ItemStack) = stack.getInternalName().endsWith("_SACK") && stack.cleanName().endsWith(" Sack")
+
+    // contains no color codes
+    fun ItemStack.getCleanLore(): List<String> = getLoreComponent().map { it.string }
 
     @Deprecated("Use getLoreComponent unless you really need color codes", ReplaceWith("this.getLoreComponent()"))
     fun ItemStack.getLore(): List<String> {
@@ -320,7 +339,7 @@ object ItemUtils {
         }
         val rawInternalName = NeuItems.getInternalName(this)?.asString()?.replace(
             "ULTIMATE_ULTIMATE_",
-            "ULTIMATE_"
+            "ULTIMATE_",
         )
         return rawInternalName?.let { ItemNameResolver.fixEnchantmentName(it) }
     }
@@ -714,6 +733,31 @@ object ItemUtils {
         return name
     }
 
+
+    fun ItemStack.costs(): List<PrimitiveItemStack> {
+        val list = mutableListOf<PrimitiveItemStack>()
+        val cleanLore = getCleanLore()
+        println("cleanLore: $cleanLore")
+        for (line in cleanLore.sublistAfter("Cost", amount = 99)) {
+            if (line.isEmpty()) break
+            val item = readFromLore(line) ?: error("can not parse cost from line: '$line'")
+            list.add(item)
+        }
+
+        return list
+    }
+
+    fun readFromLore(line: String): PrimitiveItemStack? {
+        itemLoreNamePatterns.matchMatcher(line) {
+            val amount = group("amount").formatInt()
+            return PrimitiveItemStack(NeuInternalName.SKYBLOCK_COIN, amount)
+        }
+        // add amount support
+        val internalName = NeuInternalName.fromItemNameOrNull(line) ?: return null
+        return PrimitiveItemStack(internalName, 1)
+
+    }
+
     fun ItemStack.loreCosts(): MutableList<NeuInternalName> {
         var found = false
         val list = mutableListOf<NeuInternalName>()
@@ -970,5 +1014,26 @@ object ItemUtils {
                 withColor(ChatFormatting.WHITE)
             }
         }
+    }
+
+    // message requires color codes
+    fun readItemStackFromChat(message: String): Pair<String, Int>? {
+        val pair = chatStackPatterns.matchMatcher(message) {
+            /**
+             * TODO fix the bug that readItemAmount produces two different outputs:
+             * §r§fEnchanted Book -> §fEnchanted
+             * §fEnchanted Book §r§8x -> §fEnchanted Book
+             *
+             * also maybe this is no bug, as enchanted book is no real item?
+             */
+            val group = group("item")
+            println("group: $group")
+            readItemAmount(group)
+        } ?: return null
+        println("pair: $pair")
+
+        return readBookTypeStrippedColor(pair.first)?.let {
+            it to pair.second
+        } ?: pair
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -46,6 +46,7 @@ value class NeuInternalName private constructor(private val internalName: String
                 val (name, level) = internalName.split(";", limit = 2)
                 "ENCHANTED_BOOK_${name}_$level"
             }
+
             else -> internalName
         }
 
@@ -85,6 +86,7 @@ value class NeuInternalName private constructor(private val internalName: String
         fun List<String>.toInternalNames(): List<NeuInternalName> = mapTo(mutableListOf()) { it.toInternalName() }
 
         private val itemNameCache = mutableMapOf<String, NeuInternalName?>()
+
 
         fun fromItemNameOrNull(itemName: String): NeuInternalName? = itemNameCache.getOrPut(itemName) {
             ItemNameResolver.getInternalNameOrNull(itemName.removeSuffix(" Pet")) ?: getCoins(itemName)

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/SkyHanniTypeAdapters.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/SkyHanniTypeAdapters.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.recipe.NeuRecipeType
 import at.hannibal2.skyhanni.data.model.SkyblockStat
 import at.hannibal2.skyhanni.data.model.SkyblockStatList
 import at.hannibal2.skyhanni.data.model.graph.Graph
+import at.hannibal2.skyhanni.features.dungeon.DungeonFloor
 import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.pests.PestType
@@ -140,6 +141,22 @@ enum class SkyHanniTypeAdapters(
                     return null
                 }
                 return reader.nextString().toInternalName()
+            }
+        },
+    ),
+    DUNGEON_FLOOR(
+        DungeonFloor::class.java,
+        object : TypeAdapter<DungeonFloor>() {
+            override fun write(writer: JsonWriter, value: DungeonFloor?) {
+                if (value == null) writer.nullValue() else writer.value(value.asString())
+            }
+
+            override fun read(reader: JsonReader): DungeonFloor? {
+                if (reader.peek() == JsonToken.NULL) {
+                    reader.nextNull()
+                    return null
+                }
+                return DungeonFloor.getByName(reader.nextString())
             }
         },
     ),

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
@@ -15,8 +15,10 @@ abstract class BucketedItemTrackerData<E : Enum<E>, T : SessionUptime>(clazz: KC
     final override fun getCoinName(item: TrackedItem): String =
         throw UnsupportedOperationException("Use getCoinName(bucket, item) instead")
 
+    // TODO allow variants that do not need this
     abstract fun getCoinName(bucket: E?, item: TrackedItem): String
 
+    // TODO allow variants that do not need this
     final override fun getCoinDescription(item: TrackedItem): List<String> =
         throw UnsupportedOperationException("Use getCoinDescription(bucket, item) instead")
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/ItemTrackerData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/ItemTrackerData.kt
@@ -12,6 +12,7 @@ abstract class ItemTrackerData<T : SessionUptime>(clazz: KClass<T>) : TrackerDat
 
     abstract fun getDescription(timesGained: Long): List<String>
 
+    // TODO make it so that this field is not part of every item track anymore
     abstract fun getCoinName(item: TrackedItem): String
 
     // TODO add amount in the string


### PR DESCRIPTION

## What
Renamend DungeonFloor to DungeonBoss, added a new DungeonFloor enum that also stores the master mode state.
Copied pest profit tracker into dungeon and started with display logic.

<details>
<summary>Images</summary>

<img width="519" height="151" alt="image" src="https://github.com/user-attachments/assets/67884716-9c1f-4e99-b899-92a22ac60453" />

<img width="744" height="673" alt="image" src="https://github.com/user-attachments/assets/2fda3401-6ad0-4e9e-a468-5c15c02617fe" />


</details>

## Changelog New Features
+ Added Cool new feature. - your_name_here
    * Optional extra info.


## Changelog Technical Details
+ Something technical you changed in the backend. - your_name_here
    * Optional extra info.


