### PR TITLE
Fix: /shcopyentites entity count does not reset

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
@@ -359,6 +359,7 @@ object CopyNearbyEntitiesCommand {
             val string = resultList.joinToString("\n")
             OSUtils.copyToClipboard(string)
             ChatUtils.chat("$entityCounter entities copied into the clipboard!")
+            entityCounter = 0;
         } else {
             ChatUtils.chat("No entities found in a search radius of $searchRadius!")
         }


### PR DESCRIPTION
## What
doing /shcopyentities did not reset the count each time it was called, meaning it just kept accumulating.

exclude_from_changelog