### PR TITLE
Fix: New Finnegan Perks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MayorData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorData.kt
@@ -46,7 +46,8 @@ enum class ElectionCandidate(
     FINNEGAN(
         "Finnegan",
         "§c",
-        Perk.PELT_POCALYPSE,
+        Perk.PELT_POCALYPSE, // TODO remove after 9.0.0
+        Perk.GRAND_FEAST,
         Perk.GOATED,
         Perk.BLOOMING_BUSINESS,
         Perk.PEST_ERADICATOR,
@@ -183,7 +184,8 @@ enum class Perk(val perkName: String) {
     LONG_TERM_INVESTMENT("Long Term Investment"),
 
     // Finnegan
-    PELT_POCALYPSE("Pelt-pocalypse"),
+    @Deprecated("Remove after 9.0.0") PELT_POCALYPSE("Pelt-pocalypse"),
+    GRAND_FEAST("Grand Feast"),
     GOATED("GOATed"),
     BLOOMING_BUSINESS("Blooming Business"),
     PEST_ERADICATOR("Pest Eradicator"),

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -159,7 +159,7 @@ object TrevorFeatures {
         }
 
         trapperPattern.matchMatcher(formattedMessage) {
-            timeUntilNextReady = if (Perk.PELT_POCALYPSE.isActive) 16 else 21
+            timeUntilNextReady = 16
             currentStatus = TrapperStatus.ACTIVE
             currentLabel = "§cActive Quest"
             trapperReady = false


### PR DESCRIPTION
## What
Updated for new Finnegan perks. I don't remember if the new one being missing actually causes any errors, but screw it, fix it is.

I didn't remove the PELT_POCALYPSE enum entry entirely yet so that we can potentially force it on via repo for older versions without breaking newer versions.

## Changelog Fixes
+ Adjusted Trapper Cooldown to permanently use the lower cooldown now that Pelt-pocalypse is permanent. - Luna
+ Fixed support for Finnegan's new Grand Feast mayor perk. - Luna