### PR TITLE
Improvement: Multi Endcap Support

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ItemsJson.kt
@@ -27,7 +27,7 @@ data class ItemValueCalculationDataJson(
     @Expose @SerializedName("always_active_enchants") val alwaysActiveEnchants: Map<String, AlwaysActiveEnchantJson>,
     @Expose @SerializedName("only_tier_one_prices") val onlyTierOnePrices: List<String>,
     @Expose @SerializedName("only_tier_five_prices") val onlyTierFivePrices: List<String>,
-    @Expose @SerializedName("endcap_enchants") val endcapEnchants: Map<String, EndCapData>? = mapOf(),
+    @Expose @SerializedName("endcap_enchants_new") val endcapEnchants: Map<String, List<EndCapData>>? = emptyMap(),
 )
 
 data class AlwaysActiveEnchantJson(

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -718,7 +718,8 @@ object EstimatedItemValueCalculator {
                 ?.let { endcapData ->
                     level = endcapData.minOf { it.requiredLevel }
                     endcapData.forEach { levelData ->
-                        items[levelData.endcapItem] = 1
+                        val targetLevel = levelData.requiredLevel + 1
+                        if (rawLevel >= targetLevel) items[levelData.endcapItem] = 1
                     }
                 }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -701,6 +701,7 @@ object EstimatedItemValueCalculator {
                     multiplier = 2.intPow(rawLevel - 1)
                     level = 1
                 }
+
                 in data.onlyTierFivePrices if rawLevel in 6..10 -> {
                     multiplier = 2.intPow(rawLevel - 5)
                     if (multiplier > 1) level = 5
@@ -711,12 +712,15 @@ object EstimatedItemValueCalculator {
             }
             if (rawName in EstimatedItemValue.stackingEnchants.keys) level = 1
 
-            data.endcapEnchants?.get(rawName)?.let { endcapData ->
-                if (rawLevel > endcapData.requiredLevel) {
-                    level = endcapData.requiredLevel
-                    items[endcapData.endcapItem] = 1
+            data.endcapEnchants
+                ?.get(rawName)
+                ?.takeIfNotEmpty()
+                ?.let { endcapData ->
+                    level = endcapData.minOf { it.requiredLevel }
+                    endcapData.forEach { levelData ->
+                        items[levelData.endcapItem] = 1
+                    }
                 }
-            }
 
             val enchantmentName = "$rawName;$level".toInternalName()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -716,7 +716,8 @@ object EstimatedItemValueCalculator {
                 ?.get(rawName)
                 ?.takeIfNotEmpty()
                 ?.let { endcapData ->
-                    level = endcapData.minOf { it.requiredLevel }
+                    val minRequiredLevel = endcapData.minOf { it.requiredLevel }
+                    if (rawLevel >= minRequiredLevel) level = minRequiredLevel
                     endcapData.forEach { levelData ->
                         val targetLevel = levelData.requiredLevel + 1
                         if (rawLevel >= targetLevel) items[levelData.endcapItem] = 1

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -664,10 +664,11 @@ object EstimatedItemValueCalculator {
         return getTotalAndNames(items)
     }
 
-    private fun fetchEnchantmentItems(
+    internal fun fetchEnchantmentItems(
         enchantments: Map<String, Int>,
         internalName: NeuInternalName,
         data: ItemValueCalculationDataJson,
+        isBazaarItem: (NeuInternalName) -> Boolean = { it.isBazaarItem() },
     ): Map<NeuInternalName, Int> {
 
         val items = mutableMapOf<NeuInternalName, Int>()
@@ -693,17 +694,26 @@ object EstimatedItemValueCalculator {
                 false
             }
             if (isAlwaysActive) continue
+
+            val endcapData = data.endcapEnchants
+                ?.get(rawName)
+                ?.takeIfNotEmpty()
             var level = rawLevel
+            endcapData?.let {
+                val minRequiredLevel = it.minOf { levelData -> levelData.requiredLevel }
+                if (rawLevel >= minRequiredLevel) level = minRequiredLevel
+            }
+
             var multiplier = 1
 
             when (rawName) {
-                in data.onlyTierOnePrices if rawLevel in 2..5 -> {
-                    multiplier = 2.intPow(rawLevel - 1)
+                in data.onlyTierOnePrices if level in 2..5 -> {
+                    multiplier = 2.intPow(level - 1)
                     level = 1
                 }
 
-                in data.onlyTierFivePrices if rawLevel in 6..10 -> {
-                    multiplier = 2.intPow(rawLevel - 5)
+                in data.onlyTierFivePrices if level in 6..10 -> {
+                    multiplier = 2.intPow(level - 5)
                     if (multiplier > 1) level = 5
                 }
             }
@@ -712,21 +722,16 @@ object EstimatedItemValueCalculator {
             }
             if (rawName in EstimatedItemValue.stackingEnchants.keys) level = 1
 
-            data.endcapEnchants
-                ?.get(rawName)
-                ?.takeIfNotEmpty()
-                ?.let { endcapData ->
-                    val minRequiredLevel = endcapData.minOf { it.requiredLevel }
-                    if (rawLevel >= minRequiredLevel) level = minRequiredLevel
-                    endcapData.forEach { levelData ->
-                        val targetLevel = levelData.requiredLevel + 1
-                        if (rawLevel >= targetLevel) items[levelData.endcapItem] = 1
-                    }
+            endcapData?.let {
+                it.forEach { levelData ->
+                    val targetLevel = levelData.requiredLevel + 1
+                    if (rawLevel >= targetLevel) items[levelData.endcapItem] = 1
                 }
+            }
 
             val enchantmentName = "$rawName;$level".toInternalName()
 
-            if (enchantmentName.isBazaarItem()) {
+            if (isBazaarItem(enchantmentName)) {
                 items[enchantmentName] = multiplier
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -25,7 +25,7 @@ object UtilsPatterns {
      */
     val rarityLoreLinePattern by patternGroup.pattern(
         "item.lore.rarity.line.colorless",
-        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities}) ?(?:DUNGEON )?(?<itemCategory>.+?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
+        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities}) ?(?:DUNGEON )?(?<itemCategory>.*?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
     )
 
     /**

--- a/src/test/java/at/hannibal2/skyhanni/test/EstimatedItemValueCalculatorTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/EstimatedItemValueCalculatorTest.kt
@@ -1,0 +1,61 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.data.jsonobjects.repo.EndCapData
+import at.hannibal2.skyhanni.data.jsonobjects.repo.ItemValueCalculationDataJson
+import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValueCalculator
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class EstimatedItemValueCalculatorTest {
+
+    @Test
+    fun `endcap enchants still use only tier one prices for normal book value`() {
+        val data = ItemValueCalculationDataJson(
+            alwaysActiveEnchants = emptyMap(),
+            onlyTierOnePrices = listOf("turbo_wheat"),
+            onlyTierFivePrices = emptyList(),
+            endcapEnchants = mapOf(
+                "turbo_wheat" to listOf(
+                    EndCapData(5, "TURBO_GOURD".toInternalName()),
+                    EndCapData(6, "ENCHANTED_TURBO_GOURD".toInternalName()),
+                ),
+            ),
+        )
+
+        assertEquals(
+            mapOf("TURBO_WHEAT;1".toInternalName() to 16),
+            EstimatedItemValueCalculator.fetchEnchantmentItems(
+                enchantments = mapOf("turbo_wheat" to 5),
+                internalName = "THEORETICAL_HOE_WHEAT_3".toInternalName(),
+                data = data,
+                isBazaarItem = { true },
+            ),
+        )
+        assertEquals(
+            mapOf(
+                "TURBO_GOURD".toInternalName() to 1,
+                "TURBO_WHEAT;1".toInternalName() to 16,
+            ),
+            EstimatedItemValueCalculator.fetchEnchantmentItems(
+                enchantments = mapOf("turbo_wheat" to 6),
+                internalName = "THEORETICAL_HOE_WHEAT_3".toInternalName(),
+                data = data,
+                isBazaarItem = { true },
+            ),
+        )
+        assertEquals(
+            mapOf(
+                "TURBO_GOURD".toInternalName() to 1,
+                "ENCHANTED_TURBO_GOURD".toInternalName() to 1,
+                "TURBO_WHEAT;1".toInternalName() to 16,
+            ),
+            EstimatedItemValueCalculator.fetchEnchantmentItems(
+                enchantments = mapOf("turbo_wheat" to 7),
+                internalName = "THEORETICAL_HOE_WHEAT_3".toInternalName(),
+                data = data,
+                isBazaarItem = { true },
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Dependencies
- #5655 (soft dependency, really just so that it can be tested without enchant parsing in Estimated Item Value showing everything as "Enchanted Book")
- https://github.com/hannibal002/SkyHanni-REPO/pull/689

## What
Adds support for enchantments to be upgraded multiple times by endcap items. Because apparently Hypixel doesn't know what the "end" in endcap means. This is needed for Turbo-Crop VI and VII enchantments.

You can test this by searching for Advanced Gardening Hoes on AH. (It is intentional that only one Turbo Gourd and one Enchanted Turbo Gourd is counted per item, because applying one of those upgrades all Turbo-Crop enchants by one level.)

## Changelog Improvements
+ Added support for Turbo-Crop VI and VII in Estimated Item Value. - Luna

