### PR TITLE
Backend: Fix test bootstrap race condition

### DIFF
--- a/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ItemUtilsTest.kt
@@ -9,24 +9,12 @@ import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.UtilsPatterns
-import net.minecraft.SharedConstants
-import net.minecraft.server.Bootstrap
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Items
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
 class ItemUtilsTest {
-
-    companion object {
-        @JvmStatic
-        @BeforeAll
-        fun bootstrapMinecraftRegistries() {
-            SharedConstants.tryDetectVersion()
-            Bootstrap.bootStrap()
-        }
-    }
 
     // <editor-fold desc="Item Amount Test">
     private val items: MutableMap<String, Pair<String, Int>> = mutableMapOf(

--- a/src/test/java/at/hannibal2/skyhanni/test/MinecraftTestBootstrapExtension.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/MinecraftTestBootstrapExtension.kt
@@ -1,0 +1,23 @@
+package at.hannibal2.skyhanni.test
+
+import net.minecraft.SharedConstants
+import net.minecraft.server.Bootstrap
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class MinecraftTestBootstrapExtension : BeforeAllCallback {
+    override fun beforeAll(context: ExtensionContext) {
+        synchronized(lock) {
+            if (bootstrapped) return
+
+            SharedConstants.tryDetectVersion()
+            Bootstrap.bootStrap()
+            bootstrapped = true
+        }
+    }
+
+    companion object {
+        private val lock = Any()
+        private var bootstrapped = false
+    }
+}

--- a/src/test/java/at/hannibal2/skyhanni/test/garden/GardenVisitorTooltipTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/garden/GardenVisitorTooltipTest.kt
@@ -8,13 +8,10 @@ import at.hannibal2.skyhanni.features.garden.visitor.VisitorApi
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
-import net.minecraft.SharedConstants
-import net.minecraft.server.Bootstrap
 import net.minecraft.world.item.Items
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -72,13 +69,6 @@ class GardenVisitorTooltipTest {
             "§8the required items until you've given",
             "§8the full amount!",
         )
-
-        @JvmStatic
-        @BeforeAll
-        fun bootstrapMinecraftRegistries() {
-            SharedConstants.tryDetectVersion()
-            Bootstrap.bootStrap()
-        }
 
         @Suppress("UNCHECKED_CAST")
         private fun itemNameCache(): MutableMap<String, NeuInternalName?> {

--- a/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+at.hannibal2.skyhanni.test.MinecraftTestBootstrapExtension


### PR DESCRIPTION
## What
Fixes a weird race condition in the JUnit tests that caused tests to intermittently start failing until you delete the corresponding `versions/<version>/build` directly.

## Changelog Technical Details
+ Fixed a race condition causing intermittent test failures. - Luna