### PR TITLE
Fix: Century Task Highlighter for Year 500

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/AnniversaryTeamFinderColorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/AnniversaryTeamFinderColorConfig.kt
@@ -34,7 +34,7 @@ class AnniversaryTeamFinderColorConfig {
     val green: Property<ChromaColour> = Property.of(ChromaColour.fromStaticRGB(85, 255, 85, 1))
 
     @Expose
-    @ConfigOption(name = "Red Color", desc = "Color for the team §ARED §7players.")
+    @ConfigOption(name = "Red Color", desc = "Color for the team §cRED §7players.")
     @ConfigEditorColour
     val red: Property<ChromaColour> = Property.of(ChromaColour.fromStaticRGB(255, 85, 85, 1))
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/CenturyCelebrationConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/CenturyCelebrationConfig.kt
@@ -8,6 +8,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class CenturyCelebrationConfig {
 
+    // TODO: Rename field to reflect that tasks are no longer daily
     @ConfigOption(
         name = "Raffle Task Highlighter",
         desc = "Highlights incomplete raffle tasks.",

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/CenturyCelebrationConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/CenturyCelebrationConfig.kt
@@ -9,8 +9,8 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 class CenturyCelebrationConfig {
 
     @ConfigOption(
-        name = "Daily Highlight",
-        desc = "Highlights incomplete daily tasks.",
+        name = "Raffle Task Highlighter",
+        desc = "Highlights incomplete raffle tasks.",
     )
     @Expose
     @ConfigEditorBoolean

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
@@ -266,7 +266,7 @@ class SkyblockGuideHighlightFeature private constructor(
             SkyblockGuideHighlightFeature(
                 { SkyHanniMod.feature.event.anniversaryCelebration400.highlightDailyTasks },
                 "century",
-                "Daily Tasks",
+                "Raffle Tasks",
                 "§c§lINCOMPLETE",
             )
             SkyblockGuideHighlightFeature(


### PR DESCRIPTION
## What
The screen title was changed since the tasks are no longer daily, but rather every 2 hours.

<details>
<summary>Images</summary>
<img width="627" height="160" alt="image" src="https://github.com/user-attachments/assets/a47b8d7c-043f-4033-82ff-2749ce5e5d8f" />

<img width="497" height="297" alt="image" src="https://github.com/user-attachments/assets/d8779764-ebb5-4977-acb3-3c8cd3163c11" />

</details>

## Changelog Fixes
+ Fixed the Century Raffle Task Highlighter for the Year 500 raffle event. - Alex
