### PR TITLE
Backend: Fix SystemMessageEvent being fucked

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.events.entity.EntityMoveEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.deceased
@@ -24,13 +24,17 @@ import kotlin.time.Duration.Companion.seconds
 object EntityMovementData {
 
     /**
-     * REGEX-TEST: §7Sending a visit request...
-     * REGEX-TEST: §7Finding player...
-     * REGEX-TEST: §7Warping you to your SkyBlock island...
+     * REGEX-TEST: Sending a visit request...
+     * REGEX-TEST: Finding player...
+     * REGEX-TEST: Warping you to your SkyBlock island...
      */
-    private val warpingPattern by RepoPattern.pattern(
-        "data.entity.warping",
-        "§7(?:Warping|Warping you to your SkyBlock island|Warping using transfer token|Finding player|Sending a visit request)\\.\\.\\.",
+    private val warpingPattern by RepoPattern.list(
+        "data.entity.warping.list",
+        "Warping\\.\\.\\.",
+        "Warping you to your SkyBlock island\\.\\.\\.",
+        "Warping using transfer token\\.\\.\\.",
+        "Finding player\\.\\.\\.",
+        "Sending a visit request\\.\\.\\.",
     )
 
     private var nextTeleport: OnNextTeleport? = null
@@ -108,9 +112,10 @@ object EntityMovementData {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onChat(event: SkyHanniChatEvent.Allow) {
-        if (!warpingPattern.matches(event.message)) return
-        DelayedRun.runNextTick {
-            SkyHanniWarpEvent.post()
+        warpingPattern.matchMatchers(event.cleanMessage) {
+            DelayedRun.runNextTick {
+                SkyHanniWarpEvent.post()
+            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -171,6 +171,7 @@ object PlayerChatManager {
             if (isGlobalChat(event)) return
         }
 
+        @Suppress("DEPRECATION")
         SystemMessageEvent.Allow(event.messageComponent, event.chatComponent).postChat(event)
     }
 
@@ -225,6 +226,7 @@ object PlayerChatManager {
             if (isGlobalChat(event)) return
         }
 
+        @Suppress("DEPRECATION")
         SystemMessageEvent.Modify(event.messageComponent, event.chatComponent).postChat(event)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -167,10 +167,11 @@ object PlayerChatManager {
             return
         }
         globalPattern.matchStyledMatcher(chatComponent) {
+            // this method will post PlayerAllChatEvent if needed
             if (isGlobalChat(event)) return
         }
 
-        sendSystemMessage(event)
+        SystemMessageEvent.Allow(event.messageComponent, event.chatComponent).postChat(event)
     }
 
     @HandleEvent
@@ -220,10 +221,11 @@ object PlayerChatManager {
             return
         }
         globalPattern.matchStyledMatcher(chatComponent) {
+            // this method will post PlayerAllChatEvent if needed
             if (isGlobalChat(event)) return
         }
 
-        sendSystemMessage(event)
+        SystemMessageEvent.Modify(event.messageComponent, event.chatComponent).postChat(event)
     }
 
     private fun ComponentMatcher.isGlobalChat(event: SkyHanniChatEvent.Allow): Boolean {
@@ -310,18 +312,14 @@ object PlayerChatManager {
         return true
     }
 
-    private fun sendSystemMessage(event: SkyHanniChatEvent.Allow) {
-        with(SystemMessageEvent.Allow(event.message, event.chatComponent)) {
-            post()
-            event.handleChat(blockedReason)
-        }
+    private fun SystemMessageEvent.Allow.postChat(event: SkyHanniChatEvent.Allow) {
+        post()
+        event.handleChat(blockedReason)
     }
 
-    private fun sendSystemMessage(event: SkyHanniChatEvent.Modify) {
-        with(SystemMessageEvent.Modify(event.message, event.chatComponent)) {
-            post()
-            event.handleChat(chatComponent)
-        }
+    private fun SystemMessageEvent.Modify.postChat(event: SkyHanniChatEvent.Modify) {
+        post()
+        event.handleChat(chatComponent)
     }
 
     private fun AbstractSourcedChatEvent.Allow.postChat(event: SkyHanniChatEvent.Allow) {

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/AbstractSourcedChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/AbstractSourcedChatEvent.kt
@@ -20,7 +20,7 @@ object AbstractSourcedChatEvent {
      * @param chatComponent The entire original chat component.
      * @param blockedReason The reason if the message should be blocked. null means not blocked.
      */
-    open class Allow(
+    abstract class Allow(
         val authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
         chatComponent: Component,
@@ -40,7 +40,7 @@ object AbstractSourcedChatEvent {
      * @param messageComponent The content of the actual message.
      * @param chatComponent The entire original chat component.
      */
-    open class Modify(
+    abstract class Modify(
         val authorComponent: ComponentSpan,
         messageComponent: ComponentSpan,
         chatComponent: Component,

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/SystemMessageEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/event/SystemMessageEvent.kt
@@ -1,14 +1,19 @@
 package at.hannibal2.skyhanni.data.hypixel.chat.event
 
-import at.hannibal2.skyhanni.api.event.SkyHanniEvent
-import at.hannibal2.skyhanni.data.ChatManager
-import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.events.chat.AbstractChatEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.utils.ComponentSpan
 import net.minecraft.network.chat.Component
 
 /**
  * Gets fired for any chat message not sent by another player or an [NPC][NpcChatEvent].
+ * Messages are not guaranteed to be sent by the system if the user has unusual settings.
+ * Instead, use [SkyHanniChatEvent] and stronger regexes.
  */
+@Deprecated(
+    "Use SkyHanniChatEvent and a stronger regex to filter out player messages",
+    replaceWith = ReplaceWith("SkyHanniChatEvent"),
+)
 object SystemMessageEvent {
 
     /**
@@ -16,43 +21,26 @@ object SystemMessageEvent {
      * Use this event to read the message or to completely block it from being shown in the chat.
      * Cannot be used to edit or modify the message in any way. For that, see [Modify].
      *
-     * @param message The original message text.
+     * @param messageComponent The content of the actual message.
      * @param chatComponent The entire original chat component.
      * @param blockedReason The reason if the message should be blocked. null means not blocked.
      */
-    @PrimaryFunction("onSystemMessage")
-    open class Allow(
-        open val message: String,
-        open val chatComponent: Component,
-        open var blockedReason: String? = null,
-    ) : SkyHanniEvent() {
-
-        /** The plain text message without any color codes. */
-        open val cleanMessage: String = chatComponent.string.removeColor()
-    }
+    class Allow(
+        messageComponent: ComponentSpan,
+        chatComponent: Component,
+        blockedReason: String? = null,
+    ) : AbstractChatEvent.Allow(messageComponent, chatComponent, blockedReason)
 
     /**
      * Fired during the modification phase of the chat processing pipeline.
      * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
      * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
      *
-     * @param message The original message text.
+     * @param messageComponent The content of the actual message.
      * @param chatComponent The entire original chat component.
      */
-    open class Modify(
-        open val message: String,
-        @set:Deprecated("Use replaceComponent() instead")
-        open var chatComponent: Component,
-    ) : SkyHanniEvent() {
-
-        /** The plain text message without any color codes. */
-        open val cleanMessage: String
-            get() = chatComponent.string.removeColor()
-
-        fun replaceComponent(newComponent: Component, reason: String) {
-            ChatManager.addReplacementContext(chatComponent, reason)
-            @Suppress("DEPRECATION")
-            chatComponent = newComponent
-        }
-    }
+    class Modify(
+        messageComponent: ComponentSpan,
+        chatComponent: Component,
+    ) : AbstractChatEvent.Modify(messageComponent, chatComponent)
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/chat/AbstractChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/chat/AbstractChatEvent.kt
@@ -1,33 +1,68 @@
 package at.hannibal2.skyhanni.events.chat
 
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.utils.ComponentSpan
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraft.network.chat.Component
 
+/**
+ * Contains the base Allow and Modify classes for all chat events.
+ * Do not listen to those events directly.
+ */
 object AbstractChatEvent {
 
-    // TODO docs missing
-    open class Allow(
-        val messageComponent: ComponentSpan,
-        chatComponent: Component,
-        blockedReason: String? = null,
-    ) : SystemMessageEvent.Allow(messageComponent.getText(), chatComponent, blockedReason) {
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
+    abstract class Allow(
+        open val messageComponent: ComponentSpan,
+        open val chatComponent: Component,
+        open var blockedReason: String? = null,
+    ) : SkyHanniEvent() {
         @Deprecated(
             "Use cleanMessage unless you really need color codes",
-            replaceWith = ReplaceWith("this.cleanMessage")
+            replaceWith = ReplaceWith("this.cleanMessage"),
         )
-        override val message = messageComponent.getText().removePrefix("§r")
+        open val message: String = messageComponent.getText().removePrefix("§r")
+
+        /** The plain text message without any color codes. */
+        open val cleanMessage: String = chatComponent.string.removeColor()
     }
 
-    // TODO docs missing
-    open class Modify(
-        val messageComponent: ComponentSpan,
-        chatComponent: Component,
-    ) : SystemMessageEvent.Modify(messageComponent.getText(), chatComponent) {
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
+     *
+     * @param messageComponent The content of the actual message.
+     * @param chatComponent The entire original chat component.
+     */
+    abstract class Modify(
+        open val messageComponent: ComponentSpan,
+        @set:Deprecated("Use replaceComponent() instead")
+        open var chatComponent: Component,
+    ) : SkyHanniEvent() {
         @Deprecated(
             "Use cleanMessage unless you really need color codes",
-            replaceWith = ReplaceWith("this.cleanMessage")
+            replaceWith = ReplaceWith("this.cleanMessage"),
         )
-        override val message = messageComponent.getText().removePrefix("§r")
+        open val message: String = messageComponent.getText().removePrefix("§r")
+
+        /** The plain text message without any color codes. */
+        open val cleanMessage: String
+            get() = chatComponent.string.removeColor()
+
+        fun replaceComponent(newComponent: Component, reason: String) {
+            ChatManager.addReplacementContext(chatComponent, reason)
+            @Suppress("DEPRECATION")
+            chatComponent = newComponent
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/chat/SkyHanniChatEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/chat/SkyHanniChatEvent.kt
@@ -5,8 +5,20 @@ import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import net.minecraft.network.chat.Component
 
+/**
+ * Gets fired for all chat messages received.
+ */
 object SkyHanniChatEvent {
 
+    /**
+     * Fired during the read-only phase of the chat processing pipeline.
+     * Use this event to read the message or to completely block it from being shown in the chat.
+     * Cannot be used to edit or modify the message in any way. For that, see [Modify].
+     *
+     * @param message The original message text.
+     * @param chatComponent The entire original chat component.
+     * @param blockedReason The reason if the message should be blocked. null means not blocked.
+     */
     @PrimaryFunction("onChat")
     class Allow(
         message: String,
@@ -15,6 +27,14 @@ object SkyHanniChatEvent {
         var chatLineId: Int = 0,
     ) : AbstractChatEvent.Allow(message.asComponent().intoSpan(), chatComponent, blockedReason)
 
+    /**
+     * Fired during the modification phase of the chat processing pipeline.
+     * Use this specific event to modify the text content or the visual style of the chat component before it shows up on chat.
+     * Cannot be used to block the message altogether. Do not use this event for data collection. For both, see [Allow].
+     *
+     * @param message The original message text.
+     * @param chatComponent The entire original chat component.
+     */
     class Modify(
         message: String,
         chatComponent: Component,

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatModifier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatModifier.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.features.chat.playerchat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.features.misc.MarkedPlayerManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.StringUtils.applyIfPossible
@@ -24,7 +24,7 @@ object PlayerChatModifier {
     }
 
     @HandleEvent
-    fun onChat(event: SystemMessageEvent.Modify) {
+    fun onChat(event: SkyHanniChatEvent.Modify) {
         event.applyIfPossible("PLAYER_CHAT") { cutMessage(it) }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFeatures.kt
@@ -22,6 +22,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
@@ -53,89 +54,88 @@ object DragonFeatures {
     private val tabListGroup = repoGroup.group("tablist-nocolor")
 
     /**
-     * REGEX-TEST: §5☬ §r§dYou placed a Summoning Eye! §r§7(§r§e2§r§7/§r§a8§r§7)
-     * REGEX-TEST: §5☬ §r§dYou placed a Summoning Eye! Brace yourselves! §r§7(§r§a8§r§7/§r§a8§r§7)
+     * REGEX-TEST: ☬ You placed a Summoning Eye! (2/8)
+     * REGEX-TEST: ☬ You placed a Summoning Eye! Brace yourselves! (8/8)
      */
-    @Suppress("MaxLineLength")
-    private val eyePlacedPattern by chatGroup.pattern(
-        "eye.placed.you",
-        "§5☬ §r§dYou placed a Summoning Eye! §r§7\\(§r§e\\d§r§7\\/§r§a8§r§7\\)|§5☬ §r§dYou placed a Summoning Eye! Brace yourselves! §r§7\\(§r§a8§r§7\\/§r§a8§r§7\\)",
+    private val eyePlacedPattern by chatGroup.list(
+        "eye.placed.you.list",
+        "☬ You placed a Summoning Eye! \\(\\d/8\\)",
+        "☬ You placed a Summoning Eye! Brace yourselves! \\(8/8\\)",
     )
 
     /**
-     * REGEX-TEST: §5You recovered a Summoning Eye!
+     * REGEX-TEST: You recovered a Summoning Eye!
      */
-    private val eyeRemovedPattern by chatGroup.pattern("eye.removed.you", "§5You recovered a Summoning Eye!")
+    private val eyeRemovedPattern by chatGroup.pattern("eye.removed.you", "You recovered a Summoning Eye!")
 
     /**
-     * REGEX-TEST: §5☬ §r§dThe Dragon Egg has spawned!
+     * REGEX-TEST: ☬ The Dragon Egg has spawned!
      */
-    private val eggSpawnedPattern by chatGroup.pattern("egg.spawn", "§5☬ §r§dThe Dragon Egg has spawned!")
+    private val eggSpawnedPattern by chatGroup.pattern("egg.spawn", "☬ The Dragon Egg has spawned!")
 
     /**
-     * REGEX-TEST: §f                      §r§6§lPROTECTOR DRAGON DOWN!
+     * WRAPPED-REGEX-TEST: "                      PROTECTOR DRAGON DOWN!"
      */
     private val endStartLineDragonPattern by chatGroup.pattern(
         "end.boss",
-        "§f +§r§6§l(?<dragon>$dragonNamesAsRegexUppercase) DRAGON DOWN!",
+        " +(?<dragon>$dragonNamesAsRegexUppercase) DRAGON DOWN!",
     )
 
     /**
-     * REGEX-TEST: §f                    §r§6§lENDSTONE PROTECTOR DOWN!
+     * WRAPPED-REGEX-TEST: "                    ENDSTONE PROTECTOR DOWN!"
      */
     private val endStartLineProtectorPattern by protectorRepoGroup.pattern(
         "chat.end.boss",
-        "§f +§r§6§lENDSTONE PROTECTOR DOWN!",
+        " +ENDSTONE PROTECTOR DOWN!",
     )
 
     /**
-     * REGEX-TEST: §f                   §r§eYour Damage: §r§a88,966 §r§7(Position #5)
-     * REGEX-TEST: §f                 §r§eYour Damage: §r§a3,198,068 §r§7(Position #1)
+     * WRAPPED-REGEX-TEST: "                   Your Damage: 88,966 (Position #5)"
+     * WRAPPED-REGEX-TEST: "                 Your Damage: 3,198,068 (Position #1)"
      */
-    @Suppress("MaxLineLength")
     private val endPositionPattern by chatGroup.pattern(
         "end.position",
-        "§f +§r§eYour Damage: §r§a(?<damage>[\\d.,]+) (?:§r§d§l\\(NEW RECORD!\\) )?§r§7\\(Position #(?<position>\\d+)\\)",
+        " +Your Damage: (?<damage>[\\d.,]+) (?:\\(NEW RECORD!\\) )?\\(Position #(?<position>\\d+)\\)",
     )
 
     /**
-     * REGEX-TEST: §f             §r§e§l1st Damager §r§7- §r§a[VIP] Jarre07§r§f §r§7- §r§e9,659,033
-     * REGEX-TEST: §f          §r§6§l2nd Damager §r§7- §r§b[MVP§r§9+§r§b] FlamingZoom§r§f §r§7- §r§e1,459,691
-     * REGEX-TEST: §f          §r§c§l3rd Damager §r§7- §r§b[MVP§r§f+§r§b] Dustbringer§r§f §r§7- §r§e1,091,163
-     * REGEX-TEST: §f              §r§e§l1st Damager §r§7- §r§a[VIP] filip_zd§r§f §r§7- §r§e3,965,533
+     * WRAPPED-REGEX-TEST: "             1st Damager - [VIP] Jarre07 - 9,659,033"
+     * WRAPPED-REGEX-TEST: "          2nd Damager - [MVP+] FlamingZoom - 1,459,691"
+     * WRAPPED-REGEX-TEST: "          3rd Damager - [MVP+] Dustbringer - 1,091,163"
+     * WRAPPED-REGEX-TEST: "              1st Damager - [VIP] filip_zd - 3,965,533"
      */
     @Suppress("MaxLineLength")
     private val endLeaderboardPattern by chatGroup.pattern(
         "end.place",
-        "§f +§r§.§l(?<position>\\d+).. Damager §r§7- §r§.(?:\\[[^ ]+\\] )?(?<name>.*)§r§. §r§7- §r§e(?<damage>[\\d.,]+)",
+        " +(?<position>\\d+)\\w{2} Damager - (?:\\[[^ ]+\\] )?(?<name>.*) - (?<damage>[\\d.,]+)",
     )
 
     /**
-     * REGEX-TEST: §f                       §r§eZealots Contributed: §r§a27§r§e/100
+     * WRAPPED-REGEX-TEST: "                       Zealots Contributed: 27/100"
      */
     private val endZealotsPattern by protectorRepoGroup.pattern(
         "chat.end.zealot",
-        "§f +§r§eZealots Contributed: §r§a(?<amount>\\d+)§r§e/100",
+        " +Zealots Contributed: (?<amount>\\d+)/100",
     )
 
     /**
-     * REGEX-TEST: §5☬ §r§d§lThe §r§5§c§lProtector Dragon§r§d§l has spawned!
-     * REGEX-TEST: §5☬ §r§d§lThe §r§5§c§lYoung Dragon§r§d§l has spawned!
+     * REGEX-TEST: ☬ The Protector Dragon has spawned!
+     * REGEX-TEST: ☬ The Young Dragon has spawned!
      */
     private val dragonSpawnPattern by chatGroup.pattern(
         "spawn",
-        "§5☬ §r§d§lThe §r§5§c§l(?<dragon>$dragonNamesAsRegex) Dragon§r§d§l has spawned!",
+        "☬ The (?<dragon>$dragonNamesAsRegex) Dragon has spawned!",
     )
 
     /**
-     * REGEX-TEST: Your Damage: §c2,003.2
+     * REGEX-TEST: Your Damage: 2,003.2
      */
-    private val scoreDamagePattern by scoreBoardGroup.pattern("damage", "Your Damage: §c(?<damage>[\\w,.]+)")
+    private val scoreDamagePattern by scoreBoardGroup.pattern("damage", "Your Damage: (?<damage>[\\d,.]+)")
 
     /**
-     * REGEX-TEST: Dragon HP: §a14,659,354 §c❤
+     * REGEX-TEST: Dragon HP: 14,659,354 ❤
      */
-    private val scoreDragonPattern by scoreBoardGroup.pattern("dragon", "Dragon HP: .*")
+    private val scoreDragonPattern by scoreBoardGroup.pattern("dragon", "Dragon HP: [\\d,.]+ ❤")
 
     /**
      * WRAPPED-REGEX-TEST: " JamBeastie: 7.4M❤"
@@ -145,7 +145,7 @@ object DragonFeatures {
      */
     private val tabDamagePattern by tabListGroup.pattern(
         "fight.player",
-        "\\s(?<name>.+): (?<damage>[\\d.]+[kM]?)❤",
+        " (?<name>.+): (?<damage>[\\d.]+[kM]?)❤",
     )
 
     private var yourEyes = 0
@@ -232,14 +232,9 @@ object DragonFeatures {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_END)
     fun onChat(event: SkyHanniChatEvent.Allow) {
-        val message = event.message
-
-        if (!config.chat && !config.display && !config.superiorNotify && !configProtector) return
+        val message = event.cleanMessage
 
         if (handleDragonSpawn(message)) return
-
-        if (!config.chat && !config.display && !configProtector) return
-
         if (handleEyeEvents(message)) return
         if (handleEggSpawn(message)) return
         if (handleEndStart(message)) return
@@ -272,36 +267,33 @@ object DragonFeatures {
         return true
     }
 
-    private fun handleEyeEvents(message: String): Boolean = when {
-        eyePlacedPattern.matches(message) -> {
+    private fun handleEyeEvents(message: String): Boolean {
+        eyePlacedPattern.matchMatchers(message) {
             yourEyes++
-            true
+            return true
         }
 
-        eyeRemovedPattern.matches(message) -> {
+        eyeRemovedPattern.matchMatcher(message) {
             yourEyes--
-            true
+            return true
         }
 
-        else -> false
+        return false
     }
 
     private fun handleEndStart(message: String): Boolean {
-        when {
-            endStartLineDragonPattern.matches(message) -> {
-                if (!config.chat) {
-                    reset()
-                } else {
-                    endType = EndType.DRAGON
-                }
-                return true
+        endStartLineDragonPattern.matchMatcher(message) {
+            if (!config.chat) {
+                reset()
+            } else {
+                endType = EndType.DRAGON
             }
-
-            endStartLineProtectorPattern.matches(message) -> {
-                if (!configProtector) return false
-                endType = EndType.GOLEM
-                return true
-            }
+            return true
+        }
+        endStartLineProtectorPattern.matchMatcher(message) {
+            if (!configProtector) return false
+            endType = EndType.GOLEM
+            return true
         }
         return false
     }
@@ -369,7 +361,7 @@ object DragonFeatures {
     }
 
     private fun handleEggSpawn(message: String): Boolean {
-        if (eggSpawnedPattern.matches(message)) {
+        eggSpawnedPattern.matchMatcher(message) {
             eggSpawned = true
             return true
         }
@@ -377,6 +369,7 @@ object DragonFeatures {
     }
 
     private fun printWeight(weight: Double) {
+        if (!config.chat) return
         val space = " ".repeat(if (config.skyhanniMessagePrefix) 16 else 30)
         val weightString = weight.roundTo(0).addSeparators()
         ChatUtils.chat(
@@ -399,7 +392,7 @@ object DragonFeatures {
     @HandleEvent(onlyOnIsland = IslandType.THE_END)
     fun onTabList(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.DRAGON)) return
-        if (!displayIsEnabled()) return
+        if (!dragonSpawned) return
         widgetActive = true
         for (i in 1 until event.lines.size) {
             tabDamagePattern.matchMatcher(event.lines[i]) {
@@ -419,7 +412,7 @@ object DragonFeatures {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_END)
     fun onRender(event: GuiRenderEvent) {
-        if (!displayIsEnabled()) return
+        if (!config.display) return
         if (dirty) {
             display = if (widgetActive) display() else widgetErrorMessage
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFightAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFightAPI.kt
@@ -2,8 +2,8 @@ package at.hannibal2.skyhanni.features.combat.end
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -22,19 +22,20 @@ object DragonFightAPI {
     private val group = RepoPattern.group("combat.end-dragon-fight")
 
     /**
-     * REGEX-TEST: §5☬ §r§d§lThe §r§5§c§lOld Dragon§r§d§l has spawned!§r
+     * REGEX-TEST: ☬ The Old Dragon has spawned!
      */
     private val chatSpawnPattern by group.pattern(
         "chat.spawn",
-        "§5☬ §r§d§lThe §r§5§c§l(?<type>.*)§r§d§l has spawned!§r",
+        "☬ The (?<type>.+) has spawned!",
     )
 
     /**
-     * REGEX-TEST: §r§f                           §r§6§lOLD DRAGON DOWN!§r
+     * WRAPPED-REGEX-TEST: "                           OLD DRAGON DOWN!"
+     * WRAPPED-REGEX-FAIL: "                    END STONE PROTECTOR DOWN!"
      */
     private val chatDeath by group.pattern(
         "chat.death",
-        "§r§f {27}§r§6§l(?<type>.*) DOWN!§r",
+        " +\\w+ DRAGON DOWN!",
     )
 
     /**
@@ -42,7 +43,7 @@ object DragonFightAPI {
      */
     private val scoreboardHPPattern by group.pattern(
         "scoreboard.hp",
-        "Dragon HP: (?<hp>.*) ❤",
+        "Dragon HP: (?<hp>.+) ❤",
     )
 
     /**
@@ -58,12 +59,14 @@ object DragonFightAPI {
     fun inNestArea() = IslandType.THE_END.isInIsland() && nestAreaPattern.matches(SkyBlockUtils.graphArea)
 
     @HandleEvent
-    fun onChat(event: SystemMessageEvent.Allow) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
         chatSpawnPattern.matchMatcher(event.cleanMessage) {
             currentType = group("type")
+            return
         }
         chatDeath.matchMatcher(event.cleanMessage) {
             reset()
+            return
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/anniversary/Year400Features.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/anniversary/Year400Features.kt
@@ -3,11 +3,11 @@ package at.hannibal2.skyhanni.features.event.anniversary
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.event.AnniversaryTeamFinderColorConfig
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.data.mob.MobData
 import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
 import at.hannibal2.skyhanni.events.MobEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.EntityClickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -166,7 +166,7 @@ object Year400Features {
     }
 
     @HandleEvent
-    fun onSystemMessage(event: SystemMessageEvent.Allow) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!config.teamFinder) return
         if (!fatPlayerMessagePattern.matches(event.cleanMessage)) return
         if (lastClickedPlayerTime.passedSince() >= 500.milliseconds) return

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTutorialQuest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTutorialQuest.kt
@@ -5,23 +5,56 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.MobEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import java.util.regex.Pattern
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object ForagingTutorialQuest {
+
     private val config get() = SkyHanniMod.feature.foraging.tutorialQuest
 
     private var lastParkWarpAttempt = SimpleTimeMark.farPast()
     private var lastSuggestion = SimpleTimeMark.farPast()
+
+    private val patternGroup = RepoPattern.group("foraging.tutorial.quest")
+
+    /**
+     * REGEX-TEST: You don't have the requirements to use this warp!
+     * REGEX-TEST: You haven't unlocked this fast travel destination!
+     */
+    private val lockedPattern by patternGroup.list(
+        "warp.locked.list",
+        "You don't have the requirements to use this warp!",
+        "You haven't unlocked this fast travel destination!",
+    )
+
+    /**
+     * REGEX-TEST: You must complete the Into the Woods Quest to use this!
+     */
+    private val needQuestPattern by patternGroup.pattern(
+        "need-quest",
+        "You must complete the (?<quest>.+) Quest to use this!",
+    )
+
+    /**
+     * REGEX-TEST: Requires Into the Woods Quest
+     */
+    private val requiresQuestPattern by patternGroup.pattern(
+        "requires-quest",
+        "Requires (?<quest>.+) Quest",
+    )
 
     private enum class Quest(val questName: String, val npcName: String, val npcLocation: LorenzVec) {
         FIRST("Foraging Tutorial", "Lumber Jack", LorenzVec(-123.5, 74.0, -30.0)),
@@ -31,20 +64,41 @@ object ForagingTutorialQuest {
         FIFTH("The Rebuild", "Melody", LorenzVec(-412.3, 109.0, 70.2)),
     }
 
-    private enum class NextQuest(val nextPortal: LorenzVec, val endingMessage: String) {
-        SECOND(LorenzVec(-312.1, 81.0, -9.0), "Can you maybe look for her in the §aSpruce Woods§f?"),
-        THIRD(LorenzVec(-361.2, 90.0, -14.8), "§cCult Meeting §fthere §c§lRIGHT NOW§f!"),
-        FOURTH_LAST(LorenzVec(-397.3, 98.0, -37.5), "§rYou completed each §6Trial of Fire§f! §aCongratulations!"),
-        FIFTH(LorenzVec(-436.4, 110.5, -14.4), " §rTalk to me again if you ever want to give my §dHarp §fa try!"),
-        SIXTH_FIRST(LorenzVec(-435.5, 110.0, -13.5), "§r§fIt will take me some time to assemble them, so you should §acome back later§f."),
-        SIXTH_SECOND(LorenzVec(-466.8, 120.0, -41.6), "  §r§fTalk to Molbert"),
-        SIXTH_THIRD(LorenzVec(-465.9, 119.0, -53.8), "Once you find the ideal spots, go ahead and deploy them."),
-        SIXTH_FOURTH(LorenzVec(-448.8, 120.0, -64.3), "§aPlaced trap §r§7(§r§e1§r§7/§r§a3§r§7)"),
-        SIXTH_FIFTH(LorenzVec(-439.8, 122.0, -91.3), "LorenzVec(-448.8, 120.0, -64.3)"),
-        SIXTH_SIXTH(LorenzVec(-466.8, 120.0, -43.4), "§aPlaced trap §r§7(§r§a3§r§7/§r§a3§r§7)"),
-        SIXTH_SEVENTH(LorenzVec(-435.5, 110.0, -13.5), "/§r§a3§r§7)"),
-        SIXTH_8(LorenzVec(-450.5, 120.0, -64.9), "  §r§fTalk to Molbert"),
-        SEVEN(LorenzVec(-485.3, 116.5, -40.7), " §rI hope you forgive me after this and we can still be §6friends§f."),
+    @Suppress("MaxLineLength")
+    private enum class NextQuest(val nextPortal: LorenzVec, val endingMessage: Pattern) {
+        SECOND(
+            LorenzVec(-312.1, 81.0, -9.0),
+            "\\[NPC] Charlie: I wanted Kelly to get some Spruce Logs for us today, but I've not seen her in a while\\.\\.\\. Can you maybe look for her in the Spruce Woods\\?".toPattern(),
+        ),
+        THIRD(
+            LorenzVec(-361.2, 90.0, -14.8),
+            "\\[NPC] Kelly: I've heard some people are holding a Cult Meeting there RIGHT NOW!".toPattern(),
+        ),
+        FOURTH_LAST(
+            LorenzVec(-397.3, 98.0, -37.5),
+            "\\[NPC] Ryan: But be careful, though, as each trial burns a little hotter than the last!".toPattern(),
+        ),
+        FIFTH(LorenzVec(-436.4, 110.5, -14.4), "\\[NPC] Melody ♫: Talk to me again if you ever want to give my Harp a try!".toPattern()),
+        SIXTH_FIRST(
+            LorenzVec(-435.5, 110.0, -13.5),
+            "\\[NPC] Molbert: It will take me some time to assemble them, so you should come back later\\.".toPattern(),
+        ),
+        SIXTH_SECOND(LorenzVec(-466.8, 120.0, -41.6), " +Talk to Molbert".toPattern()),
+        SIXTH_THIRD(
+            LorenzVec(-465.9, 119.0, -53.8),
+            "\\[NPC] Molbert: The traps are ready for use; All that remains is to set them up in the right place\\. Once you find the ideal spots, go ahead and deploy them\\.".toPattern(),
+        ),
+        SIXTH_FOURTH(LorenzVec(-448.8, 120.0, -64.3), "Placed trap \\(1/3\\)".toPattern()),
+        SIXTH_FIFTH(LorenzVec(-439.8, 122.0, -91.3), "Placed trap \\(2/3\\)".toPattern()),
+        SIXTH_SIXTH(LorenzVec(-466.8, 120.0, -43.4), "Placed trap \\(3/3\\)".toPattern()),
+        SIXTH_SEVENTH(
+            LorenzVec(-435.5, 110.0, -13.5),
+            "\\[NPC] Molbert: This might take some time, so you should come back later\\.".toPattern(),
+        ),
+        SEVEN(
+            LorenzVec(-485.3, 116.5, -40.7),
+            "\\[NPC] Molbert: I hope you forgive me after this and we can still be friends\\.".toPattern(),
+        ),
     }
 
     @HandleEvent
@@ -56,24 +110,25 @@ object ForagingTutorialQuest {
     }
 
     @HandleEvent
-    fun onChat(event: SystemMessageEvent.Allow) {
-        if (event.message == "§cYou don't have the requirements to use this warp!" ||
-            event.message == "§cYou haven't unlocked this fast travel destination!"
-        ) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
+        lockedPattern.matchMatchers(event.cleanMessage) {
             if (lastParkWarpAttempt.passedSince() < 1.seconds) {
                 EntityMovementData.onNextTeleport(IslandType.HUB) {
                     start(Quest.FIRST)
                 }
             }
+            return
         }
         if (IslandType.HUB.isInIsland() || IslandType.THE_PARK.isInIsland()) {
-            "§cYou must complete the §r§6(?<quest>.*) Quest §r§cto use this!".toPattern().matchMatcher(event.message) {
+            needQuestPattern.matchMatcher(event.cleanMessage) {
                 stepByName(group("quest"))
+                return
             }
         }
         for (step in NextQuest.entries) {
-            if (event.message.endsWith(step.endingMessage)) {
+            step.endingMessage.matchMatcher(event.cleanMessage) {
                 goToNext(step)
+                return
             }
         }
     }
@@ -88,7 +143,7 @@ object ForagingTutorialQuest {
 
     @HandleEvent
     fun onPlayerSpawn(event: MobEvent.Spawn.DisplayNpc) {
-        "§cRequires §6(?<quest>.*) Quest".toPattern().matchMatcher(event.mob.name) {
+        requiresQuestPattern.matchMatcher(event.mob.baseEntity.cleanName()) {
             stepByName(group("quest"))
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -3,8 +3,8 @@ package at.hannibal2.skyhanni.features.garden.pests
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.garden.pests.PestSpawnConfig
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.title.TitleManager
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestSpawnEvent
 import at.hannibal2.skyhanni.features.garden.pests.PestApi.lastPestSpawnTime
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -64,7 +64,7 @@ object PestSpawn {
     )
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onChat(event: SystemMessageEvent.Allow) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
         val message = event.cleanMessage
         var blocked = false
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/FixIronman.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/FixIronman.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryDetector
@@ -43,11 +43,11 @@ object FixIronman {
     }
 
     @HandleEvent
-    fun onChat(event: SystemMessageEvent.Modify) {
+    fun onChat(event: SkyHanniChatEvent.Modify) {
         // We don't need to always fix this
         if (!TimeUtils.isAprilFoolsDay) return
 
-        if (event.message.contains("Ironman")) {
+        if (event.cleanMessage.contains("Ironman")) {
             val newComponent = event.chatComponent.replace("Ironman", "Ironperson") ?: return
             event.replaceComponent(newComponent, "fix_ironman")
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
@@ -3,10 +3,10 @@ package at.hannibal2.skyhanni.features.inventory.chocolatefactory
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.core.config.Position
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.data.CFDataLoader
 import at.hannibal2.skyhanni.features.inventory.chocolatefactory.data.ChocolateAmount
@@ -62,27 +62,27 @@ object CFCustomReminder {
      */
     private val milestoneCostLorePattern by patternGroup.pattern(
         "milestone.cost",
-        "§cRequires (?<amount>.*) all-time Chocolate!",
+        "§cRequires (?<amount>.+) all-time Chocolate!",
     )
 
     /**
-     * REGEX-TEST: §cYou don't have enough Chocolate!
-     * REGEX-TEST: §cYou don't have the required items!
-     * REGEX-TEST: §cYou must collect 300B all-time Chocolate!
+     * REGEX-TEST: You don't have enough Chocolate!
+     * REGEX-TEST: You don't have the required items!
+     * REGEX-TEST: You must collect 300B all-time Chocolate!
      */
     private val chatMessagePattern by patternGroup.list(
         "chat.hide",
-        "§cYou don't have enough Chocolate!",
-        "§cYou don't have the required items!",
-        "§cYou must collect (.*) all-time Chocolate!",
+        "You don't have enough Chocolate!",
+        "You don't have the required items!",
+        "You must collect (.+) all-time Chocolate!",
     )
 
     @HandleEvent
-    fun onChat(event: SystemMessageEvent.Allow) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
         if (!CFApi.inChocolateFactory) return
         if (configReminder.hideChat) {
-            if (chatMessagePattern.matches(event.message)) {
+            if (chatMessagePattern.matches(event.cleanMessage)) {
                 event.blockedReason = "custom_reminder"
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CenturyPartyInvitation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CenturyPartyInvitation.kt
@@ -2,9 +2,9 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.data.mob.MobData
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ConditionalUtils
@@ -44,7 +44,7 @@ object CenturyPartyInvitation {
      */
     private val playerRankColorPattern by chatGroup.pattern(
         "nametag.player-color",
-        ".*\\[§(?<color>.).*\\] .*",
+        ".*\\[§(?<color>.).+] .+",
     )
 
     /**
@@ -52,15 +52,15 @@ object CenturyPartyInvitation {
      */
     private val chatPartyAddPattern by chatGroup.pattern(
         "chat-message.party-add",
-        "§d§lPARTY! .* SkyBlock level color is .*\\[.*\\] - \\[.*\\] §r§(?<color>.).*§e!",
+        "§d§lPARTY! .+ SkyBlock level color is .*\\[.+] - \\[.+] §r§(?<color>.).+§e!",
     )
 
     /**
-     * REGEX-TEST: §aYou had already gained the bonus, so... at least everyone is now invited!
+     * REGEX-TEST: You had already gained the bonus, so... at least everyone is now invited!
      */
     private val chatFoundAllPattern by chatGroup.pattern(
         "chat-message.found-all",
-        "§aYou had already gained the bonus, so\\.\\.\\. at least everyone is now invited!",
+        "You had already gained the bonus, so\\.\\.\\. at least everyone is now invited!",
     )
 
     /**
@@ -78,7 +78,7 @@ object CenturyPartyInvitation {
      */
     private val itemMissingColorLinePattern by chatGroup.pattern(
         "item-lore.missing-color-line",
-        "§8\\[.*\\] - \\[.*\\] §(?<color>.).*",
+        "§8\\[.+] - \\[.+] §(?<color>.).+",
     )
 
     @HandleEvent
@@ -170,19 +170,19 @@ object CenturyPartyInvitation {
     }
 
     @HandleEvent
-    fun onSystemMessage(event: SystemMessageEvent.Allow) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
 
-        val message = event.message
+        val messageWithColor = event.message
 
-        if (chatFoundAllPattern.matches(message) && inHand) {
+        if (chatFoundAllPattern.matches(event.cleanMessage) && inHand) {
             DelayedRun.runDelayed(500.milliseconds) {
                 colorsNeeded = updateColorsNeeded()
                 updateAllPlayers()
             }
         }
 
-        val colorCode = chatPartyAddPattern.matchMatcher(message) {
+        val colorCode = chatPartyAddPattern.matchMatcher(messageWithColor) {
             group("color")
         } ?: return
 
@@ -191,7 +191,7 @@ object CenturyPartyInvitation {
                 "Error reading rank color from chat",
                 "unknown color code detected",
                 "colorCode" to colorCode,
-                "message" to message,
+                "message" to messageWithColor,
             )
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -8,13 +8,13 @@ import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.model.graph.GraphNode
 import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.IslandGraphReloadEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.features.misc.pathfind.NavigationFeedback
@@ -28,7 +28,7 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -56,19 +56,13 @@ object FastFairySoulsPathfinder {
     private val patternGroup = RepoPattern.group("misc.fairy-souls")
 
     /**
+     * REGEX-TEST: SOUL! You found a Fairy Soul!
      * REGEX-TEST: You have already found that Fairy Soul!
      */
-    private val duplicatePattern by patternGroup.pattern(
-        "chat.duplicate.colorless",
-        "^You have already found that Fairy Soul!$",
-    )
-
-    /**
-     * REGEX-TEST: SOUL! You found a Fairy Soul!
-     */
-    private val newPattern by patternGroup.pattern(
-        "chat.new.colorless",
-        "^SOUL! You found a Fairy Soul!$",
+    private val foundPattern by patternGroup.list(
+        "chat.found.list",
+        "SOUL! You found a Fairy Soul!",
+        "You have already found that Fairy Soul!",
     )
 
     /**
@@ -76,7 +70,7 @@ object FastFairySoulsPathfinder {
      */
     private val loreSoulPattern by patternGroup.pattern(
         "new.colorless",
-        "Fairy Souls: (?<found>.*)\\/(?<total>.*)",
+        "Fairy Souls: (?<found>.+)/(?<total>.+)",
     )
 
     private class Data(
@@ -297,8 +291,8 @@ object FastFairySoulsPathfinder {
     }
 
     @HandleEvent
-    fun onSystemMessage(event: SystemMessageEvent.Allow) {
-        if (duplicatePattern.matches(event.cleanMessage) || newPattern.matches(event.cleanMessage)) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
+        foundPattern.matchMatchers(event.cleanMessage) {
             data?.foundNearby()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FruitBowlFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FruitBowlFeatures.kt
@@ -2,9 +2,9 @@ package at.hannibal2.skyhanni.features.misc
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.data.mob.MobData
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
@@ -49,7 +49,7 @@ object FruitBowlFeatures {
      */
     private val chatClickedPlayerPattern by chatGroup.pattern(
         "chat-message.clicked-player",
-        "FRUIT BOWL! (?<player>.*) profile name is (?<profile>[a-zA-Z]*)!",
+        "FRUIT BOWL! (?<player>.+) profile name is (?<profile>[a-zA-Z]+)!",
     )
 
     /**
@@ -65,15 +65,15 @@ object FruitBowlFeatures {
      */
     private val chatFoundMissingPattern by chatGroup.pattern(
         "chat-message.found-missing",
-        "(?<profile>[a-zA-Z]*) has been added to the fruit bowl!",
+        "(?<profile>[a-zA-Z]+) has been added to the fruit bowl!",
     )
 
     /**
-     * REGEX-TEST: §2§lFRUITALICIOUS! §r§aYou completed your fruit bowl!
+     * REGEX-TEST: FRUITALICIOUS! You completed your fruit bowl!
      */
     private val chatFoundAllPattern by chatGroup.pattern(
         "chat-message.found-all",
-        "§2§lFRUITALICIOUS! §r§aYou completed your fruit bowl!",
+        "FRUITALICIOUS! You completed your fruit bowl!",
     )
 
     /**
@@ -182,7 +182,7 @@ object FruitBowlFeatures {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSystemMessage(event: SystemMessageEvent.Allow) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!inHand) return
 
         val message = event.cleanMessage

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SpiderDenRelicPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SpiderDenRelicPathfinder.kt
@@ -8,10 +8,10 @@ import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.model.graph.GraphNode
 import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.features.misc.pathfind.NavigationFeedback
@@ -23,7 +23,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -45,18 +45,14 @@ object SpiderDenRelicPathfinder {
 
     /**
      * REGEX-TEST: +10,000 Coins! (2/28 Relics)
-     */
-    private val foundPattern by patternGroup.pattern(
-        key = "chat.found",
-        fallback = "\\+[\\d,]+ Coins! \\(\\d+/\\d+ Relics\\)",
-    )
-
-    /**
      * REGEX-TEST: You've already found this relic!
+     * REGEX-TEST: You've already found all the relics!
      */
-    private val duplicatePattern by patternGroup.pattern(
-        key = "chat.duplicate",
-        fallback = "You've already found this relic!|You've already found all the relics!",
+    private val foundPattern by patternGroup.list(
+        "chat.found.list",
+        "\\+[\\d,]+ Coins! \\(\\d+/\\d+ Relics\\)",
+        "You've already found this relic!",
+        "You've already found all the relics!",
     )
 
     private class Data(
@@ -164,9 +160,9 @@ object SpiderDenRelicPathfinder {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.SPIDER_DEN)
-    fun onSystemMessage(event: SystemMessageEvent.Allow) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!config.spiderRelicPathfinder) return
-        if (foundPattern.matches(event.chatComponent) || duplicatePattern.matches(event.chatComponent)) {
+        foundPattern.matchMatchers(event.cleanMessage) {
             data?.foundNearby()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
@@ -5,10 +5,10 @@ import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
 import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.SlayerApi
 import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.events.slayer.SlayerProgressChangeEvent
 import at.hannibal2.skyhanni.features.inventory.EquipmentApi
@@ -25,7 +25,6 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -68,7 +67,7 @@ object RemainingSlayerKills {
      */
     private val comboExpiredPattern by patternGroup.pattern(
         "combo.expired",
-        "Your Kill Combo has expired! You reached a .* Kill Combo!",
+        "Your Kill Combo has expired! You reached a \\d+ Kill Combo!",
     )
 
     /**
@@ -140,14 +139,16 @@ object RemainingSlayerKills {
         update()
     }
 
-    @HandleEvent
-    fun onChat(event: SystemMessageEvent.Allow) {
+    @HandleEvent(receiveCancelled = true)
+    fun onChat(event: SkyHanniChatEvent.Allow) {
         val message = event.cleanMessage
-        if (comboExpiredPattern.matches(message)) {
+        comboExpiredPattern.matchMatcher(message) {
             killComboWisdom = 0
+            return
         }
         killCombatWisdomPattern.matchMatcher(message) {
             killComboWisdom = group("wisdom").formatInt()
+            return
         }
         // TODO add to repo since Hypixel is planning to add more Wisdom to Grandma Wolf see
         // https://hypixel.net/threads/design-thread-magic-find.6015417/

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/spider/SlayerSpiderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/spider/SlayerSpiderFeatures.kt
@@ -3,15 +3,18 @@ package at.hannibal2.skyhanni.features.slayer.spider
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.EntityMovementData
 import at.hannibal2.skyhanni.data.SlayerApi
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.data.mob.MobCategory
 import at.hannibal2.skyhanni.events.MobEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.EntityClickEvent
 import at.hannibal2.skyhanni.events.entity.EntityMoveEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
+import at.hannibal2.skyhanni.features.slayer.SlayerType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.MobUtils.mob
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.monster.spider.Spider
 
 @SkyHanniModule
@@ -21,6 +24,14 @@ object SlayerSpiderFeatures {
     private var lastClicked: Mob? = null
     val stuckMobs = mutableSetOf<Mob>()
 
+    /**
+     * REGEX-TEST: You need to kill the Broodfather's hatchlings before it can be damaged again!
+     */
+    private val killHatchlingsPattern by RepoPattern.pattern(
+        "slayer.spider.kill-hatchlings",
+        "You need to kill the Broodfather's hatchlings before it can be damaged again!",
+    )
+
     @HandleEvent(onlyOnSkyblock = true)
     fun onMobSpawn(event: MobEvent.Spawn.SkyblockMob) {
         val mob = event.mob
@@ -29,7 +40,7 @@ object SlayerSpiderFeatures {
         }
     }
 
-    private fun Mob.isRightTier() = category == MobCategory.SLAYER && (levelOrTier in 3..5) && name == "Tarantula Broodfather"
+    private fun Mob.isRightTier() = category == MobCategory.SLAYER && (levelOrTier in 3..5) && name == SlayerType.TARANTULA.displayName
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onClickEntity(event: EntityClickEvent) {
@@ -41,13 +52,13 @@ object SlayerSpiderFeatures {
     }
 
     @HandleEvent
-    fun onChat(event: SystemMessageEvent.Allow) {
-        if (event.message != "§cYou need to kill the Broodfather's hatchlings before it can be damaged again!") return
-
-        val mob = lastClicked ?: return
-        mob.highlight(config.highlightInvincibleColor, condition = { config.highlightInvincible && mob in stuckMobs })
-        stuckMobs.add(mob)
-        EntityMovementData.addToTrack(mob)
+    fun onChat(event: SkyHanniChatEvent.Allow) {
+        killHatchlingsPattern.matchMatcher(event.cleanMessage) {
+            val mob = lastClicked ?: return
+            mob.highlight(config.highlightInvincibleColor, condition = { config.highlightInvincible && mob in stuckMobs })
+            stuckMobs.add(mob)
+            EntityMovementData.addToTrack(mob)
+        }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.utils.ColorUtils.getFirstColorCode
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RegexUtils.findAll
@@ -434,7 +434,7 @@ object StringUtils {
     /**
      * Applies a transformation on the message of a SystemMessageEvent if possible.
      */
-    fun SystemMessageEvent.Modify.applyIfPossible(
+    fun SkyHanniChatEvent.Modify.applyIfPossible(
         transformationReason: String? = null,
         transform: (String) -> String,
     ) {


### PR DESCRIPTION
## What
So, as you can see from this screenshot, SystemMessageEvent is fucked, and does not filter out anything. I replaced all usages in the code of SystemMessageEvent with SkyHanniChatEvent, and deprecated SystemMessageEvent (while also fixing SystemMessageEvent).

SystemMessageEvent will now work properly (and only get posted for "system messages"), but I deprecated it since we really shouldn't be using it anyway.

Also: I fixed the dragon tracker regex having color codes despite using event.cleanMessage

<img width="1364" height="760" alt="image" src="https://github.com/user-attachments/assets/e07e5dbc-6d9f-446f-971a-dc6bd2f9e2da" />

## Changelog Fixes
+ Fixed Dragon Profit Tracker regex. - zumbiepig

## Changelog Technical Details
+ Fixed SystemMessageEvent being posted multiple times per chat message. - zumbiepig
