### PR TITLE
Improvement: add toggle for pest timer warn reminder/expired

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTimerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTimerConfig.kt
@@ -62,6 +62,11 @@ class PestTimerConfig {
     var cooldownOverWarning: Boolean = false
 
     @Expose
+    @ConfigOption(name = "Only Warn on Reminder", desc = "Only warn when the cooldown reminder fires, not again when it expires.")
+    @ConfigEditorBoolean
+    var onlyWarnOnReminder: Boolean = false
+
+    @Expose
     @ConfigOption(name = "Repeat Warning", desc = "Repeat the warning sound and title until wardrobe is opened or pest cooldown is over.")
     @ConfigEditorBoolean
     var repeatWarning: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -269,6 +269,10 @@ object PestSpawnTimer {
     }
 
     private fun cooldownExpired() {
+        if (hasReminderShown || config.onlyWarnOnReminder) {
+            hasWarned = true
+            return
+        }
         shouldRepeatWarning = false
         TitleManager.sendTitle("§cPest Cooldown Has Expired!", duration = 3.seconds)
         ChatUtils.notifyOrDisable(


### PR DESCRIPTION
## What
Adds a toggle for pest timer warn: Only warn on reminder and not on cooldown expired.

## Changelog Improvements
+ Improved Pest Timer warning. - Rain
    * Adds a toggle to only warn on reminder.