### PR TITLE
Fix: Harvest Feast Data Handling

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteFeastJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteFeastJson.kt
@@ -6,20 +6,24 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.api.ApiUtils
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
 import kotlin.time.Duration
 
 @KSerializable
 data class EliteFeastJson(
     @Expose val current: List<String>,
-    @Expose val next: Map<String, SimpleTimeMark?>,
+    @Expose @SerializedName("next") private val _next: Map<String, Long?>,
     @Expose val isGrandFeast: Boolean,
 ) {
+    val next: Map<String, SimpleTimeMark?> = _next.mapValues { it.value?.let(SimpleTimeMark::fromUnixSeconds) }
+
     val isComplete = current.size == 3
 
     fun getBody(): String = ApiUtils.serializeNullsGson.toJson(this)
+
     fun createData(): EliteFeastData {
         val now = SkyBlockTime.now()
-        return EliteFeastData(
+        return EliteFeastData.of(
             year = now.year,
             month = now.month,
             complete = isComplete,
@@ -27,6 +31,14 @@ data class EliteFeastJson(
             next = next,
             isGrandFeast = isGrandFeast,
         )
+    }
+
+    companion object {
+        fun of(
+            current: List<String>,
+            next: Map<String, SimpleTimeMark?>,
+            isGrandFeast: Boolean,
+        ) = EliteFeastJson(current, _next = next.mapValues { it.value?.toSeconds() }, isGrandFeast)
     }
 }
 
@@ -36,9 +48,18 @@ data class EliteFeastData(
     @Expose val month: Int,
     @Expose val complete: Boolean,
     @Expose val current: List<String>,
-    @Expose val next: Map<String, SimpleTimeMark?>,
+    @Expose @SerializedName("next") private val _next: Map<String, Long?>,
     @Expose val isGrandFeast: Boolean,
 ) {
+    val next: Map<String, SimpleTimeMark?> = _next.mapValues { it.value?.let(SimpleTimeMark::fromUnixSeconds) }
+
+    private val feastEndTime: SimpleTimeMark
+        get() = if (isGrandFeast) {
+            SkyBlockTime(year, GRAND_FEAST_END_MONTH, GRAND_FEAST_END_DAY).toTimeMark()
+        } else {
+            SkyBlockTime(year, HARVEST_FEAST_END_MONTH, HARVEST_FEAST_END_DAY).toTimeMark()
+        }
+
     fun getBody(): String = ApiUtils.serializeNullsGson.toJson(this)
 
     private fun getDurations(): List<Duration> {
@@ -50,7 +71,10 @@ data class EliteFeastData(
             .minByOrNull { it.inWholeMilliseconds } ?: Duration.ZERO
     }
 
-    fun getActiveDuration(): Duration = getDurations().filter { it.isPositive() }.minByOrNull { it.inWholeMilliseconds } ?: Duration.ZERO
+    fun getActiveDuration(): Duration {
+        if (next.values.all { it == null }) return feastEndTime.timeUntil()
+		return getDurations().filter { it.isPositive() }.minByOrNull { it.inWholeMilliseconds } ?: Duration.ZERO
+	}
 
     fun getCurrentCrops(): List<CropType> {
         val fromCurrent = current.toCropTypes()
@@ -67,4 +91,27 @@ data class EliteFeastData(
     }
 
     private fun List<String>.toCropTypes(): List<CropType> = map { CropType.getByName(it) }
+
+    companion object {
+        private const val HARVEST_FEAST_END_MONTH = 10
+        private const val HARVEST_FEAST_END_DAY = 1
+        private const val GRAND_FEAST_END_MONTH = 3
+        private const val GRAND_FEAST_END_DAY = 27
+
+        fun of(
+            year: Int,
+            month: Int,
+            complete: Boolean,
+            current: List<String>,
+            next: Map<String, SimpleTimeMark?>,
+            isGrandFeast: Boolean,
+        ) = EliteFeastData(
+            year,
+            month,
+            complete,
+            current,
+            _next = next.mapValues { it.value?.toSeconds() },
+            isGrandFeast,
+        )
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
@@ -160,7 +160,7 @@ object HarvestFeastManager {
         val current = readCurrentActiveCrops(items).takeIf { it.size == 3 } ?: return
         val next = readCropTimestamps(items)
 
-        val sendData = EliteFeastJson(
+        val sendData = EliteFeastJson.of(
             current = current.map { it.cropName },
             next = next.map { it.key.cropName to it.value }.toMap(),
             isGrandFeast = assumeGrandFeast(),

--- a/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SimpleTimeMark.kt
@@ -64,13 +64,15 @@ value class SimpleTimeMark(private val millis: Long) : Comparable<SimpleTimeMark
 
     fun toMillis() = millis
 
+    fun toSeconds() = millis / 1000
+
     fun toSkyBlockTime(): SkyBlockTime = SkyBlockTime.fromTimeMark(this)
 
     fun toLocalDate(): LocalDate = toLocalDateTime().toLocalDate()
 
     companion object {
 
-        fun now() = SimpleTimeMark(System.currentTimeMillis())
+        fun now() = SimpleTimeMark(timeProvider.currentTimeMillis())
 
         private const val FAR_PAST_MS = 0L
         private const val FAR_FUTURE_MS = Long.MAX_VALUE
@@ -83,9 +85,25 @@ value class SimpleTimeMark(private val millis: Long) : Comparable<SimpleTimeMark
         fun farPast() = FAR_PAST
         fun farFuture() = FAR_FUTURE
 
+        fun fromUnixSeconds(seconds: Long) = SimpleTimeMark(seconds * 1000)
+
         fun Duration.fromNow() = now() + this
 
         fun Long.asTimeMark() = SimpleTimeMark(this)
         fun OffsetDateTime.asTimeMark() = SimpleTimeMark(toInstant().toEpochMilli())
+
+        internal var timeProvider: TimeProvider = SystemTimeProvider
+
+        internal fun resetTimeProvider() {
+            timeProvider = SystemTimeProvider
+        }
+
+        internal fun interface TimeProvider {
+            fun currentTimeMillis(): Long
+        }
+
+        private object SystemTimeProvider : TimeProvider {
+            override fun currentTimeMillis(): Long = System.currentTimeMillis()
+        }
     }
 }

--- a/src/test/java/at/hannibal2/skyhanni/test/event/HarvestFeastDataFetchingTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/event/HarvestFeastDataFetchingTest.kt
@@ -31,18 +31,16 @@ class HarvestFeastDataFetchingTest {
     }
 
     @Test
-    fun `current in-season crops have correct remaining time`() =
-        assertRemainingTime(
-            """{"complete":true,"current":["Melon","Potato","Sunflower"],"isGrandFeast":false,"month":7,"next":{"Cactus":1779309300,"Carrot":1779309300,"Cocoa Beans":1779272100,"Melon":null,"Moonflower":null,"Mushroom":null,"Nether Wart":1779272100,"Potato":null,"Pumpkin":null,"Sugar Cane":1779309300,"Sunflower":null,"Wheat":null,"Wild Rose":1779272100},"year":491}""",
-            34_192.seconds,
-        )
+    fun `current in-season crops have correct remaining time`() = assertRemainingTime(
+        """{"complete":true,"current":["Melon","Potato","Sunflower"],"isGrandFeast":false,"month":7,"next":{"Cactus":1779309300,"Carrot":1779309300,"Cocoa Beans":1779272100,"Melon":null,"Moonflower":null,"Mushroom":null,"Nether Wart":1779272100,"Potato":null,"Pumpkin":null,"Sugar Cane":1779309300,"Sunflower":null,"Wheat":null,"Wild Rose":1779272100},"year":491}""",
+        34_192.seconds,
+    )
 
     @Test
-    fun `current in-season crops have correct remaining time for last rotation`() =
-        assertRemainingTime(
-            """{"complete":true,"current":["Melon","Potato","Sunflower"],"isGrandFeast":false,"month":7,"next":{"Cactus":null,"Carrot":null,"Cocoa Beans":null,"Melon":null,"Moonflower":null,"Mushroom":null,"Nether Wart":null,"Potato":null,"Pumpkin":null,"Sugar Cane":null,"Sunflower":null,"Wheat":null,"Wild Rose":null},"year":491}""",
-            108_592.seconds,
-        )
+    fun `current in-season crops have correct remaining time for last rotation`() = assertRemainingTime(
+        """{"complete":true,"current":["Melon","Potato","Sunflower"],"isGrandFeast":false,"month":7,"next":{"Cactus":null,"Carrot":null,"Cocoa Beans":null,"Melon":null,"Moonflower":null,"Mushroom":null,"Nether Wart":null,"Potato":null,"Pumpkin":null,"Sugar Cane":null,"Sunflower":null,"Wheat":null,"Wild Rose":null},"year":491}""",
+        108_592.seconds,
+    )
 
     companion object {
         const val MOCK_TIME = 1_779_237_908_000L

--- a/src/test/java/at/hannibal2/skyhanni/test/event/HarvestFeastDataFetchingTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/event/HarvestFeastDataFetchingTest.kt
@@ -1,0 +1,50 @@
+package at.hannibal2.skyhanni.test.event
+
+import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteFeastData
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.TimeProvider
+import at.hannibal2.skyhanni.utils.api.ApiUtils
+import at.hannibal2.skyhanni.utils.json.fromJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class HarvestFeastDataFetchingTest {
+
+    @BeforeEach
+    fun setUp() {
+        SimpleTimeMark.timeProvider = TimeProvider { MOCK_TIME }
+        assertEquals(MOCK_TIME, SimpleTimeMark.now().toMillis(), "Failed to set up time mocking")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SimpleTimeMark.resetTimeProvider()
+    }
+
+    fun assertRemainingTime(jsonString: String, expectedTime: Duration) {
+        val feastData = ApiUtils.serializeNullsGson.fromJson<EliteFeastData>(jsonString)
+        assertEquals(expectedTime, feastData.getActiveDuration())
+    }
+
+    @Test
+    fun `current in-season crops have correct remaining time`() =
+        assertRemainingTime(
+            """{"complete":true,"current":["Melon","Potato","Sunflower"],"isGrandFeast":false,"month":7,"next":{"Cactus":1779309300,"Carrot":1779309300,"Cocoa Beans":1779272100,"Melon":null,"Moonflower":null,"Mushroom":null,"Nether Wart":1779272100,"Potato":null,"Pumpkin":null,"Sugar Cane":1779309300,"Sunflower":null,"Wheat":null,"Wild Rose":1779272100},"year":491}""",
+            34_192.seconds,
+        )
+
+    @Test
+    fun `current in-season crops have correct remaining time for last rotation`() =
+        assertRemainingTime(
+            """{"complete":true,"current":["Melon","Potato","Sunflower"],"isGrandFeast":false,"month":7,"next":{"Cactus":null,"Carrot":null,"Cocoa Beans":null,"Melon":null,"Moonflower":null,"Mushroom":null,"Nether Wart":null,"Potato":null,"Pumpkin":null,"Sugar Cane":null,"Sunflower":null,"Wheat":null,"Wild Rose":null},"year":491}""",
+            108_592.seconds,
+        )
+
+    companion object {
+        const val MOCK_TIME = 1_779_237_908_000L
+    }
+}


### PR DESCRIPTION
## What
Fixes Harvest Feast timer expecting milliseconds instead of seconds, and also fixes the timer for when all crops in `next` are `null` because it's the last rotation of the feast.

## Changelog Fixes
+ Fixed Harvest Feast in-season crop display sometimes showing incorrect information. - Luna