### PR TITLE
Fix: Plot Border Key working in chat/GUIs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotBorders.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotBorders.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotApi.renderPlot
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
+import net.minecraft.client.Minecraft
 import org.lwjgl.glfw.GLFW
 
 @SkyHanniModule
@@ -18,6 +19,7 @@ object GardenPlotBorders {
     @HandleEvent
     fun onKeyDown(event: KeyDownEvent) {
         if (!isEnabled()) return
+        if (Minecraft.getInstance().screen != null) return
         if (event.keyCode == config.plotBorderKey) {
             showBorders = !showBorders
         }


### PR DESCRIPTION
## What
Added a check to Plot Border Key to ensure no GUI is open before activating.

## Changelog Fixes
+ Fixed Plot Border Key activating when in chat or other GUIs. - Luna