### PR TITLE
Fix: Disable farming lanes in greenhouse plots

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneApi.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.events.garden.farming.CropClickEvent
 import at.hannibal2.skyhanni.events.garden.farming.FarmingLaneSwitchEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.GardenApi
+import at.hannibal2.skyhanni.features.garden.GardenPlotApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
@@ -29,6 +30,7 @@ object FarmingLaneApi {
     fun onCropClick(event: CropClickEvent) {
         val crop = event.crop
         if (!GardenApi.hasFarmingToolInHand()) return
+        if (GardenPlotApi.inGreenhouse()) return
 
         val lanes = lanes ?: return
         val lane = lanes[crop]


### PR DESCRIPTION
## What
Disables farming lanes in greenhouse plots. Currently, it'll say in chat "no farming lane detected" when crops or put up incorrect waypoints and times.

## Changelog Fixes
+ Fixed showing Farming Lane features while in greenhouse plots. - Growling_Grizzly