### PR TITLE
Fix: error manager crash

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ChangedChatErrorsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ChangedChatErrorsJson.kt
@@ -11,10 +11,12 @@ data class ChangedChatErrorsJson(
 data class RepoErrorData(
     @Expose @SerializedName("message_exact") private val rawMessageExact: List<String>?,
     @Expose @SerializedName("message_starts_with") private val rawMessageStartsWith: List<String>?,
+    @Expose @SerializedName("message_contains") private val rawMessageContains: List<String>?,
     @Expose @SerializedName("replace_message") val replaceMessage: String?,
     @Expose @SerializedName("custom_message") val customMessage: String?,
     @Expose @SerializedName("fixed_in") val fixedIn: ModVersion?,
 ) {
     val messageExact get() = rawMessageExact.orEmpty()
     val messageStartsWith get() = rawMessageStartsWith.orEmpty()
+    val messageContains get() = rawMessageContains.orEmpty()
 }

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -317,28 +317,39 @@ object ErrorManager {
         val rawMessage = message.removeColor()
 
         var hideError = false
-        for (repoError in repoErrors) {
-            for (string in repoError.messageStartsWith) {
-                if (rawMessage.startsWith(string)) {
-                    hideError = true
+        try {
+            for (repoError in repoErrors) {
+                for (string in repoError.messageStartsWith) {
+                    if (rawMessage.startsWith(string)) {
+                        hideError = true
+                    }
+                }
+                for (string in repoError.messageContains) {
+                    if (rawMessage.contains(string)) {
+                        hideError = true
+                    }
+                }
+                for (string in repoError.messageExact) {
+                    if (rawMessage == string) {
+                        hideError = true
+                    }
+                }
+                if (hideError) {
+                    repoError.replaceMessage?.let {
+                        finalMessage = it
+                        hideError = false
+                    }
+                    repoError.customMessage?.let {
+                        ChatUtils.userError(it)
+                        return null
+                    }
+                    break
                 }
             }
-            for (string in repoError.messageExact) {
-                if (rawMessage == string) {
-                    hideError = true
-                }
-            }
-            if (hideError) {
-                repoError.replaceMessage?.let {
-                    finalMessage = it
-                    hideError = false
-                }
-                repoError.customMessage?.let {
-                    ChatUtils.userError(it)
-                    return null
-                }
-                break
-            }
+        } catch (e: NullPointerException) {
+            ChatUtils.chat("§cFailed to format error message! Probably an JSON error in ChangedChatErrorsJson. Please report this on the discord.")
+            // can not use error manager inside error manager
+            e.printStackTrace()
         }
 
         if (finalMessage.last() !in ".?!") {


### PR DESCRIPTION
## What
if the JSON that defines the hide error logic in error manager is not valid JSON format, the code throws an new error. since this is the spot that tries to catch the original error, the new error does not get caught and crashes the game.

As a quick workaround, adding a try catch block with a plain red chat message.

## Changelog Fixes
+ Fixed rare crash with invalid error manager data. - hannibal2