### PR TITLE
Improvement: Draw position guesses for theodolite

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
@@ -76,6 +76,8 @@ object TalbotCircles {
         if (yMin > yMax || xMin > xMax || zMin > zMax) return
         if ((xMax - xMin) * (zMax - zMin) > 1_000_000) return
 
+        // using a step size reduces computation and makes it easier for players
+        // to judge distance away compared to one big highlighted blob
         for (y in yMin.toInt()..yMax.toInt())
             for (x in xMin.toInt()..xMax.toInt() step LATTICE_WIDTH)
                 for (z in zMin.toInt()..zMax.toInt() step LATTICE_WIDTH)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
@@ -78,11 +78,14 @@ object TalbotCircles {
 
         // using a step size reduces computation and makes it easier for players
         // to judge distance away compared to one big highlighted blob
-        for (y in yMin.toInt()..yMax.toInt())
-            for (x in xMin.toInt()..xMax.toInt() step LATTICE_WIDTH)
-                for (z in zMin.toInt()..zMax.toInt() step LATTICE_WIDTH)
+        for (y in yMin.toInt()..yMax.toInt()) {
+            for (x in xMin.toInt()..xMax.toInt() step LATTICE_WIDTH) {
+                for (z in zMin.toInt()..zMax.toInt() step LATTICE_WIDTH) {
                     if (constraints.all { it.contains(x, y, z) })
                         candidateBlocks.add(LorenzVec(x, y, z))
+                }
+            }
+        }
     }
 
     private fun Constraint.maxRadius(yMin: Double, yMax: Double): Double {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
@@ -23,6 +23,7 @@ object TalbotCircles {
     private val constraints = mutableListOf<Constraint>()
     private val candidateBlocks = mutableListOf<LorenzVec>()
 
+    @Suppress("HandleEventInspection")
     fun drawGuesses(event: SkyHanniRenderWorldEvent) {
         if (constraints.isEmpty()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
@@ -1,37 +1,102 @@
 package at.hannibal2.skyhanni.features.misc.trevor
 
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
-import at.hannibal2.skyhanni.utils.LocationUtils
+import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawCircleWireframe
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
+import net.minecraft.world.phys.AABB
 import java.awt.Color
 import kotlin.math.absoluteValue
+import kotlin.math.atan2
+import kotlin.math.sqrt
 import kotlin.math.tan
 
 object TalbotCircles {
 
-    private const val MAXIMUM_RADIUS = 500.0
+    private const val MAX_CONSTRAINTS_USED = 3
+    private const val LATTICE_WIDTH = 2
+    private const val TOLERANCE = 3.0
 
-    private data class Circle(val center: LorenzVec, val radius: Double)
+    private data class Constraint(val playerPosition: LorenzVec, val dY: Int, val angle: Int)
 
-    private val circles = mutableListOf<Circle>()
+    private val constraints = mutableListOf<Constraint>()
+    private val candidateBlocks = mutableListOf<LorenzVec>()
 
-    fun drawCircles(event: SkyHanniRenderWorldEvent) {
-        for (circle in circles) {
-            event.drawCircleWireframe(circle.center, circle.radius, Color.ORANGE)
+    fun drawGuesses(event: SkyHanniRenderWorldEvent) {
+        if (constraints.isEmpty()) return
+
+        if (candidateBlocks.isEmpty()) {
+            for (constraint in constraints) {
+                val radius = tan(Math.toRadians(90.0 - constraint.angle)) * constraint.dY.absoluteValue
+                event.drawCircleWireframe(constraint.playerPosition, radius, Color.ORANGE)
+            }
+        }
+
+        for (block in candidateBlocks) {
+            val isFluid = !block.getBlockStateAt().fluidState.isEmpty
+            val isAirOverNonAir = block.getBlockStateAt().isAir && !block.down().getBlockStateAt().isAir
+            if (isFluid || isAirOverNonAir) {
+                val aabb = AABB(block.toBlockPos())
+                event.drawFilledBoundingBox(aabb, Color.GREEN, alphaMultiplier = .4f, seeThroughBlocks = true)
+            }
         }
     }
 
-    fun addResult(dY: Int, angle: Int) {
-        val radius = tan(Math.toRadians(90.0 - angle)) * dY.absoluteValue
-        if (radius in 0.0..MAXIMUM_RADIUS) {
-            val playerPosition = LocationUtils.playerLocation().roundTo(2)
-            val center = LorenzVec(playerPosition.x, playerPosition.y + dY, playerPosition.z)
-            circles.add(Circle(center, radius))
+    fun addResult(dY: Int, angle: Int, playerPosition: LorenzVec) {
+        // remove contradicting constraints
+        constraints.removeIf {
+            (playerPosition.y + dY - it.playerPosition.y - it.dY).absoluteValue > 2 * TOLERANCE
         }
+
+        constraints.add(Constraint(playerPosition, dY, angle))
+
+        // if too many constraints, remove oldest constraint
+        if (constraints.size > MAX_CONSTRAINTS_USED) {
+            constraints.removeAt(0)
+        }
+        recalculateCandidates()
+    }
+
+    private fun recalculateCandidates() {
+        if (constraints.isEmpty()) return
+
+        val yMin = constraints.maxOf { it.playerPosition.y + it.dY - TOLERANCE }
+        val yMax = constraints.minOf { it.playerPosition.y + it.dY + TOLERANCE }
+        val xMin = constraints.maxOf { it.playerPosition.x - it.maxRadius(yMin, yMax) }
+        val xMax = constraints.minOf { it.playerPosition.x + it.maxRadius(yMin, yMax) }
+        val zMin = constraints.maxOf { it.playerPosition.z - it.maxRadius(yMin, yMax) }
+        val zMax = constraints.minOf { it.playerPosition.z + it.maxRadius(yMin, yMax) }
+
+        if (yMin > yMax || xMin > xMax || zMin > zMax) return
+        if ((xMax - xMin) * (zMax - zMin) > 1_000_000) return
+
+        candidateBlocks.clear()
+        for (y in yMin.toInt()..yMax.toInt())
+            for (x in xMin.toInt()..xMax.toInt() step LATTICE_WIDTH)
+                for (z in zMin.toInt()..zMax.toInt() step LATTICE_WIDTH)
+                    if (constraints.all { it.contains(x, y, z) })
+                        candidateBlocks.add(LorenzVec(x, y, z))
+    }
+
+    private fun Constraint.maxRadius(yMin: Double, yMax: Double): Double {
+        val dyMax = maxOf((yMin - playerPosition.y).absoluteValue, (yMax - playerPosition.y).absoluteValue)
+        return tan(Math.toRadians(90.0 - (angle - TOLERANCE).coerceAtLeast(0.1))) * dyMax
+    }
+
+    // assumes the height is already within-range, only checks for angle in range
+    private fun Constraint.contains(x: Int, y: Int, z: Int): Boolean {
+        val dx = (x + 0.5) - playerPosition.x
+        val dz = (z + 0.5) - playerPosition.z
+        val dist = sqrt(dx * dx + dz * dz)
+        val dy = (y.toDouble() - playerPosition.y).absoluteValue
+
+        val candidateAngle = 90 - Math.toDegrees(atan2(dist, dy))
+        return (candidateAngle - angle).absoluteValue <= 3.0
     }
 
     fun resetCircles() {
-        circles.clear()
+        constraints.clear()
+        candidateBlocks.clear()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
@@ -54,7 +54,7 @@ object TalbotCircles {
 
         constraints.add(Constraint(playerPosition, dY, angle))
 
-        // if too many constraints, remove oldest constraint
+        // if too many constraints, remove the oldest constraint
         if (constraints.size > MAX_CONSTRAINTS_USED) {
             constraints.removeAt(0)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TalbotCircles.kt
@@ -35,8 +35,10 @@ object TalbotCircles {
         }
 
         for (block in candidateBlocks) {
-            val isFluid = !block.getBlockStateAt().fluidState.isEmpty
-            val isAirOverNonAir = block.getBlockStateAt().isAir && !block.down().getBlockStateAt().isAir
+            val blockState = block.getBlockStateAt()
+            val blockStateUnder = block.down().getBlockStateAt()
+            val isFluid = !blockState.fluidState.isEmpty
+            val isAirOverNonAir = blockState.isAir && !blockStateUnder.isAir
             if (isFluid || isAirOverNonAir) {
                 val aabb = AABB(block.toBlockPos())
                 event.drawFilledBoundingBox(aabb, Color.GREEN, alphaMultiplier = .4f, seeThroughBlocks = true)
@@ -69,10 +71,11 @@ object TalbotCircles {
         val zMin = constraints.maxOf { it.playerPosition.z - it.maxRadius(yMin, yMax) }
         val zMax = constraints.minOf { it.playerPosition.z + it.maxRadius(yMin, yMax) }
 
+        candidateBlocks.clear()
+
         if (yMin > yMax || xMin > xMax || zMin > zMax) return
         if ((xMax - xMin) * (zMax - zMin) > 1_000_000) return
 
-        candidateBlocks.clear()
         for (y in yMin.toInt()..yMax.toInt())
             for (x in xMin.toInt()..xMax.toInt() step LATTICE_WIDTH)
                 for (z in zMin.toInt()..zMax.toInt() step LATTICE_WIDTH)
@@ -93,7 +96,7 @@ object TalbotCircles {
         val dy = (y.toDouble() - playerPosition.y).absoluteValue
 
         val candidateAngle = 90 - Math.toDegrees(atan2(dist, dy))
-        return (candidateAngle - angle).absoluteValue <= 3.0
+        return (candidateAngle - angle).absoluteValue <= TOLERANCE
     }
 
     fun resetCircles() {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.data.title.TitleContext
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -179,17 +179,17 @@ object TrevorFeatures {
         talbotPatternAbove.matchMatcher(formattedMessage) {
             val height = group("height").toInt()
             val angle = group("angle").toInt()
-            val playerPos = lastTheodoliteClickPosition ?: LocationUtils.playerLocation()
+            val playerPosition = lastTheodoliteClickPosition ?: LocationUtils.playerLocation()
             TrevorSolver.findMobHeight(height, true)
-            TalbotCircles.addResult(height, angle, playerPos)
+            TalbotCircles.addResult(height, angle, playerPosition)
             lastTheodoliteClickPosition = null
         }
         talbotPatternBelow.matchMatcher(formattedMessage) {
             val height = group("height").toInt()
             val angle = group("angle").toInt()
-            val origin = lastTheodoliteClickPosition ?: LocationUtils.playerLocation()
+            val playerPosition = lastTheodoliteClickPosition ?: LocationUtils.playerLocation()
             TrevorSolver.findMobHeight(height, false)
-            TalbotCircles.addResult(-height, angle, origin)
+            TalbotCircles.addResult(-height, angle, playerPosition)
             lastTheodoliteClickPosition = null
         }
         talbotPatternAt.matchMatcher(formattedMessage) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.data.title.TitleContext
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
@@ -21,10 +22,12 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.findMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -117,6 +120,7 @@ object TrevorFeatures {
     private var timeLastWarped = SimpleTimeMark.farPast()
     private var lastChatPrompt = ""
     private var lastChatPromptTime = SimpleTimeMark.farPast()
+    private var lastTheodoliteClickPosition: LorenzVec? = null
 
     var questActive = false
     var inBetweenQuests = false
@@ -175,17 +179,22 @@ object TrevorFeatures {
         talbotPatternAbove.matchMatcher(formattedMessage) {
             val height = group("height").toInt()
             val angle = group("angle").toInt()
+            val playerPos = lastTheodoliteClickPosition ?: LocationUtils.playerLocation()
             TrevorSolver.findMobHeight(height, true)
-            TalbotCircles.addResult(height, angle)
+            TalbotCircles.addResult(height, angle, playerPos)
+            lastTheodoliteClickPosition = null
         }
         talbotPatternBelow.matchMatcher(formattedMessage) {
             val height = group("height").toInt()
             val angle = group("angle").toInt()
+            val origin = lastTheodoliteClickPosition ?: LocationUtils.playerLocation()
             TrevorSolver.findMobHeight(height, false)
-            TalbotCircles.addResult(-height, angle)
+            TalbotCircles.addResult(-height, angle, origin)
+            lastTheodoliteClickPosition = null
         }
         talbotPatternAt.matchMatcher(formattedMessage) {
-            TrevorSolver.averageHeight = LocationUtils.playerLocation().y
+            TrevorSolver.averageHeight = (lastTheodoliteClickPosition ?: LocationUtils.playerLocation()).y
+            lastTheodoliteClickPosition = null
         }
 
         outOfTimePattern.matchMatcher(formattedMessage) {
@@ -311,7 +320,7 @@ object TrevorFeatures {
         }
 
         if (config.talbotCircles && !mobFound) {
-            TalbotCircles.drawCircles(event)
+            TalbotCircles.drawGuesses(event)
         }
     }
 
@@ -338,6 +347,15 @@ object TrevorFeatures {
         }
     }
 
+    @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
+    fun onUseAbility(event: ItemClickEvent) {
+        if (!config.talbotCircles && !config.solver) return
+
+        if (event.itemInHand?.getInternalName() == NeuInternalName.TALBOTS_THEODOLITE) {
+            lastTheodoliteClickPosition = LocationUtils.playerLocation()
+        }
+    }
+
     @HandleEvent(priority = HandleEvent.HIGHEST, onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
     fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!inTrapperDen || !config.cooldown) return
@@ -351,6 +369,7 @@ object TrevorFeatures {
         currentLabel = "§2Ready"
         questActive = false
         inBetweenQuests = false
+        lastTheodoliteClickPosition = null
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.data.title.TitleContext
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -348,7 +348,7 @@ object TrevorFeatures {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
-    fun onUseAbility(event: ItemClickEvent) {
+    fun onItemClick(event: ItemClickEvent) {
         if (!config.talbotCircles && !config.solver) return
 
         if (event.itemInHand?.getInternalName() == NeuInternalName.TALBOTS_THEODOLITE) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -6,12 +6,12 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.mob.MobData
 import at.hannibal2.skyhanni.data.title.TitleContext
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -20,13 +20,16 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.findMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -116,6 +119,7 @@ object TrevorFeatures {
     private var timeLastWarped = SimpleTimeMark.farPast()
     private var lastChatPrompt = ""
     private var lastChatPromptTime = SimpleTimeMark.farPast()
+    private var lastTheodoliteClickPosition: LorenzVec? = null
 
     var questActive = false
     var inBetweenQuests = false
@@ -171,17 +175,22 @@ object TrevorFeatures {
         talbotPatternAbove.matchMatcher(formattedMessage) {
             val height = group("height").toInt()
             val angle = group("angle").toInt()
+            val playerPos = lastTheodoliteClickPosition ?: LocationUtils.playerLocation()
             TrevorSolver.findMobHeight(height, true)
-            TalbotCircles.addResult(height, angle)
+            TalbotCircles.addResult(height, angle, playerPos)
+            lastTheodoliteClickPosition = null
         }
         talbotPatternBelow.matchMatcher(formattedMessage) {
             val height = group("height").toInt()
             val angle = group("angle").toInt()
+            val origin = lastTheodoliteClickPosition ?: LocationUtils.playerLocation()
             TrevorSolver.findMobHeight(height, false)
-            TalbotCircles.addResult(-height, angle)
+            TalbotCircles.addResult(-height, angle, origin)
+            lastTheodoliteClickPosition = null
         }
         talbotPatternAt.matchMatcher(formattedMessage) {
-            TrevorSolver.averageHeight = LocationUtils.playerLocation().y
+            TrevorSolver.averageHeight = (lastTheodoliteClickPosition ?: LocationUtils.playerLocation()).y
+            lastTheodoliteClickPosition = null
         }
 
         outOfTimePattern.matchMatcher(formattedMessage) {
@@ -307,7 +316,7 @@ object TrevorFeatures {
         }
 
         if (config.talbotCircles && !mobFound) {
-            TalbotCircles.drawCircles(event)
+            TalbotCircles.drawGuesses(event)
         }
     }
 
@@ -334,6 +343,15 @@ object TrevorFeatures {
         }
     }
 
+    @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
+    fun onUseAbility(event: ItemClickEvent) {
+        if (!config.talbotCircles && !config.solver) return
+
+        if (event.itemInHand?.getInternalName() == NeuInternalName.TALBOTS_THEODOLITE) {
+            lastTheodoliteClickPosition = LocationUtils.playerLocation()
+        }
+    }
+
     @HandleEvent(priority = HandleEvent.HIGHEST, onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
     fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!inTrapperDen || !config.cooldown) return
@@ -347,6 +365,7 @@ object TrevorFeatures {
         currentLabel = "§2Ready"
         questActive = false
         inBetweenQuests = false
+        lastTheodoliteClickPosition = null
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -69,6 +69,7 @@ value class NeuInternalName private constructor(private val internalName: String
         val WISP_POTION = "WISP_POTION".toInternalName()
         val ENCHANTED_HAY_BLOCK = "ENCHANTED_HAY_BLOCK".toInternalName()
         val TIGHTLY_TIED_HAY_BALE = "TIGHTLY_TIED_HAY_BALE".toInternalName()
+        val TALBOTS_THEODOLITE = "TALBOTS_THEODOLITE".toInternalName()
 
         fun String.toInternalName(): NeuInternalName {
             val formatted = uppercase().replace(" ", "_")


### PR DESCRIPTION
## What
Improves the Talbot's Theodolite visualizer by accounting for integer rounding and displaying possible blocks using grid search. Based on @HacktheTime 's idea.
Also, keeps track of the player position when the theodolite is clicked, in case of high ping, based on Azzurala's idea.

<details>
<summary>Images</summary>

<img width="3840" height="2040" alt="2026-04-29_00 56 59" src="https://github.com/user-attachments/assets/fb594b3a-2545-4a47-a656-38cbae8711f6" />

<img width="3840" height="2040" alt="2026-04-29_00 57 07" src="https://github.com/user-attachments/assets/c838c2d9-e3b6-41e4-9c14-363829d6d40b" />

<img width="3840" height="2040" alt="2026-04-29_01 04 46" src="https://github.com/user-attachments/assets/cf1f8181-7dcf-4b5b-8146-2c70ea06c4fb" />


</details>

## Changelog Improvements
+ Improved Talbot's Theodolite visualizer. - Maxwell Zhao & Hype_the_Time
    * Now shows guesses for possible locations of the mob.
