### PR TITLE
Fix: Lunar Moth kills not being tracked

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -106,7 +106,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     )
 
     val DUNG_ITEM = "DUNG".toInternalName()
-    val SUNFLOWER_ITEM = "DOUBLE_PLANT".toInternalName()
+    val ENCHANTED_SUNFLOWER_ITEM = "ENCHANTED_SUNFLOWER".toInternalName()
     val OVERCLOCKER = "OVERCLOCKER_3000".toInternalName()
     val BITS = "SKYBLOCK_BIT".toInternalName()
     const val KILL_BITS = 5
@@ -236,7 +236,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
                 // Field Mice drop 6 separate items, but we only want to count the kill once
                 PestType.FIELD_MOUSE -> internalName == DUNG_ITEM
                 // Lunar Moths drop 3 separate crops, but we only want to count the kill once
-                PestType.LUNAR_MOTH -> internalName == SUNFLOWER_ITEM
+                PestType.LUNAR_MOTH -> internalName == ENCHANTED_SUNFLOWER_ITEM
                 // Overclocker drops have the same format as crop drops and causes double counting kills
                 else -> internalName != OVERCLOCKER
             }


### PR DESCRIPTION
## What
Fixes Lunar Moth kills not being tracked, because the code was mistakenly checking for Sunflower rather than Enchanted Sunflower.

## Changelog Fixes
+ Fixed Lunar Moth kills not counting towards Pest Profit Tracker and Mantid Kill Display. - Luna

