### PR TITLE
Fix: Update Odger inventory title

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/OdgerTotalCaught.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/OdgerTotalCaught.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 object OdgerTotalCaught {
 
     private val config get() = SkyHanniMod.feature.fishing.trophyFishing
+
     private val patternGroup = RepoPattern.group("fishing.trophy.odger")
 
     /**
@@ -35,11 +36,10 @@ object OdgerTotalCaught {
         "^Bronze.*",
     )
 
-    private val odgerInventory = InventoryDetector { name -> name == "Trophy Fishing" }
-
-    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
+    // Not island-gated because Odger has an Abiphone contact
+    @HandleEvent(onlyOnSkyblock = true)
     fun onToolTipEvent(event: ToolTipTextEvent) {
-        if (!odgerInventory.isInside()) return
+        if (!TrophyFishManager.odgerInventory.isInside()) return
         if (!config.totalFishCaught) return
 
         if (event.toolTip.none { discoveredPattern.matcher(it.string).find() }) return

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishManager.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -22,6 +23,7 @@ import net.minecraft.network.chat.Style
 
 @SkyHanniModule
 object TrophyFishManager {
+
     private val config get() = SkyHanniMod.feature.fishing.trophyFishing
 
     private val patternGroup = RepoPattern.group("fishing.trophyfish")
@@ -41,6 +43,8 @@ object TrophyFishManager {
         "odger.rank.empty",
         "§.(?<rarity>.*) §c✖",
     )
+
+    val odgerInventory = InventoryDetector { name -> name == "Trophy Fish" }
 
     fun loadMissingTrophyFish(): Int {
         val savedFishes = fish ?: return 0
@@ -106,9 +110,10 @@ object TrophyFishManager {
     }
 
     // Fetch when talking with Odger
-    @HandleEvent
+    // Not island-gated because Odger has an Abiphone contact
+    @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (event.inventoryName != "Trophy Fishing") return
+        if (event.inventoryName != "Trophy Fish") return
 
         var updatedFishes = loadMissingTrophyFish()
         val savedFishes = fish ?: return


### PR DESCRIPTION
## What
Fixes some Odger/Trophy Fish features not working because of an inventory title change.

## Changelog Fixes
+ Fixed Trophy Fish Display not updating when talking to Odger. - Luna
+ Fixed Trophy Fish "Total Caught Tooltip" feature not working. - Luna

