### PR TITLE
Fix: Stacking Enchants blank lore line

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -299,7 +299,10 @@ object EnchantParser {
 
             stackingEnchants.forEach { stacking ->
                 currentItem?.let { item ->
-                    loreList.add(loreList.size - 1, Component.literal(stacking.progressString(item)))
+                    val progString: String = stacking.progressString(item)
+                    if (progString.isNotEmpty()) {
+                        loreList.add(loreList.size - 1, Component.literal(progString))
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What
Fixes an issue where Stacking Enchants with 0 Progress would add a blank lore line to the end of an item where progress would typically be displayed (e.g. a Cultivating 1 hoe with 0 crops).

## Changelog Fixes
+ Fixed items with Stacking Enchants with 0 Progress on those enchants adding a blank lore line to the end of the item if Stacking Enchant Progress was enabled. - BonkersTurnip