### PR TITLE
Fix + Feature: Update Farming Effects

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -307,6 +307,7 @@ object EffectApi {
             val effect = stack.getNonGodPotEffectOrNull() ?: continue
             for (line in stack.getLore()) {
                 if (!line.contains("Remaining") || line == "§7Time Remaining: §aCompleted!" || line.contains("Remaining Uses")) continue
+                if (line.endsWith("PAUSED")) continue
                 val duration = try {
                     TimeUtils.getDuration(line.split("§f")[1])
                 } catch (e: IndexOutOfBoundsException) {

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -31,8 +31,8 @@ enum class NonGodPotEffect(
 
     HARVEST_HARBINGER("Harvest Harbinger V", displayName = "§6Harvest Harbinger V"),
 
-    PEST_REPELLENT("Pest Repellent I", displayName = "§6Pest Repellent I§r"),
     PEST_REPELLENT_MAX("Pest Repellent II", displayName = "§6Pest Repellent II"),
+    PEST_REPELLENT("Pest Repellent I", displayName = "§6Pest Repellent I§r"),
 
     CURSE_OF_GREED("Curse of Greed I", displayName = "§4Curse of Greed I"),
 

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -21,6 +21,7 @@ enum class NonGodPotEffect(
     BLAZE("Gabagoey", true, displayName = "§fGabagoey"),
     GLOWING_MUSH("Glowing Mush Mixin", true, displayName = "§2Glowing Mush Mixin"),
     HOT_CHOCOLATE("Hot Chocolate Mixin I", true, displayName = "§6Hot Chocolate Mixin I"),
+    MASON_JAR("Celestial Mason Jar I", true, displayName = "§dCelestial Mason Jar Mixin"),
 
     DEEP_TERROR("Deepterror", true, displayName = "§4Deepterror"),
 


### PR DESCRIPTION
## What
* Add Celestial Mason Jar Mixin
* Fix Pest Repellent 1 showing when having Pest Repellent 2 active

## Changelog Improvements
+ Added Celestial Mason Jar Mixin for Non-God Pot Effects. - Alex.

## Changelog Fixes
+ Fixed Pest Repellent 1 being added when Pest Repellent 2 is active. - Alex
+ Fixed NumberFormatException being thrown from paused mixins. - Alex 