### PR TITLE
Fix: DA Item Display with non-last no bid item

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/DarkAuctionItemDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/DarkAuctionItemDisplay.kt
@@ -30,10 +30,11 @@ object DarkAuctionItemDisplay {
     /**
      * REGEX-TEST: [NPC] Sirius: The highest bidder was qtLuna with a bid of 25,950,000 Coins!
      * REGEX-TEST: [NPC] Sirius: No one made any bids!
+     * REGEX-TEST: [NPC] Sirius: No one made any bids! Let's move on to the next item.
      */
     private val highestBidPattern by patternGroup.pattern(
         "highest-bid",
-        "\\[NPC] Sirius: (?:The highest bidder was \\w+ with a bid of [\\d,]+ Coins|No one made any bids)!",
+        "\\[NPC] Sirius: (?:The highest bidder was \\w+ with a bid of [\\d,]+ Coins!|No one made any bids!.*)",
     )
 
     private var lastItem: String? = null


### PR DESCRIPTION
## What
So apparently this message does exist, I thought they changed it.

## Changelog Fixes
+ Fixed Dark Auction Item Display not working if no one made any bids and it's not the last item in the auction. - Luna
