### PR TITLE
Fix: Zombie Shootout helmet throwing error on end

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -236,6 +236,7 @@ object CarnivalZombieShootout {
         EntityUtils.getEntitiesNearby<Zombie>(50.0).mapNotNull { zombie ->
             if (zombie.findHealthReal() <= 0) return@mapNotNull null
             val helmet = zombie.getEntityHelmet() ?: return@mapNotNull null
+            if (helmet.item == Items.AIR) return@mapNotNull null
             val type = toType(helmet) ?: run {
                 ErrorManager.logErrorStateWithData(
                     "Could not identify Zombie Shootout type",


### PR DESCRIPTION
## What
fix the error thrown on end of zombie shootout due to zombies disappearing and helmet becoming air

## Changelog Fixes
+ Fixed an error being thrown on Zombie Shootout ending due to mob despawn. - Rain