### PR TITLE
Backend: Show stack traces in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ import dev.kikugie.stonecutter.StonecutterExperimentalAPI
 import net.fabricmc.loom.task.RemapSourcesJarTask
 import net.fabricmc.loom.task.ValidateAccessWidenerTask
 import net.fabricmc.loom.task.prod.ClientProductionRunTask
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import skyhannibuildsystem.ChangelogVerification
@@ -192,8 +193,12 @@ afterEvaluate {
     }
 }
 
-tasks.withType(Test::class) {
+tasks.withType<Test> {
     useJUnitPlatform()
+    testLogging {
+        showStackTraces = true
+        exceptionFormat = TestExceptionFormat.FULL
+    }
     javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
     workingDir(file(runDirectory))
     systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")


### PR DESCRIPTION
## What
Makes tests show stack traces if an exception is thrown, which is far more useful than just seeing the top-level exception.

## Changelog Technical Details
+ Enabled stack traces by default for tests. - Luna