### PR TITLE
Fix: In-world chroma rendering

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/render/layers/ChromaRenderLayer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/layers/ChromaRenderLayer.kt
@@ -24,7 +24,7 @@ class ChromaRenderLayer(
     if (texture == null) {
         RenderSetup.builder(SkyHanniRenderPipeline.CHROMA_STANDARD())
     } else {
-        RenderSetup.builder(SkyHanniRenderPipeline.CHROMA_TEXT()).withTexture("texture", texture)
+        RenderSetup.builder(SkyHanniRenderPipeline.CHROMA_TEXT()).withTexture("Sampler0", texture)
     }.createRenderSetup(),
 ) {
 


### PR DESCRIPTION
## What
Fixes in-world chroma text rendering as boxes. The issue only seemed to affect Everything Chroma.

## Changelog Fixes
+ Fixed in-world chroma text not rendering properly (especially with Everything Chroma). - Luna