### PR TITLE
Feature + Fix: Add farming toolkit crop icons and fix stereo icons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/FarmingToolkitIconConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/FarmingToolkitIconConfig.kt
@@ -1,0 +1,14 @@
+package at.hannibal2.skyhanni.config.features.garden
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class FarmingToolkitIconConfig {
+    @Expose
+    @ConfigOption(name = "Replace Menu Icons", desc = "Show crops instead of tools in the toolkit menu.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var replaceMenuIcons: Boolean = true
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
@@ -188,6 +188,11 @@ class GardenConfig {
     val seeThroughWindow: SeeThroughWindowConfig = SeeThroughWindowConfig()
 
     @Expose
+    @ConfigOption(name = "Farming Toolkit", desc = "")
+    @Accordion
+    val farmingToolkit: FarmingToolkitIconConfig = FarmingToolkitIconConfig()
+
+    @Expose
     @ConfigOption(
         name = "Plot Price",
         desc = "Show the price of the plot in coins when inside the Configure Plots inventory.",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.features.garden.contest.FarmingContestApi
 import at.hannibal2.skyhanni.features.garden.farming.GardenBestCropTime
 import at.hannibal2.skyhanni.features.garden.farming.GardenCropSpeed
 import at.hannibal2.skyhanni.features.garden.inventory.SkyMartCopperPrice
+import at.hannibal2.skyhanni.features.garden.pests.PestApi.patternGroup
 import at.hannibal2.skyhanni.features.garden.pests.PesthunterProfit
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorApi
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.CFApi
@@ -37,6 +38,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.isBabyCrop
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LocationUtils.isPlayerInside
@@ -44,6 +46,7 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.PlayerUtils
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getCultivatingCounter
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHoeExp
@@ -221,6 +224,15 @@ object GardenApi {
     }
 
     private var lastLocation: LorenzVec? = null
+
+    /**
+     * REGEX-TEST: Farming Toolkit
+     */
+    private val toolkitInventoryPattern by patternGroup.pattern(
+        "toolkit.inventory",
+        "Farming Toolkit"
+    )
+    val toolkitInventory = InventoryDetector { name -> toolkitInventoryPattern.matches(name) }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onBlockClick(event: BlockClickEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/ToolkitCropReplacer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/ToolkitCropReplacer.kt
@@ -1,0 +1,40 @@
+package at.hannibal2.skyhanni.features.garden.farming
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.render.gui.ReplaceItemEvent
+import at.hannibal2.skyhanni.features.garden.GardenApi
+import at.hannibal2.skyhanni.features.garden.GardenApi.getCropType
+import at.hannibal2.skyhanni.features.garden.GardenApi.getItemStackCopy
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
+import at.hannibal2.skyhanni.utils.ItemUtils.setLore
+import at.hannibal2.skyhanni.utils.compat.setCustomItemName
+import net.minecraft.world.item.ItemStack
+
+@SkyHanniModule
+object ToolkitCropReplacer {
+
+    private val config get() = GardenApi.config.farmingToolkit
+
+    private val iconCache: MutableMap<Int, ItemStack> = mutableMapOf()
+
+    @HandleEvent
+    fun replaceItem(event: ReplaceItemEvent) {
+        if (!config.replaceMenuIcons) return
+        if (!GardenApi.toolkitInventory.isInside()) return
+        if (event.slot !in 10..16 && event.slot !in 20..24) return
+
+        val item = event.originalItem
+        val cropType = item.getCropType() ?: return
+        val iconId = "toolkit_crop_replacer:${cropType.name}"
+
+        val replacementStack = iconCache.getOrPut(event.slot) {
+            cropType.getItemStackCopy(iconId).apply {
+                setLore(item.getLoreComponent())
+                setCustomItemName(item.hoverName)
+            }
+        }
+
+        event.replace(replacementStack.copy())
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/stereo/StereoHarmonyDiscReplacer.kt
@@ -44,6 +44,6 @@ object StereoHarmonyDiscReplacer {
             }
         }
 
-        event.replace(replacementStack)
+        event.replace(replacementStack.copy())
     }
 }


### PR DESCRIPTION
## What
Adds an option to replace farming tool icons with their respective crop in `/farmingtoolkit` to match with stereo harmony. Also fixes a bug in the stereo harmony menu where shift clicking a custom crop icon would cause it to go blank until restarting the game.

<details>
<summary>Images</summary>

menu example (no cane hoe, cocoa chopper in use)
<img width="641" height="690" alt="image" src="https://github.com/user-attachments/assets/0c19b9f9-6bc9-490a-95f6-6626076d86b9" />

</details>

## Changelog New Features
+ Added option to show crops instead of tools in Farming Toolkit menu. - Growling_Grizzly

## Changelog Fixes
+ Fixed custom crop icons in Stereo Harmony menu becoming blank when shift clicking. - Growling_Grizzly