### PR TITLE
Fix: Hoppity unclaimed notification never sending after game restart

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggType.kt
@@ -56,7 +56,9 @@ enum class HoppityEggType(
 
     fun alreadyResetToday(): Boolean {
         val sbTimeNow = SkyBlockTime.now()
-        return lastReset.day == sbTimeNow.day && lastReset.month == sbTimeNow.month
+        return lastReset.year == sbTimeNow.year &&
+            lastReset.day == sbTimeNow.day &&
+            lastReset.month == sbTimeNow.month
     }
 
     private fun calculateNextSpawn(): SimpleTimeMark {
@@ -80,9 +82,9 @@ enum class HoppityEggType(
         }
     }
 
-    fun markClaimed(mark: SimpleTimeMark? = null) {
+    fun markClaimed(mark: SimpleTimeMark = SimpleTimeMark.now()) {
         claimed = true
-        mark?.let { profileStorage?.mealLastFound?.set(this, it) }
+        profileStorage?.mealLastFound?.set(this, mark)
     }
 
     fun markSpawned(setLastReset: Boolean = false) {
@@ -121,7 +123,7 @@ enum class HoppityEggType(
 
         fun markAllFound() = resettingEntries.forEach { it.markClaimed() }
         fun anyEggsUnclaimed(): Boolean = resettingEntries.any { !it.claimed }
-        fun allEggsUnclaimed(): Boolean = resettingEntries.all { !it.claimed }
+        fun allEggsUnclaimed(): Boolean = resettingEntries.all { !it.isClaimed() }
 
         internal fun Matcher.getEggType(event: SkyHanniChatEvent.Allow): HoppityEggType =
             entries.find { it.mealName == group("meal") } ?: run {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggsManager.kt
@@ -142,28 +142,32 @@ object HoppityEggsManager {
     private var lastMeal: HoppityEggType? = null
     private var lastNote: String? = null
 
-    // has claimed all eggs at least once
+    // Prevents warnings from firing on unknown startup state before any claim or observed rollover.
     private var warningActive = false
     private var lastWarnTime = SimpleTimeMark.farPast()
+    private val observedSpawnedEggs = mutableSetOf<HoppityEggType>()
 
     private var latestWaypointOnclick: () -> Unit = {}
     private var syncedFromConfig: Boolean = false
 
     @HandleEvent(ProfileJoinEvent::class)
     fun onProfileJoin() {
+        warningActive = false
+        lastWarnTime = SimpleTimeMark.farPast()
+        observedSpawnedEggs.clear()
         if (!HoppityApi.isHoppityEvent()) return
         resettingEntries.forEach {
             val lastFound = profileStorage?.mealLastFound?.get(it) ?: SimpleTimeMark.farFuture()
             if (lastFound.isInPast()) it.markClaimed(lastFound)
 
             val nextSpawn = profileStorage?.mealNextSpawn?.get(it) ?: SimpleTimeMark.farFuture()
-            if (nextSpawn.isInPast() && it.hasRemainingSpawns() && !it.hasNotFirstSpawnedYet()) it.markSpawned()
+            if (nextSpawn.isInPast() && it.hasRemainingSpawns() && !it.hasNotFirstSpawnedYet()) markObservedSpawned(it)
         }
     }
 
     @HandleEvent
     fun onEggSpawned(event: EggSpawnedEvent) {
-        event.eggType.markSpawned(setLastReset = true)
+        markObservedSpawned(event.eggType, setLastReset = true)
     }
 
     @HandleEvent
@@ -178,9 +182,16 @@ object HoppityEggsManager {
         profileStorage?.mealNextSpawn?.filter {
             it.value.isInPast()
         }?.keys?.forEach {
-            if (HoppityApi.isHoppityEvent()) it.markSpawned()
+            if (HoppityApi.isHoppityEvent()) markObservedSpawned(it)
         }
         syncedFromConfig = true
+    }
+
+    private fun markObservedSpawned(eggType: HoppityEggType, setLastReset: Boolean = false) {
+        if (HoppityApi.isHoppityEvent() && eggType.isResetting) {
+            observedSpawnedEggs.add(eggType)
+        }
+        eggType.markSpawned(setLastReset)
     }
 
     @HandleEvent
@@ -282,7 +293,9 @@ object HoppityEggsManager {
 
     private fun checkWarn() {
         val allEggsRemaining = HoppityEggType.allEggsUnclaimed()
-        if (!warningActive) warningActive = !allEggsRemaining
+        if (!warningActive) {
+            warningActive = !allEggsRemaining || observedSpawnedEggs.containsAll(resettingEntries)
+        }
 
         if (warningActive && allEggsRemaining) warn()
     }


### PR DESCRIPTION
## What
Fixes a long-standing annoyance with the Hoppity egg tracker where if you restart your game during a Hoppity's Hunt, all eggs show as unclaimed, but it never notifies you about unclaimed eggs until you manually collect at least a single egg – even after all 6 eggs have rolled over at least once. Also makes it properly persist claimed/unclaimed state across game restarts.

## Changelog Fixes
+ Fixed Hoppity's Hunt "Unclaimed Eggs" feature never sending a notification when you restart your game during a hunt and don't collect any eggs. - Luna