### PR TITLE
Backend: Revert @Legacy to @Deprecated

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.api.event
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.IslandTypeTag
-import at.hannibal2.skyhanni.utils.Legacy
 import kotlin.reflect.KClass
 
 @Retention(AnnotationRetention.RUNTIME)
@@ -13,14 +12,14 @@ annotation class HandleEvent(
      * For cases where the event properties are themselves not needed, and solely a listener for an event fire suffices.
      * To specify multiple events, use [eventTypes] instead.
      */
-    @Legacy("Use Primary Function Name, or explicit type parameter instead.")
+    @Deprecated("Use Primary Function Name, or explicit type parameter instead.")
     val eventType: KClass<out SkyHanniEvent> = SkyHanniEvent::class,
 
     /**
      * For cases where multiple events are listened to, and properties are unnecessary.
      * To specify only one event, use [eventType] instead.
      */
-    @Legacy("Use Primary Function Name, or explicit type parameter instead.")
+    @Deprecated("Use Primary Function Name, or explicit type parameter instead.")
     val eventTypes: Array<KClass<out SkyHanniEvent>> = [],
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/config/enums/OutsideSBFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/enums/OutsideSBFeature.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.config.enums
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.utils.Legacy
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 
 enum class OutsideSBFeature(private val displayName: String) {
@@ -27,6 +26,6 @@ enum class OutsideSBFeature(private val displayName: String) {
 
     override fun toString() = displayName
 
-    @Legacy("Use onlyOnSkyblockOrFeatures instead")
+    @Deprecated("Use onlyOnSkyblockOrFeatures instead")
     fun isSelected() = MinecraftCompat.localPlayerExists && SkyHanniMod.feature.misc.showOutsideSB.get().contains(this)
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/MayorData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MayorData.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.data.Perk.Companion.toPerk
 import at.hannibal2.skyhanni.data.jsonobjects.other.MayorPerk
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.Legacy
 
 enum class ElectionCandidate(
     val mayorName: String,
@@ -187,7 +186,7 @@ enum class Perk(val perkName: String) {
     LONG_TERM_INVESTMENT("Long Term Investment"),
 
     // Finnegan
-    @Legacy("Remove after 9.0.0") PELT_POCALYPSE("Pelt-pocalypse"),
+    @Deprecated("Remove after 9.0.0") PELT_POCALYPSE("Pelt-pocalypse"),
     GRAND_FEAST("Grand Feast"),
     GOATED("GOATed"),
     BLOOMING_BUSINESS("Blooming Business"),

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/neu/NeuItemJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/neu/NeuItemJson.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.recipe.NeuCraftingRecipeJ
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.KSerializable
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.Legacy
 import at.hannibal2.skyhanni.utils.json.fromJson
 import com.google.gson.JsonObject
 import com.google.gson.annotations.Expose
@@ -29,7 +28,7 @@ data class NeuItemJson(
      * and perform further conversion ourselves. Don't use this field.
      */
     @Expose
-    @Legacy("Use neuNbt or nbtTag instead", ReplaceWith("neuNbt or nbtTag"))
+    @Deprecated("Use neuNbt or nbtTag instead", ReplaceWith("neuNbt or nbtTag"))
     @SerializedName("nbttag")
     private val nbtTagAny: Any,
     @Expose val damage: Int? = null,

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/Graph.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/Graph.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
-import at.hannibal2.skyhanni.utils.Legacy
 import at.hannibal2.skyhanni.utils.json.fromJson
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -60,7 +59,7 @@ value class Graph(
     fun toPositionsList() = map { it.position }
     fun toJson(): String = gson.toJson(this)
 
-    @Legacy("See parent deprecation")
+    @Deprecated("See parent deprecation")
     @Suppress("UNCHECKED_CAST", "PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     override fun <T> toArray(generator: IntFunction<Array<T>>): Array<T> =
         (nodes as Collection<GraphNode>).toArray(generator)

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.data.model.graph
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.Legacy
 
 enum class GraphNodeTag(
     val internalName: String,
@@ -24,7 +23,7 @@ enum class GraphNodeTag(
     POI("poi", LorenzColor.WHITE, "Point of Interest", "A relevant spot or a landmark on the map.", onlySkyblock = null),
 
     // TODO delete once no graph data contains this anymore
-    @Legacy("gets split up into WARP, JUMP_PAD and TELEPORT_PAD")
+    @Deprecated("gets split up into WARP, JUMP_PAD and TELEPORT_PAD")
     TELEPORT(
         "teleport",
         LorenzColor.BLUE,

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoReloadEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoReloadEvent.kt
@@ -1,11 +1,10 @@
 package at.hannibal2.skyhanni.data.repo
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
-import at.hannibal2.skyhanni.utils.Legacy
 import kotlinx.coroutines.runBlocking
 
 abstract class AbstractRepoReloadEvent(open val manager: AbstractRepoManager<*>) : SkyHanniEvent() {
-    @Legacy("Use suspended version of this function instead", replaceWith = ReplaceWith("getConstantAsync"))
+    @Deprecated("Use suspended version of this function instead", replaceWith = ReplaceWith("getConstantAsync"))
     inline fun <reified T : Any> getConstant(constant: String): T = runBlocking {
         getConstantAsync(constant)
     }

--- a/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/IslandChangeEvent.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.events
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
-import at.hannibal2.skyhanni.utils.Legacy
 
 /**
  * Fired when the current island state changes.
@@ -15,7 +14,7 @@ import at.hannibal2.skyhanni.utils.Legacy
  * When switching islands, the event fires twice: first with [newIsland] =[IslandType.NONE]
  * (leaving the old island), then with [oldIsland] = [IslandType.NONE] (entering the new one).
  */
-@Legacy("use IslandJoinEvent or IslandLeaveEvent instead")
+@Deprecated("use IslandJoinEvent or IslandLeaveEvent instead")
 @PrimaryFunction("onIslandChange")
 class IslandChangeEvent(val newIsland: IslandType, val oldIsland: IslandType) : SkyHanniEvent()
 

--- a/src/main/java/at/hannibal2/skyhanni/events/SkyHanniRenderEntityEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/SkyHanniRenderEntityEvent.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
-import at.hannibal2.skyhanni.utils.Legacy
 import net.minecraft.world.entity.LivingEntity
 
 // TODO replace all "cancel only" usages of this event. the only remaining stuff should be EntityOpacityManager
@@ -10,7 +9,7 @@ import net.minecraft.world.entity.LivingEntity
  * This is super inefficient, only use it if absolutely necessary, and then also only with heavy caching added.
  * For normal cases of "hide this entity" rather use [CheckRenderEntityEvent].
  */
-@Legacy("use CheckRenderEntityEvent instead")
+@Deprecated("use CheckRenderEntityEvent instead")
 open class SkyHanniRenderEntityEvent<T : LivingEntity>(
     val entity: T,
     val x: Double,

--- a/src/main/java/at/hannibal2/skyhanni/events/chat/AbstractChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/chat/AbstractChatEvent.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.events.chat
 
 import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.utils.ComponentSpan
-import at.hannibal2.skyhanni.utils.Legacy
 import net.minecraft.network.chat.Component
 
 object AbstractChatEvent {
@@ -13,7 +12,7 @@ object AbstractChatEvent {
         chatComponent: Component,
         blockedReason: String? = null,
     ) : SystemMessageEvent.Allow(messageComponent.getText(), chatComponent, blockedReason) {
-        @Legacy(
+        @Deprecated(
             "Use cleanMessage unless you really need color codes",
             replaceWith = ReplaceWith("this.cleanMessage")
         )
@@ -25,7 +24,7 @@ object AbstractChatEvent {
         val messageComponent: ComponentSpan,
         chatComponent: Component,
     ) : SystemMessageEvent.Modify(messageComponent.getText(), chatComponent) {
-        @Legacy(
+        @Deprecated(
             "Use cleanMessage unless you really need color codes",
             replaceWith = ReplaceWith("this.cleanMessage")
         )

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/ToolTipEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/ToolTipEvent.kt
@@ -2,13 +2,12 @@ package at.hannibal2.skyhanni.events.minecraft
 
 import at.hannibal2.skyhanni.api.event.CancellableSkyHanniEvent
 import at.hannibal2.skyhanni.utils.SafeItemStack
-import at.hannibal2.skyhanni.utils.Legacy
 import net.minecraft.world.inventory.Slot
 
 /**
  * Use [ToolTipTextEvent] Instead
  */
-@Legacy("Use ToolTipTextEvent instead", ReplaceWith("ToolTipTextEvent"))
+@Deprecated("Use ToolTipTextEvent instead", ReplaceWith("ToolTipTextEvent"))
 class ToolTipEvent(val slot: Slot, val itemStack: SafeItemStack, private val toolTip0: MutableList<String>) : CancellableSkyHanniEvent() {
 
     var toolTip: MutableList<String>

--- a/src/main/java/at/hannibal2/skyhanni/utils/ClipboardUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ClipboardUtils.kt
@@ -14,7 +14,7 @@ object ClipboardUtils {
         withIOContext = true,
     )
 
-    @Legacy("Use copyToClipboardAsync instead", ReplaceWith("copyToClipboardAsync(text).await()"))
+    @Deprecated("Use copyToClipboardAsync instead", ReplaceWith("copyToClipboardAsync(text).await()"))
     fun copyToClipboard(text: String, step: Int = 0) = copyToClipboardInternal(text, step)
 
     fun copyToClipboardAsync(text: String, step: Int = 0): Deferred<Boolean?> = clipboardCoroutineSettings.async {

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -47,7 +47,7 @@ object EntityUtils {
     inline val ALWAYS get(): (Entity) -> Boolean = { true }
 
     // TODO remove this relatively heavy call everywhere
-    @Legacy("Use Mob Detection Instead")
+    @Deprecated("Use Mob Detection Instead")
     fun LivingEntity.hasNameTagWith(
         y: Int,
         contains: String,
@@ -66,7 +66,7 @@ object EntityUtils {
         return list
     }
 
-    @Legacy("Use Mob Detection Instead")
+    @Deprecated("Use Mob Detection Instead")
     fun LivingEntity.getAllNameTagsInRadiusWith(
         contains: String,
         radius: Double = 3.0,
@@ -74,7 +74,7 @@ object EntityUtils {
         it.name.string.contains(contains)
     }
 
-    @Legacy("Use Mob Detection Instead")
+    @Deprecated("Use Mob Detection Instead")
     fun LivingEntity.getNameTagWith(
         y: Int,
         contains: String,
@@ -83,7 +83,7 @@ object EntityUtils {
         debugWrongEntity: Boolean = false,
     ): ArmorStand? = getAllNameTagsWith(y, contains, debugRightEntity, inaccuracy, debugWrongEntity).firstOrNull()
 
-    @Legacy("Use Mob Detection Instead")
+    @Deprecated("Use Mob Detection Instead")
     fun LivingEntity.getAllNameTagsWith(
         y: Int,
         contains: String,
@@ -113,10 +113,10 @@ object EntityUtils {
         return getEntitiesInBoundingBox<ArmorStand>(alignedBB)
     }
 
-    @Legacy("Old. Instead use entity detection feature instead.")
+    @Deprecated("Old. Instead use entity detection feature instead.")
     fun LivingEntity.hasBossHealth(health: Int): Boolean = this.hasMaxHealth(health, true)
 
-    @Legacy("Old. Instead use entity detection feature instead.")
+    @Deprecated("Old. Instead use entity detection feature instead.")
     fun LivingEntity.hasMaxHealth(health: Int, boss: Boolean = false, maxHealth: Int = baseMaxHealth): Boolean {
         val derpyMultiplier = if (ElectionApi.isDerpy) 2.0 else if (ElectionApi.isAura) 1.1 else 1.0
         if (maxHealth == (health * derpyMultiplier).toInt()) return true
@@ -155,7 +155,7 @@ object EntityUtils {
 
     fun LivingEntity.isAtFullHealth() = baseMaxHealth == findHealthReal().toInt()
 
-    @Legacy("Use specific methods instead, such as wearingSkullTexture or holdingSkullTexture")
+    @Deprecated("Use specific methods instead, such as wearingSkullTexture or holdingSkullTexture")
     fun ArmorStand.hasSkullTexture(skin: String): Boolean {
         val inventory = this.getAllEquipment()
         return inventory.any { it != null && it.getSkullTexture() == skin }

--- a/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HypixelCommands.kt
@@ -76,7 +76,7 @@ object HypixelCommands {
     }
 
     // Do not remove this deprecation tag, as we want to catch all wrong uses of /gfs in the future forever.
-    @Legacy("do not send /gfs commands manually to hypixel", ReplaceWith("GetFromSackApi.getFromSack(internalName, amount)"))
+    @Deprecated("do not send /gfs commands manually to hypixel", ReplaceWith("GetFromSackApi.getFromSack(internalName, amount)"))
     fun getFromSacks(internalName: NeuInternalName, amount: Int) {
         GetFromSackApi.getFromSack(internalName, amount)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -175,7 +175,7 @@ object ItemUtils {
 
     fun isSack(stack: SafeItemStack) = stack.getInternalName().endsWith("_SACK") && stack.cleanName().endsWith(" Sack")
 
-    @Legacy("Use getLoreComponent unless you really need color codes", ReplaceWith("this.getLoreComponent()"))
+    @Deprecated("Use getLoreComponent unless you really need color codes", ReplaceWith("this.getLoreComponent()"))
     fun SafeItemStack.getLore(): List<String> {
         val data = cachedData
         if (data.lastLoreFetchTime.passedSince() < 0.1.seconds) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/Legacy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/Legacy.kt
@@ -1,6 +1,9 @@
 package at.hannibal2.skyhanni.utils
 
-// This class is to replace @Deprecated, which gets flagged by detekt
+/**
+ * Alternative to [Deprecated] for things that can never be removed due to backwards compatibility reasons
+ * (e.g. item categories that no longer exist but may appear on legacy items).
+ */
 @Retention(AnnotationRetention.BINARY)
 @Target(
     AnnotationTarget.CLASS,

--- a/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/OSUtils.kt
@@ -59,7 +59,7 @@ object OSUtils {
         openBrowser(url)
     }
 
-    @Legacy(
+    @Deprecated(
         "Use copyToClipboardAsync instead for a success boolean return",
         ReplaceWith("copyToClipboardAsync(text)"),
     )

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderUtils.kt
@@ -155,7 +155,7 @@ object RenderUtils {
         return x to y
     }
 
-    @Legacy("Use renderRenderable instead", ReplaceWith("renderRenderable(renderable, posLabel)"))
+    @Deprecated("Use renderRenderable instead", ReplaceWith("renderRenderable(renderable, posLabel)"))
     private fun Position.renderString0(string: String, offsetX: Int = 0, offsetY: Int = 0, centered: Boolean): Int =
         DrawContextUtils.pushPopResult {
             val display = "§f$string"
@@ -172,7 +172,7 @@ object RenderUtils {
             return fr.width(display)
         }
 
-    @Legacy("Use renderRenderables instead", ReplaceWith("renderRenderables(renderables)"))
+    @Deprecated("Use renderRenderables instead", ReplaceWith("renderRenderables(renderables)"))
     fun Position.renderStrings(list: List<String>, extraSpace: Int = 0, posLabel: String) {
         if (list.isEmpty()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SizeLimitedCache.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SizeLimitedCache.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.utils.collection.SizeLimitedCache
 import com.google.common.cache.RemovalCause
 
-@Legacy("Use at.hannibal2.skyhanni.utils.collection.SizeLimitedCache import instead")
+@Deprecated("Use at.hannibal2.skyhanni.utils.collection.SizeLimitedCache import instead")
 fun <K : Any, V : Any> SizeLimitedCache(
     maxSize: Long,
     removalListener: ((K?, V?, RemovalCause) -> Unit)? = null,

--- a/src/main/java/at/hannibal2/skyhanni/utils/SizeLimitedSet.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SizeLimitedSet.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.utils.collection.SizeLimitedSet
 import com.google.common.cache.RemovalCause
 
-@Legacy("Use at.hannibal2.skyhanni.utils.collection.SizeLimitedSet import instead")
+@Deprecated("Use at.hannibal2.skyhanni.utils.collection.SizeLimitedSet import instead")
 fun <T : Any> SizeLimitedSet(
     maxSize: Long,
     removalListener: ((T?, RemovalCause) -> Unit)? = null,

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -96,7 +96,7 @@ object SkyBlockItemModifierUtils {
         @Expose val heldItem: NeuInternalName? = null,
         @Expose val candyUsed: Int = 0,
         @Expose val skin: String? = null,
-        @Legacy("Some pets do not have uuids, use uniqueId instead", replaceWith = ReplaceWith("uniqueId"))
+        @Deprecated("Some pets do not have uuids, use uniqueId instead", replaceWith = ReplaceWith("uniqueId"))
         @Expose val uuid: UUID? = null,
         @Expose val uniqueId: UUID? = null, // Only null when pet is read from a shop, or another non-"owned" source
         @Expose val hideRightClick: Boolean? = null,

--- a/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/collection/CollectionUtils.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.utils.collection
 
 import at.hannibal2.skyhanni.utils.MinMaxNumber
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.Legacy
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -220,10 +219,10 @@ object CollectionUtils {
 
     fun <T> MutableList<T>.addAll(vararg elements: T) = addAll(elements.asList())
 
-    @Legacy("use ConcurrentLinkedQueue or Mutex-like alternates", ReplaceWith(""))
+    @Deprecated("use ConcurrentLinkedQueue or Mutex-like alternates", ReplaceWith(""))
     fun <K, V> Map<K, V>.editCopy(function: MutableMap<K, V>.() -> Unit): Map<K, V> = toMutableMap().apply(function)
 
-    @Legacy("use ConcurrentLinkedQueue or Mutex-like alternates", ReplaceWith(""))
+    @Deprecated("use ConcurrentLinkedQueue or Mutex-like alternates", ReplaceWith(""))
     fun <T> List<T>.editCopy(function: MutableList<T>.() -> Unit): List<T> = toMutableList().apply(function)
 
     fun <K, V> Map<K, V>.moveEntryToTop(matcher: (Map.Entry<K, V>) -> Boolean): Map<K, V> {
@@ -447,7 +446,7 @@ object CollectionUtils {
         }
     }
 
-    @Legacy("Use the removeIf function provided by java")
+    @Deprecated("Use the removeIf function provided by java")
     fun <T> MutableList<T>.removeIf(predicate: (T) -> Boolean) = removeIf(predicate)
 
     fun <K, V> MutableMap<K, V>.removeIfKey(predicate: (K) -> Boolean) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/DrawContextUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/DrawContextUtils.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.utils.compat
 
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.SafeItemStack
-import at.hannibal2.skyhanni.utils.Legacy
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.client.renderer.state.gui.GuiElementRenderState
 
@@ -61,12 +60,12 @@ object DrawContextUtils {
         drawContext.pose().scale(x, y)
     }
 
-    @Legacy("Use pushPop instead")
+    @Deprecated("Use pushPop instead")
     fun pushMatrix() {
         drawContext.pose().pushMatrix()
     }
 
-    @Legacy("Use pushPop instead")
+    @Deprecated("Use pushPop instead")
     fun popMatrix() {
         drawContext.pose().popMatrix()
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/EntityCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/EntityCompat.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.utils.compat
 
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.SafeItemStack
-import at.hannibal2.skyhanni.utils.Legacy
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EquipmentSlot
@@ -59,23 +58,23 @@ object EntityCompat {
 
 }
 
-@Legacy("use EntityCompat directly")
+@Deprecated("use EntityCompat directly")
 fun ArmorStand.getStandHelmet(): SafeItemStack? =
     this.getItemBySlot(EquipmentSlot.HEAD)
 
-@Legacy("use EntityCompat directly")
+@Deprecated("use EntityCompat directly")
 fun Mob.getEntityHelmet(): SafeItemStack? =
     this.getItemBySlot(EquipmentSlot.HEAD)
 
-@Legacy("use EntityCompat directly")
+@Deprecated("use EntityCompat directly")
 fun LivingEntity.getAllEquipment() =
     this.equipment.items.values.toTypedArray()
 
-@Legacy("use EntityCompat directly")
+@Deprecated("use EntityCompat directly")
 fun ArmorStand.getHandItem(): SafeItemStack? =
     this.getItemBySlot(EquipmentSlot.MAINHAND)
 
-@Legacy("use EntityCompat directly")
+@Deprecated("use EntityCompat directly")
 fun ArmorStand.getInventoryItems(): Array<SafeItemStack> =
     arrayOf(
         getItemBySlot(EquipmentSlot.MAINHAND),
@@ -86,19 +85,19 @@ fun ArmorStand.getInventoryItems(): Array<SafeItemStack> =
         getItemBySlot(EquipmentSlot.OFFHAND),
     )
 
-@Legacy("use EntityCompat directly")
+@Deprecated("use EntityCompat directly")
 fun ArmorStand.getEquipmentSlots(): Map<EquipmentSlot, SafeItemStack?> =
     EquipmentSlot.entries.associateWith { getItemBySlot(it).orNull() }
 
-@Legacy("use EntityCompat directly")
+@Deprecated("use EntityCompat directly")
 fun Entity.getEntityLevel(): Level =
     this.level()
 
-@Legacy("use EntityCompat directly")
+@Deprecated("use EntityCompat directly")
 val Entity.deceased: Boolean
     get() = this.isRemoved
 
-@Legacy("use EntityCompat directly")
+@Deprecated("use EntityCompat directly")
 fun LivingEntity.findHealthReal(): Float {
     val entityHealth = health
     if (entityHealth == 1024f) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/coroutines/CoroutineManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/coroutines/CoroutineManager.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.utils.coroutines
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.Legacy
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -32,9 +31,9 @@ interface CoroutineManager {
 }
 
 // TODO when no more usages of these old functions remain, get rid of the compat class.
-@Legacy("Use CoroutineManager with CoroutineSettings options instead")
+@Deprecated("Use CoroutineManager with CoroutineSettings options instead")
 interface CompatCoroutineManager : CoroutineManager {
-    @Legacy(
+    @Deprecated(
         "Use launchCoroutine with CoroutineSettings options instead",
         ReplaceWith(
             "CoroutineSettings(name, timeout).launchCoroutine(block)",
@@ -44,7 +43,7 @@ interface CompatCoroutineManager : CoroutineManager {
     fun launchCoroutine(name: String, timeout: Duration = 10.seconds, block: suspend CoroutineScope.() -> Unit): Job =
         CoroutineSettings(name, timeout).launchCoroutine(block)
 
-    @Legacy(
+    @Deprecated(
         "Use launchCoroutine with CoroutineSettings options instead",
         ReplaceWith(
             "CoroutineSettings(name, timeout).launchCoroutine(block)",
@@ -54,7 +53,7 @@ interface CompatCoroutineManager : CoroutineManager {
     fun launchIOCoroutine(name: String, timeout: Duration = 10.seconds, block: suspend CoroutineScope.() -> Unit): Job =
         CoroutineSettings(name, timeout).withIOContext().launchCoroutine(block)
 
-    @Legacy(
+    @Deprecated(
         "Use launchUnScopedCoroutine with CoroutineSettings options instead",
         ReplaceWith(
             "CoroutineSettings(name, timeout).launchUnScopedCoroutine(block)",
@@ -64,7 +63,7 @@ interface CompatCoroutineManager : CoroutineManager {
     fun launchNoScopeCoroutine(name: String, timeout: Duration = 10.seconds, block: suspend () -> Unit): Job =
         CoroutineSettings(name, timeout).launchUnScopedCoroutine(block)
 
-    @Legacy(
+    @Deprecated(
         "Use launchCoroutine with CoroutineSettings options instead",
         ReplaceWith(
             "CoroutineSettings(name, timeout).launchCoroutine(block)",
@@ -75,7 +74,7 @@ interface CompatCoroutineManager : CoroutineManager {
         name: String, mutex: Mutex, timeout: Duration = 10.seconds, block: suspend CoroutineScope.() -> Unit
     ): Job = CoroutineSettings(name, timeout).withMutex(mutex).launchCoroutine(block)
 
-    @Legacy(
+    @Deprecated(
         "Use launchCoroutine with CoroutineSettings options instead",
         ReplaceWith(
             "CoroutineSettings(name, timeout).launchCoroutine(block)",

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.utils.LocationUtils.union
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzColor.Companion.toLorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.Legacy
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.createResourceLocation
 import at.hannibal2.skyhanni.utils.compat.deceased
@@ -819,7 +818,7 @@ object WorldRenderUtils {
         drawLineToCrosshair(location, color.toColor(), lineWidth, depth)
     }
 
-    @Legacy("use drawLineToCrosshair", ReplaceWith("drawLineToCrosshair(location, color, lineWidth, depth)"))
+    @Deprecated("use drawLineToCrosshair", ReplaceWith("drawLineToCrosshair(location, color, lineWidth, depth)"))
     fun SkyHanniRenderWorldEvent.drawLineToEye(location: LorenzVec, color: ChromaColour, lineWidth: Int, depth: Boolean) {
         drawLineToCrosshair(location, color, lineWidth, depth)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/animated/AnimatedItemStackRenderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/animated/AnimatedItemStackRenderable.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.utils.renderables.animated
 
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.Legacy
 import at.hannibal2.skyhanni.utils.inPartialSeconds
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.animated.bounce.AnimatedBounceLocalStorage
@@ -46,7 +45,7 @@ class AnimatedItemStackRenderable internal constructor(
     }
 
     @Suppress("DEPRECATION")
-    @Legacy("Use renderWithDelta instead", ReplaceWith("renderWithDelta(posX, posY, deltaTime)"))
+    @Deprecated("Use renderWithDelta instead", ReplaceWith("renderWithDelta(posX, posY, deltaTime)"))
     override fun render(mouseOffsetX: Int, mouseOffsetY: Int) = super<TimeDependentRenderable>.render(mouseOffsetX, mouseOffsetY)
 
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/animated/TimeDependentRenderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/animated/TimeDependentRenderable.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.utils.renderables.animated
 
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.Legacy
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import kotlin.time.Duration
 
@@ -17,7 +16,7 @@ interface TimeDependentRenderable : Renderable {
 
     fun renderWithDelta(mouseOffsetX: Int, mouseOffsetY: Int, deltaTime: Duration)
 
-    @Legacy("Use renderWithDelta instead", ReplaceWith("renderWithDelta(posX, posY, deltaTime)"))
+    @Deprecated("Use renderWithDelta instead", ReplaceWith("renderWithDelta(posX, posY, deltaTime)"))
     override fun render(mouseOffsetX: Int, mouseOffsetY: Int) {
         val now = SimpleTimeMark.now()
         val deltaTime = now - lastRenderTime

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/BucketedItemTrackerData.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.utils.tracker
 
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.Legacy
 import at.hannibal2.skyhanni.utils.renderables.ScrollValue
 import com.google.gson.annotations.Expose
 import kotlin.reflect.KClass
@@ -34,7 +33,7 @@ abstract class BucketedItemTrackerData<E : Enum<E>, T : SessionUptime>(clazz: KC
         }
     }
 
-    @Legacy("Make data class extend Resettable instead")
+    @Deprecated("Make data class extend Resettable instead")
     final override fun reset() {
         super.reset()
         bucketedItems.clear()


### PR DESCRIPTION
## What
Basically I wanted to introduce a `@Legacy` annotation for the item categories that are "deprecated but can never be removed", but @Rainymei misinterpreted it and changed all uses of `@Deprecated` across the codebase to `@Legacy` instead in the 26.1 port. This PR reverts that.

exclude_from_changelog