### PR TITLE
Improvement + Fix: Harvest Feast Visitor Drops + Charmed Visitor Rewards

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -13,7 +13,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = SkyHanniLogger("ConfigMigration")
-    const val CONFIG_VERSION = 133
+    const val CONFIG_VERSION = 134
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/DropsStatisticsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/visitor/DropsStatisticsConfig.kt
@@ -45,6 +45,12 @@ class DropsStatisticsConfig {
             DropsStatisticsTextEntry.VOTER_BADGE_VIP,
             DropsStatisticsTextEntry.VOTER_BADGE_ELITE,
             DropsStatisticsTextEntry.VOTER_BADGE_SUPREME,
+            DropsStatisticsTextEntry.VISITORS_GRATITUDE,
+            DropsStatisticsTextEntry.FARMING_CONTEST_DISPLAY,
+            DropsStatisticsTextEntry.ASTRONAUT_PERSONALITY,
+            DropsStatisticsTextEntry.FAST_FOOD_BARN_SKIN,
+            DropsStatisticsTextEntry.JELLY_GREENHOUSE_SKIN,
+
         )
     )
 
@@ -96,6 +102,11 @@ class DropsStatisticsConfig {
         CASHMERE_JACKET("§b6 §9Cashmere Jacket"),
         SATIN_TROUSERS("§b4 §9Satin Trousers"),
         OXFORD_SHOES("§b7 §9Oxford Shoes"),
+        VISITORS_GRATITUDE("§b7 §fVisitors' Gratitude"),
+        FARMING_CONTEST_DISPLAY("§b3 §aFarming Contest Display"),
+        ASTRONAUT_PERSONALITY("§b1 §fAstronaut Minion Skin"),
+        FAST_FOOD_BARN_SKIN("§b2 §6Fast Food Barn Skin"),
+        JELLY_GREENHOUSE_SKIN("§b2 §6Jelly Garden Greenhouse Skin"),
         ;
 
         override fun toString() = displayName

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTooltip.kt
@@ -141,7 +141,8 @@ object GardenVisitorTooltip {
                 readingShoppingList = false
             }
 
-            val (itemName, amount) = ItemUtils.readItemAmount(formattedLine) ?: continue
+            val itemLine = if (readingShoppingList) formattedLine else formattedLine.removeCharmedSuffix()
+            val (itemName, amount) = ItemUtils.readItemAmount(itemLine) ?: continue
             val internalName = NeuInternalName.fromItemNameOrNull(itemName.removeColor())
                 ?.replace("◆_", "") ?: continue
 
@@ -224,7 +225,8 @@ object GardenVisitorTooltip {
                 readingShoppingList = false
             }
 
-            val (itemName, amount) = ItemUtils.readItemAmount(formattedLine) ?: continue
+            val itemLine = if (readingShoppingList) formattedLine else formattedLine.removeCharmedSuffix()
+            val (itemName, amount) = ItemUtils.readItemAmount(itemLine) ?: continue
             val internalName = NeuInternalName.fromItemNameOrNull(itemName.removeColor())
                 ?.replace("◆_", "") ?: continue
 
@@ -263,6 +265,8 @@ object GardenVisitorTooltip {
 
         visitor.blockReason = visitor.blockReason()
     }
+
+    private fun String.removeCharmedSuffix() = removeSuffix(" §d❤")
 
     private fun getCropType(internalName: NeuInternalName) =
         CropType.getByNameOrNull(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorApi.kt
@@ -311,6 +311,17 @@ object VisitorApi {
         event.transform(124, "garden.visitors.rewardWarning.drops") { element ->
             element.addElementsAfter(arrayOf(VisitorReward.DYE_WILD_STRAWBERRY))
         }
+        event.transform(124, "garden.visitors.rewardWarning.drops") { element ->
+            element.addElementsAfter(
+                arrayOf(
+                    VisitorReward.VISITORS_GRATITUDE,
+                    VisitorReward.FARMING_CONTEST_DISPLAY,
+                    VisitorReward.ASTRONAUT_PERSONALITY,
+                    VisitorReward.FAST_FOOD_BARN_SKIN,
+                    VisitorReward.JELLY_GREENHOUSE_SKIN,
+                )
+            )
+        }
 
         event.move(18, "garden.visitors.needs", "garden.visitors.shoppingList")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorApi.kt
@@ -311,7 +311,7 @@ object VisitorApi {
         event.transform(124, "garden.visitors.rewardWarning.drops") { element ->
             element.addElementsAfter(arrayOf(VisitorReward.DYE_WILD_STRAWBERRY))
         }
-        event.transform(124, "garden.visitors.rewardWarning.drops") { element ->
+        event.transform(134, "garden.visitors.rewardWarning.drops") { element ->
             element.addElementsAfter(
                 arrayOf(
                     VisitorReward.VISITORS_GRATITUDE,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorReward.kt
@@ -35,6 +35,11 @@ enum class VisitorReward(rawInternalName: String, val displayName: String) {
     SATIN_TROUSERS("SATIN_TROUSERS", "§9Satin Trousers"),
     OXFORD_SHOES("OXFORD_SHOES", "§9Oxford Shoes"),
     CARNIVAL_TICKET("CARNIVAL_TICKET", "§aCarnival Ticket"),
+    VISITORS_GRATITUDE("VISITORS_GRATITUDE", "§fVisitors' Gratitude"),
+    FARMING_CONTEST_DISPLAY("FARMING_CONTEST_DISPLAY", "§aFarming Contest Display"),
+    ASTRONAUT_PERSONALITY("ASTRONAUT_PERSONALITY", "§fAstronaut Minion Skin"),
+    FAST_FOOD_BARN_SKIN("FAST_FOOD_BARN_SKIN", "§6Fast Food Barn Skin"),
+    JELLY_GREENHOUSE_SKIN("JELLY_GREENHOUSE_SKIN", "§6Jelly Garden Greenhouse Skin"),
     ;
 
     private val internalName = rawInternalName.toInternalName()

--- a/src/test/java/at/hannibal2/skyhanni/test/garden/GardenVisitorTooltipTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/garden/GardenVisitorTooltipTest.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.SkyHanniConfig
 import at.hannibal2.skyhanni.events.garden.visitor.VisitorOpenEvent
 import at.hannibal2.skyhanni.features.garden.visitor.GardenVisitorTooltip
 import at.hannibal2.skyhanni.features.garden.visitor.VisitorApi
+import at.hannibal2.skyhanni.features.garden.visitor.VisitorReward
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
@@ -12,6 +13,7 @@ import net.minecraft.world.item.Items
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -25,17 +27,20 @@ class GardenVisitorTooltipTest {
         SkyHanniMod.feature = SkyHanniConfig()
         SkyHanniMod.feature.garden.visitors.inventory.exactAmountAndTime = false
         SkyHanniMod.feature.garden.visitors.rewardWarning.notifyInChat = false
+        SkyHanniMod.feature.garden.visitors.rewardWarning.drops.add(VisitorReward.VISITORS_GRATITUDE)
         itemNameCache()["§9Enchanted Sugar Cane"] = "ENCHANTED_SUGAR_CANE".toInternalName()
+        itemNameCache()["Visitors' Gratitude"] = "VISITORS_GRATITUDE".toInternalName()
     }
 
     @AfterEach
     fun tearDown() {
         itemNameCache().remove("§9Enchanted Sugar Cane")
+        itemNameCache().remove("Visitors' Gratitude")
         SkyHanniMod.feature = oldConfig
     }
 
     @Test
-    fun `visitor tooltip parses copper line with heart suffix`() {
+    fun `visitor tooltip parses copper line and rare reward with heart suffix`() {
         val offerItem = ItemUtils.createItemStack(Items.GREEN_TERRACOTTA, "§aAccept Offer", spacemanLore)
         val visitor = VisitorApi.Visitor(
             visitorName = "§cSpaceman",
@@ -48,6 +53,8 @@ class GardenVisitorTooltipTest {
         }
 
         assertNotNull(visitor.pricePerCopper)
+        assertTrue("VISITORS_GRATITUDE".toInternalName() in visitor.allRewards)
+        assertTrue(VisitorReward.VISITORS_GRATITUDE in visitor.getRewardWarningAwards())
     }
 
     companion object {


### PR DESCRIPTION
## What
Adds new rare visitor rewards from Harvest Feast update, and fixes a potential issue in parsing visitor rewards – though it *may* have worked before since the NEU item resolution seems lenient.

## Changelog Improvements
+ Added tracking for the following rare visitor rewards: Visitors' Gratitude, Farming Contest Display, Astronaut Minion Skin, Fast Food Barn Skin, Jelly Garden Greenhouse Skin. - Luna

## Changelog Fixes
+ Fixed a potential issue with tracking item rewards from charmed visitors. - Luna