### PR TITLE
Feature: Add a tolerance setting for the 'Only on Ground' feature (Outdated)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
@@ -57,7 +57,7 @@ class SensitivityReducerConfig {
         name = "Only on Ground Tolerance",
         desc = "How close to ground counts as on ground when 'Only on Ground' is enabled. Useful for farms with small height drops.",
     )
-    @ConfigEditorSlider(minValue = 0f, maxValue = 1f, minStep = 1f / 16f) // Block heights are multiples of 1/16
+    @ConfigEditorSlider(minValue = 0f, maxValue = 2f, minStep = 1f / 16f) // Block heights are multiples of 1/16
     val onGroundTolerance: Property<Float> = Property.of(0f)
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
@@ -48,9 +48,14 @@ class SensitivityReducerConfig {
     var showGui: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Only in Ground", desc = "Lower sensitivity when standing on the ground.")
+    @ConfigOption(name = "Only on Ground", desc = "When enabled, lower sensitivity only while on or near the ground.")
     @ConfigEditorBoolean
     val onGround: Property<Boolean> = Property.of(false)
+
+    @Expose
+    @ConfigOption(name = "Only on Ground Tolerance", desc = "How close to ground counts as on ground when 'Only on Ground' is enabled. Useful for farms with small height drops.")
+    @ConfigEditorSlider(minValue = 0f, maxValue = 1f, minStep = 1f / 16f) // Block heights are multiples of 1/16
+    val onGroundTolerance: Property<Double> = Property.of(0.0)
 
     @Expose
     @ConfigOption(name = "Disable in Barn", desc = "Disable reduced sensitivity in barn plot.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/SensitivityReducerConfig.kt
@@ -53,9 +53,12 @@ class SensitivityReducerConfig {
     val onGround: Property<Boolean> = Property.of(false)
 
     @Expose
-    @ConfigOption(name = "Only on Ground Tolerance", desc = "How close to ground counts as on ground when 'Only on Ground' is enabled. Useful for farms with small height drops.")
+    @ConfigOption(
+        name = "Only on Ground Tolerance",
+        desc = "How close to ground counts as on ground when 'Only on Ground' is enabled. Useful for farms with small height drops.",
+    )
     @ConfigEditorSlider(minValue = 0f, maxValue = 1f, minStep = 1f / 16f) // Block heights are multiples of 1/16
-    val onGroundTolerance: Property<Double> = Property.of(0.0)
+    val onGroundTolerance: Property<Float> = Property.of(0f)
 
     @Expose
     @ConfigOption(name = "Disable in Barn", desc = "Disable reduced sensitivity in barn plot.")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -76,7 +76,7 @@ object SensitivityReducer {
         val newInBarn = GardenApi.onUnfarmablePlot
         val onGroundTolerance = config.onGroundTolerance.get()
         val newOnGround = PlayerUtils.onGround() ||
-            (config.onGround.get() && onGroundTolerance > 0.0 && !PlayerUtils.isFlying() &&
+            (config.onGround.get() && onGroundTolerance > 0f && !PlayerUtils.isFlying() &&
                 PlayerUtils.getLocation().let { !LocationUtils.canSee(it, it.down(onGroundTolerance)) })
 
         if (inBarn != newInBarn) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -10,11 +10,11 @@ import at.hannibal2.skyhanni.features.fishing.FishingApi
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.sensitivity.MouseSensitivityManager.SensitivityState
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.BlockUtils
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
-import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
@@ -74,10 +74,17 @@ object SensitivityReducer {
 
     private fun updatePlayerStatus() {
         val newInBarn = GardenApi.onUnfarmablePlot
-        val onGroundTolerance = config.onGroundTolerance.get()
-        val newOnGround = PlayerUtils.onGround() ||
-            (config.onGround.get() && onGroundTolerance > 0f && !PlayerUtils.isFlying() &&
-                PlayerUtils.getLocation().let { !LocationUtils.canSee(it, it.down(onGroundTolerance)) })
+
+        val onGroundTolerance = if (config.onGround.get()) config.onGroundTolerance.get() else 0f
+        val newOnGround = when {
+            PlayerUtils.onGround() -> true
+            PlayerUtils.isFlying() -> false
+            onGroundTolerance > 0f -> PlayerUtils.getLocation().let {
+                BlockUtils.raycast(it, it.down(onGroundTolerance))?.miss == false
+            }
+
+            else -> false
+        }
 
         if (inBarn != newInBarn) {
             inBarn = newInBarn

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/SensitivityReducer.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
+import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
@@ -68,11 +69,15 @@ object SensitivityReducer {
         config.enabled.afterChange { autoToggle() }
         config.onlyPlot.afterChange { autoToggle() }
         config.onGround.afterChange { autoToggle() }
+        config.onGroundTolerance.afterChange { autoToggle() }
     }
 
     private fun updatePlayerStatus() {
         val newInBarn = GardenApi.onUnfarmablePlot
-        val newOnGround = PlayerUtils.onGround()
+        val onGroundTolerance = config.onGroundTolerance.get()
+        val newOnGround = PlayerUtils.onGround() ||
+            (config.onGround.get() && onGroundTolerance > 0.0 && !PlayerUtils.isFlying() &&
+                PlayerUtils.getLocation().let { !LocationUtils.canSee(it, it.down(onGroundTolerance)) })
 
         if (inBarn != newInBarn) {
             inBarn = newInBarn

--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -47,6 +47,7 @@ object PlayerUtils {
 
     fun onGround(): Boolean = MinecraftCompat.localPlayer.onGround()
     fun inAir(): Boolean = !onGround()
+    fun isFlying(): Boolean = MinecraftCompat.localPlayer.getAbilities().flying
 
     fun blockPosition() = MinecraftCompat.localPlayer.blockPosition().toLorenzVec()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -47,7 +47,7 @@ object PlayerUtils {
 
     fun onGround(): Boolean = MinecraftCompat.localPlayer.onGround()
     fun inAir(): Boolean = !onGround()
-    fun isFlying(): Boolean = MinecraftCompat.localPlayer.getAbilities().flying
+    fun isFlying(): Boolean = MinecraftCompat.localPlayer.abilities.flying
 
     fun blockPosition() = MinecraftCompat.localPlayer.blockPosition().toLorenzVec()
 


### PR DESCRIPTION
## What
Add a tolerance setting for the 'Only on Ground' feature. On farms with small drops such as dirt to soulsand, the mouse sensitivity can briefly unlock.

This does a downward raycast check from the player to check the distance of the next block below. This check is ONLY run every tick where the player is not onGround, not flying, and both the Only on Ground is enabled and On Ground Tolerance is greater than 0. This ensures that the raycast check is only run on ticks where necessary and has minimal performance impact.

## Changelog Improvements
+ Added an 'Only on Ground Tolerance' to Sensitivity Reducer. - zumbiepig
    * Checks how far the next block below you is before disabling Sensitivity Reducer when 'Only on Ground' is enabled, useful for farm designs with small drops.

## Changelog Technical Details
+ Added PlayerUtils.isFlying() to check if the player is flying. - zumbiepig
    * Gets the value of `MinecraftCompat.localPlayer.getAbilities().flying`.
