### PR TITLE
Fix: /shnav not work with same locations

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -50,11 +50,24 @@ object NavigationHelper {
         }
         val title = if (searchTerm.isBlank()) "SkyHanni Navigation Locations" else "SkyHanni Navigation Locations Matching: \"$searchTerm\""
 
-        if (config.allowInstantNavigation && locations.size == 1) {
-            val (name, node) = locations.first()
-            node.pathFind(label = name, allowRerouting = true, condition = { true })
-            sendNavigateMessageWithContent("§7Only one location found, navigating to §r$name", goBack)
-            return
+        if (config.allowInstantNavigation) {
+            val exactMatch = locations.firstOrNull { (name, _) ->
+                name.substringBefore(" §7(").equals(searchTerm, ignoreCase = true)
+            }
+
+            if (exactMatch != null) {
+                val (name, node) = exactMatch
+                node.pathFind(label = name, allowRerouting = true, condition = { true })
+                sendNavigateMessageWithContent("§7Only one location found, navigating to §r$name", goBack)
+                return
+            }
+
+            if (locations.size == 1) {
+                val (name, node) = locations.first()
+                node.pathFind(label = name, allowRerouting = true, condition = { true })
+                sendNavigateMessageWithContent("§7Only one location found, navigating to §r$name", goBack)
+                return
+            }
         }
 
         TextHelper.displayPaginatedList(

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -55,17 +55,18 @@ object NavigationHelper {
                 name.substringBefore(" §7(").equals(searchTerm, ignoreCase = true)
             }
 
-            if (exactMatch != null) {
-                val (name, node) = exactMatch
-                node.pathFind(label = name, allowRerouting = true, condition = { true })
-                sendNavigateMessageWithContent("§7Only one location found, navigating to §r$name", goBack)
-                return
-            }
+            val target = exactMatch ?: locations.takeIf { it.size == 1 }?.first()
 
-            if (locations.size == 1) {
-                val (name, node) = locations.first()
+            if (target != null) {
+                val (name, node) = target
                 node.pathFind(label = name, allowRerouting = true, condition = { true })
-                sendNavigateMessageWithContent("§7Only one location found, navigating to §r$name", goBack)
+
+                val message = if (exactMatch != null) {
+                    "§7Exact match found, navigating to §r$name"
+                } else {
+                    "§7Only one location found, navigating to §r$name"
+                }
+                sendNavigateMessageWithContent(message, goBack)
                 return
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -77,9 +77,9 @@ object TextHelper {
 
     fun Component.center(width: Int = Minecraft.getInstance().gui.chat.width): Component {
         val textWidth = this.width()
-        val spaceWidth = SPACE.width()
-        val padding = (width - textWidth) / 2
-        return join(" ".repeat(padding / spaceWidth), this)
+        val spaceWidth = SPACE.width().coerceAtLeast(1)
+        val padding = ((width - textWidth) / 2).coerceAtLeast(0)
+        return join(" ".repeat((padding / spaceWidth).coerceAtLeast(0)), this)
     }
 
     fun Component.send(id: Int = 0, bypassSelfMessages: Boolean = false) =

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -78,8 +78,8 @@ object TextHelper {
     fun Component.center(width: Int = Minecraft.getInstance().gui.chat.width): Component {
         val textWidth = this.width()
         val spaceWidth = SPACE.width().coerceAtLeast(1)
-        val padding = ((width - textWidth) / 2).coerceAtLeast(0)
-        return join(" ".repeat((padding / spaceWidth).coerceAtLeast(0)), this)
+        val padding = (width - textWidth).coerceAtLeast(0) / 2
+        return join(" ".repeat(padding / spaceWidth), this)
     }
 
     fun Component.send(id: Int = 0, bypassSelfMessages: Boolean = false) =


### PR DESCRIPTION
## What
This pull request fixes `/shnav` when an exact location match exists alongside similarly named locations by preferring the exact match before opening the selection list.

Previously affected examples:
- Carpenter
- Murkwater
- more etc.

## Changelog Fixes
+ Fixed /shnav ignoring exact location matches when similarly named locations exist. - legentpc
+ Fixed potential error message in chat centering when space width is zero. - legentpc