### PR TITLE
Fix: Farming Tool Reforges

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ReforgeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ReforgeApi.kt
@@ -41,8 +41,7 @@ object ReforgeApi {
         CLOAK(ItemCategory.CLOAK),
         BELT(ItemCategory.BELT),
         AXE(ItemCategory.AXE),
-        HOE(ItemCategory.HOE),
-        AXE_AND_HOE(ItemCategory.AXE, ItemCategory.HOE),
+        FARMING_TOOL(ItemCategory.FARMING_TOOL),
         PICKAXE(ItemCategory.PICKAXE, ItemCategory.DRILL, ItemCategory.GAUNTLET),
         EQUIPMENT(
             ItemCategory.NECKLACE, ItemCategory.CLOAK, ItemCategory.BELT,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
@@ -3,6 +3,9 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import net.minecraft.world.item.ItemStack
 
+/**
+ * Deprecated entries should not be removed, they are kept to avoid errors with unupdated items.
+ */
 enum class ItemCategory {
     SWORD,
     LONGSWORD,
@@ -10,10 +13,11 @@ enum class ItemCategory {
     SHORT_BOW,
     WAND,
     FISHING_ROD,
+    @Deprecated("No longer exists") FISHING_WEAPON,
     ROD_PART,
     AXE,
     GAUNTLET,
-    HOE,
+    @Deprecated("No longer exists") HOE,
     PICKAXE,
     SHOVEL,
     DRILL,


### PR DESCRIPTION
## What
Updated the expected reforge types for farming tools per the new Harvest Feast update changing the farming tools from "Axe" or "Hoe" to a new "Farming Tool" item category.

Also fixed an old niche issue with legacy "Fishing Weapon" items people have (we shouldn't have removed the enum constant).

## Changelog Fixes
+ Fixed reforge detection for new "Farming Tool" item category. - Luna
+ Fixed errors with legacy "Fishing Weapon" items. - Luna