### PR TITLE
Backend: Add More Bridgiar Argument Types

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
@@ -88,7 +88,8 @@ object BrigadierUtils {
 
     fun String.escapeDoubleQuote(): String {
         if (firstOrNull() != DOUBLE_QUOTE) return this
-        return substring(1, lastIndex - 1)
+        if (lastOrNull() != DOUBLE_QUOTE) return this
+        return substring(1, lastIndex)
     }
 
     enum class ItemParsingFail {

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerCategory.kt
@@ -1,0 +1,19 @@
+package at.hannibal2.skyhanni.config.commands.brigadier
+
+import at.hannibal2.skyhanni.data.FriendApi
+import at.hannibal2.skyhanni.data.GuildApi
+import at.hannibal2.skyhanni.data.PartyApi
+import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.PlayerUtils
+
+enum class PlayerCategory(private val usernamesGetter: () -> Sequence<String>) {
+    ISLAND_PLAYERS({ EntityUtils.getPlayerEntities().asSequence().map { it.name.string } }),
+    SELF({ sequenceOf(PlayerUtils.getName()) }),
+    PARTY({ PartyApi.partyMembers.asSequence() }),
+    GUILD({ GuildApi.getAllMembers().asSequence() }),
+    FRIENDS({ FriendApi.getAllFriends().asSequence().map { it.name } }),
+    ;
+
+    fun usernames(): Sequence<String> = usernamesGetter()
+}
+

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.dynamicSuggestionProvider
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.toSuggestionProvider
 import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerCategory
 import com.mojang.brigadier.suggestion.SuggestionProvider
@@ -39,12 +40,12 @@ class PlayerSuggestions private constructor(
         }
     }
 
-    private val cached: List<String> by lazy {
+    private fun getPlayers(): List<String>{
         val excludedNames = exclude
             .flatMap(PlayerCategory::usernames)
             .toSet()
 
-        include
+        return include
             .flatMap(PlayerCategory::usernames)
             .filterNot(excludedNames::contains)
             .filter(filter)
@@ -52,7 +53,7 @@ class PlayerSuggestions private constructor(
     }
 
     fun toBrigadier(): SuggestionProvider<FabricClientCommandSource> {
-        return cached.toSuggestionProvider()
+        return dynamicSuggestionProvider { getPlayers() }
     }
 
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -28,11 +28,13 @@ class PlayerSuggestions private constructor(
         }
 
         fun exclude(vararg categories: PlayerCategory) = apply {
-            val excluded = categories.asSequence()
+            val excludedSeq = categories
+                .asSequence()
                 .flatMap { it.usernames() }
-                .toSet()
 
-            seq = seq.filterNot { it in excluded }
+            seq = seq.filterNot { name ->
+                excludedSeq.any { it == name }
+            }
         }
 
         fun exclude(vararg players: String) = apply {
@@ -48,13 +50,11 @@ class PlayerSuggestions private constructor(
             seq = seq.filterNot(predicate)
         }
 
-        fun build(): PlayerSuggestions {
-            return PlayerSuggestions(seq)
-        }
+        fun build(): PlayerSuggestions = PlayerSuggestions(seq)
     }
 
     companion object {
-        fun build(block: Builder.() -> Unit): SuggestionProvider<FabricClientCommandSource> {
+        fun builder(block: Builder.() -> Unit): SuggestionProvider<FabricClientCommandSource> {
             return Builder()
                 .apply(block)
                 .build()

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -67,7 +67,7 @@ enum class PlayerSource(private val usernamesGetter: () -> Sequence<String>) {
     SELF({ sequenceOf(PlayerUtils.getName()) }),
     PARTY({ PartyApi.partyMembers.asSequence() }),
     GUILD({ GuildApi.getAllMembers().asSequence() }),
-    CARRY_COSTUMER({ CarryTracker.customers.asSequence().map { it.name } }),
+    CARRY_CUSTOMER({ CarryTracker.customers.asSequence().map { it.name } }),
     ;
 
     fun usernames(): Sequence<String> = usernamesGetter()

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -10,6 +10,7 @@ import com.mojang.brigadier.suggestion.SuggestionProvider
 import com.mojang.brigadier.suggestion.Suggestions
 import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
+import net.minecraft.world.entity.player.Player
 import java.util.concurrent.CompletableFuture
 
 class PlayerSuggestions private constructor(
@@ -18,10 +19,17 @@ class PlayerSuggestions private constructor(
 ) : SuggestionProvider<FabricClientCommandSource> {
 
     fun usernames(): Set<String> {
-        val included = include.flatMapTo(linkedSetOf()) { it.usernames() }
-        val excluded = exclude.flatMapTo(linkedSetOf()) { it.usernames() }
+        val excluded = exclude
+            .asSequence()
+            .flatMap { it.usernames() }
+            .map { it.lowercase() }
+            .toSet()
 
-        return included - excluded
+        return include
+            .asSequence()
+            .flatMap { it.usernames() }
+            .filterNot { it.lowercase() in excluded }
+            .toSet()
     }
 
     fun listSuggestions(
@@ -53,25 +61,35 @@ class PlayerSuggestions private constructor(
         }
     }
 }
-
 enum class PlayerSource {
-    WORLD,
-    SELF,
-    PARTY,
-    GUILD,
-    CARRY_CUSTOMER,
-    ;
-
-    fun usernames(): Set<String> = when (this) {
-        WORLD ->
+    WORLD {
+        override fun usernames(): Sequence<String> =
             EntityUtils.getPlayerEntities()
-                .mapTo(linkedSetOf()) { it.gameProfile.name }
-        SELF ->
-            setOfNotNull(
-                MinecraftCompat.localPlayerOrNull?.gameProfile?.name,
-            )
-        PARTY -> PartyApi.partyMembers.toSet()
-        GUILD -> GuildApi.getAllMembers().toSet()
-        CARRY_CUSTOMER -> CarryTracker.customers.map { it.name }.toSet()
-    }
+                .asSequence()
+                .map { it.gameProfile.name }
+    },
+
+    SELF {
+        override fun usernames(): Sequence<String> {
+            val username = MinecraftCompat.localPlayerOrNull?.gameProfile?.name ?: return emptySequence()
+            return sequenceOf(username)
+        }
+    },
+
+    PARTY {
+        override fun usernames(): Sequence<String> =
+            PartyApi.partyMembers.asSequence()
+    },
+
+    GUILD {
+        override fun usernames(): Sequence<String> =
+            GuildApi.getAllMembers().asSequence()
+    },
+
+    CARRY_CUSTOMER {
+        override fun usernames(): Sequence<String> =
+            CarryTracker.customers.asSequence().map { it.name }
+    };
+
+    abstract fun usernames(): Sequence<String>
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -1,11 +1,5 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
-import at.hannibal2.skyhanni.data.FriendApi
-import at.hannibal2.skyhanni.data.GuildApi
-import at.hannibal2.skyhanni.data.PartyApi
-import at.hannibal2.skyhanni.features.misc.CarryTracker
-import at.hannibal2.skyhanni.utils.EntityUtils
-import at.hannibal2.skyhanni.utils.PlayerUtils
 import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.suggestion.SuggestionProvider
 import com.mojang.brigadier.suggestion.Suggestions
@@ -14,29 +8,38 @@ import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
 import java.util.concurrent.CompletableFuture
 
 class PlayerSuggestions private constructor(
-    private val include: Set<PlayerSource>,
-    private val exclude: Set<PlayerSource>,
+    private val include: Set<PlayerCategory>,
+    private val exclude: Set<PlayerCategory>,
+    private val customFilter: (String) -> Boolean,
 ) : SuggestionProvider<FabricClientCommandSource> {
 
-    fun usernames(): Set<String> {
-        val excluded = exclude
+    private val cached: List<String> by lazy {
+        val excludedNames = exclude
             .asSequence()
             .flatMap { it.usernames() }
             .toSet()
 
-        return include
+        var result = include
             .asSequence()
             .flatMap { it.usernames() }
-            .filterNot { it in excluded }
-            .toSet()
+            .filterNot { it in excludedNames }
+            .filter(customFilter)
+
+        result = result.distinct()
+
+        result.toList()
     }
 
-    fun listSuggestions(
+    fun usernames(): List<String> = cached
+
+    override fun getSuggestions(
+        context: CommandContext<FabricClientCommandSource>,
         builder: SuggestionsBuilder,
     ): CompletableFuture<Suggestions> {
+
         val remaining = builder.remainingLowerCase
 
-        usernames()
+        cached
             .asSequence()
             .filter { it.lowercase().startsWith(remaining) }
             .forEach(builder::suggest)
@@ -44,31 +47,53 @@ class PlayerSuggestions private constructor(
         return builder.buildFuture()
     }
 
-    override fun getSuggestions(
-        context: CommandContext<FabricClientCommandSource>,
-        builder: SuggestionsBuilder,
-    ): CompletableFuture<Suggestions> {
-        return listSuggestions(builder)
+    class Builder {
+        private val include = mutableSetOf<PlayerCategory>()
+        private val exclude = mutableSetOf<PlayerCategory>()
+
+        private var filter: (String) -> Boolean = { true }
+
+        fun include(vararg categories: PlayerCategory) = apply {
+            include.addAll(categories)
+        }
+
+        fun exclude(vararg categories: PlayerCategory) = apply {
+            exclude.addAll(categories)
+        }
+
+        fun filter(predicate: (String) -> Boolean) = apply {
+            val old = this.filter
+            this.filter = { old(it) && predicate(it) }
+        }
+
+        fun filterNot(vararg categories: PlayerCategory) = apply {
+            val excludedNames = categories
+                .asSequence()
+                .flatMap { it.usernames() }
+                .toSet()
+
+            filter { it !in excludedNames }
+        }
+
+        fun build(): PlayerSuggestions {
+            return PlayerSuggestions(
+                include = include,
+                exclude = exclude,
+                customFilter = filter,
+            )
+        }
     }
 
     companion object {
-        fun create(
-            include: Set<PlayerSource> = setOf(PlayerSource.WORLD),
-            exclude: Set<PlayerSource> = emptySet(),
-        ): PlayerSuggestions {
-            return PlayerSuggestions(include, exclude)
+        fun builder(): Builder = Builder()
+
+        fun all(): PlayerSuggestions =
+            builder()
+                .include(*PlayerCategory.entries.toTypedArray())
+                .build()
+
+        fun builder(block: Builder.() -> Unit): PlayerSuggestions {
+            return Builder().apply(block).build()
         }
     }
-}
-
-enum class PlayerSource(private val usernamesGetter: () -> Sequence<String>) {
-    WORLD({ EntityUtils.getPlayerEntities().asSequence().map { it.gameProfile.name } }),
-    SELF({ sequenceOf(PlayerUtils.getName()) }),
-    PARTY({ PartyApi.partyMembers.asSequence() }),
-    GUILD({ GuildApi.getAllMembers().asSequence() }),
-    FRIEND({ FriendApi.getAllFriends().map { it.name }.asSequence() }),
-    CARRY_CUSTOMER({ CarryTracker.customers.asSequence().map { it.name } }),
-    ;
-
-    fun usernames(): Sequence<String> = usernamesGetter()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
+import at.hannibal2.skyhanni.data.FriendApi
 import at.hannibal2.skyhanni.data.GuildApi
 import at.hannibal2.skyhanni.data.PartyApi
 import at.hannibal2.skyhanni.features.misc.CarryTracker
@@ -65,6 +66,7 @@ enum class PlayerSource(private val usernamesGetter: () -> Sequence<String>) {
     SELF({ sequenceOf(PlayerUtils.getName()) }),
     PARTY({ PartyApi.partyMembers.asSequence() }),
     GUILD({ GuildApi.getAllMembers().asSequence() }),
+    FRIEND({ FriendApi.getAllFriends().map { it.name }.asSequence() }),
     CARRY_CUSTOMER({ CarryTracker.customers.asSequence().map { it.name } }),
     ;
 

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -5,13 +5,11 @@ import at.hannibal2.skyhanni.data.PartyApi
 import at.hannibal2.skyhanni.features.misc.CarryTracker
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.PlayerUtils
-import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.suggestion.SuggestionProvider
 import com.mojang.brigadier.suggestion.Suggestions
 import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
-import net.minecraft.world.entity.player.Player
 import java.util.concurrent.CompletableFuture
 
 class PlayerSuggestions private constructor(

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.toSuggestionProvider
 import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerCategory
 import com.mojang.brigadier.suggestion.SuggestionProvider
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
@@ -51,16 +52,7 @@ class PlayerSuggestions private constructor(
     }
 
     fun toBrigadier(): SuggestionProvider<FabricClientCommandSource> {
-        return SuggestionProvider { _, builder ->
-
-            val remaining = builder.remainingLowerCase
-
-            cached
-                .filter { it.lowercase().startsWith(remaining) }
-                .forEach { builder.suggest(it) }
-
-            builder.buildFuture()
-        }
+        return cached.toSuggestionProvider()
     }
 
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -1,56 +1,18 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
-import com.mojang.brigadier.context.CommandContext
+import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerCategory
 import com.mojang.brigadier.suggestion.SuggestionProvider
-import com.mojang.brigadier.suggestion.Suggestions
-import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
-import java.util.concurrent.CompletableFuture
 
 class PlayerSuggestions private constructor(
     private val include: Set<PlayerCategory>,
     private val exclude: Set<PlayerCategory>,
-    private val customFilter: (String) -> Boolean,
-) : SuggestionProvider<FabricClientCommandSource> {
-
-    private val cached: List<String> by lazy {
-        val excludedNames = exclude
-            .asSequence()
-            .flatMap { it.usernames() }
-            .toSet()
-
-        var result = include
-            .asSequence()
-            .flatMap { it.usernames() }
-            .filterNot { it in excludedNames }
-            .filter(customFilter)
-
-        result = result.distinct()
-
-        result.toList()
-    }
-
-    fun usernames(): List<String> = cached
-
-    override fun getSuggestions(
-        context: CommandContext<FabricClientCommandSource>,
-        builder: SuggestionsBuilder,
-    ): CompletableFuture<Suggestions> {
-
-        val remaining = builder.remainingLowerCase
-
-        cached
-            .asSequence()
-            .filter { it.lowercase().startsWith(remaining) }
-            .forEach(builder::suggest)
-
-        return builder.buildFuture()
-    }
+    private val filter: (String) -> Boolean
+) {
 
     class Builder {
         private val include = mutableSetOf<PlayerCategory>()
         private val exclude = mutableSetOf<PlayerCategory>()
-
         private var filter: (String) -> Boolean = { true }
 
         fun include(vararg categories: PlayerCategory) = apply {
@@ -62,38 +24,51 @@ class PlayerSuggestions private constructor(
         }
 
         fun filter(predicate: (String) -> Boolean) = apply {
-            val old = this.filter
-            this.filter = { old(it) && predicate(it) }
+            val old = filter
+            filter = { old(it) && predicate(it) }
         }
 
-        fun filterNot(vararg categories: PlayerCategory) = apply {
-            val excludedNames = categories
-                .asSequence()
-                .flatMap { it.usernames() }
-                .toSet()
-
-            filter { it !in excludedNames }
+        fun filterNot(predicate: (String) -> Boolean) = apply {
+            val old = filter
+            filter = { old(it) && !predicate(it) }
         }
 
         fun build(): PlayerSuggestions {
-            return PlayerSuggestions(
-                include = include,
-                exclude = exclude,
-                customFilter = filter,
-            )
+            return PlayerSuggestions(include, exclude, filter)
+        }
+    }
+
+    private val cached: List<String> by lazy {
+        val excludedNames = exclude
+            .flatMap(PlayerCategory::usernames)
+            .toSet()
+
+        include
+            .flatMap(PlayerCategory::usernames)
+            .filterNot(excludedNames::contains)
+            .filter(filter)
+            .toList()
+    }
+
+    fun toBrigadier(): SuggestionProvider<FabricClientCommandSource> {
+        return SuggestionProvider { _, builder ->
+
+            val remaining = builder.remainingLowerCase
+
+            cached
+                .filter { it.lowercase().startsWith(remaining) }
+                .forEach { builder.suggest(it) }
+
+            builder.buildFuture()
         }
     }
 
     companion object {
-        fun builder(): Builder = Builder()
-
-        fun all(): PlayerSuggestions =
-            builder()
-                .include(*PlayerCategory.entries.toTypedArray())
+        fun build(block: Builder.() -> Unit): SuggestionProvider<FabricClientCommandSource> {
+            return Builder()
+                .apply(block)
                 .build()
-
-        fun builder(block: Builder.() -> Unit): PlayerSuggestions {
-            return Builder().apply(block).build()
+                .toBrigadier()
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -60,6 +60,7 @@ class PlayerSuggestions private constructor(
         }
     }
 }
+
 enum class PlayerSource {
     WORLD {
         override fun usernames(): Sequence<String> =

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -6,53 +6,51 @@ import com.mojang.brigadier.suggestion.SuggestionProvider
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
 
 class PlayerSuggestions private constructor(
-    private val include: Set<PlayerCategory>,
-    private val exclude: Set<PlayerCategory>,
-    private val filter: (String) -> Boolean,
+    private val sequence: Sequence<String>,
 ) {
 
-    class Builder {
-        private val include = mutableSetOf<PlayerCategory>()
-        private val exclude = mutableSetOf<PlayerCategory>()
-        private var filter: (String) -> Boolean = { true }
-
-        fun include(vararg categories: PlayerCategory) = apply {
-            include.addAll(categories)
-        }
-
-        fun exclude(vararg categories: PlayerCategory) = apply {
-            exclude.addAll(categories)
-        }
-
-        fun filter(predicate: (String) -> Boolean) = apply {
-            val old = filter
-            filter = { old(it) && predicate(it) }
-        }
-
-        fun filterNot(predicate: (String) -> Boolean) = apply {
-            val old = filter
-            filter = { old(it) && !predicate(it) }
-        }
-
-        fun build(): PlayerSuggestions {
-            return PlayerSuggestions(include, exclude, filter)
-        }
-    }
-
-    private fun getPlayers(): List<String> {
-        val excludedNames = exclude
-            .flatMap(PlayerCategory::usernames)
-            .toSet()
-
-        return include
-            .flatMap(PlayerCategory::usernames)
-            .filterNot(excludedNames::contains)
-            .filter(filter)
-            .toList()
-    }
+    fun getPlayers(): List<String> =
+        sequence.distinct().toList()
 
     fun toBrigadier(): SuggestionProvider<FabricClientCommandSource> {
         return dynamicSuggestionProvider { getPlayers() }
+    }
+
+    class Builder {
+        private var seq: Sequence<String> = emptySequence()
+
+        fun include(vararg categories: PlayerCategory) = apply {
+            seq += categories.asSequence().flatMap { it.usernames() }
+        }
+
+        fun include(vararg players: String) = apply {
+            seq += players.asSequence()
+        }
+
+        fun exclude(vararg categories: PlayerCategory) = apply {
+            val excluded = categories.asSequence()
+                .flatMap { it.usernames() }
+                .toSet()
+
+            seq = seq.filterNot { it in excluded }
+        }
+
+        fun exclude(vararg players: String) = apply {
+            val excluded = players.toSet()
+            seq = seq.filterNot { it in excluded }
+        }
+
+        fun filter(predicate: (String) -> Boolean) = apply {
+            seq = seq.filter(predicate)
+        }
+
+        fun filterNot(predicate: (String) -> Boolean) = apply {
+            seq = seq.filterNot(predicate)
+        }
+
+        fun build(): PlayerSuggestions {
+            return PlayerSuggestions(seq)
+        }
     }
 
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.dynamicSuggestionProvider
-import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.toSuggestionProvider
 import at.hannibal2.skyhanni.features.commands.tabcomplete.PlayerCategory
 import com.mojang.brigadier.suggestion.SuggestionProvider
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
@@ -9,7 +8,7 @@ import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
 class PlayerSuggestions private constructor(
     private val include: Set<PlayerCategory>,
     private val exclude: Set<PlayerCategory>,
-    private val filter: (String) -> Boolean
+    private val filter: (String) -> Boolean,
 ) {
 
     class Builder {
@@ -40,7 +39,7 @@ class PlayerSuggestions private constructor(
         }
     }
 
-    private fun getPlayers(): List<String>{
+    private fun getPlayers(): List<String> {
         val excludedNames = exclude
             .flatMap(PlayerCategory::usernames)
             .toSet()

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -22,13 +22,12 @@ class PlayerSuggestions private constructor(
         val excluded = exclude
             .asSequence()
             .flatMap { it.usernames() }
-            .map { it.lowercase() }
             .toSet()
 
         return include
             .asSequence()
             .flatMap { it.usernames() }
-            .filterNot { it.lowercase() in excluded }
+            .filterNot { it in excluded }
             .toSet()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -1,0 +1,74 @@
+package at.hannibal2.skyhanni.config.commands.brigadier
+
+import at.hannibal2.skyhanni.data.PartyApi
+import at.hannibal2.skyhanni.features.misc.CarryTracker
+import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.suggestion.SuggestionProvider
+import com.mojang.brigadier.suggestion.Suggestions
+import com.mojang.brigadier.suggestion.SuggestionsBuilder
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
+import java.util.concurrent.CompletableFuture
+
+class PlayerSuggestions private constructor(
+    private val include: Set<PlayerSource>,
+    private val exclude: Set<PlayerSource>,
+) : SuggestionProvider<FabricClientCommandSource> {
+
+    fun usernames(): Set<String> {
+        val included = include.flatMapTo(linkedSetOf()) { it.usernames() }
+        val excluded = exclude.flatMapTo(linkedSetOf()) { it.usernames() }
+
+        return included - excluded
+    }
+
+    fun listSuggestions(
+        builder: SuggestionsBuilder,
+    ): CompletableFuture<Suggestions> {
+        val remaining = builder.remainingLowerCase
+
+        usernames()
+            .asSequence()
+            .filter { it.lowercase().startsWith(remaining) }
+            .forEach(builder::suggest)
+
+        return builder.buildFuture()
+    }
+
+    override fun getSuggestions(
+        context: CommandContext<FabricClientCommandSource>,
+        builder: SuggestionsBuilder,
+    ): CompletableFuture<Suggestions> {
+        return listSuggestions(builder)
+    }
+
+    companion object {
+        fun create(
+            include: Set<PlayerSource> = setOf(PlayerSource.WORLD),
+            exclude: Set<PlayerSource> = emptySet(),
+        ): PlayerSuggestions {
+            return PlayerSuggestions(include, exclude)
+        }
+    }
+}
+
+enum class PlayerSource {
+    WORLD,
+    SELF,
+    PARTY,
+    CARRY_CUSTOMER,
+    ;
+
+    fun usernames(): Set<String> = when (this) {
+        WORLD ->
+            EntityUtils.getPlayerEntities()
+                .mapTo(linkedSetOf()) { it.gameProfile.name }
+        SELF ->
+            setOfNotNull(
+                MinecraftCompat.localPlayerOrNull?.gameProfile?.name,
+            )
+        PARTY -> PartyApi.partyMembers.toSet()
+        CARRY_CUSTOMER -> CarryTracker.customers.map { it.name }.toSet()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.commands.brigadier
 
+import at.hannibal2.skyhanni.data.GuildApi
 import at.hannibal2.skyhanni.data.PartyApi
 import at.hannibal2.skyhanni.features.misc.CarryTracker
 import at.hannibal2.skyhanni.utils.EntityUtils
@@ -57,6 +58,7 @@ enum class PlayerSource {
     WORLD,
     SELF,
     PARTY,
+    GUILD,
     CARRY_CUSTOMER,
     ;
 
@@ -69,6 +71,7 @@ enum class PlayerSource {
                 MinecraftCompat.localPlayerOrNull?.gameProfile?.name,
             )
         PARTY -> PartyApi.partyMembers.toSet()
+        GUILD -> GuildApi.getAllMembers().toSet()
         CARRY_CUSTOMER -> CarryTracker.customers.map { it.name }.toSet()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/PlayerSuggestions.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.data.GuildApi
 import at.hannibal2.skyhanni.data.PartyApi
 import at.hannibal2.skyhanni.features.misc.CarryTracker
 import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.suggestion.SuggestionProvider
@@ -61,35 +62,13 @@ class PlayerSuggestions private constructor(
     }
 }
 
-enum class PlayerSource {
-    WORLD {
-        override fun usernames(): Sequence<String> =
-            EntityUtils.getPlayerEntities()
-                .asSequence()
-                .map { it.gameProfile.name }
-    },
+enum class PlayerSource(private val usernamesGetter: () -> Sequence<String>) {
+    WORLD({ EntityUtils.getPlayerEntities().asSequence().map { it.gameProfile.name } }),
+    SELF({ sequenceOf(PlayerUtils.getName()) }),
+    PARTY({ PartyApi.partyMembers.asSequence() }),
+    GUILD({ GuildApi.getAllMembers().asSequence() }),
+    CARRY_COSTUMER({ CarryTracker.customers.asSequence().map { it.name } }),
+    ;
 
-    SELF {
-        override fun usernames(): Sequence<String> {
-            val username = MinecraftCompat.localPlayerOrNull?.gameProfile?.name ?: return emptySequence()
-            return sequenceOf(username)
-        }
-    },
-
-    PARTY {
-        override fun usernames(): Sequence<String> =
-            PartyApi.partyMembers.asSequence()
-    },
-
-    GUILD {
-        override fun usernames(): Sequence<String> =
-            GuildApi.getAllMembers().asSequence()
-    },
-
-    CARRY_CUSTOMER {
-        override fun usernames(): Sequence<String> =
-            CarryTracker.customers.asSequence().map { it.name }
-    };
-
-    abstract fun usernames(): Sequence<String>
+    fun usernames(): Sequence<String> = usernamesGetter()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/ComponentArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/ComponentArgumentType.kt
@@ -3,17 +3,15 @@ package at.hannibal2.skyhanni.config.commands.brigadier.arguments
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.escapeDoubleQuote
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.readGreedyString
 import at.hannibal2.skyhanni.utils.json.SkyHanniTypeAdapters
-import com.google.gson.JsonParseException
 import com.google.gson.JsonParser
 import com.google.gson.TypeAdapter
 import com.mojang.brigadier.StringReader
 import com.mojang.brigadier.arguments.ArgumentType
-import com.mojang.brigadier.exceptions.CommandSyntaxException
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
 import net.minecraft.network.chat.Component
 
 class ComponentArgumentType(
-    private val allowPlainText: Boolean
+    private val allowPlainText: Boolean,
 ) : ArgumentType<Component> {
     override fun parse(reader: StringReader): Component {
         val input = reader.readGreedyString().escapeDoubleQuote()

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/ComponentArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/ComponentArgumentType.kt
@@ -1,30 +1,42 @@
 package at.hannibal2.skyhanni.config.commands.brigadier.arguments
 
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.escapeDoubleQuote
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.readGreedyString
 import at.hannibal2.skyhanni.utils.json.SkyHanniTypeAdapters
+import com.google.gson.JsonParseException
+import com.google.gson.JsonParser
 import com.google.gson.TypeAdapter
 import com.mojang.brigadier.StringReader
 import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.exceptions.CommandSyntaxException
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
 import net.minecraft.network.chat.Component
 
-class ComponentArgumentType(private val allowPlainText: Boolean) : ArgumentType<Component> {
-
+class ComponentArgumentType(
+    private val allowPlainText: Boolean
+) : ArgumentType<Component> {
     override fun parse(reader: StringReader): Component {
-        val input = reader.readGreedyString()
+        val input = reader.readGreedyString().escapeDoubleQuote()
 
-        // the length check is to allow stuff like: "[:<"
-        val looksJson = input.length > 3 && (input.startsWith("{") || input.startsWith("["))
+        val looksJson =
+            input.length > 3 &&
+                (input.startsWith("{") || input.startsWith("["))
 
-        if (looksJson || !allowPlainText) {
-            try {
-                return adapter.fromJson(input)
-            } catch (_: Exception) {
-                throw INVALID_COMPONENT.create()
-            }
+        if (!looksJson && allowPlainText) {
+            return Component.literal(input)
         }
 
-        return Component.literal(input)
+        val jsonElement = try {
+            JsonParser.parseString(input)
+        } catch (_: Exception) {
+            throw INVALID_JSON.create()
+        }
+
+        return try {
+            adapter.fromJsonTree(jsonElement)
+        } catch (_: Exception) {
+            throw INVALID_COMPONENT.create()
+        }
     }
 
     companion object {
@@ -32,8 +44,11 @@ class ComponentArgumentType(private val allowPlainText: Boolean) : ArgumentType<
         fun component(allowPlainText: Boolean = false): ComponentArgumentType =
             ComponentArgumentType(allowPlainText)
 
+        private val INVALID_JSON =
+            SimpleCommandExceptionType(Component.literal("Invalid JSON"))
+
         private val INVALID_COMPONENT =
-            SimpleCommandExceptionType(Component.literal("Invalid component JSON"))
+            SimpleCommandExceptionType(Component.literal("Invalid component"))
 
         @Suppress("UNCHECKED_CAST")
         private val adapter: TypeAdapter<Component> by lazy {

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/ComponentArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/ComponentArgumentType.kt
@@ -1,0 +1,43 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.readGreedyString
+import at.hannibal2.skyhanni.utils.json.SkyHanniTypeAdapters
+import com.google.gson.TypeAdapter
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.minecraft.network.chat.Component
+
+class ComponentArgumentType(private val allowPlainText: Boolean) : ArgumentType<Component> {
+
+    override fun parse(reader: StringReader): Component {
+        val input = reader.readGreedyString()
+
+        // the length check is to allow stuff like: "[:<"
+        val looksJson = input.length > 3 && (input.startsWith("{") || input.startsWith("["))
+
+        if (looksJson || !allowPlainText) {
+            try {
+                return adapter.fromJson(input)
+            } catch (_: Exception) {
+                throw INVALID_COMPONENT.create()
+            }
+        }
+
+        return Component.literal(input)
+    }
+
+    companion object {
+
+        fun component(allowPlainText: Boolean = false): ComponentArgumentType =
+            ComponentArgumentType(allowPlainText)
+
+        private val INVALID_COMPONENT =
+            SimpleCommandExceptionType(Component.literal("Invalid component JSON"))
+
+        @Suppress("UNCHECKED_CAST")
+        private val adapter: TypeAdapter<Component> by lazy {
+            SkyHanniTypeAdapters.COMPONENT.adapter as TypeAdapter<Component>
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
@@ -27,6 +27,9 @@ class PlayerArgumentType private constructor(val suggestions: PlayerSuggestions)
             ?: throw PLAYER_NOT_FOUND.create(username)
     }
 
+    fun getAllPlayers(): List<Player> =
+        EntityUtils.getPlayerEntities() + listOfNotNull(MinecraftCompat.localPlayerOrNull)
+
     override fun <S> listSuggestions(
         context: CommandContext<S>,
         builder: SuggestionsBuilder,
@@ -40,10 +43,6 @@ class PlayerArgumentType private constructor(val suggestions: PlayerSuggestions)
     companion object {
         private val PLAYER_NOT_FOUND = DynamicCommandExceptionType {
             Component.literal("Could not find player with username: $it")
-        }
-
-        private fun getAllPlayers(): List<Player> {
-            return EntityUtils.getPlayerEntities() + listOfNotNull(MinecraftCompat.localPlayerOrNull)
         }
 
         fun player(

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
@@ -10,14 +10,9 @@ import net.minecraft.world.entity.player.Player
 
 class PlayerArgumentType private constructor() : ArgumentType<Player> {
     override fun parse(reader: StringReader): Player {
-        val username = if (reader.canRead() && reader.peek() == '"') {
-            reader.readQuotedString()
-        } else {
-            reader.readUnquotedString()
-        }
-
+        val username = reader.readString()
         return getAllPlayers()
-            .firstOrNull { it.gameProfile.name.equals(username, ignoreCase = true) }
+            .firstOrNull { it.name.string.equals(username, ignoreCase = true) }
             ?: throw PLAYER_NOT_FOUND.create(username)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
@@ -1,20 +1,14 @@
 package at.hannibal2.skyhanni.config.commands.brigadier.arguments
 
-import at.hannibal2.skyhanni.config.commands.brigadier.PlayerSource
-import at.hannibal2.skyhanni.config.commands.brigadier.PlayerSuggestions
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import com.mojang.brigadier.StringReader
 import com.mojang.brigadier.arguments.ArgumentType
-import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
-import com.mojang.brigadier.suggestion.Suggestions
-import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.player.Player
-import java.util.concurrent.CompletableFuture
 
-class PlayerArgumentType private constructor(val suggestions: PlayerSuggestions) : ArgumentType<Player> {
+class PlayerArgumentType private constructor() : ArgumentType<Player> {
     override fun parse(reader: StringReader): Player {
         val username = if (reader.canRead() && reader.peek() == '"') {
             reader.readQuotedString()
@@ -30,13 +24,6 @@ class PlayerArgumentType private constructor(val suggestions: PlayerSuggestions)
     fun getAllPlayers(): List<Player> =
         EntityUtils.getPlayerEntities() + listOfNotNull(MinecraftCompat.localPlayerOrNull)
 
-    override fun <S> listSuggestions(
-        context: CommandContext<S>,
-        builder: SuggestionsBuilder,
-    ): CompletableFuture<Suggestions> {
-        return suggestions.listSuggestions(builder)
-    }
-
     override fun getExamples(): Collection<String> =
         listOf("Notch", "Technoblade", "hannibal02")
 
@@ -45,11 +32,8 @@ class PlayerArgumentType private constructor(val suggestions: PlayerSuggestions)
             Component.literal("Could not find player with username: $it")
         }
 
-        fun player(
-            include: Set<PlayerSource> = setOf(PlayerSource.WORLD),
-            exclude: Set<PlayerSource> = emptySet(),
-        ): PlayerArgumentType {
-            return PlayerArgumentType(PlayerSuggestions.create(include, exclude))
+        fun player(): PlayerArgumentType {
+            return PlayerArgumentType()
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/PlayerArgumentType.kt
@@ -1,0 +1,56 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import at.hannibal2.skyhanni.config.commands.brigadier.PlayerSource
+import at.hannibal2.skyhanni.config.commands.brigadier.PlayerSuggestions
+import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
+import com.mojang.brigadier.suggestion.Suggestions
+import com.mojang.brigadier.suggestion.SuggestionsBuilder
+import net.minecraft.network.chat.Component
+import net.minecraft.world.entity.player.Player
+import java.util.concurrent.CompletableFuture
+
+class PlayerArgumentType private constructor(val suggestions: PlayerSuggestions) : ArgumentType<Player> {
+    override fun parse(reader: StringReader): Player {
+        val username = if (reader.canRead() && reader.peek() == '"') {
+            reader.readQuotedString()
+        } else {
+            reader.readUnquotedString()
+        }
+
+        return getAllPlayers()
+            .firstOrNull { it.gameProfile.name.equals(username, ignoreCase = true) }
+            ?: throw PLAYER_NOT_FOUND.create(username)
+    }
+
+    override fun <S> listSuggestions(
+        context: CommandContext<S>,
+        builder: SuggestionsBuilder,
+    ): CompletableFuture<Suggestions> {
+        return suggestions.listSuggestions(builder)
+    }
+
+    override fun getExamples(): Collection<String> =
+        listOf("Notch", "Technoblade", "hannibal02")
+
+    companion object {
+        private val PLAYER_NOT_FOUND = DynamicCommandExceptionType {
+            Component.literal("Could not find player with username: $it")
+        }
+
+        private fun getAllPlayers(): List<Player> {
+            return EntityUtils.getPlayerEntities() + listOfNotNull(MinecraftCompat.localPlayerOrNull)
+        }
+
+        fun player(
+            include: Set<PlayerSource> = setOf(PlayerSource.WORLD),
+            exclude: Set<PlayerSource> = emptySet(),
+        ): PlayerArgumentType {
+            return PlayerArgumentType(PlayerSuggestions.create(include, exclude))
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
@@ -34,10 +34,7 @@ class UuidArgumentType : ArgumentType<UUID> {
 
     companion object {
         private val invalidUuid = SimpleCommandExceptionType(
-            LiteralMessage(
-                "Invalid UUID format\n" +
-                    "Please provide a valid UUID in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-            )
+            LiteralMessage("Please provide a valid UUID in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
         )
 
         fun uuid(): UuidArgumentType = UuidArgumentType()

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
@@ -14,14 +14,6 @@ class UuidArgumentType : ArgumentType<UUID> {
             ?: throw invalidUuid.createWithContext(reader)
     }
 
-    private fun readUnquoted(reader: StringReader): String {
-        val start = reader.cursor
-        while (reader.canRead() && reader.peek() != ' ') {
-            reader.skip()
-        }
-        return reader.string.substring(start, reader.cursor)
-    }
-
     override fun getExamples(): Collection<String> = listOf(
         "123e4567-e89b-12d3-a456-426614174000",
         "\"123e4567-e89b-12d3-a456-426614174000\""

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
@@ -1,0 +1,45 @@
+package at.hannibal2.skyhanni.config.commands.brigadier.arguments
+
+import at.hannibal2.skyhanni.utils.StringUtils
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import com.mojang.brigadier.LiteralMessage
+import java.util.UUID
+
+class UuidArgumentType : ArgumentType<UUID> {
+    override fun parse(reader: StringReader): UUID {
+        val input =
+            if (reader.canRead() && reader.peek() == '"')
+                reader.readQuotedString()
+            else
+                readUnquoted(reader)
+
+        return StringUtils.parseUUIDOrNull(input)
+            ?: throw invalidUuid.createWithContext(reader)
+    }
+
+    private fun readUnquoted(reader: StringReader): String {
+        val start = reader.cursor
+        while (reader.canRead() && reader.peek() != ' ') {
+            reader.skip()
+        }
+        return reader.string.substring(start, reader.cursor)
+    }
+
+    override fun getExamples(): Collection<String> = listOf(
+        "123e4567-e89b-12d3-a456-426614174000",
+        "\"123e4567-e89b-12d3-a456-426614174000\""
+    )
+
+    companion object {
+        private val invalidUuid = SimpleCommandExceptionType(
+            LiteralMessage(
+                "Invalid UUID format\n" +
+                    "Please provide a valid UUID in the format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+            )
+        )
+
+        fun uuid(): UuidArgumentType = UuidArgumentType()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/UuidArgumentType.kt
@@ -9,12 +9,7 @@ import java.util.UUID
 
 class UuidArgumentType : ArgumentType<UUID> {
     override fun parse(reader: StringReader): UUID {
-        val input =
-            if (reader.canRead() && reader.peek() == '"')
-                reader.readQuotedString()
-            else
-                readUnquoted(reader)
-
+        val input = reader.readString()
         return StringUtils.parseUUIDOrNull(input)
             ?: throw invalidUuid.createWithContext(reader)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerCategory.kt
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.config.commands.brigadier
+package at.hannibal2.skyhanni.features.commands.tabcomplete
 
 import at.hannibal2.skyhanni.data.FriendApi
 import at.hannibal2.skyhanni.data.GuildApi
@@ -16,4 +16,3 @@ enum class PlayerCategory(private val usernamesGetter: () -> Sequence<String>) {
 
     fun usernames(): Sequence<String> = usernamesGetter()
 }
-

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerCategory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerCategory.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.commands.tabcomplete
 import at.hannibal2.skyhanni.data.FriendApi
 import at.hannibal2.skyhanni.data.GuildApi
 import at.hannibal2.skyhanni.data.PartyApi
+import at.hannibal2.skyhanni.features.misc.CarryTracker
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.PlayerUtils
 
@@ -12,6 +13,7 @@ enum class PlayerCategory(private val usernamesGetter: () -> Sequence<String>) {
     PARTY({ PartyApi.partyMembers.asSequence() }),
     GUILD({ GuildApi.getAllMembers().asSequence() }),
     FRIENDS({ FriendApi.getAllFriends().asSequence().map { it.name } }),
+    CARRY_CUSTOMER({ CarryTracker.getCustomers().asSequence().map { it.name } }),
     ;
 
     fun usernames(): Sequence<String> = usernamesGetter()

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
@@ -80,7 +80,7 @@ object PlayerTabComplete {
             PlayerCategory.ISLAND_PLAYERS -> config.islandPlayers
             PlayerCategory.PARTY -> config.party
             PlayerCategory.GUILD -> config.guild
-            PlayerCategory.SELF -> true
+            else -> true
         }
 
         val excludedSet = excluded.toSet()

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
@@ -18,7 +18,7 @@ object PlayerTabComplete {
 
     private val friendsEntry = lazyEntry { PlayerCategory.FRIENDS.usernames().toList() }
     private val partyMembersEntry = lazyEntry { PlayerCategory.PARTY.usernames().toList() }
-    private val guildMembersEntry = lazyEntry { PlayerCategory.GUILD.usernames().toList()}
+    private val guildMembersEntry = lazyEntry { PlayerCategory.GUILD.usernames().toList() }
     private val vipVisitsEntry = lazyEntry { vipVisits }
     private val islandPlayersEntry = lazyEntry { PlayerCategory.ISLAND_PLAYERS.usernames().toList() }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.commands.tabcomplete
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.config.commands.brigadier.PlayerCategory
 import at.hannibal2.skyhanni.data.PartyApi
 import at.hannibal2.skyhanni.data.jsonobjects.repo.VipVisitsJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
@@ -87,7 +86,6 @@ object PlayerTabComplete {
         val excludedSet = excluded.toSet()
 
         PlayerCategory.entries
-            .asSequence()
             .filter { it !in excludedSet }
             .filter { allowed(it) }
             .flatMap { it.usernames() }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
@@ -3,16 +3,13 @@ package at.hannibal2.skyhanni.features.commands.tabcomplete
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.FriendApi
-import at.hannibal2.skyhanni.data.GuildApi
+import at.hannibal2.skyhanni.config.commands.brigadier.PlayerCategory
 import at.hannibal2.skyhanni.data.PartyApi
 import at.hannibal2.skyhanni.data.jsonobjects.repo.VipVisitsJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.features.commands.suggestions.LazySuggestionEntry
 import at.hannibal2.skyhanni.features.commands.suggestions.SuggestionProvider
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.EntityUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 
 @SkyHanniModule
 object PlayerTabComplete {
@@ -20,11 +17,11 @@ object PlayerTabComplete {
     private val config get() = SkyHanniMod.feature.misc.commands.tabComplete
     private var vipVisits = listOf<String>()
 
-    private val friendsEntry = lazyEntry { FriendApi.getAllFriends().map { it.name } }
-    private val partyMembersEntry = lazyEntry { PartyApi.partyMembers }
-    private val guildMembersEntry = lazyEntry { GuildApi.getAllMembers() }
+    private val friendsEntry = lazyEntry { PlayerCategory.FRIENDS.usernames().toList() }
+    private val partyMembersEntry = lazyEntry { PlayerCategory.PARTY.usernames().toList() }
+    private val guildMembersEntry = lazyEntry { PlayerCategory.GUILD.usernames().toList()}
     private val vipVisitsEntry = lazyEntry { vipVisits }
-    private val islandPlayersEntry = lazyEntry { EntityUtils.getPlayerEntities().map { it.name.string } }
+    private val islandPlayersEntry = lazyEntry { PlayerCategory.ISLAND_PLAYERS.usernames().toList() }
 
     private val suggestions = SuggestionProvider.build {
         parent("f", "friend") {
@@ -77,26 +74,24 @@ object PlayerTabComplete {
         parent("trade") { add(islandPlayersEntry) }
     }
 
-    enum class PlayerCategory {
-        FRIENDS,
-        ISLAND_PLAYERS,
-        PARTY,
-        GUILD,
-    }
+    private fun getExcluding(vararg excluded: PlayerCategory) = LazySuggestionEntry {
 
-    private fun getExcluding(vararg categories: PlayerCategory) = LazySuggestionEntry {
-        if (config.friends && PlayerCategory.FRIENDS !in categories) {
-            addAll(FriendApi.getAllFriends().filter { it.bestFriend || !config.onlyBestFriends }.map { it.name })
+        fun allowed(category: PlayerCategory): Boolean = when (category) {
+            PlayerCategory.FRIENDS -> config.friends
+            PlayerCategory.ISLAND_PLAYERS -> config.islandPlayers
+            PlayerCategory.PARTY -> config.party
+            PlayerCategory.GUILD -> config.guild
+            PlayerCategory.SELF -> true
         }
-        if (config.islandPlayers && PlayerCategory.ISLAND_PLAYERS !in categories) {
-            addAll(EntityUtils.getPlayerEntities().map { it.name.string })
-        }
-        if (config.party && PlayerCategory.PARTY !in categories) {
-            addAll(PartyApi.partyMembers)
-        }
-        if (config.guild && PlayerCategory.GUILD !in categories) {
-            addAll(GuildApi.getAllMembers())
-        }
+
+        val excludedSet = excluded.toSet()
+
+        PlayerCategory.entries
+            .asSequence()
+            .filter { it !in excludedSet }
+            .filter { allowed(it) }
+            .flatMap { it.usernames() }
+            .forEach { add(it) }
     }
 
     private fun lazyEntry(getter: () -> List<String>) = LazySuggestionEntry { addAll(getter()) }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
@@ -41,7 +41,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 object CarryTracker {
     private val config get() = SkyHanniMod.feature.misc
 
-    val customers = mutableListOf<Customer>()
+    private val customers = mutableListOf<Customer>()
     private val carryTypes = mutableMapOf<String, CarryType>()
     private var slayerNames = emptyMap<SlayerType, List<String>>()
 
@@ -199,6 +199,8 @@ object CarryTracker {
     }
 
     fun isCustomer(customerName: String): Boolean = getCustomerOrNull(customerName) != null
+
+    fun getCustomers(): List<Customer> = customers.toList()
 
     private fun getCustomerOrNull(customerName: String): Customer? = customers.find {
         it.name.equals(customerName, ignoreCase = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CarryTracker.kt
@@ -41,7 +41,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 object CarryTracker {
     private val config get() = SkyHanniMod.feature.misc
 
-    private val customers = mutableListOf<Customer>()
+    val customers = mutableListOf<Customer>()
     private val carryTypes = mutableMapOf<String, CarryType>()
     private var slayerNames = emptyMap<SlayerType, List<String>>()
 


### PR DESCRIPTION
## What
There was no built-in way for command suggestion for player names, and uuids. so I added them.
I think the API is good enough.
Example usage:
```kotlin
 literal("add") {
                argCallback(
                    "username",
                    PlayerArgumentType.player(),
                    PlayerSuggestions.build {
                        include(PlayerCategory.ISLAND_PLAYERS, PlayerCategory.SELF)
                        filterNot { it in contributorNames }
                    }
                ) { player ->
                    val gameProfile = player.gameProfile
                    addTestContributor(gameProfile.id, player.gameProfile.name)
                }
```
## Changelog Fixes
+ Fixed putting quotes as arguments in skyhanni command chopping off. - AverageUser125

## Changelog Technical Details
+ Add Component, UUID, and Player Bridgiar Argument types. - AverageUser125
+ Added the option for skyhanni commands to suggest player names. - AverageUser125
