### PR TITLE
Improvement: remove useless vertical spacer

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboardDisplayBase.kt
@@ -128,7 +128,7 @@ abstract class EliteLeaderboardDisplayBase<E : Enum<E>, T : EliteLeaderboardType
         if (FarmingWeightData.apiError || EliteFarmersLeaderboard.apiError) return errorMessage
 
         val newList = mutableListOf<Renderable>()
-        if (inventoryOpen) newList.buildModeSwitcher() else newList.addVerticalSpacer()
+        if (inventoryOpen) newList.buildModeSwitcher()
         config?.display?.text?.get()?.let { leaderboardTextEntries -> newList.addAll(leaderboardTextEntries.mapNotNull { lineMap[it] }) }
         if (inventoryOpen) newList.buildTypeSwitcher()
         return newList


### PR DESCRIPTION
## What
Removes the vertical spacer on top of Elite Leaderboards HUDs.

<details>
<summary>Images</summary>
before
<img width="442" height="119" alt="image" src="https://github.com/user-attachments/assets/e69c86c0-b3b2-43a7-882b-f8244f2ee3ec" />
after
<img width="629" height="161" alt="image" src="https://github.com/user-attachments/assets/157cdd58-2801-4a94-ab6d-ab186cacda28" />

</details>

## Changelog Improvements
+ Improved the display of Elite Leaderboard HUDs. - Rain
