### PR TITLE
Improvement: Add Harvest Feast rare crops to Pest Profit Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -163,6 +163,14 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
 
     private fun SprayType.addSprayUsed() = modify { it.spraysUsed.addOrPut(this, 1) }
 
+    fun addRareCropDrop(drop: RareCropTracker.RareCropDropType) {
+        if (!drop.canDropFromPests) return
+        if (!PestApi.hasVacuumInHand() && !PestApi.hasLassoInHand()) return
+
+        val internalName = NeuInternalName.fromItemNameOrInternalName(drop.itemName)
+        addItem(drop.pestType ?: PestType.UNKNOWN, internalName, 1, command = false)
+    }
+
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onItemAdd(event: ItemAddEvent) {
         if (config.enabled && event.source == ItemAddManager.Source.COMMAND) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/RareCropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/RareCropTracker.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.GardenApi
+import at.hannibal2.skyhanni.features.garden.pests.PestType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
@@ -77,33 +78,38 @@ object RareCropTracker {
         tracker.initRenderer({ config.position }) { shouldShowDisplay() }
     }
 
-    enum class RareCropDropType(val dropName: String, private val messageName: String) {
-        CROPIE("§aCropie", "Cropie"),
-        SQUASH("§9Squash", "Squash"),
-        FERMENTO("§5Fermento", "Fermento"),
-        HELIANTHUS("§6Helianthus", "Helianthus"),
-        SEASONING("§2Seasoning", "Seasoning"),
-        CORNUCOPIA("§aCornucopia", "Cornucopia"),
-        CARROT_ZEST("§aCarrot Zest", "Carrot Zest"),
-        DEEPFRIES("§aDeepfries", "Deepfries"),
-        AGGOURDIAN("§aAggourdian", "Aggourdian"),
-        CANE_KNOT("§aCane Knot", "Cane Knot"),
-        MELON_JUICE("§aMelon Juice", "Melon Juice"),
-        CACTUS_FLOWER("§aCactus Flower", "Cactus Flower"),
-        DESIGNER_COFFEE_BEANS("§aDesigner Coffee Beans", "Designer Coffee Beans"),
-        FEASTFUNGUS("§aFeastfungus", "Feastfungus"),
-        BOTROOT("§aBotroot", "Botroot"),
-        SALTED_SUNFLOWER_SEEDS("§aSalted Sunflower Seeds", "Salted Sunflower Seeds"),
-        CRYSTALIZED_MOONLIGHT("§aCrystalized Moonlight", "Crystalized Moonlight"),
-        FLORAL_GELATIN("§aFloral Gelatin", "Floral Gelatin"),
-        RAREFINDER_CHIP("§9Rarefinder Chip", "Rarefinder Chip"),
-        BURROWING_SPORES("§9Burrowing Spores", "Burrowing Spores"),
-        WARTY("§5Warty", "Warty"),
+    enum class RareCropDropType(
+        val dropName: String,
+        val pestType: PestType? = null,
+    ) {
+        CROPIE("§aCropie"),
+        SQUASH("§9Squash"),
+        FERMENTO("§5Fermento"),
+        HELIANTHUS("§6Helianthus"),
+        SEASONING("§2Seasoning"),
+        CORNUCOPIA("§aCornucopia", PestType.FLY),
+        CARROT_ZEST("§aCarrot Zest", PestType.CRICKET),
+        DEEPFRIES("§aDeepfries", PestType.LOCUST),
+        AGGOURDIAN("§aAggourdian", PestType.RAT),
+        CANE_KNOT("§aCane Knot", PestType.MOSQUITO),
+        MELON_JUICE("§aMelon Juice", PestType.EARTHWORM),
+        CACTUS_FLOWER("§aCactus Flower", PestType.MITE),
+        DESIGNER_COFFEE_BEANS("§aDesigner Coffee Beans", PestType.MOTH),
+        FEASTFUNGUS("§aFeastfungus", PestType.SLUG),
+        BOTROOT("§aBotroot", PestType.BEETLE),
+        SALTED_SUNFLOWER_SEEDS("§aSalted Sunflower Seeds", PestType.DRAGONFLY),
+        CRYSTALIZED_MOONLIGHT("§aCrystalized Moonlight", PestType.FIREFLY),
+        FLORAL_GELATIN("§aFloral Gelatin", PestType.PRAYING_MANTIS),
+        RAREFINDER_CHIP("§9Rarefinder Chip"),
+        BURROWING_SPORES("§9Burrowing Spores"),
+        WARTY("§5Warty"),
         ;
+
+        val canDropFromPests: Boolean = pestType != null
 
         val chatPattern by patternGroup.pattern(
             name.lowercase().replace('_', '-'),
-            "(?:§.)*(?:VERY )?RARE CROP! (?:§.)*$messageName.*",
+            "(?:§.)*(?:VERY )?RARE CROP! (?:§.)*${dropName.removeColor()}.*",
         )
     }
 
@@ -112,6 +118,7 @@ object RareCropTracker {
         for (dropType in RareCropDropType.entries) {
             if (!dropType.chatPattern.matches(event.message)) continue
             addDrop(dropType)
+            PestProfitTracker.addRareCropDrop(dropType)
             if (config.hideChat) {
                 event.blockedReason = "rare_crop_tracker"
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/RareCropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/RareCropTracker.kt
@@ -78,10 +78,7 @@ object RareCropTracker {
         tracker.initRenderer({ config.position }) { shouldShowDisplay() }
     }
 
-    enum class RareCropDropType(
-        val dropName: String,
-        val pestType: PestType? = null,
-    ) {
+    enum class RareCropDropType(val dropName: String, val pestType: PestType? = null) {
         CROPIE("§aCropie"),
         SQUASH("§9Squash"),
         FERMENTO("§5Fermento"),


### PR DESCRIPTION
## What
Adds Harvest Feast rare crop drops to the Pest Profit Tracker if the player is holding a vacuum or a lasso at the time they gain the drop.

## Changelog Improvements
+ Harvest Feast rare crops are now added to the Pest Profit Tracker if you get them from pests. - Luna
    * Please let us know if it fails to track, e.g. if you switch off your vacuum/lasso too early.

