### PR TITLE
Fix: Pets menu detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -62,13 +62,11 @@ object PetStorageApi {
     // <editor-fold desc="Patterns">
     /**
      * REGEX-TEST: Pets
-     * REGEX-TEST: Pets (1/3)
-     * REGEX-TEST: Pets: "a"
-     * REGEX-TEST: Pets: "e" (1/2)
+     * REGEX-TEST: (1/3) Pets
      */
     val mainPetMenuNamePattern by patternGroup.pattern(
         "menu.gui.name",
-        "Pets(?:: \"(?<search>.*)\")?(?: \\((?<currentpage>\\d+)\\/(?<maxpage>\\d+)\\))? ?",
+        "(?:\\(\\d+/\\d+\\) )?Pets",
     )
 
     /**


### PR DESCRIPTION
## What
Fixes Pets menu not being detected after a recent Hypixel issue.

The search query seems to be no longer shown in the title, and the capturing groups `currentpage`/`maxpage` appear to never have been used at all, so I removed those.

## Changelog Fixes
+ Fixed Pets menu no longer being detected after a recent Hypixel update. - Luna
