### PR TITLE
Fix: Only warn for item categories that should never show up anymore

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
@@ -45,9 +45,9 @@ enum class ItemCategory {
     TROPHY_FISH,
     ARROW,
     ARROW_POISON,
-    // TODO This used to be used as a fake category for uncategorized dungeon items.
+    // TODO This was previously used as a fake category for uncategorized dungeon items.
     //  Remove it after ensuring it doesn't break anything.
-    @Deprecated("Fake category", ReplaceWith("ItemCategory.NONE")) ITEM,
+    @Deprecated("Legacy fake category", ReplaceWith("ItemCategory.NONE"), level = DeprecationLevel.ERROR) ITEM,
     PET_ITEM,
     ENCHANTED_BOOK,
     FISHING_BAIT,
@@ -82,6 +82,8 @@ enum class ItemCategory {
 
     companion object {
 
+        val deprecatedAtErrorLevel: Set<ItemCategory> = entries.filter { it.isDeprecatedAtErrorLevel() }.toSet()
+
         fun Collection<ItemCategory>.containsItem(stack: ItemStack?) =
             stack?.getItemCategoryOrNull()?.let { this.contains(it) } ?: false
 
@@ -91,7 +93,9 @@ enum class ItemCategory {
 
         val equipment = setOf(NECKLACE, BELT, CLOAK, GLOVES, BRACELET)
 
-        @Suppress("DEPRECATION")
-        val deprecated = listOf(FISHING_WEAPON, HOE, ITEM)
+        private fun ItemCategory.isDeprecatedAtErrorLevel(): Boolean {
+            val field = javaClass.getField(name)
+            return field.getAnnotation(Deprecated::class.java)?.level == DeprecationLevel.ERROR
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemCategory.kt
@@ -82,8 +82,6 @@ enum class ItemCategory {
 
     companion object {
 
-        val deprecatedAtErrorLevel: Set<ItemCategory> = entries.filter { it.isDeprecatedAtErrorLevel() }.toSet()
-
         fun Collection<ItemCategory>.containsItem(stack: ItemStack?) =
             stack?.getItemCategoryOrNull()?.let { this.contains(it) } ?: false
 
@@ -93,9 +91,7 @@ enum class ItemCategory {
 
         val equipment = setOf(NECKLACE, BELT, CLOAK, GLOVES, BRACELET)
 
-        private fun ItemCategory.isDeprecatedAtErrorLevel(): Boolean {
-            val field = javaClass.getField(name)
-            return field.getAnnotation(Deprecated::class.java)?.level == DeprecationLevel.ERROR
-        }
+        fun ItemCategory.isDeprecatedAtErrorLevel(): Boolean =
+            javaClass.getField(name).getAnnotation(Deprecated::class.java)?.level == DeprecationLevel.ERROR
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -448,7 +448,7 @@ object ItemUtils {
                     condition = { !itemCategoryRepoCheckPattern.matches(category) },
                 )
             } else {
-                if (itemCategory in ItemCategory.deprecatedAtErrorLevel) {
+                if (itemCategory.isDeprecatedAtErrorLevel()) {
                     ErrorManager.logErrorStateWithData(
                         "Item category $itemCategory for item $name is outdated",
                         "ItemCategory $itemCategory is deprecated at error level",

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -448,10 +448,10 @@ object ItemUtils {
                     condition = { !itemCategoryRepoCheckPattern.matches(category) },
                 )
             } else {
-                if (itemCategory in ItemCategory.deprecated) {
+                if (itemCategory in ItemCategory.deprecatedAtErrorLevel) {
                     ErrorManager.logErrorStateWithData(
                         "Item category $itemCategory for item $name is outdated",
-                        "ItemCategory $itemCategory is deprecated",
+                        "ItemCategory $itemCategory is deprecated at error level",
                         "item category" to itemCategory,
                         "internal name" to getInternalName(),
                         "item name" to name,


### PR DESCRIPTION
## What
For `ITEM` it makes sense to warn since that's something our parsing should never emit anymore, but for `FISHING_WEAPON` and `HOE` the whole point of keeping them around as deprecated was to **not** give users errors when they encounter outdated/legacy items.

## Changelog Fixes
+ Removed unnecessary warnings for legacy Fishing Weapon and Hoe items. - Luna