### PR TITLE
Fix + Improvement: /gfs tab-complete show internal names on 26.1.2 & Improved tab-complete to better match searched items

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
@@ -370,7 +370,7 @@ object SackApi {
         rebuildSackNameLists()
     }
 
-    @HandleEvent
+    @HandleEvent(priority = HandleEvent.LOWEST)
     fun onComponentsLoaded() {
         rebuildSackNameLists()
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SackApi.kt
@@ -149,6 +149,8 @@ object SackApi {
     var sackListNames = emptySet<String>()
         private set
 
+    private var uniqueSackItems: Set<NeuInternalName> = emptySet()
+
     var sacks = mapOf<String, List<NeuInternalName>>()
         private set
 
@@ -363,13 +365,21 @@ object SackApi {
     @HandleEvent
     fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
         val sacksData = event.getConstant<NeuSacksJson>("sacks").sacks
-        val uniqueSackItems = mutableSetOf<NeuInternalName>()
-
-        sacksData.values.flatMap { it.contents }.forEach { uniqueSackItems.add(it) }
+        uniqueSackItems = sacksData.values.flatMap { it.contents }.toSet()
         sacks = sacksData.mapValues { it.value.contents }
+        rebuildSackNameLists()
+    }
 
+    @HandleEvent
+    fun onComponentsLoaded() {
+        rebuildSackNameLists()
+    }
+
+    private fun rebuildSackNameLists() {
         sackListInternalNames = uniqueSackItems.map { it.asString() }.toSet()
-        sackListNames = uniqueSackItems.map { it.itemNameWithoutColor.removeNonAsciiNonColorCode().trim().uppercase() }.toSet()
+        sackListNames = uniqueSackItems.map {
+            it.itemNameWithoutColor.removeNonAsciiNonColorCode().trim().uppercase()
+        }.toSet()
     }
 
     @HandleEvent(ProfileJoinEvent::class, priority = HandleEvent.HIGH)

--- a/src/main/java/at/hannibal2/skyhanni/events/chat/TabCompletionEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/chat/TabCompletionEvent.kt
@@ -20,6 +20,15 @@ class TabCompletionEvent(
         suggestions.forEach(this::addSuggestion)
     }
 
+    fun addSuggestionUnchecked(suggestion: String) {
+        val adjustedSuggestion = suggestion.removePrefix("/")
+        additionalSuggestions.add(adjustedSuggestion)
+    }
+
+    fun addSuggestionsUnchecked(suggestions: Iterable<String>) {
+        suggestions.forEach(this::addSuggestionUnchecked)
+    }
+
     val command = if (leftOfCursor.startsWith("/"))
         leftOfCursor.substring(1).substringBefore(" ").lowercase()
     else ""

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/GetFromSacksTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/GetFromSacksTabComplete.kt
@@ -2,21 +2,31 @@ package at.hannibal2.skyhanni.features.commands.tabcomplete
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.GetFromSackApi.commands
+import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SackApi
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
+import at.hannibal2.skyhanni.events.chat.TabCompletionEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils.eventWithNewMessage
 import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 
+@SkyHanniModule
 object GetFromSacksTabComplete {
 
     private val config get() = SkyHanniMod.feature.misc.commands.tabComplete
 
-    fun handleTabComplete(command: String): List<String>? {
-        if (!isEnabled()) return null
-        if (command !in commands) return null
+    @HandleEvent
+    fun onTabComplete(event: TabCompletionEvent) {
+        if (!isEnabled()) return
+        if (commands.none { event.isCommand(it) }) return
+        if (!event.leftOfCursor.contains(" ")) return
 
-        return SackApi.sackListNames.map { it.replace(" ", "_") }
+        val query = event.lastWord
+        val matching = SackApi.sackListNames
+            .filter { it.contains(query, ignoreCase = true) }
+            .map { it.replace(" ", "_") }
+        event.addSuggestionsUnchecked(matching)
     }
 
     // No subscribe since it needs to be called from the GetFromSackAPI

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/TabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/TabComplete.kt
@@ -23,7 +23,6 @@ object TabComplete {
 
     @Suppress("ReturnCount")
     private fun customTabComplete(fullCommand: String, command: String): List<String>? {
-        GetFromSacksTabComplete.handleTabComplete(command)?.let { return it }
         PlayerTabComplete.handleTabComplete(fullCommand)?.let { return it }
         PartyCommands.customTabComplete(command)?.let { return it }
         ViewRecipeCommand.customTabComplete(command)?.let { return it }


### PR DESCRIPTION
## What

Fix /gfs tab-complete showing internal-name entries like INTERNALNAME:ABSOLUTE_ENDER_PEARL on 26.1.2.

Also improves /gfs tab-complete matching so typing /gfs melon shows all sack items containing melon, not only items starting with it.

Technical changes:
- Rebuild sack item display names after item components are loaded.
- Run the sack name rebuild at lowest priority so item caches are ready first.
- Move `/gfs` tab-complete to its own event handler.
- Add unchecked tab suggestions for contains-based matching.

## Changelog Improvements
+ Improved `/gfs` tab-complete to better match searched items. - legentpc

## Changelog Fixes
+ Fixed `/gfs` tab-complete showing internal names on 26.1.2. - legentpc