### PR TITLE
Backend: Fix generateRepoPatterns not working

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,12 +150,15 @@ dependencies {
 
     target.fabricLoaderVersion?.let {
         if (isDeobf) implementation(it) else modImplementation(it)
+        "productionRuntimeMods"(it)
     }
     target.fabricApiVersion?.let {
         if (isDeobf) implementation(it) else modImplementation(it)
+        "productionRuntimeMods"(it)
     }
     if (isDeobf) implementation(libs.fabricLanguageKotlin)
     else modImplementation(libs.fabricLanguageKotlin)
+    "productionRuntimeMods"(libs.fabricLanguageKotlin)
 
     target.modMenuVersion?.let {
         if (isDeobf) implementation("maven.modrinth:modmenu:$it")
@@ -178,10 +181,14 @@ dependencies {
         }
         include("org.notenoughupdates.moulconfig:modern-$moulconfigVersion:${libs.versions.moulconfig.get()}")
     }
+    "minecraftTestClientRuntimeLibraries"(
+        "org.notenoughupdates.moulconfig:modern-$moulconfigVersion:${libs.versions.moulconfig.get()}"
+    )
 
     shadowImpl(libs.libautoupdate) {
         exclude(module = "gson")
     }
+    "minecraftTestClientRuntimeLibraries"(libs.libautoupdate)
 
     testImplementation(libs.junit)
     testRuntimeOnly(libs.junit.launcher)
@@ -195,6 +202,7 @@ dependencies {
         modImplementation(target.hypixelModApiVersion)
         modRuntimeOnly(target.hypixelModApiFabricVersion)
     }
+    "productionRuntimeMods"(target.hypixelModApiFabricVersion)
 
     if (isDeobf) compileOnly(libs.roughlyenoughitems) { exclude(group = "net.fabricmc.fabric-api") }
     else modCompileOnly(libs.roughlyenoughitems) { exclude(group = "net.fabricmc.fabric-api") }
@@ -204,6 +212,7 @@ dependencies {
 
     // Calculator
     includeImplementation(libs.keval)
+    "minecraftTestClientRuntimeLibraries"(libs.keval)
 
     // Repo mgmt
     includeImplementation(libs.jgit)
@@ -213,6 +222,7 @@ dependencies {
     detektPlugins(libs.detektrules.ktlint)
 
     shadowImpl(libs.httpclient)
+    "minecraftTestClientRuntimeLibraries"(libs.httpclient)
 }
 
 fun DependencyHandler.includeImplementation(dep: Any) {
@@ -301,7 +311,6 @@ if (target == ProjectTarget.MODERN_26100) {
         javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
         dependsOn(tasks.named("configureLaunch"))
         val outputFile = project.file("build/regexes/constants.json")
-        mods.from(project.configurations.getByName("modImplementation"))
 
         jvmArgs.add("-DSkyHanniDumpRegex.enabled=true")
         jvmArgs.add("-DSkyHanniDumpRegex=${SHVersionInfo.gitHash}:${outputFile.absolutePath}")


### PR DESCRIPTION
## What
There may be a better way to do this, but this will do for now. (Can't do `mods.from(project.configurations.getByName("implementation")`.)

## Changelog Technical Details
+ Fixed generateRepoPatterns Gradle task not working. - Luna