### PR TITLE
Fix: Track Locust Larva, Pesterminator & Sunset

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -75,6 +75,7 @@ object PestApi {
 
     fun hasVacuumInHand() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.VACUUM
     fun hasLassoInHand() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.LASSO
+    fun hasVacuumOrLassoInHand() = hasVacuumInHand() || hasLassoInHand()
     fun hasSprayonatorInHand() = InventoryUtils.itemInHandId == SPRAYONATOR_ITEM
 
     fun SprayType.getPests() = PestType.filterableEntries.filter { it.spray == this }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -151,7 +151,7 @@ object PestFinder {
     private fun shouldShowBasedOnHeldItem(): Boolean {
         return when (config.whenToShow) {
             WhenToShow.ALWAYS -> true
-            WhenToShow.BOTH -> PestApi.hasVacuumInHand() || PestApi.hasLassoInHand()
+            WhenToShow.BOTH -> PestApi.hasVacuumOrLassoInHand()
             WhenToShow.ONLY_WITH_VACUUM_IN_HAND -> PestApi.hasVacuumInHand()
             WhenToShow.ONLY_WITH_LASSO_IN_HAND -> PestApi.hasLassoInHand()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -202,7 +202,7 @@ enum class PestType(
             "BEADY_EYES" to FLY,
             "VINYL_PRETTY_FLY" to FLY,
             "ENCHANTED_HAY_BALE" to FLY,
-            // Old fly drops
+            // Old Fly drops
             "TIGHTLY_TIED_HAY_BALE" to FLY,
             "ENCHANTED_HAY_BLOCK" to FLY,
 
@@ -210,6 +210,8 @@ enum class PestType(
             "ENCHANTED_POTATO" to LOCUST,
             "VINYL_CICADA_SYMPHONY" to LOCUST,
             "ENCHANTED_BAKED_POTATO" to LOCUST,
+            "LOCUST_LARVA" to LOCUST,
+            // Old Locust drops
             "SUNDER;6" to LOCUST,
 
             // Mite deterministic drops
@@ -263,6 +265,9 @@ enum class PestType(
             "FIRE_IN_A_BOTTLE" to FIREFLY,
             "VINYL_FIREFLY" to FIREFLY,
 
+            // Lunar Moth deterministic drops
+            "ULTIMATE_SUNSET;1" to LUNAR_MOTH,
+
             // Spray drops only send chat message from mice
             "COMPOST" to FIELD_MOUSE,
             "HONEY_JAR" to FIELD_MOUSE,
@@ -277,6 +282,6 @@ enum class PestType(
             it.key.toInternalName() to it.value
         }.toMap()
 
-        fun getByInternalNameItemOrNull(internalName: NeuInternalName): PestType? = internalNameRareDropMap[internalName]
+        fun getByItemInternalNameOrNull(internalName: NeuInternalName): PestType? = internalNameRareDropMap[internalName]
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -33,6 +33,7 @@ import at.hannibal2.skyhanni.utils.ItemPriceSource
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalNames
 import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
@@ -111,6 +112,11 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     const val KILL_BITS = 5
     private val PEST_SHARD = "ATTRIBUTE_SHARD_PEST_LUCK;1".toInternalName()
 
+    private val noMessageDrops = setOf(
+        "PESTERMINATOR;1",
+        "ULTIMATE_SUNSET;1",
+    ).toInternalNames()
+
     data class BucketData(
         @Expose private var totalPestsKills: Long = 0L,
         @Expose var pestKills: MutableMap<PestType, Long> = EnumMap(PestType::class.java),
@@ -166,7 +172,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
 
     fun addRareCropDrop(drop: RareCropTracker.RareCropDropType) {
         if (!drop.canDropFromPests) return
-        if (!PestApi.hasVacuumInHand() && !PestApi.hasLassoInHand()) return
+        if (!PestApi.hasVacuumOrLassoInHand()) return
 
         val internalName = NeuInternalName.fromItemNameOrInternalName(drop.dropName)
         addItem(drop.pestType ?: PestType.UNKNOWN, internalName, 1, command = false)
@@ -176,6 +182,15 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     fun onItemAdd(event: ItemAddEvent) {
         if (config.enabled && event.source == ItemAddManager.Source.COMMAND) {
             event.addItemFromEvent()
+            return
+        }
+
+        if (event.source == ItemAddManager.Source.ITEM_ADD &&
+            event.internalName in noMessageDrops &&
+            PestApi.hasVacuumOrLassoInHand()
+        ) {
+            val pest = PestType.getByItemInternalNameOrNull(event.internalName) ?: return
+            addItem(pest, event.internalName, event.amount, false)
         }
     }
 
@@ -231,7 +246,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
         pestRareDropPattern.matchMatcher(message) {
             val itemGroup = group("item")
             val internalName = NeuInternalName.fromItemNameOrNull(itemGroup) ?: return
-            val pest = PestType.getByInternalNameItemOrNull(internalName) ?: return@matchMatcher
+            val pest = PestType.getByItemInternalNameOrNull(internalName) ?: return@matchMatcher
             val amount = groupOrNull("amount")?.toIntOrNull() ?: 1
 
             addItem(pest, internalName, amount, command = false)
@@ -395,7 +410,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
             oldItems.forEach { (neuInternalName, trackedItem) ->
                 val item = neuInternalName.toInternalName()
                 val pest = pestTypeMap.getOrPut(item) {
-                    PestType.getByInternalNameItemOrNull(item) ?: PestType.UNKNOWN
+                    PestType.getByItemInternalNameOrNull(item) ?: PestType.UNKNOWN
                 }
 
                 // If the map for the pest already contains this item, combine the amounts


### PR DESCRIPTION
## What
Fixes some pest drops not tracking – Locust Larva was just missing, while the other two were not being tracked because they don't have a message (Pesterminator used to, but not anymore, because it's above 5% base drop rate).

## Changelog Fixes
+ Fixed Locust Larva and Pesterminator & Sunset books not being tracked on Pest Profit Tracker. - Luna
