### PR TITLE
Backend: replace all usages of \\s with literal space

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -195,7 +195,7 @@ object ExperimentationTableApi {
      */
     private val expOverRewardsLorePattern by patternGroup.pattern(
         "inventory.experiment-over.rewards",
-        "§8 \\+(?:§.| )*(?:\\[Lvl \\d+] )?(?<reward>.*?)(?=\\s\\((?:Stakes|Pairs)\\)|\$)(?:\\s\\((?:Stakes|Pairs)\\))?",
+        "§8 \\+(?:§.| )*(?:\\[Lvl \\d+] )?(?<reward>.*?)(?= \\((?:Stakes|Pairs)\\)|\$)(?: \\((?:Stakes|Pairs)\\))?",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/api/HotmApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotmApi.kt
@@ -52,7 +52,7 @@ object HotmApi {
         )
         val resetPattern by RepoPattern.pattern(
             "inventory.${name.lowercase()}.reset",
-            "\\s+§8- §.(?<powder>[\\d,]+) $displayName Powder",
+            " +§8- §.(?<powder>[\\d,]+) $displayName Powder",
         )
 
         fun pattern(isHeart: Boolean) = if (isHeart) heartPattern else resetPattern

--- a/src/main/java/at/hannibal2/skyhanni/api/SkyBlockXPApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkyBlockXPApi.kt
@@ -29,7 +29,7 @@ object SkyBlockXPApi {
     /**
      * REGEX-TEST: §3§l§m      §f§l§m                   §r §b24§3/§b100 §bXP
      */
-    private val xpPattern by group.pattern("xp", "[§\\w\\s]+§b(?<xp>\\d+)§3\\/§b100 §bXP")
+    private val xpPattern by group.pattern("xp", "[§\\w ]+§b(?<xp>\\d+)§3\\/§b100 §bXP")
 
     val levelXPPair get() = storage?.toLevelXPPair()
 

--- a/src/main/java/at/hannibal2/skyhanni/data/BitsApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BitsApi.kt
@@ -92,7 +92,7 @@ object BitsApi {
      */
     private val fameRankUpPattern by bitsChatGroup.pattern(
         "rankup.rank",
-        "[§\\w\\s]+FAME RANK UP (?:§.)+(?<rank>.*)",
+        "[§\\w ]+FAME RANK UP (?:§.)+(?<rank>.*)",
     )
 
     /**
@@ -137,7 +137,7 @@ object BitsApi {
      */
     private val cookieDurationPattern by bitsGuiGroup.pattern(
         "cookieduration",
-        "\\s*§7Duration: §a(?<time>.*)",
+        " *§7Duration: §a(?<time>.*)",
     )
 
     private val noCookieActiveSBMenuPattern by bitsGuiGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/HypixelData.kt
@@ -56,7 +56,7 @@ object HypixelData {
      */
     private val scoreboardVisitingAmountPattern by patternGroup.pattern(
         "scoreboard.visiting.amount",
-        "\\s+§.✌ §.\\(§.(?<currentamount>\\d+)(?:§.)?/(?<maxamount>\\d+)(?:§.)?\\)",
+        " +§.✌ §.\\(§.(?<currentamount>\\d+)(?:§.)?/(?<maxamount>\\d+)(?:§.)?\\)",
     )
 
     /**
@@ -65,7 +65,7 @@ object HypixelData {
      */
     private val skyblockAreaPattern by patternGroup.pattern(
         "skyblock.area",
-        "\\s*§(?<symbol>7⏣|5ф) §(?<color>.)(?<area>.*)",
+        " *§(?<symbol>7⏣|5ф) §(?<color>.)(?<area>.*)",
     )
 
     val connectedToHypixel get() = HypixelLocationApi.inHypixel

--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -51,7 +51,7 @@ object SlayerApi {
      */
     private val questStartPattern by patternGroup.pattern(
         "quest.start",
-        "\\s*SLAYER QUEST STARTED!",
+        " *SLAYER QUEST STARTED!",
     )
 
     /**
@@ -59,7 +59,7 @@ object SlayerApi {
      */
     private val questCompletePattern by patternGroup.pattern(
         "quest.complete",
-        "\\s*SLAYER QUEST COMPLETE!",
+        " *SLAYER QUEST COMPLETE!",
     )
     // </editor-fold>
 

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/CropUpgrades.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/CropUpgrades.kt
@@ -32,7 +32,7 @@ object CropUpgrades {
      */
     private val chatUpgradePattern by patternGroup.pattern(
         "chatupgrade",
-        "\\s+§r§6§lCROP UPGRADE §e(?<crop>[\\w ]+)§7 #(?<tier>\\d)",
+        " +§r§6§lCROP UPGRADE §e(?<crop>[\\w ]+)§7 #(?<tier>\\d)",
     )
 
     private val cropUpgradesStorage: MutableMap<CropType, Int>? get() = GardenApi.storage?.cropUpgrades

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -371,7 +371,7 @@ enum class HotfData(
          */
         override val resetTokensPattern: Pattern by patternGroup.pattern(
             "inventory.reset.token",
-            "\\s*§8- §a(?<token>\\d+) §aToken of the Forest",
+            " *§8- §a(?<token>\\d+) §aToken of the Forest",
         )
 
         /**
@@ -379,7 +379,7 @@ enum class HotfData(
          */
         override val resetChatPattern by patternGroup.pattern(
             "reset.chat",
-            "\\s*§7You have reset your §r§aHeart of the Forest§r§7! Your §r§aPerks §r§7and §r§aAbilities §r§7have been reset\\.",
+            " *§7You have reset your §r§aHeart of the Forest§r§7! Your §r§aPerks §r§7and §r§aAbilities §r§7have been reset\\.",
         )
 
         /**
@@ -395,7 +395,7 @@ enum class HotfData(
          */
         private val whisperResetPattern by patternGroup.pattern(
             "whisper.reset",
-            "\\s+§8- §.(?<whisper>[\\d,]*) Forest Whispers",
+            " +§8- §.(?<whisper>[\\d,]*) Forest Whispers",
         )
         // </editor-fold>
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -525,7 +525,7 @@ enum class HotmData(
          */
         override val resetTokensPattern by patternGroup.pattern(
             "inventory.reset.token",
-            "\\s+§8- §5(?<token>\\d+) Token of the Mountain",
+            " +§8- §5(?<token>\\d+) Token of the Mountain",
         )
 
         private val mayhemChatPattern by patternGroup.pattern(
@@ -539,7 +539,7 @@ enum class HotmData(
          */
         private val powderPattern by patternGroup.pattern(
             "widget.powder-nocolor",
-            "\\s*(?<type>\\w+): (?<amount>[\\d,.]+)",
+            " *(?<type>\\w+): (?<amount>[\\d,.]+)",
         )
         // </editor-fold>
 

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/neu/NeuReforgeJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/neu/NeuReforgeJson.kt
@@ -24,8 +24,8 @@ data class NeuReforgeJson(
 
     val nbtModifier: String by lazy {
         rawNbtModifier ?: reforgeName.lowercase()
-            .replace("[^a-z0-9\\s_-]".toRegex(), "")
-            .replace("[\\s-]".toRegex(), "_")
+            .replace("[^a-z0-9 _-]".toRegex(), "")
+            .replace("[ -]".toRegex(), "_")
     }
     @Suppress("UNCHECKED_CAST")
     val reforgeAbility: Map<LorenzRarity, String> by lazy {

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -55,7 +55,7 @@ object MobFilter {
     private val patternGroup = RepoPattern.group("mob.detection")
 
     @Language("RegExp")
-    private val mobType = "(?<mobType>[^\\w\\s✯\\-]+ )?"
+    private val mobType = "(?<mobType>[^\\w ✯\\-]+ )?"
 
     @Language("RegExp")
     private val level = "(?:\\[Lv(?<level>\\d+)\\] )?"
@@ -99,7 +99,7 @@ object MobFilter {
     @Suppress("MaxLineLength")
     val dungeonNameFilter by patternGroup.pattern(
         "filter.dungeon",
-        "^$level$mobType(?:(?<star>✯)\\s)?(?:(?<attribute>${DungeonAttribute.toRegexLine})\\s)?(?:\\[[\\w\\d]+\\]\\s)?(?<name>[^ᛤ]+)(?: ᛤ)?\\s[^\\s]+$",
+        "^$level$mobType(?:(?<star>✯) )?(?:(?<attribute>${DungeonAttribute.toRegexLine}) )?(?:\\[[\\w\\d]+\\] )?(?<name>[^ᛤ]+)(?: ᛤ)? [^ ]+$",
     )
     val summonFilter by patternGroup.pattern(
         "filter.summon",

--- a/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
@@ -59,7 +59,7 @@ enum class TabWidget(
     ),
     PROFILE(
         // language=RegExp
-        "Profile: (?<profile>[\\w\\s]+)(?:[ ♲Ⓑ☀]+)?",
+        "Profile: (?<profile>[\\w ]+)(?:[ ♲Ⓑ☀]+)?",
     ),
     SB_LEVEL(
         // language=RegExp
@@ -382,7 +382,7 @@ enum class TabWidget(
     ;
 
     /** The pattern for the first line of the widget*/
-    val pattern by repoGroup.pattern(name.replace("_", ".").lowercase(), "\\s*(?:$pattern0)")
+    val pattern by repoGroup.pattern(name.replace("_", ".").lowercase(), " *(?:$pattern0)")
 
     /** The current active information from tab list.
      *

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/SlayerAchievements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/SlayerAchievements.kt
@@ -21,7 +21,7 @@ object SlayerAchievements {
      */
     private val rngMeterPattern by AchievementManager.group.pattern(
         "rng-meter",
-        "\\s*RNG Meter - (?<xp>[\\d,]+) Stored XP",
+        " *RNG Meter - (?<xp>[\\d,]+) Stored XP",
     )
 
     private const val RNG_ACHIEVEMENT_3M = "3m rng xp"

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -45,10 +45,10 @@ object ChatFilter {
         "(?: §b>§c>§a>§r §r)?.* §6(?:joined|(?:spooked|slid) into) the lobby!(?:§r §a<§c<§b<)?".toPattern(),
 
         // Hypixel SMP
-        "§2[\\s]*?§aYou can now create your own Hypixel SMP server![\\s]*?".toPattern(),
+        "§2[ ]*?§aYou can now create your own Hypixel SMP server![ ]*?".toPattern(),
 
         // Snow Particles in the Lobby
-        "[\\s]*?.*§bFor the best experience, click the text below to enable Snow[\\s]§.*§bParticles in this lobby![\\s]*?.*§3§lClick to enable Snow Particles[\\s]*?".toPattern(),
+        "[ ]*?.*§bFor the best experience, click the text below to enable Snow[ ]§.*§bParticles in this lobby![ ]*?.*§3§lClick to enable Snow Particles[ ]*?".toPattern(),
 
         // mystery box
         "§b✦ §r.* §r§7found a §r§e.* §r§bMystery Box§r§7!".toPattern(),
@@ -352,7 +352,7 @@ object ChatFilter {
     )
     private val fireSalePatterns = listOf(
         "§c♨ §eFire Sales for .* §eare starting soon!".toPattern(),
-        "§c\\s*♨ .* (?:Skin|Rune|Dye) §e(?:for a limited time )?\\(.* §eleft\\)(?:§c|!)".toPattern(),
+        "§c *♨ .* (?:Skin|Rune|Dye) §e(?:for a limited time )?\\(.* §eleft\\)(?:§c|!)".toPattern(),
         "§c♨ §eVisit the Community Shop in the next §c.* §eto grab yours! §a§l\\[WARP]".toPattern(),
         "§c♨ §eA Fire Sale for .* §eis starting soon!".toPattern(),
         "§c♨ §r§eFire Sales? for .* §r§eended!".toPattern(),

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CurrentChatDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CurrentChatDisplay.kt
@@ -71,7 +71,7 @@ object CurrentChatDisplay {
     @Suppress("MaxLineLength")
     private val openPrivateMessagePattern by patternGroup.pattern(
         "private.open",
-        "^§aOpened a chat conversation with (?:§.)*(?:\\[.+])?(?:§.|\\s)*(?<player>.*)§r§a for the next 5 minutes\\. Use §r§b\\/chat a§r§a to leave",
+        "^§aOpened a chat conversation with (?:§.)*(?:\\[.+])?(?:§.| )*(?<player>.*)§r§a for the next 5 minutes\\. Use §r§b\\/chat a§r§a to leave",
     )
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFeatures.kt
@@ -145,7 +145,7 @@ object DragonFeatures {
      */
     private val tabDamagePattern by tabListGroup.pattern(
         "fight.player",
-        "\\s(?<name>.+): (?<damage>[\\d.]+[kM]?)❤",
+        " (?<name>.+): (?<damage>[\\d.]+[kM]?)❤",
     )
 
     private var yourEyes = 0

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
@@ -146,7 +146,7 @@ object GhostTracker {
      */
     private val bestiaryTablistPattern by patternGroup.pattern(
         "tablist.bestiary-no-color",
-        "\\s*Ghost (?<level>\\d+|[XVI]+): (?<kills>[\\d,.]+)\\/(?<killsToNext>[\\d,.]+)",
+        " *Ghost (?<level>\\d+|[XVI]+): (?<kills>[\\d,.]+)\\/(?<killsToNext>[\\d,.]+)",
     )
 
     /**
@@ -154,7 +154,7 @@ object GhostTracker {
      */
     private val maxBestiaryTablistPattern by patternGroup.pattern(
         "tablist.bestiarymax-no-color",
-        "\\s*Ghost (?<level>\\d+|[XVI]+): MAX",
+        " *Ghost (?<level>\\d+|[XVI]+): MAX",
     )
 
     private val SORROW = "SORROW".toInternalName()

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -1,8 +1,8 @@
 package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.InteractClickType
 import at.hannibal2.skyhanni.data.ClickedBlockType
+import at.hannibal2.skyhanni.data.InteractClickType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.BlockClickEvent
@@ -91,7 +91,7 @@ object DungeonApi {
      */
     private val dungeonComplete by patternGroup.pattern(
         "completecolorless",
-        "\\s+(?:Master Mode )?The Catacombs - (?:Floor [IV]{1,3}|Entrance)",
+        " +(?:Master Mode )?The Catacombs - (?:Floor [IV]{1,3}|Entrance)",
     )
 
     /**
@@ -123,7 +123,7 @@ object DungeonApi {
     @Suppress("MaxLineLength")
     val playerDungeonTeamPattern by patternGroup.pattern(
         "tablist.playerteam.colorless",
-        "^(?<sbLevel>\\[\\d+]) (?<rank>\\[[^]]+])? ?(?<playerName>\\S+)\\s?(?<symbols>[^(]*) \\((?:(?<className>\\S+) (?<classLevel>[CLXVI0]+)|(?<playerDead>DEAD))\\)\$",
+        "^(?<sbLevel>\\[\\d+]) (?<rank>\\[[^]]+])? ?(?<playerName>\\S+) ?(?<symbols>[^(]*) \\((?:(?<className>\\S+) (?<classLevel>[CLXVI0]+)|(?<playerDead>DEAD))\\)\$",
     )
 
     enum class DungeonBlessings(var power: Int) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalQuickStart.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalQuickStart.kt
@@ -27,7 +27,7 @@ object CarnivalQuickStart {
     private val chatPattern by patternGroup.pattern(
         "select.option.chat-nocolor",
         // NOTE: Do not use .* here, it doesn't match newlines.
-        "Select an option:[\\s\\S]*",
+        "Select an option:[ \\S]*",
     )
     private val pirate by patternGroup.pattern("npcs.pirate", "Carnival Pirateman")
     private val fisher by patternGroup.pattern("npcs.fisher", "Carnival Fisherman")

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
@@ -60,7 +60,7 @@ object DianaApi {
      */
     private val rareDianaMobNamePattern by group.pattern(
         "rare-mob-name",
-        "(?:Minos Inquisitor|Sphinx|King Minos|Manticore)\\s*",
+        "(?:Minos Inquisitor|Sphinx|King Minos|Manticore) *",
     )
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -97,7 +97,7 @@ object GriffinBurrowHelper {
      */
     val genericMythologicalSpawnPattern by patternGroup.pattern(
         "generic-spawn",
-        "§c§l(?:Oh|Uh oh|Yikes|Oi|Good Grief|Danger|Woah)! §r§eYou dug out (?:a )?(?:§[a-f0-9r])*(?<creatureType>[\\w\\s]+)§r§e!",
+        "§c§l(?:Oh|Uh oh|Yikes|Oi|Good Grief|Danger|Woah)! §r§eYou dug out (?:a )?(?:§[a-f0-9r])*(?<creatureType>[\\w ]+)§r§e!",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactSweepDetails.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactSweepDetails.kt
@@ -48,7 +48,7 @@ object CompactSweepDetails {
     @Suppress("MaxLineLength")
     private val sweepToughnessLogsPattern by patternGroup.pattern(
         "toughness-and-logs",
-        "\\s+(?:§.)+(?<treeType>[\\S ]+) Tree Toughness: (?<toughnessDisplay>§r§6(?<toughnessAmount>[\\d,.]+)) (?<logsDisplay>(?:§.)+(?<isItGreen>§.)(?<logsAmount>[\\d,.]+)) Logs",
+        " +(?:§.)+(?<treeType>[\\S ]+) Tree Toughness: (?<toughnessDisplay>§r§6(?<toughnessAmount>[\\d,.]+)) (?<logsDisplay>(?:§.)+(?<isItGreen>§.)(?<logsAmount>[\\d,.]+)) Logs",
     )
 
     /**
@@ -62,7 +62,7 @@ object CompactSweepDetails {
     @Suppress("MaxLineLength")
     private val penaltyPattern by patternGroup.pattern(
         "penalty",
-        "\\s+(?:§.)+(?<penaltyReason>[\\S ]+): (?<penaltyDisplay>(?:§.)+-(?<penaltyPercent>[\\d,.]+)%) Sweep (?<logsDisplay>(?:§.)?(?<isItGreen>§.)(?<logsAmount>[\\d,.]+)) Logs(?: (?<proTip>(?:§.)+[\\S ]+))?",
+        " +(?:§.)+(?<penaltyReason>[\\S ]+): (?<penaltyDisplay>(?:§.)+-(?<penaltyPercent>[\\d,.]+)%) Sweep (?<logsDisplay>(?:§.)?(?<isItGreen>§.)(?<logsAmount>[\\d,.]+)) Logs(?: (?<proTip>(?:§.)+[\\S ]+))?",
     )
 
     data class SweepDetails(

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTrackerLegacy.kt
@@ -128,7 +128,7 @@ object ForagingTrackerLegacy {
     @Suppress("MaxLineLength")
     val hoverRewardPattern by patternGroup.pattern(
         "hover-reward",
-        "(?:§.)*(?<item>[^§\\s](?:[^§]*[^§\\s])?)(?:§.)*\\s*(?:§.)*§8\\s*x?(?:(?:0-)?(?<amount>[\\d,]+)|\\((?:§.)*(?<percentage>[\\d.]+)%(?:§.)*\\))"
+        "(?:§.)*(?<item>[^§ ](?:[^§]*[^§ ])?)(?:§.)* *(?:§.)*§8 *x?(?:(?:0-)?(?<amount>[\\d,]+)|\\((?:§.)*(?<percentage>[\\d.]+)%(?:§.)*\\))",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotApi.kt
@@ -116,7 +116,7 @@ object GardenPlotApi {
      */
     private val plotSprayedTablistPattern by patternGroup.pattern(
         "tablist.spraytime-nocolor",
-        "Spray: (?<spray>[\\w\\s]+)(?:\\((?<time>.*)\\))?",
+        "Spray: (?<spray>[\\w ]+)(?:\\((?<time>.*)\\))?",
     )
     var plots = listOf<Plot>()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingContestApi.kt
@@ -39,7 +39,7 @@ object FarmingContestApi {
     )
     private val sidebarCropPattern by patternGroup.pattern(
         "sidebarcrop",
-        "\\s*(?:§e○|§6☘) §f(?<crop>.*) §a.*",
+        " *(?:§e○|§6☘) §f(?<crop>.*) §a.*",
     )
     private val bulkClaimFarmingPattern by patternGroup.pattern(
         "bulkclaim",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
@@ -30,7 +30,7 @@ object BonusPestChanceDisplay {
      */
     private val bonusPestChancePattern by patternGroup.pattern(
         "widget-no-color",
-        "\\s+Bonus Pest Chance: ൠ(?<amount>[\\d,.]+)",
+        " +Bonus Pest Chance: ൠ(?<amount>[\\d,.]+)",
     )
     private var display: Renderable? = null
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -100,7 +100,7 @@ object PestApi {
      */
     private val pestsInPlotScoreboardPattern by patternGroup.pattern(
         "scoreboard.plot.pests",
-        "\\s*(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.+) (?:§.)*ൠ(?:§.)* x(?<pests>\\d+)",
+        " *(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.+) (?:§.)*ൠ(?:§.)* x(?<pests>\\d+)",
     )
 
     /**
@@ -108,7 +108,7 @@ object PestApi {
      */
     private val noPestsInPlotScoreboardPattern by patternGroup.pattern(
         "scoreboard.plot.no-pests",
-        "\\s*(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.{1,3})$",
+        " *(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.{1,3})$",
     )
 
     /**
@@ -124,7 +124,7 @@ object PestApi {
      */
     private val infestedPlotsTabListPattern by patternGroup.pattern(
         "tablist.infected-plots-no-color",
-        "\\sPlots: (?<plots>.*)",
+        " Plots: (?<plots>.*)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -60,7 +60,7 @@ object PestSpawn {
      */
     private val clickToTPPattern by patternGroup.pattern(
         "teleport.colorless",
-        "\\s*CLICK HERE to teleport to the plot!",
+        " *CLICK HERE to teleport to the plot!",
     )
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -64,7 +64,7 @@ object PestSpawnTimer {
 
     private val pestCooldownPattern by patternGroup.pattern(
         "cooldowntime-no-color",
-        "\\sCooldown: (?<time>\\d{1,2}[ms](?: \\d{1,2}s?)?)?(?<ready>READY)?(?<maxPests>MAX PESTS)?.*",
+        " Cooldown: (?<time>\\d{1,2}[ms](?: \\d{1,2}s?)?)?(?<ready>READY)?(?<maxPests>MAX PESTS)?.*",
     )
 
     private val pestSpawnTimes: MutableList<Duration> = mutableListOf()

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -46,7 +46,7 @@ object ScoreboardPattern {
      */
     val sowdustPattern by mainSB.pattern(
         "sowdust",
-        "\\s?(?:§.)*Sowdust: (?:§.)*(?<sowdust>[\\d,]+)",
+        " ?(?:§.)*Sowdust: (?:§.)*(?<sowdust>[\\d,]+)",
     )
 
     /**
@@ -74,7 +74,7 @@ object ScoreboardPattern {
      */
     val locationPattern by mainSB.pattern(
         "location",
-        "\\s*(?<location>(?:§7⏣|§5ф) .*)",
+        " *(?<location>(?:§7⏣|§5ф) .*)",
     )
 
     /**
@@ -82,7 +82,7 @@ object ScoreboardPattern {
      */
     val lobbyCodePattern by mainSB.pattern(
         "lobbycode",
-        "\\s*§.(?:\\d{2}/?){3} §8(?<code>.*)",
+        " *§.(?:\\d{2}/?){3} §8(?<code>.*)",
     )
 
     /**
@@ -90,7 +90,7 @@ object ScoreboardPattern {
      */
     val datePattern by mainSB.pattern(
         "date",
-        "\\s*(?:(?:Late|Early) )?(?:Spring|Summer|Autumn|Winter) \\d+(?:st|nd|rd|th)?.*",
+        " *(?:(?:Late|Early) )?(?:Spring|Summer|Autumn|Winter) \\d+(?:st|nd|rd|th)?.*",
     )
 
     /**
@@ -99,7 +99,7 @@ object ScoreboardPattern {
      */
     val timePattern by mainSB.pattern(
         "time",
-        "\\s*§7\\d+:\\d+(?:am|pm)\\s*(?<symbol>§b☽|§e☀|§.⚡|§.☔)?.*",
+        " *§7\\d+:\\d+(?:am|pm) *(?<symbol>§b☽|§e☀|§.⚡|§.☔)?.*",
     )
 
     /**
@@ -152,7 +152,7 @@ object ScoreboardPattern {
      */
     val profileTypePattern by mainSB.pattern(
         "profiletype",
-        "\\s*(?:§7♲ §7Ironman|§a☀ §aStranded|§.Ⓑ §.Bingo).*",
+        " *(?:§7♲ §7Ironman|§a☀ §aStranded|§.Ⓑ §.Bingo).*",
     )
 
     // multi use
@@ -195,7 +195,7 @@ object ScoreboardPattern {
      */
     val timeLeftPattern by multiUseSB.pattern(
         "timeleft",
-        "(?:§.)*Time Left: (?:§.)*[\\w:,.\\s]+",
+        "(?:§.)*Time Left: (?:§.)*[\\w:,. ]+",
     )
 
     // dungeon scoreboard
@@ -207,7 +207,7 @@ object ScoreboardPattern {
      */
     val m7dragonsPattern by dungeonSB.pattern(
         "m7dragons",
-        "§cNo Alive Dragons|§8- (?:§.)+[\\w\\s]+Dragon§a [\\w,.]+(?:§.❤)?",
+        "§cNo Alive Dragons|§8- (?:§.)+[\\w ]+Dragon§a [\\w,.]+(?:§.❤)?",
     )
     val keysPattern by dungeonSB.pattern(
         "keys",
@@ -265,7 +265,7 @@ object ScoreboardPattern {
      */
     val submergesPattern by kuudraSB.pattern(
         "submerges",
-        "(?:§.)*Submerges In: (?:§.)*[\\w\\s?]+",
+        "(?:§.)*Submerges In: (?:§.)*[\\w ?]+",
     )
 
     // farming
@@ -286,7 +286,7 @@ object ScoreboardPattern {
      */
     val lockedPattern by farmingSB.pattern(
         "locked",
-        "\\s*§cLocked.*",
+        " *§cLocked.*",
     )
 
     /**
@@ -295,7 +295,7 @@ object ScoreboardPattern {
      */
     val cleanUpPattern by farmingSB.pattern(
         "cleanup",
-        "\\s*(?:§.)*Cleanup(?:§.)*: (?:§.)*.*",
+        " *(?:§.)*Cleanup(?:§.)*: (?:§.)*.*",
     )
 
     /**
@@ -304,7 +304,7 @@ object ScoreboardPattern {
      */
     val pastingPattern by farmingSB.pattern(
         "pasting",
-        "\\s*(?:§.)*(?:Barn )?Pasting§7: (?:§.)*[\\d,.]+%?",
+        " *(?:§.)*(?:Barn )?Pasting§7: (?:§.)*[\\d,.]+%?",
     )
 
     /**
@@ -332,7 +332,7 @@ object ScoreboardPattern {
      */
     val plotPattern by farmingSB.pattern(
         "plot",
-        "\\s*§aPlot §7-.*",
+        " *§aPlot §7-.*",
     )
 
     // mining
@@ -361,7 +361,7 @@ object ScoreboardPattern {
      */
     val windCompassArrowPattern by miningSB.pattern(
         "windcompassarrow",
-        "\\s*(?:§.|[⋖⋗≈])+\\s*(?:§.|[⋖⋗≈])*\\s*",
+        " *(?:§.|[⋖⋗≈])+ *(?:§.|[⋖⋗≈])* *",
     )
 
     /**
@@ -569,7 +569,7 @@ object ScoreboardPattern {
      */
     val essencePattern by miscSB.pattern(
         "essence",
-        "\\s*.*Essence: §.(?<essence>-?\\d+(?::?,\\d{3})*(?:\\.\\d+)?)",
+        " *.*Essence: §.(?<essence>-?\\d+(?::?,\\d{3})*(?:\\.\\d+)?)",
     )
 
     /**
@@ -577,7 +577,7 @@ object ScoreboardPattern {
      */
     val redstonePattern by miscSB.pattern(
         "redstone",
-        "\\s*(?:§.)*⚡ §cRedstone: (?:§.)*\\d+%",
+        " *(?:§.)*⚡ §cRedstone: (?:§.)*\\d+%",
     )
 
     /**
@@ -585,7 +585,7 @@ object ScoreboardPattern {
      */
     val visitingPattern by miscSB.pattern(
         "visiting",
-        "\\s*§a✌ §7\\(§.\\d+(?:§.)?/\\d+(?:§.)?\\)",
+        " *§a✌ §7\\(§.\\d+(?:§.)?/\\d+(?:§.)?\\)",
     )
 
     /**
@@ -594,7 +594,7 @@ object ScoreboardPattern {
      */
     val flightDurationPattern by miscSB.pattern(
         "flightduration",
-        "\\s*Flight Duration: §a(?::?\\d{1,3})*",
+        " *Flight Duration: §a(?::?\\d{1,3})*",
     )
 
     /**
@@ -688,7 +688,7 @@ object ScoreboardPattern {
     @Suppress("MaxLineLength")
     val thirdObjectiveLinePattern by miscSB.pattern(
         "thirdobjectiveline",
-        "§eProtect Elle §7\\(§.\\d+%§7\\)|\\s*§.\\(§.[\\w,.]+§.\\/§.[\\w,.]+§.\\)|§f Mages.*|§f Barbarians.*|§edefeat Kuudra|§eand stun him|§.Fish \\d .*[fF]ish §.[✖✔]",
+        "§eProtect Elle §7\\(§.\\d+%§7\\)| *§.\\(§.[\\w,.]+§.\\/§.[\\w,.]+§.\\)|§f Mages.*|§f Barbarians.*|§edefeat Kuudra|§eand stun him|§.Fish \\d .*[fF]ish §.[✖✔]",
     )
 
     /**
@@ -795,7 +795,7 @@ object ScoreboardPattern {
      */
     val riftDimensionPattern by riftSB.pattern(
         "dimension",
-        "\\s*(?:§f)?Rift Dimension",
+        " *(?:§f)?Rift Dimension",
     )
     val riftHotDogTitlePattern by riftSB.pattern(
         "hotdogtitle",
@@ -862,7 +862,7 @@ object ScoreboardPattern {
      */
     val bigDamagePattern by riftSB.pattern(
         "bigdamage",
-        "\\s*Big damage in: §d[\\w\\s]+",
+        " *Big damage in: §d[\\w ]+",
     )
 
     private val carnivalSB = scoreboardGroup.group("carnival")
@@ -956,7 +956,7 @@ object ScoreboardPattern {
      */
     val hotfPattern by galateaSB.pattern(
         "hotf",
-        "\\s*§aHOTF§f: §a[\\w,.]+.*",
+        " *§aHOTF§f: §a[\\w,.]+.*",
     )
 
     /**
@@ -983,9 +983,9 @@ object ScoreboardPattern {
      */
     val brokenPatterns by group.list(
         "broken",
-        "\\s*§.§l⚡ §cRedston",
-        "\\s*§ce: §e§b\\d+%",
-        "\\s*Starting in: §a0 §c[\\d:]+",
+        " *§.§l⚡ §cRedston",
+        " *§ce: §e§b\\d+%",
+        " *Starting in: §a0 §c[\\d:]+",
         "(?:§.)*᠅ §.(?<type>Gemstone|Mithril|Glacite)(?: Powder)?.*",
     )
 
@@ -997,7 +997,7 @@ object ScoreboardPattern {
      */
     val eventTimeEndsPattern by tablistGroup.pattern(
         "eventtime",
-        "\\s+Ends In: (?<time>.*)",
+        " +Ends In: (?<time>.*)",
     )
 
     /**
@@ -1005,6 +1005,6 @@ object ScoreboardPattern {
      */
     val eventTimeStartsPattern by tablistGroup.pattern(
         "eventtimestarts",
-        "\\s+Starts In: (?<time>.*)",
+        " +Starts In: (?<time>.*)",
     )
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
@@ -180,7 +180,7 @@ object CFDataLoader {
      */
     val upgradeTierPattern by CFApi.patternGroup.pattern(
         "upgradetier",
-        "(?<upgrade>.*)\\s(?<tier>[IVXLC]+)",
+        "(?<upgrade>.*) (?<tier>[IVXLC]+)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusApi.kt
@@ -29,7 +29,7 @@ object CrystalNucleusApi {
      */
     private val startPattern by patternGroup.pattern(
         "loot.start",
-        " \\s*§r§5§lCRYSTAL NUCLEUS LOOT BUNDLE.*",
+        " *§r§5§lCRYSTAL NUCLEUS LOOT BUNDLE.*",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -62,7 +62,7 @@ object MiningEventTracker {
      */
     private val eventStartedPattern by patternGroup.pattern(
         "started",
-        "(?:§.)*\\s+(?:§.)+§l(?<event>.+) STARTED!",
+        "(?:§.)* +(?:§.)+§l(?<event>.+) STARTED!",
     )
 
     /**
@@ -70,7 +70,7 @@ object MiningEventTracker {
      */
     private val eventEndedPattern by patternGroup.pattern(
         "ended",
-        "(?:§.)*\\s+(?:§.)+§l(?<event>.+) ENDED!",
+        "(?:§.)* +(?:§.)+§l(?<event>.+) ENDED!",
     )
     // </editor-fold>
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -25,7 +25,7 @@ object ColorfulItemStats {
      */
     private val genericStat by group.pattern(
         "generic-stats-no-color",
-        "(?<stat>[a-zA-Z ]+): (?<bonus>[-+]?[\\d.,%s]+)(?:\\s|$)",
+        "(?<stat>[a-zA-Z ]+): (?<bonus>[-+]?[\\d.,%s]+)(?: |$)",
     )
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ReplaceRomanNumerals.kt
@@ -14,7 +14,7 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object ReplaceRomanNumerals {
     // Using toRegex here since toPattern doesn't seem to provide the necessary functionality
-    private val splitRegex = "((§\\w)|(\\s+)|(\\W))+|(\\w*)".toRegex()
+    private val splitRegex = "((§\\w)|( +)|(\\W))+|(\\w*)".toRegex()
     private val cachedStrings = TimeLimitedCache<String, String>(5.seconds)
 
     @HandleEvent(priority = HandleEvent.LOW)

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/CrimsonMinibossRespawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/CrimsonMinibossRespawnTimer.kt
@@ -49,7 +49,7 @@ object CrimsonMinibossRespawnTimer {
      */
     private val downPattern by patternGroup.pattern(
         "down",
-        "§f\\s*§r§6§l(?<name>.+) DOWN!",
+        "§f *§r§6§l(?<name>.+) DOWN!",
     )
 
     private var currentAreaBoss: MiniBoss? = null

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/VanquisherWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/VanquisherWaypointShare.kt
@@ -49,7 +49,7 @@ object VanquisherWaypointShare {
     @Suppress("MaxLineLength")
     private val sharedPattern by patternGroup.list(
         "share",
-        "^(?<channel>Party > |Guild > |Officer > )?(?<playerName>[^:]+):.*?x:\\s*(?<x>-?[\\d.]+).*?y:\\s*(?<y>-?[\\d.]+).*?z:\\s*(?<z>-?[\\d.]+).*?Vanquisher.*",
+        "^(?<channel>Party > |Guild > |Officer > )?(?<playerName>[^:]+):.*?x: *(?<x>-?[\\d.]+).*?y: *(?<y>-?[\\d.]+).*?z: *(?<z>-?[\\d.]+).*?Vanquisher.*",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/kuudra/KuudraApi.kt
@@ -30,7 +30,7 @@ object KuudraApi {
     )
     private val completePattern by patternGroup.pattern(
         "chat.complete",
-        "§.\\s*(?:§.)*KUUDRA DOWN!",
+        "§. *(?:§.)*KUUDRA DOWN!",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -45,7 +45,7 @@ object CrimsonIsleReputationHelper {
      */
     val tabListQuestPattern by RepoPattern.pattern(
         "crimson.reputationhelper.tablist.quest-no-color",
-        "\\s*(?<status>[✖✔]) (?<name>.+?)(?: x(?<amount>\\d+))?$",
+        " *(?<status>[✖✔]) (?<name>.+?)(?: x(?<amount>\\d+))?$",
     )
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/PetNametag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/PetNametag.kt
@@ -24,7 +24,7 @@ object PetNametag {
      */
     private val petNametagPattern by RepoPattern.pattern(
         "pet.nametag",
-        "(?<start>§8\\[§7Lv(?<lvl>\\d+)§8]) (?<rarity>§.)(?<pet>[\\w\\s]+)(?<skin>§. ✦)?",
+        "(?<start>§8\\[§7Lv(?<lvl>\\d+)§8]) (?<rarity>§.)(?<pet>[\\w ]+)(?<skin>§. ✦)?",
     )
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/CruxTalismanDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/CruxTalismanDisplay.kt
@@ -32,7 +32,7 @@ object CruxTalismanDisplay {
     @Suppress("MaxLineLength")
     private val progressPattern by RepoPattern.pattern(
         "rift.everywhere.crux.progress",
-        ".*(?<tier>(?:§.)?[IV1-4-]+)\\s+(?<name>(?:§.)?\\w+)§.:\\s*(?<progress>(?:§.)*MAXED|§.\\d+§./§.\\d+).*",
+        ".*(?<tier>(?:§.)?[IV1-4-]+) +(?<name>(?:§.)?\\w+)§.: *(?<progress>(?:§.)*MAXED|§.\\d+§./§.\\d+).*",
     )
 
     private const val PARTIAL_NAME = "CRUX_TALISMAN"

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/motes/MotesSession.kt
@@ -37,7 +37,7 @@ object MotesSession {
      */
     private val lifetimeMotesPattern by patternGroup.pattern(
         "lifetime-nocolor",
-        "\\s+Lifetime Motes: (?<motes>[\\d,.]+)",
+        " +Lifetime Motes: (?<motes>[\\d,.]+)",
     )
 
     private const val MOTES_ACHIEVEMENT = "Mote Collector"

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -229,7 +229,7 @@ object SkillProgress {
         if (!config.hideInActionBar || !isDisplayEnabled()) return
         var msg = event.actionBar
         for (line in hideInActionBar) {
-            msg = msg.replace(Regex("\\s*" + Regex.escape(line)), "")
+            msg = msg.replace(Regex(" *" + Regex.escape(line)), "")
         }
         msg = msg.trim()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerCocoonWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerCocoonWarning.kt
@@ -16,7 +16,7 @@ object SlayerCocoonWarning {
      */
     private val slayerCocoonPattern by RepoPattern.pattern(
         "slayer.cocooned",
-        "\\s+§r§c§lYOU COCOONED YOUR SLAYER BOSS",
+        " +§r§c§lYOU COCOONED YOUR SLAYER BOSS",
     )
 
     private val config get() = SlayerApi.config

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -34,8 +34,8 @@ import java.util.regex.Pattern
 // TODO refactor
 @Suppress("MemberVisibilityCanBePrivate", "TooManyFunctions")
 object StringUtils {
-    private val whiteSpaceResetPattern = "^(?:\\s|§r)*|(?:\\s|§r)*$".toPattern()
-    private val whiteSpacePattern = "^\\s*|\\s*$".toPattern()
+    private val whiteSpaceResetPattern = "^(?: |§r)*|(?: |§r)*$".toPattern()
+    private val whiteSpacePattern = "^ *| *$".toPattern()
     private val resetPattern = "(?i)§R".toPattern()
     private val sFormattingPattern = "(?i)§S".toPattern()
     private val asciiWithColorCodePattern = "[^\\x00-\\x7F§]".toPattern()

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -108,7 +108,7 @@ object TimeUtils {
     val Duration.inWholeTicks: Int get() = (inWholeMilliseconds / 50).toInt()
 
     private fun String.preFixDurationString() =
-        replace(Regex("(\\d+)([yMWwdhms])(?!\\s)"), "$1$2 ") // Add a space only after common time units
+        replace(Regex("(\\d+)([yMWwdhms])(?! )"), "$1$2 ") // Add a space only after common time units
             .trim()
 
     fun getDuration(string: String): Duration =

--- a/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/UtilsPatterns.kt
@@ -170,7 +170,7 @@ object UtilsPatterns {
      */
     val tabListProfilePattern by patternGroup.pattern(
         "tablist.profile",
-        "(?:§.)+Profile: §r§a(?<profile>[\\w\\s]+[^ §]).*",
+        "(?:§.)+Profile: §r§a(?<profile>[\\w ]+[^ §]).*",
     )
 
     /**


### PR DESCRIPTION
## What
Replaced all usages of '\\w' with space in regexes.

We can save a lot of processing power by doing this since space is the only allowed whitespace character in Minecraft

chatgpt says this can speed up regexes by 3-4 times, and when we have 300 regexes running for every chat message, that could add up

## Changelog Technical Details
+ Replaced all usages of '\\w' with space in regexes. - zumbiepig
    * We can save a lot of processing power by doing this since space is the only allowed whitespace character in Minecraft.

