### PR TITLE
Fix: More Bugged Spade Sounds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/MuteBuggedSpade.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/MuteBuggedSpade.kt
@@ -14,7 +14,7 @@ object MuteBuggedSpade {
     fun onPlaySound(event: PlaySoundEvent) {
         if (!config.muteBuggedSpade || !DianaApi.isDoingDiana()) return
         val isRealMusic = event.pitch == 1f && event.volume == 1f && event.location.isZero()
-        if (event.soundName.startsWith("music.") && !isRealMusic) {
+        if (event.soundName.startsWith("music") && !isRealMusic) {
             event.cancel()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/MuteBuggedSpade.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/MuteBuggedSpade.kt
@@ -14,7 +14,7 @@ object MuteBuggedSpade {
     fun onPlaySound(event: PlaySoundEvent) {
         if (!config.muteBuggedSpade || !DianaApi.isDoingDiana()) return
         val isRealMusic = event.pitch == 1f && event.volume == 1f && event.location.isZero()
-        if (event.soundName == "music.overworld.desert" && !isRealMusic) {
+        if (event.soundName.startsWith("music.") && !isRealMusic) {
             event.cancel()
         }
     }


### PR DESCRIPTION
## What
Seems like `music.overworld.desert` is not the only track that can play. I'm widening it to all music, since we have a filter in place to not mute real music coming from Minecraft anyway.

## Changelog Fixes
+ Fixed Mute Bugged Spade Sounds not muting all bugged music. - Luna