### PR TITLE
Fix: Island Events not firing when equivalent islands are swapped between.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/hypixelapi/HypixelLocationApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/hypixelapi/HypixelLocationApi.kt
@@ -144,7 +144,6 @@ object HypixelLocationApi {
     }
 
     private fun changeIsland() {
-        if (internalIsland == island) return
         val oldIsland = island
         island = internalIsland
         logger.log("Island change: '$oldIsland' -> '$island'")


### PR DESCRIPTION
## What
As it turns out ModApi Impl had the same issues as the other impl just, nobody noticed it because the other impl used to have the NONE set as internal island in the middle.

## Changelog Fixes
+ Fixed features that check for Current Island not working when swapping from equivalent islands (HUB --> HUB). - Fazfoxy
    * This includes any feature that relied on the Graph system to check current area such as Slayer/Carnival features.
