### PR TITLE
Fix: Chat Edit/Delete Lag with large history

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -10,16 +10,18 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketSentEvent
 import at.hannibal2.skyhanni.features.chat.ChatHistoryGui
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.IdentityCharacteristics
-import at.hannibal2.skyhanni.utils.SkyHanniLogger
 import at.hannibal2.skyhanni.utils.ReflectionUtils.getClassInstance
+import at.hannibal2.skyhanni.utils.SkyHanniLogger
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils
+import at.hannibal2.skyhanni.utils.compat.append
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.system.PlatformUtils.getModInstance
 import net.minecraft.ChatFormatting
@@ -30,6 +32,7 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.protocol.Packet
 import net.minecraft.network.protocol.game.ServerboundChatCommandPacket
 import net.minecraft.network.protocol.game.ServerboundChatPacket
+import kotlin.math.floor
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -106,7 +109,7 @@ object ChatManager {
     )
 
     @HandleEvent
-    fun onSendMessageToServerPacket(event: PacketSentEvent) {
+    fun onPacketSent(event: PacketSentEvent) {
         val message = getMessageFromPacket(event.packet) ?: return
         val component = message.asComponent()
         val originatingModCall = event.findOriginatingModCall()
@@ -191,24 +194,23 @@ object ChatManager {
      * If the message is modified return the modified message otherwise return null.
      */
     fun onChatModify(original: Component): Component? {
-        val component = original
-        val message = component.formattedTextCompat().stripHypixelMessage()
+        val message = original.formattedTextCompat().stripHypixelMessage()
 
-        val key = IdentityCharacteristics(component)
-        val chatEvent = SkyHanniChatEvent.Modify(message, component)
+        val key = IdentityCharacteristics(original)
+        val chatEvent = SkyHanniChatEvent.Modify(message, original)
         chatEvent.post()
 
         val modifiedComponent = chatEvent.chatComponent
         var modified = false
-        if (modifiedComponent != component) {
+        if (modifiedComponent != original) {
             val reason = replacementReasonMap[key].orEmpty().uppercase()
             modified = true
             loggerModified.log(" ")
-            loggerModified.log("[original] " + component.formattedTextCompat())
+            loggerModified.log("[original] " + original.formattedTextCompat())
             loggerModified.log("[modified] " + modifiedComponent.formattedTextCompat())
-            messageHistory[key] = MessageFilteringResult(component, ActionKind.MODIFIED, null, modifiedComponent, reason)
+            messageHistory[key] = MessageFilteringResult(original, ActionKind.MODIFIED, null, modifiedComponent, reason)
         } else {
-            messageHistory[key] = MessageFilteringResult(component, ActionKind.ALLOWED, null, null, null)
+            messageHistory[key] = MessageFilteringResult(original, ActionKind.ALLOWED, null, null, null)
         }
 
         return modifiedComponent.takeIf { modified }
@@ -244,61 +246,126 @@ object ChatManager {
         }
     }
 
-    // TODO: Add another predicate to stop searching after a certain amount of lines have been searched
-    //  or if the lines were sent too long ago. Same thing for the deleteChatLine function.
-    fun MutableList<GuiMessage>.editChatLine(
-        component: (Component) -> Component,
-        predicate: (GuiMessage) -> Boolean,
+    // TODO add another predicate to stop searching after a certain amount of lines have been
+    //  searched or if the lines were sent too long ago. Same thing for the deleteChatMessage
+    //  function.
+    /**
+     * Edits the first message in chat that matches the given [predicate] to the [replacement].
+     */
+    fun editMessage(
+        replacement: (Component) -> Component,
         reason: String? = null,
-    ) {
-        DelayedRun.runOrNextTick {
-            indexOfFirst {
-                predicate(it)
-            }.takeIf { it != -1 }?.let {
-                val chatLine = this[it]
-                val counter = chatLine.addedTime()
-                val id = chatLine.signature
-                val oldComponent = chatLine.content
-                val newComponent = component(chatLine.content)
+        predicate: (GuiMessage) -> Boolean = { true },
+    ) = DelayedRun.runOrNextTick {
+        val mc = Minecraft.getInstance()
+        val chatGui = mc.gui.chat
 
-                val key = IdentityCharacteristics(oldComponent)
+        val (messageIndex, message) = chatGui.allMessages.withIndex().firstOrNull {
+            predicate(it.value)
+        } ?: return@runOrNextTick
+        val counter = message.addedTime()
+        val id = message.signature
+        val oldComponent = message.content
+        val newComponent = replacement(message.content)
 
-                reason?.let { reason ->
-                    messageHistory[key]?.let { history ->
-                        history.modified = newComponent
-                        history.actionKind = ActionKind.EDITED
-                        history.actionReason = reason.uppercase()
-                    }
-                }
-                this[it] = GuiMessage(counter, newComponent, id, GuiMessageTag.system())
+        val key = IdentityCharacteristics(oldComponent)
+
+        reason?.let { reason ->
+            messageHistory[key]?.let { history ->
+                history.modified = newComponent
+                history.actionKind = ActionKind.EDITED
+                history.actionReason = reason.uppercase()
             }
         }
+
+        val newMessage = GuiMessage(counter, newComponent, id, GuiMessageTag.system())
+        chatGui.allMessages[messageIndex] = newMessage
+
+        var targetIndex: Int? = null
+        val iterator = chatGui.trimmedMessages.listIterator()
+        while (iterator.hasNext()) {
+            val lineIndex = iterator.nextIndex()
+            val line = iterator.next()
+            if (line.`skyhanni$getMessageId`() == message.`skyhanni$getMessageId`()) {
+                if (targetIndex == null) targetIndex = lineIndex
+                iterator.remove()
+            }
+        }
+        if (targetIndex == null) {
+            ErrorManager.logErrorWithData(
+                IllegalStateException("Failed to find associated chat lines"),
+                "Error while editing message",
+                "message" to message,
+                "newMessage" to newMessage,
+            )
+            // Fall back to safe but potentially laggy path
+            chatGui.refreshTrimmedMessages()
+            return@runOrNextTick
+        }
+        val maxWidth = floor(chatGui.width / chatGui.scale).toInt()
+        //? if < 1.21.11 {
+        chatGui.refreshTrimmedMessages()
+        throw UnsupportedOperationException("You are running an unsupported development build. Please update to 1.21.11 or above.")
+        //? } else
+        /*val lines = newMessage.splitLines(mc.font, maxWidth)
+        for ((lineIndex, line) in lines.withIndex()) {
+            val endOfEntry = lineIndex == lines.size - 1
+            val newLine = GuiMessage.Line(newMessage.addedTime(), line, newMessage.tag(), endOfEntry)
+            newLine.`skyhanni$setMessageId`(newMessage.`skyhanni$getMessageId`())
+            chatGui.trimmedMessages.add(targetIndex++, newLine)
+        }*/
     }
 
-    fun MutableList<GuiMessage>.deleteChatLine(
+    /**
+     * Deletes the first message in chat that matches the given [predicate].
+     */
+    fun deleteMessage(
+        reason: String? = null,
+        predicate: (GuiMessage) -> Boolean = { true },
+    ) = deleteMessages(1, reason, predicate)
+
+    /**
+     * Deletes a maximum of [amount] messages in chat that match the given [predicate].
+     */
+    fun deleteMessages(
         amount: Int,
         reason: String? = null,
-        predicate: (GuiMessage) -> Boolean,
-    ) {
-        DelayedRun.runOrNextTick {
-            val iterator = iterator()
-            var removed = 0
-            while (iterator.hasNext() && removed < amount) {
-                val chatLine = iterator.next()
+        predicate: (GuiMessage) -> Boolean = { true },
+    ) = DelayedRun.runOrNextTick {
+        val mc = Minecraft.getInstance()
+        val chatGui = mc.gui.chat
 
-                // chatLine can be null. maybe bc of other mods?
-                @Suppress("SENSELESS_COMPARISON")
-                if (chatLine == null) continue
+        val iterator = chatGui.allMessages.iterator()
+        var removed = 0
+        while (iterator.hasNext() && removed < amount) {
+            val message = iterator.next()
 
-                if (predicate(chatLine)) {
-                    iterator.remove()
-                    removed++
-                    val key = IdentityCharacteristics(chatLine.content)
-                    reason?.let {
-                        messageHistory[key]?.let { history ->
-                            history.actionKind = ActionKind.RETRACTED
-                            history.actionReason = it.uppercase()
-                        }
+            // message can be null. maybe bc of other mods?
+            @Suppress("SENSELESS_COMPARISON")
+            if (message == null) continue
+
+            if (predicate(message)) {
+                iterator.remove()
+
+                val found = chatGui.trimmedMessages.removeIf {
+                    it.`skyhanni$getMessageId`() == message.`skyhanni$getMessageId`()
+                }
+                if (!found) {
+                    ErrorManager.logErrorWithData(
+                        IllegalStateException("Failed to find associated chat lines"),
+                        "Error while deleting message",
+                        "message" to message,
+                    )
+                    // Fall back to safe but potentially laggy path
+                    chatGui.refreshTrimmedMessages()
+                }
+
+                removed++
+                val key = IdentityCharacteristics(message.content)
+                reason?.let {
+                    messageHistory[key]?.let { history ->
+                        history.actionKind = ActionKind.RETRACTED
+                        history.actionReason = it.uppercase()
                     }
                 }
             }
@@ -320,6 +387,27 @@ object ChatManager {
             }
             simpleCallback {
                 SkyHanniMod.screenToOpen = ChatHistoryGui(getRecentMessageHistory())
+            }
+        }
+
+        event.registerBrigadier("shtesteditmessage") {
+            description = "Test message editing"
+            category = CommandCategory.DEVELOPER_TEST
+            simpleCallback { editMessage(replacement = { it.copy().append(" §8(edited)") }) }
+        }
+
+        event.registerBrigadier("shtestdeletemessage") {
+            description = "Test message deletion"
+            category = CommandCategory.DEVELOPER_TEST
+            simpleCallback(::deleteMessage)
+        }
+
+        event.registerBrigadier("shrefreshchat") {
+            description = "Force Minecraft to refresh chat lines"
+            category = CommandCategory.DEVELOPER_TEST
+            simpleCallback {
+                Minecraft.getInstance().gui.chat.refreshTrimmedMessages()
+                ChatUtils.chat("Refreshed chat.")
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.CopyNearbyEntitiesCommand.getMobInfo
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.getTopCenter
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzDebug
@@ -100,5 +101,6 @@ object MobDebug {
         }"
         MobData.logger.log(text)
         LorenzDebug.log(text)
+        ChatUtils.debug(text)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/AchievementManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/AchievementManager.kt
@@ -205,7 +205,7 @@ object AchievementManager {
                 TextHelper.displayPaginatedList(
                     "SkyHanni Achievements! ($unlocked/$totalCount)",
                     achievementList,
-                    ChatUtils.getUniqueMessageId(),
+                    ChatUtils.getUniqueCustomMessageId(),
                     "No Achievements Found"
                 ) { achievement ->
                     componentBuilder {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactBestiaryChatMessage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactBestiaryChatMessage.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.chat
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -32,7 +33,7 @@ object CompactBestiaryChatMessage {
 
         if (message == TITLE_MESSAGE) {
             event.blockedReason = "bestiary"
-            ChatUtils.deleteMessage("bestiary", 2) {
+            ChatManager.deleteMessages(amount = 2, reason = "bestiary") {
                 it.chatMessage.isEmpty() || it.chatMessage == BORDER
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -3,6 +3,9 @@ package at.hannibal2.skyhanni.features.chat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.IslandType.Companion.isInAnyIsland
 import at.hannibal2.skyhanni.data.ItemAddManager
@@ -17,12 +20,14 @@ import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.LorenzRarity
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.StringUtils.isVowel
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -76,7 +81,7 @@ object RareDropMessages {
      */
     private val slayerBookIDPattern by repoGroup.pattern(
         "slayerbook",
-        "SMITE;(?:6|7)|ENDER_SLAYER;(?:6|7)|MANA_STEAL;1|SMARTY_PANTS;1|BANE_OF_ARTHROPODS;6|CRITIAL;6|FIRE_ASPECT;3|ULTIMATE_REITERATE;1",
+        "SMITE;[67]|ENDER_SLAYER;[67]|MANA_STEAL;1|SMARTY_PANTS;1|BANE_OF_ARTHROPODS;6|CRITICAL;6|FIRE_ASPECT;3|ULTIMATE_REITERATE;1",
     )
 
     /**
@@ -89,12 +94,13 @@ object RareDropMessages {
     )
 
     /**
-     * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book §r§b(+§r§b208% §r§b✯ Magic Find§r§b)
-     * REGEX-TEST: §6§lRARE DROP! §r§fEnchanted Book
+     * REGEX-TEST: RARE DROP! Enchanted Book
+     * REGEX-TEST: RARE DROP! Enchanted Book (+208% ✯ Magic Find)
+     * REGEX-TEST: RARE DROP! Enchanted Book (+208 ✯ Magic Find)
      */
     private val enchantedBookPattern by repoGroup.pattern(
-        "enchantedbook",
-        "(?<start>(?:§.)+RARE DROP!) (?<color>(?:§.)*)Enchanted Book(?<end> §r§b\\([+](?:§.)*(?<mf>\\d*)% §r§b✯ Magic Find§r§b\\))?.*",
+        "enchantedbook.colorless",
+        "RARE DROP! Enchanted Book(?: \\(\\+\\d+%? ✯ Magic Find\\))?.*",
     )
 
     private val petPatterns = listOf(
@@ -144,9 +150,9 @@ object RareDropMessages {
 
         val itemName = internalName.repoItemName
         var anyRecentMessage = false
-        for (line in ChatUtils.chatLines) {
+        for (line in ChatUtils.chatMessages) {
             if (line.passedSinceSent() > 1.seconds) break
-            val message = line.chatMessage
+            val message = line.content.string.removeColor()
             if (itemName in message) return // the message already has the enchant name
             if (enchantedBookPattern.matches(message)) {
                 anyRecentMessage = true
@@ -155,15 +161,16 @@ object RareDropMessages {
         }
 
         if (anyRecentMessage && config.enchantedBook) {
-            ChatUtils.editFirstMessage(
-                component = { it.formattedTextCompat().replace("Enchanted Book", internalName.repoItemName).asComponent() },
-                "enchanted book",
-                predicate = { it.passedSinceSent() < 1.seconds && enchantedBookPattern.matches(it.chatMessage) },
-            )
+            ChatManager.editMessage(
+                replacement = {
+                    it.formattedTextCompat().replace("Enchanted Book", internalName.repoItemName).asComponent()
+                },
+                reason = "enchanted book",
+            ) { it.passedSinceSent() < 1.seconds && enchantedBookPattern.matches(it.chatMessage) }
         }
 
-        // Hypixel send Slayer Book messages late, so we do a manual internalName Regex Match
-        if (!anyRecentMessage && config.enchantedBookMissingMessage && !slayerBookIDPattern.matches(internalName.asString())) {
+        // Hypixel sends slayer book messages late, so we do a manual internalName regex match
+        if (!anyRecentMessage && config.enchantedBookMissingMessage && slayerBookIDPattern.matches(internalName.asString())) {
             var message = "§r§6§lRARE DROP! ${internalName.repoItemName}"
             if (SkyHanniMod.feature.misc.userLuck) {
                 userLuck.takeIf { it != 0f }?.let { luck ->
@@ -179,5 +186,19 @@ object RareDropMessages {
     @HandleEvent
     fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(71, "chat.petRarityDropMessage", "chat.rareDropMessages.petRarity")
+    }
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shtestenchantedbookname") {
+            description = "Test Enchanted Book Name feature"
+            category = CommandCategory.DEVELOPER_TEST
+
+            simpleCallback {
+                ChatUtils.chat("§6§lRARE DROP! §r§fEnchanted Book §r§b(+§r§b208% §r§b✯ Magic Find§r§b)", prefix = false)
+                ChatUtils.chat("Testing Enchanted Book Name")
+                onItemAdd(ItemAddEvent("ANGLER;6".toInternalName(), 1, ItemAddManager.Source.ITEM_ADD))
+            }
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/StashCompact.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.chat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.chat.TabCompletionEvent
 import at.hannibal2.skyhanni.features.chat.StashCompact.StashType.Companion.fromGroup
@@ -117,7 +118,7 @@ object StashCompact {
             val currentType = currentType ?: return@matchMatcher
             currentMessages[currentType] = StashMessage(group("count").formatInt(), group("type"))
             event.blockedReason = REASON
-            ChatUtils.deleteMessage(REASON, 2) {
+            ChatManager.deleteMessages(2, REASON) {
                 StringUtils.isEmpty(it.chatMessage) && it.passedSinceSent() < 500.milliseconds
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/WatchdogHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/WatchdogHider.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.chat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -32,7 +33,7 @@ object WatchdogHider {
             }
 
             ANNOUNCEMENT_LINE -> {
-                ChatUtils.deleteMessage("watchdog") { it.chatMessage == START_LINE }
+                ChatManager.deleteMessage(reason = "watchdog") { it.chatMessage == START_LINE }
                 startLineComponent = null
                 inWatchdog = true
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/HelpCommand.kt
@@ -19,7 +19,7 @@ import net.minecraft.network.chat.Component
 object HelpCommand {
 
     private const val COMMANDS_PER_PAGE = 15
-    private val messageId = ChatUtils.getUniqueMessageId()
+    private val messageId = ChatUtils.getUniqueCustomMessageId()
 
     private fun Map.Entry<CommandNode<*>, String>.format() = "§7 - §e/${key.name} $value"
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -40,8 +40,8 @@ object HoppityEggsManager {
     private val unclaimedEggsConfig get() = config.unclaimedEggs
     private val waypointsConfig get() = config.waypoints
     private val profileStorage get() = ProfileStorageData.profileSpecific?.chocolateFactory
-    private val nextEggMessageId = ChatUtils.getUniqueMessageId()
-    private val nextHuntMessageId = ChatUtils.getUniqueMessageId()
+    private val nextEggMessageId = ChatUtils.getUniqueCustomMessageId()
+    private val nextHuntMessageId = ChatUtils.getUniqueCustomMessageId()
 
     // <editor-fold desc="Patterns">
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -52,7 +52,7 @@ object PestSpawnTimer {
 
     private val config get() = PestApi.config.pestTimer
     private val patternGroup = RepoPattern.group("garden.pests")
-    private val cooldownOverMessageId = ChatUtils.getUniqueMessageId()
+    private val cooldownOverMessageId = ChatUtils.getUniqueCustomMessageId()
 
     /**
      * WRAPPED-REGEX-TEST: " Cooldown: READY"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -231,7 +231,7 @@ object FastFairySoulsPathfinder {
     }
 
     private fun createEmptyData(): Data = Data(0, 0, mutableListOf(), emptySet()).apply { disabled = true }
-    private val calculatingMessageId = ChatUtils.getUniqueMessageId()
+    private val calculatingMessageId = ChatUtils.getUniqueCustomMessageId()
 
     private var calculating = false
     private var calculatingStart = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SpiderDenRelicPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SpiderDenRelicPathfinder.kt
@@ -215,7 +215,7 @@ object SpiderDenRelicPathfinder {
         }
     }
 
-    private val calculatingMessageId = ChatUtils.getUniqueMessageId()
+    private val calculatingMessageId = ChatUtils.getUniqueCustomMessageId()
     private var calculating = false
     private var calculatingStart = SimpleTimeMark.farPast()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationFeedback.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationFeedback.kt
@@ -23,7 +23,7 @@ import kotlin.time.Duration.Companion.seconds
 object NavigationFeedback {
 
     private val config get() = SkyHanniMod.feature.misc.navigation.pathfinding
-    private val pathFindMessageId = ChatUtils.getUniqueMessageId()
+    private val pathFindMessageId = ChatUtils.getUniqueCustomMessageId()
     private var guiRenderable: Renderable? = null
     private var lastChatMessageSent = SimpleTimeMark.farPast()
     private var navActive: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -26,7 +26,7 @@ import at.hannibal2.skyhanni.utils.compat.hover
 object NavigationHelper {
     private val config get() = SkyHanniMod.feature.misc.navigation
 
-    private val messageId = ChatUtils.getUniqueMessageId()
+    private val messageId = ChatUtils.getUniqueCustomMessageId()
 
     val allowedTags = listOf(
         GraphNodeTag.NPC,

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
@@ -29,9 +29,9 @@ object ReminderManager {
     private const val REMINDERS_PER_PAGE = 10
 
     // Random numbers chosen, this will be used to delete the old list and action messages
-    private val REMINDERS_LIST_ID = ChatUtils.getUniqueMessageId()
-    private val REMINDERS_ACTION_ID = ChatUtils.getUniqueMessageId()
-    private val REMINDERS_MESSAGE_ID = ChatUtils.getUniqueMessageId()
+    private val REMINDERS_LIST_ID = ChatUtils.getUniqueCustomMessageId()
+    private val REMINDERS_ACTION_ID = ChatUtils.getUniqueCustomMessageId()
+    private val REMINDERS_MESSAGE_ID = ChatUtils.getUniqueCustomMessageId()
 
     private val storage get() = SkyHanniMod.feature.storage.reminders
     private val config get() = SkyHanniMod.feature.misc.reminders

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiMessageData.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiMessageData.java
@@ -2,9 +2,8 @@ package at.hannibal2.skyhanni.mixins.hooks;
 
 import net.minecraft.network.chat.Component;
 
-public interface ChatLineData {
+public interface GuiMessageData {
 
     default Component skyhanni$getFullComponent() { throw new UnsupportedOperationException("Implemented via mixin"); }
     default void skyhanni$setFullComponent(Component fullComponent) { throw new UnsupportedOperationException("Implemented via mixin"); }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageIdStore.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageIdStore.java
@@ -1,0 +1,7 @@
+package at.hannibal2.skyhanni.mixins.hooks;
+
+public interface MessageIdStore {
+
+    default int skyhanni$getMessageId() { throw new UnsupportedOperationException("Implemented via mixin"); }
+    default void skyhanni$setMessageId(int id) { throw new UnsupportedOperationException("Implemented via mixin"); }
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinChatComponent.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinChatComponent.java
@@ -1,0 +1,34 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.GuiMessage;
+import net.minecraft.client.GuiMessageTag;
+import net.minecraft.client.gui.components.ChatComponent;
+import net.minecraft.util.FormattedCharSequence;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ChatComponent.class)
+public abstract class MixinChatComponent {
+
+    @WrapOperation(
+        method = "addMessageToDisplayQueue",
+        at = @At(
+            value = "NEW",
+            target = "net/minecraft/client/GuiMessage$Line"
+        )
+    )
+    private GuiMessage.Line addMessageId(
+        int addedTime,
+        FormattedCharSequence content,
+        GuiMessageTag tag,
+        boolean endOfEntry,
+        Operation<GuiMessage.Line> original,
+        GuiMessage message
+    ) {
+        GuiMessage.Line line = original.call(addedTime, content, tag, endOfEntry);
+        line.skyhanni$setMessageId(message.skyhanni$getMessageId());
+        return line;
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiMessage.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiMessage.java
@@ -1,10 +1,13 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
-import at.hannibal2.skyhanni.mixins.hooks.ChatLineData;
+import at.hannibal2.skyhanni.mixins.hooks.GuiMessageData;
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook;
+import at.hannibal2.skyhanni.mixins.hooks.MessageIdStore;
+import at.hannibal2.skyhanni.utils.ChatUtils;
 import net.minecraft.client.GuiMessage;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -14,7 +17,22 @@ import net.minecraft.client.GuiMessageTag;
 import net.minecraft.network.chat.MessageSignature;
 
 @Mixin(GuiMessage.class)
-public class MixinChatLine implements ChatLineData {
+public abstract class MixinGuiMessage implements GuiMessageData, MessageIdStore {
+
+    @Unique
+    private int skyhanni$messageId;
+
+    @Unique
+    @Override
+    public int skyhanni$getMessageId() {
+        return skyhanni$messageId;
+    }
+
+    @Unique
+    @Override
+    public void skyhanni$setMessageId(int id) {
+        throw new UnsupportedOperationException("setMessageId is not supported on GuiMessage");
+    }
 
     @Unique
     private Component skyhanni$fullComponent;
@@ -33,9 +51,16 @@ public class MixinChatLine implements ChatLineData {
     }
 
     @Inject(method = "<init>", at = @At("RETURN"))
-    private void onInit(int creationTick, Component line, MessageSignature messageSignatureData, GuiMessageTag messageIndicator, CallbackInfo ci) {
+    private void onInit(
+        int creationTick,
+        Component line,
+        MessageSignature messageSignatureData,
+        GuiMessageTag messageIndicator,
+        CallbackInfo ci
+    ) {
+        skyhanni$messageId = ChatUtils.getUniqueGuiMessageId();
+
         Component component = GuiChatHook.getCurrentComponent();
         skyhanni$fullComponent = component == null ? line : component;
     }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiMessageLine.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiMessageLine.java
@@ -1,0 +1,25 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.mixins.hooks.MessageIdStore;
+import net.minecraft.client.GuiMessage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(GuiMessage.Line.class)
+public abstract class MixinGuiMessageLine implements MessageIdStore {
+
+    @Unique
+    private int skyhanni$messageId;
+
+    @Unique
+    @Override
+    public int skyhanni$getMessageId() {
+        return skyhanni$messageId;
+    }
+
+    @Unique
+    @Override
+    public void skyhanni$setMessageId(int id) {
+        skyhanni$messageId = id;
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorHistory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorHistory.kt
@@ -13,7 +13,7 @@ import org.lwjgl.glfw.GLFW
 
 object GraphEditorHistory {
 
-    private val undoRedoMessageId = ChatUtils.getUniqueMessageId()
+    private val undoRedoMessageId = ChatUtils.getUniqueCustomMessageId()
 
     private data class HistoryEntry(
         val state: GraphEditorState,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -2,8 +2,7 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.ChatManager.deleteChatLine
-import at.hannibal2.skyhanni.data.ChatManager.editChatLine
+import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -33,6 +32,8 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.MutableComponent
 import java.util.LinkedList
 import java.util.Queue
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.fetchAndIncrement
 import kotlin.reflect.KProperty0
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.times
@@ -141,7 +142,7 @@ object ChatUtils {
         val text = message.asComponent()
         if (onlySendOnce && !messagesThatAreOnlySentOnce.add(message)) return false
         return if (replaceSameMessage || messageId != null) {
-            text.send(messageId ?: message.getUniqueMessageIdForString())
+            text.send(messageId ?: message.getCustomMessageIdForString())
             logAndSendMessage(text, false)
         } else logAndSendMessage(text)
     }
@@ -154,7 +155,7 @@ object ChatUtils {
     ): Boolean {
         if (onlySendOnce && !messagesThatAreOnlySentOnceComponent.add(message)) return false
         return if (replaceSameMessage || messageId != null) {
-            message.send(messageId ?: message.getUniqueMessageIdForString())
+            message.send(messageId ?: message.getCustomMessageIdForString())
             logAndSendMessage(message, false)
         } else logAndSendMessage(message)
     }
@@ -213,7 +214,7 @@ object ChatUtils {
         messageId?.let {
             text.send(it)
         } ?: run {
-            if (replaceSameMessage) text.send(text.getUniqueMessageIdForString())
+            if (replaceSameMessage) text.send(text.getCustomMessageIdForString())
             else logAndSendMessage(text)
         }
     }
@@ -235,18 +236,38 @@ object ChatUtils {
         )
     }
 
-    private val uniqueMessageIdStorage = mutableMapOf<String, Int>()
-    private fun String.getUniqueMessageIdForString() = uniqueMessageIdStorage.getOrPut(this) {
-        getUniqueMessageId()
-    }
 
-    private fun Component.getUniqueMessageIdForString() = uniqueMessageIdStorage.getOrPut(this.string) {
-        getUniqueMessageId()
-    }
+    // <editor-fold desc="GUI Message IDs">
+    private val lastGuiMessageId = AtomicInt(0)
 
-    private var lastUniqueMessageId = 123242
+    /**
+     * Atomically returns a unique message ID, to be used to associate [GuiMessage]s with
+     * [GuiMessage.Line]s to be able to delete past messages without causing lag with large chat
+     * history sizes.
+     */
+    @JvmStatic
+    fun getUniqueGuiMessageId() = lastGuiMessageId.fetchAndIncrement()
+    // </editor-fold>
 
-    fun getUniqueMessageId() = lastUniqueMessageId++
+
+    // <editor-fold desc="Custom Message IDs">
+    private val lastCustomMessageId = AtomicInt(0)
+
+    /**
+     * Atomically returns a unique message ID, to be used for custom messages sent by SkyHanni to be
+     * able to easily reference and delete them later.
+     */
+    fun getUniqueCustomMessageId() = lastCustomMessageId.fetchAndIncrement()
+
+    private val stringToCustomMessageId = mutableMapOf<String, Int>()
+
+    private fun String.getCustomMessageIdForString() =
+        stringToCustomMessageId.getOrPut(this) { getUniqueCustomMessageId() }
+
+    private fun Component.getCustomMessageIdForString() =
+        stringToCustomMessageId.getOrPut(string) { getUniqueCustomMessageId() }
+    // </editor-fold>
+
 
     /**
      * Sends a message to the user that they can click and run a command
@@ -324,7 +345,7 @@ object ChatUtils {
             }
         }
 
-        if (replaceSameMessage) text.send(message.getUniqueMessageIdForString())
+        if (replaceSameMessage) text.send(message.getCustomMessageIdForString())
         else logAndSendMessage(text)
 
         if (autoOpen) OSUtils.openBrowser(url)
@@ -332,45 +353,8 @@ object ChatUtils {
 
     private val chatGui get() = Minecraft.getInstance().gui.chat
 
-    var chatLines: MutableList<GuiMessage>
+    val chatMessages: MutableList<GuiMessage>
         get() = chatGui.allMessages
-        set(value) {
-            chatGui.allMessages = value
-        }
-
-    var drawnChatLines: MutableList<GuiMessage.Line>
-        get() = chatGui.trimmedMessages
-        set(value) {
-            chatGui.trimmedMessages = value
-        }
-
-    /** Edits the first message in chat that matches the given [predicate] to the new [component]. */
-    fun editFirstMessage(
-        component: (Component) -> Component,
-        reason: String,
-        predicate: (GuiMessage) -> Boolean,
-    ) {
-        chatLines.editChatLine(component, predicate, reason)
-        refreshChat()
-    }
-
-    /**
-     * Deletes a maximum of [amount] messages in chat that match the given [predicate].
-     */
-    fun deleteMessage(
-        reason: String,
-        amount: Int = 1,
-        predicate: (GuiMessage) -> Boolean,
-    ) {
-        chatLines.deleteChatLine(amount, reason, predicate)
-        refreshChat()
-    }
-
-    private fun refreshChat() {
-        DelayedRun.runNextTick {
-            chatGui.refreshTrimmedMessages()
-        }
-    }
 
     private var deleteNext: Pair<String, (Component) -> Boolean>? = null
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -797,7 +797,7 @@ object ItemUtils {
         }
     }
 
-    private val testItemMessageId = ChatUtils.getUniqueMessageId()
+    private val testItemMessageId = ChatUtils.getUniqueCustomMessageId()
 
     private fun buildTestItemMessage(input: String) = buildList {
         add("".asComponent())

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.utils.compat
 
+import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils.skyhanniCreated
 import at.hannibal2.skyhanni.utils.ColorUtils
@@ -246,8 +247,8 @@ fun addDeletableMessageToChat(component: Component, id: Int, bypassSelfMessages:
     if (!bypassSelfMessages) component.skyhanniCreated = true
     DelayedRun.runOrNextTick {
         val chat = Minecraft.getInstance().gui.chat
-        chat.deleteMessage(idToMessageSignature(id))
-        chat.addMessage(component, idToMessageSignature(id), GuiMessageTag.system())
+        ChatManager.deleteMessage { it.signature == idToMessageSignature(id) }
+        DelayedRun.runOrNextTick { chat.addMessage(component, idToMessageSignature(id), GuiMessageTag.system()) }
     }
 }
 

--- a/src/main/resources/skyhanni.classtweaker
+++ b/src/main/resources/skyhanni.classtweaker
@@ -50,6 +50,7 @@ accessible field net/minecraft/client/gui/screens/inventory/AbstractContainerScr
 accessible field net/minecraft/client/multiplayer/MultiPlayerGameMode destroyBlockPos Lnet/minecraft/core/BlockPos;
 accessible field net/minecraft/client/renderer/GameRenderer guiRenderState Lnet/minecraft/client/gui/render/state/GuiRenderState;
 accessible field net/minecraft/world/entity/Avatar POSES Ljava/util/Map;
+accessible method net/minecraft/client/gui/components/ChatComponent addMessageToDisplayQueue (Lnet/minecraft/client/GuiMessage;)V
 
 #? < 1.21.11 {
 accessible field net/minecraft/client/renderer/rendertype/RenderType$CompositeRenderType state Lnet/minecraft/client/renderer/rendertype/RenderType$CompositeState;
@@ -71,7 +72,9 @@ accessible field net/minecraft/client/renderer/rendertype/RenderType$CompositeRe
 #accessible field net/minecraft/client/renderer/rendertype/RenderType name Ljava/lang/String;
 #?}
 
-inject-interface net/minecraft/client/GuiMessage at/hannibal2/skyhanni/mixins/hooks/ChatLineData
+inject-interface net/minecraft/client/GuiMessage at/hannibal2/skyhanni/mixins/hooks/GuiMessageData
+inject-interface net/minecraft/client/GuiMessage at/hannibal2/skyhanni/mixins/hooks/MessageIdStore
+inject-interface net/minecraft/client/GuiMessage$Line at/hannibal2/skyhanni/mixins/hooks/MessageIdStore
 inject-interface net/minecraft/network/chat/MutableComponent at/hannibal2/skyhanni/mixins/hooks/ComponentCreatedStore
 inject-interface net/minecraft/client/renderer/entity/state/EntityRenderState at/hannibal2/skyhanni/mixins/hooks/EntityRenderStateStore
 inject-interface net/minecraft/client/renderer/SubmitNodeStorage$ItemSubmit at/hannibal2/skyhanni/mixins/hooks/GlowingStateStore


### PR DESCRIPTION
## What
Refactors chat handling to avoid calling `refreshTrimmedMessages` or Minecraft methods that call it internally, which is costly because it asks Minecraft to redraw every single message in the history. Popular mods like Chat Patches increase the history size to large amounts like 16,384, making micro-stutters a frequent complaint.

## Changelog Fixes
+ Fixed lagspikes when SkyHanni edits or deletes chat messages with mods that increase chat history limit such as Chat Patches. - Luna