### PR TITLE
Backend + Fix: Update MoulConfig to 4.7.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 libautoupdate = "1.3.1"
-moulconfig = "4.5.0"
+moulconfig = "4.7.0"
 jbAnnotations = "24.1.0"
 hypixelmodapi = "1.0.2"
 hypixelmodapi-fabric = "1.0.1+build.1+mc1.21"


### PR DESCRIPTION
## What
Updates MoulConfig to 4.7.0, finally adding support for scrolling dropdown lists.

Credited to legentpc since he made the change that got merged in the end: NotEnoughUpdates/MoulConfig#83

## Changelog Fixes
+ Fixed not being able to scroll long dropdown lists in SkyHanni config. - legentpc

## Changelog Technical Details
+ Updated MoulConfig to 4.7.0. - Luna

