### PR TITLE
Fix: Minor contributor manager fixes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
@@ -51,8 +51,9 @@ object ContributorAchievement {
             Achievement(
                 "Notice Me Senpai".asComponent(),
                 componentBuilder {
-                    append("Have your friend request ignored by ")
+                    append("Have your friend request ignored by a")
                     appendWithColor("SkyHanni", TextHelper.chromaStyle)
+                    append(" contributor")
                 }
             ),
             CONTRIBUTOR_NOBODY_ACHIEVEMENT

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
@@ -51,7 +51,7 @@ object ContributorAchievement {
             Achievement(
                 "Notice Me Senpai".asComponent(),
                 componentBuilder {
-                    append("Have your friend request ignored by a")
+                    append("Have your friend request ignored by a ")
                     appendWithColor("SkyHanni", TextHelper.chromaStyle)
                     append(" contributor")
                 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PlayerUtils.kt
@@ -41,9 +41,9 @@ object PlayerUtils {
 
     fun getUuid() = getRawUuid().toUnDashedUUID()
 
-    fun getRawUuid(): UUID = MinecraftCompat.localPlayer.uuid
+    fun getRawUuid(): UUID = MinecraftCompat.localUser.profileId
 
-    fun getName(): String = MinecraftCompat.localPlayer.plainTextName
+    fun getName(): String = MinecraftCompat.localUser.name
 
     fun onGround(): Boolean = MinecraftCompat.localPlayer.onGround()
     fun inAir(): Boolean = !onGround()

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
@@ -22,8 +22,10 @@ object MinecraftCompat {
 
     val localPlayerOrNull get(): LocalPlayer? = Minecraft.getInstance().player
 
-    // This class contains the local user information, such as the username and UUID.
-    // It will always be non-null, even if the player is not in a world / singleplayer.
+    /**
+     * This class contains the local user information, such as the username and UUID.
+     * It will always be non-null, even if the player is not in a world / singleplayer.
+     */
     val localUser get(): User = Minecraft.getInstance().user
 
     val Entity?.isLocalPlayer get(): Boolean = this == localPlayerOrNull && this != null

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import net.minecraft.client.Minecraft
+import net.minecraft.client.User
 import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.client.player.LocalPlayer
 import net.minecraft.network.protocol.game.ClientboundSetTimePacket
@@ -20,6 +21,10 @@ object MinecraftCompat {
     val localPlayer get(): LocalPlayer = localPlayerOrNull ?: ErrorManager.skyHanniError("player is null")
 
     val localPlayerOrNull get(): LocalPlayer? = Minecraft.getInstance().player
+
+    // This class contains the local user information, such as the username and UUID.
+    // It will always be non-null, even if the player is not in a world / singleplayer.
+    val localUser get(): User = Minecraft.getInstance().user
 
     val Entity?.isLocalPlayer get(): Boolean = this == localPlayerOrNull && this != null
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
@@ -23,8 +23,8 @@ object MinecraftCompat {
     val localPlayerOrNull get(): LocalPlayer? = Minecraft.getInstance().player
 
     /**
-     * This class contains the local user information, such as the username and UUID.
-     * It will always be non-null, even if the player is not in a world / singleplayer.
+     * The local user's information, such as the username and UUID.
+     * This is always non-null, even if the player is not in a world / singleplayer.
      */
     val localUser get(): User = Minecraft.getInstance().user
 


### PR DESCRIPTION
## What
Fixes a typo in the achievement, and makes it not give an error in singleplayer.
Sometimes.
Also should reduce any error by calling `PlayerUtils.getName() & PlayerUtils.getUuid()`

## Changelog Fixes
+ Fixed "Notice Me Senpai" Achievement description. - AverageUser125

## Changelog Technical Details
+ Changed `PlayerUtils` to use `localUser` instead of `localPlayer` for player name and UUID lookup. - AverageUser125