### PR TITLE
Fix: ConcurrentModificationException With InventoryOpenEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
@@ -13,10 +13,10 @@ sealed class InventoryOpenEvent(private val inventory: OtherInventoryData.Invent
     val inventoryId: Int get() = inventory.windowId
     val inventoryName: String get() = inventory.title
     val inventorySize: Int get() = inventory.slotCount
-    val inventoryItems: Map<Int, SafeItemStack> get() {
+    val inventoryItems: Map<Int, SafeItemStack> = run {
         val items = inventory.items
         items.entries.removeIf { !it.value.isNotEmpty() }
-        return items
+        items
     }
     val inventoryItemsWithNull: Map<Int, SafeItemStack?> by lazy {
         (0 until inventorySize).associateWith { inventoryItems[it] }


### PR DESCRIPTION
## What
Make it create inventoryItems just once instead of multiple times.
This way no modification by another thread could cause exceptions in random places.
No point making it lazy since everything uses it.

## Changelog Fixes
+ Fixed random errors happening while in inventories. - AverageUser125