### PR TITLE
Fix: Update Syphon Amount Pattern

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
@@ -96,13 +96,13 @@ object AttributeShardsData {
     )
 
     /**
-     * REGEX-TEST: §7Syphon §b3 §7more to level up!
      * REGEX-TEST: §7Syphon §b1 §7shard to unlock!
-     * REGEX-TEST: §7Syphon §b1 §7more to level up!
+     * REGEX-TEST: §7Syphon §b1 §7shard to level up!
+     * REGEX-TEST: §7Syphon §b3 §7shards to level up!
      */
     private val syphonAmountPattern by patternGroup.pattern(
         "syphon.amount",
-        "§7Syphon §b(?<amount>\\d+) §7(?:more to level up|shard to unlock)!",
+        "§7Syphon §b(?<amount>\\d+) §7shards? to (?:level up|unlock)!",
     )
 
     /**


### PR DESCRIPTION
## What
The syphon amount line was changed in 0.24.5.

<details>
<summary>Images</summary>
<img width="334" height="232" alt="image" src="https://github.com/user-attachments/assets/59f266cd-0d55-49e5-bfa6-a52f3723cab7" />
<img width="290" height="228" alt="image" src="https://github.com/user-attachments/assets/9a1412df-bbd7-4679-8747-360dd58c1c40" />
<img width="312" height="310" alt="image" src="https://github.com/user-attachments/assets/d0016d63-e080-435d-ba9e-84c0b72e91dc" />
</details>

## Changelog Fixes
+ Fixed Attribute Menu Syphon Amount Pattern. - Alex
