### PR TITLE
Fix: Feast Chef Ted Chat Filter Option Text

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/FilterTypesConfig.kt
@@ -188,7 +188,7 @@ class FilterTypesConfig {
     var teleportPads: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Master Chef Ted", desc = "Hide annoying messages about Kernals getting added to your purse while farming.")
+    @ConfigOption(name = "Feast Chef Ted", desc = "Hide annoying messages about Kernels getting added to your purse while farming.")
     @ConfigEditorBoolean
     @FeatureToggle
     var masterChef: Boolean = false


### PR DESCRIPTION
## What
https://hypixelskyblock.minecraft.wiki/w/Feast_Chef_Ted

## Changelog Fixes
+ Fixed Feast Chef Ted chat filter config option spelling. - Alex

