### PR TITLE
Improvement: Hide gui during F3

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -47,7 +47,7 @@ object RenderEvents {
 
     private fun postGui(context: GuiGraphicsExtractor, tick: DeltaTracker) {
         if (MinecraftCompat.hideGui) return
-        if (MinecraftCompat.showDebugHud && config.hideGuiInDebugMenu) return
+        if (config.hideGuiInDebugMenu && MinecraftCompat.showDebugHud) return
         RenderData.postRenderOverlay(context)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -1,10 +1,12 @@
 package at.hannibal2.skyhanni.api.minecraftevents
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.RenderData
 import at.hannibal2.skyhanni.events.render.gui.GameOverlayRenderPostEvent
 import at.hannibal2.skyhanni.events.render.gui.GameOverlayRenderPreEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.render.SkyHanniRoundedShapeRenderManager
 import at.hannibal2.skyhanni.utils.render.item.SkyHanniItemRenderCoordinator
 import at.hannibal2.skyhanni.utils.render.item.SkyHanniPipCoordinatorRenderer
@@ -20,6 +22,7 @@ import net.fabricmc.fabric.api.client.rendering.v1.PictureInPictureRendererRegis
 
 @SkyHanniModule
 object RenderEvents {
+    private val config get() = SkyHanniMod.feature.gui
 
     init {
         HudElementRegistry.attachElementBefore(
@@ -44,7 +47,8 @@ object RenderEvents {
     }
 
     private fun postGui(context: GuiGraphicsExtractor, tick: DeltaTracker) {
-        if (Minecraft.getInstance().options.hideGui) return
+        if (MinecraftCompat.hideGui) return
+        if (MinecraftCompat.showDebugHud && config.hideGuiInDebugMenu) return
         RenderData.postRenderOverlay(context)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/RenderEvents.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.utils.render.item.SkyHanniPipCoordinatorRenderer
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry
 import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements
 import net.minecraft.client.DeltaTracker
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.resources.Identifier
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/MainTogglesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/MainTogglesConfig.kt
@@ -34,4 +34,12 @@ class MainTogglesConfig {
     )
     @ConfigEditorBoolean
     var pingApi: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Hide GUI in F3 menu",
+        desc = "Hide Skyhanni GUI elements in debug menu",
+    )
+    @ConfigEditorBoolean
+    var hideGuiInDebugMenu: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/MainTogglesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/MainTogglesConfig.kt
@@ -34,12 +34,4 @@ class MainTogglesConfig {
     )
     @ConfigEditorBoolean
     var pingApi: Boolean = true
-
-    @Expose
-    @ConfigOption(
-        name = "Hide GUI in F3 menu",
-        desc = "Hide Skyhanni GUI elements in debug menu",
-    )
-    @ConfigEditorBoolean
-    var hideGuiInDebugMenu: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
@@ -198,4 +198,12 @@ class GuiConfig {
     @ConfigOption(name = "Legion/Bobbin Overlay", desc = "")
     @Accordion
     val legionBobbinOverlay: LegionBobbinOverlayConfig = LegionBobbinOverlayConfig()
+
+    @Expose
+    @ConfigOption(
+        name = "Hide GUI in F3 menu",
+        desc = "Hide Skyhanni GUI elements in debug menu",
+    )
+    @ConfigEditorBoolean
+    var hideGuiInDebugMenu: Boolean = true
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
@@ -20,6 +20,7 @@ import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import net.minecraft.client.gui.screens.inventory.SignEditScreen
+import org.joml.Vector2i
 import org.lwjgl.glfw.GLFW
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -151,6 +152,3 @@ object GuiEditManager {
 }
 
 private data class CurrentPosition(val position: Position, val isChestGuiOverlay: Boolean)
-
-// TODO remove
-class Vector2i(val x: Int, val y: Int)

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
@@ -35,6 +35,8 @@ object MinecraftCompat {
 
     val showDebugHud get(): Boolean = Minecraft.getInstance().debugEntries.isOverlayVisible
 
+    val hideGui get(): Boolean = Minecraft.getInstance().options.hideGui
+
     //~ if < 26.1 'defaultClockTime' -> 'dayTime'
     val clientTime get(): Long = localWorldOrNull?.defaultClockTime ?: 0L
 


### PR DESCRIPTION
## What
Adds a toggle to hide all UI elements while F3 (debug menu) is active.

I got no clue what is a good way to handle this breaking `SkyhanniDebugAndTests` techincally, since that relies on debug menu being active. but I guess whoever is using it can disable the setting.

I also did really minor cleanup on the way.
like using `org.joml.Vector2i` instead of a custom made `Vector2i`,
And moving `hideGui` to `MinecraftCompat`.

I worry that this could lower performance, as this check is on a very hot path.
But it's probably fine.

## Changelog Improvements
+ Added option to hide all SkyHanni GUI elements while the F3 menu is open.