### PR TITLE
Fix: Skull Glow Depth Check

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinItemCommand.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinItemCommand.java
@@ -5,7 +5,11 @@ import net.minecraft.client.renderer.SubmitNodeStorage;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
-@Mixin(SubmitNodeStorage.ItemSubmit.class)
+@Mixin({
+    SubmitNodeStorage.ItemSubmit.class,
+    SubmitNodeStorage.ModelSubmit.class,
+    SubmitNodeStorage.ModelPartSubmit.class,
+})
 public class MixinItemCommand implements GlowingStateStore {
 
     @Unique

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelFeatureRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelFeatureRenderer.java
@@ -12,6 +12,7 @@ import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(ModelFeatureRenderer.class)

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelFeatureRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelFeatureRenderer.java
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers.renderer;
 
+import at.hannibal2.skyhanni.mixins.hooks.GlowingStateStore;
 import at.hannibal2.skyhanni.utils.render.SkyHanniOutlineVertexConsumerProvider;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -17,8 +18,8 @@ import org.spongepowered.asm.mixin.injection.At;
 public class MixinModelFeatureRenderer {
 
     @WrapOperation(method = "renderModel(Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelSubmit;Lnet/minecraft/client/renderer/rendertype/RenderType;Lcom/mojang/blaze3d/vertex/VertexConsumer;Lnet/minecraft/client/renderer/OutlineBufferSource;Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OutlineBufferSource;setColor(I)V"))
-    private void setSkyHanniOutlineColor(OutlineBufferSource outlineConsumer, int color, Operation<Integer> original, @Local(argsOnly = true) SubmitNodeStorage.ModelSubmit<?> model) {
-        if (model.state() instanceof EntityRenderState currentState && currentState.skyhanni$isUsingCustomOutline()) {
+    private void setSkyHanniOutlineColor(OutlineBufferSource outlineConsumer, int color, Operation<Void> original, @Local(argsOnly = true) SubmitNodeStorage.ModelSubmit<?> model) {
+        if (skyhanni$usesCustomOutline(model)) {
             original.call(SkyHanniOutlineVertexConsumerProvider.getVertexConsumers(), color);
         } else {
             original.call(outlineConsumer, color);
@@ -27,11 +28,17 @@ public class MixinModelFeatureRenderer {
 
     @WrapOperation(method = "renderModel(Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelSubmit;Lnet/minecraft/client/renderer/rendertype/RenderType;Lcom/mojang/blaze3d/vertex/VertexConsumer;Lnet/minecraft/client/renderer/OutlineBufferSource;Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OutlineBufferSource;getBuffer(Lnet/minecraft/client/renderer/rendertype/RenderType;)Lcom/mojang/blaze3d/vertex/VertexConsumer;"))
     private VertexConsumer getSkyHanniOutlineBuffer(OutlineBufferSource outlineConsumer, RenderType layer, Operation<VertexConsumer> original, @Local(argsOnly = true) SubmitNodeStorage.ModelSubmit<?> model) {
-        if (model.state() instanceof EntityRenderState currentState && currentState.skyhanni$isUsingCustomOutline()) {
+        if (skyhanni$usesCustomOutline(model)) {
             return original.call(SkyHanniOutlineVertexConsumerProvider.getVertexConsumers(), layer);
         } else {
             return original.call(outlineConsumer, layer);
         }
     }
 
+    @Unique
+    private boolean skyhanni$usesCustomOutline(SubmitNodeStorage.ModelSubmit<?> model) {
+        Object obj = model;
+        if (obj instanceof GlowingStateStore casted && casted.skyhanni$isUsingCustomOutline()) return true;
+        return model.state() instanceof EntityRenderState currentState && currentState.skyhanni$isUsingCustomOutline();
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelPartFeatureRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelPartFeatureRenderer.java
@@ -11,6 +11,7 @@ import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.feature.ModelPartFeatureRenderer;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(ModelPartFeatureRenderer.class)

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelPartFeatureRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelPartFeatureRenderer.java
@@ -1,0 +1,61 @@
+package at.hannibal2.skyhanni.mixins.transformers.renderer;
+
+import at.hannibal2.skyhanni.mixins.hooks.GlowingStateStore;
+import at.hannibal2.skyhanni.utils.render.SkyHanniOutlineVertexConsumerProvider;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.OutlineBufferSource;
+import net.minecraft.client.renderer.SubmitNodeStorage;
+import net.minecraft.client.renderer.feature.ModelPartFeatureRenderer;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ModelPartFeatureRenderer.class)
+public class MixinModelPartFeatureRenderer {
+
+    @WrapOperation(
+        method = "render",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OutlineBufferSource;setColor(I)V")
+    )
+    private void setSkyHanniOutlineColor(
+        OutlineBufferSource outlineConsumer,
+        int color,
+        Operation<Void> original,
+        @Local SubmitNodeStorage.ModelPartSubmit modelPart
+    ) {
+        if (skyhanni$usesCustomOutline(modelPart)) {
+            original.call(SkyHanniOutlineVertexConsumerProvider.getVertexConsumers(), color);
+        } else {
+            original.call(outlineConsumer, color);
+        }
+    }
+
+    @WrapOperation(
+        method = "render",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/OutlineBufferSource;getBuffer(Lnet/minecraft/client/renderer/rendertype/RenderType;)Lcom/mojang/blaze3d/vertex/VertexConsumer;"
+        )
+    )
+    private VertexConsumer getSkyHanniOutlineBuffer(
+        OutlineBufferSource outlineConsumer,
+        RenderType layer,
+        Operation<VertexConsumer> original,
+        @Local SubmitNodeStorage.ModelPartSubmit modelPart
+    ) {
+        if (skyhanni$usesCustomOutline(modelPart)) {
+            return original.call(SkyHanniOutlineVertexConsumerProvider.getVertexConsumers(), layer);
+        } else {
+            return original.call(outlineConsumer, layer);
+        }
+    }
+
+    @Unique
+    private boolean skyhanni$usesCustomOutline(SubmitNodeStorage.ModelPartSubmit modelPart) {
+        Object obj = modelPart;
+        return obj instanceof GlowingStateStore casted && casted.skyhanni$isUsingCustomOutline();
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinSubmitNodeCollection.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinSubmitNodeCollection.java
@@ -1,11 +1,15 @@
 package at.hannibal2.skyhanni.mixins.transformers.renderer;
 
 import at.hannibal2.skyhanni.mixins.hooks.EntityRenderDispatcherHookKt;
+import at.hannibal2.skyhanni.mixins.hooks.GlowingStateStore;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.renderer.SubmitNodeCollection;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
+import net.minecraft.client.renderer.feature.ModelPartFeatureRenderer;
+import net.minecraft.client.renderer.rendertype.RenderType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -15,11 +19,50 @@ import java.util.List;
 public class MixinSubmitNodeCollection<E> {
 
     @WrapOperation(method = "submitItem", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z"))
-    private  boolean onSubmitItem(List<E> list, E itemCommand, Operation<Boolean> original) {
+    private boolean onSubmitItem(List<E> list, E itemCommand, Operation<Boolean> original) {
+        skyhanni$markCustomOutline(itemCommand);
+        return original.call(list, itemCommand);
+    }
+
+    @WrapOperation(
+        method = "submitModel",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/feature/ModelFeatureRenderer$Storage;add(Lnet/minecraft/client/renderer/rendertype/RenderType;Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelSubmit;)V"
+        )
+    )
+    private void onSubmitModel(
+        ModelFeatureRenderer.Storage storage,
+        RenderType renderType,
+        SubmitNodeStorage.ModelSubmit<?> modelSubmit,
+        Operation<Void> original
+    ) {
+        skyhanni$markCustomOutline(modelSubmit);
+        original.call(storage, renderType, modelSubmit);
+    }
+
+    @WrapOperation(
+        method = "submitModelPart",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/feature/ModelPartFeatureRenderer$Storage;add(Lnet/minecraft/client/renderer/rendertype/RenderType;Lnet/minecraft/client/renderer/SubmitNodeStorage$ModelPartSubmit;)V"
+        )
+    )
+    private void onSubmitModelPart(
+        ModelPartFeatureRenderer.Storage storage,
+        RenderType renderType,
+        SubmitNodeStorage.ModelPartSubmit modelPartSubmit,
+        Operation<Void> original
+    ) {
+        skyhanni$markCustomOutline(modelPartSubmit);
+        original.call(storage, renderType, modelPartSubmit);
+    }
+
+    @Unique
+    private void skyhanni$markCustomOutline(Object submit) {
         EntityRenderState currentState = EntityRenderDispatcherHookKt.getEntityRenderState();
-        if (itemCommand instanceof SubmitNodeStorage.ItemSubmit casted && currentState != null && currentState.skyhanni$isUsingCustomOutline()) {
+        if (submit instanceof GlowingStateStore casted && currentState != null && currentState.skyhanni$isUsingCustomOutline()) {
             casted.skyhanni$setUsingCustomOutline();
         }
-        return original.call(list, itemCommand);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinSubmitNodeCollection.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinSubmitNodeCollection.java
@@ -11,6 +11,7 @@ import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.feature.ModelPartFeatureRenderer;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 import java.util.List;


### PR DESCRIPTION
## What
Fixes custom glow applied to skulls not respecting depth, causing them to glow through walls.

Supersedes #5696.

## Changelog Fixes
+ Fixed some skulls/helmets glowing through walls when they shouldn't. - Luna