### PR TITLE
Fix + Backend: ContributorManager V2

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.config.storage.AchievementStorage
 import at.hannibal2.skyhanni.config.storage.CustomTodosStorage
 import at.hannibal2.skyhanni.config.storage.OrderedWaypointsRoutes
+import at.hannibal2.skyhanni.config.storage.SeenContributorStorage
 import at.hannibal2.skyhanni.config.storage.SpecificSeaCreatureStorage
 import at.hannibal2.skyhanni.data.GuiEditManager
 import at.hannibal2.skyhanni.data.OtherInventoryData
@@ -139,6 +140,7 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
     lateinit var customTodos: CustomTodosStorage
     lateinit var seaCreatureStorage: SpecificSeaCreatureStorage
     lateinit var achievementStorage: AchievementStorage
+    lateinit var seenContributorStorage: SeenContributorStorage
 
     lateinit var configManager: ConfigManager
     val logger: Logger = LogManager.getLogger("SkyHanni")

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.core.config.PositionList
 import at.hannibal2.skyhanni.config.storage.AchievementStorage
 import at.hannibal2.skyhanni.config.storage.CustomTodosStorage
 import at.hannibal2.skyhanni.config.storage.OrderedWaypointsRoutes
+import at.hannibal2.skyhanni.config.storage.SeenContributorStorage
 import at.hannibal2.skyhanni.config.storage.SpecificSeaCreatureStorage
 import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.PetDataStorage
