### PR TITLE
Fix: Custom Keybinds bugginess

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -10,14 +10,16 @@ import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.KeyboardManager
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import com.mojang.blaze3d.platform.InputConstants
 import io.github.notenoughupdates.moulconfig.observer.Property
 import net.minecraft.client.KeyMapping
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.SignEditScreen
 import org.lwjgl.glfw.GLFW
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
@@ -32,38 +34,28 @@ object GardenCustomKeybinds {
     private var lastWindowOpenTime = SimpleTimeMark.farPast()
 
     @JvmStatic
-    fun shouldCancelKeyInput(key: InputConstants.Key, pressed: Boolean): Boolean {
-        if (!isActive()) return false
-        var handled = false
-        for ((keyBinding, override) in map) {
-            if (override == keyBinding.key.value) continue
-            if (override == GLFW.GLFW_KEY_UNKNOWN) {
-                if (key.value == keyBinding.key.value) {
-                    handled = true
-                }
-                continue
+    fun isKeyDown(keyBinding: KeyMapping, cir: CallbackInfoReturnable<Boolean>) {
+        if (!isActive()) return
+        val override = map[keyBinding] ?: run {
+            if (map.containsValue(keyBinding.key.value)) {
+                cir.returnValue = false
             }
-            if (key.value == override) {
-                keyBinding.isDown = pressed
-                handled = true
-                continue
-            }
-            if (key.value == keyBinding.key.value) {
-                handled = true
-            }
+            return
         }
-        return handled
+
+        cir.returnValue = override.isKeyHeld()
     }
 
     @JvmStatic
-    fun shouldCancelKeyClick(key: InputConstants.Key): Boolean {
-        if (!isActive()) return false
-        for ((keyBinding, override) in map) {
-            if (override == keyBinding.key.value) continue
-            if (key.value == keyBinding.key.value) return true
-            if (override != GLFW.GLFW_KEY_UNKNOWN && key.value == override) return true
+    fun isKeyPressed(keyBinding: KeyMapping, cir: CallbackInfoReturnable<Boolean>) {
+        if (!isActive()) return
+        val override = map[keyBinding] ?: run {
+            if (map.containsValue(keyBinding.key.value)) {
+                cir.returnValue = false
+            }
+            return
         }
-        return false
+        cir.returnValue = override.isKeyClicked()
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import io.github.notenoughupdates.moulconfig.observer.Property
 import net.minecraft.client.KeyMapping
 import net.minecraft.client.Minecraft
+import net.minecraft.client.ToggleKeyMapping
 import net.minecraft.client.gui.screens.inventory.SignEditScreen
 import org.lwjgl.glfw.GLFW
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
@@ -31,11 +32,13 @@ object GardenCustomKeybinds {
     private val mcSettings get() = Minecraft.getInstance().options
 
     private var map: Map<KeyMapping, Int> = emptyMap()
+    private val pressedToggleKeys = mutableMapOf<KeyMapping, Int>()
     private var lastWindowOpenTime = SimpleTimeMark.farPast()
+    private var wasActive = false
 
     @JvmStatic
-    fun isKeyDown(keyBinding: KeyMapping, cir: CallbackInfoReturnable<Boolean>) {
-        if (!isActive()) return
+    fun isKeyDown(keyBinding: KeyMapping, isDown: Boolean, cir: CallbackInfoReturnable<Boolean>) {
+        if (!updateActiveState()) return
         val override = map[keyBinding] ?: run {
             if (map.containsValue(keyBinding.key.value)) {
                 cir.returnValue = false
@@ -43,19 +46,27 @@ object GardenCustomKeybinds {
             return
         }
 
-        cir.returnValue = override.isKeyHeld()
+        cir.returnValue = when {
+            !keyBinding.isToggle() -> override.isKeyHeld()
+            keyBinding.isRemappedFrom(override) -> keyBinding.updateToggleState(override, isDown)
+            else -> isDown
+        }
     }
 
     @JvmStatic
     fun isKeyPressed(keyBinding: KeyMapping, cir: CallbackInfoReturnable<Boolean>) {
-        if (!isActive()) return
+        if (!updateActiveState()) return
         val override = map[keyBinding] ?: run {
             if (map.containsValue(keyBinding.key.value)) {
                 cir.returnValue = false
             }
             return
         }
-        cir.returnValue = override.isKeyClicked()
+        cir.returnValue = if (keyBinding.isToggle() && keyBinding.isRemappedFrom(override)) {
+            keyBinding.consumeToggleClick(override)
+        } else {
+            override.isKeyClicked()
+        }
     }
 
     @HandleEvent
@@ -77,6 +88,8 @@ object GardenCustomKeybinds {
     }
 
     private fun update() {
+        pressedToggleKeys.clear()
+        wasActive = false
         with(config) {
             with(mcSettings) {
                 map = buildMap {
@@ -95,6 +108,54 @@ object GardenCustomKeybinds {
             }
         }
         KeyMapping.releaseAll()
+    }
+
+    private fun updateActiveState(): Boolean {
+        val active = isActive()
+        if (wasActive == active) return active
+
+        wasActive = active
+        pressedToggleKeys.clear()
+        if (active) primePressedToggleKeys()
+        return active
+    }
+
+    private fun primePressedToggleKeys() {
+        for ((keyBinding, override) in map) {
+            if (keyBinding.isToggle() && keyBinding.isRemappedFrom(override) && override.isKeyHeld()) {
+                pressedToggleKeys[keyBinding] = override
+            }
+        }
+    }
+
+    private fun KeyMapping.isToggle(): Boolean =
+        this is ToggleKeyMapping && needsToggle.getAsBoolean()
+
+    private fun KeyMapping.isRemappedFrom(override: Int): Boolean =
+        key.value != override
+
+    private fun KeyMapping.updateToggleState(override: Int, isDown: Boolean): Boolean {
+        if (!override.isKeyHeld()) {
+            pressedToggleKeys.remove(this, override)
+            return isDown
+        }
+        if (pressedToggleKeys[this] == override) return isDown
+
+        pressedToggleKeys[this] = override
+        setDown(true)
+        return !isDown
+    }
+
+    private fun KeyMapping.consumeToggleClick(override: Int): Boolean {
+        if (!override.isKeyHeld()) {
+            pressedToggleKeys.remove(this, override)
+            return false
+        }
+        if (pressedToggleKeys[this] == override) return false
+
+        pressedToggleKeys[this] = override
+        setDown(true)
+        return true
     }
 
     private fun isEnabled(): Boolean =

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
@@ -3,41 +3,47 @@ package at.hannibal2.skyhanni.mixins.transformers;
 import at.hannibal2.skyhanni.data.model.TextInput;
 import at.hannibal2.skyhanni.features.garden.farming.GardenCustomKeybinds;
 import at.hannibal2.skyhanni.test.graph.GraphEditor;
-import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import net.minecraft.client.ToggleKeyMapping;
 
 @Mixin(KeyMapping.class)
 public class MixinKeyBinding {
 
+    @Mutable
+    @Shadow
+    private int clickCount;
+
     @Inject(method = "isDown", at = @At("HEAD"), cancellable = true)
     public void noIsKeyDown(CallbackInfoReturnable<Boolean> cir) {
         KeyMapping keyBinding = (KeyMapping) (Object) this;
+        GardenCustomKeybinds.isKeyDown(keyBinding, cir);
+        if (keyBinding instanceof ToggleKeyMapping stickyKeyBinding) {
+            if (stickyKeyBinding.needsToggle.getAsBoolean()) {
+                return;
+            }
+        }
         TextInput.Companion.onMinecraftInput(keyBinding, cir);
         GraphEditor.INSTANCE.onMinecraftInput(keyBinding, cir);
-    }
-
-    @Inject(method = "set", at = @At("HEAD"), cancellable = true)
-    private static void noSet(InputConstants.Key key, boolean pressed, CallbackInfo ci) {
-        if (GardenCustomKeybinds.shouldCancelKeyInput(key, pressed)) {
-            ci.cancel();
-        }
-    }
-
-    @Inject(method = "click", at = @At("HEAD"), cancellable = true)
-    private static void noClick(InputConstants.Key key, CallbackInfo ci) {
-        if (GardenCustomKeybinds.shouldCancelKeyClick(key)) {
-            ci.cancel();
-        }
     }
 
     @Inject(method = "consumeClick", at = @At("HEAD"), cancellable = true)
     public void noIsPressed(CallbackInfoReturnable<Boolean> cir) {
         KeyMapping keyBinding = (KeyMapping) (Object) this;
+        GardenCustomKeybinds.isKeyPressed(keyBinding, cir);
+        if (cir.isCancelled()) {
+            this.clickCount = 0;
+        }
+        if (keyBinding instanceof ToggleKeyMapping stickyKeyBinding) {
+            if (stickyKeyBinding.needsToggle.getAsBoolean()) {
+                return;
+            }
+        }
         TextInput.Companion.onMinecraftInput(keyBinding, cir);
         GraphEditor.INSTANCE.onMinecraftInput(keyBinding, cir);
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
@@ -4,16 +4,19 @@ import at.hannibal2.skyhanni.data.model.TextInput;
 import at.hannibal2.skyhanni.features.garden.farming.GardenCustomKeybinds;
 import at.hannibal2.skyhanni.test.graph.GraphEditor;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.ToggleKeyMapping;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import net.minecraft.client.ToggleKeyMapping;
 
 @Mixin(KeyMapping.class)
 public class MixinKeyBinding {
+
+    @Shadow
+    private boolean isDown;
 
     @Mutable
     @Shadow
@@ -22,7 +25,7 @@ public class MixinKeyBinding {
     @Inject(method = "isDown", at = @At("HEAD"), cancellable = true)
     public void noIsKeyDown(CallbackInfoReturnable<Boolean> cir) {
         KeyMapping keyBinding = (KeyMapping) (Object) this;
-        GardenCustomKeybinds.isKeyDown(keyBinding, cir);
+        GardenCustomKeybinds.isKeyDown(keyBinding, this.isDown, cir);
         if (keyBinding instanceof ToggleKeyMapping stickyKeyBinding) {
             if (stickyKeyBinding.needsToggle.getAsBoolean()) {
                 return;

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinKeyBinding.java
@@ -18,12 +18,14 @@ public class MixinKeyBinding {
     @Shadow
     private boolean isDown;
 
+    @SuppressWarnings("FieldCanBeLocal")
     @Mutable
     @Shadow
     private int clickCount;
 
     @Inject(method = "isDown", at = @At("HEAD"), cancellable = true)
     public void noIsKeyDown(CallbackInfoReturnable<Boolean> cir) {
+        @SuppressWarnings("DataFlowIssue")
         KeyMapping keyBinding = (KeyMapping) (Object) this;
         GardenCustomKeybinds.isKeyDown(keyBinding, this.isDown, cir);
         if (keyBinding instanceof ToggleKeyMapping stickyKeyBinding) {
@@ -37,6 +39,7 @@ public class MixinKeyBinding {
 
     @Inject(method = "consumeClick", at = @At("HEAD"), cancellable = true)
     public void noIsPressed(CallbackInfoReturnable<Boolean> cir) {
+        @SuppressWarnings("DataFlowIssue")
         KeyMapping keyBinding = (KeyMapping) (Object) this;
         GardenCustomKeybinds.isKeyPressed(keyBinding, cir);
         if (cir.isCancelled()) {

--- a/src/main/resources/skyhanni.classtweaker
+++ b/src/main/resources/skyhanni.classtweaker
@@ -32,6 +32,7 @@ accessible field net/minecraft/network/chat/TextColor name Ljava/lang/String;
 accessible field net/minecraft/world/entity/Entity DATA_CUSTOM_NAME Lnet/minecraft/network/syncher/EntityDataAccessor;
 accessible field net/minecraft/world/entity/LivingEntity DATA_HEALTH_ID Lnet/minecraft/network/syncher/EntityDataAccessor;
 accessible field net/minecraft/client/gui/components/ChatComponent chatScrollbarPos I
+accessible field net/minecraft/client/ToggleKeyMapping needsToggle Ljava/util/function/BooleanSupplier;
 accessible field net/minecraft/core/particles/ColorParticleOption color I
 mutable field net/minecraft/core/particles/ColorParticleOption color I
 accessible class net/minecraft/client/gui/Font$PreparedTextBuilder


### PR DESCRIPTION
## What
Fixed breakages caused by my recent toggle support, such as keys sometimes not registering (primarily noticed this with multi-binds) and keys sometimes getting stuck in held state.

## Changelog Fixes
+ Fixed issues with keys not registering and keys getting stuck with Garden Custom Keybinds. - Luna

