### PR TITLE
Fix: Sowdust/Copper Not Appearing in Custom Scoreboard

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
@@ -255,7 +255,11 @@ enum class TabWidget(
     ),
     COPPER(
         // language=RegExp
-        "Copper: (?<amount>\\d+)",
+        "Copper: (?<copper>.+)",
+    ),
+    SOWDUST(
+        // language=RegExp
+        "Sowdust: (?<sowdust>.+)",
     ),
     PESTS(
         // language=RegExp

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardUtils.kt
@@ -88,10 +88,12 @@ object CustomScoreboardUtils {
         "§b${getBits()}§7/§b${getBitsAvailable()}"
     } else "§b${getBits()}"
 
-    internal fun getCopper() = getGroup(ScoreboardPattern.copperPattern, getSBLines(), "copper") ?: "0"
+    internal fun getCopper() = getGroup(ScoreboardPattern.copperPattern, getSBLines(), "copper")
+        ?: TabWidget.COPPER.matchMatcherFirstLine { group("copper") }
+        ?: "0"
 
     internal fun getSowdust() = getGroup(ScoreboardPattern.sowdustPattern, getSBLines(), "sowdust")
-        ?: ScoreboardPattern.sowdustPattern.firstMatcher(TabWidget.GARDEN_LEVEL.lines.map { it.formattedTextCompat() }) { group("sowdust") }
+        ?: TabWidget.SOWDUST.matchMatcherFirstLine { group("sowdust") }
         ?: "0"
 
     internal fun getGems() = TabWidget.GEMS.matchMatcherFirstLine { group("gems") } ?: "0"


### PR DESCRIPTION
## What
Sowdust: Did not appear (or as 0) in Custom Scoreboard when breaking crops due to vastly different formatting in the Hypixel Scoreboard during crop breaks, now (correctly) falls back to tab.
Copper: Did not appear (or as 0) in Custom Scoreboard before finishing Sam/Jeff Garden Tutorials due to not appearing in Hypixel Scoreboard at this point, now falls back to tab.

## Changelog Fixes
+ Fixed Sowdust in the Custom Scoreboard when breaking crops. - BonkersTurnip
+ Fixed Copper in the Custom Scoreboard before finishing the Garden Tutorial Quests. - BonkersTurnip

## Changelog Technical Details
+ Added SOWDUST to TabWidget enum. - BonkersTurnip
+ Fixed COPPER entry of TabWidget enum only allowing digits. - BonkersTurnip