### PR TITLE
Fix: Pest Spawn Detection on Barn Plot

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -24,39 +24,39 @@ object PestSpawn {
     private val patternGroup = RepoPattern.group("garden.pests.spawn")
 
     /**
-     * REGEX-TEST: §6§lGROSS! §7A §2ൠ Pest §7has appeared in §aPlot §7- §bS 4§7!
+     * REGEX-TEST: GROSS! A ൠ Pest has appeared in Plot - S 4!
      */
     private val onePestPattern by patternGroup.pattern(
-        "one",
-        "§6§l.*! §7A §2ൠ Pest §7has appeared in §aPlot §7- §b(?<plot>.*)§7!",
+        "one.colorless",
+        ".*! A ൠ Pest has appeared in Plot - (?<plot>.*)!",
     )
 
     /**
-     * REGEX-TEST: §6§lYUCK! §24 §2ൠ Pest §7have spawned in §aPlot §7- §b14§7!
+     * REGEX-TEST: YUCK! 4 ൠ Pest have spawned in Plot - 14!
      */
     private val multiplePestsPattern by patternGroup.pattern(
-        "multiple",
-        "§6§l.*! §2(?<amount>\\d) §2ൠ Pests? §7have spawned in §aPlot §7- §b(?<plot>.*)§7!",
+        "multiple.colorless",
+        ".*! (?<amount>\\d) ൠ Pests? have spawned in Plot - (?<plot>.*)!",
     )
 
     /**
-     * REGEX-TEST: §6§lGROSS! §7While you were offline, §2ൠ §2Pest §7spawned in §aPlots §r§b12§r§7, §r§b9§r§7, §r§b5§r§7, §r§b11§r§7 and §r§b3§r§r§7!
+     * REGEX-TEST: GROSS! While you were offline, ൠ Pest spawned in Plots 12, 9, 5, 11 and 3!
      */
     private val offlinePestsPattern by patternGroup.pattern(
-        "offline",
-        "§6§l.*! §7While you were offline, §2ൠ §2Pests? §7spawned in §aPlots (?<plots>.*)!",
+        "offline.colorless",
+        ".*! While you were offline, ൠ Pests? spawned in Plots (?<plots>.*)!",
     )
     /**
-     * WRAPPED-REGEX-TEST: "  §r§e§lCLICK HERE §eto teleport to the plot!"
+     * WRAPPED-REGEX-TEST: "  CLICK HERE to teleport to the plot!"
      */
     private val clickToTPPattern by patternGroup.pattern(
-        "teleport",
-        "\\s*§r§e§lCLICK HERE §eto teleport to the plot!",
+        "teleport.colorless",
+        "\\s*CLICK HERE to teleport to the plot!",
     )
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onChat(event: SkyHanniChatEvent.Allow) {
-        val message = event.message
+        val message = event.cleanMessage
         var blocked = false
 
         onePestPattern.matchMatcher(message) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -36,6 +36,7 @@ object PestSpawn {
 
     /**
      * REGEX-TEST: YUCK! 4 ൠ Pest have spawned in Plot - 14!
+     * REGEX-TEST: YUCK! 4 ൠ Pest have spawned in The Barn!
      */
     private val multiplePestsPattern by patternGroup.list(
         "multiple.colorless",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -25,18 +26,21 @@ object PestSpawn {
 
     /**
      * REGEX-TEST: GROSS! A ൠ Pest has appeared in Plot - S 4!
+     * REGEX-TEST: GROSS! A ൠ Pest has appeared in The Barn!
      */
-    private val onePestPattern by patternGroup.pattern(
+    private val onePestPattern by patternGroup.list(
         "one.colorless",
         ".*! A ൠ Pest has appeared in Plot - (?<plot>.*)!",
+        ".*! A ൠ Pest has appeared in (?<plot>The Barn)!",
     )
 
     /**
      * REGEX-TEST: YUCK! 4 ൠ Pest have spawned in Plot - 14!
      */
-    private val multiplePestsPattern by patternGroup.pattern(
+    private val multiplePestsPattern by patternGroup.list(
         "multiple.colorless",
         ".*! (?<amount>\\d) ൠ Pests? have spawned in Plot - (?<plot>.*)!",
+        ".*! (?<amount>\\d) ൠ Pests? have spawned in (?<plot>The Barn)!",
     )
 
     /**
@@ -59,11 +63,11 @@ object PestSpawn {
         val message = event.cleanMessage
         var blocked = false
 
-        onePestPattern.matchMatcher(message) {
+        onePestPattern.matchMatchers(message) {
             spawn(1, listOf(group("plot")))
             blocked = true
         }
-        multiplePestsPattern.matchMatcher(message) {
+        multiplePestsPattern.matchMatchers(message) {
             spawn(group("amount").toInt(), listOf(group("plot")))
             blocked = true
         }
@@ -96,12 +100,13 @@ object PestSpawn {
         }
 
         if (config.chatMessageFormat == PestSpawnConfig.ChatMessageFormatEntry.COMPACT) {
+            val tpName = if (plotName == "The Barn") "barn" else plotName
             ChatUtils.clickableChat(
                 message,
                 onClick = {
-                    HypixelCommands.teleportToPlot(plotName)
+                    HypixelCommands.teleportToPlot(tpName)
                 },
-                "§eClick to run /plottp $plotName!",
+                "§eClick to run /plottp $tpName!",
             )
         }
     }


### PR DESCRIPTION
## What
This is an extremely niche case, but it was broken again a while back after I fixed it ages ago. Nowadays you might not even be able to spawn a pest there without using the Disco Destination item, but it can't hurt to support it.

## Changelog Fixes
+ Fixed pest spawns on the barn plot not being properly detected. - Luna
