### PR TITLE
Fix: Don't fire ItemAddEvent for armor slots

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
@@ -35,7 +35,7 @@ object OwnInventoryData {
 
     private var itemAmounts = mapOf<NeuInternalName, Int>()
     private var dirty = false
-    private var lastWardrobeClose = SimpleTimeMark.farPast()
+    private val armorSlots = 36..39
 
     /**
      * REGEX-TEST: §aMoved §r§e10 Wheat§r§a from your Sacks to your inventory.
@@ -56,8 +56,10 @@ object OwnInventoryData {
             if (windowId == 0) {
                 val slot = packet.slot
                 val item = packet.item ?: return
-                DelayedRun.runNextTick {
-                    OwnInventoryItemUpdateEvent(item, slot).post()
+                if (slot !in armorSlots) {
+                    DelayedRun.runNextTick {
+                        OwnInventoryItemUpdateEvent(item, slot).post()
+                    }
                 }
             }
         }
@@ -81,32 +83,20 @@ object OwnInventoryData {
         if (!dirty) return
         dirty = false
 
-
-        val armorInternalNames = InventoryUtils.getArmorInternalNames()
-
-        if (lastWardrobeClose.passedSince() < 2.seconds) {
-            lastWardrobeClose = SimpleTimeMark.farPast()
-            for (name in armorInternalNames) {
-                ignoreItem(1.seconds, name)
-            }
-        }
-
-        val map = getCurrentItems(armorInternalNames)
+        val map = getCurrentItems()
         for ((internalName, amount) in map) {
             calculateDifference(internalName, amount)
         }
         itemAmounts = map
     }
 
-    private fun getCurrentItems(
-        armorInternalNames: Set<NeuInternalName> = InventoryUtils.getArmorInternalNames(),
-    ): MutableMap<NeuInternalName, Int> {
+    private fun getCurrentItems(): MutableMap<NeuInternalName, Int> {
         val map = mutableMapOf<NeuInternalName, Int>()
         for (itemStack in InventoryUtils.getItemsInOwnInventory()) {
             val internalName = itemStack.getInternalNameOrNull() ?: continue
             map.addOrPut(internalName, itemStack.count)
         }
-        for (name in armorInternalNames) {
+        for (name in InventoryUtils.getArmorInternalNames()) {
             map.addOrPut(name, 1)
         }
         return map
@@ -128,9 +118,6 @@ object OwnInventoryData {
 
     @HandleEvent(InventoryCloseEvent::class)
     fun onInventoryClose() {
-        if (InventoryUtils.openInventoryName().startsWith("Wardrobe")) {
-            lastWardrobeClose = SimpleTimeMark.now()
-        }
         val item = MinecraftCompat.localPlayerOrNull?.getItemOnCursor() ?: return
         val internalNameOrNull = item.getInternalNameOrNull() ?: return
         ignoreItem(500.milliseconds, internalNameOrNull)

--- a/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
@@ -3,14 +3,18 @@ package at.hannibal2.skyhanni.data
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.OwnInventoryArmorUpdateEvent
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.OwnInventoryMenuUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.ItemAddInInventoryEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketSentEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
@@ -35,7 +39,6 @@ object OwnInventoryData {
 
     private var itemAmounts = mapOf<NeuInternalName, Int>()
     private var dirty = false
-    private val armorSlots = 36..39
 
     /**
      * REGEX-TEST: §aMoved §r§e10 Wheat§r§a from your Sacks to your inventory.
@@ -48,19 +51,38 @@ object OwnInventoryData {
     @HandleEvent(priority = HandleEvent.LOW, receiveCancelled = true, onlyOnSkyblock = true)
     fun onItemPickupReceivePacket(event: PacketReceivedEvent) {
         val packet = event.packet
-        if (packet is ClientboundContainerSetSlotPacket || packet is ClientboundTakeItemEntityPacket) {
-            dirty = true
-        }
-        if (packet is ClientboundContainerSetSlotPacket) {
-            val windowId = packet.containerId
-            if (windowId == 0) {
+        when (packet) {
+            is ClientboundTakeItemEntityPacket -> {
+                dirty = true
+            }
+            is ClientboundContainerSetSlotPacket -> {
+                dirty = true
+
+                if (packet.containerId != 0) return
+
                 val slot = packet.slot
-                val item = packet.item ?: return
-                if (slot !in armorSlots) {
-                    DelayedRun.runNextTick {
-                        OwnInventoryItemUpdateEvent(item, slot).post()
+                val item = packet.item
+
+                DelayedRun.runNextTick {
+                    val internalName = item.getInternalName()
+                    when (slot) {
+                        in 0..4 -> {} // crafting output+grid
+                        in 5..8 -> { // armor
+                            ChatUtils.debug("OwnInventoryArmorUpdateEvent: $slot - $item - $internalName")
+                            OwnInventoryArmorUpdateEvent(item, slot).post()
+                        }
+                        in 9..43 -> { // normal items
+                            ChatUtils.debug("OwnInventoryItemUpdateEvent: $slot - $item - $internalName")
+                            OwnInventoryItemUpdateEvent(item, slot).post()
+                        }
+                        44 -> { // skyblock menu
+                            ChatUtils.debug("OwnInventoryMenuUpdateEvent: $slot - $item - $internalName")
+                            OwnInventoryMenuUpdateEvent(item).post()
+                        }
+                        45 -> {} // offhand
                     }
                 }
+
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/QuiverApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/QuiverApi.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.achievements.Achievement
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ArrowTypeJson
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
-import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.OwnInventoryMenuUpdateEvent
 import at.hannibal2.skyhanni.events.QuiverUpdateEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -259,8 +259,8 @@ object QuiverApi {
     }
 
     @HandleEvent
-    fun onInventoryUpdate(event: OwnInventoryItemUpdateEvent) {
-        if (!isEnabled() || event.slot != 44) return
+    fun onOwnInventoryMenuUpdate(event: OwnInventoryMenuUpdateEvent) {
+        if (!isEnabled()) return
         val stack = event.itemStack
         val lore = stack.getLoreComponent().map { it.string }
 

--- a/src/main/java/at/hannibal2/skyhanni/events/OwnInventoryItemUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/OwnInventoryItemUpdateEvent.kt
@@ -3,4 +3,8 @@ package at.hannibal2.skyhanni.events
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import net.minecraft.world.item.ItemStack
 
+data class OwnInventoryArmorUpdateEvent(val itemStack: ItemStack, val slot: Int) : SkyHanniEvent()
+
 data class OwnInventoryItemUpdateEvent(val itemStack: ItemStack, val slot: Int) : SkyHanniEvent()
+
+data class OwnInventoryMenuUpdateEvent(val itemStack: ItemStack) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.data.ClickType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ItemsJson
 import at.hannibal2.skyhanni.events.fishing.BaitUpdateEvent
 import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
-import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
+import at.hannibal2.skyhanni.events.OwnInventoryMenuUpdateEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
@@ -120,7 +120,6 @@ object FishingApi {
     private var waterRods = listOf<NeuInternalName>()
     private val TREASURE_HOOK = "TREASURE_HOOK".toInternalName()
 
-    private const val BAIT_SLOT = 44
     private const val BAIT_HOTBAR_INDEX = 8
 
     var bobber: FishingHook? = null
@@ -191,8 +190,7 @@ object FishingApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
-        if (event.slot != BAIT_SLOT) return
+    fun onOwnInventoryMenuUpdate(event: OwnInventoryMenuUpdateEvent) {
         extractAndPostBaitUpdate(event.itemStack)
     }
 


### PR DESCRIPTION
## What
Fixes some annoying bugs with profit trackers where certain armor pieces (e.g. Tiki Mask) and bait (if in repo profit items) would get falsely tracked. The latter is due to a recent Hypixel change of showing bait in slot 9.

## Changelog Fixes
+ Fixed profit trackers falsely reporting gaining an item when equipping it in your wardrobe (e.g. Tiki Mask) (hopefully). - Luna
+ Fixed fishing profit tracker falsely reporting gaining bait when using it. - Luna

## Changelog Technical Details
+ OwnInventoryItemUpdateEvent is now only posted for actual inventory slots, excluding armor slots and the last hotbar slot (SkyBlock Menu). - Luna
+ Added OwnInventoryArmorUpdateEvent for updates to the player's armor slots. - Luna
+ Added OwnInventoryMenuUpdateEvent for updates to the last hotbar slot (where the SkyBlock Menu generally resides). - Luna