### PR TITLE
Fix: Updater suggesting downgrades

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/GuiOptionEditorUpdateCheck.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ConfigUtils.asStructuredText
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.compat.MouseCompat
+import at.hannibal2.skyhanni.utils.system.ModVersion
 import io.github.notenoughupdates.moulconfig.common.RenderContext
 import io.github.notenoughupdates.moulconfig.gui.GuiOptionEditor
 import io.github.notenoughupdates.moulconfig.processor.ProcessedOption
@@ -41,9 +42,11 @@ class GuiOptionEditorUpdateCheck(option: ProcessedOption) : GuiOptionEditor(opti
         val widthRemaining = adjustedWidth - max(button.width, changelog.width) - 10
 
         context.scale(2F, 2F)
-        val sameVersion = currentVersion.equals(nextVersion, ignoreCase = true)
+        val hasNewerVersion = nextVersion?.let {
+            SkyHanniMod.modVersion < ModVersion.fromString(it)
+        } == true
         val versionText = "${if (UpdateManager.updateState == UpdateManager.UpdateState.NONE) "§a" else "§c"}$currentVersion" +
-            if (nextVersion != null && !sameVersion) "➜ §a$nextVersion" else ""
+            if (hasNewerVersion) "➜ §a$nextVersion" else ""
 
         context.drawStringCenteredScaledMaxWidth(
             versionText.asStructuredText(),


### PR DESCRIPTION
## What
Fixed a small visual bug that caused the updater suggesting the user to downgrade (e.g. "7.19.0 → 7.0.0") if they weren't *exactly* on the newest version, despite it correctly saying "Up to date".

## Changelog Fixes
+ Fixed updater suggesting downgrades in some cases. - Luna