### PR TITLE
Fix: Make Sea Creature Tracker migration atomic + repo based

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/SeaCreatureJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/SeaCreatureJson.kt
@@ -22,4 +22,5 @@ data class SeaCreatureInfo(
     @Expose val rare: Boolean = false,
     @Expose val rarity: LorenzRarity,
     @Expose val lootshareSphereOverride: Boolean? = null,
+    @Expose @SerializedName("old_names") val oldNames: List<String>?,
 )

--- a/src/main/java/at/hannibal2/skyhanni/events/fishing/FishingBobberCastEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/fishing/FishingBobberCastEvent.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.events.fishing
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.world.entity.projectile.FishingHook
 
+@PrimaryFunction("onBobberCast")
 class FishingBobberCastEvent(val bobber: FishingHook) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreature.kt
@@ -9,6 +9,7 @@ data class SeaCreature(
     val rare: Boolean,
     val rarity: LorenzRarity,
     val lootshareSphereOverride: Boolean?,
+    val oldNames: List<String> = emptyList(),
 ) {
 
     val displayName = chatColor + rare() + name

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -138,8 +138,9 @@ object SeaCreatureManager {
                 val rarity = seaCreature.rarity
                 val rare = seaCreature.rare
                 val lootshareSphere = seaCreature.lootshareSphereOverride
+                val oldNames = seaCreature.oldNames.orEmpty()
 
-                val creature = SeaCreature(name, fishingExperience, chatColor, rare, rarity, lootshareSphere)
+                val creature = SeaCreature(name, fishingExperience, chatColor, rare, rarity, lootshareSphere, oldNames)
                 seaCreatureMap[chatMessage] = creature
                 for (alternateMessage in seaCreature.alternateMessages.orEmpty()) {
                     seaCreatureMap[alternateMessage] = creature

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/SeaCreatureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/SeaCreatureTracker.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ExcludedSeaCreatureAreasJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
 import at.hannibal2.skyhanni.events.fishing.SeaCreatureFishEvent
 import at.hannibal2.skyhanni.features.fishing.FishingApi
 import at.hannibal2.skyhanni.features.fishing.SeaCreatureManager
@@ -28,10 +27,12 @@ import at.hannibal2.skyhanni.utils.tracker.SessionUptime
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
 import at.hannibal2.skyhanni.utils.tracker.TrackerData
 import com.google.gson.annotations.Expose
+import kotlin.concurrent.atomics.AtomicBoolean
 
 @SkyHanniModule
 object SeaCreatureTracker {
-    private var needMigration = true
+
+    private val isMigrating = AtomicBoolean(false)
 
     private val config get() = SkyHanniMod.feature.fishing.seaCreatureTracker
 
@@ -75,12 +76,10 @@ object SeaCreatureTracker {
     }
 
     @HandleEvent
-    fun onProfileJoin() {
-        needMigration = true
-    }
+    fun onProfileJoin() = tryToMigrate()
 
     private fun drawDisplay(data: Data): List<Searchable> = buildList {
-        tryToMigrate(data.amount)
+        if (isMigrating.load()) return@buildList
 
         addSearchString("§7Sea Creature Tracker:")
 
@@ -109,26 +108,31 @@ object SeaCreatureTracker {
         addSearchString(" §7- §e${total.addSeparators()} §7Total Sea Creatures")
     }
 
-    // Hypixel renames sea creatures from time to time. This migration process fixes the invalid config entries.
-    private fun tryToMigrate(data: MutableMap<String, Int>) {
-        if (!needMigration) return
-        needMigration = false
-
-        val map = mutableMapOf(
-            "Phlhlegblast" to "Plhlegblast",
-            "Sea Emperor" to "The Sea Emperor",
-            "The Sea Emperor" to "The Loch Emperor",
-        )
-
-        for ((oldName, newName) in map) {
-            // only migrate once the repo contains the new name
-            if (SeaCreatureManager.allFishingMobs.containsKey(newName)) {
-                data[oldName]?.let {
-                    ChatUtils.debug("Sea Creature Tracker migrated $it $oldName to $newName")
-                    data[newName] = it + (data[newName] ?: 0)
-                    data.remove(oldName)
+    /**
+     * Hypixel renames sea creatures from time to time. This migration process fixes the invalid
+     * config entries.
+     */
+    private fun tryToMigrate() {
+        if (!isMigrating.compareAndSet(expectedValue = false, newValue = true)) {
+            ChatUtils.debug("Sea Creature Tracker: Already migrating")
+            return
+        }
+        try {
+            ChatUtils.debug("Sea Creature Tracker: Attempting migration")
+            tracker.modify { data ->
+                SeaCreatureManager.allFishingMobs.forEach { (newName, seaCreature) ->
+                    seaCreature.oldNames.forEach { oldName ->
+                        data.amount[oldName]?.let { amount ->
+                            data.amount.remove(oldName)
+                            data.amount[newName] = (data.amount[newName] ?: 0) + amount
+                            ChatUtils.debug("Sea Creature Tracker: Migrated $amount $oldName to $newName")
+                        }
+                    }
                 }
             }
+            ChatUtils.debug("Sea Creature Tracker: Finished migration")
+        } finally {
+            isMigrating.store(false)
         }
     }
 
@@ -175,12 +179,11 @@ object SeaCreatureTracker {
         ConditionalUtils.onToggle(config.showPercentage) {
             tracker.update()
         }
+        tryToMigrate()
     }
 
     @HandleEvent
-    fun onBobberThrow(event: FishingBobberCastEvent) {
-        tracker.firstUpdate()
-    }
+    fun onBobberCast() = tracker.firstUpdate()
 
     init {
         tracker.initRenderer({ config.position }) { shouldShowDisplay() }
@@ -203,13 +206,11 @@ object SeaCreatureTracker {
         val data = event.getConstant<ExcludedSeaCreatureAreasJson>("fishing/ExcludedSeaCreatureAreas")
         excludedIslands = data.excludedIslands?.toSet().orEmpty()
         excludedGraphAreas = data.excludedGraphAreas?.toSet().orEmpty()
+        tryToMigrate()
     }
 
-    private fun inDisabledArea() = when {
-        SkyBlockUtils.currentIsland in excludedIslands -> true
-        SkyBlockUtils.graphArea in excludedGraphAreas -> true
-        else -> false
-    }
+    private fun inDisabledArea() = SkyBlockUtils.currentIsland in excludedIslands ||
+        SkyBlockUtils.graphArea in excludedGraphAreas
 
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniBucketedItemTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniBucketedItemTracker.kt
@@ -93,7 +93,7 @@ abstract class SkyHanniBucketedItemTracker<E : Enum<E>, BucketedData : BucketedI
                 label = sourceLabel,
                 current = data.selectedBucket,
                 onChange = { new ->
-                    modifyEachMode {
+                    modify {
                         it.selectedBucket = new
                     }
                 },

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -119,14 +119,6 @@ open class SkyHanniTracker<Data : TrackerData<*>, Config : GenericIndividualTrac
         update()
     }
 
-    fun modifyEachMode(modifyFunction: (Data) -> Unit) {
-        val sharedTracker = getSharedTracker() ?: return
-        DisplayMode.entries.forEach { mode ->
-            sharedTracker.tryModify(mode, modifyFunction)
-        }
-        update()
-    }
-
     // used for Item tracker
     open fun hideInEstimatedItemValue() = false
     open fun hideOutsideInventory() = false
@@ -418,6 +410,8 @@ open class SkyHanniTracker<Data : TrackerData<*>, Config : GenericIndividualTrac
         override fun toString(): String = displayName
     }
 
+    // False positive
+    @Suppress("unused")
     enum class DefaultDisplayMode(val display: String, val mode: DisplayMode?) {
         TOTAL("Total", DisplayMode.TOTAL),
         SESSION("This Session", DisplayMode.SESSION),


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/753

## What
Refactored Sea Creature Tracker migration logic:
- Moved migration logic out of `drawDisplay` (makes no sense to be there)
- Now uses an `AtomicBoolean` to ensure we don't try to display the tracker while it's being migrated
- Old names are now read from the repo instead of being hardcoded in the code

I did some small refactors on nearby code as well, including removing `SkyHanniTracker.modifyEachMode` because it's literally duplicating the same thing the single-argument `SkyHanniTracker.modify` does in a different way for seemingly no reason.

## Changelog Fixes
+ Fixed Sea Creature Tracker error when attempting to migrate outdated sea creature names to new ones. - Luna
