### PR TITLE
Improvement: Enable Better Wiki By Default

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -13,7 +13,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = SkyHanniLogger("ConfigMigration")
-    const val CONFIG_VERSION = 135
+    const val CONFIG_VERSION = 136
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/commands/BetterWikiCommandConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/commands/BetterWikiCommandConfig.kt
@@ -17,14 +17,14 @@ class BetterWikiCommandConfig {
     )
     @ConfigEditorBoolean
     @FeatureToggle
-    var enabled: Boolean = false
+    var enabled: Boolean = true
 
     // TODO Make this method not suck
     @Expose
     @ConfigOption(name = "SkyBlock Guide", desc = "Use SkyHanni's method in the SkyBlock Guide.")
     @ConfigEditorBoolean
     @FeatureToggle
-    var sbGuide: Boolean = false
+    var skyblockGuide: Boolean = false
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
@@ -33,6 +33,11 @@ object WikiManager {
         event.move(6, "commands.useFandomWiki", "commands.fandomWiki.enabled")
         // Apparently the above got changed again at some point but never got a migration
         event.move(123, "commands.betterWiki.useFandom", "commands.betterWiki.useIndependent")
+
+        event.move(136, "commands.betterWiki.sbGuide", "commands.betterWiki.skyblockGuide", { element ->
+            config.enabled = true
+            return@move element
+        })
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/BetterWikiFromMenus.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/BetterWikiFromMenus.kt
@@ -50,7 +50,7 @@ object BetterWikiFromMenus {
             }
         }
 
-        if (inSBGuideInventory && config.sbGuide) {
+        if (inSBGuideInventory && config.skyblockGuide) {
             val wikiSearch = itemClickedName.removeColor().replace("✔ ", "").replace("✖ ", "")
             WikiManager.sendWikiMessage(wikiSearch, autoOpen = config.menuOpenWiki)
             event.cancel()


### PR DESCRIPTION
## What
Enables the better wiki command setting by default.
And does a config migration to enable it for everyone.
I just renamed `sbGuide` to `skyblockGuide`.
No clue if ConfigFixEvent got something to do this without that, but should be easy enough to change I hope.

## Changelog Improvements
+ Enabled "Better Wiki" for everyone. - AverageUser125
