### PR TITLE
Improvement: Add Melon Juice Mixin Support

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -22,6 +22,7 @@ enum class NonGodPotEffect(
     GLOWING_MUSH("Glowing Mush Mixin", true, displayName = "§2Glowing Mush Mixin"),
     HOT_CHOCOLATE("Hot Chocolate Mixin I", true, displayName = "§6Hot Chocolate Mixin I"),
     MASON_JAR("Celestial Mason Jar I", true, displayName = "§dCelestial Mason Jar Mixin"),
+    MELON_JUICE("Melon Juice Mixin I", true, displayName = "§fMelon Juice Mixin"),
 
     DEEP_TERROR("Deepterror", true, displayName = "§4Deepterror"),
 


### PR DESCRIPTION
## What
Add Melon Juice Mixin to non-God Potion effects.

## Changelog Improvements
+ Added Melon Juice Mixin to Non-God-Potion Effects. - Alex
