### PR TITLE
Fix: Update Trapper Cooldown

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -159,7 +159,7 @@ object TrevorFeatures {
         }
 
         trapperPattern.matchMatcher(formattedMessage) {
-            timeUntilNextReady = 16
+            timeUntilNextReady = 21
             currentStatus = TrapperStatus.ACTIVE
             currentLabel = "§cActive Quest"
             trapperReady = false


### PR DESCRIPTION

## What
I hate hypixel (They did not reduce the cooldown, only provided a multiplier by upgrading trapper crest, so the change made in #5650 to the cooldown is inaccurate, as it is now permanently 21 seconds

## Changelog Fixes
+ Fixed Trapper cooldown registering as ready 5 seconds early. - Stella