### PR TITLE
Feature: npc daily coin limit tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -443,6 +443,11 @@ class MiscConfig {
     var warnAboutPcTimeOffset: Boolean = true
 
     @Expose
+    @ConfigOption(name = "NPC Daily Limit Tracker", desc = "")
+    @Accordion
+    val npcDayLimitTracker: NpcDayLimitTrackerConfig = NpcDayLimitTrackerConfig()
+
+    @Expose
     @ConfigOption(name = "Coral Fish Helper", desc = "Shows a helper for which fish are cheapest to buy for the NPC §dCoral§7.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/NpcDayLimitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/NpcDayLimitTrackerConfig.kt
@@ -13,7 +13,7 @@ class NpcDayLimitTrackerConfig {
     @Expose
     @ConfigOption(
         name = "Enabled",
-        desc = "Track NPC sell coins from chat against the 500M daily limit (resets midnight GMT).",
+        desc = "Track NPC sell coins from chat against the 500M daily limit (resets midnight GMT) and show a movable HUD.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -21,35 +21,21 @@ class NpcDayLimitTrackerConfig {
 
     @Expose
     @ConfigOption(
-        name = "Show HUD",
-        desc = "Movable widget showing sold coins vs the 500M daily cap.",
-    )
-    @ConfigEditorBoolean
-    var showHud: Boolean = true
-
-    @Expose
-    @ConfigOption(
         name = "Number Format",
-        desc = "How coin amounts are shown on the HUD. Only applies when Show HUD is enabled.",
+        desc = "Short: 400k/500m\nLong: 400,000/500,000,000",
     )
     @ConfigEditorDropdown
-    val numberFormat: Property<NumberFormatEntry> = Property.of(NumberFormatEntry.CONDENSED)
+    val numberFormat: Property<NumberFormatEntry> = Property.of(NumberFormatEntry.SHORT)
 
     enum class NumberFormatEntry(private val displayName: String) {
-        CONDENSED("Condensed"),
-        FULL("Full"),
+        SHORT("Short"),
+        LONG("Long"),
         ;
 
         override fun toString(): String = displayName
     }
 
     @Expose
-    @ConfigLink(owner = NpcDayLimitTrackerConfig::class, field = "showHud")
+    @ConfigLink(owner = NpcDayLimitTrackerConfig::class, field = "enabled")
     val position: Position = Position(8, 520)
-
-    @Expose
-    var gmtEpochDay: Long = 0L
-
-    @Expose
-    var soldCoins: Long = 0L
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/NpcDayLimitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/NpcDayLimitTrackerConfig.kt
@@ -1,0 +1,55 @@
+package at.hannibal2.skyhanni.config.features.misc
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
+
+class NpcDayLimitTrackerConfig {
+    @Expose
+    @ConfigOption(
+        name = "Enabled",
+        desc = "Track NPC sell coins from chat against the 500M daily limit (resets midnight GMT).",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enabled: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Show HUD",
+        desc = "Movable widget showing sold coins vs the 500M daily cap.",
+    )
+    @ConfigEditorBoolean
+    var showHud: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Number Format",
+        desc = "How coin amounts are shown on the HUD. Only applies when Show HUD is enabled.",
+    )
+    @ConfigEditorDropdown
+    val numberFormat: Property<NumberFormatEntry> = Property.of(NumberFormatEntry.CONDENSED)
+
+    enum class NumberFormatEntry(private val displayName: String) {
+        CONDENSED("Condensed"),
+        FULL("Full"),
+        ;
+
+        override fun toString(): String = displayName
+    }
+
+    @Expose
+    @ConfigLink(owner = NpcDayLimitTrackerConfig::class, field = "showHud")
+    val position: Position = Position(8, 520)
+
+    @Expose
+    var gmtEpochDay: Long = 0L
+
+    @Expose
+    var soldCoins: Long = 0L
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -865,6 +865,17 @@ class ProfileSpecificStorage(
     @Expose
     var enchantedClockBoosts: MutableMap<EnchantedClockHelper.SimpleBoostType, EnchantedClockHelper.Status> = enumMapOf()
 
+    @Expose
+    var npcDayLimit: NpcDayLimitStorage = NpcDayLimitStorage()
+
+    class NpcDayLimitStorage {
+        @Expose
+        var gmtEpochDay: Long = 0L
+
+        @Expose
+        var soldCoins: Long = 0L
+    }
+
     // - nether
     @Expose
     var crimsonIsle: CrimsonIsleStorage = CrimsonIsleStorage()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/npc/NpcDayLimitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/npc/NpcDayLimitTracker.kt
@@ -3,23 +3,20 @@ package at.hannibal2.skyhanni.features.misc.npc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.misc.NpcDayLimitTrackerConfig.NumberFormatEntry
-import at.hannibal2.skyhanni.data.GuiEditManager
+import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
+import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import net.minecraft.client.Minecraft
-import net.minecraft.client.gui.screens.ChatScreen
-import net.minecraft.client.gui.screens.inventory.ContainerScreen
-import net.minecraft.client.gui.screens.inventory.InventoryScreen
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import java.time.LocalDate
 import java.time.ZoneOffset
-import java.util.Locale
 
 @SkyHanniModule
 object NpcDayLimitTracker {
@@ -28,6 +25,7 @@ object NpcDayLimitTracker {
     private const val POS_LABEL = "NPC Day Limit Tracker"
 
     private val config get() = SkyHanniMod.feature.misc.npcDayLimitTracker
+    private val storage get() = ProfileStorageData.profileSpecific?.npcDayLimit
 
     private val patternGroup = RepoPattern.group("misc.npcdaylimit")
 
@@ -44,81 +42,57 @@ object NpcDayLimitTracker {
     fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!config.enabled) return
 
-        for (line in event.cleanMessage.split('\n')) {
-            val trimmed = line.trim()
-            if (trimmed.isEmpty()) continue
-            npcSellPattern.matchMatcher(trimmed) {
-                val amount = group("amount").replace(",", "").toLongOrNull() ?: return@matchMatcher
-                if (amount <= 0) return@matchMatcher
-                rollDayIfNeeded()
-                config.soldCoins += amount
-            }
+        npcSellPattern.matchMatcher(event.cleanMessage) {
+            val amount = group("amount").formatLong()
+            if (amount <= 0) return@matchMatcher
+            rollDayIfNeeded()
+            soldCoins += amount
         }
     }
 
-    @HandleEvent
-    fun onGuiOverlayRender(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!shouldRenderInOverlayPass()) return
-        renderHud()
-    }
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, onlyOnSkyblock = true)
+    fun onGuiRenderOverlay() {
+        if (!config.enabled) return
 
-    @HandleEvent
-    fun onGuiOnTopRender(event: GuiRenderEvent.GuiOnTopRenderEvent) {
-        if (!shouldRenderOnTop()) return
-        renderHud()
-    }
-
-    private fun shouldRenderInOverlayPass(): Boolean {
-        if (GuiEditManager.isInGui()) return config.enabled
-        if (!config.enabled || !config.showHud || !SkyBlockUtils.inSkyBlock) return false
-        return !isDeferredScreenOpen()
-    }
-
-    private fun shouldRenderOnTop(): Boolean {
-        if (GuiEditManager.isInGui()) return false
-        if (!config.enabled || !config.showHud || !SkyBlockUtils.inSkyBlock) return false
-        return isDeferredScreenOpen()
-    }
-
-    private fun isDeferredScreenOpen(): Boolean {
-        val screen = Minecraft.getInstance().screen ?: return false
-        return screen is InventoryScreen || screen is ChatScreen || screen is ContainerScreen
-    }
-
-    private fun renderHud() {
         config.position.renderRenderable(
             Renderable.text(hudLine()),
             posLabel = POS_LABEL,
         )
     }
 
+    private var gmtEpochDay: Long
+        get() = storage?.gmtEpochDay ?: 0L
+        set(value) {
+            storage?.gmtEpochDay = value
+        }
+
+    private var soldCoins: Long
+        get() = storage?.soldCoins ?: 0L
+        set(value) {
+            storage?.soldCoins = value
+        }
+
     private fun rollDayIfNeeded() {
         val today = LocalDate.now(ZoneOffset.UTC).toEpochDay()
-        if (config.gmtEpochDay != today) {
-            config.gmtEpochDay = today
-            config.soldCoins = 0L
+        if (gmtEpochDay != today) {
+            gmtEpochDay = today
+            soldCoins = 0L
         }
     }
 
     fun soldCoinsToday(): Long {
         rollDayIfNeeded()
-        return config.soldCoins
+        return soldCoins
     }
 
     fun remainingCoinsToday(): Long {
         rollDayIfNeeded()
-        return (DAILY_LIMIT - config.soldCoins).coerceAtLeast(0L)
+        return (DAILY_LIMIT - soldCoins).coerceAtLeast(0L)
     }
 
     fun formatCoinsLabel(coins: Long): String = when (config.numberFormat.get()) {
-        NumberFormatEntry.CONDENSED -> formatCondensed(coins)
-        NumberFormatEntry.FULL -> String.format(Locale.US, "%,d", coins)
-    }
-
-    private fun formatCondensed(coins: Long): String {
-        if (coins <= 0) return "0m"
-        if (coins % 1_000_000 == 0L) return "${coins / 1_000_000}m"
-        return String.format(Locale.ROOT, "%.1fm", coins / 1_000_000.0)
+        NumberFormatEntry.SHORT -> coins.shortFormat()
+        NumberFormatEntry.LONG -> coins.addSeparators()
     }
 
     fun hudPlainText(): String {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/npc/NpcDayLimitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/npc/NpcDayLimitTracker.kt
@@ -1,0 +1,135 @@
+package at.hannibal2.skyhanni.features.misc.npc
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.features.misc.NpcDayLimitTrackerConfig.NumberFormatEntry
+import at.hannibal2.skyhanni.data.GuiEditManager
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.screens.ChatScreen
+import net.minecraft.client.gui.screens.inventory.ContainerScreen
+import net.minecraft.client.gui.screens.inventory.InventoryScreen
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.Locale
+
+@SkyHanniModule
+object NpcDayLimitTracker {
+
+    private const val DAILY_LIMIT = 500_000_000L
+    private const val POS_LABEL = "NPC Day Limit Tracker"
+
+    private val config get() = SkyHanniMod.feature.misc.npcDayLimitTracker
+
+    private val patternGroup = RepoPattern.group("misc.npcdaylimit")
+
+    /**
+     * REGEX-TEST: You sold Evergreen Chip x64 for 9,600,000 Coins!
+     * REGEX-TEST: You sold Cicada Symphony Vinyl x1 for 50,000 Coins!
+     */
+    private val npcSellPattern by patternGroup.pattern(
+        "sold",
+        "You sold .+ for (?<amount>[\\d,]+) Coins!",
+    )
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onChat(event: SkyHanniChatEvent.Allow) {
+        if (!config.enabled) return
+
+        for (line in event.cleanMessage.split('\n')) {
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) continue
+            npcSellPattern.matchMatcher(trimmed) {
+                val amount = group("amount").replace(",", "").toLongOrNull() ?: return@matchMatcher
+                if (amount <= 0) return@matchMatcher
+                rollDayIfNeeded()
+                config.soldCoins += amount
+            }
+        }
+    }
+
+    @HandleEvent
+    fun onGuiOverlayRender(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (!shouldRenderInOverlayPass()) return
+        renderHud()
+    }
+
+    @HandleEvent
+    fun onGuiOnTopRender(event: GuiRenderEvent.GuiOnTopRenderEvent) {
+        if (!shouldRenderOnTop()) return
+        renderHud()
+    }
+
+    private fun shouldRenderInOverlayPass(): Boolean {
+        if (GuiEditManager.isInGui()) return config.enabled
+        if (!config.enabled || !config.showHud || !SkyBlockUtils.inSkyBlock) return false
+        return !isDeferredScreenOpen()
+    }
+
+    private fun shouldRenderOnTop(): Boolean {
+        if (GuiEditManager.isInGui()) return false
+        if (!config.enabled || !config.showHud || !SkyBlockUtils.inSkyBlock) return false
+        return isDeferredScreenOpen()
+    }
+
+    private fun isDeferredScreenOpen(): Boolean {
+        val screen = Minecraft.getInstance().screen ?: return false
+        return screen is InventoryScreen || screen is ChatScreen || screen is ContainerScreen
+    }
+
+    private fun renderHud() {
+        config.position.renderRenderable(
+            Renderable.text(hudLine()),
+            posLabel = POS_LABEL,
+        )
+    }
+
+    private fun rollDayIfNeeded() {
+        val today = LocalDate.now(ZoneOffset.UTC).toEpochDay()
+        if (config.gmtEpochDay != today) {
+            config.gmtEpochDay = today
+            config.soldCoins = 0L
+        }
+    }
+
+    fun soldCoinsToday(): Long {
+        rollDayIfNeeded()
+        return config.soldCoins
+    }
+
+    fun remainingCoinsToday(): Long {
+        rollDayIfNeeded()
+        return (DAILY_LIMIT - config.soldCoins).coerceAtLeast(0L)
+    }
+
+    fun formatCoinsLabel(coins: Long): String = when (config.numberFormat.get()) {
+        NumberFormatEntry.CONDENSED -> formatCondensed(coins)
+        NumberFormatEntry.FULL -> String.format(Locale.US, "%,d", coins)
+    }
+
+    private fun formatCondensed(coins: Long): String {
+        if (coins <= 0) return "0m"
+        if (coins % 1_000_000 == 0L) return "${coins / 1_000_000}m"
+        return String.format(Locale.ROOT, "%.1fm", coins / 1_000_000.0)
+    }
+
+    fun hudPlainText(): String {
+        val sold = formatCoinsLabel(soldCoinsToday())
+        val limit = formatCoinsLabel(DAILY_LIMIT)
+        return "$sold/$limit"
+    }
+
+    fun hudLine(): String {
+        val sold = formatCoinsLabel(soldCoinsToday())
+        val limit = formatCoinsLabel(DAILY_LIMIT)
+        return "§6$sold§f/§6$limit"
+    }
+}


### PR DESCRIPTION
## What

- Uses regex to parse chat messages from coins sold to npc and adds them to an on screen hud. 
- Support compressed or full layouts (ex. 400,000 / 500,000,000 vs 400k / 500m)
- Able to enable but not have on hud (in case you want to turn on the hud later and it still tracked while the hud element was off)


## Change log
- Added NPC Daily Coin Limit Tracker - T0R0NT0
