### PR TITLE
Fix: Anita Extra FF showing integer limit

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/AnitaExtraFarmingFortune.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/AnitaExtraFarmingFortune.kt
@@ -54,7 +54,7 @@ object AnitaExtraFarmingFortune {
                 }
             }
         }
-
+// TODO Verify and fix jacobTickets calculation with tier 0 (divides by 0)
         var goldMedals = 0
         var jacobTickets = 0
         for ((level, price) in levelPrice) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/AnitaExtraFarmingFortune.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/AnitaExtraFarmingFortune.kt
@@ -46,10 +46,11 @@ object AnitaExtraFarmingFortune {
 
         var contributionFactor = 1.0
         val baseAmount = levelPrice[anitaUpgrade + 1]?.jacobTickets ?: return
-        for (line in event.toolTip) {
-            realAmountPattern.matchMatcher(line) {
+        if (baseAmount > 0) {
+            for (line in event.toolTip) { realAmountPattern.matchMatcher(line) {
                 val realAmount = group("realAmount").formatDouble()
                 contributionFactor = realAmount / baseAmount
+                }
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/AnitaExtraFarmingFortune.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/AnitaExtraFarmingFortune.kt
@@ -47,9 +47,10 @@ object AnitaExtraFarmingFortune {
         var contributionFactor = 1.0
         val baseAmount = levelPrice[anitaUpgrade + 1]?.jacobTickets ?: return
         if (baseAmount > 0) {
-            for (line in event.toolTip) { realAmountPattern.matchMatcher(line) {
-                val realAmount = group("realAmount").formatDouble()
-                contributionFactor = realAmount / baseAmount
+            for (line in event.toolTip) {
+                realAmountPattern.matchMatcher(line) {
+                    val realAmount = group("realAmount").formatDouble()
+                    contributionFactor = realAmount / baseAmount
                 }
             }
         }


### PR DESCRIPTION
## What
Anita Extra FF feature shows integer limit when at tier 0/15.

PSA: This is untested cause my dev env does not want to render it idk why, but this fix breaking the feature would make no sense to me.

<details>
<img width="341" height="358" alt="image" src="https://github.com/user-attachments/assets/ea9be64f-64e7-4d13-bc0a-04594b73af2f" />

</details>

## Changelog Fixes
+ Fixed Anita's Extra FF cost to max out showing integer limit. - Rain