### PR TITLE
Fix: make Sensitivity reducer less prone to disabling and re-enabling when falling off small ledges

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
@@ -55,7 +55,7 @@ class SensitivityReducerConfig {
     @Expose
     @ConfigOption(name = "Ticks Until In Air", desc = "Game Ticks until Player is no longer 'On Ground' for reduction")
     @ConfigEditorSlider(minValue = 1f, maxValue = 20f, minStep = 1f)
-    val ticksUntilInAir: Property<Float> = Property.of(1f)
+    val ticksUntilInAir: Property<Int> = Property.of(1)
 
     @Expose
     @ConfigOption(name = "Disable in Barn", desc = "Disable reduced sensitivity in barn plot.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
@@ -53,6 +53,11 @@ class SensitivityReducerConfig {
     val onGround: Property<Boolean> = Property.of(false)
 
     @Expose
+    @ConfigOption(name = "Ticks Until In Air", desc = "Game Ticks until Player is no longer 'On Ground' for reduction")
+    @ConfigEditorSlider(minValue = 1f, maxValue = 20f, minStep = 1f)
+    val ticksUntilInAir: Property<Float> = Property.of(1f)
+
+    @Expose
     @ConfigOption(name = "Disable in Barn", desc = "Disable reduced sensitivity in barn plot.")
     @ConfigEditorBoolean
     val onlyPlot: Property<Boolean> = Property.of(true)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -83,7 +83,7 @@ object SensitivityReducer {
         if (onGround != newOnGround) {
             onGround = newOnGround
             ticksInAir++
-            if (ticksInAir == 2) tryAutoToggle()
+            if (ticksInAir == 3) tryAutoToggle()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -83,9 +83,9 @@ object SensitivityReducer {
         if (onGround != newOnGround) {
             onGround = newOnGround
             val tickUntilInAir = config.ticksUntilInAir.get()
-            if (tickUntilInAir != 1f) {
+            if (tickUntilInAir != 1) {
                 ticksInAir++
-                if (ticksInAir == 3) tryAutoToggle()
+                if (ticksInAir == tickUntilInAir) tryAutoToggle()
             }
             else tryAutoToggle()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -36,6 +36,7 @@ object SensitivityReducer {
     private var onGround: Boolean = false
 
     private var shouldBeActive = false
+    private var ticksInAir = 0
 
     private val isActive get() = isAutoActive || isManualActive
     private val isAutoActive get() = SensitivityState.AUTO_REDUCED.isActive()
@@ -81,13 +82,15 @@ object SensitivityReducer {
 
         if (onGround != newOnGround) {
             onGround = newOnGround
-            tryAutoToggle()
+            ticksInAir++
+            if (ticksInAir == 2) tryAutoToggle()
         }
     }
 
     private fun tryAutoToggle() {
         if (!isAutoActive) return
 
+        ticksInAir = 0
         if (!isActive) {
             shouldBeActive = true
             MouseSensitivityManager.state = SensitivityState.AUTO_REDUCED

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -82,8 +82,12 @@ object SensitivityReducer {
 
         if (onGround != newOnGround) {
             onGround = newOnGround
-            ticksInAir++
-            if (ticksInAir == 3) tryAutoToggle()
+            val tickUntilInAir = config.ticksUntilInAir.get()
+            if (tickUntilInAir != 1f) {
+                ticksInAir++
+                if (ticksInAir == 3) tryAutoToggle()
+            }
+            else tryAutoToggle()
         }
     }
 


### PR DESCRIPTION
## What
This isn't just a pull request — it's a merge request

I'm genuinely sorry for this joke description I have made a continuous and serious...

## Changelog Fixes
+ Added config option to modify number of ticks off Ground until sensitivity reducer toggles on/off. - Fazfoxy

