### PR TITLE
Backend: More build script improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ on:
             - ".gitignore"
     workflow_dispatch: {}
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,17 @@ on:
             - "**"
         paths-ignore:
             - ".gitignore"
-    workflow_dispatch:
+    workflow_dispatch: {}
+
 permissions:
     contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest
-        name: "Build and test"
+        name: Build and test
         strategy:
+            fail-fast: false
             matrix:
                 minecraft_version:
                     - "1.21.11"
@@ -44,8 +47,8 @@ jobs:
                 uses: ./.github/actions/gradle-retry
                 with:
                     gradle-command: ${{ matrix.minecraft_version }}:assemble -x ${{ matrix.minecraft_version }}:test --stacktrace -PskipDetekt=true
-            -   uses: actions/upload-artifact@v7
-                name: Upload development build
+            -   name: Upload development build
+                uses: actions/upload-artifact@v7
                 with:
                     path: build/libs/SkyHanni-*-mc${{ matrix.minecraft_version }}.jar
                     archive: false
@@ -59,10 +62,21 @@ jobs:
                 uses: ./.github/actions/gradle-retry
                 with:
                     gradle-command: ${{ matrix.minecraft_version }}:test
-            -   uses: actions/upload-artifact@v7
-                name: "Upload test report"
+            -   name: Upload test report
+                uses: actions/upload-artifact@v7
                 if: ${{ !cancelled() }}
                 with:
-                    name: "Test Results (${{ matrix.minecraft_version }})"
+                    name: Test Results (${{ matrix.minecraft_version }})
                     path: versions/${{ matrix.minecraft_version }}/build/reports/tests/test/
                     if-no-files-found: warn
+
+    verify:
+        runs-on: ubuntu-latest
+        name: Verify build results
+        needs: build
+        if: always()
+        steps:
+            -   name: Check matrix result
+                uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+                with:
+                    jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -5,7 +5,11 @@ on:
         types: [opened, synchronize, reopened]
         branches:
             - "**"
-    workflow_dispatch:
+    workflow_dispatch: {}
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions:
     contents: read

--- a/.github/workflows/detekt_beta.yml
+++ b/.github/workflows/detekt_beta.yml
@@ -6,6 +6,11 @@ on:
             - "beta"
         paths-ignore:
             - ".gitignore"
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     detekt:
         name: Run detekt

--- a/.github/workflows/generate-constants.yaml
+++ b/.github/workflows/generate-constants.yaml
@@ -9,14 +9,18 @@ env:
 on:
     push:
         branches: [beta]
-    workflow_dispatch:
+    workflow_dispatch: {}
 
-permissions: { }
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions: {}
 
 jobs:
     regexes:
         runs-on: ubuntu-latest
-        name: "Generate regexes"
+        name: Generate regexes
         steps:
             -   uses: actions/checkout@v6
             -   name: Set up JDK 25
@@ -31,17 +35,18 @@ jobs:
                 uses: ./.github/actions/gradle-retry
                 with:
                     gradle-command: generateRepoPatterns --stacktrace
-            -   uses: actions/upload-artifact@v7
-                name: Upload generated repo regexes
+            -   name: Upload generated repo regexes
+                uses: actions/upload-artifact@v7
                 with:
                     name: Repo Regexes
                     path: versions/26.1/build/regexes/constants.json
+
     publish-regexes:
         runs-on: ubuntu-latest
         needs: regexes
-        name: "Publish regexes"
+        name: Publish regexes
         # 511310721 is the Repository ID for SkyHanni
-        if: ${{ 'push' == github.event_name && 'beta' == github.ref_name && '511310721' == github.repository_id }}
+        if: ${{ github.event.name == 'push' && github.ref.name == 'beta' && github.repository_id == '511310721' }}
         steps:
             -   uses: actions/checkout@v6
                 with:
@@ -63,9 +68,9 @@ jobs:
                     fi
                     mv constants.json constants/regexesModern.json
                     git config user.name 'github-actions[bot]'
-                    git config user.email 'github-action@users.noreply.github.com'
+                    git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
                     git add constants/regexesModern.json
-                    git commit -m "Update regexes based on https://github.com/hannibal002/Skyhanni/commit/$GITHUB_SHA"
+                    git commit -m "Update regexes based on https://github.com/hannibal002/SkyHanni/commit/$GITHUB_SHA"
             -   name: Publish new repository
                 env:
                     REPO_PAT: ${{ secrets.REPO_PAT }}

--- a/.github/workflows/generate-constants.yaml
+++ b/.github/workflows/generate-constants.yaml
@@ -46,7 +46,7 @@ jobs:
         needs: regexes
         name: Publish regexes
         # 511310721 is the Repository ID for SkyHanni
-        if: ${{ github.event.name == 'push' && github.ref.name == 'beta' && github.repository_id == '511310721' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'beta' && github.repository_id == '511310721' }}
         steps:
             -   uses: actions/checkout@v6
                 with:


### PR DESCRIPTION
## What
- Aggregates the build matrix results so that we can have a single stable workflow to set as required for pull requests
- If the build for one Minecraft version fails, it no longer cancels the build for the others.
- If a new commit is pushed to a branch while a workflow run is running, it now cancels that pending workflow run to avoid wasting time on compiling an old superseded version.
- Small formatting consistency changes.

exclude_from_changelog
