### PR TITLE
Feature: Add Lotus Atoll island support

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -41,6 +41,7 @@ enum class IslandType(private val nameFallback: String) : SkyHanniIslandType {
     MINESHAFT("Mineshaft"),
     BACKWATER_BAYOU("Backwater Bayou"),
     GALATEA("Galatea"),
+    LOTUS_ATOLL("Lotus Atoll"),
 
     NONE(""),
     ANY(""),

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
@@ -50,6 +50,7 @@ enum class IslandTypeTag(vararg types: SkyHanniIslandType) : SkyHanniIslandType 
         IslandType.BACKWATER_BAYOU,
         IslandType.LOTUS_ATOLL,
         IslandType.HUB,
+        IslandType.THE_PARK,
         IslandType.CRIMSON_ISLE,
         IslandType.WINTER,
     )

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandTypeTag.kt
@@ -48,6 +48,7 @@ enum class IslandTypeTag(vararg types: SkyHanniIslandType) : SkyHanniIslandType 
     ),
     FISHING_HOTSPOT(
         IslandType.BACKWATER_BAYOU,
+        IslandType.LOTUS_ATOLL,
         IslandType.HUB,
         IslandType.CRIMSON_ISLE,
         IslandType.WINTER,


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/707

## What
Adds Lotus Atoll island.
Add LOTUS_ATOLL to IslandType. add FISHING_HOTSPOT` tag in IslandTypeTag.

## Changelog New Features
+ Added Lotus Atoll island support. - legentpc