### PR TITLE
Improvement: Renamed the 400th Anniversary to Century Celebration.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/AnniversaryCenturyCelebrationConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/AnniversaryCenturyCelebrationConfig.kt
@@ -6,7 +6,7 @@ import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
-class AnniversaryCelebration400Config {
+class AnniversaryCenturyCelebrationConfig {
 
     @ConfigOption(
         name = "Daily Highlight",

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
@@ -63,10 +63,10 @@ class EventConfig {
     @Expose
     val century: CenturyConfig = CenturyConfig()
 
-    @ConfigOption(name = "400þ Anniversary Celebration", desc = "Features for the 400þ year of SkyBlock.")
+    @ConfigOption(name = "Century Celebration", desc = "Features for the Century Celebration Event in SkyBlock.")
     @Accordion
     @Expose
-    val anniversaryCelebration400: AnniversaryCelebration400Config = AnniversaryCelebration400Config()
+    val anniversaryCelebration400: AnniversaryCenturyCelebrationConfig = AnniversaryCenturyCelebrationConfig()
 
     @ConfigOption(name = "Year of the Seal", desc = "Features for Year of the Seal.")
     @Accordion


### PR DESCRIPTION
## What
Changed the 400th Anniversary Event  tab name to Century Celebration to reduce the need to Change it for every Century Celebration 
Also changed the corresponding class name to reflect the new Name. 


## Changelog Improvements
+ Changed "400th Anniversary Celebration" to "Century Celebration". - Shana