### PR TITLE
Fix: Rarity Line Exclusions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -419,7 +419,9 @@ object ItemUtils {
         if (this.getPetInfo() != null) return getPetRarity(this) to ItemCategory.PET
 
         val cleanName = this.cleanName()
-        for (line in this.getLore().reversed()) {
+        val cleanLore = this.getLoreComponent().map { it.string.removeColor() }
+        for (line in cleanLore.reversed()) {
+            if (UtilsPatterns.notRarityLoreLinePattern.matches(line)) continue
             val (category, rarity) = UtilsPatterns.rarityLoreLinePattern.matchMatcher(line) {
                 group("itemCategory").replace(" ", "_") to group("rarity").replace(" ", "_")
             } ?: continue
@@ -435,7 +437,7 @@ object ItemUtils {
                     "item name" to hoverName.formattedTextCompatLeadingWhiteLessResets(),
                     "inventory name" to InventoryUtils.openInventoryName(),
                     "pattern result" to category,
-                    "lore" to getLore(),
+                    "lore" to cleanLore,
                     betaOnly = true,
                     condition = { !itemCategoryRepoCheckPattern.matches(category) },
                 )
@@ -448,7 +450,7 @@ object ItemUtils {
                     "item name" to hoverName.formattedTextCompatLeadingWhiteLessResets(),
                     "inventory name" to InventoryUtils.openInventoryName(),
                     "pattern result" to rarity,
-                    "lore" to getLore(),
+                    "lore" to cleanLore,
                     betaOnly = true,
                     condition = { !rarityCategoryRepoCheckPattern.matches(rarity) },
                 )

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -9,23 +9,32 @@ object UtilsPatterns {
 
     private val patternGroup = RepoPattern.group("utils")
 
+    // COMMON|UNCOMMON|RARE|EPIC|LEGENDARY|MYTHIC|DIVINE|SPECIAL|VERY SPECIAL|ULTIMATE
+    private val rarities = enumJoinToPattern<LorenzRarity> { it.name.replace("_", " ") }
     /**
-     * REGEX-TEST: §d§l§ka§r §d§lMYTHIC ACCESSORY §d§l§ka
-     * REGEX-TEST: §d§l§ka§r §d§lSHINY MYTHIC DUNGEON CHESTPLATE §d§l§ka
-     * REGEX-TEST: §c§l§ka§r §c§lVERY SPECIAL HATCESSORY §c§l§ka
-     * REGEX-TEST: §6§lSHINY LEGENDARY DUNGEON BOOTS
-     * REGEX-TEST: §6§lLEGENDARY DUNGEON BOOTS
-     * REGEX-TEST: §5§lEPIC BOOTS
-     * REGEX-TEST: §f§lCOMMON
-     * REGEX-TEST: §f§lCOMMON COMBAT SHARD §8(ID C9)
-     * REGEX-TEST: §7Rarity: §6§lLEGENDARY
-     * REGEX-TEST: §7Rarity: §9§lRARE
+     * REGEX-TEST: a MYTHIC ACCESSORY a
+     * REGEX-TEST: a SHINY MYTHIC DUNGEON CHESTPLATE a
+     * REGEX-TEST: a VERY SPECIAL HATCESSORY a
+     * REGEX-TEST: SHINY LEGENDARY DUNGEON BOOTS
+     * REGEX-TEST: LEGENDARY DUNGEON BOOTS
+     * REGEX-TEST: EPIC BOOTS
+     * REGEX-TEST: COMMON
+     * REGEX-TEST: COMMON COMBAT SHARD (ID C9)
+     * REGEX-TEST: Rarity: LEGENDARY
+     * REGEX-TEST: Rarity: RARE
      */
     val rarityLoreLinePattern by patternGroup.pattern(
-        "item.lore.rarity.line",
-        "^(?:§7Rarity: )?(?:§.){2,3}(?:.§. (?:§.){2})?(?:SHINY )?(?<rarity>" +
-            enumJoinToPattern<LorenzRarity> { it.name.replace("_", " ") } +
-            ") ?(?:DUNGEON )?(?<itemCategory>[^§]*)(?: (?:§.){3}.)?(?: §8\\(ID \\w\\d+\\))?$",
+        "item.lore.rarity.line.colorless",
+        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities}) ?(?:DUNGEON )?(?<itemCategory>.+?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
+    )
+
+    /**
+     * REGEX-TEST: RARE CROP
+     * REGEX-TEST: RARE CROPS
+     */
+    val notRarityLoreLinePattern by patternGroup.pattern(
+        "item.lore.not-rarity.line",
+        "^RARE CROPS?$",
     )
 
     /**


### PR DESCRIPTION
## What
Added the ability to exclude certain strings from the usual item rarity/category parsing that cannot be neatly excluded in the main regex without making it messy. While I'm at it, I also made the main pattern colorless.

<details>
<summary>Images</summary>

<img width="1129" height="536" alt="image" src="https://github.com/user-attachments/assets/01d0cc2e-094d-4dbd-ab3e-ed55d49e743f" />

</details>

## Changelog Fixes
+ Fixed unknown item category error in Harvest Feast menu. - Luna
