### PR TITLE
Fix: Hoppity Rabbits Found Regex

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCollectionStats.kt
@@ -102,11 +102,11 @@ object HoppityCollectionStats {
     )
 
     /**
-     * REGEX-TEST: §2§l§m                      §f§l§m   §r §e395§6/§e457
+     * WRAPPED-REGEX-TEST: "§2§l§m                          §e497§6/§e517"
      */
     private val rabbitsFoundPattern by patternGroup.pattern(
         "rabbits.found",
-        "§.§l§m[ §a-z]+§r §.(?<current>[0-9]+)§./§.(?<total>[0-9]+)",
+        "§.§l§m[ §a-z]+ §.(?<current>[0-9]+)§./§.(?<total>[0-9]+)",
     )
 
     /**


### PR DESCRIPTION
## What
Fixes the Hoppity Rabbits Found regex pattern.
Should be made colorless, but that can be done later 😄.

## Changelog Fixes
+ Fixed Found Hoppity Rabbits not being detected. - Alex
