### PR TITLE
Backend: Chat events documentations

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/AbstractSourcedChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/AbstractSourcedChatEvent.kt
@@ -34,7 +34,7 @@ object AbstractSourcedChatEvent {
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
-     * Cannot be used to block the message altogether. For that, see [Allow].
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
      * @param authorComponent The chat component representing the author.
      * @param messageComponent The content of the actual message.

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/AbstractSourcedChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/AbstractSourcedChatEvent.kt
@@ -4,25 +4,49 @@ import at.hannibal2.skyhanni.events.chat.AbstractChatEvent
 import at.hannibal2.skyhanni.utils.ComponentSpan
 import net.minecraft.network.chat.Component
 
+/**
+ * Contains the base Allow and Modify classes for chat events that include an author.
+ * Do not listen to those events directly.
+ */
 object AbstractSourcedChatEvent {
 
-    // TODO docs missing
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param authorComponent The chat component representing the author.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     open class Allow(
         val authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
         chatComponent: Component,
         blockedReason: String? = null,
     ) : AbstractChatEvent.Allow(messageComponent, chatComponent, blockedReason) {
+
+        /** The plain text name of the author. */
         val author = authorComponent.getText()
     }
 
-    // TODO docs missing
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. For that, see [Allow].
+     *
+     * @param authorComponent The chat component representing the author.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     */
     open class Modify(
         val authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : AbstractChatEvent.Modify(messageComponent, chatComponent, blockedReason) {
+    ) : AbstractChatEvent.Modify(messageComponent, chatComponent) {
+
+        /** The plain text name of the author. */
         val author = authorComponent.getText()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/CoopChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/CoopChatEvent.kt
@@ -29,7 +29,7 @@ object CoopChatEvent {
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
-     * Cannot be used to block the message altogether. For that, see [Allow].
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
      * @param authorComponent The message author's name.
      * @param messageComponent The content of the actual message.

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/CoopChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/CoopChatEvent.kt
@@ -3,8 +3,22 @@ package at.hannibal2.skyhanni.data.hypixel.chat.event
 import at.hannibal2.skyhanni.utils.ComponentSpan
 import net.minecraft.network.chat.Component
 
+/**
+ * Gets fired when any player sends a message in the coop chat on Hypixel.
+ * This explicitly excludes any other message channel like all chat or party chat.
+ */
 object CoopChatEvent {
 
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param authorComponent The message author's name.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     class Allow(
         authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
@@ -12,10 +26,18 @@ object CoopChatEvent {
         blockedReason: String? = null,
     ) : AbstractSourcedChatEvent.Allow(authorComponent, messageComponent, chatComponent, blockedReason)
 
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. For that, see [Allow].
+     *
+     * @param authorComponent The message author's name.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     */
     class Modify(
         authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : AbstractSourcedChatEvent.Modify(authorComponent, messageComponent, chatComponent, blockedReason)
+    ) : AbstractSourcedChatEvent.Modify(authorComponent, messageComponent, chatComponent)
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/GuildChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/GuildChatEvent.kt
@@ -3,8 +3,23 @@ package at.hannibal2.skyhanni.data.hypixel.chat.event
 import at.hannibal2.skyhanni.utils.ComponentSpan
 import net.minecraft.network.chat.Component
 
+/**
+ * Gets fired when any player sends a message in the guild chat on Hypixel.
+ * This explicitly excludes any other message channel like all chat or party chat.
+ */
 object GuildChatEvent {
 
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param author The message author's name.
+     * @param message The content of the actual message.
+     * @param guildRank The rank tag of the player within the guild.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     class Allow(
         author: ComponentSpan,
         message: ComponentSpan,
@@ -13,11 +28,20 @@ object GuildChatEvent {
         blockedReason: String? = null,
     ) : AbstractSourcedChatEvent.Allow(author, message, chatComponent, blockedReason)
 
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. For that, see [Allow].
+     *
+     * @param author The message author's name.
+     * @param message The content of the actual message.
+     * @param guildRank The rank tag of the player within the guild.
+     * @param chatComponent The entire original chat component.
+     */
     class Modify(
         author: ComponentSpan,
         message: ComponentSpan,
         val guildRank: ComponentSpan?,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : AbstractSourcedChatEvent.Modify(author, message, chatComponent, blockedReason)
+    ) : AbstractSourcedChatEvent.Modify(author, message, chatComponent)
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/GuildChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/GuildChatEvent.kt
@@ -31,7 +31,7 @@ object GuildChatEvent {
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
-     * Cannot be used to block the message altogether. For that, see [Allow].
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
      * @param author The message author's name.
      * @param message The content of the actual message.

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/NpcChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/NpcChatEvent.kt
@@ -3,8 +3,21 @@ package at.hannibal2.skyhanni.data.hypixel.chat.event
 import at.hannibal2.skyhanni.utils.ComponentSpan
 import net.minecraft.network.chat.Component
 
+/**
+ * Gets fired when an NPC sends a message in the chat.
+ */
 object NpcChatEvent {
 
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param authorComponent The NPC's name.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     class Allow(
         authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
@@ -12,10 +25,18 @@ object NpcChatEvent {
         blockedReason: String? = null,
     ) : AbstractSourcedChatEvent.Allow(authorComponent, messageComponent, chatComponent, blockedReason)
 
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. For that, see [Allow].
+     *
+     * @param authorComponent The NPC's name.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     */
     class Modify(
         authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : AbstractSourcedChatEvent.Modify(authorComponent, messageComponent, chatComponent, blockedReason)
+    ) : AbstractSourcedChatEvent.Modify(authorComponent, messageComponent, chatComponent)
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/NpcChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/NpcChatEvent.kt
@@ -28,7 +28,7 @@ object NpcChatEvent {
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
-     * Cannot be used to block the message altogether. For that, see [Allow].
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
      * @param authorComponent The NPC's name.
      * @param messageComponent The content of the actual message.

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PartyChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PartyChatEvent.kt
@@ -38,7 +38,7 @@ object PartyChatEvent {
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
-     * Cannot be used to block the message altogether. For that, see [Allow].
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
      * @param authorComponent The message author's name.
      * @param messageComponent The content of the actual message.

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PartyChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PartyChatEvent.kt
@@ -5,27 +5,55 @@ import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraft.network.chat.Component
 
+/**
+ * Gets fired when any player sends a message in the party chat on Hypixel.
+ * This explicitly excludes any other message channel like all chat or guild chat.
+ */
 object PartyChatEvent {
 
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param authorComponent The message author's name.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     class Allow(
         authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
         chatComponent: Component,
         blockedReason: String? = null,
     ) : AbstractSourcedChatEvent.Allow(authorComponent, messageComponent, chatComponent, blockedReason) {
+
+        /** The plain name of the player who sent the message without any formatting. */
         val authorName = author.cleanPlayerName()
 
+        /** The plain text message without any color codes. */
         override val cleanMessage: String = messageComponent.getText().removeColor()
     }
 
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. For that, see [Allow].
+     *
+     * @param authorComponent The message author's name.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     */
     class Modify(
         authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : AbstractSourcedChatEvent.Modify(authorComponent, messageComponent, chatComponent, blockedReason) {
+    ) : AbstractSourcedChatEvent.Modify(authorComponent, messageComponent, chatComponent) {
+
+        /** The plain name of the player who sent the message without any formatting. */
         val authorName = author.cleanPlayerName()
 
+        /** The plain text message without any color codes. */
         override val cleanMessage: String
             get() = messageComponent.getText().removeColor()
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PlayerAllChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PlayerAllChatEvent.kt
@@ -4,8 +4,26 @@ import at.hannibal2.skyhanni.utils.ComponentSpan
 import at.hannibal2.skyhanni.utils.compat.toChatFormatting
 import net.minecraft.network.chat.Component
 
+/**
+ * Gets fired when any player sends a message in the public chat on Hypixel.
+ * This explicitly excludes specialized channels like party chat or guild chat.
+ */
 object PlayerAllChatEvent {
 
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param levelComponent The SkyBlock level.
+     * @param privateIslandRank The rank prefix displayed when the player is on a private island.
+     * @param privateIslandGuest The guest indicator tag on private islands.
+     * @param chatColor The color code string applied to the original chat message.
+     * @param authorComponent The message author's name.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     class Allow(
         val levelComponent: ComponentSpan?,
         val privateIslandRank: ComponentSpan?,
@@ -16,11 +34,30 @@ object PlayerAllChatEvent {
         chatComponent: Component,
         blockedReason: String? = null,
     ) : AbstractSourcedChatEvent.Allow(authorComponent, messageComponent, chatComponent, blockedReason) {
+
+        /** The color code of the SkyBlock level of the player who sent the message */
         val levelColor = levelComponent?.sampleStyleAtStart()?.color?.toChatFormatting()
+
+        /** The SkyBlock level of the player who sent the message */
         val level = levelComponent?.getText()?.toInt()
+
+        /** Is the player who sent the message currently visiting someone else's private island? */
         val isAGuest get() = privateIslandGuest != null
     }
 
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. For that, see [Allow].
+     *
+     * @param levelComponent The SkyBlock level.
+     * @param privateIslandRank The rank prefix displayed when the player is on a private island.
+     * @param privateIslandGuest The guest indicator tag on private islands.
+     * @param chatColor The color code string applied to the original chat message.
+     * @param authorComponent The message author's name.
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     */
     class Modify(
         val levelComponent: ComponentSpan?,
         val privateIslandRank: ComponentSpan?,
@@ -29,10 +66,15 @@ object PlayerAllChatEvent {
         authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : AbstractSourcedChatEvent.Modify(authorComponent, messageComponent, chatComponent, blockedReason) {
+    ) : AbstractSourcedChatEvent.Modify(authorComponent, messageComponent, chatComponent) {
+
+        /** The color code of the SkyBlock level of the player who sent the message */
         val levelColor = levelComponent?.sampleStyleAtStart()?.color?.toChatFormatting()
+
+        /** The SkyBlock level of the player who sent the message */
         val level = levelComponent?.getText()?.toInt()
+
+        /** Is the player who sent the message currently visiting someone else's private island? */
         val isAGuest get() = privateIslandGuest != null
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PlayerAllChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PlayerAllChatEvent.kt
@@ -48,7 +48,7 @@ object PlayerAllChatEvent {
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
-     * Cannot be used to block the message altogether. For that, see [Allow].
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
      * @param levelComponent The SkyBlock level.
      * @param privateIslandRank The rank prefix displayed when the player is on a private island.

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PlayerShowItemChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PlayerShowItemChatEvent.kt
@@ -3,8 +3,24 @@ package at.hannibal2.skyhanni.data.hypixel.chat.event
 import at.hannibal2.skyhanni.utils.ComponentSpan
 import net.minecraft.network.chat.Component
 
+/**
+ * Gets fired when a player shows an item or pet in the public chat via /show
+ */
 object PlayerShowItemChatEvent {
 
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param levelComponent The SkyBlock level.
+     * @param action The text indicating the action performed with the item.
+     * @param author The message author's name.
+     * @param item The chat component representing the shown item.
+     * @param message The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     class Allow(
         val levelComponent: ComponentSpan?,
         val action: ComponentSpan,
@@ -15,6 +31,18 @@ object PlayerShowItemChatEvent {
         blockedReason: String? = null,
     ) : AbstractSourcedChatEvent.Allow(author, message, chatComponent, blockedReason)
 
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. For that, see [Allow].
+     *
+     * @param levelComponent The SkyBlock level.
+     * @param action The text indicating the action performed with the item.
+     * @param author The message author's name.
+     * @param item The chat component representing the shown item.
+     * @param message The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     */
     class Modify(
         val levelComponent: ComponentSpan?,
         val action: ComponentSpan,
@@ -22,6 +50,5 @@ object PlayerShowItemChatEvent {
         val item: ComponentSpan,
         message: ComponentSpan,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : AbstractSourcedChatEvent.Modify(author, message, chatComponent, blockedReason)
+    ) : AbstractSourcedChatEvent.Modify(author, message, chatComponent)
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PlayerShowItemChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PlayerShowItemChatEvent.kt
@@ -34,7 +34,7 @@ object PlayerShowItemChatEvent {
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
-     * Cannot be used to block the message altogether. For that, see [Allow].
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
      * @param levelComponent The SkyBlock level.
      * @param action The text indicating the action performed with the item.

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PrivateMessageChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PrivateMessageChatEvent.kt
@@ -31,7 +31,7 @@ object PrivateMessageChatEvent {
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
-     * Cannot be used to block the message altogether. For that, see [Allow].
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
      * @param direction Indicates whether the message is incoming or outgoing.
      * @param author The message author's name or the recipient's name.

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PrivateMessageChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/PrivateMessageChatEvent.kt
@@ -3,8 +3,23 @@ package at.hannibal2.skyhanni.data.hypixel.chat.event
 import at.hannibal2.skyhanni.utils.ComponentSpan
 import net.minecraft.network.chat.Component
 
+/**
+ * Gets fired when a private message is sent or received on Hypixel.
+ * This explicitly excludes any other message channel like all chat or party chat.
+ */
 object PrivateMessageChatEvent {
 
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param direction Indicates whether the message is incoming or outgoing.
+     * @param author The message author's name or the recipient's name.
+     * @param message The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     class Allow(
         val direction: Direction,
         author: ComponentSpan,
@@ -13,17 +28,32 @@ object PrivateMessageChatEvent {
         blockedReason: String? = null,
     ) : AbstractSourcedChatEvent.Allow(author, message, chatComponent, blockedReason)
 
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. For that, see [Allow].
+     *
+     * @param direction Indicates whether the message is incoming or outgoing.
+     * @param author The message author's name or the recipient's name.
+     * @param message The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     */
     class Modify(
         val direction: Direction,
         author: ComponentSpan,
         message: ComponentSpan,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : AbstractSourcedChatEvent.Modify(author, message, chatComponent, blockedReason)
+    ) : AbstractSourcedChatEvent.Modify(author, message, chatComponent)
 }
 
+/**
+ * Represents the direction of a private message.
+ */
 enum class Direction(val text: String) {
+    /** An outgoing message sent by the client player. */
     OUTGOING("To"),
+
+    /** An incoming message received from another player. */
     INCOMING("From"),
     ;
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/SystemMessageEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/SystemMessageEvent.kt
@@ -34,7 +34,7 @@ object SystemMessageEvent {
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
-     * Cannot be used to block the message altogether. For that, see [Allow].
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
      * @param message The original message text.
      * @param chatComponent The entire original chat component.

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/SystemMessageEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/SystemMessageEvent.kt
@@ -6,26 +6,46 @@ import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraft.network.chat.Component
 
-// A SkyHanniChatEvent after filtering all player send events, leaving messages from the game/system.
+/**
+ * Gets fired for any chat message not sent by another player or an [NPC][NpcChatEvent].
+ */
 object SystemMessageEvent {
 
-    // TODO docs missing
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param message The original message text.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     @PrimaryFunction("onSystemMessage")
     open class Allow(
         open val message: String,
         open val chatComponent: Component,
         open var blockedReason: String? = null,
     ) : SkyHanniEvent() {
+
+        /** The plain text message without any color codes. */
         open val cleanMessage: String = chatComponent.string.removeColor()
     }
 
-    // TODO docs missing
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. For that, see [Allow].
+     *
+     * @param message The original message text.
+     * @param chatComponent The entire original chat component.
+     */
     open class Modify(
         open val message: String,
         @set:Deprecated("Use replaceComponent() instead")
         open var chatComponent: Component,
-        open val blockedReason: String? = null,
     ) : SkyHanniEvent() {
+
+        /** The plain text message without any color codes. */
         open val cleanMessage: String
             get() = chatComponent.string.removeColor()
 

--- a/src/main/java/at/hannibal2/skyhanni/events/chat/AbstractChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/chat/AbstractChatEvent.kt
@@ -24,8 +24,7 @@ object AbstractChatEvent {
     open class Modify(
         val messageComponent: ComponentSpan,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : SystemMessageEvent.Modify(messageComponent.getText(), chatComponent, blockedReason) {
+    ) : SystemMessageEvent.Modify(messageComponent.getText(), chatComponent) {
         @Legacy(
             "Use cleanMessage unless you really need color codes",
             replaceWith = ReplaceWith("this.cleanMessage")

--- a/src/main/java/at/hannibal2/skyhanni/events/chat/SkyHanniChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/chat/SkyHanniChatEvent.kt
@@ -18,6 +18,5 @@ object SkyHanniChatEvent {
     class Modify(
         message: String,
         chatComponent: Component,
-        blockedReason: String? = null,
-    ) : AbstractChatEvent.Modify(message.asComponent().intoSpan(), chatComponent, blockedReason)
+    ) : AbstractChatEvent.Modify(message.asComponent().intoSpan(), chatComponent)
 }


### PR DESCRIPTION
## What
Added extensive documentations to all chat events to clearly distinguish between the `Allow` (read-only) and `Modify` (editing) phases of the chat processing pipeline. Cleaned up the backend by removing the `blockedReason` parameter from all Modify classes since blocking should exclusively be handled during the Allow phase.

## Changelog Technical Details
+ Added comprehensive docs to the chat event classes. - hannibal2
+ Removed the unused `blockedReason` parameter from all Modify chat event classes. - hannibal2