### PR TITLE
Fix: Make HorizontalContainerRenderable width/height lazy

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/container/HorizontalContainerRenderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/container/HorizontalContainerRenderable.kt
@@ -13,9 +13,9 @@ class HorizontalContainerRenderable private constructor(
     override val verticalAlign: RenderUtils.VerticalAlignment = RenderUtils.VerticalAlignment.TOP,
 ) : ContainerRenderable() {
 
-    override val width = renderables.sumOf { it.width } + spacing * (renderables.size - 1)
+    override val width by lazy { renderables.sumOf { it.width } + spacing * (renderables.size - 1) }
 
-    override val height = renderables.maxOfOrNull { it.height } ?: 0
+    override val height by lazy { renderables.maxOfOrNull { it.height } ?: 0 }
 
     override fun render(mouseOffsetX: Int, mouseOffsetY: Int) {
         var x = mouseOffsetX


### PR DESCRIPTION
## What
Fixes certain features such as Mining Event Tracker failing to load intermittently depending on class load order because the render system was called outside the render thread.

## Changelog Fixes
+ Fixed Mining Event Tracker sometimes failing to load with an error. - Luna