### PR TITLE
Fix: Add Trophy Item Category

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
@@ -75,6 +75,7 @@ enum class ItemCategory {
     MUTATION,
     WATERING_CAN,
     FARMING_TOOL,
+    TROPHY,
 
     NONE,
     ;


### PR DESCRIPTION
## What

Currently only on alpha, but the constant stream of item category warnings is annoying.

## Changelog Fixes
+ Fixed error with new Trophy items. - Alex
