### PR TITLE
Backend: Enforce WRAPPED-REGEX-TEST for surrounding whitespace

### DIFF
--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -62,10 +62,20 @@ class RepoPatternElement private constructor(
 
             kDoc.getDefaultSection().getContent().lines().forEach { line ->
                 if (line.contains("REGEX-TEST: ")) {
-                    regexTests.add(line.substringAfter("REGEX-TEST: "))
+                    val test = line.substringAfter("REGEX-TEST: ")
+                    require(test.trim() == test) {
+                        "Plain REGEX-TEST must not contain leading or trailing whitespace. If the whitespace is " +
+                            "intentional, use WRAPPED-REGEX-TEST instead."
+                    }
+                    regexTests.add(test)
                 }
                 if (line.contains("REGEX-FAIL: ")) {
-                    failingRegexTests.add(line.substringAfter("REGEX-FAIL: "))
+                    val test = line.substringAfter("REGEX-FAIL: ")
+                    require(test.trim() == test) {
+                        "Plain REGEX-FAIL must not contain leading or trailing whitespace. If the whitespace is " +
+                            "intentional, use WRAPPED-REGEX-FAIL instead."
+                    }
+                    failingRegexTests.add(test)
                 }
                 wrappedRegexTestPattern.matcher(line).let { matcher ->
                     if (!matcher.find()) return@forEach

--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -26,6 +26,7 @@ class RepoPatternElement private constructor(
 
     companion object {
         private val wrappedRegexTestPattern = "WRAPPED-REGEX-TEST: \"(?<test>.*)\"".toPattern()
+        private val wrappedRegexFailPattern = "WRAPPED-REGEX-FAIL: \"(?<test>.*)\"".toPattern()
 
         fun KtPropertyDelegate.asRepoPatternElement(): RepoPatternElement? {
             val expression = this.expression as? KtDotQualifiedExpression ?: return null
@@ -70,6 +71,11 @@ class RepoPatternElement private constructor(
                     if (!matcher.find()) return@forEach
                     val test = matcher.group("test") ?: return@forEach
                     regexTests.add(test)
+                }
+                wrappedRegexFailPattern.matcher(line).let { matcher ->
+                    if (!matcher.find()) return@forEach
+                    val test = matcher.group("test") ?: return@forEach
+                    failingRegexTests.add(test)
                 }
             }
             return regexTests to failingRegexTests

--- a/detekt/src/main/kotlin/RepoPatternElement.kt
+++ b/detekt/src/main/kotlin/RepoPatternElement.kt
@@ -61,6 +61,18 @@ class RepoPatternElement private constructor(
             val failingRegexTests = mutableListOf<String>()
 
             kDoc.getDefaultSection().getContent().lines().forEach { line ->
+                wrappedRegexTestPattern.matcher(line).let { matcher ->
+                    if (!matcher.find()) return@let
+                    val test = matcher.group("test") ?: return@let
+                    regexTests.add(test)
+                    return@forEach
+                }
+                wrappedRegexFailPattern.matcher(line).let { matcher ->
+                    if (!matcher.find()) return@let
+                    val test = matcher.group("test") ?: return@let
+                    failingRegexTests.add(test)
+                    return@forEach
+                }
                 if (line.contains("REGEX-TEST: ")) {
                     val test = line.substringAfter("REGEX-TEST: ")
                     require(test.trim() == test) {
@@ -68,6 +80,7 @@ class RepoPatternElement private constructor(
                             "intentional, use WRAPPED-REGEX-TEST instead."
                     }
                     regexTests.add(test)
+                    return@forEach
                 }
                 if (line.contains("REGEX-FAIL: ")) {
                     val test = line.substringAfter("REGEX-FAIL: ")
@@ -76,16 +89,7 @@ class RepoPatternElement private constructor(
                             "intentional, use WRAPPED-REGEX-FAIL instead."
                     }
                     failingRegexTests.add(test)
-                }
-                wrappedRegexTestPattern.matcher(line).let { matcher ->
-                    if (!matcher.find()) return@forEach
-                    val test = matcher.group("test") ?: return@forEach
-                    regexTests.add(test)
-                }
-                wrappedRegexFailPattern.matcher(line).let { matcher ->
-                    if (!matcher.find()) return@forEach
-                    val test = matcher.group("test") ?: return@forEach
-                    failingRegexTests.add(test)
+                    return@forEach
                 }
             }
             return regexTests to failingRegexTests

--- a/src/main/java/at/hannibal2/skyhanni/api/CollectionApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/CollectionApi.kt
@@ -38,7 +38,7 @@ object CollectionApi {
     )
 
     /**
-     * REGEX-TEST:                           43,649/50k
+     * WRAPPED-REGEX-TEST: "                          43,649/50k"
      * REGEX-TEST: Total collected: 277,252
      */
     private val counterPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -81,10 +81,10 @@ object ExperimentationTableApi {
     )
 
     /**
-     * REGEX-TEST:  §r§8+§r§5Metaphysical Serum
-     * REGEX-TEST:  §r§8+§r§3149k Enchanting Exp
+     * WRAPPED-REGEX-TEST: " §r§8+§r§5Metaphysical Serum"
+     * WRAPPED-REGEX-TEST: " §r§8+§r§3149k Enchanting Exp"
      * REGEX-TEST: §8 +§r§3400k Enchanting Exp
-     * REGEX-TEST:  §r§8+§r§327k Enchanting Exp
+     * WRAPPED-REGEX-TEST: " §r§8+§r§327k Enchanting Exp"
      * REGEX-TEST: §r§8+§r§7[Lvl 1] §r§5Guardian
      */
     private val experimentsDropPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -63,7 +63,7 @@ object SkillApi {
 
     // TODO find out whats going on here
     /**
-     * REGEX-TEST:  Farming 35: 12.4%
+     * WRAPPED-REGEX-TEST: " Farming 35: 12.4%"
      */
     private val skillTabPattern by patternGroup.pattern(
         "skill.tab.colorless",
@@ -71,8 +71,8 @@ object SkillApi {
     )
 
     /**
-     * REGEX-TEST:  Farming 60: MAX
-     * REGEX-TEST:  Mining 60: MAX
+     * WRAPPED-REGEX-TEST: " Farming 60: MAX"
+     * WRAPPED-REGEX-TEST: " Mining 60: MAX"
      */
     private val maxSkillTabPattern by patternGroup.pattern(
         "skill.tab.max.colorless",
@@ -80,8 +80,8 @@ object SkillApi {
     )
 
     /**
-     * REGEX-TEST:  Mining 14: 22,922/75k
-     * REGEX-TEST:  Combat 49: 7,678/4M
+     * WRAPPED-REGEX-TEST: " Mining 14: 22,922/75k"
+     * WRAPPED-REGEX-TEST: " Combat 49: 7,678/4M"
      */
     private val skillTabNoPercentPattern by patternGroup.pattern(
         "skill.tab.nopercent.colorless",

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -70,13 +70,13 @@ object PetStorageApi {
     )
 
     /**
-     * REGEX-TEST:  [Lvl 100] Hedgehog
-     * REGEX-TEST:  [Lvl 68] Blaze
-     * REGEX-TEST:  [Lvl 51] Kuudra
-     * REGEX-TEST:  [Lvl 100] Flying Fish
-     * REGEX-TEST:  [Lvl 100] Chicken ✦
-     * REGEX-TEST:  [Lvl 200] [122✦] Golden Dragon
-     * REGEX-FAIL:  No pet selected
+     * WRAPPED-REGEX-TEST: " [Lvl 100] Hedgehog"
+     * WRAPPED-REGEX-TEST: " [Lvl 68] Blaze"
+     * WRAPPED-REGEX-TEST: " [Lvl 51] Kuudra"
+     * WRAPPED-REGEX-TEST: " [Lvl 100] Flying Fish"
+     * WRAPPED-REGEX-TEST: " [Lvl 100] Chicken ✦"
+     * WRAPPED-REGEX-TEST: " [Lvl 200] [122✦] Golden Dragon"
+     * WRAPPED-REGEX-FAIL: " No pet selected"
      */
     @Suppress("MaxLineLength")
     private val petTabWidgetNamePattern by patternGroup.pattern(
@@ -85,13 +85,13 @@ object PetStorageApi {
     )
 
     /**
-     * REGEX-TEST:  +163,119,730.2 XP
-     * REGEX-TEST:  33,915/179.7k XP (18.9%)
-     * REGEX-TEST:  2,877.5/9.7k XP (29.7%)
-     * REGEX-TEST:  931,886.2/1.4M XP (67.2%)
-     * REGEX-TEST:  251,016.4/561.7k XP (44.7%)
-     * REGEX-TEST:  3,138.4/9.7k XP (32.4%)
-     * REGEX-TEST:  MAX LEVEL
+     * WRAPPED-REGEX-TEST: " +163,119,730.2 XP"
+     * WRAPPED-REGEX-TEST: " 33,915/179.7k XP (18.9%)"
+     * WRAPPED-REGEX-TEST: " 2,877.5/9.7k XP (29.7%)"
+     * WRAPPED-REGEX-TEST: " 931,886.2/1.4M XP (67.2%)"
+     * WRAPPED-REGEX-TEST: " 251,016.4/561.7k XP (44.7%)"
+     * WRAPPED-REGEX-TEST: " 3,138.4/9.7k XP (32.4%)"
+     * WRAPPED-REGEX-TEST: " MAX LEVEL"
      */
     @Suppress("MaxLineLength")
     private val petTabWidgetXpPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/data/BitsApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BitsApi.kt
@@ -133,7 +133,7 @@ object BitsApi {
     )
 
     /**
-     * REGEX-TEST:  §7Duration: §a140d 8h 35m 36s
+     * WRAPPED-REGEX-TEST: " §7Duration: §a140d 8h 35m 36s"
      */
     private val cookieDurationPattern by bitsGuiGroup.pattern(
         "cookieduration",

--- a/src/main/java/at/hannibal2/skyhanni/data/CrimsonIsleReputationApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/CrimsonIsleReputationApi.kt
@@ -16,8 +16,8 @@ object CrimsonIsleReputationApi {
     private val patternGroup = RepoPattern.group("crimson.reputationapi")
 
     /**
-     * REGEX-TEST:  19,130
-     * REGEX-TEST:  635
+     * WRAPPED-REGEX-TEST: " 19,130"
+     * WRAPPED-REGEX-TEST: " 635"
      */
     private val tablistReputationCountPattern by patternGroup.pattern(
         "tablistreputation",

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -60,8 +60,8 @@ object HypixelData {
     )
 
     /**
-     * REGEX-TEST:  §7⏣ §bVillage
-     * REGEX-TEST:  §5ф §dWizard Tower
+     * WRAPPED-REGEX-TEST: " §7⏣ §bVillage"
+     * WRAPPED-REGEX-TEST: " §5ф §dWizard Tower"
      */
     private val skyblockAreaPattern by patternGroup.pattern(
         "skyblock.area",

--- a/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
@@ -76,11 +76,11 @@ object SackApi {
     )
 
     /**
-     * REGEX-TEST:  Rough: §e78,999 §8(78,999)
-     * REGEX-TEST:  §fRough: §e78,999 §8(78,999)
-     * REGEX-TEST:  §aFlawed: §e604 §8(48,320)
-     * REGEX-TEST:  §9Fine: §e35 §8(224,000)
-     * REGEX-TEST:  §7Amount: §a5,968
+     * WRAPPED-REGEX-TEST: " Rough: §e78,999 §8(78,999)"
+     * WRAPPED-REGEX-TEST: " §fRough: §e78,999 §8(78,999)"
+     * WRAPPED-REGEX-TEST: " §aFlawed: §e604 §8(48,320)"
+     * WRAPPED-REGEX-TEST: " §9Fine: §e35 §8(224,000)"
+     * WRAPPED-REGEX-TEST: " §7Amount: §a5,968"
      */
     @Suppress("MaxLineLength")
     private val gemstoneCountPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -97,7 +97,7 @@ object EffectApi {
     )
 
     /**
-     * REGEX-TEST:  Repellent: MAX (12s)
+     * WRAPPED-REGEX-TEST: " Repellent: MAX (12s)"
      */
     private val repellentPattern by RepoPattern.pattern(
         "misc.nongodpot.repellant-no-color",
@@ -105,9 +105,9 @@ object EffectApi {
     )
 
     /**
-     * REGEX-TEST:  Smoldering Polarization I: 58s
-     * REGEX-TEST:  Wisp's Ice-Flavored Water I: 29m
-     * REGEX-TEST:      Mushed Glowy Tonic I 43m
+     * WRAPPED-REGEX-TEST: " Smoldering Polarization I: 58s"
+     * WRAPPED-REGEX-TEST: " Wisp's Ice-Flavored Water I: 29m"
+     * WRAPPED-REGEX-TEST: "     Mushed Glowy Tonic I 43m"
      * REGEX-TEST: Wisp's Ice-Flavored Water I 10m
      */
     private val tabEffectPattern by RepoPattern.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/CropUpgrades.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/CropUpgrades.kt
@@ -28,7 +28,7 @@ object CropUpgrades {
     )
 
     /**
-     * REGEX-TEST:   §r§6§lCROP UPGRADE §eNether Wart§7 #7
+     * WRAPPED-REGEX-TEST: "  §r§6§lCROP UPGRADE §eNether Wart§7 #7"
      */
     private val chatUpgradePattern by patternGroup.pattern(
         "chatupgrade",

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/cropmilestones/CropMilestonesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/cropmilestones/CropMilestonesApi.kt
@@ -53,8 +53,8 @@ object CropMilestonesApi {
     )
 
     /**
-     * REGEX-TEST:  Cocoa Beans 31: 68%
-     * REGEX-TEST:  Potato 32: 97.7%
+     * WRAPPED-REGEX-TEST: " Cocoa Beans 31: 68%"
+     * WRAPPED-REGEX-TEST: " Potato 32: 97.7%"
      */
     val tabListPercentPattern by patternGroup.pattern(
         "tablist.percent-no-color",
@@ -62,8 +62,8 @@ object CropMilestonesApi {
     )
 
     /**
-     * REGEX-TEST:  Potato 46: MAX
-     * REGEX-TEST:  Cocoa Beans 46: MAX
+     * WRAPPED-REGEX-TEST: " Potato 46: MAX"
+     * WRAPPED-REGEX-TEST: " Cocoa Beans 46: MAX"
      */
     val tabListMaxPattern by patternGroup.pattern(
         "tablist.max-no-color",
@@ -71,7 +71,7 @@ object CropMilestonesApi {
     )
 
     /**
-     * REGEX-TEST:   §r§b§lGARDEN MILESTONE §3Melon §845➜§346
+     * WRAPPED-REGEX-TEST: "  §r§b§lGARDEN MILESTONE §3Melon §845➜§346"
      */
     val levelUpPattern by patternGroup.pattern(
         "levelup",

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -367,7 +367,7 @@ enum class HotfData(
         )
 
         /**
-         * REGEX-TEST:   §8- §a5 §aToken of the Forest
+         * WRAPPED-REGEX-TEST: "  §8- §a5 §aToken of the Forest"
          */
         override val resetTokensPattern: Pattern by patternGroup.pattern(
             "inventory.reset.token",
@@ -375,7 +375,7 @@ enum class HotfData(
         )
 
         /**
-         * REGEX-TEST:  §7You have reset your §r§aHeart of the Forest§r§7! Your §r§aPerks §r§7and §r§aAbilities §r§7have been reset.
+         * WRAPPED-REGEX-TEST: " §7You have reset your §r§aHeart of the Forest§r§7! Your §r§aPerks §r§7and §r§aAbilities §r§7have been reset."
          */
         override val resetChatPattern by patternGroup.pattern(
             "reset.chat",
@@ -391,7 +391,7 @@ enum class HotfData(
         )
 
         /**
-         * REGEX-TEST:  §8- §3114,060 Forest Whispers
+         * WRAPPED-REGEX-TEST: " §8- §3114,060 Forest Whispers"
          */
         private val whisperResetPattern by patternGroup.pattern(
             "whisper.reset",

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -522,7 +522,7 @@ enum class HotmData(
         )
 
         /**
-         * REGEX-TEST:   §8- §54 Token of the Mountain
+         * WRAPPED-REGEX-TEST: "  §8- §54 Token of the Mountain"
          */
         override val resetTokensPattern by patternGroup.pattern(
             "inventory.reset.token",
@@ -535,8 +535,8 @@ enum class HotmData(
         )
 
         /**
-         * REGEX-TEST:  Mithril: 99,918
-         * REGEX-TEST:  Gemstone: 37,670
+         * WRAPPED-REGEX-TEST: " Mithril: 99,918"
+         * WRAPPED-REGEX-TEST: " Gemstone: 37,670"
          */
         private val powderPattern by patternGroup.pattern(
             "widget.powder-nocolor",

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoApi.kt
@@ -76,7 +76,7 @@ object BingoApi {
     var lastBingoCardOpenTime = SimpleTimeMark.farPast()
 
     /**
-     * REGEX-TEST:  §9Ⓑ §9Bingo
+     * WRAPPED-REGEX-TEST: " §9Ⓑ §9Bingo"
      */
     private val detectionPattern by RepoPattern.pattern(
         "bingo.detection.scoreboard",

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactExperimentRewards.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactExperimentRewards.kt
@@ -47,11 +47,11 @@ object CompactExperimentRewards {
 
     /**
      * REGEX-TEST: §8 +§r§3600k Enchanting Exp
-     * REGEX-TEST:  §r§8+§r§3132k Enchanting Exp
-     * REGEX-TEST:  §r§8+§r§aThunderlord V
-     * REGEX-TEST:  §r§8+§r§3143k Enchanting Exp
-     * REGEX-TEST:  §r§8+§r§aGrand Experience Bottle
-     * REGEX-TEST:  §r§8+§r§aCaster V
+     * WRAPPED-REGEX-TEST: " §r§8+§r§3132k Enchanting Exp"
+     * WRAPPED-REGEX-TEST: " §r§8+§r§aThunderlord V"
+     * WRAPPED-REGEX-TEST: " §r§8+§r§3143k Enchanting Exp"
+     * WRAPPED-REGEX-TEST: " §r§8+§r§aGrand Experience Bottle"
+     * WRAPPED-REGEX-TEST: " §r§8+§r§aCaster V"
      */
     private val experimentsDropPattern by patternGroup.pattern(
         "drop",

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CompactJacobClaim.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CompactJacobClaim.kt
@@ -27,7 +27,7 @@ object CompactJacobClaim {
 
     // <editor-fold desc="Patterns">
     /**
-     * REGEX-TEST:   FARMING CONTEST REWARDS CLAIMED
+     * WRAPPED-REGEX-TEST: "  FARMING CONTEST REWARDS CLAIMED"
      */
     private val openingPattern by patternGroup.pattern(
         "opening.colorless",
@@ -35,8 +35,8 @@ object CompactJacobClaim {
     )
 
     /**
-     * REGEX-TEST:    » Sunflower Contest on Autumn 31st, Year 472
-     * REGEX-TEST:    » Melon Slice Contest on Early Spring 17th, Year 473
+     * WRAPPED-REGEX-TEST: "   » Sunflower Contest on Autumn 31st, Year 472"
+     * WRAPPED-REGEX-TEST: "   » Melon Slice Contest on Early Spring 17th, Year 473"
      */
     private val specificContestLine by patternGroup.pattern(
         "contest.specific",
@@ -44,7 +44,7 @@ object CompactJacobClaim {
     )
 
     /**
-     * REGEX-TEST:   REWARDS
+     * WRAPPED-REGEX-TEST: "  REWARDS"
      */
     private val rewardsHeaderPattern by patternGroup.pattern(
         "rewards.colorless",
@@ -52,9 +52,9 @@ object CompactJacobClaim {
     )
 
     /**
-     * REGEX-TEST:     Jacob's Ticket x271
-     * REGEX-TEST:     Carnival Ticket x21
-     * REGEX-TEST:     Carnival Ticket
+     * WRAPPED-REGEX-TEST: "    Jacob's Ticket x271"
+     * WRAPPED-REGEX-TEST: "    Carnival Ticket x21"
+     * WRAPPED-REGEX-TEST: "    Carnival Ticket"
      */
     private val ticketPattern by patternGroup.pattern(
         "tickets.colorless",
@@ -62,12 +62,12 @@ object CompactJacobClaim {
     )
 
     /**
-     * REGEX-TEST:     1x Turbo-Cacti I Book
-     * REGEX-TEST:     1x Turbo-Pumpkin I Book
-     * REGEX-TEST:     4x Turbo-Wheat I Book
-     * REGEX-TEST:     6x Turbo-Mushrooms I Book
-     * REGEX-TEST:     1x Turbo-Warts I Book
-     * REGEX-TEST:     1x Turbo-Sunflower I Book
+     * WRAPPED-REGEX-TEST: "    1x Turbo-Cacti I Book"
+     * WRAPPED-REGEX-TEST: "    1x Turbo-Pumpkin I Book"
+     * WRAPPED-REGEX-TEST: "    4x Turbo-Wheat I Book"
+     * WRAPPED-REGEX-TEST: "    6x Turbo-Mushrooms I Book"
+     * WRAPPED-REGEX-TEST: "    1x Turbo-Warts I Book"
+     * WRAPPED-REGEX-TEST: "    1x Turbo-Sunflower I Book"
      */
     private val bookPattern by patternGroup.pattern(
         "book.colorless",
@@ -75,10 +75,10 @@ object CompactJacobClaim {
     )
 
     /**
-     * REGEX-TEST:     +8 gold medals
-     * REGEX-TEST:     +7 silver medals
-     * REGEX-TEST:     +5 bronze medals
-     * REGEX-TEST:     +1 gold medal
+     * WRAPPED-REGEX-TEST: "    +8 gold medals"
+     * WRAPPED-REGEX-TEST: "    +7 silver medals"
+     * WRAPPED-REGEX-TEST: "    +5 bronze medals"
+     * WRAPPED-REGEX-TEST: "    +1 gold medal"
      */
     private val medalsPattern by patternGroup.pattern(
         "medals.colorless",
@@ -86,7 +86,7 @@ object CompactJacobClaim {
     )
 
     /**
-     * REGEX-TEST:     +2,293 Bits
+     * WRAPPED-REGEX-TEST: "    +2,293 Bits"
      */
     private val bitsPattern by patternGroup.pattern(
         "bits.colorless",
@@ -94,8 +94,8 @@ object CompactJacobClaim {
     )
 
     /**
-     * REGEX-TEST:     Overclocker 3000
-     * REGEX-TEST:     Overclocker 3000 x4
+     * WRAPPED-REGEX-TEST: "    Overclocker 3000"
+     * WRAPPED-REGEX-TEST: "    Overclocker 3000 x4"
      */
     private val overclockerPattern by patternGroup.pattern(
         "overclocker",

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CrystalNucleusChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CrystalNucleusChatFilter.kt
@@ -131,12 +131,12 @@ object CrystalNucleusChatFilter {
     )
 
     /**
-     * REGEX-TEST:   §r§9FTX 3070
-     * REGEX-TEST:   §r§9Electron Transmitter
-     * REGEX-TEST:   §r§9Superlite Motor
-     * REGEX-TEST:   §r§9Synthetic Heart
-     * REGEX-TEST:   §r§9Control Switch
-     * REGEX-TEST:   §r§9Robotron Reflector
+     * WRAPPED-REGEX-TEST: "  §r§9FTX 3070"
+     * WRAPPED-REGEX-TEST: "  §r§9Electron Transmitter"
+     * WRAPPED-REGEX-TEST: "  §r§9Superlite Motor"
+     * WRAPPED-REGEX-TEST: "  §r§9Synthetic Heart"
+     * WRAPPED-REGEX-TEST: "  §r§9Control Switch"
+     * WRAPPED-REGEX-TEST: "  §r§9Robotron Reflector"
      */
     private val componentListPattern by patternGroup.pattern(
         "component.list",

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -80,7 +80,7 @@ object PowderMiningChatFilter {
     )
 
     /**
-     * REGEX-TEST:   §r§6§lCHEST LOCKPICKED
+     * WRAPPED-REGEX-TEST: "  §r§6§lCHEST LOCKPICKED"
      */
     private val lockPickedPattern by patternGroup.pattern(
         "powder.picked",
@@ -88,7 +88,7 @@ object PowderMiningChatFilter {
     )
 
     /**
-     * REGEX-TEST:   §r§5§lLOOT CHEST COLLECTED
+     * WRAPPED-REGEX-TEST: "  §r§5§lLOOT CHEST COLLECTED"
      */
     private val lootChestCollectedPattern by patternGroup.pattern(
         "lootchest.collected",
@@ -96,7 +96,7 @@ object PowderMiningChatFilter {
     )
 
     /**
-     * REGEX-TEST:   §r§a§lREWARDS
+     * WRAPPED-REGEX-TEST: "  §r§a§lREWARDS"
      */
     private val rewardHeaderPattern by patternGroup.pattern(
         "reward.header",
@@ -104,22 +104,22 @@ object PowderMiningChatFilter {
     )
 
     /**
-     * REGEX-TEST:     §r§a§r§aGreen Goblin Egg
-     * REGEX-TEST:     §r§9Goblin Egg
-     * REGEX-TEST:     §r§dDiamond Essence
-     * REGEX-TEST:     §r§dGold Essence
-     * REGEX-TEST:     §r§dGold Essence §r§8x3
-     * REGEX-TEST:     §r§dGemstone Powder §r§8x537
-     * REGEX-TEST:     §r§dDiamond Essence §r§8x2
-     * REGEX-TEST:     §r§2Mithril Powder §r§8x153
-     * REGEX-TEST:     §r§5Treasurite
-     * REGEX-TEST:     §r§f⸕ Rough Amber Gemstone §r§8x24
-     * REGEX-TEST:     §r§f❤ Rough Ruby Gemstone §r§8x24
-     * REGEX-TEST:     §r§f❈ Rough Amethyst Gemstone §r§8x24
-     * REGEX-TEST:     §r§9§r§eYellow Goblin Egg
-     * REGEX-TEST:     §r§a⸕ Flawed Amber Gemstone
-     * REGEX-TEST:     §r§aWishing Compass §r§8x3
-     * REGEX-TEST:     §r§a⸕ Flawed Amber Gemstone §r§8x2
+     * WRAPPED-REGEX-TEST: "    §r§a§r§aGreen Goblin Egg"
+     * WRAPPED-REGEX-TEST: "    §r§9Goblin Egg"
+     * WRAPPED-REGEX-TEST: "    §r§dDiamond Essence"
+     * WRAPPED-REGEX-TEST: "    §r§dGold Essence"
+     * WRAPPED-REGEX-TEST: "    §r§dGold Essence §r§8x3"
+     * WRAPPED-REGEX-TEST: "    §r§dGemstone Powder §r§8x537"
+     * WRAPPED-REGEX-TEST: "    §r§dDiamond Essence §r§8x2"
+     * WRAPPED-REGEX-TEST: "    §r§2Mithril Powder §r§8x153"
+     * WRAPPED-REGEX-TEST: "    §r§5Treasurite"
+     * WRAPPED-REGEX-TEST: "    §r§f⸕ Rough Amber Gemstone §r§8x24"
+     * WRAPPED-REGEX-TEST: "    §r§f❤ Rough Ruby Gemstone §r§8x24"
+     * WRAPPED-REGEX-TEST: "    §r§f❈ Rough Amethyst Gemstone §r§8x24"
+     * WRAPPED-REGEX-TEST: "    §r§9§r§eYellow Goblin Egg"
+     * WRAPPED-REGEX-TEST: "    §r§a⸕ Flawed Amber Gemstone"
+     * WRAPPED-REGEX-TEST: "    §r§aWishing Compass §r§8x3"
+     * WRAPPED-REGEX-TEST: "    §r§a⸕ Flawed Amber Gemstone §r§8x2"
      */
     val genericMiningRewardMessage by patternGroup.pattern(
         "reward.generic",

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFeatures.kt
@@ -138,10 +138,10 @@ object DragonFeatures {
     private val scoreDragonPattern by scoreBoardGroup.pattern("dragon", "Dragon HP: .*")
 
     /**
-     * REGEX-TEST:  JamBeastie: 7.4M❤
-     * REGEX-TEST:  42069HzMonitor: 3M❤
-     * REGEX-TEST:  ItsJxxxxx2001: 457k❤
-     * REGEX-TEST:  Thunderblade73: 12.3k❤
+     * WRAPPED-REGEX-TEST: " JamBeastie: 7.4M❤"
+     * WRAPPED-REGEX-TEST: " 42069HzMonitor: 3M❤"
+     * WRAPPED-REGEX-TEST: " ItsJxxxxx2001: 457k❤"
+     * WRAPPED-REGEX-TEST: " Thunderblade73: 12.3k❤"
      */
     private val tabDamagePattern by tabListGroup.pattern(
         "fight.player",

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
@@ -141,8 +141,8 @@ object GhostTracker {
     )
 
     /**
-     * REGEX-TEST:  Ghost 21: 29,614/40,000
-     * REGEX-TEST:  Ghost 15: 12,449/12,500
+     * WRAPPED-REGEX-TEST: " Ghost 21: 29,614/40,000"
+     * WRAPPED-REGEX-TEST: " Ghost 15: 12,449/12,500"
      */
     private val bestiaryTablistPattern by patternGroup.pattern(
         "tablist.bestiary-no-color",
@@ -150,7 +150,7 @@ object GhostTracker {
     )
 
     /**
-     * REGEX-TEST:  Ghost 25: MAX
+     * WRAPPED-REGEX-TEST: " Ghost 25: MAX"
      */
     private val maxBestiaryTablistPattern by patternGroup.pattern(
         "tablist.bestiarymax-no-color",

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -87,7 +87,7 @@ object DungeonApi {
     )
 
     /**
-     * REGEX-TEST:                                  Master Mode The Catacombs - Floor V
+     * WRAPPED-REGEX-TEST: "                                 Master Mode The Catacombs - Floor V"
      */
     private val dungeonComplete by patternGroup.pattern(
         "completecolorless",

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDeathCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonDeathCounter.kt
@@ -20,24 +20,24 @@ object DungeonDeathCounter {
     private val patternGroup = RepoPattern.group("dungeon.deathcounter")
 
     /**
-     * REGEX-TEST:  ☠ Someone disconnected from the Dungeon and became a ghost.
-     * REGEX-TEST:  ☠ You were killed by Someone and became a ghost.
-     * REGEX-TEST:  ☠ You were crushed and became a ghost.
-     * REGEX-TEST:  ☠ You suffocated and became a ghost.
-     * REGEX-TEST:  ☠ You fell into a deep hole and became a ghost.
-     * REGEX-TEST:  ☠ You died to a trap and became a ghost.
-     * REGEX-TEST:  ☠ You died to a mob and became a ghost.
-     * REGEX-TEST:  ☠ You died and became a ghost.
-     * REGEX-TEST:  ☠ You burnt to death and became a ghost.
-     * REGEX-TEST:  ☠ Someone was killed by Someone and became a ghost.
-     * REGEX-TEST:  ☠ Someone was crushed and became a ghost.
-     * REGEX-TEST:  ☠ Someone suffocated and became a ghost.
-     * REGEX-TEST:  ☠ Someone fell to their death with help from Someone and became a ghost.
-     * REGEX-TEST:  ☠ Someone fell into a deep hole and became a ghost.
-     * REGEX-TEST:  ☠ Someone died to a trap and became a ghost.
-     * REGEX-TEST:  ☠ Someone died to a mob and became a ghost.
-     * REGEX-TEST:  ☠ Someone died and became a ghost.
-     * REGEX-TEST:  ☠ Someone burnt to death and became a ghost.
+     * WRAPPED-REGEX-TEST: " ☠ Someone disconnected from the Dungeon and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ You were killed by Someone and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ You were crushed and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ You suffocated and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ You fell into a deep hole and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ You died to a trap and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ You died to a mob and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ You died and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ You burnt to death and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ Someone was killed by Someone and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ Someone was crushed and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ Someone suffocated and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ Someone fell to their death with help from Someone and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ Someone fell into a deep hole and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ Someone died to a trap and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ Someone died to a mob and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ Someone died and became a ghost."
+     * WRAPPED-REGEX-TEST: " ☠ Someone burnt to death and became a ghost."
      */
     private val deathPattern by patternGroup.pattern(
         "death.message",

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -56,12 +56,12 @@ object DungeonFinderFeatures {
     )
 
     /**
-     * REGEX-TEST:  4sn_: Archer (29)
-     * REGEX-TEST:  kaydo_odyak: Berserk (26)
-     * REGEX-TEST:  ItsKind: §eBerserk§b (§e38§b)
-     * REGEX-TEST:  sphxia: §eTank§b (§e36§b)
-     * REGEX-TEST:  Skept1x: §eMage§b (§e35§b)
-     * REGEX-TEST:  Mewlius: §eArcher§b (§e41§b)
+     * WRAPPED-REGEX-TEST: " 4sn_: Archer (29)"
+     * WRAPPED-REGEX-TEST: " kaydo_odyak: Berserk (26)"
+     * WRAPPED-REGEX-TEST: " ItsKind: §eBerserk§b (§e38§b)"
+     * WRAPPED-REGEX-TEST: " sphxia: §eTank§b (§e36§b)"
+     * WRAPPED-REGEX-TEST: " Skept1x: §eMage§b (§e35§b)"
+     * WRAPPED-REGEX-TEST: " Mewlius: §eArcher§b (§e41§b)"
      */
     private val memberPattern by patternGroup.pattern(
         "member",

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactSweepDetails.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactSweepDetails.kt
@@ -38,12 +38,12 @@ object CompactSweepDetails {
     )
 
     /**
-     * REGEX-TEST:   §r§7Fig Tree Toughness: §r§63.5 §r§a18.13 Logs
-     * REGEX-TEST:   §r§7Fig Tree Toughness: §r§63.5 §r§a18.19 Logs
-     * REGEX-TEST:   §r§7Fig Tree Toughness: §r§63.5 §r§818.19 Logs
-     * REGEX-TEST:   §r§7Fig Tree Toughness: §r§63.5 §r§818.04 Logs
-     * REGEX-TEST:   §r§7Fig Tree Toughness: §r§63.5 §r§818 Logs
-     * REGEX-TEST:   §r§7Dark Oak Tree Toughness: §r§60 §r§a35 Logs
+     * WRAPPED-REGEX-TEST: "  §r§7Fig Tree Toughness: §r§63.5 §r§a18.13 Logs"
+     * WRAPPED-REGEX-TEST: "  §r§7Fig Tree Toughness: §r§63.5 §r§a18.19 Logs"
+     * WRAPPED-REGEX-TEST: "  §r§7Fig Tree Toughness: §r§63.5 §r§818.19 Logs"
+     * WRAPPED-REGEX-TEST: "  §r§7Fig Tree Toughness: §r§63.5 §r§818.04 Logs"
+     * WRAPPED-REGEX-TEST: "  §r§7Fig Tree Toughness: §r§63.5 §r§818 Logs"
+     * WRAPPED-REGEX-TEST: "  §r§7Dark Oak Tree Toughness: §r§60 §r§a35 Logs"
      */
     @Suppress("MaxLineLength")
     private val sweepToughnessLogsPattern by patternGroup.pattern(
@@ -52,12 +52,12 @@ object CompactSweepDetails {
     )
 
     /**
-     * REGEX-TEST:   §r§7Axe throw: §r§c-50% Sweep §r§a9.02 Logs
-     * REGEX-TEST:   §r§7Axe throw: §r§c-50% Sweep §r§89.02 Logs
-     * REGEX-TEST:   §r§7Wrong Style: §r§c-50% Sweep §r§a9.1 Logs §r§cCut the trunk first!!
-     * REGEX-TEST:   §r§7Wrong Style: §r§c-50% Sweep §r§a4.51 Logs §r§cCut the trunk first!!
-     * REGEX-TEST:   §r§7Wrong Style: §c-50% Sweep §a2.38 Logs §cCut branches and trunk first!!
-     * REGEX-TEST:   §r§7Wrong Style: §r§c-50% Sweep §r§a2.38 Logs §r§cCut branches and trunk first!!
+     * WRAPPED-REGEX-TEST: "  §r§7Axe throw: §r§c-50% Sweep §r§a9.02 Logs"
+     * WRAPPED-REGEX-TEST: "  §r§7Axe throw: §r§c-50% Sweep §r§89.02 Logs"
+     * WRAPPED-REGEX-TEST: "  §r§7Wrong Style: §r§c-50% Sweep §r§a9.1 Logs §r§cCut the trunk first!!"
+     * WRAPPED-REGEX-TEST: "  §r§7Wrong Style: §r§c-50% Sweep §r§a4.51 Logs §r§cCut the trunk first!!"
+     * WRAPPED-REGEX-TEST: "  §r§7Wrong Style: §c-50% Sweep §a2.38 Logs §cCut branches and trunk first!!"
+     * WRAPPED-REGEX-TEST: "  §r§7Wrong Style: §r§c-50% Sweep §r§a2.38 Logs §r§cCut branches and trunk first!!"
      */
     @Suppress("MaxLineLength")
     private val penaltyPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
@@ -88,7 +88,7 @@ object ForagingTrackerLegacy {
     )
 
     /**
-     * REGEX-TEST:                                 §r§9§lTREE GIFT
+     * WRAPPED-REGEX-TEST: "                                §r§9§lTREE GIFT"
      */
     val giftHeaderPattern by patternGroup.pattern(
         "header",
@@ -96,9 +96,9 @@ object ForagingTrackerLegacy {
     )
 
     /**
-     * REGEX-TEST:                  §r§7You helped cut §r§a100% §r§7of the §r§aFig Tree§r§7.
-     * REGEX-TEST:              §r§7You helped cut §r§a100% §r§7of the §r§aMangrove Tree§r§7.
-     * REGEX-TEST:                  §r§7You helped cut §r§c15.2% §r§7of the §r§aFig Tree§r§7.
+     * WRAPPED-REGEX-TEST: "                 §r§7You helped cut §r§a100% §r§7of the §r§aFig Tree§r§7."
+     * WRAPPED-REGEX-TEST: "             §r§7You helped cut §r§a100% §r§7of the §r§aMangrove Tree§r§7."
+     * WRAPPED-REGEX-TEST: "                 §r§7You helped cut §r§c15.2% §r§7of the §r§aFig Tree§r§7."
      */
     val percentageContributedPattern by patternGroup.pattern(
         "contribution-percentage",
@@ -107,7 +107,7 @@ object ForagingTrackerLegacy {
 
     /**
      * REGEX-TEST: §f                       §e+5 rewards gained! §8(hover)
-     * REGEX-TEST:                             §r§e+0 rewards gained!
+     * WRAPPED-REGEX-TEST: "                            §r§e+0 rewards gained!"
      */
     val rewardsGainedPattern by patternGroup.pattern(
         "rewards-gained",
@@ -132,7 +132,7 @@ object ForagingTrackerLegacy {
     )
 
     /**
-     * REGEX-TEST:                                 §r§d§lBONUS GIFT
+     * WRAPPED-REGEX-TEST: "                                §r§d§lBONUS GIFT"
      */
     val bonusGiftSeparatorPattern by patternGroup.pattern(
         "bonus-gift.separator",
@@ -140,15 +140,15 @@ object ForagingTrackerLegacy {
     )
 
     /**
-     * REGEX-TEST:                           §r§7§r§aStretching Sticks §r§8(§r§a20%§r§8)
-     * REGEX-TEST:           §r§7§r§aEnchanted Book (§r§d§lFirst Impression I§r§a) §r§8(§r§a0.4%§r§8)
-     * REGEX-TEST:           §r§7§r§aEnchanted Book (§r§d§lFirst Impression I§r§a) §r§8(§r§a0.4%§r§8)
-     * REGEX-TEST:                            §r§7§r§fSweep Booster §r§8(§r§a1%§r§8)
-     * REGEX-TEST:                     §r§7§r§fForaging Wisdom Booster §r§8(§r§a0.5%§r§8)
-     * REGEX-TEST:                   §r§7§r§aEnchanted Book (§r§d§lMissile I§r§a) §r§8(§r§a0.2%§r§8)
-     * REGEX-TEST:                           §r§7§r§cTree the Fish §r§8(§r§a0.05%§r§8)
-     * REGEX-TEST:                             §r§6Chameleon §r§8(§r§a0.08%§r§8)
-     * REGEX-FAIL:                      §r§7A §r§dPhanflare §r§7fell from the Tree!
+     * WRAPPED-REGEX-TEST: "                          §r§7§r§aStretching Sticks §r§8(§r§a20%§r§8)"
+     * WRAPPED-REGEX-TEST: "          §r§7§r§aEnchanted Book (§r§d§lFirst Impression I§r§a) §r§8(§r§a0.4%§r§8)"
+     * WRAPPED-REGEX-TEST: "          §r§7§r§aEnchanted Book (§r§d§lFirst Impression I§r§a) §r§8(§r§a0.4%§r§8)"
+     * WRAPPED-REGEX-TEST: "                           §r§7§r§fSweep Booster §r§8(§r§a1%§r§8)"
+     * WRAPPED-REGEX-TEST: "                    §r§7§r§fForaging Wisdom Booster §r§8(§r§a0.5%§r§8)"
+     * WRAPPED-REGEX-TEST: "                  §r§7§r§aEnchanted Book (§r§d§lMissile I§r§a) §r§8(§r§a0.2%§r§8)"
+     * WRAPPED-REGEX-TEST: "                          §r§7§r§cTree the Fish §r§8(§r§a0.05%§r§8)"
+     * WRAPPED-REGEX-TEST: "                            §r§6Chameleon §r§8(§r§a0.08%§r§8)"
+     * WRAPPED-REGEX-FAIL: "                     §r§7A §r§dPhanflare §r§7fell from the Tree!"
      */
     val bonusGiftRewardPattern by patternGroup.pattern(
         "bonus-gift.reward",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -54,7 +54,7 @@ object FarmingFortuneDisplay {
     private val patternGroup = RepoPattern.group("garden.fortunedisplay")
 
     /**
-     * REGEX-TEST:  Farming Fortune: ☘1234
+     * WRAPPED-REGEX-TEST: " Farming Fortune: ☘1234"
      */
     private val universalTabFortunePattern by patternGroup.pattern(
         "tablist.universal-no-color",
@@ -96,10 +96,10 @@ object FarmingFortuneDisplay {
     )
 
     /**
-     * REGEX-TEST:  Bonus: INACTIVE
-     * REGEX-TEST:  Bonus: +200☘ 29m
-     * REGEX-TEST:  Bonus: +200☘ 5m 2s
-     * REGEX-TEST:  Bonus: +200☘ 8s
+     * WRAPPED-REGEX-TEST: " Bonus: INACTIVE"
+     * WRAPPED-REGEX-TEST: " Bonus: +200☘ 29m"
+     * WRAPPED-REGEX-TEST: " Bonus: +200☘ 5m 2s"
+     * WRAPPED-REGEX-TEST: " Bonus: +200☘ 8s"
      */
     private val pestFortuneBuffPattern by patternGroup.pattern(
         "pestfortunebuff-no-color",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenLevelDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenLevelDisplay.kt
@@ -87,7 +87,7 @@ object GardenLevelDisplay {
     )
 
     /**
-     * REGEX-TEST:     §r§8+§r§215 §r§7Garden Experience
+     * WRAPPED-REGEX-TEST: "    §r§8+§r§215 §r§7Garden Experience"
      */
     private val visitorRewardPattern by patternGroup.pattern(
         "chat.increase",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -125,9 +125,9 @@ object GardenNextJacobContest {
      * REGEX-TEST: ○ Cactus
      * REGEX-TEST: ☘ Carrot
      * REGEX-TEST: ○ Melon
-     * REGEX-TEST:  ☘ Mushroom
-     * REGEX-TEST:  ○ Pumpkin
-     * REGEX-TEST:  ○ Wheat
+     * WRAPPED-REGEX-TEST: " ☘ Mushroom"
+     * WRAPPED-REGEX-TEST: " ○ Pumpkin"
+     * WRAPPED-REGEX-TEST: " ○ Wheat"
      */
     private val cropPattern by patternGroup.pattern(
         "crop-no-color",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
@@ -25,8 +25,8 @@ object BonusPestChanceDisplay {
     private val patternGroup = RepoPattern.group("garden.bonuspestchance")
 
     /**
-     * REGEX-TEST:  Bonus Pest Chance: ൠ70
-     * REGEX-TEST:  Bonus Pest Chance: ൠ70
+     * WRAPPED-REGEX-TEST: " Bonus Pest Chance: ൠ70"
+     * WRAPPED-REGEX-TEST: " Bonus Pest Chance: ൠ70"
      */
     private val bonusPestChancePattern by patternGroup.pattern(
         "widget-no-color",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -87,8 +87,8 @@ object PestApi {
     )
 
     /**
-     * REGEX-TEST:  §7⏣ §aPlot §7- §b22a
-     * REGEX-TEST:  §7⏣ §aThe Garden
+     * WRAPPED-REGEX-TEST: " §7⏣ §aPlot §7- §b22a"
+     * WRAPPED-REGEX-TEST: " §7⏣ §aThe Garden"
      */
     private val noPestsInScoreboardPattern by patternGroup.pattern(
         "scoreboard.no-pests",
@@ -96,7 +96,7 @@ object PestApi {
     )
 
     /**
-     * REGEX-TEST:    §aPlot §7- §b4 §4§lൠ§7 x1
+     * WRAPPED-REGEX-TEST: "   §aPlot §7- §b4 §4§lൠ§7 x1"
      */
     private val pestsInPlotScoreboardPattern by patternGroup.pattern(
         "scoreboard.plot.pests",
@@ -104,7 +104,7 @@ object PestApi {
     )
 
     /**
-     * REGEX-TEST:  §aPlot §7- §b3
+     * WRAPPED-REGEX-TEST: " §aPlot §7- §b3"
      */
     private val noPestsInPlotScoreboardPattern by patternGroup.pattern(
         "scoreboard.plot.no-pests",
@@ -120,7 +120,7 @@ object PestApi {
     )
 
     /**
-     * REGEX-TEST:  Plots: 4, 12, 13, 18, 20
+     * WRAPPED-REGEX-TEST: " Plots: 4, 12, 13, 18, 20"
      */
     private val infestedPlotsTabListPattern by patternGroup.pattern(
         "tablist.infected-plots-no-color",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorCompactChat.kt
@@ -20,17 +20,17 @@ object GardenVisitorCompactChat {
     private val patternGroup = RepoPattern.group("garden.visitor.compact")
 
     /**
-     * REGEX-TEST:     §8+§f2x §dGold Essence
-     * REGEX-TEST:     §fDead Bush
-     * REGEX-TEST:     §8+§52 Pelts
-     * REGEX-TEST:     $8+§215 §7Garden Experience
-     * REGEX-TEST:     §8+§35k §7Farming XP
-     * REGEX-TEST:     §8+§311k §7Farming XP
-     * REGEX-TEST:     §8+§c32 Copper
-     * REGEX-TEST:     §7§aFine Flour §8x3
-     * REGEX-TEST:     §7§9Turbo-Carrot I Book
-     * REGEX-TEST:     §7§8+§d1,241 Gemstone Powder
-     * REGEX-TEST:     §7§8+§2Crystal Hollows Pass
+     * WRAPPED-REGEX-TEST: "    §8+§f2x §dGold Essence"
+     * WRAPPED-REGEX-TEST: "    §fDead Bush"
+     * WRAPPED-REGEX-TEST: "    §8+§52 Pelts"
+     * WRAPPED-REGEX-TEST: "    $8+§215 §7Garden Experience"
+     * WRAPPED-REGEX-TEST: "    §8+§35k §7Farming XP"
+     * WRAPPED-REGEX-TEST: "    §8+§311k §7Farming XP"
+     * WRAPPED-REGEX-TEST: "    §8+§c32 Copper"
+     * WRAPPED-REGEX-TEST: "    §7§aFine Flour §8x3"
+     * WRAPPED-REGEX-TEST: "    §7§9Turbo-Carrot I Book"
+     * WRAPPED-REGEX-TEST: "    §7§8+§d1,241 Gemstone Powder"
+     * WRAPPED-REGEX-TEST: "    §7§8+§2Crystal Hollows Pass"
      */
     @Suppress("MaxLineLength")
     private val visitorRewardPattern by patternGroup.pattern(
@@ -61,7 +61,7 @@ object GardenVisitorCompactChat {
     )
 
     /**
-     * REGEX-TEST:   §a§lREWARDS
+     * WRAPPED-REGEX-TEST: "  §a§lREWARDS"
      */
     private val rewardsTextPattern by patternGroup.pattern(
         "rewardstext",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTimer.kt
@@ -37,8 +37,8 @@ object GardenVisitorTimer {
     private val config get() = VisitorApi.config.timer
 
     /**
-     * REGEX-TEST:  Next Visitor: 11m
-     * REGEX-TEST:  Next Visitor: Queue Full!
+     * WRAPPED-REGEX-TEST: " Next Visitor: 11m"
+     * WRAPPED-REGEX-TEST: " Next Visitor: Queue Full!"
      */
     private val timePattern by RepoPattern.pattern(
         "garden.visitor.timer.time.new.colorless",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorTooltip.kt
@@ -43,8 +43,8 @@ object GardenVisitorTooltip {
     private val patternGroup = RepoPattern.group("garden.visitor.tooltip")
 
     /**
-     * REGEX-TEST:  §8+§c20 Copper
-     * REGEX-TEST:  §8+§c150 Copper §d❤
+     * WRAPPED-REGEX-TEST: " §8+§c20 Copper"
+     * WRAPPED-REGEX-TEST: " §8+§c150 Copper §d❤"
      */
     private val copperPattern by patternGroup.pattern(
         "copper",
@@ -52,7 +52,7 @@ object GardenVisitorTooltip {
     )
 
     /**
-     * REGEX-TEST:  §8+§215 §7Garden Experience
+     * WRAPPED-REGEX-TEST: " §8+§215 §7Garden Experience"
      */
     private val gardenExperiencePattern by patternGroup.pattern(
         "gardenexperience",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorApi.kt
@@ -47,9 +47,9 @@ object VisitorApi {
     val patternGroup = RepoPattern.group("garden.visitor.api")
 
     /**
-     * REGEX-TEST:  §r§aEmissary Carlton
-     * REGEX-TEST:  §r§6Madame Eleanor Q. Goldsworth III
-     * REGEX-TEST:  §r§9Lazy Miner
+     * WRAPPED-REGEX-TEST: " §r§aEmissary Carlton"
+     * WRAPPED-REGEX-TEST: " §r§6Madame Eleanor Q. Goldsworth III"
+     * WRAPPED-REGEX-TEST: " §r§9Lazy Miner"
      */
     private val visitorNamePattern by patternGroup.pattern(
         "visitor.name",

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -70,7 +70,7 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:  §5ф §dWizard Tower
+     * WRAPPED-REGEX-TEST: " §5ф §dWizard Tower"
      */
     val locationPattern by mainSB.pattern(
         "location",
@@ -86,7 +86,7 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:  Early Spring 13th
+     * WRAPPED-REGEX-TEST: " Early Spring 13th"
      */
     val datePattern by mainSB.pattern(
         "date",
@@ -94,8 +94,8 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:  §78:50am
-     * REGEX-TEST:  §75:50am §b☽
+     * WRAPPED-REGEX-TEST: " §78:50am"
+     * WRAPPED-REGEX-TEST: " §75:50am §b☽"
      */
     val timePattern by mainSB.pattern(
         "time",
@@ -146,9 +146,9 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:  §7♲ §7Ironman
-     * REGEX-TEST:  §a☀ §aStranded
-     * REGEX-TEST:  §9Ⓑ §9Bingo
+     * WRAPPED-REGEX-TEST: " §7♲ §7Ironman"
+     * WRAPPED-REGEX-TEST: " §a☀ §aStranded"
+     * WRAPPED-REGEX-TEST: " §9Ⓑ §9Bingo"
      */
     val profileTypePattern by mainSB.pattern(
         "profiletype",
@@ -282,7 +282,7 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:    §cLocked
+     * WRAPPED-REGEX-TEST: "   §cLocked"
      */
     val lockedPattern by farmingSB.pattern(
         "locked",
@@ -290,8 +290,8 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:    §fCleanup§7: §e0.3%
-     * REGEX-TEST:    §fCleanup§7: §b2 §4§lൠ§7 x1
+     * WRAPPED-REGEX-TEST: "   §fCleanup§7: §e0.3%"
+     * WRAPPED-REGEX-TEST: "   §fCleanup§7: §b2 §4§lൠ§7 x1"
      */
     val cleanUpPattern by farmingSB.pattern(
         "cleanup",
@@ -299,8 +299,8 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:    §fPasting§7: §e41.9%
-     * REGEX-TEST:    §fBarn Pasting§7: §e10.2%
+     * WRAPPED-REGEX-TEST: "   §fPasting§7: §e41.9%"
+     * WRAPPED-REGEX-TEST: "   §fBarn Pasting§7: §e10.2%"
      */
     val pastingPattern by farmingSB.pattern(
         "pasting",
@@ -328,7 +328,7 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:    §aPlot §7- §b3 §4§lൠ§7 x8
+     * WRAPPED-REGEX-TEST: "   §aPlot §7- §b3 §4§lൠ§7 x8"
      */
     val plotPattern by farmingSB.pattern(
         "plot",
@@ -357,7 +357,7 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:   ≈
+     * WRAPPED-REGEX-TEST: "  ≈"
      */
     val windCompassArrowPattern by miningSB.pattern(
         "windcompassarrow",
@@ -573,7 +573,7 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:  §e§l⚡ §cRedstone: §e§b4%
+     * WRAPPED-REGEX-TEST: " §e§l⚡ §cRedstone: §e§b4%"
      */
     val redstonePattern by miscSB.pattern(
         "redstone",
@@ -581,7 +581,7 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:  §a✌ §7(§a9§7/20)
+     * WRAPPED-REGEX-TEST: " §a✌ §7(§a9§7/20)"
      */
     val visitingPattern by miscSB.pattern(
         "visiting",
@@ -683,7 +683,7 @@ object ScoreboardPattern {
      * REGEX-TEST: §eProtect Elle §7(§a98%§7)
      * REGEX-TEST: §fFish 1 Flyfish §c✖
      * REGEX-TEST: §fFish 1 Skeleton Fish §c✖
-     * REGEX-TEST:   §7(§e1§7/§a100§7)
+     * WRAPPED-REGEX-TEST: "  §7(§e1§7/§a100§7)"
      */
     @Suppress("MaxLineLength")
     val thirdObjectiveLinePattern by miscSB.pattern(
@@ -699,7 +699,7 @@ object ScoreboardPattern {
      * REGEX-TEST: §eFind the 4 Missing Pieces
      * REGEX-TEST: §eTalk to the Goblin King
      * REGEX-TEST: §eBring items to Moby
-     * REGEX-TEST:  Glowing Mushroom §8x8
+     * WRAPPED-REGEX-TEST: " Glowing Mushroom §8x8"
      */
     @Suppress("MaxLineLength")
     val wtfAreThoseLinesPattern by miscSB.pattern(
@@ -791,7 +791,7 @@ object ScoreboardPattern {
     private val riftSB = scoreboardGroup.group("rift")
 
     /**
-     * REGEX-TEST:  §fRift Dimension
+     * WRAPPED-REGEX-TEST: " §fRift Dimension"
      */
     val riftDimensionPattern by riftSB.pattern(
         "dimension",
@@ -858,7 +858,7 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:  Big damage in: §d2m 59s
+     * WRAPPED-REGEX-TEST: " Big damage in: §d2m 59s"
      */
     val bigDamagePattern by riftSB.pattern(
         "bigdamage",
@@ -951,8 +951,8 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:     §aHOTF§f: §a28k§3.7k§b (+35)
-     * REGEX-TEST:     §aHOTF§f: §a28k§9 (+29 Exp)
+     * WRAPPED-REGEX-TEST: "    §aHOTF§f: §a28k§3.7k§b (+35)"
+     * WRAPPED-REGEX-TEST: "    §aHOTF§f: §a28k§9 (+29 Exp)"
      */
     val hotfPattern by galateaSB.pattern(
         "hotf",
@@ -974,8 +974,8 @@ object ScoreboardPattern {
      * This pattern is to catch those lines.
      */
     /**
-     * REGEX-TEST:  §e§l⚡ §cRedston
-     * REGEX-TEST:       §ce: §e§b0%
+     * WRAPPED-REGEX-TEST: " §e§l⚡ §cRedston"
+     * WRAPPED-REGEX-TEST: "      §ce: §e§b0%"
      * REGEX-TEST: Starting in: §a0 §c1:55
      * REGEX-TEST: §2᠅ §fMithril§f:§695
      * REGEX-TEST: §d᠅ §fGemstone§f
@@ -993,7 +993,7 @@ object ScoreboardPattern {
     private val tablistGroup = group.group("tablist-no-color")
 
     /**
-     * REGEX-TEST:  Ends In: 27h
+     * WRAPPED-REGEX-TEST: " Ends In: 27h"
      */
     val eventTimeEndsPattern by tablistGroup.pattern(
         "eventtime",
@@ -1001,7 +1001,7 @@ object ScoreboardPattern {
     )
 
     /**
-     * REGEX-TEST:  Starts In: 7h
+     * WRAPPED-REGEX-TEST: " Starts In: 7h"
      */
     val eventTimeStartsPattern by tablistGroup.pattern(
         "eventtimestarts",

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StockOfStonkFeature.kt
@@ -44,8 +44,8 @@ object StockOfStonkFeature {
     )
 
     /**
-     * REGEX-TEST:    Minimum Bid: 2,400,002 Coins
-     * REGEX-TEST:    Minimum Bid: 2,400,002 Coins
+     * WRAPPED-REGEX-TEST: "   Minimum Bid: 2,400,002 Coins"
+     * WRAPPED-REGEX-TEST: "   Minimum Bid: 2,400,002 Coins"
      */
     private val bidPattern by patternGroup.pattern(
         "bid.new",

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/TradeValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/TradeValue.kt
@@ -40,8 +40,8 @@ object TradeValue {
     private var yourDisplay = emptyList<Renderable>()
 
     /**
-     * REGEX-TEST:  §71
-     * REGEX-TEST:  §8(1,000)
+     * WRAPPED-REGEX-TEST: " §71"
+     * WRAPPED-REGEX-TEST: " §8(1,000)"
      */
     private val coinPattern by RepoPattern.pattern(
         "inventory.tradevalue.coins",

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -104,7 +104,7 @@ object MineshaftPityDisplay {
 
 
     /**
-     * REGEX-TEST:  Glacite Mineshafts: 124/2,000
+     * WRAPPED-REGEX-TEST: " Glacite Mineshafts: 124/2,000"
      */
     private val tabPityPattern by group.pattern(
         "tablist",

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
@@ -25,7 +25,7 @@ object CrystalNucleusApi {
     private val config get() = SkyHanniMod.feature.mining.crystalNucleusTracker
 
     /**
-     * REGEX-TEST:   §r§5§lCRYSTAL NUCLEUS LOOT BUNDLE
+     * WRAPPED-REGEX-TEST: "  §r§5§lCRYSTAL NUCLEUS LOOT BUNDLE"
      */
     private val startPattern by patternGroup.pattern(
         "loot.start",

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/FossilExcavatorApi.kt
@@ -21,7 +21,7 @@ object FossilExcavatorApi {
     private val chatPatternGroup = patternGroup.group("chat")
 
     /**
-     * REGEX-TEST:   §r§6§lEXCAVATION COMPLETE
+     * WRAPPED-REGEX-TEST: "  §r§6§lEXCAVATION COMPLETE"
      */
     private val startPattern by chatPatternGroup.pattern("start", " {2}§r§6§lEXCAVATION COMPLETE ?")
 
@@ -31,7 +31,7 @@ object FossilExcavatorApi {
     private val endPattern by chatPatternGroup.pattern("end", "§a§l▬{64}")
 
     /**
-     * REGEX-TEST:     §r§6Tusk Fossil
+     * WRAPPED-REGEX-TEST: "    §r§6Tusk Fossil"
      */
     private val itemPattern by chatPatternGroup.pattern("item", " {4}§r(?<item>.+)")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/CorpseApi.kt
@@ -17,10 +17,10 @@ object CorpseApi {
     private val chatPatternGroup = patternGroup.group("chat")
 
     /**
-     * REGEX-TEST:   §r§b§l§r§9§lLAPIS §r§b§lCORPSE LOOT!
-     * REGEX-TEST:   §r§b§l§r§7§lTUNGSTEN §r§b§lCORPSE LOOT!
-     * REGEX-TEST:   §r§b§l§r§6§lUMBER §r§b§lCORPSE LOOT!
-     * REGEX-TEST:   §r§b§l§r§f§lVANGUARD §r§b§lCORPSE LOOT!
+     * WRAPPED-REGEX-TEST: "  §r§b§l§r§9§lLAPIS §r§b§lCORPSE LOOT!"
+     * WRAPPED-REGEX-TEST: "  §r§b§l§r§7§lTUNGSTEN §r§b§lCORPSE LOOT!"
+     * WRAPPED-REGEX-TEST: "  §r§b§l§r§6§lUMBER §r§b§lCORPSE LOOT!"
+     * WRAPPED-REGEX-TEST: "  §r§b§l§r§f§lVANGUARD §r§b§lCORPSE LOOT!"
      */
     private val startPattern by chatPatternGroup.pattern(
         "start",
@@ -33,8 +33,8 @@ object CorpseApi {
     private val endPattern by chatPatternGroup.pattern("end", "§a§l▬{64}")
 
     /**
-     * REGEX-TEST:     §r§9☠ Fine Onyx Gemstone §r§8x2
-     * REGEX-TEST:     §r§fEnchanted Book (Ice Cold I§r§f)
+     * WRAPPED-REGEX-TEST: "    §r§9☠ Fine Onyx Gemstone §r§8x2"
+     * WRAPPED-REGEX-TEST: "    §r§fEnchanted Book (Ice Cold I§r§f)"
      */
     private val itemPattern by chatPatternGroup.pattern("item", " {4}§r(?<item>.+)")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -21,8 +21,8 @@ object KuudraApi {
     private val patternGroup = RepoPattern.group("data.kuudra")
 
     /**
-     * REGEX-TEST:  §7⏣ §cKuudra's Hollow §8(T5)
-     * REGEX-TEST:  §7⏣ §cKuudra's Hollow §8(T2)
+     * WRAPPED-REGEX-TEST: " §7⏣ §cKuudra's Hollow §8(T5)"
+     * WRAPPED-REGEX-TEST: " §7⏣ §cKuudra's Hollow §8(T2)"
      */
     private val tierPattern by patternGroup.pattern(
         "scoreboard.tier",

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -39,9 +39,9 @@ object CrimsonIsleReputationHelper {
     var tabListQuestsMissing = false
 
     /**
-     * REGEX-TEST:  ✖ Rescue Mission
-     * REGEX-TEST:  ✔ Digested Mushrooms x20
-     * REGEX-TEST:  ✖ Slugfish x1
+     * WRAPPED-REGEX-TEST: " ✖ Rescue Mission"
+     * WRAPPED-REGEX-TEST: " ✔ Digested Mushrooms x20"
+     * WRAPPED-REGEX-TEST: " ✖ Slugfish x1"
      */
     val tabListQuestPattern by RepoPattern.pattern(
         "crimson.reputationhelper.tablist.quest-no-color",

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/GeorgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/GeorgeHelper.kt
@@ -35,11 +35,11 @@ object GeorgeHelper {
     private val patternGroup = RepoPattern.group("george.taming-sixty")
 
     /**
-     * REGEX-TEST:   §dMythic Enderman
-     * REGEX-TEST:   §6Legendary Black Cat
-     * REGEX-TEST:   §5Epic Rift Ferret
-     * REGEX-TEST:   §5Epic Jellyfish
-     * REGEX-TEST:   §9Rare Frost Wisp
+     * WRAPPED-REGEX-TEST: "  §dMythic Enderman"
+     * WRAPPED-REGEX-TEST: "  §6Legendary Black Cat"
+     * WRAPPED-REGEX-TEST: "  §5Epic Rift Ferret"
+     * WRAPPED-REGEX-TEST: "  §5Epic Jellyfish"
+     * WRAPPED-REGEX-TEST: "  §9Rare Frost Wisp"
      */
     private val neededPetPattern by patternGroup.pattern(
         "needed-pet.loreline",

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
@@ -33,7 +33,7 @@ object MotesSession {
     private val patternGroup = RepoPattern.group("rift.everywhere.motes")
 
     /**
-     * REGEX-TEST:  Lifetime Motes: 593,922
+     * WRAPPED-REGEX-TEST: " Lifetime Motes: 593,922"
      */
     private val lifetimeMotesPattern by patternGroup.pattern(
         "lifetime-nocolor",

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
@@ -48,7 +48,7 @@ object RemainingSlayerKills {
     private val patternGroup = RepoPattern.group("slayer.remaining-kills")
 
     /**
-     * REGEX-TEST:  ☯ Combat Wisdom 2
+     * WRAPPED-REGEX-TEST: " ☯ Combat Wisdom 2"
      */
     private val combatWisdomPattern by patternGroup.pattern(
         "combat-wisdom",

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerCocoonWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerCocoonWarning.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 @SkyHanniModule
 object SlayerCocoonWarning {
     /**
-     * REGEX-TEST:   §r§c§lYOU COCOONED YOUR SLAYER BOSS
+     * WRAPPED-REGEX-TEST: "  §r§c§lYOU COCOONED YOUR SLAYER BOSS"
      */
     private val slayerCocoonPattern by RepoPattern.pattern(
         "slayer.cocooned",

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -88,7 +88,7 @@ object UtilsPatterns {
 
     /**
      * REGEX-TEST: 8x Enchanted Pork
-     * REGEX-TEST:   §810x §r§bGlacite Jewel
+     * WRAPPED-REGEX-TEST: "  §810x §r§bGlacite Jewel"
      */
     val readAmountBeforePattern by patternGroup.pattern(
         "item.amount.front",


### PR DESCRIPTION
## What
Makes it illegal to create plain `REGEX-TEST` or `REGEX-FAIL` with leading or trailing whitespace, requiring the usage of `WRAPPED-REGEX-TEST` or the newly added `WRAPPED-REGEX-FAIL` instead.

Why? Because it's too easy to accidentally add extra leading/trailing whitespace, and even when it is intentional, it's difficult to tell at a glance what's a separator and what's actually part of the pattern. Trailing whitespace is especially bad, because it's invisible in a lot of places (though Git tends to warn you about it).

## Changelog Technical Details
+ Added WRAPPED-REGEX-FAIL type for regex tests. - Luna
+ Changed regex tests that contain leading or trailing whitespace to require WRAPPED-REGEX-TEST or WRAPPED-REGEX-FAIL. - Luna