### PR TITLE
Fix: Mineshaft pity tab widget falsely reported as missing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -208,12 +208,13 @@ object MineshaftPityDisplay {
 
     @HandleEvent
     fun onPityWidget(event: WidgetUpdateEvent) {
-        if (!MiningApi.inGlacialTunnels() && !MiningApi.inDwarvenBaseCamp()) return
+        if (!IslandType.DWARVEN_MINES.isInIsland()) return
         if (!event.isWidget(TabWidget.PITY)) return
         for (line in event.lines) {
             tabPityPattern.matchMatcher(line) {
                 everFoundPityWidget = true
                 tablistPity = MAX_COUNTER - group("pity").formatInt()
+                update()
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -206,9 +206,8 @@ object MineshaftPityDisplay {
     private var tablistPity = MAX_COUNTER
     private var everFoundPityWidget = false
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES)
     fun onPityWidget(event: WidgetUpdateEvent) {
-        if (!IslandType.DWARVEN_MINES.isInIsland()) return
         if (!event.isWidget(TabWidget.PITY)) return
         for (line in event.lines) {
             tabPityPattern.matchMatcher(line) {


### PR DESCRIPTION
## What
Loosened the condition for the `WidgetUpdateEvent` handler to only check for the island type. AFAIK, Hypixel tab widget settings apply on a per-island basis, so there's really no point in also checking the area the player is in, which was implicitly done via `MiningApi`. Moreover, the area data from that API doesn't even seem to be immediately available the moment the player just joins the island, causing the feature to not properly retrieve the player's initial pity counter and report the tab pity widget as missing.

This PR also updates the display when a change for Glacite Mineshafts in the pity tab widget is detected.

## Changelog Fixes
+ Fixed Glacite Mineshaft pity display falsely reporting pity tab widget as missing. - Piggered