### PR TITLE
Fix: trade menu display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/TradeValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/TradeValue.kt
@@ -134,11 +134,11 @@ object TradeValue {
 
         if (indicator == 0) {
             yourDisplay = buildList {
-                addToList(map.values, "§eTrade Value")
+                addToList(map.values, "§eTrade Value Your")
             }
         } else {
             otherDisplay = buildList {
-                addToList(map.values, "§eTrade Value")
+                addToList(map.values, "§eTrade Value Other")
             }
         }
     }


### PR DESCRIPTION
## What
Both displays had the same internal name.

## Changelog Fixes
+ Fixed not being able to move both displays while in the trade menu. - hannibal2