### PR TITLE
Improvement: Hotspot Tonic Mixin in Non God Pot Effect Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -22,6 +22,7 @@ enum class NonGodPotEffect(
     GLOWING_MUSH("Glowing Mush Mixin", true, displayName = "§2Glowing Mush Mixin"),
     HOT_CHOCOLATE("Hot Chocolate Mixin I", true, displayName = "§6Hot Chocolate Mixin I"),
     MASON_JAR("Celestial Mason Jar I", true, displayName = "§dCelestial Mason Jar Mixin"),
+    HOTSPOT_TONIC("Hotspot Tonic", true, displayName = "§2Hotspot Tonic Mixin"),
 
     DEEP_TERROR("Deepterror", true, displayName = "§4Deepterror"),
 


### PR DESCRIPTION
## What
What If...? is an American animated [anthology television series](https://en.wikipedia.org/wiki/Anthology_television_series) created by [A. C. Bradley](https://en.wikipedia.org/wiki/A._C._Bradley_(screenwriter)) for the streaming service [Disney+](https://en.wikipedia.org/wiki/Disney%2B), based on the [Marvel Comics](https://en.wikipedia.org/wiki/Marvel_Comics) series [of the same name](https://en.wikipedia.org/wiki/What_If_(comics)). It is [the fourth television series](https://en.wikipedia.org/wiki/List_of_Marvel_Cinematic_Universe_television_series_(Marvel_Studios)) in the [Marvel Cinematic Universe](https://en.wikipedia.org/wiki/Marvel_Cinematic_Universe) (MCU) from [Marvel Studios](https://en.wikipedia.org/wiki/Marvel_Studios), the first animated series from the studio, and the first series produced by [Marvel Studios Animation](https://en.wikipedia.org/wiki/Marvel_Studios_Animation). The series explores [alternate timelines](https://en.wikipedia.org/wiki/Alternate_history) in the [multiverse](https://en.wikipedia.org/wiki/Multiverse_(Marvel_Cinematic_Universe)) that show what would happen if major moments from [the MCU films](https://en.wikipedia.org/wiki/List_of_Marvel_Cinematic_Universe_films) occurred differently. Bradley served as [head writer](https://en.wikipedia.org/wiki/Head_writer) for the first two seasons, with [Matthew Chauncey](https://en.wikipedia.org/wiki/Matthew_Chauncey) taking over for the [third](https://en.wikipedia.org/wiki/What_If...%3F_season_3), and [Bryan Andrews](https://en.wikipedia.org/wiki/Bryan_Andrews_(filmmaker)) as the lead director.

This is a very huge pr, please review very carefully

## Changelog Improvements
+ Added the Hotspot Tonic Mixin to the Non-Godpot Effect Display Feature. - jani



