### PR TITLE
Backend: Use loom-back-compat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
-import at.skyhanni.sharedvariables.MappingStyle
 import at.skyhanni.sharedvariables.MultiVersionStage
 import at.skyhanni.sharedvariables.ProjectTarget
 import at.skyhanni.sharedvariables.SHVersionInfo
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.DetektCreateBaselineTask
+import dev.kikugie.loomx.LoomCompatProjectExtension
 import dev.kikugie.stonecutter.StonecutterExperimentalAPI
 import net.fabricmc.loom.api.LoomGradleExtensionAPI
 import net.fabricmc.loom.api.fabricapi.FabricApiExtension
@@ -22,8 +22,7 @@ plugins {
     idea
     java
     alias(libs.plugins.shadow)
-    id("net.fabricmc.fabric-loom-remap") apply false
-    id("net.fabricmc.fabric-loom") apply false
+    id("dev.kikugie.loom-back-compat")
     kotlin("jvm")
     id("com.google.devtools.ksp")
     kotlin("plugin.power-assert")
@@ -32,15 +31,10 @@ plugins {
 }
 
 val target = ProjectTarget.entries.find { it.projectPath == project.path }!!
-val isDeobf = target.mappingStyle == MappingStyle.NONE
+val loomCompat = extensions.getByType(LoomCompatProjectExtension::class.java)
+val isDeobf = loomCompat.isUnobfuscated
 
-if (isDeobf) apply(plugin = "net.fabricmc.fabric-loom")
-else apply(plugin = "net.fabricmc.fabric-loom-remap")
-
-// Manual accessors for the conditionally-applied loom plugin.
-// These replace the typed accessors that Kotlin DSL would normally generate for
-// plugins applied in the plugins block. Since both loom plugins are declared with
-// apply false, no accessors are auto-generated, so we define them explicitly.
+// String-based accessors for Loom configurations provided by the active compatibility variant.
 val loom: LoomGradleExtensionAPI get() = extensions.getByType(LoomGradleExtensionAPI::class.java)
 fun DependencyHandler.minecraft(dep: Any): Dependency? = add("minecraft", dep)
 fun DependencyHandler.mappings(dep: Any): Dependency? = add("mappings", dep)
@@ -97,7 +91,7 @@ val shadowImpl: Configuration by configurations.creating {
 }
 
 val shadowModImpl: Configuration by configurations.creating {
-    if (!isDeobf) configurations.getByName("modImplementation").extendsFrom(this)
+    configurations.getByName("modImplementation").extendsFrom(this)
 }
 
 val shadowOnly: Configuration by configurations.creating
@@ -133,14 +127,7 @@ tasks.register("checkPrDescription", ChangelogVerification::class) {
 dependencies {
     val versionName = target.minecraftVersion.versionNameOverride ?: target.minecraftVersion.versionName
     minecraft("com.mojang:minecraft:$versionName")
-    @Suppress("UnstableApiUsage")
-    if (!isDeobf) {
-        if (target.mappingDependency == "official") {
-            mappings(loom.officialMojangMappings())
-        } else {
-            mappings(target.mappingDependency)
-        }
-    }
+    loomx.applyMojangMappings()
 
     compileOnly(libs.jbAnnotations)
     ksp(project(":annotation-processors"))?.let { compileOnly(it) }
@@ -149,33 +136,25 @@ dependencies {
     implementation(libs.autoservice.annotations)
 
     target.fabricLoaderVersion?.let {
-        if (isDeobf) implementation(it) else modImplementation(it)
+        modImplementation(it)
     }
     target.fabricApiVersion?.let {
-        if (isDeobf) implementation(it) else modImplementation(it)
+        modImplementation(it)
     }
-    if (isDeobf) implementation(libs.fabricLanguageKotlin)
-    else modImplementation(libs.fabricLanguageKotlin)
+    modImplementation(libs.fabricLanguageKotlin)
 
     target.modMenuVersion?.let {
-        if (isDeobf) implementation("maven.modrinth:modmenu:$it")
-        else modImplementation("maven.modrinth:modmenu:$it")
+        modImplementation("maven.modrinth:modmenu:$it")
     }
 
-    if (isDeobf) runtimeOnly(libs.devauth)
-    else modRuntimeOnly(libs.devauth)
+    modRuntimeOnly(libs.devauth)
 
     val moulconfigVersion = target.minecraftVersion.moulconfigMinecraftVersionOverride ?: target.minecraftVersion.versionName
-    if (isDeobf) {
-        shadowImpl("org.notenoughupdates.moulconfig:modern-$moulconfigVersion:${libs.versions.moulconfig.get()}") {
-            exclude("org.jetbrains.kotlin")
-            exclude("org.jetbrains.kotlinx")
-        }
-    } else {
-        shadowModImpl("org.notenoughupdates.moulconfig:modern-$moulconfigVersion:${libs.versions.moulconfig.get()}") {
-            exclude("org.jetbrains.kotlin")
-            exclude("org.jetbrains.kotlinx")
-        }
+    shadowModImpl("org.notenoughupdates.moulconfig:modern-$moulconfigVersion:${libs.versions.moulconfig.get()}") {
+        exclude("org.jetbrains.kotlin")
+        exclude("org.jetbrains.kotlinx")
+    }
+    if (!isDeobf) {
         include("org.notenoughupdates.moulconfig:modern-$moulconfigVersion:${libs.versions.moulconfig.get()}")
     }
 
@@ -188,16 +167,10 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.mockk.agent)
 
-    if (isDeobf) {
-        implementation(target.hypixelModApiVersion)
-        runtimeOnly(target.hypixelModApiFabricVersion)
-    } else {
-        modImplementation(target.hypixelModApiVersion)
-        modRuntimeOnly(target.hypixelModApiFabricVersion)
-    }
+    modImplementation(target.hypixelModApiVersion)
+    modRuntimeOnly(target.hypixelModApiFabricVersion)
 
-    if (isDeobf) compileOnly(libs.roughlyenoughitems) { exclude(group = "net.fabricmc.fabric-api") }
-    else modCompileOnly(libs.roughlyenoughitems) { exclude(group = "net.fabricmc.fabric-api") }
+    modCompileOnly(libs.roughlyenoughitems) { exclude(group = "net.fabricmc.fabric-api") }
 
     // getting clock offset
     includeImplementation(libs.commons.net)
@@ -216,11 +189,10 @@ dependencies {
 }
 
 fun DependencyHandler.includeImplementation(dep: Any) {
-    if (isDeobf) {
-        add("shadowImpl", dep)
-    } else {
+    add("shadowOnly", dep)
+    modImplementation(dep)
+    if (!isDeobf) {
         include(dep)
-        modImplementation(dep)
     }
 }
 
@@ -371,7 +343,7 @@ tasks.shadowJar {
     }
     configurations = buildList {
         add(shadowImpl)
-        if (!isDeobf) add(shadowModImpl)
+        add(shadowModImpl)
         if (isDeobf) add(shadowOnly)
     }
     exclude("META-INF/versions/**")
@@ -412,7 +384,7 @@ val sourcesJar by tasks.registering(Jar::class) {
 
 publishing.publications {
     create<MavenPublication>("maven") {
-        if (!isDeobf) artifact(tasks.named("remapJar"))
+        if (!isDeobf) artifact(loomCompat.modJar)
         artifact(sourcesJar) { classifier = "sources" }
         pom {
             name.set("SkyHanni")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ methanol = "1.8.3"
 jgit = "7.6.0.202603022253-r"
 
 shadow = "9.3.1"
-loom = "1.15-SNAPSHOT"
+loomBackCompat = "0.3"
 kotlin = "2.3.20"
 ksp = "2.3.6"
 detekt = "2.0.0-alpha.2"
@@ -60,7 +60,7 @@ ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.re
 
 [plugins]
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
-loom = { id = "net.fabricmc.fabric-loom-remap", version.ref = "loom" }
+loom-back-compat = { id = "dev.kikugie.loom-back-compat", version.ref = "loomBackCompat" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-powerAssert = { id = "org.jetbrains.kotlin.plugin.power-assert", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 import at.skyhanni.sharedvariables.MultiVersionStage
+import at.skyhanni.sharedvariables.ProjectTarget
 
 pluginManagement {
     includeBuild("sharedVariables")
@@ -16,6 +17,7 @@ pluginManagement {
                 includeGroupByRegex("(com|io)\\.github\\..*")
             }
         }
+        maven("https://maven.kikugie.dev/releases")
         maven("https://maven.kikugie.dev/snapshots") // stone cutter
     }
     resolutionStrategy.eachPlugin {
@@ -33,9 +35,14 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
     id("at.skyhanni.shared-variables")
     id("dev.kikugie.stonecutter") version "0.9"
+    id("dev.kikugie.loom-back-compat") version "0.3"
 }
 
 MultiVersionStage.initFrom(file(".gradle/private.properties"))
+
+loomx {
+    loomVersion = "1.15-SNAPSHOT"
+}
 
 include("annotation-processors")
 include("detekt")

--- a/sharedVariables/src/MappingStyle.kt
+++ b/sharedVariables/src/MappingStyle.kt
@@ -1,6 +1,0 @@
-package at.skyhanni.sharedvariables
-
-enum class MappingStyle(val identifier: String) {
-    SEARGE("srg"),
-    NONE("none"),
-}

--- a/sharedVariables/src/ProjectTarget.kt
+++ b/sharedVariables/src/ProjectTarget.kt
@@ -3,8 +3,6 @@ package at.skyhanni.sharedvariables
 enum class ProjectTarget(
     val projectName: String,
     val minecraftVersion: MinecraftVersion,
-    val mappingDependency: String,
-    val mappingStyle: MappingStyle,
     val fabricLoaderVersion: String? = null,
     val fabricApiVersion: String? = null,
     val hypixelModApiVersion: String = "net.hypixel:mod-api:1.0.1",
@@ -15,8 +13,6 @@ enum class ProjectTarget(
     MODERN_12111(
         "1.21.11",
         MinecraftVersion.MC12111,
-        "official",
-        MappingStyle.SEARGE,
         fabricLoaderVersion = "net.fabricmc:fabric-loader:0.18.6",
         fabricApiVersion = "net.fabricmc.fabric-api:fabric-api:0.141.3+1.21.11",
         modMenuVersion = "17.0.0",
@@ -25,8 +21,6 @@ enum class ProjectTarget(
     MODERN_26100(
         "26.1",
         MinecraftVersion.MC26100,
-        "official",
-        MappingStyle.NONE,
         fabricLoaderVersion = "net.fabricmc:fabric-loader:0.18.6",
         fabricApiVersion = "net.fabricmc.fabric-api:fabric-api:0.147.0+26.1.2",
         hypixelModApiVersion = "net.hypixel:mod-api:1.0.2",

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.loom) apply false
+    alias(libs.plugins.loom.back.compat) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.powerAssert) apply false
     alias(libs.plugins.ksp) apply false


### PR DESCRIPTION
## What
Switches from custom boilerplate to [loom-back-compat](https://codeberg.org/KikuGie/loom-back-compat) AKA loomx.

## Changelog Technical Details
+ Updated the build script to use the loom-back-compat library for cleaner syntax. - Luna