### PR TITLE
Backend: Fix Harvest Feast debug data

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
@@ -117,9 +117,12 @@ object HarvestFeastManager {
     fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Harvest Feast Data")
 
+        val now = SkyBlockTime.now()
+
         if (currentFeastData == null) {
-            val now = SkyBlockTime.now()
             event.addIrrelevant("Harvest Feast data is null for year ${now.year} and month ${now.month}.")
+        } else {
+            event.addIrrelevant("Harvest Feast data was successfully loaded for year ${now.year} and month ${now.month}.")
         }
 
         // TODO: Add more debug


### PR DESCRIPTION
## What
```
SkyHanni 7.22.0 1.21.11: Caught a IllegalStateException in at.hannibal2.skyhanni.features.event.spook.TheGreatSpook.onDebug(at.hannibal2.skyhanni.events.DebugDataCollectEvent) at DebugDataCollectEvent: DebugDataCollectEvent duplicate titles and no data in between
 
Caused by java.lang.IllegalStateException: DebugDataCollectEvent duplicate titles and no data in between
	at SH.test.command.ErrorManager.skyHanniError(ErrorManager.kt:132)
	at SH.events.DebugDataCollectEvent.title(DebugDataCollectEvent.kt:15)
	at SH.features.event.spook.TheGreatSpook.onDebug(TheGreatSpook.kt:229)
<Skyhanni event post>

Extra data:
current title: 'Harvest Feast Data'
new title: 'Great Spook'
[...]
[SkyHanni] [SkyHanni/7.22.0] 33 more errors in DebugDataCollectEvent are hidden!
```

## Changelog Technical Details
+ Fixed Harvest Feast declaring a debug title but no data when we have active feast data, causing errors when using /shdebug. - Luna
