### PR TITLE
Fix: Disable data submission on alpha server

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.enums.SharePolicy
 import at.hannibal2.skyhanni.data.ElectionApi
+import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteFeastData
@@ -169,6 +170,7 @@ object HarvestFeastManager {
         currentFeastData = sendData.createData().takeIf { it.complete } ?: return
         
         if (config.sharePolicy == SharePolicy.DISABLED) return
+        if (HypixelData.hypixelAlpha) return
 
         if (config.sharePolicy == SharePolicy.ASK) {
             ChatUtils.clickableChat(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.config.enums.SharePolicy
+import at.hannibal2.skyhanni.data.HypixelData
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteFarmingContest
 import at.hannibal2.skyhanni.data.model.TabWidget
@@ -300,6 +301,7 @@ object GardenNextJacobContest {
     private fun onHaveAllContests() {
         nextContestsAvailableAt = SkyBlockTime(SkyBlockTime.now().year + 1, 1, 2).toTimeMark()
         if (!isSendEnabled()) return
+        if (HypixelData.hypixelAlpha) return
         if (config.shareAutomatically == SharePolicy.ASK) {
             ChatUtils.clickableChat(
                 "§2Click here to submit this year's farming contests. Thank you for helping everyone out!",

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -132,6 +132,7 @@ object MiningEventTracker {
     private fun sendData(eventName: String, time: String?) {
         // Option to opt out of data sending
         if (!config.allowDataSharing) return
+        if (HypixelData.hypixelAlpha) return
 
         // we now ignore mineshaft events.
         if (IslandType.MINESHAFT.isInIsland()) return


### PR DESCRIPTION
## What
Disables Harvest Feast, Jacob Contest, and Mining Event data submission if connected to alpha.hypixel.net.

## Changelog Fixes
+ Fixed SkyHanni incorrectly submitting Harvest Feast, Jacob Contest, and Mining Event data on the alpha server. - Luna