### PR TITLE
Fix: Add thousands separators in SkyHanni User Luck

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/AchievementManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/AchievementManager.kt
@@ -273,7 +273,7 @@ object AchievementManager {
                 Component.empty(),
                 componentBuilder {
                     appendWithColor("Value: ", ChatFormatting.GRAY)
-                    appendWithColor("$luck✴", ChatFormatting.GREEN)
+                    appendWithColor("${luck.addSeparators()}✴", ChatFormatting.GREEN)
                 },
                 Component.empty(),
                 Component.literal("Gain more by completing achievements!").withColor(ChatFormatting.DARK_GRAY),

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/HoeLevelDisplay.kt
@@ -159,7 +159,7 @@ object HoeLevelDisplay {
                 Component.empty(),
                 componentBuilder {
                     appendWithColor("Value: ", ChatFormatting.GRAY)
-                    appendWithColor("$luck✴", ChatFormatting.GREEN)
+                    appendWithColor("${luck.addSeparators()}✴", ChatFormatting.GREEN)
                 },
                 Component.empty(),
                 Component.literal("Gain more by leveling up your farming tools!").withColor(ChatFormatting.DARK_GRAY),

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/UserLuckBreakdown.kt
@@ -279,7 +279,7 @@ object UserLuckBreakdown {
             }
 
             "skills" -> {
-                val luckString = skillOverflowLuck.values.sum()
+                val luckString = skillOverflowLuck.values.sum().addSeparators()
                 val firstHalf = arrayOf(
                     "§8Grouped",
                     "",
@@ -293,7 +293,7 @@ object UserLuckBreakdown {
                 val sourcesList = mutableListOf<String>()
                 for ((skillType, luck) in skillOverflowLuck) {
                     if (luck == 0) continue
-                    sourcesList.add(" §a+$luck✴ §f${skillType.displayName} Skill")
+                    sourcesList.add(" §a+${luck.addSeparators()}✴ §f${skillType.displayName} Skill")
                 }
                 val finalList = mutableListOf<String>()
                 finalList.addAll(firstHalf)


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by a plus. For example, `Feature + Fix: Add new command and fix bug in command`.
Commonly used labels are Improvement, Backend, Feature and Fix.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

-->

## What
Most sources of SkyHanni User Luck have [thousands separators](https://en.wikipedia.org/wiki/Thousands_separator), but some are missing them. This pull requests adds thousands separators to all sources of SkyHanni User Luck that are missing them.

<details>
<summary>Images</summary>

### Before
<img width="3437" height="699" alt="image" src="https://github.com/user-attachments/assets/3f99cded-9e7e-45de-b782-fc32aef8f68b" />

### After
<img width="3437" height="699" alt="image" src="https://github.com/user-attachments/assets/a523db39-5e85-4fe7-9e17-68018e8d9b4c" />

<!-- drop images here -->

</details>

## Changelog Fixes
+ Added thousands separators in SkyHanni User Luck. - BrookeAFK