### PR TITLE
Fix: Rarity Line v2

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -25,7 +25,7 @@ object UtilsPatterns {
      */
     val rarityLoreLinePattern by patternGroup.pattern(
         "item.lore.rarity.line.colorless",
-        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities}) ?(?:DUNGEON )?(?<itemCategory>.+?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
+        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities}) ?(?:DUNGEON )?(?<itemCategory>.*?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
     )
 
     /**


### PR DESCRIPTION
## What
I thought it would be a good cleanup to change the `+` to a `*`, because it's misused in a lot of other places. Turns out, it was not.

## Changelog Fixes
+ Fixed error getting item category on items that have no category. - Luna

