### PR TITLE
Fix: Update Trophy Hunter Armor check for tiered bonus

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfishing/TrophyFishDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfishing/TrophyFishDisplayConfig.kt
@@ -41,7 +41,7 @@ class TrophyFishDisplayConfig {
     var keybind: Int = GLFW.GLFW_KEY_UNKNOWN
 
     @Expose
-    @ConfigOption(name = "Hunter Armor", desc = "Only show when wearing a full Hunter Armor or Ember Armor.")
+    @ConfigOption(name = "Hunter Armor", desc = "Only show when wearing at least two matching Hunter Armor pieces or a full Ember Armor set.")
     @ConfigEditorBoolean
     val requireArmor: Property<Boolean> = Property.of(false)
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfishing/TrophyFishDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfishing/TrophyFishDisplayConfig.kt
@@ -41,7 +41,7 @@ class TrophyFishDisplayConfig {
     var keybind: Int = GLFW.GLFW_KEY_UNKNOWN
 
     @Expose
-    @ConfigOption(name = "Hunter Armor", desc = "Only show when wearing at least two matching Hunter Armor pieces or a full Ember Armor set.")
+    @ConfigOption(name = "Hunter Armor", desc = "Only show when wearing 2+ Hunter Armor pieces or full Ember Armor.")
     @ConfigEditorBoolean
     val requireArmor: Property<Boolean> = Property.of(false)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -77,7 +77,7 @@ object FishingApi {
      */
     private val trophyArmorNames by RepoPattern.pattern(
         "fishing.trophyfishing.armor",
-        "(?:BRONZE|SILVER|GOLD|DIAMOND)_HUNTER_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS)",
+        "(?<tier>BRONZE|SILVER|GOLD|DIAMOND)_HUNTER_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS)",
     )
 
     /**
@@ -340,9 +340,14 @@ object FishingApi {
     }
 
     private fun isWearingTrophyArmor(): Boolean =
-        InventoryUtils.getArmor().all {
-            trophyArmorNames.matches(it?.getInternalName()?.asString())
-        }
+        InventoryUtils.getArmor()
+            .mapNotNull { stack ->
+                val internalName = stack?.getInternalName()?.asString() ?: return@mapNotNull null
+                trophyArmorNames.matchMatcher(internalName) { group("tier") }
+            }
+            .groupingBy { it }
+            .eachCount()
+            .any { (_, count) -> count >= 2 }
 
     fun isWearingEmberArmor(): Boolean =
         InventoryUtils.getArmor().all {


### PR DESCRIPTION
## What
With the release of Lotus Atoll, Trophy Hunter Armor now only requires 2 matching pieces to trigger the Sea Creature immunity. I've changed the code to reflect this, and also making sure the pieces are actually matching, so e.g. wearing Bronze Hunter Helmet + Silver Hunter Chestplate doesn't trigger trophy fishing mode.

## Changelog Fixes
+ Updated trophy fishing detection to only require 2 pieces of Trophy Hunter Armor. - Luna