### PR TITLE
Feature: Protect Rare Reforges in Blacksmith

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ReforgeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ReforgeApi.kt
@@ -17,11 +17,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 @SkyHanniModule
 object ReforgeApi {
     var reforges: List<Reforge> = emptyList()
-        private set(value) {
-            field = value
-            basicReforges = value.filterNot { it.isReforgeStone }
-            reforgeStones = value.filter { it.isReforgeStone }
-        }
+        private set
 
     var basicReforges: List<Reforge> = emptyList()
         private set
@@ -105,8 +101,8 @@ object ReforgeApi {
 
     @HandleEvent
     fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
-        val reforgeStoneData = event.getConstant<Map<String, NeuReforgeJson>>("reforgestones").values
-        val reforgeData = event.getConstant<Map<String, NeuReforgeJson>>("reforges").values
-        reforges = (reforgeStoneData + reforgeData).map { it.mapReforge() }
+        reforgeStones = event.getConstant<Map<String, NeuReforgeJson>>("reforgestones").values.map { it.mapReforge() }
+        basicReforges = event.getConstant<Map<String, NeuReforgeJson>>("reforges").values.map { it.mapReforge() }
+        reforges = (reforgeStones + basicReforges)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/helper/ReforgeHelperConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/helper/ReforgeHelperConfig.kt
@@ -24,6 +24,12 @@ class ReforgeHelperConfig {
     var reforgeStonesOnlyHex: Boolean = true
 
     @Expose
+    @ConfigOption(name = "Block Rare Reforge", desc = "Blocks overwriting non-Blacksmith reforges")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var blockNonBasicReforge: Boolean = true
+
+    @Expose
     @ConfigOption(
         name = "Show Diff",
         desc = "Shows the difference of the new reforge to the current one in the selection list."

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
@@ -142,7 +142,7 @@ object ReforgeHelper {
         if (event.slot?.index == reforgeButton) {
             val lastLine = event.slot.item.getLoreComponent().lastOrNull()?.string
             if (!clickToReforgePattern.matches(lastLine)) return
-            if (!handleNonBasicReforgeBlock(event)) return
+            if (handleNonBasicReforgeBlock(event)) return
             if (handleReforgeButtonClick(event)) return
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
+import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.NumberUtil.toStringWithPlus
@@ -85,6 +86,7 @@ object ReforgeHelper {
 
     private var isInReforgeMenu = false
     private var isInHexReforgeMenu = false
+    private var rareReforgeBlocked = false
 
     private fun isReforgeMenu(chestName: String) = reforgeMenuPattern.matches(chestName)
     private fun isHexReforgeMenu(chestName: String) = reforgeHexMenuPattern.matches(chestName)
@@ -135,9 +137,12 @@ object ReforgeHelper {
     @HandleEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled()) return
+        rareReforgeBlocked = false
+
         if (event.slot?.index == reforgeButton) {
             val lastLine = event.slot.item.getLoreComponent().lastOrNull()?.string
             if (!clickToReforgePattern.matches(lastLine)) return
+            if (!handleNonBasicReforgeBlock(event)) return
             if (handleReforgeButtonClick(event)) return
         }
 
@@ -164,6 +169,18 @@ object ReforgeHelper {
             }
         }
         return false
+    }
+
+    private fun handleNonBasicReforgeBlock(event: GuiContainerEvent.SlotClickEvent): Boolean {
+        if (!config.blockNonBasicReforge) return false
+        val current = currentReforge ?: return false
+        if (current in ReforgeApi.basicReforges) return false
+        if (KeyboardManager.isModifierKeyDown()) return false
+
+        rareReforgeBlocked = true
+        SoundUtils.playBeepSound()
+        event.cancel()
+        return true
     }
 
     @HandleEvent
@@ -227,6 +244,7 @@ object ReforgeHelper {
         sortAfter = null
         itemToReforge = null
         display = emptyList()
+        rareReforgeBlocked = false
     }
 
     private fun updateDisplay() {
@@ -396,6 +414,17 @@ object ReforgeHelper {
     fun onForegroundDrawn(event: GuiContainerEvent.ForegroundDrawnEvent) {
         if (!isEnabled()) return
         if (currentReforge == null) return
+
+        if (rareReforgeBlocked) {
+            inventoryContainer?.getSlot(reforgeButton)?.let {
+                val modifier = KeyboardManager.getModifierKeyName(true)
+                event.drawSlotText(
+                    it.x - 55, it.y + 20,
+                    "§cThis item has a non-Blacksmith reforge! ($modifier to bypass)",
+                    1f
+                )
+            }
+        }
 
         inventoryContainer?.getSlot(reforgeItem)?.let {
             event.drawSlotText(it.x - 5, it.y, "§e${currentReforge?.name}", 1f)


### PR DESCRIPTION
## What
Some guy reforges his bloodshot equipment, so now it will block said action.
It will block any reforge from power stone to blacksmith reforge

This is a draft since I still need to figure out  the proper key press logic.

## Changelog New Features
+ Block Overriding Rare Reforges in Blacksmith and Hex. - AverageUser125