### PR TITLE
Fix: Bandaid fix all possible ESP's with skull wearing entities

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.EntityUtils.isCorrupted
+import at.hannibal2.skyhanni.utils.ItemUtils.isSkull
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LocationUtils.getBoxCenter
 import at.hannibal2.skyhanni.utils.LocationUtils.union
@@ -25,6 +26,7 @@ import at.hannibal2.skyhanni.utils.getLorenzVec
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import io.github.notenoughupdates.moulconfig.observer.Property
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.EquipmentSlot
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.decoration.ArmorStand
 import net.minecraft.world.entity.monster.zombie.Zombie
@@ -166,9 +168,9 @@ class Mob(
 
     private fun internalHighlight() {
         highlightColor?.let { color ->
-            RenderLivingEntityHelper.setEntityColor(baseEntity, color) { !isInvisible() && condition() }
+            RenderLivingEntityHelper.setEntityColor(baseEntity, color) { !isInvisible() && condition() && !baseEntity.equipment[EquipmentSlot.HEAD].isSkull()}
             extraEntities.forEach {
-                RenderLivingEntityHelper.setEntityColor(it, color) { !isInvisible() && condition() }
+                RenderLivingEntityHelper.setEntityColor(it, color) { !isInvisible() && condition() && !baseEntity.equipment[EquipmentSlot.HEAD].isSkull()}
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.HypixelCommands
+import at.hannibal2.skyhanni.utils.ItemUtils.isSkull
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.MobUtils.mob
@@ -24,7 +25,9 @@ import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.compat.findHealthReal
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.EquipmentSlot
 import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.entity.monster.zombie.Zombie
 import java.awt.Color
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -103,7 +106,9 @@ object SeaCreatureFeatures {
     private fun isEnabled() = SkyBlockUtils.inSkyBlock && !DungeonApi.inDungeon() && !KuudraApi.inKuudra
 
     private val getEntityOutlineColor: (entity: Entity) -> Color? = { entity ->
-        (entity as? LivingEntity)?.mob?.let { mob ->
+        val livingEntity = entity as? LivingEntity?
+        livingEntity?.mob?.let { mob ->
+            if (livingEntity.equipment[EquipmentSlot.HEAD].isSkull()) return@let null
             if (SeaCreatureSettings.getConfig(mob)?.shouldHighlight == true && entity.distanceToPlayer() < 30) {
                 LorenzColor.GREEN.toColor()
             } else null

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PartyMemberOutlines.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PartyMemberOutlines.kt
@@ -8,8 +8,10 @@ import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
+import at.hannibal2.skyhanni.utils.ItemUtils.isSkull
 import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.EquipmentSlot
 import java.awt.Color
 
 @SkyHanniModule
@@ -26,7 +28,9 @@ object PartyMemberOutlines {
     }
 
     private fun getEntityOutlineColor(entity: Entity): Color? {
-        if (entity !is RemotePlayer || !PartyApi.partyMembers.contains(entity.name.string)) return null
+        val playerEntity = entity as? RemotePlayer? ?: return null
+        if (!PartyApi.partyMembers.contains(playerEntity.name.string)) return null
+        if (playerEntity.equipment[EquipmentSlot.HEAD].isSkull()) return null
         return config.outlineColor.toColor()
     }
 }


### PR DESCRIPTION
## What
We've had this issue since 1.21.10, this should fix all examples
You can complain this is a bandaid but a bandaid is better than letting people latch onto this if they heavily notice.

exclude_from_changelog
