### PR TITLE
Improvement: Add option to keep mouse locked on teleport

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -13,7 +13,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = SkyHanniLogger("ConfigMigration")
-    const val CONFIG_VERSION = 134
+    const val CONFIG_VERSION = 135
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.kt
@@ -133,6 +133,11 @@ class GardenConfig {
     val yawPitchDisplay: YawPitchDisplayConfig = YawPitchDisplayConfig()
 
     @Expose
+    @ConfigOption(name = "Mouse Lock", desc = "")
+    @Accordion
+    val mouseLock: MouseLockConfig = MouseLockConfig()
+
+    @Expose
     @ConfigOption(name = "Sensitivity Reducer", desc = "")
     @Accordion
     val sensitivityReducer: SensitivityReducerConfig = SensitivityReducerConfig()

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/MouseLockConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/MouseLockConfig.kt
@@ -1,0 +1,45 @@
+package at.hannibal2.skyhanni.config.features.garden
+
+import at.hannibal2.skyhanni.config.NoConfigLink
+import at.hannibal2.skyhanni.config.core.config.Position
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class MouseLockConfig {
+
+    @ConfigOption(
+        name = "Note",
+        desc = "You can use the §e/shmouselock §rcommand to lock and unlock your mouse rotation.",
+    )
+    @ConfigEditorInfoText
+    val notice: String = ""
+
+    @Expose
+    @ConfigOption(name = "Chat Message", desc = "Show a message in chat when toggling mouse lock.")
+    @ConfigEditorBoolean
+    var chatMessage: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Unlock on Teleport",
+        desc = "Choose whether teleporting to a plot should unlock your mouse rotation.",
+    )
+    @ConfigEditorDropdown
+    val unlockOnTeleport: UnlockOnTeleport = UnlockOnTeleport.ALWAYS
+
+    @Expose
+    @NoConfigLink
+    val display: Position = Position(400, 200, 0.8f)
+
+    enum class UnlockOnTeleport(private val displayName: String, val condition: (String) -> Boolean) {
+        ALWAYS("Always", { true }),
+        BARN_ONLY("Barn Only", { it == "The Barn" }),
+        NEVER("Never", { false }),
+        ;
+
+        override fun toString() = displayName
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -332,15 +332,6 @@ class MiscConfig {
     @FeatureToggle
     var lesserOrbHider: Boolean = false
 
-    @Expose
-    @ConfigOption(name = "Lock Mouse Message", desc = "Show a message in chat when toggling §e/shmouselock§7.")
-    @ConfigEditorBoolean
-    var lockMouseLookChatMessage: Boolean = true
-
-    @Expose
-    @NoConfigLink
-    val lockedMouseDisplay: Position = Position(400, 200, 0.8f)
-
     // doesn't work properly
     /*@ConfigOption(
         name = "Fix Ghost Entities",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.events.garden.PlotChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.garden.pests.PestApi
 import at.hannibal2.skyhanni.features.garden.pests.SprayType
-import at.hannibal2.skyhanni.features.garden.sensitivity.LockMouseLook
+import at.hannibal2.skyhanni.features.garden.sensitivity.MouseLock
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
@@ -292,11 +292,9 @@ object GardenPlotApi {
 
     fun getPlot(location: LorenzVec) = plots.find { it.box.isInside(location) }
 
-    fun Plot.sendTeleportTo() {
-        if (isBarn()) HypixelCommands.teleportToPlot("barn")
-        else HypixelCommands.teleportToPlot(name)
-        LockMouseLook.unlockMouse()
-    }
+    val Plot.tpName get() = if (isBarn()) "barn" else name
+
+    fun Plot.sendTeleportTo() = HypixelCommands.teleportToPlot(tpName)
 
     init {
         val plotMap = listOf(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
-import at.hannibal2.skyhanni.features.garden.sensitivity.MouseLock
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
@@ -45,14 +44,12 @@ object GardenWarpCommands {
         if (message == "/barn") {
             event.cancel()
             HypixelCommands.teleportToPlot("barn")
-            MouseLock.unlockMouse()
         }
 
         tpPlotPattern.matchMatcher(event.message) {
             event.cancel()
             val plotName = group("plot")
             HypixelCommands.teleportToPlot(plotName)
-            MouseLock.unlockMouse()
         }
     }
 
@@ -76,7 +73,6 @@ object GardenWarpCommands {
                 if (lastWarpTime.passedSince() < 2.seconds) return
                 lastWarpTime = SimpleTimeMark.now()
 
-                MouseLock.unlockMouse()
                 HypixelCommands.teleportToPlot("barn")
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
-import at.hannibal2.skyhanni.features.garden.sensitivity.LockMouseLook
+import at.hannibal2.skyhanni.features.garden.sensitivity.MouseLock
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
@@ -45,14 +45,14 @@ object GardenWarpCommands {
         if (message == "/barn") {
             event.cancel()
             HypixelCommands.teleportToPlot("barn")
-            LockMouseLook.unlockMouse()
+            MouseLock.unlockMouse()
         }
 
         tpPlotPattern.matchMatcher(event.message) {
             event.cancel()
             val plotName = group("plot")
             HypixelCommands.teleportToPlot(plotName)
-            LockMouseLook.unlockMouse()
+            MouseLock.unlockMouse()
         }
     }
 
@@ -76,7 +76,7 @@ object GardenWarpCommands {
                 if (lastWarpTime.passedSince() < 2.seconds) return
                 lastWarpTime = SimpleTimeMark.now()
 
-                LockMouseLook.unlockMouse()
+                MouseLock.unlockMouse()
                 HypixelCommands.teleportToPlot("barn")
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/MouseLock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/MouseLock.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.garden.sensitivity
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -80,5 +81,11 @@ object MouseLock {
                 if (isActive) unlockMouse() else lockMouse()
             }
         }
+    }
+
+    @HandleEvent
+    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+        event.move(135, "misc.lockMouseLookChatMessage", "garden.mouseLock.chatMessage")
+        event.move(135, "misc.lockedMouseDisplay", "garden.mouseLock.display")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/MouseLock.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/sensitivity/MouseLock.kt
@@ -8,23 +8,28 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
-object LockMouseLook {
+object MouseLock {
+
     /**
-     * REGEX-TEST: Teleported you to Plot
+     * REGEX-TEST: Teleported you to Plot - 1!
+     * REGEX-TEST: Teleported you to The Barn!
+     * REGEX-FAIL: Teleported you to the spawn location!
      */
-    private val gardenTeleportPattern by RepoPattern.pattern(
-        "chat.garden.teleport.colorless",
-        "Teleported you to .*",
+    private val gardenTeleportPattern by RepoPattern.list(
+        "chat.garden.teleport.list",
+        "Teleported you to Plot - (?<plot>.+)!",
+        "Teleported you to (?<plot>The Barn)!",
     )
 
-    private val config get() = SkyHanniMod.feature.misc
+    private val config get() = SkyHanniMod.feature.garden.mouseLock
     private val isActive get() = MouseSensitivityManager.SensitivityState.LOCKED.isActive()
     private val lockedRenderable by lazy { Renderable.text("§eMouse Locked") }
 
@@ -33,15 +38,19 @@ object LockMouseLook {
 
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent.Allow) {
-        if (!gardenTeleportPattern.matches(event.chatComponent)) return
-        unlockMouse()
+        gardenTeleportPattern.matchMatchers(event.cleanMessage) {
+            val plot = group("plot")
+            if (config.unlockOnTeleport.condition(plot)) {
+                DelayedRun.runNextTick(::unlockMouse)
+            }
+        }
     }
 
     fun unlockMouse() {
         if (!isActive) return
 
         MouseSensitivityManager.state = MouseSensitivityManager.SensitivityState.UNCHANGED
-        if (config.lockMouseLookChatMessage) {
+        if (config.chatMessage) {
             ChatUtils.chat("§bMouse rotation is now unlocked.")
         }
     }
@@ -50,7 +59,7 @@ object LockMouseLook {
         if (isActive) return
 
         MouseSensitivityManager.state = MouseSensitivityManager.SensitivityState.LOCKED
-        if (config.lockMouseLookChatMessage) {
+        if (config.chatMessage) {
             ChatUtils.chat("§bMouse rotation is now locked.")
         }
     }
@@ -58,7 +67,7 @@ object LockMouseLook {
     @HandleEvent
     fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isActive) return
-        config.lockedMouseDisplay.renderRenderable(lockedRenderable, posLabel = "Mouse Locked")
+        config.display.renderRenderable(lockedRenderable, posLabel = "Mouse Locked")
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
I'm making this a separate PR because it's a highly-requested feature, a Grand Feast is coming up in a few days, and zumbiepig's PR may not get merged in time.

## Changelog Improvements
+ Added an option to keep your mouse locked when teleporting to a plot. - Luna
    * You can choose to still unlock it when teleporting to the barn plot.
