### PR TITLE
Fix: New Fairy Soul Detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -298,7 +298,7 @@ object FastFairySoulsPathfinder {
 
     @HandleEvent
     fun onSystemMessage(event: SystemMessageEvent.Allow) {
-        if (duplicatePattern.matches(event.chatComponent) || newPattern.matches(event.chatComponent)) {
+        if (duplicatePattern.matches(event.cleanMessage) || newPattern.matches(event.cleanMessage)) {
             data?.foundNearby()
         }
     }


### PR DESCRIPTION
## What
Hypixel uses legacy color codes directly, so matching the colorless regex against `chatComponent` was failing.

```
{"text":"§d§lSOUL! §fYou found a ","extra":[{"text":"§dFairy Soul","hover_event":{"value":{"text":"Exchange these with the ","extra":[{"text":"Fairy ","color":"#FF55FF","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},{"text":"in the\n","color":"#AAAAAA","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},{"text":"Wilderness","color":"#00AA00","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},{"text":".\n\n","color":"#AAAAAA","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},{"text":"Fairy Souls: ","color":"#AAAAAA","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},{"text":"8","color":"#FF55FF","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},{"text":"/","color":"#AAAAAA","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},{"text":"5\n","color":"#FF55FF","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},{"text":"Total Souls Collected: ","color":"#AAAAAA","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},{"text":"268","color":"#FF55FF","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false}],"color":"#AAAAAA","bold":false,"italic":false,"underlined":false,"strikethrough":false,"obfuscated":false},"action":"show_text"}},"§f!"]}
```

## Changelog Fixes
+ Fixed having to click Fairy Souls twice to mark them as found. - Luna