### PR TITLE
Feature: Add Greenhouse Slot Protection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/greenhouse/GreenhouseConfig.kt
@@ -2,10 +2,15 @@ package at.hannibal2.skyhanni.config.features.garden.greenhouse
 
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.utils.LorenzColor
 import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.ChromaColour
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import org.lwjgl.glfw.GLFW
 
 class GreenhouseConfig {
 
@@ -43,6 +48,31 @@ class GreenhouseConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var highlightWaterStatus: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Protect Greenhouse Slots",
+        desc = "Enable protecting greenhouse slots from being broken.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enableProtectGreenhouseSlots: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Protect Greenhouse Slots Toggle Key",
+        desc = "Toggle the protected status of the slot you are looking at.",
+    )
+    @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
+    var protectGreenhouseSlotsToggleKey: Int = GLFW.GLFW_KEY_UNKNOWN
+
+    @Expose
+    @ConfigOption(
+        name = "Protected Slot Color",
+        desc = "Choose the color used to highlight protected greenhouse slots.",
+    )
+    @ConfigEditorColour
+    var protectGreenhouseSlotsColor: ChromaColour = LorenzColor.GOLD.toChromaColor(127)
 
     @Expose
     @ConfigLink(owner = GreenhouseConfig::class, field = "showDisplay")

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -653,9 +653,13 @@ class ProfileSpecificStorage(
         @Expose
         var greenhouse: GreenHouseStorage = GreenHouseStorage()
 
-        class GreenHouseStorage(
-            @Expose var nextCycle: SimpleTimeMark = farPast(),
-        )
+        class GreenHouseStorage {
+            @Expose
+            var nextCycle: SimpleTimeMark = farPast()
+
+            @Expose
+            var protectedSlots: MutableSet<LorenzVec> = mutableSetOf()
+        }
     }
 
     // - gui

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/ProtectGreenhouseSlots.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/ProtectGreenhouseSlots.kt
@@ -1,0 +1,109 @@
+package at.hannibal2.skyhanni.features.garden.greenhouse
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.ClickType
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.events.BlockClickEvent
+import at.hannibal2.skyhanni.events.entity.EntityClickEvent
+import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.features.garden.GardenPlotApi
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.toLorenzVec
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
+
+import net.minecraft.client.Minecraft
+import net.minecraft.world.phys.BlockHitResult
+import net.minecraft.world.phys.AABB
+import net.minecraft.world.phys.EntityHitResult
+import net.minecraft.world.phys.HitResult
+
+@SkyHanniModule
+object ProtectGreenhouseSlots {
+
+    private const val MAX_PROTECTED_SLOTS = 300
+    private const val MUTATION_Y_LEVEL = 74.0
+
+    private val config get() = SkyHanniMod.feature.garden.greenhouse
+    private val storage get() = ProfileStorageData.profileSpecific?.garden?.greenhouse
+
+    @Suppress("ReturnCount")
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onKeyDown(event: KeyDownEvent) {
+        if (!isEnabled()) return
+        if (Minecraft.getInstance().screen != null) return
+        if (event.keyCode != config.protectGreenhouseSlotsToggleKey) return
+
+        val hitResult = Minecraft.getInstance().hitResult ?: return
+        val protectedSlots = storage?.protectedSlots ?: return
+
+        val slot = when (hitResult.type) {
+            HitResult.Type.BLOCK -> (hitResult as BlockHitResult).blockPos
+            HitResult.Type.ENTITY -> (hitResult as EntityHitResult).entity.blockPosition()
+            else -> return
+        }.atY(0).toLorenzVec()
+
+        if (!protectedSlots.remove(slot)) {
+
+            if (protectedSlots.size >= MAX_PROTECTED_SLOTS) {
+                ChatUtils.userError(
+                    "You can protect a maximum of $MAX_PROTECTED_SLOTS slots. " +
+                        "Run /shclearprotectedghslots to clear protected slots.",
+                )
+                return
+            }
+
+            protectedSlots.add(slot)
+        }
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onBlockClick(event: BlockClickEvent) {
+        if (!isEnabled()) return
+        if (event.clickType != ClickType.LEFT_CLICK) return
+        if (event.position.toBlockPos().atY(0).toLorenzVec() in storage?.protectedSlots.orEmpty()) {
+            event.cancel()
+        }
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onEntityClick(event: EntityClickEvent) {
+        if (!isEnabled()) return
+        if (event.clickType != ClickType.LEFT_CLICK) return
+        if (event.clickedEntity.blockPosition().atY(0).toLorenzVec() in storage?.protectedSlots.orEmpty()) {
+            event.cancel()
+        }
+    }
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shclearprotectedghslots") {
+            this.description = "Clears all protected greenhouse slots."
+            this.category = CommandCategory.USERS_RESET
+            simpleCallback {
+                val protectedSlots = storage?.protectedSlots ?: return@simpleCallback
+                protectedSlots.clear()
+                ChatUtils.chat("Cleared protected greenhouse slots.")
+            }
+        }
+    }
+
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+        if (!isEnabled()) return
+
+        for (slot in storage?.protectedSlots.orEmpty()) {
+            event.drawFilledBoundingBox(
+                AABB(slot.x, MUTATION_Y_LEVEL, slot.z, slot.x + 1, MUTATION_Y_LEVEL + 1, slot.z + 1),
+                config.protectGreenhouseSlotsColor
+            )
+        }
+    }
+
+    private fun isEnabled(): Boolean = config.enableProtectGreenhouseSlots && GardenPlotApi.inGreenhouse()
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/ProtectGreenhouseSlots.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/ProtectGreenhouseSlots.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
-import at.hannibal2.skyhanni.data.ClickType
+import at.hannibal2.skyhanni.data.InteractClickType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.BlockClickEvent
@@ -14,12 +14,11 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.garden.GardenPlotApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.toLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
-
+import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.Minecraft
-import net.minecraft.world.phys.BlockHitResult
 import net.minecraft.world.phys.AABB
