### PR TITLE
Fix: Add Lunar Moth Pest

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/BossType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/BossType.kt
@@ -127,6 +127,7 @@ enum class BossType(
     GARDEN_PEST_PRAYING_MANTIS("§cPraying Mantis", Type.GARDEN_PESTS),
     GARDEN_PEST_FIREFLY("§cFirefly", Type.GARDEN_PESTS),
     GARDEN_PEST_DRAGONFLY("§cDragonfly", Type.GARDEN_PESTS),
+    GARDEN_PEST_LUNAR_MOTH("§c§lLunar Moth", Type.GARDEN_PESTS),
 
     // TODO Corleone
     // TODO bal

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -49,7 +49,7 @@ enum class PestType(
         "PEST_FIELD_MOUSE_MONSTER".toInternalName(),
         crop = null,
         pluralName = "Field Mice",
-        eliteLbName = "mouse"
+        eliteLbName = "mouse",
     ),
     FLY(
         "Fly",
@@ -75,6 +75,7 @@ enum class PestType(
         vinyl = null,
         "PEST_LUNAR_MOTH_MONSTER".toInternalName(),
         crop = null, // Always drops Sunflower, Moonflower, *and* Wild Rose
+        eliteLbName = "lunar-moth",
     ),
     MITE(
         "Mite",
@@ -124,7 +125,7 @@ enum class PestType(
         VinylType.PRAY_FOR_ME,
         "PEST_PRAYING_MANTIS_MONSTER".toInternalName(),
         CropType.WILD_ROSE,
-        eliteLbName = "mantis"
+        eliteLbName = "mantis",
     ),
     FIREFLY(
         "Firefly",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -74,7 +74,7 @@ enum class PestType(
         SprayType.MOONDEW,
         vinyl = null,
         "PEST_LUNAR_MOTH_MONSTER".toInternalName(),
-        crop = null, // No single crop (Sunflower, Moonflower, Wild Rose)
+        crop = null, // Always drops Sunflower, Moonflower, *and* Wild Rose
     ),
     MITE(
         "Mite",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -68,6 +68,14 @@ enum class PestType(
         "PEST_LOCUST_MONSTER".toInternalName(),
         CropType.POTATO,
     ),
+    LUNAR_MOTH(
+        "Lunar Moth",
+        BossType.GARDEN_PEST_LUNAR_MOTH,
+        SprayType.MOONDEW,
+        vinyl = null,
+        "PEST_LUNAR_MOTH_MONSTER".toInternalName(),
+        crop = null, // No single crop (Sunflower, Moonflower, Wild Rose)
+    ),
     MITE(
         "Mite",
         BossType.GARDEN_PEST_MITE,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayType.kt
@@ -7,15 +7,14 @@ import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 enum class SprayType(
     val displayName: String,
     val internalName: NeuInternalName? = null,
-    val miscEffect: String? = null,
 ) {
     COMPOST("Compost"),
     PLANT_MATTER("Plant Matter"),
     DUNG("Dung"),
     HONEY_JAR("Honey Jar"),
     TASTY_CHEESE("Tasty Cheese", "CHEESE_FUEL".toInternalName()),
-    FINE_FLOUR("Fine Flour", miscEffect = "§6+20☘ Farming Fortune"),
     JELLY("Jelly"),
+    MOONDEW("Moondew"),
     ;
 
     fun toInternalName(): NeuInternalName {
@@ -25,7 +24,7 @@ enum class SprayType(
 
     fun getSprayEffect(): String = getPests().takeIf { it.isNotEmpty() }?.let { pests ->
         pests.joinToString("§7, §6") { it.displayName }
-    } ?: this.miscEffect ?: "§cUnknown Effect"
+    } ?: "§cUnknown Effect"
 
     companion object {
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -99,6 +99,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     )
 
     val DUNG_ITEM = "DUNG".toInternalName()
+    val SUNFLOWER_ITEM = "DOUBLE_PLANT".toInternalName()
     val OVERCLOCKER = "OVERCLOCKER_3000".toInternalName()
     val BITS = "SKYBLOCK_BIT".toInternalName()
     const val KILL_BITS = 5
@@ -204,6 +205,8 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
 
             // Field Mice drop 6 separate items, but we only want to count the kill once
             if (pest == PestType.FIELD_MOUSE && internalName == DUNG_ITEM) addKill(pest)
+            // Lunar Moths drop 3 separate crops, but we only want to count the kill once
+            if (pest == PestType.FIELD_MOUSE && internalName == SUNFLOWER_ITEM) addKill(pest)
             // overclocker drops have the same format as crop drops and causes double counting kills
             else if (pest != PestType.FIELD_MOUSE && internalName != OVERCLOCKER) addKill(pest)
         }


### PR DESCRIPTION
## What
Adds support for the new Lunar Moth pest (exclusively caught in traps with Moondew bait). 

Also removes Fine Flour as a spray, since Hypixel removed this a while back.

## Changelog Fixes
+ Fixed Lunar Moth pest not being recognized. - Luna