### PR TITLE
Backend: Deprecate formattedTextCompat methods

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -60,6 +60,7 @@ private enum class FormattedTextSettings {
 
 private data class TextCacheKey(val settings: FormattedTextSettings, val component: Component)
 
+@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
 fun Component.unformattedTextForChatCompat(): String {
     return unformattedTextCache.getOrPut(this) {
         computeUnformattedTextCompat()
@@ -73,17 +74,12 @@ private fun Component.computeUnformattedTextCompat(): String {
     return (this.contents as? PlainTextContents)?.text().orEmpty()
 }
 
+@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
 fun Component.unformattedTextCompat(): String =
     iterator().joinToString(separator = "") { it.unformattedTextForChatCompat() }
 
-// has to be a separate function for pattern mappings
-fun Component?.formattedTextCompatLessResets(): String = this.formattedTextCompat(noExtraResets = true)
-fun Component?.formattedTextCompatLeadingWhite(): String = this.formattedTextCompat(leadingWhite = true)
-fun Component?.formattedTextCompatLeadingWhiteLessResets(): String =
-    this.formattedTextCompat(noExtraResets = true, leadingWhite = true)
-
 @JvmOverloads
-@Suppress("unused")
+@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
 fun Component?.formattedTextCompat(noExtraResets: Boolean = false, leadingWhite: Boolean = false): String {
     this ?: return ""
     val cacheKey = TextCacheKey(FormattedTextSettings.getByArgs(noExtraResets, leadingWhite), this)
@@ -91,6 +87,19 @@ fun Component?.formattedTextCompat(noExtraResets: Boolean = false, leadingWhite:
         computeFormattedTextCompat(noExtraResets, leadingWhite)
     }
 }
+
+@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+@Suppress("DEPRECATION")
+fun Component?.formattedTextCompatLessResets(): String = this.formattedTextCompat(noExtraResets = true)
+
+@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+@Suppress("DEPRECATION")
+fun Component?.formattedTextCompatLeadingWhite(): String = this.formattedTextCompat(leadingWhite = true)
+
+@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+@Suppress("DEPRECATION")
+fun Component?.formattedTextCompatLeadingWhiteLessResets(): String =
+    this.formattedTextCompat(noExtraResets = true, leadingWhite = true)
 
 private fun Component?.computeFormattedTextCompat(noExtraResets: Boolean, leadingWhite: Boolean): String {
     this ?: return ""

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -60,7 +60,7 @@ private enum class FormattedTextSettings {
 
 private data class TextCacheKey(val settings: FormattedTextSettings, val component: Component)
 
-@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+@Deprecated("Use string unless you really need color codes")
 fun Component.unformattedTextForChatCompat(): String {
     return unformattedTextCache.getOrPut(this) {
         computeUnformattedTextCompat()
@@ -74,12 +74,12 @@ private fun Component.computeUnformattedTextCompat(): String {
     return (this.contents as? PlainTextContents)?.text().orEmpty()
 }
 
-@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+@Deprecated("Use string unless you really need color codes")
 fun Component.unformattedTextCompat(): String =
     iterator().joinToString(separator = "") { it.unformattedTextForChatCompat() }
 
 @JvmOverloads
-@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+@Deprecated("Use string unless you really need color codes")
 fun Component?.formattedTextCompat(noExtraResets: Boolean = false, leadingWhite: Boolean = false): String {
     this ?: return ""
     val cacheKey = TextCacheKey(FormattedTextSettings.getByArgs(noExtraResets, leadingWhite), this)
@@ -88,15 +88,15 @@ fun Component?.formattedTextCompat(noExtraResets: Boolean = false, leadingWhite:
     }
 }
 
-@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+@Deprecated("Use string unless you really need color codes")
 @Suppress("DEPRECATION")
 fun Component?.formattedTextCompatLessResets(): String = this.formattedTextCompat(noExtraResets = true)
 
-@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+@Deprecated("Use string unless you really need color codes")
 @Suppress("DEPRECATION")
 fun Component?.formattedTextCompatLeadingWhite(): String = this.formattedTextCompat(leadingWhite = true)
 
-@Deprecated("Use string unless you really need color codes", ReplaceWith("this.string"))
+@Deprecated("Use string unless you really need color codes")
 @Suppress("DEPRECATION")
 fun Component?.formattedTextCompatLeadingWhiteLessResets(): String =
     this.formattedTextCompat(noExtraResets = true, leadingWhite = true)


### PR DESCRIPTION
## What
Way less ambitious PR. Just marking them as deprecated and a little reordering, that's pretty much it.

## Changelog Technical Details
+ Marked all TextCompat.formattedTextCompat\* methods as deprecated. - Luna