### PR TITLE
Backend: Consolidate & deprecate formattedTextCompat methods

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.client.player.LocalPlayer
 import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.Entity
@@ -34,7 +34,7 @@ object DataWatcherApi {
     fun onDataWatcherUpdate(event: DataWatcherUpdatedEvent<Entity>) {
         for (updatedEntry in event.updatedEntries) {
             if (updatedEntry.accessor == Entity.DATA_CUSTOM_NAME) {
-                EntityCustomNameUpdateEvent(event.entity, event.entity.customName.formattedTextCompatLessResets()).post()
+                EntityCustomNameUpdateEvent(event.entity, event.entity.customName.formattedTextCompat(leadingWhite = false)).post()
             }
 
             if (updatedEntry.accessor == LivingEntity.DATA_HEALTH_ID) {

--- a/src/main/java/at/hannibal2/skyhanni/api/SkyBlockXPApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkyBlockXPApi.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.UtilsPatterns
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -79,7 +79,7 @@ object SkyBlockXPApi {
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!UtilsPatterns.skyblockMenuGuiPattern.matches(event.inventoryName)) return
 
-        val stack = event.inventoryItems.values.find { itemNamePattern.matches(it.hoverName.formattedTextCompatLeadingWhiteLessResets()) } ?: return
+        val stack = event.inventoryItems.values.find { itemNamePattern.matches(it.hoverName.formattedTextCompat()) } ?: return
 
         var level: Int? = null
         var xp: Int? = null

--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/EnoughUpdatesManager.kt
@@ -28,7 +28,7 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.mapNotNullAsync
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getIdentifierString
 import at.hannibal2.skyhanni.utils.compat.getVanillaItem
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
@@ -171,7 +171,7 @@ object EnoughUpdatesManager {
 
         val json = JsonObject()
         json.addProperty("itemid", stack.itemType.getIdentifierString())
-        json.addProperty("displayname", stack.hoverName.formattedTextCompatLeadingWhiteLessResets())
+        json.addProperty("displayname", stack.hoverName.formattedTextCompat())
         json.add("nbttag", ComponentUtils.convertToNeuNbtInfoJson(stack))
 
         val jsonLore = JsonArray()

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -185,7 +185,7 @@ object PetStorageApi {
                     LorenzRarity.getByComponent(component, group("pet")) ?: return@matchMatcher false
                 val petHeldItem = event.lines.firstNotNullOfOrNull { line ->
                     val trimmedLine =
-                        line.formattedTextCompat().trim().removeResets().takeIf { it.isNotBlank() }
+                        line.formattedTextCompat(extraResets = true, leadingWhite = false).trim().removeResets().takeIf { it.isNotBlank() }
                             ?: return@firstNotNullOfOrNull null
                     PetUtils.resolvePetItemOrNull(trimmedLine)
                 }
@@ -233,7 +233,7 @@ object PetStorageApi {
             val petSkinTag = groupOrNull("skin")
 
             val hoverInfo = event.chatComponent.hover?.siblings?.joinToString {
-                it.formattedTextCompat()
+                it.formattedTextCompat(extraResets = true, leadingWhite = false)
             }?.split("\n") ?: return
 
             val petHeldItem = autoPetHoverHeldItemPattern.firstMatcher(hoverInfo) {

--- a/src/main/java/at/hannibal2/skyhanni/data/ActionBarData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ActionBarData.kt
@@ -64,13 +64,15 @@ object ActionBarData {
      * If the action bar is modified return the new one, otherwise return null.
      */
     fun onChatReceive(component: Component): Component? {
-        val message = debugActionBar ?: component.formattedTextCompat().stripHypixelMessage()
+        val message = debugActionBar ?: component.formattedTextCompat(extraResets = true, leadingWhite = false).stripHypixelMessage()
 
         actionBar = message
         val actionBarEvent = ActionBarUpdateEvent(actionBar, component)
         actionBarEvent.post()
 
-        if (component.formattedTextCompat() != actionBarEvent.chatComponent.formattedTextCompat()) {
+        if (component.formattedTextCompat(extraResets = true, leadingWhite = false) !=
+            actionBarEvent.chatComponent.formattedTextCompat(extraResets = true, leadingWhite = false)
+        ) {
             return actionBarEvent.chatComponent
         }
         return null

--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -21,7 +21,6 @@ import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils
-import at.hannibal2.skyhanni.utils.compat.append
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.system.PlatformUtils.getModInstance
 import net.minecraft.ChatFormatting
@@ -157,7 +156,7 @@ object ChatManager {
      * If the message is cancelled return true.
      */
     fun onChatAllow(original: Component): Boolean {
-        val message = original.formattedTextCompat().stripHypixelMessage()
+        val message = original.formattedTextCompat(extraResets = true, leadingWhite = false).stripHypixelMessage()
         var cancelled = false
 
         val key = IdentityCharacteristics(original)
@@ -189,7 +188,7 @@ object ChatManager {
      * If the message is modified return the modified message otherwise return null.
      */
     fun onChatModify(original: Component): Component? {
-        val message = original.formattedTextCompat().stripHypixelMessage()
+        val message = original.formattedTextCompat(extraResets = true, leadingWhite = false).stripHypixelMessage()
 
         val key = IdentityCharacteristics(original)
         val chatEvent = SkyHanniChatEvent.Modify(message, original)
@@ -201,8 +200,8 @@ object ChatManager {
             val reason = replacementReasonMap[key].orEmpty().uppercase()
             modified = true
             loggerModified.log(" ")
-            loggerModified.log("[original] " + original.formattedTextCompat())
-            loggerModified.log("[modified] " + modifiedComponent.formattedTextCompat())
+            loggerModified.log("[original] " + original.formattedTextCompat(extraResets = true, leadingWhite = false))
+            loggerModified.log("[modified] " + modifiedComponent.formattedTextCompat(extraResets = true, leadingWhite = false))
             messageHistory[key] = MessageFilteringResult(original, ActionKind.MODIFIED, null, modifiedComponent, reason)
         } else {
             messageHistory[key] = MessageFilteringResult(original, ActionKind.ALLOWED, null, null, null)
@@ -218,7 +217,7 @@ object ChatManager {
         val key = IdentityCharacteristics(original)
         if (messageHistory.contains(key)) return
         val blockReason = "OTHER_MOD"
-        val message = original.formattedTextCompat().stripHypixelMessage()
+        val message = original.formattedTextCompat(extraResets = true, leadingWhite = false).stripHypixelMessage()
 
         loggerFiltered.log("[$blockReason] $message")
         loggerAll.log("[$blockReason] $message")
@@ -235,8 +234,8 @@ object ChatManager {
         val key2 = IdentityCharacteristics(modified)
         if (messageHistory[key2]?.actionKind == ActionKind.ALLOWED && messageHistory[key] == null) {
             loggerModified.log(" ")
-            loggerModified.log("[original] " + original.formattedTextCompat())
-            loggerModified.log("[modified] " + modified.formattedTextCompat())
+            loggerModified.log("[original] " + original.formattedTextCompat(extraResets = true, leadingWhite = false))
+            loggerModified.log("[modified] " + modified.formattedTextCompat(extraResets = true, leadingWhite = false))
             messageHistory[key2] = MessageFilteringResult(original, ActionKind.MODIFIED, null, modified, "OTHER_MOD")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/ElectionApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ElectionApi.kt
@@ -35,7 +35,7 @@ import at.hannibal2.skyhanni.utils.api.ApiStaticGetPath
 import at.hannibal2.skyhanni.utils.api.ApiUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.put
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.json.fromJson
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.hours
@@ -180,7 +180,7 @@ object ElectionApi {
         if (!calendarGuiPattern.matches(event.inventoryName)) return
 
         val stack: SafeItemStack = event.inventoryItems.values.firstOrNull {
-            mayorHeadPattern.matchMatcher(it.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            mayorHeadPattern.matchMatcher(it.hoverName.formattedTextCompat()) {
                 group("name") == "Jerry"
             } ?: false
         } ?: return

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -290,7 +290,7 @@ object HypixelData {
         val world = MinecraftCompat.localWorldOrNull ?: return null
 
         val objective = world.scoreboard.getSidebarObjective() ?: return null
-        val displayName = objective.displayName.formattedTextCompat()
+        val displayName = objective.displayName.formattedTextCompat(extraResets = true, leadingWhite = false)
         return displayName
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
 import at.hannibal2.skyhanni.utils.StringUtils.trimWhiteSpace
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.annotations.Expose
 import java.util.regex.Pattern
@@ -203,7 +203,7 @@ object MaxwellApi {
 
         if (yourBagsGuiPattern.matches(event.inventoryName)) {
             for (stack in event.inventoryItems.values) {
-                if (accessoryBagStack.matches(stack.hoverName.formattedTextCompatLeadingWhiteLessResets())) processStack(stack)
+                if (accessoryBagStack.matches(stack.hoverName.formattedTextCompat())) processStack(stack)
             }
         }
         if (statsTuningGuiPattern.matches(event.inventoryName)) {
@@ -216,11 +216,11 @@ object MaxwellApi {
         for (stack in inventoryItems.values) {
             for (line in stack.getLore()) {
                 statsTuningDataPattern.readTuningFromLine(line)?.let {
-                    it.name = "§.. (?<name>.+)".toPattern().matchMatcher(stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+                    it.name = "§.. (?<name>.+)".toPattern().matchMatcher(stack.hoverName.formattedTextCompat()) {
                         group("name")
                     } ?: ErrorManager.skyHanniError(
                         "found no name in thaumaturgy",
-                        "stack name" to stack.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                        "stack name" to stack.hoverName.formattedTextCompat(),
                         "line" to line,
                     )
                     map.add(it)
@@ -320,7 +320,7 @@ object MaxwellApi {
                         UnknownMaxwellPower("Unknown power: $power"),
                         "Unknown power: $power",
                         "line" to line,
-                        "displayName" to stack.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                        "displayName" to stack.hoverName.formattedTextCompat(),
                         "lore" to stack.getLore(),
                     )
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OwnInventoryData.kt
@@ -24,7 +24,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
@@ -149,7 +149,7 @@ object OwnInventoryData {
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         ignoreItem(500.milliseconds) { true }
 
-        val itemName = event.item?.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val itemName = event.item?.hoverName.formattedTextCompat()
         checkAHMovements(itemName)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
@@ -37,7 +37,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeNonAsciiNonColorCode
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.hover
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.annotations.Expose
@@ -201,7 +201,7 @@ object SackApi {
 
     private fun MutableMap.MutableEntry<Int, SafeItemStack>.processGemstoneItem(savingSacks: Boolean) {
         var gemTypeProp: GemstoneType? = null
-        gemstoneItemNamePattern.matchMatcher(value.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+        gemstoneItemNamePattern.matchMatcher(value.hoverName.formattedTextCompat()) {
             val gemName = group("gem") ?: return@matchMatcher
             gemTypeProp = GemstoneType.getByNameOrNull(gemName) ?: return@matchMatcher
         }
@@ -244,7 +244,7 @@ object SackApi {
             priceUpdater(price)
             gem.price += price
             if (savingSacks) setSackItem(internalName, stored)
-            if (quality == GemstoneQuality.FINE || gemstoneStackFilter != null) gemstoneItem[value.hoverName.formattedTextCompatLeadingWhiteLessResets()] = gem
+            if (quality == GemstoneQuality.FINE || gemstoneStackFilter != null) gemstoneItem[value.hoverName.formattedTextCompat()] = gem
         }
     }
 
@@ -262,7 +262,7 @@ object SackApi {
                 3 -> {
                     rune.slot = key
                     rune.lvl3 = stored
-                    runeItem[value.hoverName.formattedTextCompatLeadingWhiteLessResets()] = rune
+                    runeItem[value.hoverName.formattedTextCompat()] = rune
                 }
             }
             if (savingSacks) setSackItem(value.getInternalName(), stored)

--- a/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScoreboardData.kt
@@ -19,7 +19,6 @@ import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.compat.getPlayerNames
 import at.hannibal2.skyhanni.utils.compat.getSidebarObjective
 import net.minecraft.ChatFormatting
@@ -37,9 +36,11 @@ object ScoreboardData {
 
     private var sidebarLines: List<String> = emptyList() // TODO rename to raw
     var sidebarLinesRaw: List<String> = emptyList() // TODO delete
-    val objectiveTitle: String
-        get() =
-            MinecraftCompat.localWorldOrNull?.scoreboard?.getSidebarObjective()?.displayName.formattedTextCompat().orEmpty()
+    val objectiveTitle: String get() = MinecraftCompat.localWorldOrNull
+        ?.scoreboard
+        ?.getSidebarObjective()
+        ?.displayName
+        .formattedTextCompat(extraResets = true, leadingWhite = false)
 
     private var dirty = false
 
@@ -99,7 +100,7 @@ object ScoreboardData {
                 if (type != ObjectiveCriteria.RenderType.INTEGER) return
                 val objectiveName = packet.objectiveName
                 if (objectiveName == "health") return
-                val objectiveValue = packet.displayName.formattedTextCompat()
+                val objectiveValue = packet.displayName.formattedTextCompat(extraResets = true, leadingWhite = false)
                 ScoreboardTitleUpdateEvent(objectiveValue, objectiveName).post()
             }
         }
@@ -156,7 +157,7 @@ object ScoreboardData {
         val objective = scoreboard.getSidebarObjective() ?: return emptyList()
         val scores = scoreboard.listPlayerScores(objective)
         val list = scores.getPlayerNames(scoreboard)
-        return list.map { it.formattedTextCompatLessResets() }
+        return list.map { it.formattedTextCompat(leadingWhite = false) }
     }
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/data/SkillExperience.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SkillExperience.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ToolTipData.kt
@@ -8,8 +8,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.network.chat.Component
@@ -34,7 +33,7 @@ object ToolTipData {
         stack: SafeItemStack,
         originalToolTip: MutableList<Component>,
     ): MutableList<Component> {
-        val tooltip = originalToolTip.map { it.formattedTextCompatLessResets().removePrefix("§5") }.toMutableList()
+        val tooltip = originalToolTip.map { it.formattedTextCompat(leadingWhite = false).removePrefix("§5") }.toMutableList()
         val tooltipCopy = tooltip.toMutableList()
         getTooltip(tooltip)
         RenderItemTooltipEvent(context, stack).post()
@@ -73,7 +72,7 @@ object ToolTipData {
                 "slotNumber" to slot.index,
                 "slotIndex" to slot.containerSlot,
                 "itemStack" to itemStack,
-                "name" to itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                "name" to itemStack.hoverName.formattedTextCompat(),
                 "internal name" to itemStack.getInternalName(),
                 "lore" to itemStack.getLore(),
             )

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -24,7 +24,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.chat.TextHelper
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
 import kotlin.time.Duration
@@ -290,13 +290,13 @@ object EffectApi {
     private fun InventoryUpdatedEvent.isGodPotEffectsFilterSelect(): Boolean =
         effectsInventoryPattern.matches(this.inventoryName) &&
             this.inventoryItems.values.firstOrNull {
-                filterPattern.matches(it.hoverName.formattedTextCompatLeadingWhiteLessResets())
+                filterPattern.matches(it.hoverName.formattedTextCompat())
             }?.getLore()?.any {
                 godPotEffectsFilterSelectPattern.matches(it)
             } ?: false
 
     private fun SafeItemStack.getNonGodPotEffectOrNull(): NonGodPotEffect? = NonGodPotEffect.entries.firstOrNull {
-        hoverName.formattedTextCompatLeadingWhiteLessResets().contains(it.inventoryItemName)
+        hoverName.formattedTextCompat().contains(it.inventoryItemName)
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/ComposterUpgradesData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/ComposterUpgradesData.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.features.garden.composter.ComposterApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 
 @SkyHanniModule
 object ComposterUpgradesData {
@@ -17,7 +17,7 @@ object ComposterUpgradesData {
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (event.inventoryName != "Composter Upgrades") return
         for (item in event.inventoryItems.values) {
-            ComposterUpgrade.regex.matchMatcher(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            ComposterUpgrade.regex.matchMatcher(item.hoverName.formattedTextCompat()) {
                 val name = group("name")
                 val level = group("level")?.romanToDecimalIfNecessary() ?: 0
                 val composterUpgrade = ComposterUpgrade.getByName(name) ?: continue

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/CurrencyPerHotxPerk.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/CurrencyPerHotxPerk.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import org.lwjgl.glfw.GLFW
 
 abstract class CurrencyPerHotxPerk<HotxType : HotxHandler<*, *, *>>(private val hotx: HotxType, private val displayText: String) {
@@ -21,7 +21,7 @@ abstract class CurrencyPerHotxPerk<HotxType : HotxHandler<*, *, *>>(private val 
         showCurrentCurrency: Boolean,
         currencySpentDesign: CurrencySpentDesign,
     ) {
-        val itemName = event.itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val itemName = event.itemStack.hoverName.formattedTextCompat()
         val perk = hotx.getPerkByNameOrNull(itemName.removeColor()) ?: return
 
         if (perk.getLevelUpCost() == null) return

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.indexOfFirstMatch
 import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.world.inventory.Slot
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -83,7 +83,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
 
         if (this.handleCurrency()) return
 
-        val entry = data.firstOrNull { it.guiNamePattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) } ?: return
+        val entry = data.firstOrNull { it.guiNamePattern.matches(item.hoverName.formattedTextCompat()) } ?: return
         entry.slot = this
         entry.item = item
 
@@ -138,8 +138,8 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
         val item = this.item ?: return false
 
         val isHeartItem = when {
-            heartItemPattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) -> true
-            resetItemPattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) -> false
+            heartItemPattern.matches(item.hoverName.formattedTextCompat()) -> true
+            resetItemPattern.matches(item.hoverName.formattedTextCompat()) -> false
             else -> return false
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -16,8 +16,9 @@ import at.hannibal2.skyhanni.utils.MobUtils.takeNonDefault
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEntityHelmet
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.LivingEntity
@@ -64,7 +65,10 @@ object IslandExceptions {
     ) = when {
         baseEntity is Zombie &&
             armorStand != null &&
-            (armorStand.name.formattedTextCompatLessResets() == "§e﴾ §5♃ §c§lThe Watcher§r§r §e﴿" || armorStand.name.formattedTextCompatLessResets() == "§3§lWatchful Eye§r") ->
+            armorStand.name.formattedTextCompat(leadingWhite = false).equalsOneOf(
+                "§e﴾ §5♃ §c§lThe Watcher§r§r §e﴿",
+                "§3§lWatchful Eye§r",
+            ) ->
             MobData.MobResult.found(
                 MobFactories.special(baseEntity, armorStand.cleanName(), armorStand),
             )
@@ -72,22 +76,26 @@ object IslandExceptions {
         baseEntity is CaveSpider -> MobUtils.getClosestArmorStand(baseEntity, 2.0).takeNonDefault()
             .makeMobResult { MobFactories.dungeon(baseEntity, it) }
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.formattedTextCompatLessResets() == "Shadow Assassin" ->
+        baseEntity is RemotePlayer &&
+            baseEntity.isNpc() &&
+            baseEntity.name.formattedTextCompat(leadingWhite = false) == "Shadow Assassin" ->
             MobUtils.getClosestArmorStandWithName(baseEntity, 3.0, "Shadow Assassin")
                 .makeMobResult { MobFactories.dungeon(baseEntity, it) }
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.formattedTextCompatLessResets() == "The Professor" ->
+        baseEntity is RemotePlayer &&
+            baseEntity.isNpc() &&
+            baseEntity.name.formattedTextCompat(leadingWhite = false) == "The Professor" ->
             MobUtils.getArmorStand(baseEntity, 9)
                 .makeMobResult { MobFactories.boss(baseEntity, it) }
 
         baseEntity is RemotePlayer &&
             baseEntity.isNpc() &&
             (nextEntity is Giant || nextEntity == null) &&
-            baseEntity.name.formattedTextCompatLessResets().contains("Livid") -> MobUtils.getArmorStand(baseEntity, 10)
-            ?.takeIf { getNextEntity(it, -1)?.takeIf { entity -> entity.name.formattedTextCompatLessResets().contains("Livid") } == null }
+            baseEntity.name.formattedTextCompat(leadingWhite = false).contains("Livid") -> MobUtils.getArmorStand(baseEntity, 10)
+            ?.takeIf { !getNextEntity(it, -1)?.name.formattedTextCompat(leadingWhite = false).contains("Livid") }
             .makeMobResult { MobFactories.boss(baseEntity, it, overriddenName = "Real Livid") }
 
-        baseEntity is IronGolem && MobFilter.wokeSleepingGolemPattern.matches(armorStand?.name.formattedTextCompatLessResets().orEmpty()) ->
+        baseEntity is IronGolem && MobFilter.wokeSleepingGolemPattern.matches(armorStand?.name.formattedTextCompat(leadingWhite = false)) ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.DUNGEON, armorStand, "Sleeping Golem")) // Consistency fix
 
         else -> null
@@ -117,7 +125,9 @@ object IslandExceptions {
         baseEntity is Slime && armorStand != null && armorStand.cleanName().startsWith("﴾ [Lv10] B") ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.BOSS, armorStand, name = "Bacte"))
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.formattedTextCompatLessResets() == "Branchstrutter " ->
+        baseEntity is RemotePlayer &&
+            baseEntity.isNpc() &&
+            baseEntity.name.formattedTextCompat(leadingWhite = false) == "Branchstrutter " ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Branchstrutter"))
 
         else -> null
@@ -128,7 +138,7 @@ object IslandExceptions {
         armorStand: ArmorStand?,
         nextEntity: LivingEntity?,
     ) = when {
-        baseEntity is Slime && MobFilter.heavyPearlPattern.matches(armorStand?.name.formattedTextCompatLessResets()) ->
+        baseEntity is Slime && MobFilter.heavyPearlPattern.matches(armorStand?.name.formattedTextCompat(leadingWhite = false)) ->
             MobData.MobResult.found(MobFactories.special(baseEntity, "Heavy Pearl"))
 
         baseEntity is Pig && nextEntity is Pig -> MobData.MobResult.illegal // Matriarch Tongue
@@ -193,7 +203,7 @@ object IslandExceptions {
         baseEntity is Ocelot &&
             armorStand?.isDefaultValue() == false &&
             // TODO fix pattern
-            armorStand.name.formattedTextCompatLessResets().startsWith("§8[§7Lv155§8] §cAzrael§r") ->
+            armorStand.name.formattedTextCompat(leadingWhite = false).startsWith("§8[§7Lv155§8] §cAzrael§r") ->
             MobUtils.getArmorStand(baseEntity, 1)
                 .makeMobResult { MobFactories.basic(baseEntity, it) }
 
@@ -202,7 +212,7 @@ object IslandExceptions {
                 .makeMobResult { MobFactories.basic(baseEntity, it) }
 
         baseEntity is RemotePlayer &&
-            baseEntity.name.formattedTextCompatLessResets()
+            baseEntity.name.formattedTextCompat(leadingWhite = false)
                 .let { it == "Minos Champion" || it == "Minos Inquisitor" || it == "Minotaur " } &&
             armorStand != null ->
             MobUtils.getArmorStand(baseEntity, 2)
@@ -210,7 +220,7 @@ object IslandExceptions {
 
         baseEntity is Zombie &&
             armorStand?.isDefaultValue() == true &&
-            MobUtils.getNextEntity(baseEntity, 4)?.name.formattedTextCompatLessResets().startsWith("§e") ->
+            MobUtils.getNextEntity(baseEntity, 4)?.name.formattedTextCompat(leadingWhite = false).startsWith("§e") ->
             petCareHandler(baseEntity)
 
         baseEntity is Zombie && armorStand != null && !armorStand.isDefaultValue() -> null // Impossible Rat
@@ -249,7 +259,7 @@ object IslandExceptions {
         val armorStand = MobUtils.getArmorStand(baseEntity, 2)
         return when {
             baseEntity is MagmaCube &&
-                MobFilter.jerryMagmaCubePattern.matches(armorStand?.name.formattedTextCompatLessResets()) ->
+                MobFilter.jerryMagmaCubePattern.matches(armorStand?.name.formattedTextCompat(leadingWhite = false)) ->
                 MobData.MobResult.found(Mob(baseEntity, MobCategory.BOSS, armorStand, "Jerry Magma Cube"))
 
             else -> null

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.toSingletonListOrEmpty
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getAllEquipment
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import io.github.notenoughupdates.moulconfig.ChromaColour
@@ -120,7 +120,7 @@ class Mob(
      * @property isRunic does not change.
      */
     val isRunic = !RiftApi.inRift() &&
-        armorStand?.name.formattedTextCompatLessResets().startsWith("§5") &&
+        armorStand?.name.formattedTextCompat(leadingWhite = false).startsWith("§5") &&
         category == MobCategory.BASIC
 
     fun isInRender() = baseEntity.distanceToPlayer() < MobData.ENTITY_RENDER_RANGE_IN_BLOCKS

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -21,7 +21,7 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.drainTo
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.put
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.refreshReference
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.client.player.LocalPlayer
 import net.minecraft.network.protocol.game.ClientboundAddEntityPacket
@@ -318,7 +318,7 @@ object MobDetection {
             val entity = retry.entity
             if (retry.times == MAX_RETRIES) {
                 MobData.logger.log(
-                    "`${retry.entity.name.formattedTextCompatLessResets()}`${retry.entity.id} missed {\n " +
+                    "`${retry.entity.name.formattedTextCompat(leadingWhite = false)}`${retry.entity.id} missed {\n " +
                         "is already Found: ${MobData.entityToMob[retry.entity] != null})." +
                         "\n Position: ${retry.entity.getLorenzVec()}\n " +
                         "DistanceC: ${

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFactories.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFactories.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.RegexUtils.findMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.decoration.ArmorStand
 
@@ -115,7 +115,8 @@ object MobFactories {
             additionalEntities = listOf(clickArmorStand),
         )
 
-    fun player(baseEntity: LivingEntity): Mob = Mob(baseEntity, MobCategory.PLAYER, name = baseEntity.name.formattedTextCompatLessResets())
+    fun player(baseEntity: LivingEntity): Mob =
+        Mob(baseEntity, MobCategory.PLAYER, name = baseEntity.name.formattedTextCompat(leadingWhite = false))
     fun projectile(baseEntity: LivingEntity, name: String): Mob =
         Mob(baseEntity = baseEntity, category = MobCategory.PROJECTILE, name = name)
 

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeWhileInclusive
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getStandHelmet
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.RemotePlayer
@@ -222,7 +222,7 @@ object MobFilter {
     fun Player.isRealPlayer() = uuid.version() == 4
 
     fun LivingEntity.isDisplayNpc() =
-        (this is Player && isNpc() && displayNpcNameCheck(this.name.formattedTextCompatLessResets())) ||
+        (this is Player && isNpc() && displayNpcNameCheck(this.name.formattedTextCompat(leadingWhite = false))) ||
             (this is Villager && this.maxHealth == 20f) || // Villager NPCs in the Village
             (this is Witch && this.id <= 500) || // Alchemist NPC
             (this is AbstractCow && this.id <= 500) || // Shania NPC (in Rift and Outside)
@@ -352,7 +352,9 @@ object MobFilter {
             )
         }
         return when {
-            (baseEntity is Pig || baseEntity is Horse) && illegalEntitiesPattern.matches(armorStand.name.formattedTextCompatLessResets()) -> MobResult.illegal
+            (baseEntity is Pig || baseEntity is Horse) &&
+                illegalEntitiesPattern.matches(armorStand.name.formattedTextCompat(leadingWhite = false)) -> MobResult.illegal
+
             baseEntity is Guardian && armorStand.cleanName()
                 .matches("^\\d+".toRegex()) -> MobResult.illegal // Wierd Sea Guardian Ability
             else -> null
@@ -366,7 +368,8 @@ object MobFilter {
         if (DungeonApi.inDungeon()) {
             when {
                 (baseEntity is EnderMan || baseEntity is Giant) &&
-                    extraEntityList.lastOrNull()?.name.formattedTextCompatLessResets() == "§e﴾ §c§lLivid§r§r §a7M§c❤ §e﴿" -> MobResult.illegal // Livid Start Animation
+                    extraEntityList.lastOrNull()?.name.formattedTextCompat(leadingWhite = false)
+                    == "§e﴾ §c§lLivid§r§r §a7M§c❤ §e﴿" -> MobResult.illegal // Livid Start Animation
                 else -> null
             }
         } else when (SkyBlockUtils.currentIsland) {
@@ -380,7 +383,7 @@ object MobFilter {
     private fun armorStandOnlyMobs(baseEntity: LivingEntity, armorStand: ArmorStand): MobResult? {
         if (baseEntity !is Zombie) return null
         when {
-            illegalEntitiesPattern.matches(armorStand.name.formattedTextCompatLessResets()) -> return MobResult.illegal
+            illegalEntitiesPattern.matches(armorStand.name.formattedTextCompat(leadingWhite = false)) -> return MobResult.illegal
             baseEntity.firstPassenger is Player && MobUtils.getArmorStand(baseEntity, 2)
                 ?.wearingSkullTexture(RAT_SKULL_TEXTURE) ?: false -> return MobResult.illegal // Rat Morph
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/FirstMinionTier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/FirstMinionTier.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.PrimitiveRecipe
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 
 object FirstMinionTier {
 

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
@@ -25,7 +25,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
@@ -270,7 +270,7 @@ object MinionCraftHelper {
         if (event.inventoryName != "Crafted Minions") return
 
         for ((_, b) in event.inventoryItems) {
-            val name = b.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val name = b.hoverName.formattedTextCompat()
             if (!name.startsWith("§e")) continue
             val internalName = NeuInternalName.fromItemName("$name I")
                 .replace("MINION", "GENERATOR").replace(";", "_").replace("CAVE_SPIDER", "CAVESPIDER")

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatHistoryGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatHistoryGui.kt
@@ -80,7 +80,7 @@ class ChatHistoryGui(private val history: List<ChatManager.MessageFilteringResul
                         OSUtils.copyToClipboard(msg.message.convertToJsonString())
                         ChatUtils.chat("Copied structured chat line to clipboard", false)
                     } else {
-                        val message = msg.message.formattedTextCompat().stripHypixelMessage()
+                        val message = msg.message.formattedTextCompat(extraResets = true, leadingWhite = false).stripHypixelMessage()
                         OSUtils.copyToClipboard(message)
                         ChatUtils.chat("Copied chat line to clipboard")
                     }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
@@ -40,7 +40,7 @@ object CopyChat {
     private fun processCopyChat(mouseX: Int, mouseY: Int) {
         val chatLine = getChatLine(mouseX, mouseY) ?: return
 
-        val formatted = chatLine.fullComponent.formattedTextCompat()
+        val formatted = chatLine.fullComponent.formattedTextCompat(extraResets = true, leadingWhite = false)
 
         val (clipboard, infoMessage) = when {
             KeyboardManager.isMenuKeyDown() ->

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -163,7 +163,9 @@ object RareDropMessages {
         if (anyRecentMessage && config.enchantedBook) {
             ChatManager.editMessage(
                 replacement = {
-                    it.formattedTextCompat().replace("Enchanted Book", internalName.repoItemName).asComponent()
+                    it.formattedTextCompat(extraResets = true, leadingWhite = false)
+                        .replace("Enchanted Book", internalName.repoItemName)
+                        .asComponent()
                 },
                 reason = "enchanted book",
             ) { it.passedSinceSent() < 1.seconds && enchantedBookPattern.matches(it.chatMessage) }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatFilter.kt
@@ -14,7 +14,7 @@ object PlayerChatFilter {
     private val filters = mutableMapOf<String, MultiFilter>()
 
     fun shouldChatFilter(original: Component): Boolean {
-        val message = original.formattedTextCompat().lowercase()
+        val message = original.formattedTextCompat(extraResets = true, leadingWhite = false).lowercase()
         for (filter in filters) {
             filter.value.matchResult(message)?.let {
                 return true

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BestiaryData.kt
@@ -25,7 +25,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.addRenderableButton
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -157,7 +157,7 @@ object BestiaryData {
         for ((index, stack) in stackList) {
             if (stack.hoverName.string == " ") continue
             if (!indexes.contains(index)) continue
-            val name = stack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val name = stack.hoverName.formattedTextCompat()
             var familiesFound: Long = 0
             var totalFamilies: Long = 0
             var familiesCompleted: Long = 0
@@ -183,11 +183,11 @@ object BestiaryData {
 
     private fun notInCategory() {
         for ((index, stack) in stackList) {
-            if (stack.hoverName.formattedTextCompatLeadingWhiteLessResets() == " ") continue
+            if (stack.hoverName.formattedTextCompat() == " ") continue
             if (!indexes.contains(index)) continue
-            val name = " [IVX0-9]+$".toPattern().matcher(stack.hoverName.formattedTextCompatLeadingWhiteLessResets()).replaceFirst("")
+            val name = " [IVX0-9]+$".toPattern().matcher(stack.hoverName.formattedTextCompat()).replaceFirst("")
             val level =
-                " ([IVX0-9]+$)".toRegex().find(stack.hoverName.formattedTextCompatLeadingWhiteLessResets())?.groupValues?.get(1) ?: "0"
+                " ([IVX0-9]+$)".toRegex().find(stack.hoverName.formattedTextCompat())?.groupValues?.get(1) ?: "0"
             var totalKillToMax: Long = 0
             var currentTotalKill: Long = 0
             var totalKillToTier: Long = 0

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -42,8 +42,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhite
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.stackUnderCursor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
@@ -164,7 +163,7 @@ object InstanceChestProfit {
 
         if (isInCroesusMenu() && (config.croesusAllChestsOverlay || config.croesusHighlight)) {
             event.inventoryItems.forEach { (slot, item) ->
-                val chestType = CroesusChestType.getByStackName(item.hoverName.formattedTextCompatLeadingWhite())
+                val chestType = CroesusChestType.getByStackName(item.hoverName.formattedTextCompat(extraResets = true))
                 if (chestType != null) {
                     if (!alreadyProcessedChests.contains(chestType)) {
                         alreadyProcessedChests.add(chestType)
@@ -191,7 +190,7 @@ object InstanceChestProfit {
         val slots = slotsWithFavorites
         if (isInCroesusMenu()) {
             slots.forEach {
-                if (it == event.stack.hoverName.formattedTextCompatLeadingWhite()) event.stackTip = "§6✯"
+                if (it == event.stack.hoverName.formattedTextCompat(extraResets = true)) event.stackTip = "§6✯"
             }
         }
         if (isInstanceChestGUI()) {
@@ -330,12 +329,12 @@ object InstanceChestProfit {
 
         val itemsWithCost: MutableMap<String, Double> = mutableMapOf()
         items.forEach {
-            if (fakeItemNamePattern.matches(it.value.hoverName.formattedTextCompatLeadingWhiteLessResets())) return@forEach
+            if (fakeItemNamePattern.matches(it.value.hoverName.formattedTextCompat())) return@forEach
             if (it.value.getInternalNameOrNull() != null) {
                 val cost = EstimatedItemValueCalculator.getTotalPrice(it.value)
                 if (cost != null) itemsWithCost.addOrPut(it.value.getInternalName().repoItemName, (cost * it.value.count))
             }
-            val name = it.value.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val name = it.value.hoverName.formattedTextCompat()
             if (attributeShardPattern.matches(name)) {
                 val price = getAttribute(name)
                 itemsWithCost.addOrPut(name, price)

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -57,7 +57,7 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import com.google.gson.JsonArray
@@ -595,7 +595,7 @@ object DamageIndicatorManager {
         var found = false
         for (shield in HellionShield.entries) {
             entity.getNameTagWith(3, shield.name)?.let { armorStand ->
-                val number = armorStand.name.formattedTextCompatLessResets().split(" ♨")[1].substring(0, 1)
+                val number = armorStand.name.formattedTextCompat(leadingWhite = false).split(" ♨")[1].substring(0, 1)
                 entity.setHellionShield(shield)
                 if (SlayerApi.config.blazes.hellion.coloredMobs) {
                     entityData.nameAbove = shield.formattedName + " $number"
@@ -795,9 +795,9 @@ object DamageIndicatorManager {
                 BossType.SLAYER_ENDERMAN_4 -> 100
                 else -> 100
             }
-            val hits = enderSlayerHitsNumberPattern.matchMatcher(armorStandHits.name.formattedTextCompatLessResets()) {
+            val hits = enderSlayerHitsNumberPattern.matchMatcher(armorStandHits.name.formattedTextCompat(leadingWhite = false)) {
                 group("hits").toInt()
-            } ?: error("No hits number found in ender slayer name '${armorStandHits.name.formattedTextCompatLessResets()}'")
+            } ?: error("No hits number found in ender slayer name '${armorStandHits.name.formattedTextCompat(leadingWhite = false)}'")
 
             hitPhaseText = NumberUtil.percentageColor(hits.toLong(), maxHits.toLong()).getChatColor() + "$hits Hits"
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/ProfitPerDragon.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.world.entity.decoration.ArmorStand
 import java.util.UUID
 import kotlin.math.floor
@@ -34,7 +34,7 @@ object ProfitPerDragon {
         scannedLootUUIDs.removeIf { uuid -> entities.none { it.uuid == uuid } }
 
         for (entity in entities) {
-            val entityName = entity.name.formattedTextCompatLessResets()
+            val entityName = entity.name.formattedTextCompat(leadingWhite = false)
             val amount: Int = entityName.split("§8x").last().toIntOrNull() ?: 1
             val internalNameFromEntityName = NeuInternalName.fromItemNameOrNull(entityName)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneMinisNametagHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/ArachneMinisNametagHider.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
@@ -20,7 +20,7 @@ object ArachneMinisNametagHider {
         val entity = event.entity
         if (!entity.hasCustomName()) return
 
-        val name = entity.name.formattedTextCompatLessResets()
+        val name = entity.name.formattedTextCompat(leadingWhite = false)
         if (name.contains("§cArachne's Brood§r")) {
             event.cancel()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/WikiManager.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.stackUnderCursor
 import java.net.URLEncoder
 
@@ -82,7 +82,7 @@ object WikiManager {
 
     private fun wikiTheItem(item: SafeItemStack, autoOpen: Boolean, useIndependent: Boolean = config.useIndependent) {
         val itemDisplayName =
-            item.hoverName.formattedTextCompatLeadingWhiteLessResets().replace("§a✔ ", "").replace("§c✖ ", "")
+            item.hoverName.formattedTextCompat().replace("§a✔ ", "").replace("§c✖ ", "")
         val internalName = item.getInternalName().asString()
         val wikiUrlSearch = if (internalName != "NONE") internalName else itemDisplayName.removeColor()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -36,7 +36,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.toSingletonListOrEmpty
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -168,7 +168,7 @@ object CroesusChestTracker {
                         floorPattern.matchMatcher(it) { group("floor").romanToDecimal() }
                     } ?: "0"
                     )
-            if (run.floor == "F0" && kuudraPattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets())) run.floor =
+            if (run.floor == "F0" && kuudraPattern.matches(item.hoverName.formattedTextCompat())) run.floor =
                 ("T" + KuudraApi.getKuudraRunTierNumber(lore.firstNotNullOfOrNull { kuudraPattern.matchMatcher(it) { group("tier") } }))
             run.openState = OpenedState.getOpenState(lore)
         }
@@ -177,7 +177,7 @@ object CroesusChestTracker {
     private fun pageSetup(event: InventoryFullyOpenedEvent) {
         inCroesusInventory = true
         pageSwitchable = true
-        croesusEmpty = croesusEmptyPattern.matches(event.inventoryItems[EMPTY_SLOT]?.hoverName.formattedTextCompatLeadingWhiteLessResets())
+        croesusEmpty = croesusEmptyPattern.matches(event.inventoryItems[EMPTY_SLOT]?.hoverName.formattedTextCompat())
         if (event.inventoryItems[BACK_ARROW_SLOT]?.`is`(Items.ARROW) != true) {
             currentPage = 0
         }
@@ -220,7 +220,7 @@ object CroesusChestTracker {
     fun onRenderItemTip(event: RenderItemTipEvent) {
         if (!config.kismetStackSize) return
         if (chestInventory == null) return
-        if (!kismetPattern.matches(event.stack.hoverName.formattedTextCompatLeadingWhiteLessResets())) return
+        if (!kismetPattern.matches(event.stack.hoverName.formattedTextCompat())) return
         if (kismetUsedInChestPattern.matches(event.stack.getLore().lastOrNull())) return
         event.stackTip = "§a$kismetAmountCache"
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -115,11 +115,11 @@ object DungeonCopilot {
 
         if (!searchForKey) return
 
-        if (entity.name.formattedTextCompatLessResets() == "§6§8Wither Key") {
+        if (entity.name.formattedTextCompat(leadingWhite = false) == "§6§8Wither Key") {
             changeNextStep("Pick up Wither Key")
             searchForKey = false
         }
-        if (entity.name.formattedTextCompatLessResets() == "§c§cBlood Key") {
+        if (entity.name.formattedTextCompat(leadingWhite = false) == "§c§cBlood Key") {
             changeNextStep("Pick up Blood Key")
             searchForKey = false
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
@@ -18,7 +18,7 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getStandHelmet
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.core.particles.ParticleTypes
 import net.minecraft.world.entity.Entity
@@ -65,7 +65,7 @@ object DungeonHideItems {
         val head = entity.getStandHelmet()
         val skullTexture = head?.getSkullTexture()
         if (config.hideSuperboomTNT) {
-            if (entity.name.formattedTextCompatLessResets().startsWith("§9Superboom TNT")) {
+            if (entity.name.formattedTextCompat(leadingWhite = false).startsWith("§9Superboom TNT")) {
                 event.cancel()
             }
 
@@ -76,7 +76,7 @@ object DungeonHideItems {
         }
 
         if (config.hideBlessing) {
-            if (entity.name.formattedTextCompatLessResets().startsWith("§dBlessing of ")) {
+            if (entity.name.formattedTextCompat(leadingWhite = false).startsWith("§dBlessing of ")) {
                 event.cancel()
             }
 
@@ -86,7 +86,7 @@ object DungeonHideItems {
         }
 
         if (config.hideReviveStone) {
-            if (entity.name.formattedTextCompatLessResets() == "§6Revive Stone") {
+            if (entity.name.formattedTextCompat(leadingWhite = false) == "§6Revive Stone") {
                 event.cancel()
             }
 
@@ -97,7 +97,7 @@ object DungeonHideItems {
         }
 
         if (config.hidePremiumFlesh) {
-            if (entity.name.formattedTextCompatLessResets() == "§9Premium Flesh") {
+            if (entity.name.formattedTextCompat(leadingWhite = false) == "§9Premium Flesh") {
                 event.cancel()
                 hideParticles[entity] = SimpleTimeMark.now()
             }
@@ -118,9 +118,9 @@ object DungeonHideItems {
 
         if (config.hideHealerOrbs) {
             when {
-                entity.name.formattedTextCompatLessResets().startsWith("§c§lDAMAGE §e") -> event.cancel()
-                entity.name.formattedTextCompatLessResets().startsWith("§c§lABILITY DAMAGE §e") -> event.cancel()
-                entity.name.formattedTextCompatLessResets().startsWith("§a§lDEFENSE §e") -> event.cancel()
+                entity.name.formattedTextCompat(leadingWhite = false).startsWith("§c§lDAMAGE §e") -> event.cancel()
+                entity.name.formattedTextCompat(leadingWhite = false).startsWith("§c§lABILITY DAMAGE §e") -> event.cancel()
+                entity.name.formattedTextCompat(leadingWhite = false).startsWith("§a§lDEFENSE §e") -> event.cancel()
             }
 
             when (skullTexture) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
@@ -36,7 +36,7 @@ import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isWool
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat.Companion.activePotionEffect
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
@@ -68,7 +68,7 @@ object DungeonLividFinder {
             .filterTo(mutableListOf()) {
                 it.isNpc() &&
                     (
-                        lividNamePattern.matches(it.name.formattedTextCompatLessResets()) ||
+                        lividNamePattern.matches(it.name.formattedTextCompat(leadingWhite = false)) ||
                             lividTextureToColor.containsKey(it.getSkinTexture())
                         )
             }
@@ -129,7 +129,7 @@ object DungeonLividFinder {
 
         for (entity in lividEntities) {
             val lividColor = entity.getLividColor() ?: run {
-                lividNamePattern.matchMatcher(entity.name.formattedTextCompatLessResets()) {
+                lividNamePattern.matchMatcher(entity.name.formattedTextCompat(leadingWhite = false)) {
                     val name = group("name")
                     val nameColor = lividNameToColor[name] ?: return@matchMatcher
                     val texture = entity.getSkinTexture() ?: return@matchMatcher
@@ -206,7 +206,7 @@ object DungeonLividFinder {
         if (livid == null) return // in case livid detection fails, don't hide anything
         if (event.entity is RemotePlayer && event.entity in fakeLivids) event.cancel()
         if (event.entity is ArmorStand) {
-            lividArmorStandNamePattern.matchMatcher(event.entity.name.formattedTextCompatLessResets()) {
+            lividArmorStandNamePattern.matchMatcher(event.entity.name.formattedTextCompat(leadingWhite = false)) {
                 val colorChar = group("colorCode")[0]
 
                 if (colorChar.toLorenzColor() != color) event.cancel()
@@ -218,7 +218,7 @@ object DungeonLividFinder {
 
     private fun RemotePlayer.isLividColor(color: LorenzColor): Boolean {
         val chatColor = color.getChatColor()
-        return name.formattedTextCompatLessResets().startsWith("$chatColor﴾ $chatColor§lLivid")
+        return name.formattedTextCompat(leadingWhite = false).startsWith("$chatColor﴾ $chatColor§lLivid")
     }
 
     private fun RemotePlayer.getLividColor(): LorenzColor? {
@@ -329,7 +329,7 @@ object DungeonLividFinder {
             add("inBoss: ${inLividBossRoom()}")
             add("isBlind: $isBlind")
             add("blockColor: ${blockLocation.getBlockStateAt()}")
-            add("livid: '${livid?.name.formattedTextCompatLessResets()}'")
+            add("livid: '${livid?.name.formattedTextCompat(leadingWhite = false)}'")
             add("color: '${color?.name}'")
             add("lividTextureToColor:")
             for ((key, value) in lividTextureToColor) add("  $value: $key")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.world.entity.item.ItemEntity
 
 @SkyHanniModule
@@ -45,7 +45,7 @@ object DungeonSecretChime {
     @HandleEvent
     fun onItemPickup(event: EntityRemovedEvent<ItemEntity>) {
         if (!isEnabled()) return
-        val itemName = event.entity.item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val itemName = event.entity.item.hoverName.formattedTextCompat()
         if (NeuInternalName.fromItemName(itemName) in dungeonSecretItems) {
             playSound()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
@@ -21,7 +21,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
 import at.hannibal2.skyhanni.utils.compat.container
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
@@ -69,7 +69,7 @@ object DungeonSpiritLeapOverlay {
             for ((slot, stack) in chest.getUpperItems()) {
                 val lore = stack.getLore()
                 if (lore.isNotEmpty()) {
-                    val playerInfo = DungeonApi.getPlayerInfo(stack.hoverName.formattedTextCompatLeadingWhiteLessResets().cleanPlayerName())
+                    val playerInfo = DungeonApi.getPlayerInfo(stack.hoverName.formattedTextCompat().cleanPlayerName())
                     add(PlayerStackInfo(playerInfo, stack, slot.index))
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/floor7/TerminalWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/floor7/TerminalWaypoints.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.utils.AllEntitiesGetter
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
@@ -48,7 +48,9 @@ object TerminalWaypoints {
             group("playerName")
         } ?: return
 
-        val playerEntity = EntityUtils.getEntities<ServerPlayer>().find { it.name.formattedTextCompatLessResets() == playerName } ?: return
+        val playerEntity = EntityUtils.getEntities<ServerPlayer>().find {
+            it.name.formattedTextCompat(leadingWhite = false) == playerName
+        } ?: return
         val terminal = TerminalInfo.getClosestTerminal(playerEntity.getLorenzVec())
         terminal?.highlight = false
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/anniversary/Year400Features.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/anniversary/Year400Features.kt
@@ -111,7 +111,7 @@ object Year400Features {
     }
 
     private fun addPlayer(mob: Mob) {
-        val displayName = mob.baseEntity.displayName.formattedTextCompat()
+        val displayName = mob.baseEntity.displayName.formattedTextCompat(extraResets = true, leadingWhite = false)
         val colorCode = playerColorNametagPattern.matchMatcher(displayName) {
             group("color")
         } ?: run {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -18,7 +18,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEntityHelmet
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.itemType
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
@@ -243,7 +243,7 @@ object CarnivalZombieShootout {
                     "Could not identify Zombie Shootout type",
                     "zombie type for zombie entity helmet is null",
                     "helmet" to helmet,
-                    "helmet.displayName" to helmet.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                    "helmet.displayName" to helmet.hoverName.formattedTextCompat(),
                     "helmet.item" to helmet.itemType,
                     "helmet.unlocalizedName" to helmet.itemType.descriptionId,
                 )

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
@@ -52,7 +52,7 @@ import at.hannibal2.skyhanni.utils.SkyblockSeason
 import at.hannibal2.skyhanni.utils.SkyblockSeasonModifier
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedGlassPane
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.world.inventory.Slot
 import net.minecraft.world.item.Items
 import kotlin.time.Duration.Companion.seconds
@@ -192,7 +192,7 @@ object HoppityApi {
             // Stack must be a skull.
             stack.`is`(Items.PLAYER_HEAD) &&
             // All strays have a display name, all the time.
-            stack.hoverName.string.isNotEmpty() && stack.hoverName.formattedTextCompatLeadingWhiteLessResets().isNotEmpty()
+            stack.hoverName.string.isNotEmpty() && stack.hoverName.formattedTextCompat().isNotEmpty()
     }
 
     private fun Map<Int, SafeItemStack>.filterStrayProcessable() = filterMayBeStray(this).filter {
@@ -250,7 +250,7 @@ object HoppityApi {
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         // Remove any processed stray slots that are no longer in the inventory.
         processedStraySlots.entries.removeIf {
-            it.key !in event.inventoryItems || event.inventoryItems[it.key]?.hoverName.formattedTextCompatLeadingWhiteLessResets() != it.value
+            it.key !in event.inventoryItems || event.inventoryItems[it.key]?.hoverName.formattedTextCompat() != it.value
         }
 
         // Only process if we're in the Chocolate Factory.
@@ -258,7 +258,7 @@ object HoppityApi {
 
         event.inventoryItems.filterStrayProcessable().forEach { (slotNumber, itemStack) ->
             var processed = false
-            CFStrayTracker.strayCaughtPattern.matchMatcher(itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            CFStrayTracker.strayCaughtPattern.matchMatcher(itemStack.hoverName.formattedTextCompat()) {
                 processed = CFStrayTracker.handleStrayClicked(slotNumber, itemStack)
                 when (groupOrNull("name") ?: return@matchMatcher) {
                     "Fish the Rabbit" -> {
@@ -284,7 +284,7 @@ object HoppityApi {
                 hoppityDataSet.duplicate = itemStack.getLore().any { line -> duplicateDoradoStrayPattern.matches(line) }
                 EggFoundEvent(STRAY, slotNumber).post()
             }
-            if (processed) processedStraySlots[slotNumber] = itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            if (processed) processedStraySlots[slotNumber] = itemStack.hoverName.formattedTextCompat()
         }
     }
 
@@ -292,7 +292,7 @@ object HoppityApi {
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!miscProcessInvPattern.matches(InventoryUtils.openInventoryName())) return
         val slot = event.slot?.takeIf { it.isMiscProcessable() } ?: return
-        val hoverName = slot.item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val hoverName = slot.item.hoverName.formattedTextCompat()
 
         if (sideDishNamePattern.matches(hoverName)) {
             EggFoundEvent(SIDE_DISH, event.slotId).post()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -54,7 +54,7 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumOfPair
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.DyeCompat
 import at.hannibal2.skyhanni.utils.compat.DyeCompat.Companion.isDye
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -280,7 +280,7 @@ object HoppityCollectionStats {
         this.getLore().any { milestoneRabbitLorePattern.matches(it) }
 
     private fun missingRabbitStackNeedsFix(stack: SafeItemStack): Boolean =
-        stack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        stack.hoverName.formattedTextCompat()
             .isNotEmpty() && stack.isDye() && (stack.isDye(8) || stack.isMilestoneRabbit())
 
     private val replacementCache: MutableMap<String, SafeItemStack> = mutableMapOf()
@@ -289,7 +289,7 @@ object HoppityCollectionStats {
     fun replaceItem(event: ReplaceItemEvent) {
         if (!inInventory || replacementCache.isEmpty()) return
         if (!event.hasItem) return
-        replacementCache[event.originalItem.hoverName.formattedTextCompatLeadingWhiteLessResets()]?.let { event.replace(it) }
+        replacementCache[event.originalItem.hoverName.formattedTextCompat()]?.let { event.replace(it) }
     }
 
     private fun reCalcHotspotCount() {
@@ -341,7 +341,7 @@ object HoppityCollectionStats {
         }
 
         event.inventoryItems.values.filter(::missingRabbitStackNeedsFix).forEach { stack ->
-            val rarity = HoppityApi.rarityByRabbit(stack.hoverName.formattedTextCompatLeadingWhiteLessResets())
+            val rarity = HoppityApi.rarityByRabbit(stack.hoverName.formattedTextCompat())
             // Add NBT for the dye color itself
             val newItemStack = if (collectionConfig.rarityDyeRecolor) DyeCompat.createDyeStack(
                 when (rarity) {
@@ -362,8 +362,8 @@ object HoppityCollectionStats {
             else buildDescriptiveMilestoneLore(stack)
 
             newItemStack.setLoreString(newLore)
-            newItemStack.setCustomItemName(stack.hoverName.formattedTextCompatLeadingWhiteLessResets())
-            replacementCache[stack.hoverName.formattedTextCompatLeadingWhiteLessResets()] = newItemStack
+            newItemStack.setCustomItemName(stack.hoverName.formattedTextCompat())
+            replacementCache[stack.hoverName.formattedTextCompat()] = newItemStack
         }
 
         inInventory = true
@@ -398,7 +398,7 @@ object HoppityCollectionStats {
         }
 
         replaceIndex?.let {
-            CFApi.milestoneByRabbit(itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets())?.let {
+            CFApi.milestoneByRabbit(itemStack.hoverName.formattedTextCompat())?.let {
                 val displayAmount = it.amount.shortFormat()
                 val operationFormat = when (milestoneType) {
                     HoppityEggType.CHOCOLATE_SHOP_MILESTONE -> "spending"
@@ -424,7 +424,7 @@ object HoppityCollectionStats {
 
         residentRabbitPattern.firstMatcher(lore) {
             val island = IslandType.getByNameOrNull(group("island")) ?: return@firstMatcher
-            stack.hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor().takeIfKnownRabbit()?.let { residentName ->
+            stack.hoverName.formattedTextCompat().removeColor().takeIfKnownRabbit()?.let { residentName ->
                 residentRabbitData.getOrPut(island) {
                     mutableMapOf()
                 }[residentName] = !rabbitNotFoundPattern.anyMatches(lore)
@@ -439,7 +439,7 @@ object HoppityCollectionStats {
         val hotspotData = hotspotRabbitData ?: return
         hotspotLocationPattern.firstMatcher(lore) {
             val location = IslandType.getByNameOrNull(group("location")) ?: return@firstMatcher
-            stack.hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor().takeIfKnownRabbit()?.let { rabbitName ->
+            stack.hoverName.formattedTextCompat().removeColor().takeIfKnownRabbit()?.let { rabbitName ->
                 hotspotData.hotspotRabbits.getOrPut(location) {
                     mutableMapOf()
                 }[rabbitName] = !rabbitNotFoundPattern.anyMatches(lore)
@@ -453,20 +453,20 @@ object HoppityCollectionStats {
         if (lore.isEmpty()) return
         if (!rabbitNotFoundPattern.anyMatches(lore) && !collectionConfig.highlightFoundRabbits) return
 
-        if (highlightMap.containsKey(stack.hoverName.formattedTextCompatLeadingWhiteLessResets())) return
+        if (highlightMap.containsKey(stack.hoverName.formattedTextCompat())) return
 
-        if (stack.hoverName.formattedTextCompatLeadingWhiteLessResets() == "§aAbi" && collectionConfig.highlightRabbits.contains(
+        if (stack.hoverName.formattedTextCompat() == "§aAbi" && collectionConfig.highlightRabbits.contains(
                 HighlightRabbitTypes.ABI,
             )
         ) {
-            highlightMap[stack.hoverName.formattedTextCompatLeadingWhiteLessResets()] = HighlightRabbitTypes.ABI.color
+            highlightMap[stack.hoverName.formattedTextCompat()] = HighlightRabbitTypes.ABI.color
             return
         }
 
         // cache rabbits until collection is closed
         for ((pattern, rabbitType) in highlightConfigMap) {
             if (pattern.anyMatches(lore) && collectionConfig.highlightRabbits.contains(rabbitType)) {
-                highlightMap[stack.hoverName.formattedTextCompatLeadingWhiteLessResets()] = rabbitType.color
+                highlightMap[stack.hoverName.formattedTextCompat()] = rabbitType.color
                 break
             }
         }
@@ -474,14 +474,14 @@ object HoppityCollectionStats {
         residentRabbitPattern.firstMatcher(lore) {
             val island = IslandType.getByNameOrNull(group("island")) ?: return@firstMatcher
             if (island.isInIsland() && collectionConfig.highlightRabbits.contains(HighlightRabbitTypes.RESIDENTS)) {
-                highlightMap[stack.hoverName.formattedTextCompatLeadingWhiteLessResets()] = HighlightRabbitTypes.RESIDENTS.color
+                highlightMap[stack.hoverName.formattedTextCompat()] = HighlightRabbitTypes.RESIDENTS.color
             }
         }
 
         hotspotLocationPattern.firstMatcher(lore) {
             val island = IslandType.getByNameOrNull(group("location")) ?: return@firstMatcher
             if (island.isInIsland() && collectionConfig.highlightRabbits.contains(HighlightRabbitTypes.HOTSPOTS)) {
-                highlightMap[stack.hoverName.formattedTextCompatLeadingWhiteLessResets()] = HighlightRabbitTypes.HOTSPOTS.color
+                highlightMap[stack.hoverName.formattedTextCompat()] = HighlightRabbitTypes.HOTSPOTS.color
             }
         }
     }
@@ -511,7 +511,7 @@ object HoppityCollectionStats {
         if (!inInventory || collectionConfig.highlightRabbits.isEmpty()) return
 
         for (slot in InventoryUtils.getItemsInOpenChest()) {
-            val name = slot.item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val name = slot.item.hoverName.formattedTextCompat()
 
             if (name.isEmpty()) continue
             highlightMap[name]?.let {
@@ -806,7 +806,7 @@ object HoppityCollectionStats {
 
     private fun logRabbits(event: InventoryFullyOpenedEvent) {
         for (item in event.inventoryItems.values) {
-            val itemName = item.hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor().takeIfKnownRabbit() ?: continue
+            val itemName = item.hoverName.formattedTextCompat().removeColor().takeIfKnownRabbit() ?: continue
 
             val itemLore = item.getLore()
             saveLocationRabbit(itemName, itemLore)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityRabbitTheFishChecker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityRabbitTheFishChecker.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -73,7 +73,7 @@ object HoppityRabbitTheFishChecker {
         rabbitTheFishIndex = event.inventoryItems.filter {
             it.value.hoverName.string.isNotEmpty() && it.key != 22
         }.entries.firstOrNull {
-            rabbitTheFishItemPattern.matches(it.value.hoverName.formattedTextCompatLeadingWhiteLessResets())
+            rabbitTheFishItemPattern.matches(it.value.hoverName.formattedTextCompat())
         }?.key
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/ReplaceHoppityWithContributor.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CircularList
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.indexOfFirstOrNull
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import net.minecraft.network.chat.Component
 
 @SkyHanniModule
@@ -63,11 +62,14 @@ object ReplaceHoppityWithContributor {
         val last = lore.lastOrNull() ?: return
         if (!last.string.endsWith(" RABBIT")) return
 
-        val realName = itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val realName = itemStack.hoverName.formattedTextCompat()
         val cleanName = realName.removeColor()
         val fakeName = replaceMap[cleanName] ?: return
 
-        event.toolTip[0] = event.toolTip[0].formattedTextCompat().replace(cleanName, fakeName).asComponent()
+        event.toolTip[0] = event.toolTip[0]
+            .formattedTextCompat(extraResets = true, leadingWhite = false)
+            .replace(cleanName, fakeName)
+            .asComponent()
 
         event.toolTip.add(" ")
         event.toolTip.add("§8§oSome might say this rabbit is also known as $realName")
@@ -75,7 +77,9 @@ object ReplaceHoppityWithContributor {
         val index = event.toolTip.indexOfFirstOrNull { it.string.contains(" a duplicate") }
         if (index == null) return
         val oldLine = event.toolTip[index]
-        event.toolTip[index] = Component.literal(oldLine.formattedTextCompat().replace(cleanName, fakeName))
+        event.toolTip[index] = Component.literal(
+            oldLine.formattedTextCompat(extraResets = true, leadingWhite = false).replace(cleanName, fakeName),
+        )
     }
 
     fun isEnabled() = SkyBlockUtils.inSkyBlock && config.contributorRabbitName

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/WarpMenuUniques.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/WarpMenuUniques.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -38,7 +38,7 @@ object WarpMenuUniques {
         event.slot ?: return
         if (InventoryUtils.openInventoryName() != "Fast Travel") return
 
-        val name = islandNamePattern.matchMatcher(event.slot.item.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+        val name = islandNamePattern.matchMatcher(event.slot.item.hoverName.formattedTextCompat()) {
             group("name")
         } ?: return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/FishyTreatProfit.kt
@@ -27,7 +27,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.add
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils
@@ -101,7 +101,7 @@ object FishyTreatProfit {
 
         val additionalCost = getAdditionalCost(additionalMaterials)
 
-        val (name, amount) = ItemUtils.readItemAmount(itemName.formattedTextCompatLeadingWhiteLessResets()) ?: return
+        val (name, amount) = ItemUtils.readItemAmount(itemName.formattedTextCompat()) ?: return
 
         var internalName = NeuInternalName.fromItemNameOrNull(name)
         if (internalName == null) {
@@ -202,7 +202,7 @@ object FishyTreatProfit {
                     ErrorManager.logErrorStateWithData(
                         "Error in FishyTreat Profit", "Could not read item amount",
                         "rawItemName" to rawItemName,
-                        "name" to item.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                        "name" to item.hoverName.formattedTextCompat(),
                         "lore" to lore,
                     )
                     continue

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/UpgradeReminder.kt
@@ -23,7 +23,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedGlassPane
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.annotations.Expose
 import kotlin.time.Duration
@@ -211,7 +211,7 @@ object UpgradeReminder {
 
         companion object {
             fun fromItem(item: SafeItemStack): CommunityShopUpgrade? {
-                val name = item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+                val name = item.hoverName.formattedTextCompat()
                 val lore = item.getLore()
                 val upgrade = CommunityShopUpgrade(name)
                 upgrade.duration = upgradeDurationPattern.firstMatcher(lore) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/ChumBucketHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/ChumBucketHider.kt
@@ -9,8 +9,7 @@ import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getAllEquipment
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.world.entity.Entity
@@ -42,7 +41,7 @@ object ChumBucketHider {
             return
         }
 
-        val name = entity.name.formattedTextCompatLessResets()
+        val name = entity.name.formattedTextCompat(leadingWhite = false)
 
         // First text line
         if (name.endsWith("'s Chum Bucket") || name.endsWith("'s Chumcap Bucket")) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -38,7 +38,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.addLavas
 import at.hannibal2.skyhanni.utils.compat.addWaters
 import at.hannibal2.skyhanni.utils.compat.deceased
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getCompoundOrDefault
 import at.hannibal2.skyhanni.utils.compat.getStringOrDefault
 import at.hannibal2.skyhanni.utils.getLorenzVec
@@ -214,12 +214,12 @@ object FishingApi {
         }
 
         val baitAmount = stack.getLoreComponent().asSequence()
-            .map { it.formattedTextCompatLessResets() }
+            .map { it.formattedTextCompat(leadingWhite = false) }
             .firstNotNullOfOrNull { lineText ->
                 baitRemainingPattern.matchMatcher(lineText.removeColor()) { group("amount").formatInt() }
             } ?: return
 
-        val baitType = BaitType(stack.hoverName.formattedTextCompatLessResets(), stack.getInternalName())
+        val baitType = BaitType(stack.hoverName.formattedTextCompat(leadingWhite = false), stack.getInternalName())
         postBaitUpdate(baitType, baitAmount, stack)
     }
 
@@ -321,7 +321,7 @@ object FishingApi {
     private val frostyNpcLocation = LorenzVec(-1.5, 76.0, 92.5)
 
     private fun countIsZero(entity: ArmorStand): Boolean {
-        val name = entity.name.formattedTextCompatLessResets()
+        val name = entity.name.formattedTextCompat(leadingWhite = false)
         // a dragon, will always be fought
         if (name == "Reindrake") return true
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.compat.deceased
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import net.minecraft.world.entity.decoration.ArmorStand
@@ -81,7 +81,7 @@ object FishingHookDisplay {
         if (!armorStand.hasCustomName() || !armorStand.isCustomNameVisible) return
         val alertText = Renderable.text(
             if (armorStand.name.string == "!!!") config.customAlertText.replace("&", "§")
-            else armorStand.name.formattedTextCompatLessResets(),
+            else armorStand.name.formattedTextCompat(leadingWhite = false),
         )
 
         isRendering = true
@@ -94,7 +94,7 @@ object FishingHookDisplay {
     }
 
     private fun ArmorStand.hasCorrectName(): Boolean =
-        (name.string == "!!!") || pattern.matcher(name.formattedTextCompatLessResets()).matches()
+        (name.string == "!!!") || pattern.matcher(name.formattedTextCompat(leadingWhite = false)).matches()
 
     fun isEnabled() = config.enabled && FishingApi.holdingRod
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/ShowFishingItemName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/ShowFishingItemName.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactLocation
 import net.minecraft.world.entity.item.ItemEntity
@@ -48,7 +48,7 @@ object ShowFishingItemName {
                 text = "§6Coins"
             } else {
                 val name =
-                    itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets().transformIf({ isBait }) { "§7" + this.removeColor() }
+                    itemStack.hoverName.formattedTextCompat().transformIf({ isBait }) { "§7" + this.removeColor() }
                 text += if (isBait) "§c§l- §r" else "§a§l+ §r"
 
                 val size = itemStack.count

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishManager.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.compat.defaultStyleConstructor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.setHoverShowText
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Style
@@ -125,7 +125,7 @@ object TrophyFishManager {
                     "unknown trophy fish rarity in odger inventory",
                     "rawRarity" to rawRarity,
                     "line" to line,
-                    "stack.name" to stack.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                    "stack.name" to stack.hoverName.formattedTextCompat(),
                     "internalName" to internalName,
                 )
 

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/AgathaCouponProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/AgathaCouponProfit.kt
@@ -25,7 +25,7 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.add
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sublistAfter
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils
@@ -125,7 +125,7 @@ object AgathaCouponProfit {
             val internalName = item.getInternalNameOrNull() ?: return null
             internalName to item.repoItemName.asComponent()
         } else {
-            val internalName = NeuInternalName.fromItemNameOrNull(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) ?: return null
+            val internalName = NeuInternalName.fromItemNameOrNull(item.hoverName.formattedTextCompat()) ?: return null
             internalName to item.hoverName
         }
     }
@@ -146,7 +146,7 @@ object AgathaCouponProfit {
                 ErrorManager.logErrorStateWithData(
                     "Error in AnitaCoupon Profit", "Could not read item amount",
                     "rawItemName" to rawItemName,
-                    "name" to item.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                    "name" to item.hoverName.formattedTextCompat(),
                     "lore" to lore,
                 )
                 continue

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
@@ -308,7 +308,7 @@ object ForagingTracker : SkyHanniBucketedItemTracker<ForagingTrackerLegacy.TreeT
     private fun Component.getHoverLootPairs(): Set<Pair<NeuInternalName, Int>> = buildSet {
         val treeType = treeType ?: return this
         lastHover = hover
-        val lootLines = hover?.formattedTextCompat()?.split("\n")?.takeIfNotEmpty() ?: return this
+        val lootLines = hover?.formattedTextCompat(extraResets = true, leadingWhite = false)?.split("\n")?.takeIfNotEmpty() ?: return this
         ChatUtils.debug("found loot lines:\n${lootLines.joinToString("\n").replace("§", "&")}")
         lootLines.forEach { line ->
             val (item, amountString) = ForagingTrackerLegacy.hoverRewardPattern.matchMatcher(line) {

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
@@ -42,7 +42,7 @@ object TreeProgressDisplay {
             return
         }
         for (entity in EntityUtils.getEntities<ArmorStand>()) {
-            val name = entity.displayName.formattedTextCompat()
+            val name = entity.displayName.formattedTextCompat(extraResets = true, leadingWhite = false)
             ModernPatterns.currentTreeProgressPattern.matchMatcher(name) {
                 display = if (config.compact) {
                     Renderable.text("${group("treeType")} §b§l${group("percent")}%")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/AnitaMedalProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/AnitaMedalProfit.kt
@@ -28,7 +28,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.add
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils
@@ -104,7 +104,7 @@ object AnitaMedalProfit {
         // Ignore items without medal cost, e.g. InfiniDirt Wand
         val bronzeCost = getBronzeCost(requiredItems) ?: return
 
-        val (name, amount) = ItemUtils.readItemAmount(itemName.formattedTextCompatLeadingWhiteLessResets()) ?: return
+        val (name, amount) = ItemUtils.readItemAmount(itemName.formattedTextCompat()) ?: return
 
         var internalName = NeuInternalName.fromItemNameOrNull(name)
         if (internalName == null) {
@@ -222,7 +222,7 @@ object AnitaMedalProfit {
                     ErrorManager.logErrorStateWithData(
                         "Error in Anita Medal Contest", "Could not read item amount",
                         "rawItemName" to rawItemName,
-                        "name" to item.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                        "name" to item.hoverName.formattedTextCompat(),
                         "lore" to lore,
                     )
                     continue

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -45,7 +45,7 @@ import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.json.toJsonArray
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -259,7 +259,7 @@ object GardenNextJacobContest {
             val lore = item.getLoreComponent()
             if (!lore.any { it.string.contains("Jacob's Farming Contest") }) return@mapNotNull null
 
-            val day = dayPattern.matchMatcher(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            val day = dayPattern.matchMatcher(item.hoverName.formattedTextCompat()) {
                 group("day").toInt()
             } ?: return@mapNotNull null
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
@@ -25,7 +25,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.getTablistEndTime
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.annotations.Expose
@@ -365,11 +365,11 @@ object GardenPlotApi {
         for (plot in plots) {
             val itemStack = event.inventoryItems[plot.inventorySlot] ?: continue
             val lore = itemStack.getLore()
-            plotNamePattern.matchMatcher(itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            plotNamePattern.matchMatcher(itemStack.hoverName.formattedTextCompat()) {
                 val plotName = group("name")
                 plot.name = plotName
             }
-            barnNamePattern.matchMatcher(itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            barnNamePattern.matchMatcher(itemStack.hoverName.formattedTextCompat()) {
                 plot.name = group("name")
             }
             plot.locked = false

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -57,7 +57,7 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addVerticalSpacer
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.addRenderableButton
 import at.hannibal2.skyhanni.utils.renderables.addLine
@@ -140,7 +140,7 @@ object ComposterOverlay {
     fun onToolTip(event: ToolTipTextEvent) {
         if (!composterUpgradesInventory.isInside()) return
         for (upgrade in ComposterUpgrade.entries) {
-            val name = event.itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val name = event.itemStack.hoverName.formattedTextCompat()
             if (name.contains(upgrade.displayName)) {
                 maxLevel = ComposterUpgrade.regex.matchMatcher(name) {
                     group("level")?.romanToDecimalIfNecessary() ?: 0

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/GardenComposterInventoryFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/GardenComposterInventoryFeatures.kt
@@ -18,7 +18,7 @@ import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.compat.append
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.world.inventory.ChestMenu
 
@@ -50,7 +50,9 @@ object GardenComposterInventoryFeatures {
             if (next) {
                 if (line.string.endsWith(" Copper")) continue
                 if (line.string == "") break
-                val (itemName, amount) = ItemUtils.readItemAmount(line.formattedTextCompatLessResets().removePrefix("§5")) ?: run {
+                val (itemName, amount) = ItemUtils.readItemAmount(
+                    line.formattedTextCompat(leadingWhite = false).removePrefix("§5"),
+                ) ?: run {
                     ErrorManager.logErrorStateWithData(
                         "Error reading item line",
                         "could not read item line",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobContestFFNeededDisplay.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.addLine
 import kotlin.math.ceil
@@ -44,7 +44,7 @@ object JacobContestFFNeededDisplay {
             return
         }
 
-        val time = FarmingContestApi.getSBTimeFor(stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) ?: return
+        val time = FarmingContestApi.getSBTimeFor(stack.hoverName.formattedTextCompat()) ?: return
         val contest = FarmingContestApi.getContestAtTime(time) ?: return
 
         val newDisplay = drawDisplay(contest)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/JacobFarmingContestsInventory.kt
@@ -29,7 +29,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.StringUtils.addSkyHanniUtm
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.world.inventory.ChestMenu
@@ -73,8 +73,8 @@ object JacobFarmingContestsInventory {
         for ((slot, item) in event.inventoryItems) {
             if (!item.getLore().any { it.startsWith("§7Your score: §e") }) continue
 
-            foundEvents.add(item.hoverName.formattedTextCompatLeadingWhiteLessResets())
-            val time = FarmingContestApi.getSBTimeFor(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) ?: continue
+            foundEvents.add(item.hoverName.formattedTextCompat())
+            val time = FarmingContestApi.getSBTimeFor(item.hoverName.formattedTextCompat()) ?: continue
             FarmingContestApi.addContest(time, item)
             if (config.realTime) {
                 readRealTime(time, slot)
@@ -96,7 +96,7 @@ object JacobFarmingContestsInventory {
         if (!config.openOnElite.isKeyHeld()) return
 
         val slot = event.slot ?: return
-        val itemName = slot.item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val itemName = slot.item.hoverName.formattedTextCompat()
 
         when (val chestName = InventoryUtils.openInventoryName()) {
             "Your Contests" -> {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/DnaAnalyzerSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/greenhouse/DnaAnalyzerSolver.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SafeItemStack
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 
 @SkyHanniModule
 object DnaAnalyzerSolver {
@@ -267,7 +267,7 @@ object DnaAnalyzerSolver {
 
         companion object {
             fun SafeItemStack.toColor(): Colors? {
-                val name = this.hoverName.formattedTextCompatLeadingWhiteLessResets()
+                val name = this.hoverName.formattedTextCompat()
                 return when {
                     name.startsWith("§cDNA") -> RED
                     name.startsWith("§eDNA") -> YELLOW

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenInventoryNumbers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/GardenInventoryNumbers.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -54,7 +54,7 @@ object GardenInventoryNumbers {
         if (InventoryUtils.openInventoryName() == "Composter Upgrades") {
             if (!config.composterUpgrades) return
 
-            ComposterUpgrade.regex.matchMatcher(event.stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            ComposterUpgrade.regex.matchMatcher(event.stack.hoverName.formattedTextCompat()) {
                 val level = group("level")?.romanToDecimalIfNecessary() ?: 0
                 event.stackTip = "$level"
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.StringUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.item.Items
@@ -67,7 +67,7 @@ object LogBookStats {
         val list = mutableListOf<VisitorInfo>()
 
         for ((index, item) in event.inventoryItems) {
-            val visitorName = item.hoverName.formattedTextCompatLeadingWhiteLessResets().takeIfNotEmpty() ?: continue
+            val visitorName = item.hoverName.formattedTextCompat().takeIfNotEmpty() ?: continue
             var timesVisited = 0L
             var timesAccepted = 0L
             val lore = item.getLore()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/plots/GardenNextPlotPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/plots/GardenNextPlotPrice.kt
@@ -37,7 +37,7 @@ object GardenNextPlotPrice {
             }
 
             if (next) {
-                val readItemAmount = ItemUtils.readItemAmount(line.formattedTextCompat())
+                val readItemAmount = ItemUtils.readItemAmount(line.formattedTextCompat(extraResets = true, leadingWhite = false))
                 readItemAmount?.let {
                     val (itemName, amount) = it
                     val lowestBin = NeuInternalName.fromItemName(itemName).getPrice()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/plots/GardenPlotIcon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/plots/GardenPlotIcon.kt
@@ -16,7 +16,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.SafeItemStack
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.world.SimpleContainer
 import net.minecraft.world.item.Items
 
@@ -148,7 +148,7 @@ object GardenPlotIcon {
             val stack = originalStack[index] ?: return
             val lore = stack.getLore()
             list.clear()
-            list.add(0, stack.hoverName.formattedTextCompatLeadingWhiteLessResets())
+            list.add(0, stack.hoverName.formattedTextCompat())
             for (i in lore.indices) {
                 list.add(i + 1, stack.getLore()[i])
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -358,7 +358,7 @@ object PestApi {
     fun getNearestInfestedPlot() = getInfestedPlots().minByOrNull { it.middle.distanceSqToPlayer() }
 
     fun isNearPestTrap() = EntityUtils.getEntitiesNearby<ArmorStand>(10.0).any {
-        pestTrapPattern.matches(it.displayName.formattedTextCompat())
+        pestTrapPattern.matches(it.displayName.formattedTextCompat(extraResets = true, leadingWhite = false))
     }
 
     fun GardenPlotApi.Plot.getPestTypesInPlot() = gardenPestTypes.getOrDefault(this, listOf())

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PesthunterProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PesthunterProfit.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.indexOfFirstOrNull
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.mapToComponents
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils
@@ -79,7 +79,7 @@ object PesthunterProfit {
         if (slot == 49) return null
 
         val totalCost = getFullCost(getRequiredItems(item)).takeIf { it >= 0 } ?: return null
-        val nameString = itemName.formattedTextCompatLeadingWhiteLessResets()
+        val nameString = itemName.formattedTextCompat()
         val (name, amount) = ItemUtils.readItemAmount(nameString) ?: return null
         val fixedDisplayName = name.replace("[Lvl 100]", "[Lvl {LVL}]")
         val internalName = NeuInternalName.fromItemNameOrNull(fixedDisplayName)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorChat.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.RemotePlayer
 import kotlin.time.Duration.Companion.seconds
@@ -116,7 +116,7 @@ object GardenVisitorChat {
      */
     private fun doesVisitorEntityExist(name: String) =
         EntityUtils.getEntitiesInBoundingBox<RemotePlayer>(GardenApi.barnArea).any {
-            it.name.formattedTextCompatLessResets().trim().equals(name, true)
+            it.name.formattedTextCompat(leadingWhite = false).trim().equals(name, true)
         }
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorApi.kt
@@ -199,7 +199,7 @@ object VisitorApi {
                 continue
             }
 
-            visitorNamePattern.matchMatcher(line.formattedTextCompat()) {
+            visitorNamePattern.matchMatcher(line.formattedTextCompat(extraResets = true, leadingWhite = false)) {
                 visitorsInTab.add(group("name").trim())
             }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/VisitorListener.kt
@@ -29,7 +29,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactLocation
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.protocol.game.ServerboundInteractPacket
@@ -108,7 +108,7 @@ object VisitorListener {
 
         val visitorOffer = VisitorApi.VisitorOffer(offerItem)
 
-        var name = npcItem.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        var name = npcItem.hoverName.formattedTextCompat()
         if (name.length == name.removeColor().length + 4) {
             name = name.substring(2)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/gifting/UniqueGiftingOpportunitiesFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gifting/UniqueGiftingOpportunitiesFeatures.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.RemotePlayer
@@ -40,7 +40,7 @@ object UniqueGiftingOpportunitiesFeatures {
         "\\+1 Unique Gift given! To (?<player>.+)!",
     )
 
-    private fun hasGiftedPlayer(player: Player) = playerList?.contains(player.name.formattedTextCompatLessResets()) == true
+    private fun hasGiftedPlayer(player: Player) = playerList?.contains(player.name.formattedTextCompat(leadingWhite = false)) == true
 
     private fun addGiftedPlayer(playerName: String) {
         playerList?.add(playerName)
@@ -57,11 +57,11 @@ object UniqueGiftingOpportunitiesFeatures {
 
     private fun analyzeArmorStand(entity: ArmorStand) {
         if (!config.useArmorStandDetection) return
-        if (entity.name.formattedTextCompatLessResets() != HAS_GIFTED_NAMETAG) return
+        if (entity.name.formattedTextCompat(leadingWhite = false) != HAS_GIFTED_NAMETAG) return
 
         val matchedPlayer = entity.getLorenzVec().getEntitiesNearby<Player>(2.0)
             .singleOrNull { !it.isNpc() } ?: return
-        addGiftedPlayer(matchedPlayer.name.formattedTextCompatLessResets())
+        addGiftedPlayer(matchedPlayer.name.formattedTextCompat(leadingWhite = false))
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/CustomScoreboardUtils.kt
@@ -108,7 +108,7 @@ object CustomScoreboardUtils {
         val first = TabWidget.EVENT.lines.first()
         return TabWidget.EVENT.pattern.matchMatcher(first) {
             val matcher = TextHelper.matcher(first, group("event")) ?: return null
-            matcher.formattedTextCompat()
+            matcher.formattedTextCompat(extraResets = true, leadingWhite = false)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventBroodmother.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventBroodmother.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 // scoreboard
 // widget update event
 object ScoreboardEventBroodmother : ScoreboardEvent() {
-    override fun getDisplay() = TabWidget.BROODMOTHER.lines.map { it.formattedTextCompat().trim() }
+    override fun getDisplay() = TabWidget.BROODMOTHER.lines.map { it.formattedTextCompat(extraResets = true, leadingWhite = false).trim() }
 
     override val configLine = "Broodmother§7: §eDormant"
 

--- a/src/main/java/at/hannibal2/skyhanni/features/hunting/LassoDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/hunting/LassoDisplay.kt
@@ -51,7 +51,7 @@ object LassoDisplay {
             if (!leashEntity.isLocalPlayer) continue
             val entitiesNearby = entity.blockPosition().toLorenzVec().up(2).getEntitiesNearby<ArmorStand>(2.0)
             for (armorStandEntity in entitiesNearby) {
-                val name = armorStandEntity.displayName.formattedTextCompat()
+                val name = armorStandEntity.displayName.formattedTextCompat(extraResets = true, leadingWhite = false)
                 if (name.contains("§l§m")) {
                     progressBar = name
                 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/BitsPerCookieVisual.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/BitsPerCookieVisual.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcherWithIndex
 import at.hannibal2.skyhanni.utils.RegexUtils.indexOfFirstMatch
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -53,7 +53,7 @@ object BitsPerCookieVisual {
     fun onToolTip(event: ToolTipTextEvent) {
         if (!isEnabled()) return
         if (event.itemStack.getInternalNameOrNull() != boosterCookie) return
-        if (wrongCookiePattern.matches(event.itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets())) return
+        if (wrongCookiePattern.matches(event.itemStack.hoverName.formattedTextCompat())) return
         var timeReplaced = false
 
         val toolTip = event.toolTip

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.item.Items
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/DojoRankDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/DojoRankDisplay.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.takeIfNotEmpty
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -51,7 +51,7 @@ object DojoRankDisplay {
 
         var totalScore = 0
         for (stack in items) {
-            val name = stack.hoverName.formattedTextCompatLeadingWhiteLessResets().takeIfNotEmpty() ?: continue
+            val name = stack.hoverName.formattedTextCompat().takeIfNotEmpty() ?: continue
             testNamePattern.matchMatcher(name) {
                 val testColor = group("color")
                 val testName = group("name")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/EquipmentApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/EquipmentApi.kt
@@ -24,7 +24,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedGlassPane
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.seconds
 
@@ -125,12 +125,12 @@ object EquipmentApi {
             }
             add("Equipment:")
             storage.slots.forEach { item ->
-                val name = item?.hoverName.formattedTextCompatLeadingWhiteLessResets()
+                val name = item?.hoverName.formattedTextCompat()
                 add(" - $name")
             }
             add("Rift Equipment:")
             storage.riftSlots.forEach { item ->
-                val name = item?.hoverName.formattedTextCompatLeadingWhiteLessResets()
+                val name = item?.hoverName.formattedTextCompat()
                 add(" - $name")
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/EssenceShopHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/EssenceShopHelper.kt
@@ -30,7 +30,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.item.Items
 import kotlin.time.Duration.Companion.seconds
@@ -240,15 +240,15 @@ object EssenceShopHelper {
 
     private fun processEssenceShopHeader(event: InventoryOpenEvent) {
         val essenceHeaderStack = event.inventoryItems[4]
-        if (essenceHeaderStack == null || !essenceShopPattern.matches(essenceHeaderStack.hoverName.formattedTextCompatLeadingWhiteLessResets())) {
+        if (essenceHeaderStack == null || !essenceShopPattern.matches(essenceHeaderStack.hoverName.formattedTextCompat())) {
             ErrorManager.logErrorWithData(
                 NoSuchElementException(""),
                 "Could not read current Essence Count from inventory",
                 extraData = listOf(
                     "inventoryName" to event.inventoryName,
-                    "essenceHeaderStack" to essenceHeaderStack?.hoverName.formattedTextCompatLeadingWhiteLessResets().orEmpty(),
+                    "essenceHeaderStack" to essenceHeaderStack?.hoverName.formattedTextCompat(),
                     "populatedInventorySize" to event.inventoryItems.filter {
-                        it.value.hoverName.formattedTextCompatLeadingWhiteLessResets().isNotEmpty()
+                        it.value.hoverName.formattedTextCompat().isNotEmpty()
                     }.size,
                     "eventType" to event.javaClass.simpleName,
                 ).toTypedArray(),

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FavoritePowerStone.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 
 @SkyHanniModule
 object FavoritePowerStone {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedClay
 import at.hannibal2.skyhanni.utils.compat.container
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.mojang.blaze3d.systems.RenderSystem
 import net.minecraft.client.Minecraft
@@ -202,7 +202,7 @@ object HarpFeatures {
         if (!event.stack.isStainedClay()) return
 
         // Example: §9| §7Click! will select the 9
-        val index = buttonColors.indexOfFirst { it == event.stack.hoverName.formattedTextCompatLeadingWhiteLessResets()[1] }
+        val index = buttonColors.indexOfFirst { it == event.stack.hoverName.formattedTextCompat()[1] }
         if (index == -1) return // this should never happen unless there's an update
 
         val keyCode = getKey(index) ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -58,7 +58,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetLevel
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getRanchersSpeed
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getSecondsHeld
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
@@ -230,7 +230,7 @@ object ItemDisplayOverlayFeatures {
         if (COLLECTION_LEVEL.isSelected() && InventoryUtils.openInventoryName().endsWith(" Collections")) {
             if (lore.any { it.contains("Click to view!") }) {
                 if (CollectionApi.isCollectionTier0(lore)) return "0"
-                val name = item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+                val name = item.hoverName.formattedTextCompat()
                 if (name.startsWith("§e")) {
                     val text = name.split(" ").last()
                     return "" + text.romanToDecimalIfNecessary()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -31,7 +31,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
@@ -249,7 +249,7 @@ object ItemPickupLog {
             ItemCategory.PET -> true
             else -> false
         }
-        val default = hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val default = hoverName.formattedTextCompat()
         return runCatching {
             if (compact) getInternalName().repoItemName else default
         }.getOrElse {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemStars.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemStars.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getDungeonStarCount
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getStarCount
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
 
@@ -41,7 +41,7 @@ object ItemStars {
         val stack = event.itemStack
         if (stack.count != 1) return
         val stars = stack.grabStarCount() ?: return
-        starPattern.findMatcher(stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+        starPattern.findMatcher(stack.hoverName.formattedTextCompat()) {
             val name = group("name")
             event.toolTip[0] = Component.literal("$name §c$stars✪")
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/MaxPurseItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/MaxPurseItems.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.takeIfNotEmpty
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -46,7 +46,7 @@ object MaxPurseItems {
     private fun getPrices() {
         for (slot in InventoryUtils.getItemsInOpenChest()) {
             val item = slot.item
-            val name = item.hoverName.formattedTextCompatLeadingWhiteLessResets().takeIfNotEmpty() ?: continue
+            val name = item.hoverName.formattedTextCompat().takeIfNotEmpty() ?: continue
             createOrderPattern.matchMatcher(name) {
                 orderPattern.firstMatcher(item.getLore()) {
                     // +0.1 because I expect people to use the gold nugget option

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/OldSkyblockMenu.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/OldSkyblockMenu.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedGlassPane
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Items
 import kotlin.reflect.KFunction
@@ -51,7 +51,7 @@ object OldSkyblockMenu {
         if (!isEnabled()) return
 
         val sbButton = slotMap[event.slot]?.takeIf { !it.disabled } ?: return
-        val isAlreadySbButton = event.originalItem.hoverName.formattedTextCompatLeadingWhiteLessResets().endsWith(sbButton.displayName)
+        val isAlreadySbButton = event.originalItem.hoverName.formattedTextCompat().endsWith(sbButton.displayName)
         if (isAlreadySbButton) return
 
         event.replace(sbButton.item)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/PageScrolling.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/PageScrolling.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.MouseCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.ScrollValue
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.seconds
@@ -74,7 +74,7 @@ object PageScrolling {
         if (dWheel == 0) return
         val patterns = if ((dWheel > 0) xor config.invertScroll) forwardPattern else backwardPattern
         val slot = InventoryUtils.getItemsInOpenChest().firstOrNull {
-            patterns.matches(it.item.hoverName.formattedTextCompatLeadingWhiteLessResets())
+            patterns.matches(it.item.hoverName.formattedTextCompat())
         } ?: return
         InventoryUtils.clickSlot(slot.index)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/QuickCraftFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/QuickCraftFeatures.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.network.chat.Component
 import net.minecraft.world.inventory.ChestMenu

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/RngMeterInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/RngMeterInventory.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/SkyblockGuideHighlightFeature.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import org.intellij.lang.annotations.Language
 
@@ -130,7 +130,7 @@ class SkyblockGuideHighlightFeature private constructor(
 
             for ((slot, item) in event.inventoryItems) {
                 if (slot == 4) continue // Overview Item
-                val loreAndName = listOf(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) + item.getLore()
+                val loreAndName = listOf(item.hoverName.formattedTextCompat()) + item.getLore()
                 if (!current.conditionPattern.anyMatches(loreAndName)) continue
                 missing.add(slot)
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/StatsTuning.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributeShardsData.kt
@@ -36,7 +36,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.seconds
 
@@ -377,7 +377,7 @@ object AttributeShardsData {
             if (!isAttributeShard(internalName)) continue
             var tier = 0
             var toNextTier = 0
-            attributeShardNamePattern.matchMatcher(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            attributeShardNamePattern.matchMatcher(item.hoverName.formattedTextCompat()) {
                 tier = groupOrNull("tier")?.romanToDecimal() ?: 0
             }
             val lore = item.getLore()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributesShardsInventory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/attribute/AttributesShardsInventory.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 
 @SkyHanniModule
 object AttributesShardsInventory {
@@ -21,7 +21,7 @@ object AttributesShardsInventory {
 
         val internalName = event.stack.getInternalNameOrNull() ?: return
         if (!AttributeShardsData.isAttributeShard(internalName)) return
-        AttributeShardsData.attributeShardNamePattern.matchMatcher(event.stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+        AttributeShardsData.attributeShardNamePattern.matchMatcher(event.stack.hoverName.formattedTextCompat()) {
             val tier = groupOrNull("tier")?.romanToDecimal() ?: 0
             val color = when (tier) {
                 0 -> "§c"

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -39,7 +39,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.equalsIgnoreColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.api.ApiUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.world.inventory.ChestMenu
@@ -169,7 +169,7 @@ object BazaarApi {
     @HandleEvent
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         val item = event.item ?: return
-        val itemName = item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val itemName = item.hoverName.formattedTextCompat()
         if (isBazaarOrderInventory(InventoryUtils.openInventoryName())) {
             val internalName = item.getInternalNameOrNull() ?: return
             if (itemName.contains("SELL")) {
@@ -198,16 +198,16 @@ object BazaarApi {
     private fun getOpenedProduct(inventoryItems: Map<Int, SafeItemStack>): NeuInternalName? {
         val buyInstantly = inventoryItems[10] ?: return null
 
-        if (buyInstantly.hoverName.formattedTextCompatLeadingWhiteLessResets() != "§aBuy Instantly") return null
+        if (buyInstantly.hoverName.formattedTextCompat() != "§aBuy Instantly") return null
         val bazaarItem = inventoryItems[13] ?: return null
 
-        return NeuInternalName.fromItemName(bazaarItem.hoverName.formattedTextCompatLeadingWhiteLessResets())
+        return NeuInternalName.fromItemName(bazaarItem.hoverName.formattedTextCompat())
     }
 
     private fun updateTaxRate(inventoryItems: Map<Int, SafeItemStack>) {
         val sellInstantly = inventoryItems[11] ?: return
 
-        if (sellInstantly.hoverName.formattedTextCompatLeadingWhiteLessResets() != "§6Sell Instantly") return
+        if (sellInstantly.hoverName.formattedTextCompat() != "§6Sell Instantly") return
         taxPattern.firstMatcher(sellInstantly.getLore()) {
             taxRate = group("tax").formatDouble()
         }
@@ -238,7 +238,7 @@ object BazaarApi {
                 continue
             }
 
-            if (stack.hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor() == currentSearchedItem) {
+            if (stack.hoverName.formattedTextCompat().removeColor() == currentSearchedItem) {
                 slot.highlight(LorenzColor.GREEN)
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderHelper.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SafeItemStack
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.world.inventory.ChestMenu
@@ -61,7 +61,7 @@ object BazaarOrderHelper {
         val slots = mutableMapOf<Int, LorenzColor>()
         val errorItems = mutableSetOf<NeuInternalName>()
         for ((slot, stack) in inventoryItems) {
-            bazaarItemNamePattern.matchMatcher(stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            bazaarItemNamePattern.matchMatcher(stack.hoverName.formattedTextCompat()) {
                 val buyOrSell = group("type").let { (it == "BUY") to (it == "SELL") }
                 if (buyOrSell.let { !it.first && !it.second }) return@matchMatcher
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialCollector.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/CraftMaterialCollector.kt
@@ -21,7 +21,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/caketracker/CakeTracker.kt
@@ -33,7 +33,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockTime
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.addRenderableButton
 import at.hannibal2.skyhanni.utils.renderables.ScrollValue
@@ -228,7 +228,7 @@ object CakeTracker {
     private fun checkCakeContainer(event: InventoryFullyOpenedEvent) {
         if (!cakeContainerPattern.matches(event.inventoryName)) return
         knownCakesInCurrentInventory = event.inventoryItems.values.mapNotNull { item ->
-            cakeNamePattern.matchMatcher(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            cakeNamePattern.matchMatcher(item.hoverName.formattedTextCompat()) {
                 val year = group("year").formatInt()
                 addCake(year)
                 year
@@ -242,9 +242,9 @@ object CakeTracker {
         if (!auctionBrowserPattern.matches(event.inventoryName)) return false
         searchingForCakes = auctionCakeSearchPattern.matches(event.inventoryName)
         slotHighlightCache = event.inventoryItems.filter {
-            cakeNamePattern.matches(it.value.hoverName.formattedTextCompatLeadingWhiteLessResets())
+            cakeNamePattern.matches(it.value.hoverName.formattedTextCompat())
         }.mapValues { (_, item) ->
-            val year = cakeNamePattern.matchGroup(item.hoverName.formattedTextCompatLeadingWhiteLessResets(), "year")?.toInt() ?: -1
+            val year = cakeNamePattern.matchGroup(item.hoverName.formattedTextCompat(), "year")?.toInt() ?: -1
             val owned = storage?.ownedCakes?.contains(year) ?: false
             if (owned) config.ownedColor else config.missingColor
         }
@@ -274,7 +274,7 @@ object CakeTracker {
     private fun checkInventoryCakes() {
         if (timeOpenedCakeInventory.passedSince() < 500.milliseconds) return
         val currentYears = InventoryUtils.getItemsInOpenChest().mapNotNull { item ->
-            cakeNamePattern.matchGroup(item.item.hoverName.formattedTextCompatLeadingWhiteLessResets(), "year")?.toInt()
+            cakeNamePattern.matchGroup(item.item.hoverName.formattedTextCompat(), "year")?.toInt()
         }
 
         val addedYears = currentYears.filter { it !in knownCakesInCurrentInventory }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
@@ -36,7 +36,6 @@ import at.hannibal2.skyhanni.utils.UtilsPatterns
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.nextAfter
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
 import java.util.TreeSet
@@ -225,7 +224,7 @@ object CFApi {
     fun getNextLevelName(stack: SafeItemStack): String? = upgradeLorePattern.firstMatcher(stack.getLore()) {
         val isEmployee = stack.getLore().any { it == "§8Employee" }
         val upgradeName = if (!isEmployee) groupOrNull("upgradename")
-        else employeeNamePattern.matchMatcher(stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+        else employeeNamePattern.matchMatcher(stack.hoverName.formattedTextCompat()) {
             groupOrNull("employee")
         }
         val nextLevel = groupOrNull("nextlevel") ?: groupOrNull("nextlevelalt")
@@ -292,7 +291,7 @@ object CFApi {
 
     fun partyModeReplace(text: Component): Component {
         return if (config.partyMode.get() && inChocolateFactory && chromaEnabled) {
-            text.formattedTextCompat().replace(partyModeRegex, "§z").asComponent()
+            text.formattedTextCompat(extraResets = true, leadingWhite = false).replace(partyModeRegex, "§z").asComponent()
         } else text
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
@@ -23,7 +23,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.seconds
 
@@ -72,7 +72,7 @@ object CFBlockOpen {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-        val slotDisplayName = event.slot?.item?.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val slotDisplayName = event.slot?.item?.hoverName.formattedTextCompat()
         if (!openCfItemPattern.matches(slotDisplayName)) return
         if (EnchantedClockHelper.enchantedClockPattern.matches(InventoryUtils.openInventoryName())) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
@@ -27,7 +27,7 @@ import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.minutes
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
@@ -127,7 +127,7 @@ object CFCustomReminder {
                 missing to "§6${amount.shortFormat()} Chocolate Milestone"
             }
 
-        val nextLevelName = CFApi.getNextLevelName(item) ?: item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val nextLevelName = CFApi.getNextLevelName(item) ?: item.hoverName.formattedTextCompat()
         return cost to nextLevelName
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
@@ -31,7 +31,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 
 @SkyHanniModule
 object CFDataLoader {
@@ -343,7 +343,7 @@ object CFDataLoader {
     private fun processPrestigeItem(list: MutableList<CFUpgrade>, item: SafeItemStack) {
         val profileStorage = profileStorage ?: return
 
-        prestigeLevelPattern.matchMatcher(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+        prestigeLevelPattern.matchMatcher(item.hoverName.formattedTextCompat()) {
             CFApi.currentPrestige = group("prestige").romanToDecimal()
         }
         var prestigeCost: Long? = null

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanApi.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockTime
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.inPartialMinutes
 import kotlin.math.ceil
 import kotlin.time.Duration

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanSlots.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/hitman/HitmanSlots.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 
@@ -60,7 +60,7 @@ object HitmanSlots {
     private fun handleSlotStorageUpdate(event: InventoryOpenEvent) {
         if (!config.hitmanCosts) return
         val leftToPurchase = event.inventoryItems.filterNotBorderSlots().count { (_, item) ->
-            item.hoverName.formattedTextCompatLeadingWhiteLessResets().isNotEmpty() && item.getLore().isNotEmpty() &&
+            item.hoverName.formattedTextCompat().isNotEmpty() && item.getLore().isNotEmpty() &&
                 slotCostPattern.matches(item.getSingleLineLore())
         }
         val ownedSlots = CFApi.hitmanCosts.size - leftToPurchase

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayTracker.kt
@@ -30,7 +30,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeResets
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
@@ -280,7 +280,7 @@ object CFStrayTracker {
         InventoryUtils.getItemsInOpenChest().filter {
             claimedStraysSlots.contains(it.containerSlot)
         }.forEach {
-            if (!strayCaughtPattern.matches(it.item.hoverName.formattedTextCompatLeadingWhiteLessResets())) {
+            if (!strayCaughtPattern.matches(it.item.hoverName.formattedTextCompat())) {
                 claimedStraysSlots.removeAt(claimedStraysSlots.indexOf(it.containerSlot))
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/stray/CFStrayWarning.kt
@@ -34,7 +34,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import net.minecraft.world.inventory.ChestMenu
 import kotlin.math.sin
@@ -66,7 +66,7 @@ object CFStrayWarning {
         } ?: false
 
     private fun isSpecial(stack: SafeItemStack) =
-        clickMeGoldenRabbitPattern.matches(stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) || stack.getSkullTexture() in specialRabbitTextures
+        clickMeGoldenRabbitPattern.matches(stack.hoverName.formattedTextCompat()) || stack.getSkullTexture() in specialRabbitTextures
 
     private fun shouldWarnAboutStray(item: SafeItemStack) = when (config.rabbitWarning.rabbitWarningLevel) {
         StrayTypeEntry.SPECIAL -> isSpecial(item)
@@ -76,7 +76,7 @@ object CFStrayWarning {
         StrayTypeEntry.RARE_P -> isRarityOrHigher(item, LorenzRarity.RARE)
         StrayTypeEntry.UNCOMMON_P -> isRarityOrHigher(item, LorenzRarity.UNCOMMON)
 
-        StrayTypeEntry.ALL -> clickMeRabbitPattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets()) || isSpecial(item)
+        StrayTypeEntry.ALL -> clickMeRabbitPattern.matches(item.hoverName.formattedTextCompat()) || isSpecial(item)
 
         StrayTypeEntry.NONE -> false
     }
@@ -84,8 +84,8 @@ object CFStrayWarning {
     private fun handleRabbitWarnings(item: SafeItemStack) {
         if (caughtRabbitPattern.matches(item.getSingleLineLore())) return
 
-        val clickMeMatches = clickMeRabbitPattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets())
-        val goldenClickMeMatches = clickMeGoldenRabbitPattern.matches(item.hoverName.formattedTextCompatLeadingWhiteLessResets())
+        val clickMeMatches = clickMeRabbitPattern.matches(item.hoverName.formattedTextCompat())
+        val goldenClickMeMatches = clickMeGoldenRabbitPattern.matches(item.hoverName.formattedTextCompat())
         if (!clickMeMatches && !goldenClickMeMatches || !shouldWarnAboutStray(item)) return
 
         val isSpecial = goldenClickMeMatches || item.getSkullTexture() in specialRabbitTextures
@@ -144,7 +144,7 @@ object CFStrayWarning {
                 StrayTypeEntry.UNCOMMON_P -> isRarityOrHigher(stack, LorenzRarity.UNCOMMON)
 
                 StrayTypeEntry.ALL -> {
-                    clickMeRabbitPattern.matches(it.value.hoverName.formattedTextCompatLeadingWhiteLessResets()) || isSpecial(stack)
+                    clickMeRabbitPattern.matches(it.value.hoverName.formattedTextCompat()) || isSpecial(stack)
                 }
 
                 StrayTypeEntry.NONE -> false

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationXPOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentationXPOverlay.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSlotText
 import at.hannibal2.skyhanni.utils.compat.DyeCompat.Companion.isDye
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 
@@ -42,7 +42,7 @@ object ExperimentationXPOverlay {
         if (!isEnabled()) return
         event.stack ?: return
         if (!event.stack.isDye()) return
-        enchantingXPPattern.matchMatcher(event.stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+        enchantingXPPattern.matchMatcher(event.stack.hoverName.formattedTextCompat()) {
             val text = "${group("xp")}k"
             val stringWidth = Minecraft.getInstance().font.width(text)
             event.drawSlotText(event.x + 2 + stringWidth, event.y + 10, text, .6f)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
@@ -25,7 +25,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getIdentifierString
 import at.hannibal2.skyhanni.utils.itemType
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -117,7 +117,7 @@ object ExperimentsAddonsHelper {
         "Orange" -> LorenzColor.GOLD
         "Purple" -> LorenzColor.DARK_PURPLE
         else -> try {
-            LorenzColor.valueOf(hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor().uppercase())
+            LorenzColor.valueOf(hoverName.formattedTextCompat().removeColor().uppercase())
         } catch (exception: IllegalArgumentException) {
             null
         }
@@ -135,7 +135,7 @@ object ExperimentsAddonsHelper {
     }
 
     private fun tryHighlightUltrasequencer() = InventoryUtils.getItemsInOpenChest().filter {
-        it.item.hoverName.formattedTextCompatLeadingWhiteLessResets().trim().isNotEmpty() && it.index in hypixelUltrasequencerData &&
+        it.item.hoverName.formattedTextCompat().trim().isNotEmpty() && it.index in hypixelUltrasequencerData &&
             hypixelUltrasequencerData.indexOf(it.index) > (userUltrasequencerProgress.size - 1)
     }.sortedBy {
         hypixelUltrasequencerData.indexOf(it.index)
@@ -248,7 +248,7 @@ object ExperimentsAddonsHelper {
     }
 
     private fun InventoryUpdatedEvent.readPhaseOrNull(): HelperPhase? {
-        val phaseItemName = inventoryItems[PHASE_STATUS_SLOT]?.hoverName?.formattedTextCompatLeadingWhiteLessResets() ?: return null
+        val phaseItemName = inventoryItems[PHASE_STATUS_SLOT]?.hoverName?.formattedTextCompat() ?: return null
         return when {
             replicatePhaseItemPattern.matches(phaseItemName) -> HelperPhase.REPLICATE
             readPhaseItemPattern.matches(phaseItemName) -> HelperPhase.READ
@@ -257,7 +257,7 @@ object ExperimentsAddonsHelper {
     }
 
     private fun InventoryUpdatedEvent.readChronomatronRoundOrNull(): Int? {
-        val roundItemName = inventoryItems[ROUND_STATUS_SLOT]?.hoverName?.formattedTextCompatLeadingWhiteLessResets() ?: return null
+        val roundItemName = inventoryItems[ROUND_STATUS_SLOT]?.hoverName?.formattedTextCompat() ?: return null
         return roundItemPattern.matchGroup(roundItemName, "round")?.formatIntOrNull()
     }
 
@@ -306,7 +306,7 @@ object ExperimentsAddonsHelper {
 
     private fun InventoryUpdatedEvent.readUltrasequencer() {
         val orderedUltrasequencerSlots = inventoryItems.filter {
-            it.value.hoverName.formattedTextCompatLeadingWhiteLessResets().trim().isNotEmpty()
+            it.value.hoverName.formattedTextCompat().trim().isNotEmpty()
         }.mapNotNull { (slot, stack) ->
             val sequenceNumber = stack.hoverName.string.removeColor().toIntOrNull() ?: return@mapNotNull null
             currentUltraSequencerRound = maxOf(currentUltraSequencerRound, sequenceNumber)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -35,7 +35,7 @@ import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.enumMapOf
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
@@ -175,7 +175,7 @@ object ExperimentsProfitTracker {
     }
 
     private fun NeuInternalName.formatWarningString(amount: Int) = buildString {
-        val displayName = getItemStackOrNull()?.hoverName?.formattedTextCompatLeadingWhiteLessResets() ?: "XP Bottle"
+        val displayName = getItemStackOrNull()?.hoverName?.formattedTextCompat() ?: "XP Bottle"
         val amountFormat = "§8${amount}x ".takeIf { amount > 1 }.orEmpty()
         appendLine("§aExperiments Tracker§7:")
         appendLine("§eAutomatically tracked usage of $amountFormat$displayName §ewhile near the Experimentation Table§7.")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/SuperPairsItemVisibility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/SuperPairsItemVisibility.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.events.render.gui.ReplaceItemEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SafeItemStack
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 
 // Todo: Merge this with SuperpairDataDisplay
 //  Store slots over there
@@ -39,7 +39,7 @@ object SuperPairsItemVisibility {
         if (!config.enabled) return
         if (!ExperimentationTableApi.inTable || ExperimentationTableApi.currentExperimentType != TaskType.SUPERPAIRS) return
         if (superpairsSlotMap.isEmpty() || event.slot !in superpairsSlotMap.keys) return
-        if (!unknownSuperpairsClickPattern.matches(event.originalItem.hoverName.formattedTextCompatLeadingWhiteLessResets())) return
+        if (!unknownSuperpairsClickPattern.matches(event.originalItem.hoverName.formattedTextCompat())) return
         val replacementItem = superpairsSlotMap[event.slot] ?: return
         event.replace(replacementItem)
     }
@@ -56,7 +56,7 @@ object SuperPairsItemVisibility {
             it !in superpairsSlotMap.keys
         } ?: return
         val clickedItem = item ?: return
-        if (unknownSuperpairsClickPattern.matches(clickedItem.hoverName.formattedTextCompatLeadingWhiteLessResets())) superpairsSlotsToRead.add(slotNumber)
+        if (unknownSuperpairsClickPattern.matches(clickedItem.hoverName.formattedTextCompat())) superpairsSlotsToRead.add(slotNumber)
         else superpairsSlotMap[slotNumber] = clickedItem
     }
 
@@ -66,7 +66,7 @@ object SuperPairsItemVisibility {
         if (superpairsSlotsToRead.isEmpty()) return
 
         inventoryItems.filter {
-            it.key in superpairsSlotsToRead && !unknownSuperpairsClickPattern.matches(it.value.hoverName.formattedTextCompatLeadingWhiteLessResets())
+            it.key in superpairsSlotsToRead && !unknownSuperpairsClickPattern.matches(it.value.hoverName.formattedTextCompat())
         }.forEach {
             superpairsSlotMap[it.key] = it.value
             superpairsSlotsToRead.remove(it.key)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/SuperpairDataDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/SuperpairDataDisplay.kt
@@ -23,7 +23,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.compat.DyeCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import kotlin.time.Duration.Companion.milliseconds
 
 // TODO: Split reading into ExperimentationSuperpairApi, leaving display to just use the data
@@ -134,12 +134,12 @@ object SuperpairDataDisplay {
         val currentTier = ExperimentationTableApi.currentExperimentTier ?: return
 
         val item = event.item ?: return
-        if (isOutOfBounds(event.slotId, currentTier) || item.hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor() == "?") return
+        if (isOutOfBounds(event.slotId, currentTier) || item.hoverName.formattedTextCompat().removeColor() == "?") return
 
         val items = uncoveredItems.toMutableMap()
         val itemExistsInData = items.any { it.value.slotId == event.slotId && it.key == items.keys.max() }
         val clicksItem = InventoryUtils.getItemAtSlotIndex(4)
-        val clicksItemName = clicksItem?.hoverName?.formattedTextCompatLeadingWhiteLessResets()?.removeColor().orEmpty()
+        val clicksItemName = clicksItem?.hoverName?.formattedTextCompat()?.removeColor().orEmpty()
         val hasRemainingClicks = remainingClicksPattern.matchMatcher(clicksItemName) {
             group("clicks").toInt() > 0
         } ?: false
@@ -150,7 +150,7 @@ object SuperpairDataDisplay {
 
     private fun handleItem(items: MutableMap<Int, SuperpairItem>, slot: Int) = DelayedRun.runDelayed(200.milliseconds) {
         val itemNow = InventoryUtils.getItemAtSlotIndex(slot) ?: return@runDelayed
-        val itemName = itemNow.hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor()
+        val itemName = itemNow.hoverName.formattedTextCompat().removeColor()
         val reward = itemNow.convertToReward()
         val itemData = SuperpairItem(slot, reward, DyeCompat.toDamage(itemNow))
         val uncovered = items.keys.maxOrNull() ?: -1
@@ -321,7 +321,7 @@ object SuperpairDataDisplay {
         ((currentExperiment.gridSize - 2) / 2) - currentFoundData.filter { it.key != FoundType.POWERUP }.values.sumOf { it.size }
 
     private fun SafeItemStack.convertToReward() = when {
-        guardianPetInternalNamePattern.matches(getInternalNameOrNull()?.asString().orEmpty()) -> hoverName.formattedTextCompatLeadingWhiteLessResets().split("] ")[1]
+        guardianPetInternalNamePattern.matches(getInternalNameOrNull()?.asString().orEmpty()) -> hoverName.formattedTextCompat().split("] ")[1]
         hoverName.string.removeColor() == "Enchanted Book" -> getLore()[2].removeColor()
         else -> hoverName.string.removeColor()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedGlassPane
 import at.hannibal2.skyhanni.utils.compat.DyeCompat
 import at.hannibal2.skyhanni.utils.compat.DyeCompat.Companion.isDye
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.annotations.Expose
 import kotlin.time.Duration.Companion.milliseconds
@@ -99,7 +99,7 @@ object WardrobeApi {
         var totalPrice = 0.0
         for (stack in slot.armor.filterNotNull().filter { it.getInternalNameOrNull() != null }) {
             EstimatedItemValueCalculator.getTotalPrice(stack)?.let { price ->
-                add("  §7- ${stack.hoverName.formattedTextCompatLeadingWhiteLessResets()}: §6${price.shortFormat()}")
+                add("  §7- ${stack.hoverName.formattedTextCompat()}: §6${price.shortFormat()}")
                 totalPrice += price
             }
         }
@@ -154,7 +154,7 @@ object WardrobeApi {
                 getWardrobeItem(itemsList[slot.leggingsSlot]),
                 getWardrobeItem(itemsList[slot.bootsSlot]),
             )
-            if (equippedSlotPattern.matches(itemsList[slot.inventorySlot]?.hoverName.formattedTextCompatLeadingWhiteLessResets())) {
+            if (equippedSlotPattern.matches(itemsList[slot.inventorySlot]?.hoverName.formattedTextCompat())) {
                 currentSlot = slot.id
                 foundCurrentSlot = true
             }
@@ -197,7 +197,7 @@ object WardrobeApi {
                 } else {
                     add(slotInfo)
                     setOf("Helmet", "Chestplate", "Leggings", "Boots").forEachIndexed { id, armorName ->
-                        slot.getData()?.armor?.get(id)?.hoverName?.formattedTextCompatLeadingWhiteLessResets()?.let { name ->
+                        slot.getData()?.armor?.get(id)?.hoverName?.formattedTextCompat()?.let { name ->
                             add("   $armorName: $name")
                         }
                     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/ActualGemstonePowderDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/ActualGemstonePowderDisplay.kt
@@ -194,7 +194,12 @@ object ActualGemstonePowderDisplay {
             if (upgradeDrill > 0) drillFactors.add(SimpleFactor("Goblin Egg", upgradeDrill / 100.0))
 
             if (drillFactors.isNotEmpty()) {
-                hotmFactors.add(AdditiveFactor(heldItem.displayName.formattedTextCompat(), factors = drillFactors))
+                hotmFactors.add(
+                    AdditiveFactor(
+                        heldItem.displayName.formattedTextCompat(extraResets = true, leadingWhite = false),
+                        factors = drillFactors,
+                    ),
+                )
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorTooltipHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorTooltipHider.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.SimpleContainer
 

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/InfernoMinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/InfernoMinionFeatures.kt
@@ -15,7 +15,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -57,7 +57,7 @@ object InfernoMinionFeatures {
 
         val fuelItemName = event.container.getSlot(MINION_FUEL_SLOT).item.hoverName
         val containsFuel =
-            NeuInternalName.fromItemNameOrNull(fuelItemName.formattedTextCompatLeadingWhiteLessResets()) in fuelItemIds
+            NeuInternalName.fromItemNameOrNull(fuelItemName.formattedTextCompat()) in fuelItemIds
         if (!containsFuel) return
 
         if (event.slot?.index == MINION_FUEL_SLOT || event.slot?.index == MINION_PICKUP_SLOT) {
@@ -72,7 +72,7 @@ object InfernoMinionFeatures {
         if (!inInventory) return
         event.slot?.index ?: return
 
-        val containsFuel = NeuInternalName.fromItemNameOrNull(event.itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()) in fuelItemIds
+        val containsFuel = NeuInternalName.fromItemNameOrNull(event.itemStack.hoverName.formattedTextCompat()) in fuelItemIds
         if (!containsFuel) return
 
         if (event.slot.index == MINION_FUEL_SLOT) {

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -52,7 +52,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
@@ -190,7 +190,7 @@ object MinionFeatures {
         if (!minionTitlePattern.find(inventoryName)) return
 
         event.inventoryItems[48]?.let {
-            if (minionCollectItemPattern.matches(it.hoverName.formattedTextCompatLeadingWhiteLessResets())) {
+            if (minionCollectItemPattern.matches(it.hoverName.formattedTextCompat())) {
                 MinionOpenEvent(inventoryName, event.inventoryItems).post()
                 return
             }
@@ -330,7 +330,7 @@ object MinionFeatures {
         val coinsPerDay = (coins / (duration.inWholeMilliseconds)) * 1000 * 60 * 60 * 24
 
         val format = coinsPerDay.toInt().addSeparators()
-        return "§7Coins/day with ${stack.hoverName.formattedTextCompatLeadingWhiteLessResets()}§7: §6$format coins"
+        return "§7Coins/day with ${stack.hoverName.formattedTextCompat()}§7: §6$format coins"
     }
 
     // TODO reshape to data class, use Resettable

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/BrewingStandOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/BrewingStandOverlay.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 
 @SkyHanniModule
 object BrewingStandOverlay {
@@ -16,7 +16,7 @@ object BrewingStandOverlay {
         if (event.inventoryName != "Brewing Stand") return
 
         val stack = event.stack
-        val name = stack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val name = stack.hoverName.formattedTextCompat()
 
         val slotNumber = event.slot.index
         when (slotNumber) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CakeCounterFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CakeCounterFeatures.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.world.entity.decoration.ArmorStand
@@ -100,7 +100,7 @@ object CakeCounterFeatures {
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
     fun onEntityChangeName(event: EntityCustomNameUpdateEvent<ArmorStand>) {
         val entity = event.entity
-        val name = entity.name.formattedTextCompatLessResets()
+        val name = entity.name.formattedTextCompat(leadingWhite = false)
         val entityId = entity.id
 
         if (cakesEatenEntityId == null) {
@@ -141,7 +141,7 @@ object CakeCounterFeatures {
 
         val nearbyArmorStands = cakesStand.blockPosition().toLorenzVec().getEntitiesNearby<ArmorStand>(1.0)
         soulsStandExists = nearbyArmorStands.any { armorStand ->
-            soulsFoundPattern.matchMatcher(armorStand.name.formattedTextCompatLessResets()) {
+            soulsFoundPattern.matchMatcher(armorStand.name.formattedTextCompat(leadingWhite = false)) {
                 soulsFoundEntityId = armorStand.id
                 ChatUtils.debug("Found \"Souls Found\" entity (from \"Cakes Eaten\" location)")
                 updateSoulsFound()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CenturyPartyInvitation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CenturyPartyInvitation.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sublistAfter
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import kotlin.time.Duration.Companion.milliseconds
@@ -146,7 +146,7 @@ object CenturyPartyInvitation {
     }
 
     private fun addPlayer(mob: Mob) {
-        val displayName = mob.baseEntity.name.formattedTextCompatLessResets()
+        val displayName = mob.baseEntity.name.formattedTextCompat(leadingWhite = false)
         val colorCode = playerRankColorPattern.matchMatcher(displayName) {
             group("color")
         } ?: run {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CoralFishHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CoralFishHelper.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.DyeCompat
 import at.hannibal2.skyhanni.utils.compat.DyeCompat.Companion.isDye
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.SearchTextInput
 import at.hannibal2.skyhanni.utils.renderables.Searchable
@@ -61,7 +61,7 @@ object CoralFishHelper {
         val neededFish = mutableListOf<String>()
 
         for (item in items) {
-            val itemName = item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val itemName = item.hoverName.formattedTextCompat()
             if (!ModernPatterns.coralFishNamePattern.matches(itemName)) continue
 
             if (!item.isDye(DyeCompat.GRAY)) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/EnchantedClockHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/EnchantedClockHelper.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.annotations.Expose
 import kotlin.time.Duration
@@ -111,7 +111,7 @@ object EnchantedClockHelper {
             fun byUsageStringOrNull(usageString: String) = entries.firstOrNull { it.usageString == usageString }
             fun bySimpleBoostType(simple: SimpleBoostType) = entries.firstOrNull { it.name == simple.name }
             fun byItemStackOrNull(stack: SafeItemStack) = entries.firstOrNull {
-                it.formattedName == stack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+                it.formattedName == stack.hoverName.formattedTextCompat()
             }
 
             fun populateFromJson(json: EnchantedClockJson) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MagicalPowerDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MagicalPowerDisplay.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -86,7 +86,7 @@ object MagicalPowerDisplay {
         val internalName = item.getInternalNameOrNull() ?: return
 
         var endMP = rarity.toMP() ?: ErrorManager.skyHanniError(
-            "Unknown rarity '$rarity' for item '${item.hoverName.formattedTextCompatLeadingWhiteLessResets()}§7'",
+            "Unknown rarity '$rarity' for item '${item.hoverName.formattedTextCompat()}§7'",
         )
 
         when (internalName) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MarkedPlayerManager.kt
@@ -23,7 +23,7 @@ import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchAll
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.RemotePlayer
 
@@ -57,7 +57,7 @@ object MarkedPlayerManager {
     fun onEntityEnterWorld(event: EntityEnterWorldEvent<RemotePlayer>) {
         if (!isEnabled()) return
         val entity = event.entity
-        val name = entity.name.formattedTextCompatLessResets().lowercase()
+        val name = entity.name.formattedTextCompat(leadingWhite = false).lowercase()
         if (name in playerNamesToMark) {
             markedPlayers[name] = entity
             entity.setColor()
@@ -70,7 +70,7 @@ object MarkedPlayerManager {
         for (entity in EntityUtils.getPlayerEntities()) {
             if (entity in markedPlayers.values) continue
 
-            val name = entity.name.formattedTextCompatLessResets().lowercase()
+            val name = entity.name.formattedTextCompat(leadingWhite = false).lowercase()
             if (name in playerNamesToMark) {
                 markedPlayers[name] = entity
                 entity.setColor()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -24,7 +24,6 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.merge
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import kotlinx.coroutines.flow.merge
 import net.minecraft.client.Minecraft
 import net.minecraft.network.chat.Component
 import java.util.regex.Matcher
@@ -71,7 +70,7 @@ object AdvancedPlayerList {
         var i = 0
 
         for (component in original) {
-            val line = component.formattedTextCompat()
+            val line = component.formattedTextCompat(extraResets = true, leadingWhite = false)
             i++
             if (i == 1) continue
             if (line.isEmpty() || line.contains("Server Info")) break

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
@@ -168,7 +168,7 @@ object TabListReader {
 
         for (entry in fullTabComponents.indices step 20) {
             val titleComponent = fullTabComponents[entry]
-            val trimmedTitle = Component.literal(titleComponent.formattedTextCompat().trim())
+            val trimmedTitle = Component.literal(titleComponent.formattedTextCompat(extraResets = true, leadingWhite = false).trim())
             val column = getColumnFromComponent(this, trimmedTitle) ?: TabColumn(trimmedTitle).also {
                 add(it)
             }
@@ -238,7 +238,7 @@ object TabListReader {
         }
         upgradesPattern.matchMatcher(component) {
             if (!inUpgrades) return@matchMatcher
-            if (!component.formattedTextCompat().startsWith("§e")) return@matchMatcher
+            if (!component.formattedTextCompat(extraResets = true, leadingWhite = false).startsWith("§e")) return@matchMatcher
 
             val firstComponent = TextHelper.matcher(component, group("firstPart")) ?: return@apply
             val secondComponent = TextHelper.matcher(component, group("secondPart")) ?: return@apply
@@ -251,7 +251,7 @@ object TabListReader {
             return@apply
         }
 
-        val formatted = component.formattedTextCompat()
+        val formatted = component.formattedTextCompat(extraResets = true, leadingWhite = false)
         when {
             // Separators are truly emptied
             formatted.removeColor().trim().isEmpty() -> {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/customtodos/CustomTodosGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/customtodos/CustomTodosGui.kt
@@ -42,7 +42,7 @@ object CustomTodosGui {
         todos.forEach { todo ->
             if (todo.triggerTarget != CustomTodo.TriggerTarget.TAB_LIST) return@forEach
             event.tabList.forEach { line ->
-                if (matchString(todo, line.formattedTextCompat())) todo.setDoneNow()
+                if (matchString(todo, line.formattedTextCompat(extraResets = true, leadingWhite = false))) todo.setDoneNow()
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -30,7 +30,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
@@ -208,7 +208,7 @@ object EstimatedItemValue {
 
     private fun SafeItemStack.shouldIgnoreDraw(): Boolean {
         this.getInternalNameOrNull()?.let { internalName ->
-            val name = this.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val name = this.hoverName.formattedTextCompat()
             return (
                 this.getItemCategoryOrNull() == ItemCategory.ENCHANTED_BOOK ||
                     name.contains("Salesperson") ||

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -81,7 +81,7 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumByKey
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.compat.NbtCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getCompoundOrDefault
 import at.hannibal2.skyhanni.utils.compat.getStringOrDefault
 import io.github.notenoughupdates.moulconfig.observer.Property
@@ -221,11 +221,11 @@ object EstimatedItemValueCalculator {
                 val oneBelow = itemRarity.oneBelow(logError = false)
                 if (oneBelow == null) {
                     ErrorManager.logErrorStateWithData(
-                        "Wrong item rarity detected in estimated item value for item ${stack.hoverName.formattedTextCompatLeadingWhiteLessResets()}",
+                        "Wrong item rarity detected in estimated item value for item ${stack.hoverName.formattedTextCompat()}",
                         "Recombobulated item is common",
                         "internal name" to stack.getInternalName(),
                         "itemRarity" to itemRarity,
-                        "item name" to stack.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                        "item name" to stack.hoverName.formattedTextCompat(),
                         "item nbt" to stack.readNbtDump(),
                     )
                     return null
@@ -236,12 +236,12 @@ object EstimatedItemValueCalculator {
 
         return reforgeCosts[itemRarity]?.toInt() ?: run {
             ErrorManager.logErrorStateWithData(
-                "Could not calculate reforge cost for item ${stack.hoverName.formattedTextCompatLeadingWhiteLessResets()}",
+                "Could not calculate reforge cost for item ${stack.hoverName.formattedTextCompat()}",
                 "Item not in NEU repo reforge cost",
                 "reforgeCosts" to reforgeCosts,
                 "itemRarity" to itemRarity,
                 "internal name" to stack.getInternalName(),
-                "item name" to stack.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                "item name" to stack.hoverName.formattedTextCompat(),
                 "reforgeStone" to reforgeStone,
                 "item nbt" to stack.readNbtDump(),
             )
@@ -468,7 +468,7 @@ object EstimatedItemValueCalculator {
             kuudraArmorTiers.getOrNull(index)?.let { tierName ->
                 EstimatedItemValue.crimsonPrestigeCosts[tierName] ?: run {
                     ErrorManager.logErrorStateWithData(
-                        "Could not find crimson prestige cost for ${stack.hoverName.formattedTextCompatLeadingWhiteLessResets()}",
+                        "Could not find crimson prestige cost for ${stack.hoverName.formattedTextCompat()}",
                         "EstimatedItemValue has no crimsonPrestigeCosts for $tierName tier",
                         "internalName" to internalName,
                         "tierIndex" to tierIndex,
@@ -917,11 +917,11 @@ object EstimatedItemValueCalculator {
             if (internalName in EstimatedItemValue.hasLegacyGemstoneSlots) return null
 
             ErrorManager.logErrorStateWithData(
-                "Could not find gemstone slot price for ${this.hoverName.formattedTextCompatLeadingWhiteLessResets()}",
+                "Could not find gemstone slot price for ${this.hoverName.formattedTextCompat()}",
                 "EstimatedItemValue has no gemstoneUnlockCosts for $internalName",
                 "internal name" to internalName,
                 "gemstoneUnlockCosts" to EstimatedItemValue.gemstoneUnlockCosts,
-                "item name" to hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                "item name" to hoverName.formattedTextCompat(),
                 "item nbt" to readNbtDump(),
             )
             return null

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -334,7 +334,12 @@ object EnchantParser {
             val strippedLine = loreList[i].unformattedTextCompat()
 
             if (startEnchant == -1) {
-                if (this.enchants.containsEnchantment(enchants, loreList[i].formattedTextCompat())) startEnchant = i
+                if (
+                    this.enchants.containsEnchantment(
+                        enchants,
+                        loreList[i].formattedTextCompat(extraResets = true, leadingWhite = false),
+                    )
+                ) startEnchant = i
             } else {
                 if (strippedLine.trim().isEmpty() && endEnchant == -1) endEnchant = i - 1 // Handles item tooltips end line
                 else if (strippedLine.contains("\n\n")) { // Handles chat component tooltips end line
@@ -355,7 +360,9 @@ object EnchantParser {
         val isRoman = !SkyHanniMod.feature.misc.replaceRomanNumerals.get()
         val regex = "[\\d,.kKmMbB]+\$".toRegex()
         for (i in startEnchant..endEnchant) {
-            val matcher = enchantmentPattern.matcher(loreList[i].formattedTextCompat().replace("\n", ""))
+            val matcher = enchantmentPattern.matcher(
+                loreList[i].formattedTextCompat(extraResets = true, leadingWhite = false).replace("\n", ""),
+            )
             var containsEnchant = false
             var enchantsOnThisLine = 0
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationFeedback.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationFeedback.kt
@@ -62,7 +62,7 @@ object NavigationFeedback {
     }
 
     private fun sendGuiFeedback(component: Component): Boolean {
-        val guiFormattedText = component.formattedTextCompat().replace("§e[SkyHanni] ", "§e")
+        val guiFormattedText = component.formattedTextCompat(extraResets = true, leadingWhite = false).replace("§e[SkyHanni] ", "§e")
         guiRenderable = Renderable.clickable(
             Renderable.text(guiFormattedText),
             onLeftClick = IslandGraphs::cancelClick,

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadCompactName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadCompactName.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.decoration.ArmorStand
 
@@ -35,7 +35,7 @@ object TeleportPadCompactName {
         if (!SkyHanniMod.feature.misc.teleportPad.compactName) return
         val entity = event.entity
 
-        val name = entity.name.formattedTextCompatLessResets()
+        val name = entity.name.formattedTextCompat(leadingWhite = false)
 
         noNamePattern.matchMatcher(name) {
             event.cancel()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadInventoryNumber.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadInventoryNumber.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -78,7 +78,7 @@ object TeleportPadInventoryNumber {
     fun onRenderItemTip(event: RenderInventoryItemTipEvent) {
         if (!inTeleportPad) return
 
-        padNumberPattern.matchMatcher(event.stack.hoverName.formattedTextCompatLeadingWhiteLessResets().lowercase()) {
+        padNumberPattern.matchMatcher(event.stack.hoverName.formattedTextCompat().lowercase()) {
             numbers[group("number")]?.let {
                 event.stackTip = "$it"
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -33,7 +33,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.compat.command
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
@@ -336,7 +336,7 @@ object TrevorFeatures {
     @HandleEvent(priority = HandleEvent.HIGHEST, onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
     fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!inTrapperDen || !config.cooldown) return
-        if (event.entity.name.formattedTextCompatLessResets() == "§e§lCLICK") event.cancel()
+        if (event.entity.name.formattedTextCompat(leadingWhite = false) == "§e§lCLICK") event.cancel()
     }
 
     private fun resetTrapper() {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat.Companion.hasPotionEffect
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.LivingEntity
@@ -59,7 +59,7 @@ object TrevorSolver {
             if (entity is RemotePlayer) continue
             val mob = MobData.entityToMob[entity]
             if (mob?.isAlive == false) continue
-            val name = entity.name.formattedTextCompatLessResets()
+            val name = entity.name.formattedTextCompat(leadingWhite = false)
             val isTrevor = mob?.let { it.name != name && isTrevorMob(it) } ?: false
             val entityHealth = if (entity is LivingEntity) entity.baseMaxHealth.derpy() else 0
             currentMob = TrevorMob.findByName(name)

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/RescueMissionWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/RescueMissionWaypoints.kt
@@ -27,7 +27,7 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.ParkourHelper
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -128,7 +128,7 @@ object RescueMissionWaypoints {
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!menuPattern.matches(event.inventoryName)) return
-        val name = event.inventoryItems[22]?.hoverName?.formattedTextCompatLeadingWhiteLessResets() ?: return
+        val name = event.inventoryItems[22]?.hoverName?.formattedTextCompat() ?: return
 
         tier = questTierPattern.matchMatcher(name) {
             group("tier").toLetter()

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangHider.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.events.ReceiveParticleEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.getAllEquipment
 import net.minecraft.world.entity.decoration.ArmorStand
 

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/dailyquest/DailyQuestHelper.kt
@@ -47,7 +47,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeWordsAtEnd
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -145,7 +145,7 @@ object DailyQuestHelper {
             if (dojoQuest.state != QuestState.ACCEPTED) return
 
             for ((slot, stack) in chest.getUpperItems()) {
-                if (stack.hoverName.formattedTextCompatLeadingWhiteLessResets().contains(dojoQuest.dojoName)) {
+                if (stack.hoverName.formattedTextCompat().contains(dojoQuest.dojoName)) {
                     slot.highlight(LorenzColor.AQUA)
                 }
             }
@@ -196,7 +196,7 @@ object DailyQuestHelper {
         val itemName = fetchQuest.itemName
 
         val count =
-            InventoryUtils.countItemsInLowerInventory { it.hoverName.formattedTextCompatLeadingWhiteLessResets().removeColor() == itemName }
+            InventoryUtils.countItemsInLowerInventory { it.hoverName.formattedTextCompat().removeColor() == itemName }
         updateProcessQuest(fetchQuest, count)
     }
 
@@ -296,7 +296,7 @@ object DailyQuestHelper {
         val item = quest.displayItem.getItemStack()
 
         val displayName = if (category == QuestCategory.FETCH || category == QuestCategory.FISHING) {
-            val name = item.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val name = item.hoverName.formattedTextCompat()
             if (category == QuestCategory.FISHING) {
                 name.removeWordsAtEnd(1)
             } else name

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/PetExpTooltip.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/PetExpTooltip.kt
@@ -20,7 +20,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PetUtils
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getPetInfo
 import at.hannibal2.skyhanni.utils.StringUtils
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.network.chat.Component
 
 @SkyHanniModule
@@ -38,7 +38,7 @@ object PetExpTooltip {
 
         val itemStack = event.itemStack
         val petExperience = itemStack.getPetInfo()?.exp?.roundTo(1) ?: return
-        val name = itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val name = itemStack.hoverName.formattedTextCompat()
         try {
             val index = findIndex(event.toolTip) ?: return
             val fixedIndex = if (index > event.toolTip.size) {

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/PetNametag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/PetNametag.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.groupOrEmpty
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.decoration.ArmorStand
 
@@ -31,7 +31,7 @@ object PetNametag {
     fun onNameTagRender(event: EntityDisplayNameEvent<ArmorStand>) {
         if (!isEnabled()) return
 
-        val standName: String = event.chatComponent.formattedTextCompatLessResets()
+        val standName: String = event.chatComponent.formattedTextCompat(leadingWhite = false)
 
         petNametagPattern.matchMatcher(standName) {
             val start = group("start")

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BacteApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BacteApi.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
@@ -75,7 +75,7 @@ object BacteApi {
     fun onSecondPassed(event: SecondPassedEvent) {
         val bacte = bacte ?: return
 
-        val name = bacte.armorStand?.name?.formattedTextCompatLessResets() ?: return
+        val name = bacte.armorStand?.name?.formattedTextCompat(leadingWhite = false) ?: return
 
         namePattern.matchMatcher(name) {
             currentPhase = Phase.fromNumber(group("name").length)

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.compat.deceased
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
@@ -80,7 +80,7 @@ object LivingCaveDefenseBlocks {
                 // read new entity data
                 val compareLocation = event.location.add(-0.5, -1.5, -0.5)
                 entity = compareLocation.getEntitiesNearby<RemotePlayer>(2.0)
-                    .filter { isCorrectMob(it.name.formattedTextCompatLessResets()) }
+                    .filter { isCorrectMob(it.name.formattedTextCompat(leadingWhite = false)) }
                     .filter { !it.isAtFullHealth() }
                     .minByOrNull { it.distanceTo(compareLocation) }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingMetalSuitProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingMetalSuitProgress.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getLivingMetalProgress
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.addLine
 
@@ -53,7 +53,7 @@ object LivingMetalSuitProgress {
             addLine {
                 addString("§7- ")
                 addItemStack(stack)
-                addString("${stack.hoverName.formattedTextCompatLeadingWhiteLessResets()}: ")
+                addString("${stack.hoverName.formattedTextCompat()}: ")
                 addString(
                     progress?.let {
                         drawProgressBar(it) + " §b${it.formatPercentage()}"

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -79,7 +79,7 @@ object CraftRoomHolographicMob {
 
     private fun LivingEntity.display() = buildString {
         if (config.showName) {
-            val mobName = displayName.formattedTextCompat()
+            val mobName = displayName.formattedTextCompat(extraResets = true, leadingWhite = false)
             append("§a$mobName ")
         }
         if (config.showHealth) {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/stillgorechateau/RiftBloodEffigies.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/stillgorechateau/RiftBloodEffigies.kt
@@ -21,7 +21,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
@@ -149,7 +149,7 @@ object RiftBloodEffigies {
         if (!isEnabled()) return
 
         eLoop@for (entity in LocationUtils.playerLocation().getEntitiesNearby<ArmorStand>(15.0)) {
-            effigiesTimerPattern.matchMatcher(entity.name.formattedTextCompatLessResets()) {
+            effigiesTimerPattern.matchMatcher(entity.name.formattedTextCompat(leadingWhite = false)) {
                 val index = getIndex(entity) ?: continue@eLoop
                 val time = TimeUtils.getDuration(group("time"))
                 effigies[index]?.let {
@@ -159,7 +159,7 @@ object RiftBloodEffigies {
                 continue@eLoop
             }
 
-            if (effigiesBreakPattern.matches(entity.name.formattedTextCompatLessResets())) {
+            if (effigiesBreakPattern.matches(entity.name.formattedTextCompat(leadingWhite = false))) {
                 val index = getIndex(entity) ?: continue
                 effigies[index]?.state = EffigyState.NOT_BROKEN
                 continue

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/RiftTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/RiftTimer.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
 import kotlin.time.Duration

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/ShowMotesNpcSellPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/ShowMotesNpcSellPrice.kt
@@ -24,7 +24,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.addRenderableButton
 import at.hannibal2.skyhanni.utils.renderables.addLine
@@ -145,7 +145,7 @@ object ShowMotesNpcSellPrice {
                 addString("  §7- ")
                 addItemStack(stack)
                 val tips = buildList {
-                    add("§6Item: ${stack.hoverName.formattedTextCompatLeadingWhiteLessResets()}")
+                    add("§6Item: ${stack.hoverName.formattedTextCompat()}")
                     add("§6Value per: §d$valuePer Motes")
                     add("§6Total in chest: §d${(value / valuePer).toInt()}")
                     add("")
@@ -153,7 +153,7 @@ object ShowMotesNpcSellPrice {
                 }
                 add(
                     Renderable.hoverTips(
-                        "§6${stack.hoverName.formattedTextCompatLeadingWhiteLessResets()}: §b$price",
+                        "§6${stack.hoverName.formattedTextCompat()}: §b$price",
                         tips,
                         highlightsOnHoverSlots = index,
                         stack = stack,

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/HideMobNames.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/HideMobNames.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.world.entity.decoration.ArmorStand
 import java.util.regex.Pattern
 import kotlin.time.Duration.Companion.minutes
@@ -56,7 +56,7 @@ object HideMobNames {
         val entity = event.entity
         if (!entity.hasCustomName()) return
 
-        val name = entity.name.formattedTextCompatLessResets()
+        val name = entity.name.formattedTextCompat(leadingWhite = false)
         val id = entity.id
         if (lastMobName[id] == name) {
             if (id in mobNamesHidden) {

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -38,7 +38,7 @@ import at.hannibal2.skyhanni.utils.TimeUtils.ticks
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
@@ -73,7 +73,7 @@ object VampireSlayerFeatures {
 
     // Nicked support
     private val username
-        get() = EntityUtils.getEntities<LocalPlayer>().firstOrNull()?.name?.formattedTextCompatLessResets()
+        get() = EntityUtils.getEntities<LocalPlayer>().firstOrNull()?.name?.formattedTextCompat(leadingWhite = false)
             ?: error("own player is null")
 
     private val BLOOD_ICHOR_TEXTURE by lazy { SkullTextureHolder.getTexture("BLOOD_ICHOR") }
@@ -119,9 +119,9 @@ object VampireSlayerFeatures {
 
     private fun List<String>.spawnedByCoop(stand: ArmorStand): Boolean = any {
         var contain = false
-        if (".*§(?:\\d|\\w)+Spawned by: §(?:\\d|\\w)(\\w*).*".toRegex().matches(stand.name.formattedTextCompatLessResets())) {
+        if (".*§(?:\\d|\\w)+Spawned by: §(?:\\d|\\w)(\\w*).*".toRegex().matches(stand.name.formattedTextCompat(leadingWhite = false))) {
             val name = ".*§(?:\\d|\\w)+Spawned by: §(?:\\d|\\w)(\\w*)".toRegex()
-                .find(stand.name.formattedTextCompatLessResets())?.groupValues?.get(1)
+                .find(stand.name.formattedTextCompat(leadingWhite = false))?.groupValues?.get(1)
             contain = it == name
         }
         contain
@@ -133,11 +133,11 @@ object VampireSlayerFeatures {
 
         for (stand in getAllNameTagsInRadiusWith("TWINCLAWS")) {
             if (!".*(?:§(?:\\d|\\w))+TWINCLAWS (?:§(?:\\w|\\d))+[0-9.,]+s.*".toRegex()
-                    .matches(stand.name.formattedTextCompatLessResets())
+                    .matches(stand.name.formattedTextCompat(leadingWhite = false))
             ) continue
             val coopList = configCoopBoss.coopMembers.split(",").toList()
             val containUser = getAllNameTagsInRadiusWith("Spawned by").any {
-                it.name.formattedTextCompatLessResets().contains(username)
+                it.name.formattedTextCompat(leadingWhite = false).contains(username)
             }
             val containCoop = getAllNameTagsInRadiusWith("Spawned by").any {
                 configCoopBoss.highlight && coopList.spawnedByCoop(it)
@@ -161,12 +161,12 @@ object VampireSlayerFeatures {
     }
 
     private fun RemotePlayer.process() {
-        if (name.formattedTextCompatLessResets() != "Bloodfiend ") return
+        if (name.formattedTextCompat(leadingWhite = false) != "Bloodfiend ") return
 
         processTwinClawsTitle()
         for (it in getAllNameTagsInRadiusWith("Spawned by")) {
             val coopList = configCoopBoss.coopMembers.split(",").toList()
-            val containUser = it.name.formattedTextCompatLessResets().contains(username)
+            val containUser = it.name.formattedTextCompat(leadingWhite = false).contains(username)
             val containCoop = coopList.spawnedByCoop(it)
             val neededHealth = baseMaxHealth * 0.2f
             if (containUser && taggedEntityList.contains(id)) {
@@ -219,13 +219,13 @@ object VampireSlayerFeatures {
             val containCoop = coopList.isNotEmpty() &&
                 coopList.any {
                     var contain = false
-                    if (regexA.matches(armorStand.name.formattedTextCompatLessResets())) {
-                        val name = regexB.find(armorStand.name.formattedTextCompatLessResets())?.groupValues?.get(1)
+                    if (regexA.matches(armorStand.name.formattedTextCompat(leadingWhite = false))) {
+                        val name = regexB.find(armorStand.name.formattedTextCompat(leadingWhite = false))?.groupValues?.get(1)
                         contain = it == name
                     }
                     contain
                 }
-            if (armorStand.name.formattedTextCompatLessResets().contains(username) || containCoop) return
+            if (armorStand.name.formattedTextCompat(leadingWhite = false).contains(username) || containCoop) return
             if (!taggedEntityList.contains(event.clickedEntity.id)) {
                 taggedEntityList.add(event.clickedEntity.id)
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningSoulsName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningSoulsName.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sorted
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import net.minecraft.world.entity.Mob
@@ -61,9 +61,9 @@ object SummoningSoulsName {
         for (entity in EntityUtils.getEntities<Mob>()) {
             val id = entity.id
             val consumer = entity.getNameTagWith(2, "§c❤")
-            if (consumer != null && !consumer.name.formattedTextCompatLessResets().contains("§e0")) {
+            if (consumer != null && !consumer.name.formattedTextCompat(leadingWhite = false).contains("§e0")) {
                 mobsLastLocation[id] = entity.getLorenzVec()
-                mobsName[id] = consumer.name.formattedTextCompatLessResets()
+                mobsName[id] = consumer.name.formattedTextCompat(leadingWhite = false)
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiIngameHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiIngameHook.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
 import at.hannibal2.skyhanni.data.ScoreboardData
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import net.minecraft.client.gui.Font
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.network.chat.Component

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGui.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGui.java
@@ -107,7 +107,7 @@ public class MixinGui {
 
     @WrapMethod(method = "setTitle")
     private void handleTitle(Component component, Operation<Void> original) {
-        String formattedText = TextCompatKt.formattedTextCompat(component);
+        String formattedText = TextCompatKt.formattedTextCompat(component, false, false);
         if (!new TitleReceivedEvent(formattedText, false).post()) {
             original.call(component);
         }
@@ -115,7 +115,7 @@ public class MixinGui {
 
     @WrapMethod(method = "setSubtitle")
     private void handleSubtitle(Component component, Operation<Void> original) {
-        String formattedText = TextCompatKt.formattedTextCompat(component);
+        String formattedText = TextCompatKt.formattedTextCompat(component, false, false);
         if (!new TitleReceivedEvent(formattedText, true).post()) {
             original.call(component);
         }

--- a/src/main/java/at/hannibal2/skyhanni/test/TestCopyBestiaryValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/TestCopyBestiaryValues.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeWordsAtEnd
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.nextAfter
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.GsonBuilder
 import com.google.gson.annotations.Expose
@@ -70,7 +70,7 @@ object TestCopyBestiaryValues {
     }
 
     private fun copy(titleItem: SafeItemStack, inventoryItems: Map<Int, SafeItemStack>) {
-        val titleName = titleItem.hoverName.formattedTextCompatLeadingWhiteLessResets().removeWordsAtEnd(1)
+        val titleName = titleItem.hoverName.formattedTextCompat().removeWordsAtEnd(1)
 
         val obj = BestiaryObject()
         obj.name = titleName

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyItemCommand.kt
@@ -13,7 +13,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getReadableNBTDump
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getMinecraftId
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 
 @SkyHanniModule
 object CopyItemCommand {
@@ -30,7 +30,7 @@ object CopyItemCommand {
     fun copyItemToClipboard(itemStack: SafeItemStack) {
         val resultList = mutableListOf<String>()
         resultList.add("internal name: " + itemStack.getInternalName().asString())
-        resultList.add("display name: '" + itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets().toString() + "'")
+        resultList.add("display name: '" + itemStack.hoverName.formattedTextCompat().toString() + "'")
         resultList.add("minecraft id: '" + itemStack.getMinecraftId() + "'")
         resultList.add("lore:")
         for (line in itemStack.getLore()) {

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
@@ -30,8 +30,6 @@ import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEquipmentSlots
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import at.hannibal2.skyhanni.utils.compat.findHealthReal
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.Display
@@ -68,9 +66,9 @@ object CopyNearbyEntitiesCommand {
             val simpleName = entity.javaClass.simpleName
             add("entity: $simpleName")
             val displayName = entity.displayName
-            add("name: '" + entity.name.formattedTextCompatLessResets() + "'")
+            add("name: '" + entity.name.formattedTextCompat(leadingWhite = false) + "'")
             if (entity is ArmorStand) add("cleanName: '" + entity.cleanName() + "'")
-            add("displayName: '${displayName.formattedTextCompat()}'")
+            add("displayName: '${displayName.formattedTextCompat(extraResets = true, leadingWhite = false)}'")
             add("entityId: ${entity.id}")
             add("Category of Mob: ${getCategory(entity, mob)}")
             add("uuid version: ${entity.uuid.version()} (${entity.uuid})")
@@ -108,7 +106,7 @@ object CopyNearbyEntitiesCommand {
                 if (armor != null) {
                     add("armor:")
                     for ((i, itemStack) in armor.withIndex()) {
-                        val name = itemStack?.hoverName.formattedTextCompatLeadingWhiteLessResets()
+                        val name = itemStack?.hoverName.formattedTextCompat()
                         add("-  at: $i: $name")
                     }
                 }
@@ -181,8 +179,8 @@ object CopyNearbyEntitiesCommand {
     private fun MutableList<String>.addItem(entity: ItemEntity) {
         add("EntityItem:")
         val stack = entity.item
-        val stackName = stack.hoverName.formattedTextCompatLeadingWhiteLessResets()
-        val stackDisplayName = stack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val stackName = stack.hoverName.formattedTextCompat()
+        val stackDisplayName = stack.hoverName.formattedTextCompat()
         val cleanName = stack.cleanName()
         val itemEnchanted = stack.isEnchanted
         val stackSize = stack.count
@@ -276,7 +274,7 @@ object CopyNearbyEntitiesCommand {
         add("EntityBlockDisplay:")
         val block = entity.blockState.block
 
-        add("-  block: ${block.name.formattedTextCompat()}")
+        add("-  block: ${block.name.formattedTextCompat(extraResets = true, leadingWhite = false)}")
     }
 
     private fun MutableList<String>.addTextDisplayEntity(entity: Display.TextDisplay) {
@@ -301,7 +299,7 @@ object CopyNearbyEntitiesCommand {
                 add("-     $skullTexture")
             }
             val cleanName = stack.cleanName()
-            val stackName = stack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val stackName = stack.hoverName.formattedTextCompat()
             val type = stack.javaClass.name
             add("-     name: '$stackName'")
             add("-     cleanName: '$cleanName'")
@@ -393,5 +391,5 @@ object CopyNearbyEntitiesCommand {
     }
 
     private fun LivingEntity.asString() =
-        this.id.toString() + " - " + this.javaClass.simpleName + " \"" + this.name.formattedTextCompatLessResets() + "\""
+        this.id.toString() + " - " + this.javaClass.simpleName + " \"" + this.name.formattedTextCompat(leadingWhite = false) + "\""
 }

--- a/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/TestChatCommand.kt
@@ -70,7 +70,10 @@ object TestChatCommand {
         println("${component.unformattedTextForChatCompat()} ${component.style} ${component.siblings}")
         println(component)
 
-        val rawText = component.formattedTextCompat().stripHypixelMessage().replace("§", "&").replace("\n", "\\n")
+        val rawText = component.formattedTextCompat(extraResets = true, leadingWhite = false)
+            .stripHypixelMessage()
+            .replace("§", "&")
+            .replace("\n", "\\n")
         if (!isSilent) ChatUtils.chat("Testing message: §7$rawText", prefixColor = "§a")
 
         test(component)

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -160,7 +160,7 @@ object ChatUtils {
     }
 
     private fun logAndSendMessage(message: Component, send: Boolean = true): Boolean {
-        val formattedMessage = message.formattedTextCompat()
+        val formattedMessage = message.formattedTextCompat(extraResets = true, leadingWhite = false)
         log.log(formattedMessage)
 
         if (!MinecraftCompat.localPlayerExists) {
@@ -482,7 +482,7 @@ object ChatUtils {
             `skyhanni$setFullComponent`(value)
         }
 
-    val GuiMessage.chatMessage get() = content.formattedTextCompat().stripHypixelMessage()
+    val GuiMessage.chatMessage get() = content.formattedTextCompat(extraResets = true, leadingWhite = false).stripHypixelMessage()
     fun GuiMessage.passedSinceSent() = (Minecraft.getInstance().gui.guiTicks - addedTime()).ticks
 
     fun consoleLog(text: String) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComponentUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComponentUtils.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemModel
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.setLoreString
-import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getIdentifierString
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
@@ -81,7 +80,11 @@ object ComponentUtils {
         )
         val lore = stack.getLore()
         val color = stack.get(DataComponents.DYED_COLOR)?.rgb
-        val displayInfo = DisplayInfo(name = stack.hoverName.formattedTextCompat(), lore = lore, color = color)
+        val displayInfo = DisplayInfo(
+            name = stack.hoverName.formattedTextCompat(extraResets = true, leadingWhite = false),
+            lore = lore,
+            color = color,
+        )
         val customData = stack.get(DataComponents.CUSTOM_DATA)
         val itemModel = stack.getItemModel()?.getIdentifierString()
         val extraAttributes: JsonObject? = if (customData != null) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHandItem
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getStandHelmet
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.normalizeAsArray
 import at.hannibal2.skyhanni.utils.render.FrustumUtils
 import net.minecraft.client.Minecraft
@@ -93,9 +93,9 @@ object EntityUtils {
     ): List<ArmorStand> {
         val center = getLorenzVec().up(y)
         return getArmorStandsInRadius(center, inaccuracy).filter {
-            val result = it.name.formattedTextCompatLessResets().contains(contains)
+            val result = it.name.formattedTextCompat(leadingWhite = false).contains(contains)
             if (debugWrongEntity && !result) {
-                ChatUtils.consoleLog("wrong entity in aabb: '" + it.name.formattedTextCompatLessResets() + "'")
+                ChatUtils.consoleLog("wrong entity in aabb: '" + it.name.formattedTextCompat(leadingWhite = false) + "'")
             }
             if (debugRightEntity && result) {
                 ChatUtils.consoleLog("mob: " + center.printWithAccuracy(2))

--- a/src/main/java/at/hannibal2/skyhanni/utils/EssenceUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EssenceUtils.kt
@@ -13,10 +13,9 @@ import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimal
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 
 @SkyHanniModule
 object EssenceUtils {
@@ -148,7 +147,7 @@ object EssenceUtils {
         for (value in inventoryItems.values) {
             // Right now Carnival and Essence Upgrade patterns are 'in-sync'
             // This may change in the future, and this would then need its own pattern
-            essenceUpgradePattern.matchMatcher(value.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+            essenceUpgradePattern.matchMatcher(value.hoverName.formattedTextCompat()) {
                 val upgradeName = groupOrNull("upgrade") ?: continue
                 val nextUpgradeRoman = groupOrNull("tier") ?: continue
                 val nextUpgrade = nextUpgradeRoman.romanToDecimal()

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -33,7 +33,6 @@ import at.hannibal2.skyhanni.utils.PrimitiveIngredient.Companion.toPrimitiveItem
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getExtraAttributes
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHypixelEnchantments
@@ -56,8 +55,7 @@ import at.hannibal2.skyhanni.utils.compat.NbtCompat
 import at.hannibal2.skyhanni.utils.compat.append
 import at.hannibal2.skyhanni.utils.compat.appendWithColor
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getCompoundOrDefault
 import at.hannibal2.skyhanni.utils.compat.getItemOnCursor
 import at.hannibal2.skyhanni.utils.compat.getStringOrDefault
@@ -181,7 +179,7 @@ object ItemUtils {
         if (data.lastLoreFetchTime.passedSince() < 0.1.seconds) {
             return data.lastLore
         }
-        val lore = this.get(DataComponents.LORE)?.lines?.map { it.formattedTextCompatLessResets() }.orEmpty()
+        val lore = this.get(DataComponents.LORE)?.lines?.map { it.formattedTextCompat(leadingWhite = false) }.orEmpty()
         data.lastLore = lore
         data.lastLoreFetchTime = SimpleTimeMark.now()
         return lore
@@ -196,7 +194,7 @@ object ItemUtils {
 
     fun DataComponentMap?.getLore(): List<String> {
         this ?: return emptyList()
-        return this.get(DataComponents.LORE)?.lines?.map { it.formattedTextCompatLessResets() }.orEmpty()
+        return this.get(DataComponents.LORE)?.lines?.map { it.formattedTextCompat(leadingWhite = false) }.orEmpty()
     }
 
     fun CompoundTag?.getReadableNBTDump(initSeparator: String = "  ", includeLore: Boolean = false): List<String> {
@@ -219,7 +217,7 @@ object ItemUtils {
 
     fun getDisplayName(compound: DataComponentMap?): String? {
         compound ?: return null
-        val name = compound.get(DataComponents.CUSTOM_NAME)?.formattedTextCompatLeadingWhiteLessResets()
+        val name = compound.get(DataComponents.CUSTOM_NAME)?.formattedTextCompat()
         if (name.isNullOrEmpty()) return null
         return name
     }
@@ -431,7 +429,7 @@ object ItemUtils {
                 category to rarity
             } ?: continue
 
-            val name = hoverName.formattedTextCompatLeadingWhiteLessResets()
+            val name = hoverName.formattedTextCompat()
             val itemCategory = getItemCategory(category, name, cleanName)
             val itemRarity = LorenzRarity.getByName(rarity)
 
@@ -594,7 +592,7 @@ object ItemUtils {
     private fun getPetRarity(pet: SafeItemStack): LorenzRarity? {
         val rarityId = pet.getInternalName().asString().split(";").last().toInt()
         val rarity = LorenzRarity.getById(rarityId)
-        val name = pet.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val name = pet.hoverName.formattedTextCompat()
         if (rarity == null) {
             ErrorManager.logErrorStateWithData(
                 "Could not read rarity for pet $name",
@@ -722,7 +720,7 @@ object ItemUtils {
             addMissingRepoItem(name, "Could not find item name for $name")
             return "§c$name"
         }
-        val name = itemStack.hoverName.formattedTextCompatLeadingWhiteLessResets()
+        val name = itemStack.hoverName.formattedTextCompat()
 
         // show enchanted book name
         if (itemStack.getItemCategoryOrNull() == ItemCategory.ENCHANTED_BOOK) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils.getEntitiesNearby
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.LocationUtils.rayIntersects
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getInventoryItems
 import net.minecraft.client.resources.language.I18n
 import net.minecraft.world.entity.Entity
@@ -35,7 +35,7 @@ object MobUtils {
     fun getClosestArmorStandWithName(entity: Entity, range: Double, name: String) =
         getArmorStandByRangeAll(entity, range).filter { it.cleanName().startsWith(name) }.minByOrNull { it.distanceTo(entity) }
 
-    fun ArmorStand.isDefaultValue() = this.name.formattedTextCompatLessResets() == defaultArmorStandName
+    fun ArmorStand.isDefaultValue() = this.name.formattedTextCompat(leadingWhite = false) == defaultArmorStandName
 
     fun ArmorStand?.takeNonDefault() = this?.takeIf { !it.isDefaultValue() }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.makePrimitiveStack
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isVanillaItem
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeNonAsciiNonColorCode
@@ -24,7 +23,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removePrefix
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.getVanillaItem
 import at.hannibal2.skyhanni.utils.json.fromJsonOrNull
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -120,7 +119,7 @@ object NeuItems {
                 ChatUtils.debug("skipped `$this`from readAllNeuItems")
                 return@forEach
             }
-            val cleanName = stack.hoverName.formattedTextCompatLeadingWhiteLessResets().lowercase().removePrefix(neuPetLevelRegex).takeIf {
+            val cleanName = stack.hoverName.formattedTextCompat().lowercase().removePrefix(neuPetLevelRegex).takeIf {
                 it.isNotEmpty()
             } ?: return@forEach
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyBlockItemModifierUtils.kt
@@ -13,9 +13,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getStringList
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.isPositive
 import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
-import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.getBooleanOrDefault
 import at.hannibal2.skyhanni.utils.compat.getByteOrDefault
 import at.hannibal2.skyhanni.utils.compat.getCompoundOrDefault

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -438,7 +438,7 @@ object StringUtils {
         transformationReason: String? = null,
         transform: (String) -> String,
     ) {
-        val original = chatComponent.formattedTextCompat()
+        val original = chatComponent.formattedTextCompat(extraResets = true, leadingWhite = false)
         val new = transform(original)
         if (new == original) return
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
@@ -45,17 +45,19 @@ object TabListData {
         internal set
 
     private suspend fun copyCommand(asComponents: Boolean = true) {
-        fun Component?.localCopyFormat() = if (asComponents) this?.toString().orEmpty() else this?.formattedTextCompat().orEmpty()
+        fun Component?.localCopyFormat() =
+            if (asComponents) this?.toString().orEmpty()
+            else this?.formattedTextCompat(extraResets = true, leadingWhite = false).orEmpty()
 
         val tabHeader = header.localCopyFormat()
         val tabFooter = footer.localCopyFormat()
         val joinedResults = tablistCache.joinToString("\n") {
-            val line = if (asComponents) it.toString() else it.formattedTextCompat()
+            val line = if (asComponents) it.toString() else it.formattedTextCompat(extraResets = true, leadingWhite = false)
             if (it.string == "") " " else line
         }
         val widgets = TabWidget.entries.filter { it.isActive }.joinToString("\n") {
             val widgetFormat = it.lines.joinToString { line ->
-                if (asComponents) line.toString() else line.formattedTextCompat()
+                if (asComponents) line.toString() else line.formattedTextCompat(extraResets = true, leadingWhite = false)
             }
             "\n${it.name} : \n$widgetFormat"
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -177,7 +177,7 @@ object TimeUtils {
             } else {
                 Component.literal("$datePart$timePart".trim())
             },
-        ).formattedTextCompat()
+        ).formattedTextCompat(extraResets = true, leadingWhite = false)
     }
 
     fun getCurrentLocalDate(): LocalDate = LocalDate.now(ZoneId.of("UTC"))

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/ItemCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/ItemCompat.kt
@@ -18,8 +18,9 @@ fun SafeItemStack.getTooltip(advanced: Boolean): MutableList<Component> {
 
 fun SafeItemStack.getTooltipCompat(advanced: Boolean): MutableList<String> {
     val tooltipType = if (advanced) TooltipFlag.ADVANCED else TooltipFlag.NORMAL
-    return this.getTooltipLines(Item.TooltipContext.EMPTY, Minecraft.getInstance().player, tooltipType).map { it.formattedTextCompat() }
-        .toMutableList()
+    return this.getTooltipLines(Item.TooltipContext.EMPTY, Minecraft.getInstance().player, tooltipType).map {
+        it.formattedTextCompat(extraResets = true, leadingWhite = false)
+    }.toMutableList()
 }
 
 fun Item.getIdentifierString(): String {

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -39,27 +39,13 @@ import net.minecraft.client.multiplayer.chat.GuiMessageSource
 private val unformattedTextCache = TimeLimitedCache<Component, String>(3.minutes)
 private val formattedTextCache = TimeLimitedCache<TextCacheKey, String>(3.minutes)
 
-private enum class FormattedTextSettings {
-    DEFAULT,
-    LESS_RESETS,
-    LEADING_WHITE,
-    LEADING_WHITE_LESS_RESETS,
-    ;
+private data class TextCacheKey(
+    val extraResets: Boolean,
+    val leadingWhite: Boolean,
+    val component: Component,
+)
 
-    companion object {
-        fun getByArgs(noExtraResets: Boolean, leadingWhite: Boolean): FormattedTextSettings {
-            return when {
-                noExtraResets && leadingWhite -> LEADING_WHITE_LESS_RESETS
-                noExtraResets -> LESS_RESETS
-                leadingWhite -> LEADING_WHITE
-                else -> DEFAULT
-            }
-        }
-    }
-}
-
-private data class TextCacheKey(val settings: FormattedTextSettings, val component: Component)
-
+@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
 fun Component.unformattedTextForChatCompat(): String {
     return unformattedTextCache.getOrPut(this) {
         computeUnformattedTextCompat()
@@ -73,26 +59,23 @@ private fun Component.computeUnformattedTextCompat(): String {
     return (this.contents as? PlainTextContents)?.text().orEmpty()
 }
 
-fun Component.unformattedTextCompat(): String =
-    iterator().joinToString(separator = "") { it.unformattedTextForChatCompat() }
-
-// has to be a separate function for pattern mappings
-fun Component?.formattedTextCompatLessResets(): String = this.formattedTextCompat(noExtraResets = true)
-fun Component?.formattedTextCompatLeadingWhite(): String = this.formattedTextCompat(leadingWhite = true)
-fun Component?.formattedTextCompatLeadingWhiteLessResets(): String =
-    this.formattedTextCompat(noExtraResets = true, leadingWhite = true)
+@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+fun Component.unformattedTextCompat(): String = iterator().joinToString(separator = "") {
+    @Suppress("DEPRECATION")
+    it.unformattedTextForChatCompat()
+}
 
 @JvmOverloads
-@Suppress("unused")
-fun Component?.formattedTextCompat(noExtraResets: Boolean = false, leadingWhite: Boolean = false): String {
+@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+fun Component?.formattedTextCompat(extraResets: Boolean = false, leadingWhite: Boolean = true): String {
     this ?: return ""
-    val cacheKey = TextCacheKey(FormattedTextSettings.getByArgs(noExtraResets, leadingWhite), this)
+    val cacheKey = TextCacheKey(extraResets, leadingWhite, this)
     return formattedTextCache.getOrPut(cacheKey) {
-        computeFormattedTextCompat(noExtraResets, leadingWhite)
+        computeFormattedTextCompat(extraResets, leadingWhite)
     }
 }
 
-private fun Component?.computeFormattedTextCompat(noExtraResets: Boolean, leadingWhite: Boolean): String {
+private fun Component?.computeFormattedTextCompat(extraResets: Boolean, leadingWhite: Boolean): String {
     this ?: return ""
     val sb = StringBuilder(50)
     var wasFormatted = false
@@ -102,8 +85,9 @@ private fun Component?.computeFormattedTextCompat(noExtraResets: Boolean, leadin
             sb.append(chatStyle)
             wasFormatted = true
         }
+        @Suppress("DEPRECATION")
         sb.append(component.unformattedTextForChatCompat())
-        if (!noExtraResets) {
+        if (extraResets) {
             sb.append("§r")
             wasFormatted = true
         } else if (component == Component.empty()) {

--- a/src/test/java/at/hannibal2/skyhanni/test/TestLegacyColorFormat.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/TestLegacyColorFormat.kt
@@ -1,11 +1,7 @@
 package at.hannibal2.skyhanni.test
 
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhite
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
-import at.hannibal2.skyhanni.utils.compat.unformattedTextForChatCompat
 import at.hannibal2.skyhanni.utils.compat.withColor
 import net.minecraft.network.chat.Style
 import net.minecraft.network.chat.Component
@@ -33,33 +29,61 @@ class TestLegacyColorFormat {
         .append(Component.literal("Done").setStyle(Style.EMPTY.withObfuscated(true)))
 
     @Test
-    fun `test formatted text compat`() {
-        Assertions.assertEquals("§8[§r§9302§r§8] §r§6♫ §r§b[MVP§r§d+§r§b] lrg89§r§f: test", testText1.formattedTextCompat())
-        Assertions.assertEquals("Test §r§lExtra §rResets §r§r§r§kDone", testText2.formattedTextCompat())
+    @Suppress("DEPRECATION")
+    fun `test formattedTextCompat extraResets=true leadingWhite=false`() {
+        Assertions.assertEquals(
+            "§8[§r§9302§r§8] §r§6♫ §r§b[MVP§r§d+§r§b] lrg89§r§f: test",
+            testText1.formattedTextCompat(extraResets = true, leadingWhite = false),
+        )
+        Assertions.assertEquals(
+            "Test §r§lExtra §rResets §r§r§r§kDone",
+            testText2.formattedTextCompat(extraResets = true, leadingWhite = false),
+        )
     }
 
     @Test
-    fun `test formatted text compat less resets`() {
-        Assertions.assertEquals("§8[§9302§8] §6♫ §b[MVP§d+§b] lrg89§f: test", testText1.formattedTextCompatLessResets())
-        Assertions.assertEquals("Test §lExtra Resets §r§kDone", testText2.formattedTextCompatLessResets())
+    @Suppress("DEPRECATION")
+    fun `test formattedTextCompat extraResets=false leadingWhite=false`() {
+        Assertions.assertEquals(
+            "§8[§9302§8] §6♫ §b[MVP§d+§b] lrg89§f: test",
+            testText1.formattedTextCompat(extraResets = false, leadingWhite = false),
+        )
+        Assertions.assertEquals(
+            "Test §lExtra Resets §r§kDone",
+            testText2.formattedTextCompat(extraResets = false, leadingWhite = false),
+        )
     }
 
     @Test
-    fun `test formatted text compat leading white`() {
-        Assertions.assertEquals("§8[§r§9302§r§8] §r§6♫ §r§b[MVP§r§d+§r§b] lrg89§r§f: test", testText1.formattedTextCompatLeadingWhite())
-        Assertions.assertEquals("§fTest §r§lExtra §rResets §r§r§r§kDone", testText2.formattedTextCompatLeadingWhite())
+    @Suppress("DEPRECATION")
+    fun `test formattedTextCompat extraResets=true leadingWhite=true`() {
+        Assertions.assertEquals(
+            "§8[§r§9302§r§8] §r§6♫ §r§b[MVP§r§d+§r§b] lrg89§r§f: test",
+            testText1.formattedTextCompat(extraResets = true, leadingWhite = true),
+        )
+        Assertions.assertEquals(
+            "§fTest §r§lExtra §rResets §r§r§r§kDone",
+            testText2.formattedTextCompat(extraResets = true, leadingWhite = true),
+        )
     }
 
     @Test
-    fun `test formatted text compat leading white less resets`() {
-        Assertions.assertEquals("§8[§9302§8] §6♫ §b[MVP§d+§b] lrg89§f: test", testText1.formattedTextCompatLeadingWhiteLessResets())
-        Assertions.assertEquals("§fTest §lExtra Resets §r§kDone", testText2.formattedTextCompatLeadingWhiteLessResets())
+    @Suppress("DEPRECATION")
+    fun `test formattedTextCompat extraResets=false leadingWhite=true`() {
+        Assertions.assertEquals(
+            "§8[§9302§8] §6♫ §b[MVP§d+§b] lrg89§f: test",
+            testText1.formattedTextCompat(extraResets = false, leadingWhite = true),
+        )
+        Assertions.assertEquals(
+            "§fTest §lExtra Resets §r§kDone",
+            testText2.formattedTextCompat(extraResets = false, leadingWhite = true),
+        )
     }
 
     @Test
-    fun `test unformatted text`() {
+    @Suppress("DEPRECATION")
+    fun `test unformattedTextCompat`() {
         Assertions.assertEquals("[302] ♫ [MVP+] lrg89: test", testText1.unformattedTextCompat())
         Assertions.assertEquals("Test Extra Resets §rDone", testText2.unformattedTextCompat())
     }
-
 }

--- a/src/test/java/at/hannibal2/skyhanni/test/TextHelperTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/TextHelperTest.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.test
 
 import at.hannibal2.skyhanni.utils.chat.TextHelper
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.withColor
 import net.minecraft.ChatFormatting
 import net.minecraft.network.chat.Component
@@ -20,7 +20,7 @@ class TextHelperTest {
 
         Assertions.assertEquals(listOf("Cookie Buff", "10 months, 19 days"), split.map { it.string })
         Assertions.assertFalse(split.any { "\n" in it.string })
-        Assertions.assertEquals("§dCookie Buff", split[0].formattedTextCompatLessResets())
-        Assertions.assertEquals("§a10 months, 19 days", split[1].formattedTextCompatLessResets())
+        Assertions.assertEquals("§dCookie Buff", split[0].formattedTextCompat(leadingWhite = false))
+        Assertions.assertEquals("§a10 months, 19 days", split[1].formattedTextCompat(leadingWhite = false))
     }
 }


### PR DESCRIPTION
## What
This PR does a few things to consolidate `formattedTextCompat*` methods: first, it renames the `noExtraResets` parameter of `formattedTextCompat` to `extraResets`, flipping all call sites. Then, it flips the default from `extraResets = true, leadingWhite = false` to `extraResets = false, leadingWhite = true`. Finally, it performs the following replacements:
- `formattedTextCompat()` (75 uses) → `formattedTextCompat(extraResets = true, leadingWhite = false)`
- `formattedTextCompatLeadingWhite()` (5 uses) → `formattedTextCompat(extraResets = true)`
- `formattedTextCompatLeadingWhiteLessResets()` (193 uses) → `formattedTextCompat()`
- `formattedTextCompatLessResets()` (95 uses) → `formattedTextCompat(leadingWhite = false)`

I got confirmation from @NopoTheGamer on Discord, the "has to be separate for pattern mappings" concern is no longer relevant.

It also marks `formattedTextCompat` and related public methods as deprecated.

The goal of this PR is to generally leave all functionality as-is to be on the safe side, and just improve code readability a bit and clearly indicate deprecation – cases of "this could easily just use the clean name or `formattedTextCompat` with no arguments" will be dealt with in a separate PR.

A few lines that got newly flagged by Detekt due to these changes had to be reformatted.

## Changelog Technical Details
+ Consolidated and deprecated formattedTextCompat methods. - Luna