+import net.minecraft.world.phys.BlockHitResult
 import net.minecraft.world.phys.EntityHitResult
 import net.minecraft.world.phys.HitResult
 
@@ -65,7 +64,7 @@ object ProtectGreenhouseSlots {
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onBlockClick(event: BlockClickEvent) {
         if (!isEnabled()) return
-        if (event.clickType != ClickType.LEFT_CLICK) return
+        if (event.clickType != InteractClickType.LEFT_CLICK) return
         if (event.position.toBlockPos().atY(0).toLorenzVec() in storage?.protectedSlots.orEmpty()) {
             event.cancel()
         }
@@ -74,7 +73,7 @@ object ProtectGreenhouseSlots {
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onEntityClick(event: EntityClickEvent) {
         if (!isEnabled()) return
-        if (event.clickType != ClickType.LEFT_CLICK) return
+        if (event.clickType != InteractClickType.LEFT_CLICK) return
         if (event.clickedEntity.blockPosition().atY(0).toLorenzVec() in storage?.protectedSlots.orEmpty()) {
             event.cancel()
         }


### PR DESCRIPTION
## What
This pull request adds a new feature to allow users to protect slots in their greenhouses. When the feature is enabled, the user can use a custom key binding to toggle the protectedness of the slot the user is currently looking at. The user will then be prevented from breaking the block/mutation at that slot.

Use cases include protecting growing mutations or protecting spawn setups.

<details>
<summary>Images</summary>

<img width="3840" height="2040" alt="image" src="https://github.com/user-attachments/assets/6a74c51b-a520-4d80-afa8-c58a0b463549" />


</details>

## Changelog New Features
+ Added Greenhouse slot protection to prevent accidentally breaking things in the greenhouse. - Maxwell Zhao
    * Users can toggle protected slots using a keybinding.