### PR TITLE
Fix: Allow Hide Base Pest Drops without Pest Profit Tracker enabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -198,7 +198,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
             CropType.getByNameOrNull(rawName)
                 ?.addCollectionCounter(CropCollectionType.PEST_BASE, primitiveStack.amount * amount.toLong())
 
-            if (config.hideChat && config.enabled) blockedReason = "pest_drop"
+            if (config.hideChat) blockedReason = "pest_drop"
 
             addItem(pest, internalName, amount, command = false)
 


### PR DESCRIPTION
## What
Removed requirement for Pest Profit Tracker to be enabled for the player to hide basic pest drops. I wasn't sure if the option was best suited to stay in this config category, so I've left it in place for now but I'm not sure it makes a whole lot of sense for the category it's in.

## Changelog Fixes
+ Fixed hiding regular pest drop messages not working if you didn't have the Pest Profit Tracker enabled. - BonkersTurnip