### PR TITLE
Fix: Exception while parsing bestiary level for item overlay

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -320,9 +320,8 @@ object ItemDisplayOverlayFeatures {
 
         if (BESTIARY_LEVEL.isSelected() && (
                 chestName.contains("Bestiary ➜") ||
-                chestName.contains("Fishing ➜")
-            ) &&
-            lore.any {
+                    chestName.contains("Fishing ➜")
+                ) && lore.any {
                 it.contains("Deaths: ")
             }
         ) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -329,11 +329,7 @@ object ItemDisplayOverlayFeatures {
                 val tier = (group("tier").romanToDecimalIfNecessary() - 1)
                 return tier.toString()
             } ?: run {
-                val tier = itemName.split(" ")
-
-                tier.last().romanToDecimalIfNecessaryOrNull()?.run {
-                    return toString()
-                }
+                return itemName.split(" ").last().romanToDecimalIfNecessaryOrNull()?.toString()
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -45,6 +45,7 @@ import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
+import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessaryOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -319,8 +320,9 @@ object ItemDisplayOverlayFeatures {
 
         if (BESTIARY_LEVEL.isSelected() && (
                 chestName.contains("Bestiary ➜") ||
-                    chestName.contains("Fishing ➜")
-                ) && lore.any {
+                chestName.contains("Fishing ➜")
+            ) &&
+            lore.any {
                 it.contains("Deaths: ")
             }
         ) {
@@ -330,7 +332,9 @@ object ItemDisplayOverlayFeatures {
             } ?: run {
                 val tier = itemName.split(" ")
 
-                return tier.last().romanToDecimalIfNecessary().toString()
+                tier.last().romanToDecimalIfNecessaryOrNull()?.run {
+                    return toString()
+                }
             }
         }
 


### PR DESCRIPTION
## What
Fixes exception throw by `ItemDisplayOverlayFeatures` in fishing bestiary.

<details>

```
SkyHanni 7.25.0 26.1.2: Caught a IllegalArgumentException in at.hannibal2.skyhanni.features.inventory.ItemDisplayOverlayFeatures.onRenderItemTip(at.hannibal2.skyhanni.events.RenderItemTipEvent) at RenderItemTipEvent: Failed to parse input string as either Arabic or Roman numerals: 'Witch'
 
Caused by java.lang.IllegalArgumentException: Failed to parse input string as either Arabic or Roman numerals: 'Witch'
	at SH.utils.NumberUtil.romanToDecimalIfNecessary(NumberUtil.kt:121)
	at SH.features.inventory.ItemDisplayOverlayFeatures.getStackTip(ItemDisplayOverlayFeatures.kt:333)
	at SH.features.inventory.ItemDisplayOverlayFeatures.onRenderItemTip(ItemDisplayOverlayFeatures.kt:132)
<Skyhanni event post>
```

</details>

## Changelog Fixes
+ Fixed exception thrown while parsing Fishing Bestiary level. - Twarug