### PR TITLE
Fix: Use standard texture check in Fruit Digging solver

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
-import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -121,10 +121,7 @@ object CarnivalFruitDigging {
         DRAGON_FRUIT("Dragonfruit", 1200, 1, "CARNIVAL_DRAGON_FRUIT"),
         ;
 
-        private val textureId: String by lazy {
-            if (textureKey.isEmpty()) ""
-            else StringUtils.decodeBase64(SkullTextureHolder.getTexture(textureKey)).substringAfterLast("/texture/").substringBefore("\"")
-        }
+        private val texture by SkullTextureHolder.texture(textureKey)
 
         fun getAmountDugSoFar(): Int {
             return count - (remainingFruit[this] ?: 0)
@@ -150,8 +147,8 @@ object CarnivalFruitDigging {
         }
 
         companion object {
-            fun fromTexture(texture: String): Fruit? {
-                return Fruit.entries.find { it.textureId.isNotEmpty() && texture.contains(it.textureId) }
+            fun fromTexture(texture: String?): Fruit? {
+                return Fruit.entries.find { texture != null && it.texture == texture }
             }
 
             fun fromName(name: String): Fruit? {
@@ -355,11 +352,9 @@ object CarnivalFruitDigging {
         val dugCell = lastSquareDug?.let { gameGrid[it] } ?: return
 
         val itemStack = entity.item
-        val textureHash = itemStack.getSkullTexture()?.let {
-            runCatching { StringUtils.decodeBase64(it) }.getOrNull()
-        } ?: return
+        val texture = itemStack.getSkullTexture()
 
-        val fruit = Fruit.fromTexture(textureHash) ?: return
+        val fruit = Fruit.fromTexture(texture) ?: return
 
         var updated = false
         if (solvedCell.solvedFruit == Fruit.UNKNOWN) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -148,7 +148,8 @@ object CarnivalFruitDigging {
 
         companion object {
             fun fromTexture(texture: String?): Fruit? {
-                return Fruit.entries.find { texture != null && it.texture == texture }
+                texture ?: return null
+                return Fruit.entries.find { it.texture == texture }
             }
 
             fun fromName(name: String): Fruit? {


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/770

## What
Unbreaks build and changes the Fruit Digging solver texture matching logic to be the same as every other feature class.

The breakage is only in an unreleased version, so:

exclude_from_changelog