### PR TITLE
Fix: crop milestone progress resetting and show Wrong data 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/garden/cropmilestones/CropMilestonesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/cropmilestones/CropMilestonesApi.kt
@@ -213,7 +213,8 @@ object CropMilestonesApi {
 
     internal fun CropType.addMilestoneCounter(counter: Long, sendLevelUp: Boolean = true) {
         if (counter == 0L) return
-        amountToNextTierCache[this] = amountToNextTierCache[this]?.plus(counter) ?: counter
+        val existing = amountToNextTierCache[this] ?: milestoneCalculateTierProgress()
+        amountToNextTierCache[this] = existing?.plus(counter) ?: counter
         val milestoneCounter = this.getMilestoneCounter() ?: 0
         this.setMilestoneCounter(milestoneCounter + counter)
         this.milestoneCheckProgress(sendLevelUp)


### PR DESCRIPTION
## What
Crop milestone progress display was showing an incorrect value until
/cropmilestones was opened.

An issue where crop milestone progress showed incorrect data on the first use of /cropmilestones, but displayed correctly on subsequent uses.

## Changelog Fixes
+ Fixed an issue where crop milestone progress showed incorrect data on the first use of /cropmilestones, but displayed correctly on subsequent uses. — legendpc