### PR TITLE
Fix: Lore parsing for categoryless recombobulated items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
@@ -17,7 +17,7 @@ enum class ItemCategory {
     ROD_PART,
     AXE,
     GAUNTLET,
-    @Deprecated("No longer exists") HOE,
+    @Deprecated("No longer exists", ReplaceWith("ItemCategory.FARMING_TOOL")) HOE,
     PICKAXE,
     SHOVEL,
     DRILL,
@@ -45,7 +45,9 @@ enum class ItemCategory {
     TROPHY_FISH,
     ARROW,
     ARROW_POISON,
-    ITEM,
+    // TODO This used to be used as a fake category for uncategorized dungeon items.
+    //  Remove it after ensuring it doesn't break anything.
+    @Deprecated("Fake category", ReplaceWith("ItemCategory.NONE")) ITEM,
     PET_ITEM,
     ENCHANTED_BOOK,
     FISHING_BAIT,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
@@ -89,5 +89,8 @@ enum class ItemCategory {
         val armor = setOf(HELMET, CHESTPLATE, LEGGINGS, BOOTS)
 
         val equipment = setOf(NECKLACE, BELT, CLOAK, GLOVES, BRACELET)
+
+        @Suppress("DEPRECATION")
+        val deprecated = listOf(FISHING_WEAPON, HOE, ITEM)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -445,6 +445,20 @@ object ItemUtils {
                     betaOnly = true,
                     condition = { !itemCategoryRepoCheckPattern.matches(category) },
                 )
+            } else {
+                if (itemCategory in ItemCategory.deprecated) {
+                    ErrorManager.logErrorStateWithData(
+                        "Item category $itemCategory for item $name is outdated",
+                        "ItemCategory $itemCategory is deprecated",
+                        "item category" to itemCategory,
+                        "internal name" to getInternalName(),
+                        "item name" to name,
+                        "inventory name" to InventoryUtils.openInventoryName(),
+                        "pattern result" to category,
+                        "lore" to cleanLore,
+                        betaOnly = true,
+                    )
+                }
             }
             if (itemRarity == null) {
                 ErrorManager.logErrorStateWithData(

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -434,12 +434,14 @@ object ItemUtils {
             val itemRarity = LorenzRarity.getByName(rarity)
 
             if (itemCategory == null) {
+                val pattern = UtilsPatterns.rarityLoreLinePattern.pattern()
                 ErrorManager.logErrorStateWithData(
                     "Could not read category for item $name",
                     "Failed to read category from item rarity via item lore",
                     "internal name" to getInternalName(),
                     "item name" to name,
                     "inventory name" to InventoryUtils.openInventoryName(),
+                    "pattern" to pattern,
                     "pattern result" to category,
                     "lore" to cleanLore,
                     betaOnly = true,
@@ -461,12 +463,14 @@ object ItemUtils {
                 }
             }
             if (itemRarity == null) {
+                val pattern = UtilsPatterns.rarityLoreLinePattern.pattern()
                 ErrorManager.logErrorStateWithData(
                     "Could not read rarity for item $name",
                     "Failed to read rarity from item rarity via item lore",
                     "internal name" to getInternalName(),
                     "item name" to name,
                     "inventory name" to InventoryUtils.openInventoryName(),
+                    "pattern" to pattern,
                     "pattern result" to rarity,
                     "lore" to cleanLore,
                     betaOnly = true,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -30,6 +30,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PetUtils.getMaxLevel
 import at.hannibal2.skyhanni.utils.PrimitiveIngredient.Companion.toPrimitiveItemStacks
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAttributes
@@ -320,7 +321,7 @@ object ItemUtils {
         }
         val rawInternalName = NeuItems.getInternalName(this)?.asString()?.replace(
             "ULTIMATE_ULTIMATE_",
-            "ULTIMATE_"
+            "ULTIMATE_",
         )
         return rawInternalName?.let { ItemNameResolver.fixEnchantmentName(it) }
     }
@@ -423,18 +424,21 @@ object ItemUtils {
         for (line in cleanLore.reversed()) {
             if (UtilsPatterns.notRarityLoreLinePattern.matches(line)) continue
             val (category, rarity) = UtilsPatterns.rarityLoreLinePattern.matchMatcher(line) {
-                group("itemCategory").replace(" ", "_") to group("rarity").replace(" ", "_")
+                val category = (groupOrNull("itemCategory") ?: "").replace(" ", "_")
+                val rarity = group("rarity").replace(" ", "_")
+                category to rarity
             } ?: continue
 
-            val itemCategory = getItemCategory(category, hoverName.formattedTextCompatLeadingWhiteLessResets(), cleanName)
+            val name = hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val itemCategory = getItemCategory(category, name, cleanName)
             val itemRarity = LorenzRarity.getByName(rarity)
 
             if (itemCategory == null) {
                 ErrorManager.logErrorStateWithData(
-                    "Could not read category for item ${this.hoverName.formattedTextCompatLeadingWhiteLessResets()}",
+                    "Could not read category for item $name",
                     "Failed to read category from item rarity via item lore",
                     "internal name" to getInternalName(),
-                    "item name" to hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                    "item name" to name,
                     "inventory name" to InventoryUtils.openInventoryName(),
                     "pattern result" to category,
                     "lore" to cleanLore,
@@ -444,10 +448,10 @@ object ItemUtils {
             }
             if (itemRarity == null) {
                 ErrorManager.logErrorStateWithData(
-                    "Could not read rarity for item name().formattedTextCompatLeadingWhiteLessResets()",
+                    "Could not read rarity for item $name",
                     "Failed to read rarity from item rarity via item lore",
                     "internal name" to getInternalName(),
-                    "item name" to hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                    "item name" to name,
                     "inventory name" to InventoryUtils.openInventoryName(),
                     "pattern result" to rarity,
                     "lore" to cleanLore,
@@ -462,7 +466,7 @@ object ItemUtils {
     }
 
     private fun getItemCategory(itemCategory: String, name: String, cleanName: String = name.removeColor()) =
-        if (itemCategory.isEmpty()) when {
+        if (itemCategory.isEmpty() || itemCategory == "ITEM") when {
             UtilsPatterns.abiPhonePattern.matches(name) -> ItemCategory.ABIPHONE
             UtilsPatterns.baitPattern.matches(cleanName) -> ItemCategory.FISHING_BAIT
             UtilsPatterns.enchantedBookPattern.matches(name) -> ItemCategory.ENCHANTED_BOOK

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -22,10 +22,11 @@ object UtilsPatterns {
      * REGEX-TEST: COMMON COMBAT SHARD (ID C9)
      * REGEX-TEST: Rarity: LEGENDARY
      * REGEX-TEST: Rarity: RARE
+     * REGEX-TEST: a DIVINE a
      */
     val rarityLoreLinePattern by patternGroup.pattern(
         "item.lore.rarity.line.colorless",
-        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities}) ?(?:DUNGEON )?(?<itemCategory>.*?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
+        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities})(?: (?!(?:a(?: \\(ID \\w\\d+\\))?)?$)(?:DUNGEON )?)?(?<itemCategory>.*?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -23,10 +23,12 @@ object UtilsPatterns {
      * REGEX-TEST: Rarity: LEGENDARY
      * REGEX-TEST: Rarity: RARE
      * REGEX-TEST: a DIVINE a
+     * REGEX-TEST: LEGENDARY DUNGEON ITEM
+     * REGEX-TEST: a MYTHIC DUNGEON ITEM a
      */
     val rarityLoreLinePattern by patternGroup.pattern(
         "item.lore.rarity.line.colorless",
-        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities})(?: (?!(?:a(?: \\(ID \\w\\d+\\))?)?$)(?:DUNGEON )?)?(?<itemCategory>.*?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
+        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities})(?: (?!(?:a(?: \\(ID \\w\\d+\\))?)?$)(?:DUNGEON (?:ITEM(?=(?: a)?(?: \\(ID \\w\\d+\\))?$))?)?)?(?<itemCategory>.*?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -28,7 +28,7 @@ object UtilsPatterns {
      */
     val rarityLoreLinePattern by patternGroup.pattern(
         "item.lore.rarity.line.colorless",
-        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities})(?: (?!(?:a(?: \\(ID \\w\\d+\\))?)?$)(?:DUNGEON (?:ITEM(?=(?: a)?(?: \\(ID \\w\\d+\\))?$))?)?)?(?<itemCategory>.*?)(?: a)?(?: \\(ID \\w\\d+\\))?$",
+        "^(?:Rarity: )?(?:a )?(?:SHINY )?(?<rarity>${rarities})(?: DUNGEON)?(?: (?<itemCategory>[A-Z].*?))?(?: a)?(?: \\(ID \\w\\d+\\))?$",
     )
 
     /**

--- a/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraft.SharedConstants
 import net.minecraft.server.Bootstrap
 import net.minecraft.world.item.Item
@@ -62,10 +61,10 @@ class ItemUtilsTest {
     fun testItemWithoutCategory() {
         assertItemCategoryAndRarity(
             item = Items.CAKE,
-            displayName = "§f§f§bComplete Century Cake Bundle",
+            displayName = "§dComplete Century Cake Bundle",
             lore = categorylessLore,
             internalName = "FULL_CENTURY_CAKE_PACK",
-            expectedRarity = LorenzRarity.DIVINE,
+            expectedRarity = LorenzRarity.MYTHIC,
             expectedCategory = ItemCategory.NONE,
         )
     }
@@ -74,7 +73,7 @@ class ItemUtilsTest {
     fun testRecombobulatedItemWithoutCategory() {
         assertItemCategoryAndRarity(
             item = Items.CAKE,
-            displayName = "§f§f§bComplete Century Cake Bundle",
+            displayName = "§bComplete Century Cake Bundle",
             lore = categorylessLore.dropLast(1) + "a DIVINE a",
             internalName = "FULL_CENTURY_CAKE_PACK",
             expectedRarity = LorenzRarity.DIVINE,
@@ -106,6 +105,54 @@ class ItemUtilsTest {
         )
     }
 
+    @Test
+    fun testDungeonItemWithoutCategory() {
+        assertItemCategoryAndRarity(
+            item = Items.STICK,
+            displayName = "§6Necron's Handle",
+            lore = dungeonCategorylessLore,
+            internalName = "NECRON_HANDLE",
+            expectedRarity = LorenzRarity.LEGENDARY,
+            expectedCategory = ItemCategory.NONE,
+        )
+    }
+
+    @Test
+    fun testRecombobulatedDungeonItemWithoutCategory() {
+        assertItemCategoryAndRarity(
+            item = Items.STICK,
+            displayName = "§6Necron's Handle",
+            lore = dungeonCategorylessLore.dropLast(1) + "a MYTHIC DUNGEON ITEM a",
+            internalName = "NECRON_HANDLE",
+            expectedRarity = LorenzRarity.MYTHIC,
+            expectedCategory = ItemCategory.NONE,
+        )
+    }
+
+    @Test
+    fun testDungeonItemWithCategory() {
+        assertItemCategoryAndRarity(
+            item = Items.IRON_SWORD,
+            displayName = "§6Hyperion",
+            lore = dungeonCategoryLore,
+            internalName = "HYPERION",
+            expectedRarity = LorenzRarity.LEGENDARY,
+            expectedCategory = ItemCategory.SWORD,
+        )
+    }
+
+    @Test
+    fun testRecombobulatedDungeonItemWithCategory() {
+        assertItemCategoryAndRarity(
+            item = Items.IRON_SWORD,
+            displayName = "§6Hyperion",
+            lore = dungeonCategoryLore.dropLast(1) + "a MYTHIC DUNGEON SWORD a",
+            internalName = "HYPERION",
+            expectedRarity = LorenzRarity.MYTHIC,
+            expectedCategory = ItemCategory.SWORD,
+        )
+    }
+
     private fun assertItemCategoryAndRarity(
         item: Item,
         displayName: String,
@@ -130,7 +177,7 @@ class ItemUtilsTest {
         "",
         "Right-click to consume!",
         "",
-        "DIVINE",
+        "MYTHIC",
     )
 
     private val categoryLore = listOf(
@@ -145,6 +192,31 @@ class ItemUtilsTest {
         "This item can be reforged!",
         "\u2763 Requires Farming Skill 20.",
         "EPIC FARMING TOOL",
+    )
+
+    private val dungeonCategorylessLore = listOf(
+        "Right-click to view recipes!",
+        "",
+        "LEGENDARY DUNGEON ITEM",
+    )
+
+    private val dungeonCategoryLore = listOf(
+        "Gear Score: 615",
+        "Damage: +260",
+        "Strength: +150",
+        "Ferocity: +30",
+        "Intelligence: +350",
+        "Gemstones: [\u270e] [\u2694]",
+        "",
+        "Deals +50% damage to \u2620 Wither mobs.",
+        "Grants +1 \u2741 Damage and +2 \u270e",
+        "Intelligence per Catacombs level.",
+        "",
+        "Right-click to use your class ability!",
+        "",
+        "This item can be reforged!",
+        "\u2763 Requires The Catacombs Floor VII Completion.",
+        "LEGENDARY DUNGEON SWORD",
     )
     // </editor-fold>
 }

--- a/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
@@ -1,10 +1,34 @@
 package at.hannibal2.skyhanni.test
 
+import at.hannibal2.skyhanni.utils.CachedItemData.Companion.cachedData
+import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
+import at.hannibal2.skyhanni.utils.LorenzRarity
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import net.minecraft.SharedConstants
+import net.minecraft.server.Bootstrap
+import net.minecraft.world.item.Item
+import net.minecraft.world.item.Items
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
 class ItemUtilsTest {
 
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun bootstrapMinecraftRegistries() {
+            SharedConstants.tryDetectVersion()
+            Bootstrap.bootStrap()
+        }
+    }
+
+    // <editor-fold desc="Item Amount Test">
     private val items: MutableMap<String, Pair<String, Int>> = mutableMapOf(
         "§5Hoe of Greatest Tilling" to Pair("§5Hoe of Greatest Tilling", 1),
         "§fSilver medal §8x2" to Pair("§fSilver medal", 2),
@@ -18,6 +42,7 @@ class ItemUtilsTest {
         " §8+§b10 Bits" to Pair("Bits", 10),
         " §8+§37.2k §7Farming XP" to Pair("§7Farming XP", 7_200),
     )
+    // </editor-fold>
 
     @Test
     fun testReadItemAmount() {
@@ -31,4 +56,95 @@ class ItemUtilsTest {
             }
         }
     }
+
+    // <editor-fold desc="Item Category & Rarity Test">
+    @Test
+    fun testItemWithoutCategory() {
+        assertItemCategoryAndRarity(
+            item = Items.CAKE,
+            displayName = "§f§f§bComplete Century Cake Bundle",
+            lore = categorylessLore,
+            internalName = "FULL_CENTURY_CAKE_PACK",
+            expectedRarity = LorenzRarity.DIVINE,
+            expectedCategory = ItemCategory.NONE,
+        )
+    }
+
+    @Test
+    fun testRecombobulatedItemWithoutCategory() {
+        assertItemCategoryAndRarity(
+            item = Items.CAKE,
+            displayName = "§f§f§bComplete Century Cake Bundle",
+            lore = categorylessLore.dropLast(1) + "a DIVINE a",
+            internalName = "FULL_CENTURY_CAKE_PACK",
+            expectedRarity = LorenzRarity.DIVINE,
+            expectedCategory = ItemCategory.NONE,
+        )
+    }
+
+    @Test
+    fun testItemWithCategory() {
+        assertItemCategoryAndRarity(
+            item = Items.DIAMOND_HOE,
+            displayName = "§5Euclid's Wheat Hoe Mk. III",
+            lore = categoryLore,
+            internalName = "THEORETICAL_HOE_WHEAT_3",
+            expectedRarity = LorenzRarity.EPIC,
+            expectedCategory = ItemCategory.FARMING_TOOL,
+        )
+    }
+
+    @Test
+    fun testRecombobulatedItemWithCategory() {
+        assertItemCategoryAndRarity(
+            item = Items.DIAMOND_HOE,
+            displayName = "§5Euclid's Wheat Hoe Mk. III",
+            lore = categoryLore.dropLast(1) + "a LEGENDARY FARMING TOOL a",
+            internalName = "THEORETICAL_HOE_WHEAT_3",
+            expectedRarity = LorenzRarity.LEGENDARY,
+            expectedCategory = ItemCategory.FARMING_TOOL,
+        )
+    }
+
+    private fun assertItemCategoryAndRarity(
+        item: Item,
+        displayName: String,
+        lore: List<String>,
+        internalName: String,
+        expectedRarity: LorenzRarity,
+        expectedCategory: ItemCategory,
+    ) {
+        val stack = ItemUtils.createItemStack(item, displayName, lore)
+        stack.cachedData.lastInternalName = internalName.toInternalName()
+        stack.cachedData.lastInternalNameFetchTime = SimpleTimeMark.now()
+
+        assertEquals(expectedRarity, stack.getItemRarityOrNull())
+        assertEquals(expectedCategory, stack.getItemCategoryOrNull())
+    }
+
+    private val categorylessLore = listOf(
+        "Consumable",
+        "",
+        "Consume to unwrap a century cake",
+        "of every color!",
+        "",
+        "Right-click to consume!",
+        "",
+        "DIVINE",
+    )
+
+    private val categoryLore = listOf(
+        "Farming Tool",
+        "",
+        "Wheat Fortune: +4",
+        "Farming Wisdom: +1",
+        "",
+        "Level 1 -> 2   (0/1k)",
+        "                          0%",
+        "",
+        "This item can be reforged!",
+        "\u2763 Requires Farming Skill 20.",
+        "EPIC FARMING TOOL",
+    )
+    // </editor-fold>
 }


### PR DESCRIPTION

## What
Fixed error when parsing item category from lore for items that have no category and are recombobulated.

Since as of making this PR, 7.20.0 is not out yet, I'm not making a separate changelog entry for this.

exclude_from_changelog 