### PR TITLE
Fix: Kotlin accessors leaking to Minecraft classes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -34,8 +34,10 @@ import net.minecraft.network.protocol.game.ServerboundChatCommandPacket
 import net.minecraft.network.protocol.game.ServerboundChatPacket
 import kotlin.math.floor
 
-//? if >= 26.1
+//? if >= 26.1 {
 import net.minecraft.client.multiplayer.chat.GuiMessageSource
+//?} else
+//import at.hannibal2.skyhanni.mixins.hooks.MessageStore.Companion.parent
 
 @SkyHanniModule
 object ChatManager {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CopyChat.kt
@@ -21,8 +21,10 @@ import net.minecraft.network.chat.Component
 import net.minecraft.util.FormattedCharSequence
 import org.joml.Matrix3x2f
 
-//? if >= 26.1
+//? if >= 26.1 {
 import net.minecraft.client.gui.components.ChatComponent
+//?} else
+//import at.hannibal2.skyhanni.mixins.hooks.MessageStore.Companion.parent
 
 object CopyChat {
     private val config get() = SkyHanniMod.feature.chat.copyChat

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/LavaReplacement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/LavaReplacement.kt
@@ -18,6 +18,7 @@ import net.minecraft.world.level.material.Fluid
 import net.minecraft.world.level.material.Fluids
 
 //? if >= 26.1 {
+import at.hannibal2.skyhanni.mixins.hooks.FluidModelTransparencyOverride.Companion.transparency
 import com.mojang.blaze3d.platform.Transparency
 import net.minecraft.client.renderer.block.FluidModel
 import net.minecraft.client.renderer.block.FluidStateModelSet

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FluidModelTransparencyOverride.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/FluidModelTransparencyOverride.kt
@@ -2,24 +2,26 @@ package at.hannibal2.skyhanni.mixins.hooks
 
 //? if >= 26.1 {
 import com.mojang.blaze3d.platform.Transparency
+import net.minecraft.client.renderer.block.FluidModel
 
-// Naming is intentional
-@Suppress("FunctionName")
 interface FluidModelTransparencyOverride {
 
+    // Naming is intentional
+    @Suppress("FunctionName")
     fun `skyhanni$getTransparency`(): Transparency? = throw UnsupportedOperationException("Implemented via mixin")
 
+    @Suppress("FunctionName")
     fun `skyhanni$setTransparency`(value: Transparency?) {
         throw UnsupportedOperationException("Implemented via mixin")
     }
 
-    // Kotlin-only accessor
-    @get:JvmSynthetic
-    @set:JvmSynthetic
-    var transparency: Transparency?
-        get() = `skyhanni$getTransparency`()
-        set(value) {
-            `skyhanni$setTransparency`(value)
-        }
+    companion object {
+
+        var FluidModel.transparency: Transparency?
+            get() = (this as FluidModelTransparencyOverride).`skyhanni$getTransparency`()
+            set(value) {
+                (this as FluidModelTransparencyOverride).`skyhanni$setTransparency`(value)
+            }
+    }
 }
 //?}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageStore.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MessageStore.kt
@@ -7,17 +7,22 @@ package at.hannibal2.skyhanni.mixins.hooks
 
 interface MessageStore {
 
+    // Naming is intentional
+    @Suppress("FunctionName")
     fun `skyhanni$getParent`(): GuiMessage? = throw UnsupportedOperationException("Implemented via mixin")
 
+    @Suppress("FunctionName")
     fun `skyhanni$setParent`(parent: GuiMessage?) {
         throw UnsupportedOperationException("Implemented via mixin")
     }
 
-    // Kotlin-only accessor
-    @get:JvmSynthetic
-    @set:JvmSynthetic
-    var parent: GuiMessage?
-        get() = `skyhanni$getParent`()
-        set(parent) { `skyhanni$setParent`(parent) }
+    companion object {
+
+        var GuiMessage.Line.parent: GuiMessage?
+            get() = (this as MessageStore).`skyhanni$getParent`()
+            set(value) {
+                (this as MessageStore).`skyhanni$setParent`(value)
+            }
+    }
 }
 *///?}


### PR DESCRIPTION
## What
My previous attempt at the "Kotlin-only accessors" ended up still leaking unnamespaced getters/setters to Java bytecode, because apparently `@JvmSynthetic` only hides it from source code. This creates a conflict with SkyOcean, which causes the game to hang because both mods try to implement the same methods. Both mods are at fault here, they will implement a fix on their end too.

Currently, I believe this only happens if you have the latest Git build of both mods installed. The bad code on our end isn't in a beta yet, so I'm skipping the changelog entry.

<details>
<summary>Logs</summary>

```
[18:09:02] [Render thread/INFO]: Caught error loading resourcepacks, removing all selected resourcepacks
java.util.concurrent.CompletionException: java.lang.IncompatibleClassChangeError: Conflicting default methods: at/hannibal2/skyhanni/mixins/hooks/FluidModelTransparencyOverride.setTransparency me/owdding/skyocean/hooks/FluidModelTransparencyOverride.setTransparency
    at java.base/java.util.concurrent.CompletableFuture.wrapInCompletionException(CompletableFuture.java:323)
    at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:359)
    at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:364)
    at java.base/java.util.concurrent.CompletableFuture.biApply(CompletableFuture.java:1334)
    at java.base/java.util.concurrent.CompletableFuture$BiApply.tryFire(CompletableFuture.java:1301)
    at java.base/java.util.concurrent.CompletableFuture$CoCompletion.tryFire(CompletableFuture.java:1240)
    at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:531)
    at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1794)
    at knot//net.minecraft.server.packs.resources.SimpleReloadInstance.lambda$prepareTasks$1(SimpleReloadInstance.java:51)
    at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(ForkJoinTask.java:1750)
    at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(ForkJoinTask.java:1742)
    at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(ForkJoinTask.java:1659)
    at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
    at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
    at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
    at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: java.lang.IncompatibleClassChangeError: Conflicting default methods: at/hannibal2/skyhanni/mixins/hooks/FluidModelTransparencyOverride.setTransparency me/owdding/skyocean/hooks/FluidModelTransparencyOverride.setTransparency
    at knot//net.minecraft.client.renderer.block.FluidModel.setTransparency(FluidModel.java)
    at knot//at.hannibal2.skyhanni.features.fishing.LavaReplacement.addOpaqueWaterModel(LavaReplacement.kt:116)
    at knot//net.minecraft.client.renderer.block.FluidStateModelSet.modifyReturnValue$dhg000$skyhanni$bake(FluidStateModelSet.java:2523)
    at knot//net.minecraft.client.renderer.block.FluidStateModelSet.bake$mixinextras$wrapped$18(FluidStateModelSet.java:39)
    at knot//net.minecraft.client.renderer.block.FluidStateModelSet.mixinextras$bridge$bake$mixinextras$wrapped$18$19(FluidStateModelSet.java)
    at knot//net.minecraft.client.renderer.block.FluidStateModelSet.wrapMethod$bil000$fabric-rendering-fluids-v1$bake(FluidStateModelSet.java:538)
    at knot//net.minecraft.client.renderer.block.FluidStateModelSet.bake(FluidStateModelSet.java)
    at knot//net.minecraft.client.resources.model.ModelManager.lambda$loadModels$1(ModelManager.java:234)
    at java.base/java.util.concurrent.CompletableFuture.biApply(CompletableFuture.java:1332)
    ... 12 more
```

</details>

exclude_from_changelog