### PR TITLE
Feature: hide non-boss entity nametags during slayer boss

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/ActiveBossTransparencyConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/ActiveBossTransparencyConfig.kt
@@ -25,4 +25,9 @@ class ActiveBossTransparencyConfig {
     @ConfigOption(name = "Other Players", desc = "Also change the transparency for other players.")
     @ConfigEditorBoolean
     var applyToPlayers: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Hide Name Tags", desc = "Hide custom names of mobs when they are transparent.")
+    @ConfigEditorBoolean
+    val hideNameTags: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/ActiveBossTransparency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/ActiveBossTransparency.kt
@@ -81,6 +81,8 @@ object ActiveBossTransparency {
                 if (!config.applyToPlayers) return
             }
             if (category == MobCategory.PLAYER && !config.applyToPlayers) return
+
+            if (config.hideNameTags) mob.armorStand?.isCustomNameVisible = false
         }
 
         event.newTransparency = config.transparencyLevel.coerceIn(15, 70)


### PR DESCRIPTION
## What
Add a toggle to hide non-boss entity nametags (e.g., Primordial Bats) once a Slayer Boss spawns.
This adds ontop of the "Active Boss Transparency" Feature
To be honest, I am unsure if this should be part of "Hide Irrelevant Mobs" or "Active Boss Transparency", but I think the latter makes more sense.

## Changelog New Features
+ Add a toggle to hide non-boss entity nametags once a Slayer Boss spawns - AverageUser125
