### PR TITLE
Fix: Invalid ModelPartFeatureRenderer mixin on 26.1

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelPartFeatureRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/renderer/MixinModelPartFeatureRenderer.java
@@ -25,8 +25,7 @@ public abstract class MixinModelPartFeatureRenderer {
         OutlineBufferSource outlineConsumer,
         int color,
         Operation<Void> original,
-        //~ if < 26.1 '@Local(argsOnly = true)' -> '@Local'
-        @Local(argsOnly = true) SubmitNodeStorage.ModelPartSubmit modelPart
+        @Local SubmitNodeStorage.ModelPartSubmit modelPart
     ) {
         if (skyhanni$usesCustomOutline(modelPart)) {
             original.call(SkyHanniOutlineVertexConsumerProvider.getVertexConsumers(), color);


### PR DESCRIPTION
## What
This didn't get caught by the mixin force-load. It doesn't crash the game, but it probably breaks some glow-related features.

## Changelog Fixes
+ Fixed a potential issue with glowing entities on 26.1. - Luna