@@ -272,6 +273,7 @@ enum class ConfigFileType(val fileName: String, val clazz: Class<*>, val propert
     CUSTOM_TODOS("custom_todos", CustomTodosStorage::class.java, SkyHanniMod::customTodos),
     SEA_CREATURES("sea_creature_settings", SpecificSeaCreatureStorage::class.java, SkyHanniMod::seaCreatureStorage),
     ACHIEVEMENTS("achievements", AchievementStorage::class.java, SkyHanniMod::achievementStorage),
+    SEEN_CONTRIBUTORS("seen_contributors", SeenContributorStorage::class.java, SkyHanniMod::seenContributorStorage),
     ;
 
     val file by lazy { File(ConfigManager.configDirectory, "$fileName.json") }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
@@ -88,7 +88,8 @@ object BrigadierUtils {
 
     fun String.escapeDoubleQuote(): String {
         if (firstOrNull() != DOUBLE_QUOTE) return this
-        return substring(1, lastIndex - 1)
+        if (lastOrNull() != DOUBLE_QUOTE) return this
+        return substring(1, lastIndex)
     }
 
     enum class ItemParsingFail {

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -27,19 +27,22 @@ class PlayerSuggestions private constructor(
     class Builder {
         private var seq: Sequence<String> = emptySequence()
 
-        fun includeAllSources() {
-            seq = PlayerNameSource.entries.asSequence().flatMap { it.usernames }
+        fun includeAllSources(): Builder {
+            seq += PlayerNameSource.entries.asSequence().flatMap { it.usernames }
+            return this
         }
 
-        fun include(vararg categories: PlayerNameSource) = apply {
+        fun include(vararg categories: PlayerNameSource): Builder {
             seq += categories.asSequence().flatMap { it.usernames }
+            return this
         }
 
-        fun include(categories: Collection<PlayerNameSource>) = apply {
+        fun include(categories: Collection<PlayerNameSource>): Builder {
             seq += categories.asSequence().flatMap { it.usernames }
+            return this
         }
 
-        fun exclude(vararg categories: PlayerNameSource) = apply {
+        fun exclude(vararg categories: PlayerNameSource): Builder {
             val oldSeq = seq
             seq = sequence {
                 val excluded = categories
@@ -49,27 +52,33 @@ class PlayerSuggestions private constructor(
 
                 yieldAll(oldSeq.filterNot { it in excluded })
             }
+            return this
         }
 
-        fun includePlayers(vararg players: String) = apply {
+        fun includePlayers(vararg players: String): Builder {
             seq += players.asSequence()
+            return this
         }
 
-        fun includePlayers(players: Collection<String>) = apply {
+        fun includePlayers(players: Collection<String>): Builder {
             seq += players.asSequence()
+            return this
         }
 
-        fun excludePlayers(vararg players: String) = apply {
+        fun excludePlayers(vararg players: String): Builder {
             val excluded = players.toSet()
             seq = seq.filterNot { it in excluded }
+            return this
         }
 
-        fun filter(predicate: (String) -> Boolean) = apply {
+        fun filter(predicate: (String) -> Boolean): Builder {
             seq = seq.filter(predicate)
+            return this
         }
 
-        fun filterNot(predicate: (String) -> Boolean) = apply {
+        fun filterNot(predicate: (String) -> Boolean): Builder {
             seq = seq.filterNot(predicate)
+            return this
         }
 
         fun build(): PlayerSuggestions = PlayerSuggestions(seq)

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -1,0 +1,89 @@
+package at.hannibal2.skyhanni.config.commands.brigadier
+
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.dynamicSuggestionProvider
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource
+import com.mojang.brigadier.suggestion.SuggestionProvider
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
+
+/**
+ * Builder-backed utility for creating dynamic Brigadier player suggestions.
+ *
+ * Supports combining player categories and explicit names, then filtering or
+ * excluding entries before converting them into a [SuggestionProvider].
+ */
+class PlayerSuggestions private constructor(
+    private val sequence: Sequence<String>,
+) {
+
+    fun getPlayers(): List<String> =
+        getSequence().toList()
+
+    fun getSequence(): Sequence<String> = sequence.distinct()
+
+    fun toSuggestionProvider(): SuggestionProvider<FabricClientCommandSource> {
+        return dynamicSuggestionProvider { getPlayers() }
+    }
+
+    class Builder {
+        private var seq: Sequence<String> = emptySequence()
+
+        fun includeAllSources() {
+            seq = PlayerNameSource.entries.asSequence().flatMap { it.usernames }
+        }
+
+        fun include(vararg categories: PlayerNameSource) = apply {
+            seq += categories.asSequence().flatMap { it.usernames }
+        }
+
+        fun include(categories: Collection<PlayerNameSource>) = apply {
+            seq += categories.asSequence().flatMap { it.usernames }
+        }
+
+        fun exclude(vararg categories: PlayerNameSource) = apply {
+            val oldSeq = seq
+            seq = sequence {
+                val excluded = categories
+                    .asSequence()
+                    .flatMap { it.usernames }
+                    .toSet()
+
+                yieldAll(oldSeq.filterNot { it in excluded })
+            }
+        }
+
+        fun includePlayers(vararg players: String) = apply {
+            seq += players.asSequence()
+        }
+
+        fun includePlayers(players: Collection<String>) = apply {
+            seq += players.asSequence()
+        }
+
+        fun excludePlayers(vararg players: String) = apply {
+            val excluded = players.toSet()
+            seq = seq.filterNot { it in excluded }
+        }
+
+        fun filter(predicate: (String) -> Boolean) = apply {
+            seq = seq.filter(predicate)
+        }
+
+        fun filterNot(predicate: (String) -> Boolean) = apply {
+            seq = seq.filterNot(predicate)
+        }
+
+        fun build(): PlayerSuggestions = PlayerSuggestions(seq)
+    }
+
+    companion object {
+        fun builder(block: Builder.() -> Unit): SuggestionProvider<FabricClientCommandSource> {
+            return buildPlayerSuggestions(block).toSuggestionProvider()
+        }
+
+        fun buildPlayerSuggestions(block: Builder.() -> Unit): PlayerSuggestions {
+            return Builder()
+                .apply(block)
+                .build()
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/ComponentArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/ComponentArgumentType.kt
@@ -1,0 +1,57 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.escapeDoubleQuote
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.readGreedyString
+import at.hannibal2.skyhanni.utils.json.SkyHanniTypeAdapters
+import com.google.gson.JsonParser
+import com.google.gson.TypeAdapter
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.minecraft.network.chat.Component
+
+class ComponentArgumentType(
+    private val allowPlainText: Boolean,
+) : ArgumentType<Component> {
+    override fun parse(reader: StringReader): Component {
+        val input = reader.readGreedyString().escapeDoubleQuote().trim()
+
+        val looksJson =
+            input.length >= 2 &&
+                (input.startsWith("{") || input.startsWith("["))
+
+        if (!looksJson && allowPlainText) {
+            return Component.literal(input)
+        }
+
+        val jsonElement = try {
+            JsonParser.parseString(input)
+        } catch (_: Exception) {
+            throw INVALID_JSON.create()
+        }
+
+        val result = try {
+            adapter.fromJsonTree(jsonElement)
+        } catch (_: Exception) {
+            null
+        }
+
+        return result ?: throw INVALID_COMPONENT.create()
+    }
+
+    companion object {
+
+        fun component(allowPlainText: Boolean = false) = ComponentArgumentType(allowPlainText)
+
+        private val INVALID_JSON =
+            SimpleCommandExceptionType(Component.literal("Invalid JSON"))
+
+        private val INVALID_COMPONENT =
+            SimpleCommandExceptionType(Component.literal("Invalid component"))
+
+        @Suppress("UNCHECKED_CAST")
+        private val adapter: TypeAdapter<Component> by lazy {
+            SkyHanniTypeAdapters.COMPONENT.adapter as TypeAdapter<Component>
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
@@ -16,7 +16,7 @@ class PlayerArgumentType private constructor() : ArgumentType<Player> {
             ?: throw PLAYER_NOT_FOUND.create(username)
     }
 
-    fun getAllPlayers(): List<Player> =
+    private fun getAllPlayers(): List<Player> =
         EntityUtils.getPlayerEntities() + listOfNotNull(MinecraftCompat.localPlayerOrNull)
 
     override fun getExamples(): Collection<String> =

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
@@ -1,0 +1,34 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
+import net.minecraft.network.chat.Component
+import net.minecraft.world.entity.player.Player
+
+class PlayerArgumentType private constructor() : ArgumentType<Player> {
+    override fun parse(reader: StringReader): Player {
+        val username = reader.readString()
+        return getAllPlayers()
+            .firstOrNull { it.name.string.equals(username, ignoreCase = true) }
+            ?: throw PLAYER_NOT_FOUND.create(username)
+    }
+
+    fun getAllPlayers(): List<Player> =
+        EntityUtils.getPlayerEntities() + listOfNotNull(MinecraftCompat.localPlayerOrNull)
+
+    override fun getExamples(): Collection<String> =
+        listOf("Notch", "Technoblade", "hannibal02")
+
+    companion object {
+        private val PLAYER_NOT_FOUND = DynamicCommandExceptionType {
+            Component.literal("Could not find player with username: $it")
+        }
+
+        fun player(): PlayerArgumentType {
+            return PlayerArgumentType()
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
@@ -1,10 +1,10 @@
 package at.hannibal2.skyhanni.config.commands.brigadier.arguments
 
 import at.hannibal2.skyhanni.utils.StringUtils
+import com.mojang.brigadier.LiteralMessage
 import com.mojang.brigadier.StringReader
 import com.mojang.brigadier.arguments.ArgumentType
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
-import com.mojang.brigadier.LiteralMessage
 import java.util.UUID
 
 class UuidArgumentType private constructor() : ArgumentType<UUID> {
@@ -16,12 +16,12 @@ class UuidArgumentType private constructor() : ArgumentType<UUID> {
 
     override fun getExamples(): Collection<String> = listOf(
         "123e4567-e89b-12d3-a456-426614174000",
-        "\"123e4567-e89b-12d3-a456-426614174000\""
+        "\"123e4567-e89b-12d3-a456-426614174000\"",
     )
 
     companion object {
         private val invalidUuid = SimpleCommandExceptionType(
-            LiteralMessage("Please provide a valid UUID in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+            LiteralMessage("Please provide a valid UUID in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
         )
 
         fun uuid(): UuidArgumentType = UuidArgumentType()

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
@@ -7,7 +7,7 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
 import com.mojang.brigadier.LiteralMessage
 import java.util.UUID
 
-class UuidArgumentType : ArgumentType<UUID> {
+class UuidArgumentType private constructor() : ArgumentType<UUID> {
     override fun parse(reader: StringReader): UUID {
         val input = reader.readString()
         return StringUtils.parseUUIDOrNull(input)

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
@@ -1,0 +1,29 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import at.hannibal2.skyhanni.utils.StringUtils
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import com.mojang.brigadier.LiteralMessage
+import java.util.UUID
+
+class UuidArgumentType : ArgumentType<UUID> {
+    override fun parse(reader: StringReader): UUID {
+        val input = reader.readString()
+        return StringUtils.parseUUIDOrNull(input)
+            ?: throw invalidUuid.createWithContext(reader)
+    }
+
+    override fun getExamples(): Collection<String> = listOf(
+        "123e4567-e89b-12d3-a456-426614174000",
+        "\"123e4567-e89b-12d3-a456-426614174000\""
+    )
+
+    companion object {
+        private val invalidUuid = SimpleCommandExceptionType(
+            LiteralMessage("Please provide a valid UUID in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+        )
+
+        fun uuid(): UuidArgumentType = UuidArgumentType()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/TabCompleteConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/TabCompleteConfig.kt
@@ -42,6 +42,11 @@ class TabCompleteConfig {
     var guild: Boolean = false
 
     @Expose
+    @ConfigOption(name = "Carry Customers", desc = "Tab-complete Carry Customers")
+    @ConfigEditorBoolean
+    var carryCustomer: Boolean = false
+
+    @Expose
     @ConfigOption(name = "VIP Visits", desc = "Tab-complete the visit to special users with cake souls on it.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/TabCompleteConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/TabCompleteConfig.kt
@@ -42,7 +42,7 @@ class TabCompleteConfig {
     var guild: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Carry Customers", desc = "Tab-complete Carry Customers")
+    @ConfigOption(name = "Carry Customers", desc = "Tab-complete Carry Customers.")
     @ConfigEditorBoolean
     var carryCustomer: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
@@ -104,6 +104,22 @@ class DevConfig {
     var contributorNametags: Boolean = true
 
     @Expose
+    @ConfigOption(
+        name = "Discover Contributor Message",
+        desc = "Sends a message to your chat when you see a unique contributor.",
+    )
+    @ConfigEditorBoolean
+    var discoverContributorMessage: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Contributor Fangirling Tracker",
+        desc = "Tracks how many times you have been noticed as a contributor by a player",
+    )
+    @ConfigEditorBoolean
+    var contributorMentionTracker: Boolean = true
+
+    @Expose
     @ConfigOption(name = "Flip Contributors", desc = "Make SkyHanni contributors appear upside down in the world.")
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DevConfig.kt
@@ -114,7 +114,7 @@ class DevConfig {
     @Expose
     @ConfigOption(
         name = "Contributor Fangirling Tracker",
-        desc = "Tracks how many times you have been noticed as a contributor by a player",
+        desc = "Tracks how many times you have been noticed as a contributor by a player.",
     )
     @ConfigEditorBoolean
     var contributorMentionTracker: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/AchievementStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/AchievementStorage.kt
@@ -5,5 +5,5 @@ import com.google.gson.annotations.Expose
 
 class AchievementStorage {
     @Expose
-    var achievements: MutableMap<String, Achievement> = mutableMapOf()
+    val achievements: MutableMap<String, Achievement> = mutableMapOf()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/SeenContributorStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/SeenContributorStorage.kt
@@ -1,0 +1,15 @@
+package at.hannibal2.skyhanni.config.storage
+
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import com.google.gson.annotations.Expose
+import java.util.UUID
+
+class SeenContributorStorage {
+    // uuid to first seen timestamp in milliseconds
+    @Expose
+    val seenContributors: MutableMap<UUID, SimpleTimeMark> = mutableMapOf()
+
+    // Records of timestamps when a skyhanni contributor was recognized
+    @Expose
+    val contributorMentions: MutableList<SimpleTimeMark> = mutableListOf()
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/SeenContributorStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/SeenContributorStorage.kt
@@ -9,7 +9,7 @@ class SeenContributorStorage {
     @Expose
     val seenContributors: MutableMap<UUID, SimpleTimeMark> = mutableMapOf()
 
-    // Records of timestamps when a skyhanni contributor was recognized
+    // Records of timestamps when a Skyhanni contributor was recognized
     @Expose
     val contributorMentions: MutableList<SimpleTimeMark> = mutableListOf()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/SeenContributorStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/SeenContributorStorage.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.Expose
 import java.util.UUID
 
 class SeenContributorStorage {
-    // uuid to first seen timestamp in milliseconds
+    // uuid to first seen timestamp
     @Expose
     val seenContributors: MutableMap<UUID, SimpleTimeMark> = mutableMapOf()
 

--- a/src/main/java/at/hannibal2/skyhanni/data/FriendApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/FriendApi.kt
@@ -5,12 +5,19 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.data.jsonobjects.local.FriendsJson
 import at.hannibal2.skyhanni.data.jsonobjects.local.FriendsJson.PlayerFriends.Friend
+import at.hannibal2.skyhanni.events.FriendAddEvent
+import at.hannibal2.skyhanni.events.FriendRemoveEvent
+import at.hannibal2.skyhanni.events.FriendRequestDeclinedEvent
+import at.hannibal2.skyhanni.events.FriendRequestExpiredEvent
+import at.hannibal2.skyhanni.events.FriendRequestSentEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
 import at.hannibal2.skyhanni.utils.compat.command
 import at.hannibal2.skyhanni.utils.compat.hover
@@ -18,6 +25,7 @@ import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
 import java.util.UUID
+import kotlin.time.Duration.Companion.minutes
 
 @SkyHanniModule
 object FriendApi {
@@ -71,6 +79,23 @@ object FriendApi {
         "/viewprofile (?<uuid>.*)",
     )
 
+    /**
+     * REGEX-TEST: The friend request to ouppy has expired.
+     */
+    private val friendRequestExpiredPattern by patternGroup.pattern(
+        "friend-request-expired",
+        "The friend request to (?<name>.*) has expired.",
+    )
+
+    /**
+     * REGEX-TEST: You sent a friend request to enbylae!
+     */
+    private val friendRequestSentPattern by patternGroup.pattern(
+        "friend-request-sent",
+        "You sent a friend request to (?<name>.*)!",
+    )
+
+    private val pendingRequests = mutableListOf<String>()
     private val tempFriends = mutableListOf<Friend>()
 
     private fun getFriends() = SkyHanniMod.friendsData.players.getOrPut(PlayerUtils.getRawUuid()) {
@@ -106,6 +131,7 @@ object FriendApi {
         }
         addedFriendPattern.matchMatcher(event.message) {
             val name = group("name").cleanPlayerName()
+            removePendingRequest(name)
             addFriend(name)
         }
 
@@ -116,6 +142,16 @@ object FriendApi {
         bestFriendPattern.matchMatcher(event.message) {
             val name = group("name").cleanPlayerName()
             setBestFriend(name, true)
+        }
+
+        friendRequestExpiredPattern.matchMatcher(event.cleanMessage) {
+            val name = group("name")
+            removePendingRequest(name)
+            FriendRequestExpiredEvent(name).post()
+        }
+        friendRequestSentPattern.matchMatcher(event.cleanMessage) {
+            val name = group("name")
+            addPendingRequest(name)
         }
     }
 
@@ -128,12 +164,14 @@ object FriendApi {
 
     private fun addFriend(name: String) {
         tempFriends.add(Friend().also { it.name = name })
+        FriendAddEvent(name).post()
     }
 
     private fun removedFriend(name: String) {
         tempFriends.removeIf { it.name == name }
         getFriends().entries.removeIf { it.value.name == name }
         saveConfig()
+        FriendRemoveEvent(name).post()
     }
 
     private fun readFriendsList(event: SkyHanniChatEvent.Allow) {
@@ -184,5 +222,25 @@ object FriendApi {
         }
 
         return null
+    }
+
+    private fun addPendingRequest(name: String) {
+        pendingRequests.add(name)
+
+        // This is 6 minutes instead of 5 minutes to be extra sure that the request has expired
+        DelayedRun.runDelayed(6.minutes) {
+            val stillPending = pendingRequests.contains(name)
+            if (!stillPending) return@runDelayed
+
+            removePendingRequest(name)
+            if (!SkyBlockUtils.onHypixel) return@runDelayed
+            FriendRequestDeclinedEvent(name).post()
+        }
+
+        FriendRequestSentEvent(name).post()
+    }
+
+    private fun removePendingRequest(name: String) {
+        pendingRequests.removeIf { it == name }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/FriendAddEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/FriendAddEvent.kt
@@ -1,0 +1,19 @@
+package at.hannibal2.skyhanni.events
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
+
+@PrimaryFunction("onFriendAdd")
+class FriendAddEvent(val playerName: String) : SkyHanniEvent()
+
+@PrimaryFunction("onFriendRemove")
+class FriendRemoveEvent(val playerName: String) : SkyHanniEvent()
+
+@PrimaryFunction("onFriendRequestExpired")
+class FriendRequestExpiredEvent(val playerName: String) : SkyHanniEvent()
+
+@PrimaryFunction("onFriendRequestSent")
+class FriendRequestSentEvent(val playerName: String) : SkyHanniEvent()
+
+@PrimaryFunction("onFriendRequestDeclined")
+class FriendRequestDeclinedEvent(val playerName: String) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.events.FriendAddEvent
 import at.hannibal2.skyhanni.events.FriendRequestDeclinedEvent
 import at.hannibal2.skyhanni.events.FriendRequestExpiredEvent
 import at.hannibal2.skyhanni.events.achievements.AchievementRegistrationEvent
-import at.hannibal2.skyhanni.features.misc.ContributorManager.contributorNames
+import at.hannibal2.skyhanni.features.misc.ContributorManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
@@ -74,28 +74,28 @@ object ContributorAchievement {
     @HandleEvent(priority = HandleEvent.LOW)
     fun onProfileJoin() {
         val friends = FriendApi.getAllFriends()
-        if (friends.any { it.name in contributorNames }) {
+        if (friends.any { it.name in ContributorManager.contributorNames }) {
             AchievementManager.completeAchievement(CONTRIBUTOR_FRIEND_ACHIEVEMENT)
         }
     }
 
     @HandleEvent
     fun onFriendAdd(event: FriendAddEvent) {
-        if (event.playerName in contributorNames) {
+        if (event.playerName in ContributorManager.contributorNames) {
             AchievementManager.completeAchievement(CONTRIBUTOR_FRIEND_ACHIEVEMENT)
         }
     }
 
     @HandleEvent
     fun onFriendRequestExpired(event: FriendRequestExpiredEvent) {
-        if (event.playerName in contributorNames) {
+        if (event.playerName in ContributorManager.contributorNames) {
             AchievementManager.completeAchievement(CONTRIBUTOR_NOBODY_ACHIEVEMENT)
         }
     }
 
     @HandleEvent
     fun onFriendRequestDeclined(event: FriendRequestDeclinedEvent) {
-        if (event.playerName in contributorNames) {
+        if (event.playerName in ContributorManager.contributorNames) {
             AchievementManager.completeAchievement(CONTRIBUTOR_REJECTED_ACHIEVEMENT)
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
@@ -1,0 +1,106 @@
+package at.hannibal2.skyhanni.features.achievements
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.FriendApi
+import at.hannibal2.skyhanni.data.achievements.Achievement
+import at.hannibal2.skyhanni.events.FriendAddEvent
+import at.hannibal2.skyhanni.events.FriendRequestDeclinedEvent
+import at.hannibal2.skyhanni.events.FriendRequestExpiredEvent
+import at.hannibal2.skyhanni.events.achievements.AchievementRegistrationEvent
+import at.hannibal2.skyhanni.features.misc.ContributorManager.contributorNames
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.chat.TextHelper
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.compat.appendWithColor
+import at.hannibal2.skyhanni.utils.compat.componentBuilder
+
+@SkyHanniModule
+object ContributorAchievement {
+    private const val CONTRIBUTOR_ACHIEVEMENT = "Contrib Achievement"
+    private const val CONTRIBUTOR_FRIEND_ACHIEVEMENT = "Contrib Friend"
+    private const val CONTRIBUTOR_NOBODY_ACHIEVEMENT = "Contrib Stranger"
+    private const val CONTRIBUTOR_REJECTED_ACHIEVEMENT = "Contrib Rejected"
+
+    @HandleEvent
+    fun onAchievementRegistration(event: AchievementRegistrationEvent) {
+        event.register(
+            Achievement(
+                "EEEEKK!".asComponent(),
+                componentBuilder {
+                    append("Be in the same lobby as a")
+                    appendWithColor(" SkyHanni ", TextHelper.chromaStyle)
+                    append("contributor")
+                }
+            ),
+            CONTRIBUTOR_ACHIEVEMENT
+        )
+
+        event.register(
+            Achievement(
+                "I Know a Guy".asComponent(),
+                componentBuilder {
+                    append("Have a ")
+                    appendWithColor("SkyHanni ", TextHelper.chromaStyle)
+                    append("contributor as a friend")
+                }
+            ),
+            CONTRIBUTOR_FRIEND_ACHIEVEMENT
+        )
+
+        event.register(
+            Achievement(
+                "Notice Me Senpai".asComponent(),
+                componentBuilder {
+                    append("Have your friend request ignored by ")
+                    appendWithColor("SkyHanni", TextHelper.chromaStyle)
+                }
+            ),
+            CONTRIBUTOR_NOBODY_ACHIEVEMENT
+        )
+
+        event.register(
+            Achievement(
+                "Rejected".asComponent(),
+                componentBuilder {
+                    append("Have your friend request declined by a ")
+                    appendWithColor("SkyHanni", TextHelper.chromaStyle)
+                    append(" contributor")
+                }
+            ),
+            CONTRIBUTOR_REJECTED_ACHIEVEMENT
+        )
+    }
+
+    @HandleEvent(priority = HandleEvent.LOW)
+    fun onProfileJoin() {
+        val friends = FriendApi.getAllFriends()
+        if (friends.any { it.name in contributorNames }) {
+            AchievementManager.completeAchievement(CONTRIBUTOR_FRIEND_ACHIEVEMENT)
+        }
+    }
+
+    @HandleEvent
+    fun onFriendAdd(event: FriendAddEvent) {
+        if (event.playerName in contributorNames) {
+            AchievementManager.completeAchievement(CONTRIBUTOR_FRIEND_ACHIEVEMENT)
+        }
+    }
+
+    @HandleEvent
+    fun onFriendRequestExpired(event: FriendRequestExpiredEvent) {
+        if (event.playerName in contributorNames) {
+            AchievementManager.completeAchievement(CONTRIBUTOR_NOBODY_ACHIEVEMENT)
+        }
+    }
+
+    @HandleEvent
+    fun onFriendRequestDeclined(event: FriendRequestDeclinedEvent) {
+        if (event.playerName in contributorNames) {
+            AchievementManager.completeAchievement(CONTRIBUTOR_REJECTED_ACHIEVEMENT)
+        }
+    }
+
+    fun onUniqueContributorSeen() {
+        AchievementManager.completeAchievement(CONTRIBUTOR_ACHIEVEMENT)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerNameSource.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerNameSource.kt
@@ -1,0 +1,21 @@
+package at.hannibal2.skyhanni.features.commands.tabcomplete
+
+import at.hannibal2.skyhanni.data.FriendApi
+import at.hannibal2.skyhanni.data.GuildApi
+import at.hannibal2.skyhanni.data.PartyApi
+import at.hannibal2.skyhanni.features.misc.CarryTracker
+import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.PlayerUtils
+
+enum class PlayerNameSource(private val usernamesGetter: () -> List<String>) {
+    ISLAND_PLAYERS({ EntityUtils.getPlayerEntities().map { it.name.string } }),
+    SELF({ listOf(PlayerUtils.getName()) }),
+    PARTY({ PartyApi.partyMembers }),
+    GUILD({ GuildApi.getAllMembers() }),
+    FRIENDS({ FriendApi.getAllFriends().map { it.name } }),
+    BEST_FRIENDS({ FriendApi.getAllFriends().filter { it.bestFriend }.map { it.name } }),
+    CARRY_CUSTOMER({ CarryTracker.getCustomers().map { it.name } }),
+    ;
+
+    val usernames: List<String> get() = usernamesGetter()
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
@@ -3,16 +3,20 @@ package at.hannibal2.skyhanni.features.commands.tabcomplete
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.FriendApi
-import at.hannibal2.skyhanni.data.GuildApi
+import at.hannibal2.skyhanni.config.commands.brigadier.PlayerSuggestions
 import at.hannibal2.skyhanni.data.PartyApi
 import at.hannibal2.skyhanni.data.jsonobjects.repo.VipVisitsJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.commands.suggestions.LazySuggestionEntry
 import at.hannibal2.skyhanni.features.commands.suggestions.SuggestionProvider
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource.BEST_FRIENDS
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource.CARRY_CUSTOMER
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource.FRIENDS
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource.GUILD
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource.ISLAND_PLAYERS
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource.PARTY
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource.SELF
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.EntityUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 
 @SkyHanniModule
 object PlayerTabComplete {
@@ -20,29 +24,27 @@ object PlayerTabComplete {
     private val config get() = SkyHanniMod.feature.misc.commands.tabComplete
     private var vipVisits = listOf<String>()
 
-    private val friendsEntry = lazyEntry { FriendApi.getAllFriends().map { it.name } }
-    private val partyMembersEntry = lazyEntry { PartyApi.partyMembers }
-    private val guildMembersEntry = lazyEntry { GuildApi.getAllMembers() }
     private val vipVisitsEntry = lazyEntry { vipVisits }
-    private val islandPlayersEntry = lazyEntry { EntityUtils.getPlayerEntities().map { it.name.string } }
+    private val allPlayers = getExcluding()
 
+    // TODO: cache lazy entries, and also cache getExcluding calls with the same parameters
     private val suggestions = SuggestionProvider.build {
         parent("f", "friend") {
-            parent("accept", "add", "deny") { add(getExcluding(PlayerCategory.FRIENDS)) }
-            parent("best") { add(friendsEntry) }
-            parent("remove", "nickname") { add(friendsEntry) }
+            parent("accept", "add", "deny") { add(getExcluding(FRIENDS)) }
+            parent("best") { add(FRIENDS.lazyEntry()) }
+            parent("remove", "nickname") { add(FRIENDS.lazyEntry()) }
             parent("list") { literal("best") }
             literal("help", "notifications", "removeall", "requests")
         }
 
         parent("g", "guild") {
-            parent("invite") { add(getExcluding(PlayerCategory.GUILD)) }
-            parent("kick", "transfer", "setrank", "promote", "demote") { add(guildMembersEntry) }
+            parent("invite") { add(getExcluding(GUILD)) }
+            parent("kick", "transfer", "setrank", "promote", "demote") { add(GUILD.lazyEntry()) }
             parent("mute", "unmute") {
-                add(guildMembersEntry)
+                add(GUILD.lazyEntry())
                 literal("everyone")
             }
-            parent("member") { add(guildMembersEntry) }
+            parent("member") { add(GUILD.lazyEntry()) }
             literal(
                 "top", "toggle", "tagcolor", "tag", "slow", "settings", "rename", "quest", "permissions", "party", "onlinemode",
                 "online", "officerchat", "notifications", "mypermissions", "motd", "menu", "members", "log", "leave", "info", "history",
@@ -51,53 +53,63 @@ object PlayerTabComplete {
         }
 
         parent("p", "party") {
-            parent("accept", "invite") { add(getExcluding(PlayerCategory.PARTY)) }
+            parent("accept", "invite") { add(getExcluding(PARTY)) }
             conditional({ PartyApi.partyMembers.isNotEmpty() }) {
-                parent("kick", "demote", "promote", "transfer") { add(partyMembersEntry) }
+                parent("kick", "demote", "promote", "transfer") { add(PARTY.lazyEntry()) }
                 literal("chat", "disband", "kickoffline", "leave", "list", "mute", "poll", "private", "settings", "warp")
             }
-            add(getExcluding(PlayerCategory.PARTY))
+            add(getExcluding(PARTY))
         }
 
-        parent("w", "msg", "tell", "boop", "boo") { add(getExcluding()) }
+        parent("w", "msg", "tell", "boop", "boo") { add(allPlayers) }
 
         parent("visit") {
-            add(getExcluding())
+            add(allPlayers)
             conditional({ config.vipVisits }) {
                 add(vipVisitsEntry)
             }
         }
 
-        parent("invite") { add(getExcluding()) }
-        parent("ah") { add(getExcluding()) }
+        parent("invite") { add(allPlayers) }
+        parent("ah") { add(allPlayers) }
 
-        parent("pv") { add(getExcluding()) }
-        parent("shmarkplayer") { add(getExcluding()) }
+        parent("pv") {
+            add(allPlayers)
+            add(SELF.lazyEntry())
+        }
 
-        parent("trade") { add(islandPlayersEntry) }
+        parent("trade") { add(ISLAND_PLAYERS.lazyEntry()) }
     }
 
-    enum class PlayerCategory {
-        FRIENDS,
-        ISLAND_PLAYERS,
-        PARTY,
-        GUILD,
+    private fun getExcluding(vararg excluded: PlayerNameSource) = LazySuggestionEntry {
+
+        fun allowed(category: PlayerNameSource): Boolean = when (category) {
+            FRIENDS -> config.friends
+            ISLAND_PLAYERS -> config.islandPlayers
+            PARTY -> config.party
+            GUILD -> config.guild
+            CARRY_CUSTOMER -> config.carryCustomer
+            else -> false
+        }
+
+        val allowedSet = PlayerNameSource.entries.filter {
+            it !in excluded && allowed(it)
+        }.toMutableSet()
+
+        if (config.onlyBestFriends) {
+            if (allowedSet.remove(FRIENDS)) {
+                allowedSet.add(BEST_FRIENDS)
+            }
+        }
+
+        addAll(
+            PlayerSuggestions.buildPlayerSuggestions {
+                include(allowedSet)
+            }.getSequence()
+        )
     }
 
-    private fun getExcluding(vararg categories: PlayerCategory) = LazySuggestionEntry {
-        if (config.friends && PlayerCategory.FRIENDS !in categories) {
-            addAll(FriendApi.getAllFriends().filter { it.bestFriend || !config.onlyBestFriends }.map { it.name })
-        }
-        if (config.islandPlayers && PlayerCategory.ISLAND_PLAYERS !in categories) {
-            addAll(EntityUtils.getPlayerEntities().map { it.name.string })
-        }
-        if (config.party && PlayerCategory.PARTY !in categories) {
-            addAll(PartyApi.partyMembers)
-        }
-        if (config.guild && PlayerCategory.GUILD !in categories) {
-            addAll(GuildApi.getAllMembers())
-        }
-    }
+    private fun PlayerNameSource.lazyEntry() = lazyEntry { usernames }
 
     private fun lazyEntry(getter: () -> List<String>) = LazySuggestionEntry { addAll(getter()) }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
@@ -200,6 +200,8 @@ object CarryTracker {
 
     fun isCustomer(customerName: String): Boolean = getCustomerOrNull(customerName) != null
 
+    fun getCustomers(): List<Customer> = customers.toList()
+
     private fun getCustomerOrNull(customerName: String): Customer? = customers.find {
         it.name.equals(customerName, ignoreCase = true)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -74,7 +74,7 @@ object ContributorManager {
      */
     private val contribMentionPattern by patternGroup.pattern(
         "mention",
-        """\b(?:skyhanni|skyhani|sh).*\b(?:dev\w*|contrib\w*)\b"""
+        """\b(?:skyhanni|skyhani|sh)\b.*\b(?:dev\w*|contrib\w*)\b"""
     )
 
     private val repoReloadCoroutine = CoroutineSettings("contributor list repo reload")
@@ -259,7 +259,7 @@ object ContributorManager {
         val msg = event.messageComponent.getText()
         if (!isContributorMentionMessage(msg)) return
         val author = event.author
-        // This also counts the current player themselves
+        // contributorNames includes the current player
         if (author in contributorNames) return
         if (!contributorMentionersThisSession.add(author)) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -167,10 +167,10 @@ object ContributorManager {
         }
 
         event.registerBrigadier("shaddcontributormention") {
-            description = "Add a contributor mention to the counter."
+            description = "Add/Remove a contributor mention."
             category = CommandCategory.DEVELOPER_DEBUG
             simpleCallback { addContributorMention() }
-            argCallback("amount", BrigadierArguments.integer(1)) { amount ->
+            argCallback("amount", BrigadierArguments.integer()) { amount ->
                 addContributorMention(amount)
             }
         }
@@ -276,10 +276,27 @@ object ContributorManager {
             ChatUtils.userError("Only contributors can add contributor mentions to the counter.")
             return
         }
-        val ts = SimpleTimeMark.now()
-        repeat(amount) {
-            contributorMentions.addLast(ts)
+
+        when {
+            amount > 0 -> {
+                val ts = SimpleTimeMark.now()
+                repeat(amount) {
+                    contributorMentions.addLast(ts)
+                }
+            }
+
+            amount < 0 -> {
+                repeat(-amount) {
+                    contributorMentions.removeLastOrNull()
+                }
+            }
+
+            else -> {
+                ChatUtils.userError("Amount cannot be 0.")
+                return
+            }
         }
+
         ChatUtils.chat("Total contributor mentions: ${contributorMentions.size}")
         saveConfig("added contributor mention record")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -285,7 +285,8 @@ object ContributorManager {
             }
 
             amount < 0 -> {
-                repeat(-amount) {
+                val amountToRemove = minOf(-amount, contributorMentions.size)
+                repeat(amountToRemove) {
                     contributorMentions.removeLastOrNull()
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -302,8 +302,8 @@ object ContributorManager {
     }
 
     private fun isContributorMentionMessage(message: String): Boolean {
-        if (message.contains(CONTRIBUTOR_ACHIEVEMENT_GOT)) return true
-        if (message.contains(FOUND_WILD_CONTRIBUTOR)) return true
+        if (message.startsWith(CONTRIBUTOR_ACHIEVEMENT_GOT)) return true
+        if (message.startsWith(FOUND_WILD_CONTRIBUTOR)) return true
 
         val msg = message.lowercase()
         return contribMentionPattern.find(msg)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -55,8 +55,7 @@ object ContributorManager {
     var contributorNames = emptyList<String>()
         private set
     private var namesToUuid = emptyMap<String, UUID>()
-    var isContributor: Boolean? = null
-        private set
+    private var isContributor: Boolean? = null
 
     private val seenContributors get() = SkyHanniMod.seenContributorStorage.seenContributors
     private val contributorMentions get() = SkyHanniMod.seenContributorStorage.contributorMentions

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -212,7 +212,7 @@ object ContributorManager {
             return
         }
         ChatUtils.clickableLinkChat(
-            "If you need support, please do not contact contributors directly. \n" +
+            "If you need support, please do not contact contributors directly.\n" +
                 "You can report issues or get help on the SkyHanni Discord.\n ",
             "https://discord.gg/skyhanni-997079228510117908",
             prefixColor = "§c"

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -62,7 +62,7 @@ object ContributorManager {
     private val contributorMentions get() = SkyHanniMod.seenContributorStorage.contributorMentions
     private val contributorMentionersThisSession = mutableSetOf<String>()
 
-    private const val CONTRIBUTOR_ACHIEVEMENT_GOT = "[SkyHanni] Achievement Get! EEEEKK!"
+    private const val CONTRIBUTOR_ACHIEVEMENT_GOT = "[SkyHanni] Achievement Get! EEEEKK!!"
     private const val FOUND_WILD_CONTRIBUTOR = "A wild SkyHanni contributor appears!"
     private val patternGroup = RepoPattern.group("contributor")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -225,9 +225,8 @@ object ContributorManager {
                 ChatUtils.chat {
                     append("Seen contributors (${seenContributors.size}):\n")
                     appendWithColor(
-                        seenContributors.keys
-                            .mapNotNull(::getDisplayNameFromUUID)
-                            .joinToString("\n"),
+                        seenContributors.keys.joinToString("\n")
+                            { uuid -> getDisplayNameFromUUID(uuid) ?: uuid.toString() },
                         ChatFormatting.AQUA,
                     )
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -1,22 +1,37 @@
 package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.SkyHanniMod.launch
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.achievements.Achievement
+import at.hannibal2.skyhanni.config.ConfigFileType
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
+import at.hannibal2.skyhanni.config.commands.brigadier.PlayerSuggestions
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.ComponentArgumentType
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.PlayerArgumentType
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.UuidArgumentType
+import at.hannibal2.skyhanni.data.hypixel.chat.event.PlayerAllChatEvent
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ContributorJsonEntry
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ContributorsJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.achievements.AchievementRegistrationEvent
 import at.hannibal2.skyhanni.events.entity.EntityDisplayNameEvent
-import at.hannibal2.skyhanni.features.achievements.AchievementManager
+import at.hannibal2.skyhanni.features.achievements.ContributorAchievement
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.chat.TextHelper
-import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.PlayerUtils
+import at.hannibal2.skyhanni.utils.RegexUtils.find
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.mapKeysNotNull
 import at.hannibal2.skyhanni.utils.compat.append
+import at.hannibal2.skyhanni.utils.compat.appendWithColor
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
-import at.hannibal2.skyhanni.utils.compat.withColor
+import at.hannibal2.skyhanni.utils.compat.hover
+import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.ChatFormatting
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.player.Player
 import java.util.UUID
@@ -25,14 +40,48 @@ import java.util.UUID
 object ContributorManager {
     private val config get() = SkyHanniMod.feature.dev
 
-    var contributors: Map<UUID, ContributorJsonEntry> = emptyMap()
-        private set
+    var contributors = emptyMap<UUID, ContributorJsonEntry>()
+        private set(value) {
+            field = value
+            namesToUuid = value.entries
+                .mapNotNull { (uuid, entry) ->
+                    entry.displayName?.let { it to uuid }
+                }
+                .toMap()
+            contributorNames = namesToUuid.keys.toList()
+            isContributor = null
+        }
+    // Do not modify these: they are automatically updated when the contributors map is updated
     var contributorNames = emptyList<String>()
         private set
+    private var namesToUuid = emptyMap<String, UUID>()
+    var isContributor: Boolean? = null
+        private set
+
+    private val seenContributors get() = SkyHanniMod.seenContributorStorage.seenContributors
+    private val contributorMentions get() = SkyHanniMod.seenContributorStorage.contributorMentions
+    private val contributorMentionersThisSession = mutableSetOf<String>()
+
+    private const val CONTRIBUTOR_ACHIEVEMENT_GOT = "[SkyHanni] Achievement Get! EEEEKK!"
+    private const val FOUND_WILD_CONTRIBUTOR = "A wild SkyHanni contributor appears!"
+    private val patternGroup = RepoPattern.group("contributor")
+
+    /**
+     * REGEX-TEST: skyhanni dev
+     * REGEX-TEST: skyhani contributor
+     * REGEX-TEST: skyhanni devs are the best
+     * REGEX-TEST: sh dev in the house
+     */
+    private val contribMentionPattern by patternGroup.pattern(
+        "mention",
+        """\b(?:skyhanni|skyhani|sh).*\b(?:dev\w*|contrib\w*)\b"""
+    )
+
+    private val repoReloadCoroutine = CoroutineSettings("contributor list repo reload")
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
-        val map = event.getConstant<ContributorsJson>("ContributorList").contributors
+    fun onRepoReload(event: RepositoryReloadEvent) = repoReloadCoroutine.launch {
+        val map = event.getConstantAsync<ContributorsJson>("ContributorList").contributors
 
         contributors = map.mapKeysNotNull {
             try {
@@ -46,45 +95,236 @@ object ContributorManager {
                 null
             }
         }
-        contributorNames = map.values.mapNotNull { it.displayName }
+    }
+
+    // <editor-fold desc="Commands">
+    @HandleEvent
+    fun onCommand(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shlistseencontributors") {
+            description = "List all contributors you've seen in chat or in nametags"
+            category = CommandCategory.USERS_ACTIVE
+            simpleCallback { listSeenContributors() }
+        }
+
+        event.registerBrigadier("shresetseencontributors") {
+            description = "Reset the list of seen contributors"
+            category = CommandCategory.USERS_RESET
+            simpleCallback { resetSeenContributors() }
+        }
+
+        event.registerBrigadier("shtestcontributor") {
+            description = "Manage contributors: add or remove"
+            category = CommandCategory.DEVELOPER_TEST
+
+            literal("add") {
+                literal("player") {
+                    arg(
+                        "username",
+                        PlayerArgumentType.player(),
+                        PlayerSuggestions.builder {
+                            include(PlayerNameSource.ISLAND_PLAYERS)
+                            filterNot { it in contributorNames }
+                            include(PlayerNameSource.SELF)
+                        },
+                    ) { playerRef ->
+                        callback {
+                            val gameProfile = getArg(playerRef).gameProfile
+                            addTestContributor(gameProfile.id, gameProfile.name, null)
+                        }
+                        argCallback("suffix", ComponentArgumentType.component(allowPlainText = true)) { suffix ->
+                            val gameProfile = getArg(playerRef).gameProfile
+                            addTestContributor(gameProfile.id, gameProfile.name, suffix)
+                        }
+                    }
+                }
+                literal("uuid") {
+                    arg("uuid", UuidArgumentType.uuid()) { uuidRef ->
+                        arg("displayName", BrigadierArguments.string()) { displayNameRef ->
+                            callback {
+                                addTestContributor(
+                                    getArg(uuidRef),
+                                    getArg(displayNameRef),
+                                    null,
+                                )
+                            }
+                            argCallback("suffix", ComponentArgumentType.component(allowPlainText = true)) { suffix ->
+                                addTestContributor(
+                                    getArg(uuidRef),
+                                    getArg(displayNameRef),
+                                    suffix,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            literal("remove") {
+                argCallback("name", BrigadierArguments.string(), contributorNames) { name ->
+                    removeTestContributor(name)
+                }
+            }
+        }
+
+        event.registerBrigadier("shaddcontributormention") {
+            description = "Add a contributor mention to the counter."
+            category = CommandCategory.DEVELOPER_DEBUG
+            simpleCallback { addContributorMention() }
+            argCallback("amount", BrigadierArguments.integer(1)) { amount ->
+                addContributorMention(amount)
+            }
+        }
+    }
+
+    private fun addTestContributor(uuid: UUID, displayName: String, suffix: Component?) {
+        val alreadyExists = contributors.containsKey(uuid)
+
+        val testEntry = ContributorJsonEntry(
+            displayName = displayName,
+            componentSuffix = suffix
+        )
+        contributors = contributors + (uuid to testEntry)
+
+        ChatUtils.chat {
+            append(if (alreadyExists) "Test contributor updated: " else "Test contributor added: ")
+            appendWithColor(displayName, ChatFormatting.AQUA)
+            appendWithColor(" (UUID: $uuid)", ChatFormatting.GRAY)
+        }
+    }
+
+    private fun removeTestContributor(displayName: String) {
+        val uuidToRemove = contributors.entries.find { it.value.displayName == displayName }?.key
+        if (uuidToRemove == null) {
+            ChatUtils.userError("Contributor not found: $displayName")
+            return
+        }
+        contributors = contributors.filterKeys { it != uuidToRemove }
+
+        ChatUtils.chat {
+            append("Test contributor removed: ")
+            appendWithColor(displayName, ChatFormatting.AQUA)
+        }
+    }
+
+    private fun listSeenContributors() {
+        if (seenContributors.isEmpty()) {
+            ChatUtils.chat("You haven't seen any contributors yet.")
+            return
+        }
+        ChatUtils.clickableLinkChat(
+            "If you need support, please do not contact contributors directly. \n" +
+                "You can report issues or get help on the SkyHanni Discord.\n ",
+            "https://discord.gg/skyhanni-997079228510117908",
+            prefixColor = "§c"
+        )
+        ChatUtils.clickableChat(
+            "[View seen contributors]",
+            oneTimeClick = true,
+            prefix = false,
+            onClick = {
+                ChatUtils.chat {
+                    append("Seen contributors (${seenContributors.size}):\n")
+                    appendWithColor(
+                        seenContributors.keys
+                            .mapNotNull(::getDisplayNameFromUUID)
+                            .joinToString("\n"),
+                        ChatFormatting.AQUA,
+                    )
+                }
+            },
+            hover = "§eClick to view contributors you've encountered."
+        )
+    }
+
+    private fun resetSeenContributors() {
+        ChatUtils.clickableChat(
+            "Are you sure you want to clear the list of seen contributors? This cannot be undone.",
+            oneTimeClick = true,
+            onClick = {
+                seenContributors.clear()
+                saveConfig("cleared seen contributors list")
+                ChatUtils.chat {
+                    appendWithColor("Seen contributors list cleared.", ChatFormatting.GREEN)
+                }
+            },
+            hover = "§eClick to confirm clearing the seen contributors list."
+        )
+    }
+    // </editor-fold>
+
+    @HandleEvent
+    fun onPlayerAllChat(event: PlayerAllChatEvent.Allow) {
+        if (!isSelfContributor()) return
+        if (!config.contributorMentionTracker) return
+        val msg = event.messageComponent.getText()
+        if (!isContributorMentionMessage(msg)) return
+        val author = event.author
+        // This also counts the current player themselves
+        if (author in contributorNames) return
+        if (!contributorMentionersThisSession.add(author)) return
+
+        ChatUtils.clickableChat(
+            "Hey people seem to be talking about you, want to increment the popularity counter?",
+            oneTimeClick = true,
+            onClick = { addContributorMention() },
+            hover = "§eClick to add this EEEEKK occurrence!",
+        )
+    }
+
+    private fun addContributorMention(amount: Int = 1) {
+        if (!isSelfContributor()) {
+            ChatUtils.userError("Only contributors can add contributor mentions to the counter.")
+            return
+        }
+        val ts = SimpleTimeMark.now()
+        repeat(amount) {
+            contributorMentions.addLast(ts)
+        }
+        ChatUtils.chat("Total contributor mentions: ${contributorMentions.size}")
+        saveConfig("added contributor mention record")
+    }
+
+    private fun isContributorMentionMessage(message: String): Boolean {
+        if (message.contains(CONTRIBUTOR_ACHIEVEMENT_GOT)) return true
+        if (message.contains(FOUND_WILD_CONTRIBUTOR)) return true
+
+        val msg = message.lowercase()
+        return contribMentionPattern.find(msg)
     }
 
     @HandleEvent
     fun onRenderNametag(event: EntityDisplayNameEvent<Player>) {
-        if (!config.contributorNametags) return
-
         val gameProfile = event.entity.gameProfile
         getSuffix(gameProfile.id)?.let {
-            AchievementManager.completeAchievement(CONTRIBUTOR_ACHIEVEMENT)
+            recordSeenContributor(gameProfile.id, gameProfile.name)
+            if (!config.contributorNametags) return
             event.chatComponent.append(it)
         }
     }
 
-    private const val CONTRIBUTOR_ACHIEVEMENT = "Contrib Achievement"
+    private fun recordSeenContributor(uuid: UUID, username: String) {
+        if (uuid == PlayerUtils.getRawUuid()) return
+        if (uuid in seenContributors) return
+        seenContributors[uuid] = SimpleTimeMark.now()
 
-    @HandleEvent
-    fun onAchievementRegistration(event: AchievementRegistrationEvent) {
-        val achievement = Achievement(
-            "EEEEKK!".asComponent(),
-            componentBuilder {
-                append("Be in the same lobby as a")
-                append(" SkyHanni ") {
-                    withColor(TextHelper.chromaStyle)
+        if (config.discoverContributorMessage) {
+            ChatUtils.chat {
+                appendWithColor(FOUND_WILD_CONTRIBUTOR, ChatFormatting.GOLD)
+                appendWithColor(" (hover)", ChatFormatting.GRAY)
+                hover = componentBuilder {
+                    appendWithColor("You have encountered ", ChatFormatting.GRAY)
+                    appendWithColor(username, ChatFormatting.AQUA)
+                    appendWithColor(" for the first time!", ChatFormatting.GRAY)
                 }
-                append("contributor")
-            }
-        )
-        event.register(achievement, CONTRIBUTOR_ACHIEVEMENT)
-    }
-
-    fun getUUIDFromDisplayName(displayName: String): UUID? {
-        for ((uuid, entry) in contributors.entries) {
-            if (entry.displayName == displayName) {
-                return uuid
             }
         }
-        return null
+
+        saveConfig("added new seen contributor")
+        ContributorAchievement.onUniqueContributorSeen()
     }
+
+    fun getDisplayNameFromUUID(uuid: UUID): String? = contributors[uuid]?.displayName
+    fun getUUIDFromDisplayName(displayName: String): UUID? = namesToUuid[displayName]
 
     fun getSuffix(uuid: UUID): Component? {
         return contributors[uuid]?.componentSuffix ?: Component.literal(contributors[uuid]?.suffix ?: return null)
@@ -92,4 +332,21 @@ object ContributorManager {
 
     fun shouldSpin(uuid: UUID): Boolean = contributors[uuid]?.spinny ?: false
     fun shouldBeUpsideDown(uuid: UUID): Boolean = contributors[uuid]?.upsideDown ?: false
+
+    // Due to using PlayerUtils.getRawUuid(), this will only work if logged in
+    // which is why it HAS to be a lazy-loaded value instead of being calculated on repo load
+    fun isSelfContributor(): Boolean {
+        isContributor?.let { return it }
+
+        val result = PlayerUtils.getRawUuid() in contributors
+        isContributor = result
+        return result
+    }
+
+    private fun saveConfig(reason: String) {
+        SkyHanniMod.configManager.saveConfig(
+            ConfigFileType.SEEN_CONTRIBUTORS,
+            reason
+        )
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -266,7 +266,7 @@ object ContributorManager {
             "Hey people seem to be talking about you, want to increment the popularity counter?",
             oneTimeClick = true,
             onClick = { addContributorMention() },
-            hover = "§eClick to add this EEEEKK occurrence!",
+            hover = "§eClick to add this contributor mention",
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -5,11 +5,13 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
+import at.hannibal2.skyhanni.config.commands.brigadier.PlayerSuggestions
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerNameSource
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.AllEntitiesGetter
@@ -184,7 +186,15 @@ object MarkedPlayerManager {
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shmarkplayer") {
             description = "Add a highlight effect to a player for better visibility"
-            argCallback("name", BrigadierArguments.string()) { displayName ->
+            argCallback(
+                "name",
+                BrigadierArguments.string(),
+                PlayerSuggestions.builder {
+                    includeAllSources()
+                    includePlayers(playerNamesToMark)
+                    exclude(PlayerNameSource.SELF)
+                },
+            ) { displayName ->
                 val name = displayName.lowercase()
 
                 if (name == PlayerUtils.getName().lowercase()) {

--- a/src/main/java/at/hannibal2/skyhanni/shader/RobloxReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/shader/RobloxReminder.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.OSUtils
-import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
@@ -88,7 +87,7 @@ object RobloxReminder {
     }
 
     // Tech-savvy ppl who have debug enabled should have fun as well :)
-    private fun isContributor() = PlayerUtils.getRawUuid() in ContributorManager.contributors || SkyBlockUtils.debug
+    private fun isContributor() = ContributorManager.isSelfContributor() || SkyBlockUtils.debug
 
     private fun robuxError() {
         if (!TimeUtils.isAprilFoolsDay) return

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.ErrorManagerJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.RepoErrorData
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.achievements.AchievementRegistrationEvent
-import at.hannibal2.skyhanni.events.minecraft.ClientConnectEvent
 import at.hannibal2.skyhanni.features.achievements.AchievementManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -30,6 +29,7 @@ import net.minecraft.client.Minecraft
 import kotlin.time.Duration.Companion.minutes
 
 /** Crashes if [value] is false and in developer environment */
+@Suppress("unused")
 fun requireDevEnv(value: Boolean) = requireDevEnv(value, null)
 
 /** Crashes if [value] is false and in developer environment */
@@ -130,7 +130,7 @@ object ErrorManager {
         val achievement = Achievement(
             "I'm Helping!!!".asComponent(),
             "Copy an error message to the clipboard to help the developers fix it.".asComponent(),
-            100f
+            100f,
         )
         event.register(achievement, COPY_ERROR_ACHIEVEMENT)
     }
@@ -368,7 +368,7 @@ object ErrorManager {
         } catch (e: NullPointerException) {
             ChatUtils.chat(
                 "§cFailed to format error message! " +
-                    "Probably a JSON error in ChangedChatErrorsJson. Please report this on the discord."
+                    "Probably a JSON error in ChangedChatErrorsJson. Please report this on the discord.",
             )
             // can not use error manager inside error manager
             Error("Failed to format error message", e).printStackTrace()

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -161,8 +161,9 @@ object ErrorManager {
                 if (copied) {
                     AchievementManager.completeAchievement(COPY_ERROR_ACHIEVEMENT)
                     "$name copied into the clipboard, please report it on the SkyHanni discord!"
+                } else {
+                    "$name could not be copied to clipboard!"
                 }
-                else "$name could not be copied to clipboard!"
             } ?: "Error id not found!",
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -6,17 +6,21 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.MinecraftData
+import at.hannibal2.skyhanni.data.achievements.Achievement
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ChangedChatErrorsJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ErrorManagerJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.RepoErrorData
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.achievements.AchievementRegistrationEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientConnectEvent
+import at.hannibal2.skyhanni.features.achievements.AchievementManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ClipboardUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
@@ -119,6 +123,17 @@ object ErrorManager {
         }
     }
 
+    private const val COPY_ERROR_ACHIEVEMENT = "Copy Error"
+
+    @HandleEvent
+    fun onAchievementRegistration(event: AchievementRegistrationEvent) {
+        val achievement = Achievement(
+            "I'm Helping!!!".asComponent(),
+            "Copy an error message to the clipboard to help the developers fix it.".asComponent(),
+            100f
+        )
+        event.register(achievement, COPY_ERROR_ACHIEVEMENT)
+    }
 
     // Extra data from last thrown error
     private var cachedExtraData: String? = null
@@ -143,7 +158,10 @@ object ErrorManager {
         ChatUtils.chat(
             errorMessage?.let {
                 val copied = ClipboardUtils.copyToClipboardAsync(it).await() ?: false
-                if (copied) "$name copied into the clipboard, please report it on the SkyHanni discord!"
+                if (copied) {
+                    AchievementManager.completeAchievement(COPY_ERROR_ACHIEVEMENT)
+                    "$name copied into the clipboard, please report it on the SkyHanni discord!"
+                }
                 else "$name could not be copied to clipboard!"
             } ?: "Error id not found!",
         )


### PR DESCRIPTION
## What
Store the seen contributors in a new storage just for them, also eeek occurrences.

## Changelog Improvements
+ Improved Command Tab Completion to include Carry Customers. - AverageUser125
+ Improved `/shmarkplayer` player completion. - AverageUser125
    
## Changelog Fixes
+ Fixed SkyHanni command arguments containing quotes getting truncated. - AverageUser125

## Changelog New Features
+ Added a chat message when you encounter a SkyHanni contributor for the first time. - AverageUser125

## Changelog Technical Details
+ Added storage for seen SkyHanni contributors. - AverageUser125
+ Added storage for tracking timestamps of when another player mentioned a SkyHanni contributor in chat (only active for contributor players). - AverageUser125
+ Added Component, UUID, and Player Brigadier Argument types. - AverageUser125