### PR TITLE
Improvement: Add ignoreTaylor Option to GardenVisitorShoppingList

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/ShoppingListConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/ShoppingListConfig.kt
@@ -78,4 +78,9 @@ class ShoppingListConfig {
     @ConfigOption(name = "Ignore Spaceman", desc = "Exclude crops requested by Spaceman from the shopping list.")
     @ConfigEditorBoolean
     var ignoreSpaceman: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Ignore Taylor", desc = "Exclude crops requested by Taylor from the shopping list.")
+    @ConfigEditorBoolean
+    var ignoreTaylor: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorShoppingList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorShoppingList.kt
@@ -67,6 +67,11 @@ object GardenVisitorShoppingList {
         drawVisitors(newVisitors, shoppingList)
     }
 
+    private fun getIgnoredVisitors(): Set<String> = buildSet {
+        if (config.ignoreSpaceman) add("Spaceman")
+        if (config.ignoreTaylor) add("Taylor")
+    }
+
     /**
      * Aggregates shopping lists from all active visitors.
      * @return Pair of (globalShoppingList, newVisitorNames)
@@ -74,15 +79,14 @@ object GardenVisitorShoppingList {
     private fun prepareDrawingData(): Pair<MutableMap<NeuInternalName, Int>, MutableList<String>> {
         val globalShoppingList = mutableMapOf<NeuInternalName, Int>()
         val newVisitors = mutableListOf<String>()
+        val ignoredVisitors = getIgnoredVisitors()
 
         for ((visitorName, visitor) in VisitorApi.getVisitorsMap()) {
             if (visitor.status == VisitorApi.VisitorStatus.ACCEPTED ||
                 visitor.status == VisitorApi.VisitorStatus.REFUSED
             ) continue
 
-            if (visitor.visitorName.removeColor() == "Spaceman" &&
-                config.ignoreSpaceman
-            ) continue
+            if (visitor.visitorName.removeColor() in ignoredVisitors) continue
 
             val shoppingList = visitor.shoppingList
             if (shoppingList.isEmpty()) {


### PR DESCRIPTION
## What
Added `ignoreTaylor` boolean config option to `ShoppingListConfig`, mirroring the existing `ignoreSpaceman` option.
Refactored visitor ignore logic in `prepareDrawingData` by extracting a `getIgnoredVisitors()` helper that builds a set of ignored visitor names from config, replacing the individual if blocks with a single set membership check.

## Changelog Improvements
+ Added the option to exclude crops requested by Taylor from the visitor's shopping list. - Ambrosy