### PR TITLE
Fix: Auto-Load Shaft Routes examples

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/orderedwaypoints/OrderedWaypointsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/orderedwaypoints/OrderedWaypointsConfig.kt
@@ -137,7 +137,7 @@ class OrderedWaypointsConfig {
     @Expose
     @ConfigOption(
         name = "Auto-Load Shaft Routes",
-        desc = "Automatically loads a matching route if found when entering a Mineshaft. (format is from the Scoreboard e.g. Jasp_1/Peri_C)"
+        desc = "Automatically loads a matching route if found when entering a Mineshaft. (Format is from the scoreboard, e.g. JASP_1/PERI_C)"
     )
     @ConfigEditorBoolean
     var autoLoadMatchingShaftRoute: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/orderedwaypoints/OrderedWaypointsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/orderedwaypoints/OrderedWaypointsConfig.kt
@@ -137,7 +137,8 @@ class OrderedWaypointsConfig {
     @Expose
     @ConfigOption(
         name = "Auto-Load Shaft Routes",
-        desc = "Automatically loads a matching route if found when entering a Mineshaft. (Format is from the scoreboard, e.g. JASP_1/PERI_C)"
+        desc = "Automatically loads a matching route if found when entering a Mineshaft. " +
+            "(Format is from the scoreboard, e.g. JASP_1/PERI_C)"
     )
     @ConfigEditorBoolean
     var autoLoadMatchingShaftRoute: Boolean = false


### PR DESCRIPTION
## What
Fixes misleading examples in the config for Auto-Load Shaft routes that are never going to work because it needs to match the shaft type case-sensitively.

## Changelog Fixes
+ Fixed description for Auto-Load Shaft Routes giving incorrect examples for route names. - Luna