### PR TITLE
Feature: Add Fishing Bait Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingBaitDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingBaitDisplayConfig.kt
@@ -1,0 +1,26 @@
+package at.hannibal2.skyhanni.config.features.fishing
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
+
+class FishingBaitDisplayConfig {
+    @Expose
+    @ConfigOption(name = "Enable", desc = "Show the current fishing bait while holding a fishing rod.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enabled: Boolean = true
+
+    @Expose
+    @ConfigLink(owner = FishingBaitDisplayConfig::class, field = "enabled")
+    val position: Position = Position(260, -15)
+
+    @Expose
+    @ConfigOption(name = "Show bait icon", desc = "Display an icon next to the Fishing Bait Display.")
+    @ConfigEditorBoolean
+    val showIcon: Property<Boolean> = Property.of(true)
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
@@ -43,6 +43,11 @@ class FishingConfig {
     val fishingHookDisplay: FishingHookDisplayConfig = FishingHookDisplayConfig()
 
     @Expose
+    @ConfigOption(name = "Fishing Bait Display", desc = "")
+    @Accordion
+    val fishingBaitDisplay: FishingBaitDisplayConfig = FishingBaitDisplayConfig()
+
+    @Expose
     @ConfigOption(name = "Bait Warnings", desc = "")
     @Accordion
     val fishingBaitWarnings: FishingBaitWarningsConfig = FishingBaitWarningsConfig()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingBaitDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingBaitDisplay.kt
@@ -1,0 +1,154 @@
+package at.hannibal2.skyhanni.features.fishing
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.ProfileJoinEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemCategory
+import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RenderUtils
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.UtilsPatterns
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
+import net.minecraft.world.item.ItemStack
+
+@SkyHanniModule
+object FishingBaitDisplay {
+
+    private val config get() = SkyHanniMod.feature.fishing.fishingBaitDisplay
+
+    private const val BAIT_SLOT = 44
+    private const val BAIT_HOTBAR_INDEX = 8
+    private val baitCategories = setOf(ItemCategory.BAIT, ItemCategory.FISHING_BAIT)
+    private val baitRemainingPattern by RepoPattern.pattern(
+        "fishing.baitdisplay.remaining",
+        "Bait Remaining: (?<amount>[\\d,]+)",
+    )
+
+    private var display = emptyList<Renderable>()
+    private var bait: BaitDisplayEntry? = null
+
+    private data class BaitDisplayEntry(
+        val itemStack: ItemStack?,
+        val displayName: String,
+        val amount: Int?,
+    )
+
+    private val noBaitEntry = BaitDisplayEntry(
+        itemStack = null,
+        displayName = "§cNo Bait",
+        amount = null,
+    )
+
+    @HandleEvent
+    fun onProfileJoin(event: ProfileJoinEvent) {
+        updateBaitFromInventory()
+    }
+
+    @HandleEvent
+    fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
+        if (event.slot != BAIT_SLOT) return
+        bait = event.itemStack.getBaitDisplayEntry()
+        updateDisplay()
+    }
+
+    @HandleEvent
+    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (!isEnabled()) return
+        if (!FishingApi.holdingRod) return
+        if (bait == null) updateBaitFromInventory()
+        if (display.isEmpty()) updateDisplay()
+        if (display.isEmpty()) return
+
+        config.position.renderRenderable(
+            Renderable.horizontal(
+                display,
+                spacing = 1,
+                verticalAlign = RenderUtils.VerticalAlignment.CENTER,
+            ),
+            posLabel = "Fishing Bait Display",
+        )
+    }
+
+    @HandleEvent
+    fun onConfigLoad(event: ConfigLoadEvent) {
+        ConditionalUtils.onToggle(config.showIcon) {
+            updateDisplay()
+        }
+    }
+
+    private fun updateDisplay() {
+        display = drawDisplay()
+    }
+
+    private fun updateBaitFromInventory() {
+        bait = InventoryUtils.getItemsInOwnInventoryWithNull()
+            ?.getOrNull(BAIT_HOTBAR_INDEX)
+            ?.getBaitDisplayEntry()
+            ?: noBaitEntry
+        updateDisplay()
+    }
+
+    private fun drawDisplay() = buildList {
+        val bait = bait ?: return@buildList
+
+        if (config.showIcon.get()) {
+            bait.itemStack?.let {
+                addItemStack(it, scale = 1.0)
+            }
+        }
+        bait.amount?.let {
+            addString("§b${it.addSeparators()}x")
+        }
+        val namePrefix = if (isEmpty()) "" else " "
+        addString("$namePrefix${bait.displayName}")
+    }
+
+    private fun ItemStack.getBaitDisplayEntry(): BaitDisplayEntry {
+        val displayName = hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val cleanDisplayName = displayName.removeColor()
+        val category = getItemCategoryOrNull()
+        val amount = getBaitRemainingAmount()
+        val isBait = category != null && category in baitCategories ||
+            UtilsPatterns.baitPattern.matches(cleanDisplayName) ||
+            amount != null
+        val isNoBait = cleanDisplayName == "No Bait"
+        if (!isBait && !isNoBait) return noBaitEntry
+
+        val icon = copy().also { it.count = 1 }
+
+        return BaitDisplayEntry(
+            itemStack = icon,
+            displayName = if (isNoBait) "§cNo Bait" else displayName,
+            amount = amount,
+        )
+    }
+
+    private fun ItemStack.getBaitRemainingAmount(): Int? {
+        for (line in getLoreComponent()) {
+            baitRemainingPattern.matchMatcher(line.string.removeColor()) {
+                return group("amount").formatInt()
+            }
+        }
+        return null
+    }
+
+    fun isEnabled() = SkyBlockUtils.inSkyBlock && config.enabled
+}


### PR DESCRIPTION
## What
Adds a Fishing Bait Display that shows the active bait from the 9th hotbar slot while holding a fishing rod.

The display reads the bait name and remaining amount from the slot item.

## Changelog New Features
+ Added Fishing Bait Display. - bendonaldson
    * Shows the currently selected fishing bait and remaining amount while holding a fishing rod.
