### PR TITLE
Fix: Extend Barn Bounds to full plot

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -13,7 +13,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = SkyHanniLogger("ConfigMigration")
-    const val CONFIG_VERSION = 133
+    const val CONFIG_VERSION = 134
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/KeyBindConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/KeyBindConfig.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.utils.KeyboardManager
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
@@ -46,9 +47,23 @@ class KeyBindConfig {
     var sunsGrasp: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Exclude Barn", desc = "Disable this feature while on the barn plot.")
+    @ConfigOption(name = "Exclude Barn", desc = "Disable this feature while on the main barn area, or the whole barn plot.")
+    @ConfigEditorDropdown
+    var excludeBarn: ExcludeBarn = ExcludeBarn.OFF
+
+    enum class ExcludeBarn(private val displayName: String) {
+        OFF("Off"),
+        MAIN("Main Barn Area"),
+        FULL("Full Barn Plot"),
+        ;
+
+        override fun toString() = displayName
+    }
+
+    @Expose
+    @ConfigOption(name = "Exclude Greenhouse", desc = "Disable this feature while on a greenhouse plot.")
     @ConfigEditorBoolean
-    var excludeBarn: Boolean = false
+    var excludeGreenhouse: Boolean = true
 
     @ConfigOption(name = "Disable All", desc = "Disable all keys.")
     @ConfigEditorButton(buttonText = "Disable")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -88,7 +88,7 @@ object GardenApi {
             }
         }
     private val cropIconCache = TimeLimitedCache<String, ItemStack>(10.minutes)
-    val barnArea = AABB(35.5, 70.0, -4.5, -32.5, 100.0, -46.5)
+    val barnArea = AABB(47.5, 67.0, 47.5, -47.5, 180.0, -47.5)
     private var gardenExpTiers = emptyList<Int>()
     private var extraFarmingTools = emptySet<NeuInternalName>()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -74,9 +74,11 @@ object GardenApi {
     var lastCropBrokenTime = SimpleTimeMark.farPast()
     val mushroomCowPet
         get() = CurrentPetApi.isCurrentPetOrHigherRarity(RARE_MOOSHROOM_COW_PET)
-    private var inBarn = false
-    val onBarnPlot get() = inBarn && inGarden()
-    val onUnfarmablePlot get() = inGarden() && (inBarn || GardenPlotApi.inGreenhouse())
+    private var inBarnPlot = false
+    private var inMainBarn = false
+    val onBarnPlot get() = inBarnPlot && inGarden()
+    val onMainBarn get() = inMainBarn && inGarden()
+    val onUnfarmablePlot get() = inGarden() && (inMainBarn || GardenPlotApi.inGreenhouse())
     val storage get() = ProfileStorageData.profileSpecific?.garden
     val config get() = SkyHanniMod.feature.garden
     var totalAmountVisitorsExisting = 0
@@ -88,7 +90,8 @@ object GardenApi {
             }
         }
     private val cropIconCache = TimeLimitedCache<String, ItemStack>(10.minutes)
-    val barnArea = AABB(47.5, 67.0, 47.5, -47.5, 180.0, -47.5)
+    val barnPlotArea = AABB(47.5, 67.0, 47.5, -47.5, 180.0, -47.5)
+    val mainBarnArea = AABB(35.5, 67.0, -4.5, -32.5, 100.0, -46.5)
     private var gardenExpTiers = emptyList<Int>()
     private var extraFarmingTools = emptySet<NeuInternalName>()
 
