### PR TITLE
Feature: Add Fruit Digging Helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/CarnivalConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/CarnivalConfig.kt
@@ -15,6 +15,11 @@ class CarnivalConfig {
     val zombieShootout: ZombieShootoutConfig = ZombieShootoutConfig()
 
     @Expose
+    @ConfigOption(name = "Fruit Digging", desc = "")
+    @Accordion
+    val fruitDigging: FruitDiggingConfig = FruitDiggingConfig()
+
+    @Expose
     @ConfigOption(
         name = "Reminder Daily Tickets",
         desc = "Reminds you when tickets can be claimed from the Carnival Leader."

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
@@ -1,11 +1,13 @@
 package at.hannibal2.skyhanni.config.features.event.carnival
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.utils.LorenzColor
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class FruitDiggingConfig {
@@ -16,12 +18,12 @@ class FruitDiggingConfig {
     var enabled: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Show found fruit", desc = "Show uncovered fruit.")
+    @ConfigOption(name = "Show un-diggable fruit", desc = "Show fruit that's destroyed or already dug.")
     @ConfigEditorBoolean
-    var displayFoundFruit: Boolean = true
+    var displayFoundFruit: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Found Color", desc = "Color of the fruit you just dug up.")
+    @ConfigOption(name = "Found Color", desc = "Color of un-diggable fruit.")
     @ConfigEditorColour
     var foundColor: ChromaColour = LorenzColor.GREEN.toChromaColor()
 
@@ -31,7 +33,7 @@ class FruitDiggingConfig {
     var displayAdjacentTreasure: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Adjacent Color", desc = "Color of the fruit clue (nearby fruit).")
+    @ConfigOption(name = "Adjacent Color", desc = "Color of the treasure clue (nearby fruit).")
     @ConfigEditorColour
     var adjacentColor: ChromaColour = LorenzColor.GOLD.toChromaColor()
 
@@ -46,12 +48,21 @@ class FruitDiggingConfig {
     var minesColor: ChromaColour = LorenzColor.RED.toChromaColor()
 
     @Expose
-    @ConfigOption(name = "Show fruit guesses", desc = "Show guesses for fruits that have not been dug up yet.")
+    @ConfigOption(name = "Show fruit guesses", desc = "Show guesses for fruits that have not been dug up yet. This includes anchor.")
     @ConfigEditorBoolean
     var displayFruitGuesses: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Fruit Guess Color", desc = "Color of the mines clue.")
+    @ConfigOption(name = "Fruit Guess Color", desc = "Color of fruit guesses.")
     @ConfigEditorColour
     var fruitGuessColor: ChromaColour = LorenzColor.AQUA.toChromaColor()
+
+    @Expose
+    @ConfigOption(name = "Remaining Fruit Display", desc = "Show remaining Fruit Digging components.")
+    @ConfigEditorBoolean
+    var remainingFruitDisplay: Boolean = true
+
+    @Expose
+    @ConfigLink(owner = FruitDiggingConfig::class, field = "remainingFruitDisplay")
+    val remainingFruitPosition: Position = Position(200, 20)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
@@ -20,7 +20,7 @@ class FruitDiggingConfig {
     @Expose
     @ConfigOption(name = "Show un-diggable fruit", desc = "Show fruit that's destroyed or already dug.")
     @ConfigEditorBoolean
-    var displayFoundFruit: Boolean = false
+    var displayFoundFruit: Boolean = true
 
     @Expose
     @ConfigOption(name = "Found Color", desc = "Color of un-diggable fruit.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
@@ -28,12 +28,12 @@ class FruitDiggingConfig {
     var foundColor: ChromaColour = LorenzColor.GREEN.toChromaColor()
 
     @Expose
-    @ConfigOption(name = "Show treasure", desc = "Show adjacent highest fruit from treasure dousing mode.")
+    @ConfigOption(name = "Show Treasure/Anchor", desc = "Show nearby fruit clues from treasure and anchor dousing modes.")
     @ConfigEditorBoolean
     var displayAdjacentTreasure: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Adjacent Color", desc = "Color of the treasure clue (nearby fruit).")
+    @ConfigOption(name = "Adjacent Color", desc = "Color of treasure and anchor clues (nearby fruit).")
     @ConfigEditorColour
     var adjacentColor: ChromaColour = LorenzColor.GOLD.toChromaColor()
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
@@ -1,0 +1,47 @@
+package at.hannibal2.skyhanni.config.features.event.carnival
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.utils.LorenzColor
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.ChromaColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class FruitDiggingConfig {
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Helper for the Fruit Digging minigame.")
+    @FeatureToggle
+    @ConfigEditorBoolean
+    var enabled: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Show found fruit", desc = "Show uncovered fruit.")
+    @ConfigEditorBoolean
+    var displayFoundFruit: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Found Color", desc = "Color of the fruit you just dug up.")
+    @ConfigEditorColour
+    var foundColor: ChromaColour = LorenzColor.GREEN.toChromaColor()
+
+    @Expose
+    @ConfigOption(name = "Show treasure", desc = "Show adjacent highest fruit from treasure dousing mode.")
+    @ConfigEditorBoolean
+    var displayAdjacentTreasure: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Adjacent Color", desc = "Color of the fruit clue (nearby fruit).")
+    @ConfigEditorColour
+    var adjacentColor: ChromaColour = LorenzColor.GOLD.toChromaColor()
+
+    @Expose
+    @ConfigOption(name = "Show adjacent mine count", desc = "Show number of adjacent mines from mines dousing mode.")
+    @ConfigEditorBoolean
+    var displayAdjacentMines: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Mines Color", desc = "Color of the mines clue.")
+    @ConfigEditorColour
+    var minesColor: ChromaColour = LorenzColor.RED.toChromaColor()
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/carnival/FruitDiggingConfig.kt
@@ -44,4 +44,14 @@ class FruitDiggingConfig {
     @ConfigOption(name = "Mines Color", desc = "Color of the mines clue.")
     @ConfigEditorColour
     var minesColor: ChromaColour = LorenzColor.RED.toChromaColor()
+
+    @Expose
+    @ConfigOption(name = "Show fruit guesses", desc = "Show guesses for fruits that have not been dug up yet.")
+    @ConfigEditorBoolean
+    var displayFruitGuesses: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Fruit Guess Color", desc = "Color of the mines clue.")
+    @ConfigEditorColour
+    var fruitGuessColor: ChromaColour = LorenzColor.AQUA.toChromaColor()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.DataWatcherUpdatedEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
@@ -12,6 +13,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
@@ -38,10 +40,15 @@ object CarnivalFruitDigging {
     private val config get() = SkyHanniMod.feature.event.carnival.fruitDigging
 
     private const val GRID_LENGTH = 7
+    private const val TOTAL_TURNS = 15
 
     private var isPlayingFruitDigging = false
-    private var lastSquareDug: GamePos? = null
-    private var remainingFruit = Fruit.entries.associateWith { it.count }.toMutableMap()
+    private var lastRevealedSquare: GamePos? = null
+
+    private var fruitToAmountRemaining = Fruit.entries.associateWith { it.count }.toMutableMap()
+    private var fruitToAmountObtained = Fruit.entries.associateWith { 0 }.toMutableMap()
+
+    private var turnsSoFar: Int? = null
 
     private val patternGroup = RepoPattern.group("event.carnival")
 
@@ -98,6 +105,15 @@ object CarnivalFruitDigging {
         "^(?<name>[A-Za-z ]+)(?: \\(\\+\\d+\\))?$",
     )
 
+    /**
+     * REGEX-TEST: §fFruits: §a2§7/§c15
+     * REGEX-TEST: Fruits: §a2§7/§c15
+     */
+    private val scoreboardFruitsPattern by patternGroup.pattern(
+        "fruitdigging.scoreboard.fruits",
+        "^(?:§f)?Fruits: §.(?<blocksDug>\\d+)§./§.15$",
+    )
+
     enum class Fruit(val inGameName: String, val points: Int, val count: Int, val textureId: String = "", val isEdible: Boolean = true) {
         UNKNOWN("Unknown", 0, 0, "", false),
         NO_FRUIT("No Fruit", 0, 0, "", false),
@@ -116,26 +132,29 @@ object CarnivalFruitDigging {
 
         fun allFruitsWorthLess(): List<Fruit> = entries.filter { it.isEdible && it.points < this.points }
 
-        fun getAmountDugSoFar(): Int {
-            return count - (remainingFruit[this] ?: 0)
+        fun getAmountObtained(): Int {
+            return fruitToAmountObtained[this] ?: 0
         }
 
         fun getPointValue(): Int {
-            val lastDug = gameGrid.getLastDug()
+            val lastRevealed = gameGrid.getLastRevealed()
             var multiplier = 1.0
-            if (lastDug == POMEGRANATE) multiplier = 1.5
-            else if (lastDug == DURIAN) multiplier = 0.5
+            if (lastRevealed == POMEGRANATE) multiplier = 1.5
+            else if (lastRevealed == DURIAN) multiplier = 0.5
 
             if (this == APPLE) {
-                return (multiplier * (points + 100 * getAmountDugSoFar())).toInt()
+                return (multiplier * (points + 100 * getAmountObtained())).toInt()
             }
             if (this == CHERRY) {
-                return (multiplier * (points + 300 * getAmountDugSoFar())).toInt()
+                return (multiplier * (points + 300 * getAmountObtained())).toInt()
             }
             return (multiplier * points).toInt()
         }
 
         fun getNameWithPointValue(): String {
+            if (!isEdible) {
+                return inGameName
+            }
             return inGameName + " (" + getPointValue() + ")"
         }
 
@@ -152,12 +171,15 @@ object CarnivalFruitDigging {
 
     private class Cell {
         var adjacentMines: Int? = null
-        var treasureFruit: Fruit = Fruit.UNKNOWN
-        var solvedFruit: Fruit = Fruit.UNKNOWN
-        var anchoredFruit: Fruit = Fruit.UNKNOWN
-        var uncoveredFruit: Fruit = Fruit.UNKNOWN
+        var solvedFruit: Fruit = Fruit.UNKNOWN // if we know with certainty what this block is (anchor)
+        var anchoredFruit: Fruit = Fruit.UNKNOWN // dousing output
+        var treasureFruit: Fruit = Fruit.UNKNOWN // dousing output
+        var treasureFulfilled: Boolean = false // the treasure fruit was found after the dousing
+
+        var uncoveredFruit: Fruit = Fruit.UNKNOWN // this fruit as revealed by digging/watermelon
         var isDiggable: Boolean = true
-        var removedFromRemaining: Boolean = false
+        var removedFromRemaining: Boolean = false // counted toward map of remaining fruits
+        var obtained: Boolean = false // dug or revealed by watermelon
 
         fun getFoundFruit(): Fruit = if (uncoveredFruit != Fruit.UNKNOWN) uncoveredFruit else solvedFruit
     }
@@ -172,13 +194,22 @@ object CarnivalFruitDigging {
             return this[pos]
         }
 
-        fun getLastDug(): Fruit {
-            val lastDugPos = lastSquareDug ?: return Fruit.NO_FRUIT
-            return this[lastDugPos].uncoveredFruit
+        fun getLastRevealed(): Fruit {
+            val lastRevealedPos = lastRevealedSquare ?: return Fruit.NO_FRUIT
+            return this[lastRevealedPos].uncoveredFruit
         }
     }
 
     private var gameGrid = GameGrid()
+
+    @HandleEvent
+    fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
+        if (!isEnabled()) return
+
+        scoreboardFruitsPattern.firstMatcher(event.new) {
+            turnsSoFar = group("blocksDug").toInt()
+        }
+    }
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
     fun onGuiRenderOverlay() {
@@ -218,10 +249,14 @@ object CarnivalFruitDigging {
 
                 // label treasure
                 if (config.displayAdjacentTreasure) {
-                    if (cell.treasureFruit != Fruit.UNKNOWN)
-                        label.add(Pair("≤ ${cell.treasureFruit.inGameName}", config.adjacentColor.toColor()))
-                    if (cell.anchoredFruit != Fruit.UNKNOWN && cell.anchoredFruit != cell.treasureFruit)
-                        label.add(Pair("≥ ${cell.anchoredFruit.inGameName}", config.adjacentColor.toColor()))
+                    if (cell.treasureFruit != Fruit.UNKNOWN) {
+                        // F for treasure that is found
+                        val prefix = if (cell.treasureFulfilled) "≤ (F)" else "≤"
+                        label.add(Pair("$prefix ${cell.treasureFruit.inGameName}", config.adjacentColor.toColor()))
+                    } else if (cell.anchoredFruit != Fruit.UNKNOWN) {
+                        // anchor always tells exact location, so we don't need to "find" it
+                        label.add(Pair("≥ (F) ${cell.anchoredFruit.inGameName}", config.adjacentColor.toColor()))
+                    }
                 }
 
                 // label num of adjacent mines
@@ -250,7 +285,7 @@ object CarnivalFruitDigging {
         cell.isDiggable = false
 
         if (blockNew.block == Blocks.SANDSTONE) {
-            lastSquareDug = pos
+            lastRevealedSquare = pos
         } else if (blockNew.block == Blocks.SANDSTONE_STAIRS) {
             updateRemainingFruit(cell, cell.solvedFruit)
         }
@@ -269,7 +304,7 @@ object CarnivalFruitDigging {
 
         val solvedPos = GamePos.fromLorenzVec(entity.position().toLorenzVec()) ?: return false
         val solvedCell = gameGrid[solvedPos]
-        val dugCell = lastSquareDug?.let { gameGrid[it] } ?: return false
+        val dugCell = lastRevealedSquare?.let { gameGrid[it] } ?: return false
 
         val itemStack = entity.item
         if (itemStack.item == Items.AIR) return false // TODO check if this is even needed
@@ -311,6 +346,7 @@ object CarnivalFruitDigging {
             val cell = gameGrid[gamePos]
             updateRemainingFruit(cell, fruit)
             cell.uncoveredFruit = fruit
+            updateObtainedFruit(gamePos, cell, fruit)
         }
     }
 
@@ -331,7 +367,7 @@ object CarnivalFruitDigging {
 
         minesPattern.matchMatcher(message) {
             val bombs = group("bombs").toInt()
-            lastSquareDug?.let {
+            lastRevealedSquare?.let {
                 gameGrid[it].adjacentMines = bombs
             }
             return
@@ -340,14 +376,14 @@ object CarnivalFruitDigging {
         treasurePattern.matchMatcher(message) {
             val fruitName = group("fruit")
             val fruit = Fruit.entries.find { it.inGameName == fruitName } ?: return
-            lastSquareDug?.let {
+            lastRevealedSquare?.let {
                 gameGrid[it].treasureFruit = fruit
             }
             return
         }
 
         if (noFruitsNearbyPattern.matches(message)) {
-            lastSquareDug?.let {
+            lastRevealedSquare?.let {
                 val cell = gameGrid[it]
                 cell.treasureFruit = Fruit.NO_FRUIT
                 cell.anchoredFruit = Fruit.NO_FRUIT
@@ -364,8 +400,10 @@ object CarnivalFruitDigging {
     fun resetData() {
         isPlayingFruitDigging = false
         gameGrid = GameGrid()
-        remainingFruit = Fruit.entries.associateWith { it.count }.toMutableMap()
-        lastSquareDug = null
+        fruitToAmountRemaining = Fruit.entries.associateWith { it.count }.toMutableMap()
+        fruitToAmountObtained = Fruit.entries.associateWith { 0 }.toMutableMap()
+        lastRevealedSquare = null
+        turnsSoFar = null
     }
 
     private fun startGame() {
@@ -376,20 +414,43 @@ object CarnivalFruitDigging {
     private fun updateRemainingFruit(cell: Cell, fruit: Fruit) {
         if (fruit == Fruit.UNKNOWN || fruit == Fruit.NO_FRUIT) return
         if (!cell.removedFromRemaining && !cell.isDiggable) {
-            val count = remainingFruit[fruit] ?: return
-            remainingFruit[fruit] = count - 1
+            val count = fruitToAmountRemaining[fruit] ?: return
+            fruitToAmountRemaining[fruit] = count - 1
             cell.removedFromRemaining = true
+        }
+    }
+
+    private fun updateObtainedFruit(pos: GamePos, cell: Cell, fruit: Fruit) {
+        if (fruit == Fruit.UNKNOWN || fruit == Fruit.NO_FRUIT) return
+        if (cell.obtained) return
+
+        fruitToAmountObtained[fruit] = (fruitToAmountObtained[fruit] ?: 0) + 1
+        cell.obtained = true
+
+        pos.getAdjacent().forEach {
+            val adjacentCell = gameGrid[it]
+            if (fruit == Fruit.BOMB) {
+                adjacentCell.adjacentMines = adjacentCell.adjacentMines?.minus(1)
+            } else if (adjacentCell.treasureFruit == fruit) {
+                adjacentCell.treasureFulfilled = true
+            }
         }
     }
 
     private fun buildRemainingFruitDisplay(): List<Renderable> {
         val fruitLines = Fruit.entries
-            .filter { (remainingFruit[it] ?: 0) > 0 }
+            .filter { (fruitToAmountRemaining[it] ?: 0) > 0 }
             .sortedWith(compareByDescending<Fruit> { it.getPointValue() }.thenBy { it.inGameName })
-            .map { fruit -> Renderable.text("${fruit.getNameWithPointValue()}: ${remainingFruit[fruit]}") }
+            .map { fruit -> Renderable.text("§a${fruit.getNameWithPointValue()}§f: §c${fruitToAmountRemaining[fruit]}") }
 
-        if (fruitLines.isEmpty()) return emptyList()
-        return listOf(Renderable.text("Fruit Digging")) + fruitLines
+        if (fruitLines.isEmpty() && turnsSoFar == null) return emptyList()
+
+        val lines = mutableListOf(Renderable.text("§a§lFruit Digging"))
+        turnsSoFar?.let {
+            lines.add(Renderable.text("Blocks Dug: $it/$TOTAL_TURNS"))
+        }
+        lines.addAll(fruitLines)
+        return lines
     }
 
     private data class GamePos(val row: Int, val col: Int) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -174,7 +174,7 @@ object CarnivalFruitDigging {
 
         fun getLastDug(): Fruit {
             val lastDugPos = lastSquareDug ?: return Fruit.NO_FRUIT
-            return this[lastDugPos].solvedFruit
+            return this[lastDugPos].uncoveredFruit
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -3,23 +3,24 @@ package at.hannibal2.skyhanni.features.event.carnival
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.DataWatcherUpdatedEvent
+import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
-import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
-import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.core.BlockPos
@@ -40,6 +41,7 @@ object CarnivalFruitDigging {
 
     private var isPlayingFruitDigging = false
     private var lastSquareDug: GamePos? = null
+    private var remainingFruit = Fruit.entries.associateWith { it.count }.toMutableMap()
 
     private val patternGroup = RepoPattern.group("event.carnival")
 
@@ -131,6 +133,8 @@ object CarnivalFruitDigging {
         var adjacentTreasure: Fruit = Fruit.UNKNOWN
         var anchoredFruit: Fruit = Fruit.UNKNOWN
         var uncoveredFruit: Fruit = Fruit.UNKNOWN
+        var isDiggable: Boolean = true
+        var removedFromRemaining: Boolean = false
     }
 
     private class GameGrid {
@@ -146,6 +150,12 @@ object CarnivalFruitDigging {
 
     private var gameGrid = GameGrid()
 
+    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
+    fun onGuiRenderOverlay() {
+        if (!isEnabled() || !config.remainingFruitDisplay) return
+        config.remainingFruitPosition.renderRenderables(buildRemainingFruitDisplay(), posLabel = "Remaining Fruit")
+    }
+
     @HandleEvent
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
@@ -156,20 +166,20 @@ object CarnivalFruitDigging {
                 val cell = gameGrid[pos]
 
                 // indicate if not diggable
-                if (pos.toLorenzVec().getBlockAt() != Blocks.SAND) {
+                if (!cell.isDiggable) {
                     val aabb = AABB(pos.toBlockPos()).expandTowards(0.0, 0.1, 0.0)
-                    event.drawFilledBoundingBox(aabb, Color.GRAY, seeThroughBlocks = true)
+                    event.drawFilledBoundingBox(aabb, Color.GRAY, seeThroughBlocks = false)
                 }
 
                 val label = mutableListOf<Pair<String, Color>>()
 
                 // label uncovered fruit
-                if (config.displayFoundFruit && cell.uncoveredFruit != Fruit.UNKNOWN) {
+                if (config.displayFoundFruit && cell.uncoveredFruit != Fruit.UNKNOWN && !cell.isDiggable) {
                     label.add(Pair(cell.uncoveredFruit.inGameName, config.foundColor.toColor()))
                 }
 
-                // label anchor if not dug
-                if (config.displayFruitGuesses && cell.uncoveredFruit == Fruit.UNKNOWN) {
+                // label anchor if not dug or destroyed
+                if (config.displayFruitGuesses && cell.uncoveredFruit == Fruit.UNKNOWN && cell.isDiggable) {
                     if (cell.anchoredFruit != Fruit.UNKNOWN)
                         label.add(Pair(cell.anchoredFruit.inGameName, config.fruitGuessColor.toColor()))
                 }
@@ -198,19 +208,16 @@ object CarnivalFruitDigging {
     fun onBlockChange(event: ServerBlockChangeEvent) {
         val blockOld = event.oldState
         val blockNew = event.newState
-        if (blockOld.block == Blocks.SAND && blockNew.block == Blocks.SANDSTONE) {
-            val pos = GamePos.fromLorenzVec(event.location) ?: return
-            lastSquareDug = pos
-        }
-    }
 
-    @HandleEvent
-    fun onEntitySpawnAny(event: EntityEnterWorldEvent<Entity>) {
-        if (!isEnabled()) return
-        val entity = event.entity
-        if (entity is ItemEntity) {
-            if (handleItemEntity(entity))
-                ChatUtils.chat("fruit detected with onEntitySpawnAny()")
+        if (blockOld.block != Blocks.SAND) return
+        val pos = GamePos.fromLorenzVec(event.location) ?: return
+        val cell = gameGrid[pos]
+        cell.isDiggable = false
+
+        if (blockNew.block == Blocks.SANDSTONE) {
+            lastSquareDug = pos
+        } else if (blockNew.block == Blocks.SANDSTONE_STAIRS) {
+            updateRemainingFruit(cell, cell.anchoredFruit)
         }
     }
 
@@ -219,12 +226,11 @@ object CarnivalFruitDigging {
         if (!isEnabled()) return
         val entity = event.entity
         if (entity is ItemEntity) {
-            if (handleItemEntity(entity))
-                ChatUtils.chat("fruit detected with onDataWatcherUpdate()")
+            handleAnchoredFruit(entity)
         }
     }
 
-    private fun handleItemEntity(entity: ItemEntity) : Boolean {
+    private fun handleAnchoredFruit(entity: ItemEntity) : Boolean {
 
         val gamePos = GamePos.fromLorenzVec(entity.position().toLorenzVec()) ?: return false
         val cell = gameGrid[gamePos]
@@ -240,6 +246,7 @@ object CarnivalFruitDigging {
         val fruit = Fruit.fromTexture(textureHash) ?: return false
 
         cell.anchoredFruit = fruit
+        updateRemainingFruit(cell, fruit)
         return true
     }
 
@@ -252,16 +259,15 @@ object CarnivalFruitDigging {
         val name = event.newName?.removeColor() ?: return
         if (name.isBlank()) return
 
-        // TODO move gamepos resolution up here
-
         val pos = entity.blockPosition().toLorenzVec()
+        val gamePos = GamePos.fromLorenzVec(pos) ?: return
 
         revealFruitPattern.matchMatcher(name) {
             val fruitName = group("name")
             val fruit = Fruit.fromName(fruitName) ?: return
-            GamePos.fromLorenzVec(pos)?.let { gamePos ->
-                gameGrid[gamePos].uncoveredFruit = fruit
-            }
+            val cell = gameGrid[gamePos]
+            updateRemainingFruit(cell, fruit)
+            cell.uncoveredFruit = fruit
         }
     }
 
@@ -272,7 +278,7 @@ object CarnivalFruitDigging {
         val message = event.cleanMessage
 
         if (startPattern.matches(message)) {
-            isPlayingFruitDigging = true
+            startGame()
             return
         }
         if (endPattern.matches(message)) {
@@ -313,6 +319,33 @@ object CarnivalFruitDigging {
     fun resetData() {
         isPlayingFruitDigging = false
         gameGrid = GameGrid()
+        remainingFruit = Fruit.entries.associateWith { it.count }.toMutableMap()
+        lastSquareDug = null
+    }
+
+    private fun startGame() {
+        resetData()
+        isPlayingFruitDigging = true
+    }
+
+    private fun updateRemainingFruit(cell: Cell, fruit: Fruit) {
+        if (fruit == Fruit.UNKNOWN || fruit == Fruit.NO_FRUIT) return
+        if (!cell.removedFromRemaining && !cell.isDiggable) {
+            val count = remainingFruit[fruit] ?: return
+            remainingFruit[fruit] = count - 1
+            cell.removedFromRemaining = true
+        }
+    }
+
+    private fun buildRemainingFruitDisplay(): List<Renderable> {
+        val fruitLines = Fruit.entries.mapNotNull { fruit ->
+            val count = remainingFruit[fruit] ?: return@mapNotNull null
+            if (count <= 0) return@mapNotNull null
+            Renderable.text("${fruit.inGameName}: $count")
+        }
+
+        if (fruitLines.isEmpty()) return emptyList()
+        return listOf(Renderable.text("Fruit Digging")) + fruitLines
     }
 
     private data class GamePos(val row: Int, val col: Int) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -2,22 +2,34 @@ package at.hannibal2.skyhanni.features.event.carnival
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.DataWatcherUpdatedEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
+import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
+import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.toLorenzVec
+import net.minecraft.core.BlockPos
+import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.decoration.ArmorStand
+import net.minecraft.world.entity.item.ItemEntity
+import net.minecraft.world.item.Items
 import net.minecraft.world.level.block.Blocks
+import net.minecraft.world.phys.AABB
+import java.awt.Color
 
 @SkyHanniModule
 object CarnivalFruitDigging {
@@ -58,10 +70,11 @@ object CarnivalFruitDigging {
 
     /**
      * REGEX-TEST: TREASURE! There are no fruits nearby!
+     * REGEX-TEST: ANCHOR! There are no fruits nearby!
      */
-    private val noTreasurePattern by patternGroup.pattern(
-        "fruitdigging.notreasure",
-        "^TREASURE! There are no fruits nearby!$",
+    private val noFruitsNearbyPattern by patternGroup.pattern(
+        "fruitdigging.nofruitsnearby",
+        "^(?:TREASURE|ANCHOR)! There are no fruits nearby!$",
     )
 
     /**
@@ -84,28 +97,39 @@ object CarnivalFruitDigging {
     )
 
     // use Spanish names to prevent text from overflowing the block
-    enum class Fruit(val inGameName: String, val points: Int, val count: Int, val isEdible: Boolean = true) {
-        UNKNOWN("Unknown", 0, 0, false),
-        NO_FRUIT("No Fruit", 0, 0, false),
-        BOMB("Bomb", 0, 10, false),
-        RUM("Rum", 0, 5, false),
-        MANGO("Mango", 300, 10),
-        APPLE("Apple", 0, 8),
-        WATERMELON("Watermelon", 100, 4),
-        POMEGRANATE("Pomegranate", 200, 4),
-        COCONUT("Coconut", 200, 3),
-        CHERRY("Cherry", 200, 2),
-        DURIAN("Durian", 800, 2),
-        DRAGON_FRUIT("Dragonfruit", 1200, 1);
+    enum class Fruit(val inGameName: String, val points: Int, val count: Int, val textureId: String = "", val isEdible: Boolean = true) {
+        UNKNOWN("Unknown", 0, 0, "", false),
+        NO_FRUIT("No Fruit", 0, 0, "", false),
+        BOMB("Bomb", 0, 10, "a76a2811d1e176a07b6d0a657b910f134896ce30850f6e80c7c83732d85381ea", false),
+        RUM("Rum", 0, 5, "407b275d28b927b1bf7f6dd9f45fbdad2af8571c54c8f027d1bff6956fbf3c16", false),
+        MANGO("Mango", 300, 10, "f363a62126a35537f8189343a22660de75e810c6ac004a7d3da65f1c040a839"),
+        APPLE("Apple", 100, 8, "17ea278d6225c447c5943d652798d0bbbd1418434ce8c54c54fdac79994ddd6c"),
+        WATERMELON("Watermelon", 100, 4, "efe4ef83baf105e8dee6cf03dfe7407f1911b3b9952c891ae34139560f2931d6"),
+        POMEGRANATE("Pomegranate", 200, 4, "40824d18079042d5769f264f44394b95b9b99ce689688cc10c9eec3f882ccc08"),
+        COCONUT("Coconut", 200, 3, "10ceb1455b471d016a9f06d25f6e468df9fcf223e2c1e4795b16e84fcca264ee"),
+        CHERRY("Cherry", 200, 2, "c92b099a62cd2fbf8ada09dec145c75d7fda4dc57b968bea3a8fa11e37aa48b2"),
+        DURIAN("Durian", 800, 2, "ac268d36c2c6047ffeec00124096376b56dbb4d756a55329363a1b27fcd659cd"),
+        DRAGON_FRUIT("Dragonfruit", 1200, 1, "3cc761bcb0579763d9b8ab6b7b96fa77eb6d9605a804d838fec39e7b25f95591");
 
         fun allFruitsWorthMore(): List<Fruit> = entries.filter { it.isEdible && it.points > this.points }
 
         fun allFruitsWorthLess(): List<Fruit> = entries.filter { it.isEdible && it.points < this.points }
+
+        companion object {
+            fun fromTexture(texture: String) : Fruit? {
+                return Fruit.entries.find { it.textureId.isNotEmpty() && texture.contains(it.textureId) }
+            }
+
+            fun fromName(name: String) : Fruit? {
+                return Fruit.entries.find { it.inGameName.equals(name, ignoreCase = true) }
+            }
+        }
     }
 
     private class Cell {
         var adjacentMines: Int? = null
         var adjacentTreasure: Fruit = Fruit.UNKNOWN
+        var anchoredFruit: Fruit = Fruit.UNKNOWN
         var uncoveredFruit: Fruit = Fruit.UNKNOWN
     }
 
@@ -131,23 +155,40 @@ object CarnivalFruitDigging {
                 val pos = GamePos(row, col)
                 val cell = gameGrid[pos]
 
-                val worldPos = pos.toLorenzVec().add(0.5, 1.1, 0.5)
-                val lines = mutableListOf<Pair<String, java.awt.Color>>()
-                if (config.displayFoundFruit && cell.uncoveredFruit != Fruit.UNKNOWN) {
-                    lines.add(Pair(cell.uncoveredFruit.inGameName, config.foundColor.toColor()))
-                }
-                if (config.displayAdjacentTreasure && cell.adjacentTreasure != Fruit.UNKNOWN) {
-                    lines.add(Pair(cell.adjacentTreasure.inGameName, config.adjacentColor.toColor()))
-                }
-                if (config.displayAdjacentMines) {
-                    cell.adjacentMines?.let { lines.add(Pair(it.toString(), config.minesColor.toColor())) }
+                // indicate if not diggable
+                if (pos.toLorenzVec().getBlockAt() != Blocks.SAND) {
+                    val aabb = AABB(pos.toBlockPos()).expandTowards(0.0, 0.1, 0.0)
+                    event.drawFilledBoundingBox(aabb, Color.GRAY, seeThroughBlocks = true)
                 }
 
-                if (lines.isEmpty()) continue
-                val yOffsetStart = (lines.size - 1) * -5f
-                lines.forEachIndexed { i, (text, color) ->
-                    event.drawString(worldPos, text, seeThroughBlocks = true, yOffset = yOffsetStart + i * 10f,
-                        color = color, scale = .3)
+                val label = mutableListOf<Pair<String, Color>>()
+
+                // label uncovered fruit
+                if (config.displayFoundFruit && cell.uncoveredFruit != Fruit.UNKNOWN) {
+                    label.add(Pair(cell.uncoveredFruit.inGameName, config.foundColor.toColor()))
+                }
+
+                // label anchor if not dug
+                if (config.displayFruitGuesses && cell.uncoveredFruit == Fruit.UNKNOWN) {
+                    if (cell.anchoredFruit != Fruit.UNKNOWN)
+                        label.add(Pair(cell.anchoredFruit.inGameName, config.fruitGuessColor.toColor()))
+                }
+
+                // label treasure
+                if (config.displayAdjacentTreasure && cell.adjacentTreasure != Fruit.UNKNOWN) {
+                    label.add(Pair(cell.adjacentTreasure.inGameName, config.adjacentColor.toColor()))
+                }
+
+                // label num of adjacent mines
+                if (config.displayAdjacentMines) {
+                    cell.adjacentMines?.let { label.add(Pair(it.toString(), config.minesColor.toColor())) }
+                }
+
+                if (label.isEmpty()) continue
+                val textPos = pos.toLorenzVec().add(0.5, 1.1, 0.5)
+                val yOffsetStart = -5f * (label.size - 1)
+                label.forEachIndexed { i, (text, color) ->
+                    event.drawString(textPos, text, seeThroughBlocks = true, yOffset = yOffsetStart + i * 10, color = color, scale = .3)
                 }
             }
         }
@@ -164,19 +205,60 @@ object CarnivalFruitDigging {
     }
 
     @HandleEvent
+    fun onEntitySpawnAny(event: EntityEnterWorldEvent<Entity>) {
+        if (!isEnabled()) return
+        val entity = event.entity
+        if (entity is ItemEntity) {
+            if (handleItemEntity(entity))
+                ChatUtils.chat("fruit detected with onEntitySpawnAny()")
+        }
+    }
+
+    @HandleEvent
+    fun onDataWatcherUpdate(event: DataWatcherUpdatedEvent<Entity>) {
+        if (!isEnabled()) return
+        val entity = event.entity
+        if (entity is ItemEntity) {
+            if (handleItemEntity(entity))
+                ChatUtils.chat("fruit detected with onDataWatcherUpdate()")
+        }
+    }
+
+    private fun handleItemEntity(entity: ItemEntity) : Boolean {
+
+        val gamePos = GamePos.fromLorenzVec(entity.position().toLorenzVec()) ?: return false
+        val cell = gameGrid[gamePos]
+        if (cell.anchoredFruit != Fruit.UNKNOWN) return false
+
+        val itemStack = entity.item
+        if (itemStack.item == Items.AIR) return false // TODO check if this is even needed
+
+        val textureHash = itemStack.getSkullTexture()?.let {
+            runCatching { StringUtils.decodeBase64(it) }.getOrNull()
+        } ?: return false
+
+        val fruit = Fruit.fromTexture(textureHash) ?: return false
+
+        cell.anchoredFruit = fruit
+        return true
+    }
+
+    @HandleEvent
     fun onEntityNameUpdate(event: EntityCustomNameUpdateEvent<ArmorStand>) {
         if (!isEnabled()) return
 
+        // Armor stand appears when a fruit is dug or exposed by watermelon
         val entity = event.entity
         val name = event.newName?.removeColor() ?: return
         if (name.isBlank()) return
+
+        // TODO move gamepos resolution up here
 
         val pos = entity.blockPosition().toLorenzVec()
 
         revealFruitPattern.matchMatcher(name) {
             val fruitName = group("name")
-            val fruit = Fruit.entries.find { it.inGameName.equals(fruitName, ignoreCase = true) } ?: return@matchMatcher
-
+            val fruit = Fruit.fromName(fruitName) ?: return
             GamePos.fromLorenzVec(pos)?.let { gamePos ->
                 gameGrid[gamePos].uncoveredFruit = fruit
             }
@@ -215,7 +297,7 @@ object CarnivalFruitDigging {
             return
         }
 
-        if (noTreasurePattern.matches(message)) {
+        if (noFruitsNearbyPattern.matches(message)) {
             lastSquareDug?.let {
                 gameGrid[it].adjacentTreasure = Fruit.NO_FRUIT
             }
@@ -237,6 +319,8 @@ object CarnivalFruitDigging {
         fun isValid() = row in 0..<GRID_LENGTH && col in 0..<GRID_LENGTH
 
         fun toLorenzVec() = LorenzVec(START_X + col, GRID_Y, START_Z + row)
+
+        fun toBlockPos() = BlockPos((START_X + col).toInt(), GRID_Y.toInt(), (START_Z + row).toInt())
 
         fun getAdjacent(): List<GamePos> {
             val list = mutableListOf<GamePos>()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -1,0 +1,267 @@
+package at.hannibal2.skyhanni.features.event.carnival
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ColorUtils.toColor
+import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.toLorenzVec
+import net.minecraft.world.entity.decoration.ArmorStand
+import net.minecraft.world.level.block.Blocks
+
+@SkyHanniModule
+object CarnivalFruitDigging {
+
+    private val config get() = SkyHanniMod.feature.event.carnival.fruitDigging
+
+    private const val GRID_LENGTH = 7
+
+    private var isPlayingFruitDigging = false
+    private var lastSquareDug: GamePos? = null
+
+    private val patternGroup = RepoPattern.group("event.carnival")
+
+    /**
+     * REGEX-TEST: [NPC] Carnival Pirateman: Good luck, matey!
+     */
+    private val startPattern by patternGroup.pattern(
+        "fruitdigging.started",
+        "^\\[NPC] Carnival Pirateman: Good luck, matey!$",
+    )
+
+    /**
+     * WRAPPED-REGEX-TEST: "                               Fruit Digging"
+     */
+    private val endPattern by patternGroup.pattern(
+        "fruitdigging.end",
+        " {31}Fruit Digging",
+    )
+
+    /**
+     * REGEX-TEST: TREASURE! There is a Durian nearby.
+     * REGEX-TEST: TREASURE! There is an Apple nearby.
+     */
+    private val treasurePattern by patternGroup.pattern(
+        "fruitdigging.treasure",
+        "^TREASURE! There is an? (?<fruit>.*) nearby\\.$",
+    )
+
+    /**
+     * REGEX-TEST: TREASURE! There are no fruits nearby!
+     */
+    private val noTreasurePattern by patternGroup.pattern(
+        "fruitdigging.notreasure",
+        "^TREASURE! There are no fruits nearby!$",
+    )
+
+    /**
+     * REGEX-TEST: MINES! There is 1 bomb hidden nearby.
+     * REGEX-TEST: MINES! There are 2 bombs hidden nearby.
+     */
+    private val minesPattern by patternGroup.pattern(
+        "fruitdigging.mines",
+        "^MINES! There (?:is|are) (?<bombs>\\d+) bombs? hidden nearby\\.$",
+    )
+
+    /**
+     * REGEX-TEST: Pomegranate (+300)
+     * REGEX-TEST: Bomb
+     * REGEX-TEST: Rum
+     */
+    private val revealFruitPattern by patternGroup.pattern(
+        "fruitdigging.reveal",
+        "^(?<name>[A-Za-z ]+)(?: \\(\\+\\d+\\))?$",
+    )
+
+    // use Spanish names to prevent text from overflowing the block
+    enum class Fruit(val inGameName: String, val points: Int, val count: Int, val isEdible: Boolean = true) {
+        UNKNOWN("Unknown", 0, 0, false),
+        NO_FRUIT("No Fruit", 0, 0, false),
+        BOMB("Bomb", 0, 10, false),
+        RUM("Rum", 0, 5, false),
+        MANGO("Mango", 300, 10),
+        APPLE("Apple", 0, 8),
+        WATERMELON("Watermelon", 100, 4),
+        POMEGRANATE("Pomegranate", 200, 4),
+        COCONUT("Coconut", 200, 3),
+        CHERRY("Cherry", 200, 2),
+        DURIAN("Durian", 800, 2),
+        DRAGON_FRUIT("Dragonfruit", 1200, 1);
+
+        fun allFruitsWorthMore(): List<Fruit> = entries.filter { it.isEdible && it.points > this.points }
+
+        fun allFruitsWorthLess(): List<Fruit> = entries.filter { it.isEdible && it.points < this.points }
+    }
+
+    private class Cell {
+        var adjacentMines: Int? = null
+        var adjacentTreasure: Fruit = Fruit.UNKNOWN
+        var uncoveredFruit: Fruit = Fruit.UNKNOWN
+    }
+
+    private class GameGrid {
+        private val cells = Array(GRID_LENGTH) { Array(GRID_LENGTH) { Cell() } }
+
+        operator fun get(pos: GamePos): Cell = cells[pos.row][pos.col]
+
+        operator fun get(vec: LorenzVec): Cell? {
+            val pos = GamePos.fromLorenzVec(vec) ?: return null
+            return this[pos]
+        }
+    }
+
+    private var gameGrid = GameGrid()
+
+    @HandleEvent
+    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+        if (!isEnabled()) return
+
+        for (row in 0 until GRID_LENGTH) {
+            for (col in 0 until GRID_LENGTH) {
+                val pos = GamePos(row, col)
+                val cell = gameGrid[pos]
+
+                val worldPos = pos.toLorenzVec().add(0.5, 1.1, 0.5)
+                val lines = mutableListOf<Pair<String, java.awt.Color>>()
+                if (config.displayFoundFruit && cell.uncoveredFruit != Fruit.UNKNOWN) {
+                    lines.add(Pair(cell.uncoveredFruit.inGameName, config.foundColor.toColor()))
+                }
+                if (config.displayAdjacentTreasure && cell.adjacentTreasure != Fruit.UNKNOWN) {
+                    lines.add(Pair(cell.adjacentTreasure.inGameName, config.adjacentColor.toColor()))
+                }
+                if (config.displayAdjacentMines) {
+                    cell.adjacentMines?.let { lines.add(Pair(it.toString(), config.minesColor.toColor())) }
+                }
+
+                if (lines.isEmpty()) continue
+                val yOffsetStart = (lines.size - 1) * -5f
+                lines.forEachIndexed { i, (text, color) ->
+                    event.drawString(worldPos, text, seeThroughBlocks = true, yOffset = yOffsetStart + i * 10f,
+                        color = color, scale = .3)
+                }
+            }
+        }
+    }
+
+    @HandleEvent
+    fun onBlockChange(event: ServerBlockChangeEvent) {
+        val blockOld = event.oldState
+        val blockNew = event.newState
+        if (blockOld.block == Blocks.SAND && blockNew.block == Blocks.SANDSTONE) {
+            val pos = GamePos.fromLorenzVec(event.location) ?: return
+            lastSquareDug = pos
+        }
+    }
+
+    @HandleEvent
+    fun onEntityNameUpdate(event: EntityCustomNameUpdateEvent<ArmorStand>) {
+        if (!isEnabled()) return
+
+        val entity = event.entity
+        val name = event.newName?.removeColor() ?: return
+        if (name.isBlank()) return
+
+        val pos = entity.blockPosition().toLorenzVec()
+
+        revealFruitPattern.matchMatcher(name) {
+            val fruitName = group("name")
+            val fruit = Fruit.entries.find { it.inGameName.equals(fruitName, ignoreCase = true) } ?: return@matchMatcher
+
+            GamePos.fromLorenzVec(pos)?.let { gamePos ->
+                gameGrid[gamePos].uncoveredFruit = fruit
+            }
+        }
+    }
+
+    @HandleEvent
+    fun onChat(event: SkyHanniChatEvent.Allow) {
+        if (!config.enabled || !CarnivalAPI.inCarnivalArea) return
+
+        val message = event.cleanMessage
+
+        if (startPattern.matches(message)) {
+            isPlayingFruitDigging = true
+            return
+        }
+        if (endPattern.matches(message)) {
+            resetData()
+            return
+        }
+
+        minesPattern.matchMatcher(message) {
+            val bombs = group("bombs").toInt()
+            lastSquareDug?.let {
+                gameGrid[it].adjacentMines = bombs
+            }
+            return
+        }
+
+        treasurePattern.matchMatcher(message) {
+            val fruitName = group("fruit")
+            val fruit = Fruit.entries.find { it.inGameName == fruitName } ?: return
+            lastSquareDug?.let {
+                gameGrid[it].adjacentTreasure = fruit
+            }
+            return
+        }
+
+        if (noTreasurePattern.matches(message)) {
+            lastSquareDug?.let {
+                gameGrid[it].adjacentTreasure = Fruit.NO_FRUIT
+            }
+            return
+        }
+    }
+
+    @HandleEvent
+    fun onWorldChange() {
+        resetData()
+    }
+
+    fun resetData() {
+        isPlayingFruitDigging = false
+        gameGrid = GameGrid()
+    }
+
+    private data class GamePos(val row: Int, val col: Int) {
+        fun isValid() = row in 0..<GRID_LENGTH && col in 0..<GRID_LENGTH
+
+        fun toLorenzVec() = LorenzVec(START_X + col, GRID_Y, START_Z + row)
+
+        fun getAdjacent(): List<GamePos> {
+            val list = mutableListOf<GamePos>()
+            for (dr in -1..1) {
+                for (dc in -1..1) {
+                    if (dr == 0 && dc == 0) continue
+                    val pos = GamePos(row + dr, col + dc)
+                    if (pos.isValid()) list.add(pos)
+                }
+            }
+            return list
+        }
+
+        companion object {
+            const val START_X = -112.0
+            const val START_Z = 19.0
+            const val GRID_Y = 72.0
+
+            fun fromLorenzVec(vec: LorenzVec): GamePos? {
+                val col = (vec.x - START_X).toInt()
+                val row = (vec.z - START_Z).toInt()
+                return GamePos(row, col).takeIf { it.isValid() }
+            }
+        }
+    }
+
+    private fun isEnabled() = config.enabled && CarnivalAPI.inCarnivalArea && isPlayingFruitDigging
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -98,7 +98,6 @@ object CarnivalFruitDigging {
         "^(?<name>[A-Za-z ]+)(?: \\(\\+\\d+\\))?$",
     )
 
-    // use Spanish names to prevent text from overflowing the block
     enum class Fruit(val inGameName: String, val points: Int, val count: Int, val textureId: String = "", val isEdible: Boolean = true) {
         UNKNOWN("Unknown", 0, 0, "", false),
         NO_FRUIT("No Fruit", 0, 0, "", false),
@@ -117,12 +116,35 @@ object CarnivalFruitDigging {
 
         fun allFruitsWorthLess(): List<Fruit> = entries.filter { it.isEdible && it.points < this.points }
 
+        fun getAmountDugSoFar(): Int {
+            return count - (remainingFruit[this] ?: 0)
+        }
+
+        fun getPointValue(): Int {
+            val lastDug = gameGrid.getLastDug()
+            var multiplier = 1.0
+            if (lastDug == POMEGRANATE) multiplier = 1.5
+            else if (lastDug == DURIAN) multiplier = 0.5
+
+            if (this == APPLE) {
+                return (multiplier * (points + 100 * getAmountDugSoFar())).toInt()
+            }
+            if (this == CHERRY) {
+                return (multiplier * (points + 300 * getAmountDugSoFar())).toInt()
+            }
+            return (multiplier * points).toInt()
+        }
+
+        fun getNameWithPointValue(): String {
+            return inGameName + " (" + getPointValue() + ")"
+        }
+
         companion object {
-            fun fromTexture(texture: String) : Fruit? {
+            fun fromTexture(texture: String): Fruit? {
                 return Fruit.entries.find { it.textureId.isNotEmpty() && texture.contains(it.textureId) }
             }
 
-            fun fromName(name: String) : Fruit? {
+            fun fromName(name: String): Fruit? {
                 return Fruit.entries.find { it.inGameName.equals(name, ignoreCase = true) }
             }
         }
@@ -130,11 +152,14 @@ object CarnivalFruitDigging {
 
     private class Cell {
         var adjacentMines: Int? = null
-        var adjacentTreasure: Fruit = Fruit.UNKNOWN
+        var treasureFruit: Fruit = Fruit.UNKNOWN
+        var solvedFruit: Fruit = Fruit.UNKNOWN
         var anchoredFruit: Fruit = Fruit.UNKNOWN
         var uncoveredFruit: Fruit = Fruit.UNKNOWN
         var isDiggable: Boolean = true
         var removedFromRemaining: Boolean = false
+
+        fun getFoundFruit(): Fruit = if (uncoveredFruit != Fruit.UNKNOWN) uncoveredFruit else solvedFruit
     }
 
     private class GameGrid {
@@ -145,6 +170,11 @@ object CarnivalFruitDigging {
         operator fun get(vec: LorenzVec): Cell? {
             val pos = GamePos.fromLorenzVec(vec) ?: return null
             return this[pos]
+        }
+
+        fun getLastDug(): Fruit {
+            val lastDugPos = lastSquareDug ?: return Fruit.NO_FRUIT
+            return this[lastDugPos].solvedFruit
         }
     }
 
@@ -174,19 +204,24 @@ object CarnivalFruitDigging {
                 val label = mutableListOf<Pair<String, Color>>()
 
                 // label uncovered fruit
-                if (config.displayFoundFruit && cell.uncoveredFruit != Fruit.UNKNOWN && !cell.isDiggable) {
-                    label.add(Pair(cell.uncoveredFruit.inGameName, config.foundColor.toColor()))
+                if (config.displayFoundFruit && !cell.isDiggable) {
+                    val foundFruit = cell.getFoundFruit()
+                    if (foundFruit != Fruit.UNKNOWN)
+                        label.add(Pair(foundFruit.inGameName, config.foundColor.toColor()))
                 }
 
-                // label anchor if not dug or destroyed
+                // label solved fruit if not dug or destroyed
                 if (config.displayFruitGuesses && cell.uncoveredFruit == Fruit.UNKNOWN && cell.isDiggable) {
-                    if (cell.anchoredFruit != Fruit.UNKNOWN)
-                        label.add(Pair(cell.anchoredFruit.inGameName, config.fruitGuessColor.toColor()))
+                    if (cell.solvedFruit != Fruit.UNKNOWN)
+                        label.add(Pair(cell.solvedFruit.getNameWithPointValue(), config.fruitGuessColor.toColor()))
                 }
 
                 // label treasure
-                if (config.displayAdjacentTreasure && cell.adjacentTreasure != Fruit.UNKNOWN) {
-                    label.add(Pair(cell.adjacentTreasure.inGameName, config.adjacentColor.toColor()))
+                if (config.displayAdjacentTreasure) {
+                    if (cell.treasureFruit != Fruit.UNKNOWN)
+                        label.add(Pair("≤ ${cell.treasureFruit.inGameName}", config.adjacentColor.toColor()))
+                    if (cell.anchoredFruit != Fruit.UNKNOWN && cell.anchoredFruit != cell.treasureFruit)
+                        label.add(Pair("≥ ${cell.anchoredFruit.inGameName}", config.adjacentColor.toColor()))
                 }
 
                 // label num of adjacent mines
@@ -217,7 +252,7 @@ object CarnivalFruitDigging {
         if (blockNew.block == Blocks.SANDSTONE) {
             lastSquareDug = pos
         } else if (blockNew.block == Blocks.SANDSTONE_STAIRS) {
-            updateRemainingFruit(cell, cell.anchoredFruit)
+            updateRemainingFruit(cell, cell.solvedFruit)
         }
     }
 
@@ -226,15 +261,15 @@ object CarnivalFruitDigging {
         if (!isEnabled()) return
         val entity = event.entity
         if (entity is ItemEntity) {
-            handleAnchoredFruit(entity)
+            handleAnchor(entity)
         }
     }
 
-    private fun handleAnchoredFruit(entity: ItemEntity) : Boolean {
+    private fun handleAnchor(entity: ItemEntity): Boolean {
 
-        val gamePos = GamePos.fromLorenzVec(entity.position().toLorenzVec()) ?: return false
-        val cell = gameGrid[gamePos]
-        if (cell.anchoredFruit != Fruit.UNKNOWN) return false
+        val solvedPos = GamePos.fromLorenzVec(entity.position().toLorenzVec()) ?: return false
+        val solvedCell = gameGrid[solvedPos]
+        val dugCell = lastSquareDug?.let { gameGrid[it] } ?: return false
 
         val itemStack = entity.item
         if (itemStack.item == Items.AIR) return false // TODO check if this is even needed
@@ -245,9 +280,17 @@ object CarnivalFruitDigging {
 
         val fruit = Fruit.fromTexture(textureHash) ?: return false
 
-        cell.anchoredFruit = fruit
-        updateRemainingFruit(cell, fruit)
-        return true
+        var updated = false
+        if (solvedCell.solvedFruit == Fruit.UNKNOWN) {
+            solvedCell.solvedFruit = fruit
+            updateRemainingFruit(solvedCell, fruit)
+            updated = true
+        }
+        if (solvedCell.isDiggable && dugCell.anchoredFruit == Fruit.UNKNOWN) {
+            dugCell.anchoredFruit = fruit
+            updated = true
+        }
+        return updated
     }
 
     @HandleEvent
@@ -298,14 +341,16 @@ object CarnivalFruitDigging {
             val fruitName = group("fruit")
             val fruit = Fruit.entries.find { it.inGameName == fruitName } ?: return
             lastSquareDug?.let {
-                gameGrid[it].adjacentTreasure = fruit
+                gameGrid[it].treasureFruit = fruit
             }
             return
         }
 
         if (noFruitsNearbyPattern.matches(message)) {
             lastSquareDug?.let {
-                gameGrid[it].adjacentTreasure = Fruit.NO_FRUIT
+                val cell = gameGrid[it]
+                cell.treasureFruit = Fruit.NO_FRUIT
+                cell.anchoredFruit = Fruit.NO_FRUIT
             }
             return
         }
@@ -338,11 +383,10 @@ object CarnivalFruitDigging {
     }
 
     private fun buildRemainingFruitDisplay(): List<Renderable> {
-        val fruitLines = Fruit.entries.mapNotNull { fruit ->
-            val count = remainingFruit[fruit] ?: return@mapNotNull null
-            if (count <= 0) return@mapNotNull null
-            Renderable.text("${fruit.inGameName}: $count")
-        }
+        val fruitLines = Fruit.entries
+            .filter { (remainingFruit[it] ?: 0) > 0 }
+            .sortedWith(compareByDescending<Fruit> { it.getPointValue() }.thenBy { it.inGameName })
+            .map { fruit -> Renderable.text("${fruit.getNameWithPointValue()}: ${remainingFruit[fruit]}") }
 
         if (fruitLines.isEmpty()) return emptyList()
         return listOf(Renderable.text("Fruit Digging")) + fruitLines


### PR DESCRIPTION
## What
This PR establishes parsing and data representation of the fruit digging carnival game state. It is able to store and display information learned from the various dousing states.

This also sets the stage for having a solver/move recommender in the future.

<details>
<summary>Images</summary>

<img width="3840" height="2040" alt="2026-06-04_00 36 13" src="https://github.com/user-attachments/assets/fa3929af-75cd-4f23-8ea8-9f51c62e9716" />
<img width="3840" height="2040" alt="2026-06-04_00 36 47" src="https://github.com/user-attachments/assets/4e29145f-0055-47fb-95f2-ceb34b66c3a1" />


</details>

## Changelog New Features
+ Added fruit digging helper. - Maxwell Zhao, Thunderblade73, & ILike2WatchMemes 
    * Remembers and displays information learned from the various dousing modes.
    * Keeps track of remaining fruits.