### PR TITLE
Backend: Surface actual error for Roman conversion in SlayerApi

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -18,13 +18,14 @@ import at.hannibal2.skyhanni.features.misc.pathfind.AreaNode
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.features.slayer.SlayerType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
+import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessaryOrNull
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -179,7 +180,7 @@ object SlayerApi {
         // wait with sending SlayerChangeEvent until profile is detected
         if (ProfileStorageData.profileSpecific == null) return
 
-        val lines = getSlayerLines()
+        val (lines, source) = getSlayerLines()
 
         val slayerQuest = lines.getOrNull(1).orEmpty()
         val slayerProgress = lines.getOrNull(2).orEmpty()
@@ -189,8 +190,12 @@ object SlayerApi {
         if (slayerQuest != latestCategory) {
             val old = latestCategory
             latestCategory = slayerQuest
-            tier = slayerQuest.split(" ").lastOrNull()?.romanToDecimalIfNecessary()
-                ?: error(("latestCategory does not contain roman number or int: '$slayerQuest'"))
+            tier = slayerQuest.split(" ").lastOrNull()?.romanToDecimalIfNecessaryOrNull()
+                ?: ErrorManager.skyHanniError(
+                    "latestCategory does not contain roman number or int: '$slayerQuest'",
+                    "lines" to lines,
+                    "source" to source.name,
+                )
             SlayerChangeEvent(old, latestCategory).post()
         }
 
@@ -210,12 +215,18 @@ object SlayerApi {
         }
     }
 
-    private fun getSlayerLines(): List<String> =
-        ScoreboardData.sidebarLinesFormatted.dropWhile { it != "Slayer Quest" }
-            .ifEmpty { TabWidget.SLAYER.lines.map { it.string } }.map { it.trim() }
+    private fun getSlayerLines(): Pair<List<String>, SlayerLinesSource> {
+        val scoreboardLines = ScoreboardData.sidebarLinesFormatted.dropWhile { it != "Slayer Quest" }.map { it.trim() }
+        if (scoreboardLines.isNotEmpty()) return scoreboardLines to SlayerLinesSource.SCOREBOARD
+
+        val tabLines = TabWidget.SLAYER.lines.map { it.string.trim() }
+        if (tabLines.isNotEmpty()) return tabLines to SlayerLinesSource.TAB
+
+        return emptyList<String>() to SlayerLinesSource.NONE
+    }
 
     private fun updateSlayerState() {
-        val lines = getSlayerLines()
+        val (lines, _) = getSlayerLines()
 
         val slayerType = lines.getOrNull(1)
         val type = slayerType?.let { Type.getByName(it) }
@@ -318,5 +329,11 @@ object SlayerApi {
         -> Type.VAMPIRE
 
         else -> null
+    }
+
+    private enum class SlayerLinesSource {
+        NONE,
+        SCOREBOARD,
+        TAB,
     }
 }


### PR DESCRIPTION
## What
This won't fix the errors people have been reporting, but it will give us the whole line to get more information. It's probably a corrupted scoreboard line sent by Hypixel, but I want to see more information before moving to fully ignore those cases.

```
SkyHanni 7.19.0 1.21.11: Caught a IllegalArgumentException in at.hannibal2.skyhanni.data.SlayerApi.onTick(at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent) at SkyHanniTickEvent: Failed to parse input string as either Arabic or Roman numerals: 'Location:'
 
Caused by java.lang.IllegalArgumentException: Failed to parse input string as either Arabic or Roman numerals: 'Location:'
    at SH.utils.NumberUtil.romanToDecimalIfNecessary(NumberUtil.kt:121)
    at SH.data.SlayerApi.onTick(SlayerApi.kt:192)
<Skyhanni event post>
```

## Changelog Technical Details
+ Added more details to SlayerApi error handling. - Luna
