### PR TITLE
Improvement: Sun's Grasp support for Custom Keybinds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/KeyBindConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/KeyBindConfig.kt
@@ -37,6 +37,15 @@ class KeyBindConfig {
     var fishingRod: Boolean = false
 
     @Expose
+    @ConfigOption(
+        name = "Include Empty Hand with Sun's Grasp",
+        desc = "Also use custom keybinds while holding nothing in your hand if you have a Sun's Grasp equipped.\n" +
+            "§eRequires main toggle to be enabled!",
+    )
+    @ConfigEditorBoolean
+    var sunsGrasp: Boolean = true
+
+    @Expose
     @ConfigOption(name = "Exclude Barn", desc = "Disable this feature while on the barn plot.")
     @ConfigEditorBoolean
     var excludeBarn: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -5,10 +5,13 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.features.fishing.FishingApi.isFishingRod
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.GardenApi.isFarmingTool
+import at.hannibal2.skyhanni.features.inventory.EquipmentApi
+import at.hannibal2.skyhanni.features.inventory.EquipmentSlot
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
@@ -19,6 +22,7 @@ import net.minecraft.client.KeyMapping
 import net.minecraft.client.Minecraft
 import net.minecraft.client.ToggleKeyMapping
 import net.minecraft.client.gui.screens.inventory.SignEditScreen
+import net.minecraft.world.item.Items
 import org.lwjgl.glfw.GLFW
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 import kotlin.time.Duration.Companion.milliseconds
@@ -27,6 +31,7 @@ import kotlin.time.Duration.Companion.milliseconds
 object GardenCustomKeybinds {
 
     private val SQUEAKY_MOUSEMAT = "SQUEAKY_MOUSEMAT".toInternalName()
+    private val SUNS_GRASP = "SUNS_GRASP".toInternalName()
 
     private val config get() = GardenApi.config.keyBind
     private val mcSettings get() = Minecraft.getInstance().options
@@ -163,10 +168,15 @@ object GardenCustomKeybinds {
             config.enabled &&
             !(GardenApi.onUnfarmablePlot && config.excludeBarn)
 
-    private fun isHoldingTool() = InventoryUtils.getItemInHand()?.getInternalNameOrNull()?.let { heldItem ->
-        heldItem.isFarmingTool() ||
-            (config.mousemat && heldItem == SQUEAKY_MOUSEMAT) ||
-            (config.fishingRod && heldItem.isFishingRod())
+    private fun isHoldingTool(): Boolean = InventoryUtils.getItemInHand()?.let { heldItem ->
+        val internalName = heldItem.getInternalName()
+
+        val wearingSunsGrasp = EquipmentApi.getEquipment(EquipmentSlot.GLOVES)?.getInternalName() == SUNS_GRASP
+
+        return internalName.isFarmingTool() ||
+            (config.mousemat && internalName == SQUEAKY_MOUSEMAT) ||
+            (config.fishingRod && internalName.isFishingRod()) ||
+            (config.sunsGrasp && wearingSunsGrasp && heldItem.item == Items.AIR)
     } ?: false
 
     private fun isActive(): Boolean =

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/EquipmentApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/EquipmentApi.kt
@@ -1,6 +1,10 @@
 package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.EnumArgumentType
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.InternalNameArgumentType
 import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
@@ -14,6 +18,7 @@ import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
+import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -93,6 +98,20 @@ object EquipmentApi {
             if (item.cleanName() != chatItem) return@matchMatcher
             setEquipment(slot, item)
             lastClickedEquipment = null
+        }
+    }
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shspoofequipment") {
+            description = "Spoofs a SkyBlock equipment slot."
+            category = CommandCategory.DEVELOPER_TEST
+
+            arg("slot", EnumArgumentType.name<EquipmentSlot>()) { slot ->
+                argCallback("internalName", InternalNameArgumentType.internalName()) { internalName ->
+                    setEquipment(getArg(slot), internalName.getItemStack())
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## What
Adds support for treating an empty hand as a farming tool for purposes of Custom Keybinds while you have a Sun's Grasp equipped, as well as a convenient dev spoof command.

## Changelog Improvements
+ Added Sun's Grasp support for Garden Custom Keybinds. - Luna

## Changelog Technical Details
+ Added /shspoofequipment command. - Luna