### PR TITLE
Fix: Prevent stack overflow in ErrorManager

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -354,11 +354,16 @@ tasks.withType<KotlinCompile> {
         val jvmTargetStr = if (isDeobf) target.minecraftVersion.formattedKotlinJvmTarget
                            else target.minecraftVersion.formattedJavaLanguageVersion
         jvmTarget.set(JvmTarget.fromTarget(jvmTargetStr))
-        optIn.addAll("kotlin.concurrent.atomics.ExperimentalAtomicApi")
-        // 0 (all cores) triggers a race condition in JvmIrCodegenFactory's parallel codegen on Kotlin 2.3.x,
-        // leaving corrupt .class files that break subsequent incremental builds.
-        // see: https://youtrack.jetbrains.com/issue/KT-85498/
-        freeCompilerArgs.addAll("-Xbackend-threads=1")
+        optIn.addAll(
+            "kotlin.concurrent.atomics.ExperimentalAtomicApi",
+        )
+        freeCompilerArgs.addAll(
+            // 0 (all cores) triggers a race condition in JvmIrCodegenFactory's parallel codegen on Kotlin 2.3.x,
+            // leaving corrupt .class files that break subsequent incremental builds.
+            // see: https://youtrack.jetbrains.com/issue/KT-85498/
+            "-Xbackend-threads=1",
+            "-Xnested-type-aliases",
+        )
     }
 }
 

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -213,9 +213,14 @@ object ErrorManager {
 
     // This is intentionally not an enum, because unnecessary object allocation can be problematic
     // if we're dealing with a stack overflow.
-    private const val ERROR_STATE_LOGGED = 0
-    private const val ERROR_STATE_BLOCKED_NOT_NEEDED = 1
-    private const val ERROR_STATE_BLOCKED_CAN_NOT_SHOW = 2
+    @JvmInline
+    private value class ErrorState(val value: Int) {
+        companion object {
+            val LOGGED = ErrorState(0)
+            val BLOCKED_NOT_NEEDED = ErrorState(1)
+            val BLOCKED_CAN_NOT_SHOW = ErrorState(2)
+        }
+    }
 
     @Suppress("ReturnCount")
     private fun logError(
@@ -226,18 +231,18 @@ object ErrorManager {
         vararg extraData: Pair<String, Any?>,
         betaOnly: Boolean = false,
         condition: () -> Boolean = { true },
-    ): Int {
-        if (!condition()) return ERROR_STATE_BLOCKED_NOT_NEEDED
+    ): ErrorState {
+        if (!condition()) return ErrorState.BLOCKED_NOT_NEEDED
 
         // TODO add missing debug enabled check
-        if (betaOnly && !SkyHanniMod.isBetaVersion) return ERROR_STATE_BLOCKED_NOT_NEEDED
+        if (betaOnly && !SkyHanniMod.isBetaVersion) return ErrorState.BLOCKED_NOT_NEEDED
 
         val throwable = originalThrowable.maybeSkipError()
         if (!ignoreErrorCache) {
             val cachedError = throwable.stackTrace.getOrNull(0)?.let {
                 CachedError(it.fileName ?: "<unknown>", it.lineNumber, message)
             } ?: CachedError("<empty stack trace>", 0, message)
-            if (cachedError in cache) return ERROR_STATE_BLOCKED_NOT_NEEDED
+            if (cachedError in cache) return ErrorState.BLOCKED_NOT_NEEDED
             cache.add(cachedError)
         }
 
@@ -264,10 +269,10 @@ object ErrorManager {
 
         val isConnected = MinecraftCompat.localPlayerOrNull != null
 
-        val finalMessage = buildFinalMessage(message) ?: return ERROR_STATE_BLOCKED_CAN_NOT_SHOW
+        val finalMessage = buildFinalMessage(message) ?: return ErrorState.BLOCKED_CAN_NOT_SHOW
         if (!isConnected) {
             errorsToShowOnJoin[randomId] = finalMessage
-            return ERROR_STATE_BLOCKED_CAN_NOT_SHOW
+            return ErrorState.BLOCKED_CAN_NOT_SHOW
         }
         ChatUtils.clickableChat(
             "§c[$label]: $finalMessage Click here to copy the error into the clipboard.",
@@ -275,7 +280,7 @@ object ErrorManager {
             "§eClick to copy!",
             prefix = false,
         )
-        return ERROR_STATE_LOGGED
+        return ErrorState.LOGGED
     }
 
     private fun getLabel(): String {
@@ -287,8 +292,8 @@ object ErrorManager {
     // random id -> final message
     private val errorsToShowOnJoin = mutableMapOf<String, String>()
 
-    private fun Int.crashIfNotYetOnAServer(): Boolean {
-        if (this == ERROR_STATE_BLOCKED_NOT_NEEDED) return false
+    private fun ErrorState.crashIfNotYetOnAServer(): Boolean {
+        if (this == ErrorState.BLOCKED_NOT_NEEDED) return false
 
         // TODO find way to properly do this before the config loads
         val devCrash = false
@@ -302,7 +307,7 @@ object ErrorManager {
             }
         }
 
-        return this == ERROR_STATE_LOGGED
+        return this == ErrorState.LOGGED
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -213,13 +213,11 @@ object ErrorManager {
 
     // This is intentionally not an enum, because unnecessary object allocation can be problematic
     // if we're dealing with a stack overflow.
-    @JvmInline
-    private value class ErrorState(val value: Int) {
-        companion object {
-            val LOGGED = ErrorState(0)
-            val BLOCKED_NOT_NEEDED = ErrorState(1)
-            val BLOCKED_CAN_NOT_SHOW = ErrorState(2)
-        }
+    private typealias ErrorStateT = Int
+    private object ErrorState {
+        const val LOGGED = 0
+        const val BLOCKED_NOT_NEEDED = 1
+        const val BLOCKED_CAN_NOT_SHOW = 2
     }
 
     @Suppress("ReturnCount")
@@ -231,7 +229,7 @@ object ErrorManager {
         vararg extraData: Pair<String, Any?>,
         betaOnly: Boolean = false,
         condition: () -> Boolean = { true },
-    ): ErrorState {
+    ): ErrorStateT {
         if (!condition()) return ErrorState.BLOCKED_NOT_NEEDED
 
         // TODO add missing debug enabled check
@@ -292,7 +290,7 @@ object ErrorManager {
     // random id -> final message
     private val errorsToShowOnJoin = mutableMapOf<String, String>()
 
-    private fun ErrorState.crashIfNotYetOnAServer(): Boolean {
+    private fun ErrorStateT.crashIfNotYetOnAServer(): Boolean {
         if (this == ErrorState.BLOCKED_NOT_NEEDED) return false
 
         // TODO find way to properly do this before the config loads

--- a/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/ErrorManager.kt
@@ -26,6 +26,8 @@ import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import net.minecraft.CrashReport
 import net.minecraft.client.Minecraft
+import java.util.Collections
+import java.util.IdentityHashMap
 import kotlin.time.Duration.Companion.minutes
 
 /** Crashes if [value] is false and in developer environment */
@@ -209,11 +211,11 @@ object ErrorManager {
 
     data class CachedError(val className: String, val lineNumber: Int, val errorMessage: String)
 
-    enum class ErrorState {
-        LOGGED,
-        BLOCKED_NOT_NEEDED,
-        BLOCKED_CAN_NOT_SHOW,
-    }
+    // This is intentionally not an enum, because unnecessary object allocation can be problematic
+    // if we're dealing with a stack overflow.
+    private const val ERROR_STATE_LOGGED = 0
+    private const val ERROR_STATE_BLOCKED_NOT_NEEDED = 1
+    private const val ERROR_STATE_BLOCKED_CAN_NOT_SHOW = 2
 
     @Suppress("ReturnCount")
     private fun logError(
@@ -224,18 +226,18 @@ object ErrorManager {
         vararg extraData: Pair<String, Any?>,
         betaOnly: Boolean = false,
         condition: () -> Boolean = { true },
-    ): ErrorState {
-        if (!condition()) return ErrorState.BLOCKED_NOT_NEEDED
+    ): Int {
+        if (!condition()) return ERROR_STATE_BLOCKED_NOT_NEEDED
 
         // TODO add missing debug enabled check
-        if (betaOnly && !SkyHanniMod.isBetaVersion) return ErrorState.BLOCKED_NOT_NEEDED
+        if (betaOnly && !SkyHanniMod.isBetaVersion) return ERROR_STATE_BLOCKED_NOT_NEEDED
 
         val throwable = originalThrowable.maybeSkipError()
         if (!ignoreErrorCache) {
             val cachedError = throwable.stackTrace.getOrNull(0)?.let {
                 CachedError(it.fileName ?: "<unknown>", it.lineNumber, message)
             } ?: CachedError("<empty stack trace>", 0, message)
-            if (cachedError in cache) return ErrorState.BLOCKED_NOT_NEEDED
+            if (cachedError in cache) return ERROR_STATE_BLOCKED_NOT_NEEDED
             cache.add(cachedError)
         }
 
@@ -262,10 +264,10 @@ object ErrorManager {
 
         val isConnected = MinecraftCompat.localPlayerOrNull != null
 
-        val finalMessage = buildFinalMessage(message) ?: return ErrorState.BLOCKED_CAN_NOT_SHOW
+        val finalMessage = buildFinalMessage(message) ?: return ERROR_STATE_BLOCKED_CAN_NOT_SHOW
         if (!isConnected) {
             errorsToShowOnJoin[randomId] = finalMessage
-            return ErrorState.BLOCKED_CAN_NOT_SHOW
+            return ERROR_STATE_BLOCKED_CAN_NOT_SHOW
         }
         ChatUtils.clickableChat(
             "§c[$label]: $finalMessage Click here to copy the error into the clipboard.",
@@ -273,7 +275,7 @@ object ErrorManager {
             "§eClick to copy!",
             prefix = false,
         )
-        return ErrorState.LOGGED
+        return ERROR_STATE_LOGGED
     }
 
     private fun getLabel(): String {
@@ -285,8 +287,8 @@ object ErrorManager {
     // random id -> final message
     private val errorsToShowOnJoin = mutableMapOf<String, String>()
 
-    private fun ErrorState.crashIfNotYetOnAServer(): Boolean {
-        if (this == ErrorState.BLOCKED_NOT_NEEDED) return false
+    private fun Int.crashIfNotYetOnAServer(): Boolean {
+        if (this == ERROR_STATE_BLOCKED_NOT_NEEDED) return false
 
         // TODO find way to properly do this before the config loads
         val devCrash = false
@@ -300,7 +302,7 @@ object ErrorManager {
             }
         }
 
-        return this == ErrorState.LOGGED
+        return this == ERROR_STATE_LOGGED
     }
 
     @HandleEvent
@@ -419,7 +421,13 @@ object ErrorManager {
     private fun Throwable.getCustomStackTrace(
         fullStackTrace: Boolean,
         parent: List<String> = emptyList(),
+        seenThrowables: MutableSet<Throwable> = Collections.newSetFromMap(IdentityHashMap()),
     ): List<String> = buildList {
+        if (!seenThrowables.add(this@getCustomStackTrace)) {
+            add("<Infinite recurring causes>")
+            return@buildList
+        }
+
         add("Caused by ${this@getCustomStackTrace.javaClass.name}: $message")
 
         for (traceElement in stackTrace) {
@@ -447,13 +455,8 @@ object ErrorManager {
             add(visualText)
         }
 
-        if (this === cause) {
-            add("<Infinite recurring causes>")
-            return@buildList
-        }
-
         cause?.let {
-            addAll(it.getCustomStackTrace(fullStackTrace, this))
+            addAll(it.getCustomStackTrace(fullStackTrace, this, seenThrowables))
         }
     }
 


### PR DESCRIPTION
## What
Potentially fixes this (or at least, stops the real error from being obscured):
https://discord.com/channels/997079228510117908/1520172858729304074
https://bytebin.lucko.me/GDGFQ1npP6

## Changelog Fixes
+ Fixed a rare case with error handling sometimes infinitely recursing and causing the game to freeze or crash. - Luna