@@ -112,7 +115,8 @@ object GardenApi {
     fun onTick(event: SkyHanniTickEvent) {
         if (!inGarden()) return
         if (event.isMod(10, 1)) {
-            inBarn = barnArea.isPlayerInside()
+            inMainBarn = mainBarnArea.isPlayerInside()
+            inBarnPlot = barnPlotArea.isPlayerInside()
             if (cropInHand.isTimeFlower()) checkItemInHand()
 
             // We ignore random hypixel moments

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -2,14 +2,17 @@ package at.hannibal2.skyhanni.features.garden.farming
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.config.features.garden.KeyBindConfig
+import at.hannibal2.skyhanni.config.features.garden.KeyBindConfig.ExcludeBarn
 import at.hannibal2.skyhanni.features.fishing.FishingApi.isFishingRod
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.GardenApi.isFarmingTool
+import at.hannibal2.skyhanni.features.garden.GardenPlotApi
 import at.hannibal2.skyhanni.features.inventory.EquipmentApi
 import at.hannibal2.skyhanni.features.inventory.EquipmentSlot
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.KeyboardManager
@@ -166,7 +169,9 @@ object GardenCustomKeybinds {
     private fun isEnabled(): Boolean =
         GardenApi.inGarden() &&
             config.enabled &&
-            !(GardenApi.onUnfarmablePlot && config.excludeBarn)
+            !(GardenPlotApi.inGreenhouse() && config.excludeGreenhouse) &&
+            !(GardenApi.onMainBarn && config.excludeBarn == KeyBindConfig.ExcludeBarn.MAIN) &&
+            !(GardenApi.onBarnPlot && config.excludeBarn == KeyBindConfig.ExcludeBarn.FULL)
 
     private fun isHoldingTool(): Boolean = InventoryUtils.getItemInHand()?.let { heldItem ->
         val internalName = heldItem.getInternalName()
@@ -226,5 +231,8 @@ object GardenCustomKeybinds {
         event.move(3, "garden.keyBindBack", "garden.keyBind.back")
         event.move(3, "garden.keyBindJump", "garden.keyBind.jump")
         event.move(3, "garden.keyBindSneak", "garden.keyBind.sneak")
+        event.transform(134, "garden.keyBind.excludeBarn") {
+            ConfigUtils.migrateBooleanToEnum(it, ExcludeBarn.MAIN, ExcludeBarn.OFF)
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorChat.kt
@@ -115,7 +115,7 @@ object GardenVisitorChat {
      * Used as fallback when tab list hasn't updated yet.
      */
     private fun doesVisitorEntityExist(name: String) =
-        EntityUtils.getEntitiesInBoundingBox<RemotePlayer>(GardenApi.barnArea).any {
+        EntityUtils.getEntitiesInBoundingBox<RemotePlayer>(GardenApi.mainBarnArea).any {
             it.name.formattedTextCompatLessResets().trim().equals(name, true)
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorDropStatistics.kt
@@ -134,7 +134,7 @@ object GardenVisitorDropStatistics {
 
     @HandleEvent
     fun onVisitorAccept(event: VisitorAcceptEvent) {
-        if (!GardenApi.onBarnPlot) return
+        if (!GardenApi.onMainBarn) return
         if (!ProfileStorageData.loaded) return
         val storage = GardenApi.storage?.visitorDrops ?: return
 
@@ -147,7 +147,7 @@ object GardenVisitorDropStatistics {
 
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent.Allow) {
-        if (!GardenApi.onBarnPlot) return
+        if (!GardenApi.onMainBarn) return
         if (!ProfileStorageData.loaded) return
         if (lastAccept.passedSince() > 1.seconds) return
 
@@ -293,7 +293,7 @@ object GardenVisitorDropStatistics {
     fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.enabled.get()) return
         if (GardenApi.hideExtraGuis()) return
-        if (config.onlyOnBarn.get() && !GardenApi.onBarnPlot) return
+        if (config.onlyOnBarn.get() && !GardenApi.onMainBarn) return
         config.pos.renderRenderables(display, posLabel = "Visitor Stats")
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorShoppingList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorShoppingList.kt
@@ -322,7 +322,7 @@ object GardenVisitorShoppingList {
         if (config.inFarmingAreas && IslandType.THE_FARMING_ISLANDS.isInIsland()) return true
         if (hideExtraGuis()) return false
         if (GardenApi.inGarden()) {
-            if (GardenApi.onBarnPlot) return true
+            if (GardenApi.onMainBarn) return true
             if (!config.onlyWhenClose) return true
         }
         return false

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorStatus.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorStatus.kt
@@ -38,14 +38,14 @@ object GardenVisitorStatus {
         ) return
         if (!event.isMod(10, 2)) return
 
-        if (GardenApi.onBarnPlot) {
+        if (GardenApi.onMainBarn) {
             checkVisitorsReady()
         }
     }
 
     @HandleEvent(OwnInventoryItemUpdateEvent::class)
     fun onOwnInventoryItemUpdate() {
-        if (GardenApi.onBarnPlot) {
+        if (GardenApi.onMainBarn) {
             update()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/NpcVisitorFix.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/NpcVisitorFix.kt
@@ -95,7 +95,7 @@ object NpcVisitorFix {
     }
 
     private fun findNametags(visitorName: String): MutableList<ArmorStand> {
-        return EntityUtils.getEntitiesInBoundingBox<ArmorStand>(GardenApi.barnArea) {
+        return EntityUtils.getEntitiesInBoundingBox<ArmorStand>(GardenApi.mainBarnArea) {
             it.name.string.removeColor() == visitorName
         }.toMutableList()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
@@ -128,7 +128,7 @@ object VisitorListener {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onTooltip(event: ToolTipEvent) {
-        if (!GardenApi.onBarnPlot) return
+        if (!GardenApi.onMainBarn) return
         if (!VisitorApi.inInventory) return
         val visitor = VisitorApi.getVisitor(lastClickedNpc) ?: return
 
@@ -137,7 +137,7 @@ object VisitorListener {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
-        if (!GardenApi.onBarnPlot) return
+        if (!GardenApi.onMainBarn) return
         if (config.highlightStatus != VisitorConfig.HighlightMode.NAME && config.highlightStatus != VisitorConfig.HighlightMode.BOTH) return
 
         val entity = event.entity
@@ -148,7 +148,7 @@ object VisitorListener {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
-        if (!GardenApi.onBarnPlot) return
+        if (!GardenApi.onMainBarn) return
         if (config.highlightStatus != VisitorConfig.HighlightMode.NAME && config.highlightStatus != VisitorConfig.HighlightMode.BOTH) return
 
         for (visitor in VisitorApi.getVisitors()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorRewardWarning.kt
@@ -88,7 +88,7 @@ object VisitorRewardWarning {
 
     @HandleEvent(priority = HandleEvent.HIGH)
     fun onTooltip(event: ToolTipTextEvent) {
-        if (!GardenApi.onBarnPlot) return
+        if (!GardenApi.onMainBarn) return
         if (!VisitorApi.inInventory) return
         val visitor = VisitorApi.getVisitor(lastClickedNpc) ?: return
         if (config.bypassKey.isKeyHeld()) return


### PR DESCRIPTION
## What
Extends the bounds of the barn plot in the code to cover the entire barn plot. Fixes any issues with custom keybinds not being disabled in certain parts of the barn or visitors not being found if below the accepted y-level.

## Changelog Fixes
+ Fixed Visitors not being detected below Y=70. - BonkersTurnip
+ Fixed Custom Keybinds not being disabled in the majority of the Barn plot even when Exclude Barn was enabled. - BonkersTurnip