### PR TITLE
Fix: Dont reset chat scroll

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -368,7 +368,7 @@ object ChatUtils {
 
     private fun refreshChat() {
         DelayedRun.runNextTick {
-            chatGui.rescaleChat()
+            chatGui.refreshTrimmedMessages()
         }
     }
 


### PR DESCRIPTION
## What
when we did chat stuff we were resetting the chat scroll for some reason

## Changelog Fixes
+ Fixed Chat Scroll sometimes getting reset. - nopo

