### PR TITLE
Fix: DiscordRPCManager NPE

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordRPCManager.kt
@@ -26,6 +26,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.addSkyHanniUtm
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -263,6 +264,7 @@ object DiscordRPCManager {
             largeImageKey = DiscordLocationKey.getDiscordIconKey(location),
             largeImageText = location,
             buttons = buildList {
+                if (!MinecraftCompat.localPlayerExists) return@buildList
                 if (config.showEliteSkyBlockButton.get()) DiscordRichPresence.Button(
                     label = "Open EliteSkyBlock",
                     url = getEliteSbUrl(),


### PR DESCRIPTION
## What
Fixes a NullPointerException in DiscordRPCManager that can happen when trying to fetch Elite/SkyCrypt URLs while the local player is null.

https://discord.com/channels/997079228510117908/1500836530816684042

## Changelog Fixes
+ Fixed error in Discord RPC that can sometimes happen when starting the game or switching lobbies. - Luna
