### PR TITLE
Fix: Visual Words compatibility with Caxton

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiChatHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiChatHook.kt
@@ -9,6 +9,7 @@ object GuiChatHook {
     @JvmStatic
     var currentComponent: Component? = null
 
+    @JvmStatic
     var replacementComponent: Component? = null
 
     fun replaceEntireComponent(title: String, chatStyle: Style) {
@@ -23,6 +24,7 @@ object GuiChatHook {
         replacementComponent = component
     }
 
+    @JvmStatic
     fun getReplacement(): Component {
         return replacementComponent ?: "No replacement component was set".asComponent()
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/VisualWordsHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/VisualWordsHook.kt
@@ -2,22 +2,30 @@ package at.hannibal2.skyhanni.mixins.hooks
 
 import at.hannibal2.skyhanni.features.misc.visualwords.ModifyVisualWords
 import at.hannibal2.skyhanni.utils.compat.OrderedTextUtils
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import net.minecraft.network.chat.FormattedText
 import net.minecraft.util.FormattedCharSequence
 
 object VisualWordsHook {
+    @JvmStatic
+    @get:JvmName("isCaxtonLoaded")
+    val caxtonLoaded by lazy { PlatformUtils.isModInstalled("caxton") }
 
+    @JvmStatic
     fun modifyOrderedText(value: FormattedCharSequence): FormattedCharSequence =
         ModifyVisualWords.transformText(value) ?: value
 
+    @JvmStatic
     fun modifyString(value: String): String {
         val replaced = ModifyVisualWords.transformText(OrderedTextUtils.legacyTextToOrderedText(value)) ?: return value
         return OrderedTextUtils.orderedTextToLegacyString(replaced)
     }
 
+    @JvmStatic
     fun modifyFormattedText(value: FormattedText): FormattedText =
         ModifyVisualWords.transformFormattedText(value) ?: value
 
+    @JvmStatic
     fun <T> withoutWordChanges(block: () -> T): T {
         ModifyVisualWords.changeWords = false
         try {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinFont.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinFont.java
@@ -9,33 +9,33 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(Font.class)
-public class MixinTextRenderer {
+public class MixinFont {
 
     //? if < 1.21.11 {
     @ModifyVariable(method = "prepareText(Lnet/minecraft/util/FormattedCharSequence;FFIZI)Lnet/minecraft/client/gui/Font$PreparedText;", index = 1, at = @At("HEAD"), argsOnly = true)
     //?} else
     //@ModifyVariable(method = "prepareText(Lnet/minecraft/util/FormattedCharSequence;FFIZZI)Lnet/minecraft/client/gui/Font$PreparedText;", index = 1, at = @At("HEAD"), argsOnly = true)
     private FormattedCharSequence modifyOrderedText(FormattedCharSequence value) {
-        return VisualWordsHook.INSTANCE.modifyOrderedText(value);
+        return VisualWordsHook.modifyOrderedText(value);
     }
 
     @ModifyVariable(method = "prepareText(Ljava/lang/String;FFIZI)Lnet/minecraft/client/gui/Font$PreparedText;", index = 1, at = @At("HEAD"), argsOnly = true)
     private String modifyString(String value) {
-        return VisualWordsHook.INSTANCE.modifyString(value);
+        return VisualWordsHook.modifyString(value);
     }
 
     @ModifyVariable(method = "width(Lnet/minecraft/util/FormattedCharSequence;)I", index = 1, at = @At("HEAD"), argsOnly = true)
     private FormattedCharSequence modifyWidthOrderedText(FormattedCharSequence value) {
-        return VisualWordsHook.INSTANCE.modifyOrderedText(value);
+        return VisualWordsHook.modifyOrderedText(value);
     }
 
     @ModifyVariable(method = "width(Ljava/lang/String;)I", index = 1, at = @At("HEAD"), argsOnly = true)
     private String modifyWidthString(String value) {
-        return VisualWordsHook.INSTANCE.modifyString(value);
+        return VisualWordsHook.modifyString(value);
     }
 
     @ModifyVariable(method = "width(Lnet/minecraft/network/chat/FormattedText;)I", index = 1, at = @At("HEAD"), argsOnly = true)
     private FormattedText modifyWidthFormattedText(FormattedText value) {
-        return VisualWordsHook.INSTANCE.modifyFormattedText(value);
+        return VisualWordsHook.modifyFormattedText(value);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinFont.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinFont.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(Font.class)
-public class MixinFont {
+public abstract class MixinFont {
 
     //? if < 1.21.11 {
     @ModifyVariable(method = "prepareText(Lnet/minecraft/util/FormattedCharSequence;FFIZI)Lnet/minecraft/client/gui/Font$PreparedText;", index = 1, at = @At("HEAD"), argsOnly = true)

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiGraphics.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiGraphics.java
@@ -43,7 +43,8 @@ public abstract class MixinGuiGraphics {
         return GuiChatHook.getReplacementComponent() != null ? GuiChatHook.getReplacement() : originalComponent;
     }
 
-    @ModifyArg(
+    //? if > 1.21.10 {
+    /*@ModifyArg(
         method = "drawString(Lnet/minecraft/client/gui/Font;Lnet/minecraft/util/FormattedCharSequence;IIIZ)V",
         at = @At(
             value = "INVOKE",
@@ -66,6 +67,6 @@ public abstract class MixinGuiGraphics {
             false,
             textState.scissor
         );
-    }
+    }*///?}
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiGraphics.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiGraphics.java
@@ -3,10 +3,13 @@ package at.hannibal2.skyhanni.mixins.transformers;
 import at.hannibal2.skyhanni.events.ChatHoverEvent;
 import at.hannibal2.skyhanni.mixins.hooks.GuiChatHook;
 import at.hannibal2.skyhanni.mixins.hooks.RenderItemHookKt;
+import at.hannibal2.skyhanni.mixins.hooks.VisualWordsHook;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.render.state.GuiTextRenderState;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.Style;
+import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -17,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GuiGraphics.class)
-public class MixinDrawContext {
+public abstract class MixinGuiGraphics {
 
     @Inject(method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V", at = @At("RETURN"))
     private void drawItemPost(LivingEntity entity, Level world, ItemStack stack, int x, int y, int seed, CallbackInfo ci) {
@@ -31,13 +34,38 @@ public class MixinDrawContext {
 
     @Inject(method = "renderComponentHoverEffect", at = @At(value = "INVOKE", target = "Ljava/util/Objects;requireNonNull(Ljava/lang/Object;)Ljava/lang/Object;", shift = At.Shift.AFTER))
     private void onRenderComponentHoverEffect(Font font, Style style, int i, int j, CallbackInfo ci) {
-        GuiChatHook.INSTANCE.setReplacementComponent(null);
+        GuiChatHook.setReplacementComponent(null);
         new ChatHoverEvent(style.getHoverEvent()).post();
     }
 
     @ModifyArg(method = "renderComponentHoverEffect", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Font;split(Lnet/minecraft/network/chat/FormattedText;I)Ljava/util/List;"), index = 0)
     private FormattedText replaceWithNewList(FormattedText originalComponent) {
-        return GuiChatHook.INSTANCE.getReplacementComponent() != null ? GuiChatHook.INSTANCE.getReplacement() : originalComponent;
+        return GuiChatHook.getReplacementComponent() != null ? GuiChatHook.getReplacement() : originalComponent;
+    }
+
+    @ModifyArg(
+        method = "drawString(Lnet/minecraft/client/gui/Font;Lnet/minecraft/util/FormattedCharSequence;IIIZ)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/render/state/GuiRenderState;submitText(Lnet/minecraft/client/gui/render/state/GuiTextRenderState;)V"
+        ),
+        index = 0
+    )
+    private GuiTextRenderState modifyVisualWordsTextState(GuiTextRenderState textState) {
+        if (!VisualWordsHook.isCaxtonLoaded()) return textState;
+        FormattedCharSequence text = VisualWordsHook.modifyOrderedText(textState.text);
+        return text == textState.text ? textState : new GuiTextRenderState(
+            textState.font,
+            text,
+            textState.pose,
+            textState.x,
+            textState.y,
+            textState.color,
+            textState.backgroundColor,
+            textState.dropShadow,
+            false,
+            textState.scissor
+        );
     }
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinStringSplitter.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinStringSplitter.java
@@ -15,7 +15,7 @@ import java.util.List;
 //import java.util.function.BiConsumer;
 
 @Mixin(StringSplitter.class)
-public class MixinStringSplitter {
+public abstract class MixinStringSplitter {
 
     //? if < 1.21.11 {
     @WrapMethod(

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinStringSplitter.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinStringSplitter.java
@@ -15,7 +15,7 @@ import java.util.List;
 //import java.util.function.BiConsumer;
 
 @Mixin(StringSplitter.class)
-public class MixinTextHandler {
+public class MixinStringSplitter {
 
     //? if < 1.21.11 {
     @WrapMethod(
@@ -30,7 +30,7 @@ public class MixinTextHandler {
         method = "splitLines(Lnet/minecraft/network/chat/FormattedText;ILnet/minecraft/network/chat/Style;)Ljava/util/List;"
     )
     private List<FormattedText> dontWrapOtherLines(FormattedText text, int maxWidth, Style style, Operation<List<FormattedText>> original) {
-        return VisualWordsHook.INSTANCE.withoutWordChanges(() -> original.call(text, maxWidth, style));
+        return VisualWordsHook.withoutWordChanges(() -> original.call(text, maxWidth, style));
     }
 
     @ModifyVariable(
@@ -40,7 +40,7 @@ public class MixinTextHandler {
         argsOnly = true
     )
     private FormattedText modifyStringVisitable(FormattedText visitable) {
-        return VisualWordsHook.INSTANCE.modifyFormattedText(visitable);
+        return VisualWordsHook.modifyFormattedText(visitable);
     }
 
 }


### PR DESCRIPTION
## What
Adds an additional mixin that only runs when Caxton is installed, so that Visual Words continues to work with it. This seems like the safest approach right now without a bigger rewrite of the functionality that could potentially break things for players without Caxton.

Includes some general style cleanup in modified files.

## Changelog Fixes
+ Fixed Visual Words not working with the Caxton mod installed. - Luna