### PR TITLE
Feature: Crash on Skyblock Join

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnJoin.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnJoin.kt
@@ -14,7 +14,7 @@ object CrashOnJoin {
         Minecraft.getInstance().delayCrash(
             CrashReport(
                 "SkyHanni Crash on Join",
-                Throwable("Joining Skyblock may lead to bans!")
+                Throwable("Joining SkyBlock may lead to bans!")
             ),
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnJoin.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnJoin.kt
@@ -1,0 +1,21 @@
+package at.hannibal2.skyhanni.features.misc
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.ProfileJoinEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import net.minecraft.CrashReport
+import net.minecraft.client.Minecraft
+
+@SkyHanniModule
+object CrashOnDeath {
+    @HandleEvent
+    fun onProfileJoin(event: ProfileJoinEvent) {
+        Minecraft.getInstance().delayCrash(
+            CrashReport(
+                "SkyHanni Crash on Death",
+                Throwable("Disable Crash on Death in SkyHanni if you want to stop crashing")
+            ),
+        )
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnJoin.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CrashOnJoin.kt
@@ -8,13 +8,13 @@ import net.minecraft.CrashReport
 import net.minecraft.client.Minecraft
 
 @SkyHanniModule
-object CrashOnDeath {
+object CrashOnJoin {
     @HandleEvent
     fun onProfileJoin(event: ProfileJoinEvent) {
         Minecraft.getInstance().delayCrash(
             CrashReport(
-                "SkyHanni Crash on Death",
-                Throwable("Disable Crash on Death in SkyHanni if you want to stop crashing")
+                "SkyHanni Crash on Join",
+                Throwable("Joining Skyblock may lead to bans!")
             ),
         )
     }


### PR DESCRIPTION
## What
Unfortunately, players interacting with skyblock encourages actions that result in them getting banned or wiped. Skyhanni, in good conscience, should not sit idly by and allow this to happen. Anyone who disagrees with my idea is "fucking useless" and should try to not be a twit. 

## Changelog New Features
+ Added untogglable feature that prevents players from accessing skyblock. - Chissl

