### PR TITLE
Fix: Remove unnecessary profile widget warnings

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ProfileStorageData.kt
@@ -126,6 +126,11 @@ object ProfileStorageData {
         noTabListTime = SimpleTimeMark.now()
         val foundSkyBlockTabList = TabWidget.AREA.isActive
         if (foundSkyBlockTabList) {
+            if (HypixelData.profileName.isNotEmpty()) {
+                ChatUtils.debug("Profile widget missing but we already got profile name, skipping warning")
+                noTabListTime = SimpleTimeMark.farPast()
+                return
+            }
             ChatUtils.clickableChat(
                 "§cCannot read profile name from tab list! Open /widget and make sure the Profile Widget " +
                     "is enabled and visible.",


### PR DESCRIPTION
## What
The warning for the Profile tab list widget being missing will now only be sent if we haven't gotten the player's profile name from the chat message yet (which may happen if the player has only ever had one profile).

## Changelog Fixes
+ Fixed "Cannot read profile name from tab list" warning showing even if we already know the profile name. - Luna
