### PR TITLE
Backend: Code Cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
@@ -4,19 +4,15 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SackApi
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.events.minecraft.add
 import at.hannibal2.skyhanni.events.minecraft.addAll
-import at.hannibal2.skyhanni.features.commands.tabcomplete.GetFromSacksTabComplete
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.Calculator
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ChatUtils.isCommand
-import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
@@ -101,7 +97,7 @@ object GetFromSackApi {
     }
 
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    fun onInventoryClose() {
         inventoryMap.clear()
     }
 
@@ -124,24 +120,7 @@ object GetFromSackApi {
         }
     }
 
-    @HandleEvent(onlyOnSkyblock = true)
-    fun onMessageToServer(event: MessageSendToServerEvent) {
-        if ((!config.queuedGFS && !config.bazaarGFS) || SkyBlockUtils.isOnAlphaServer) return
-        if (!event.isCommand(commandsWithSlash)) return
-        val replacedEvent = GetFromSacksTabComplete.handleUnderlineReplace(event)
-        queuedHandler(replacedEvent)
-        bazaarHandler(replacedEvent)
-        if (replacedEvent.isCancelled) {
-            event.cancel()
-            return
-        }
-        if (replacedEvent !== event) {
-            event.cancel()
-            ChatUtils.sendMessageToServer(replacedEvent.message)
-        }
-    }
-
-    private fun queuedHandler(event: MessageSendToServerEvent) {
+    internal fun queuedHandler(event: MessageSendToServerEvent) {
         if (!config.queuedGFS || SkyBlockUtils.isOnAlphaServer) return
         if (event.senderIsSkyhanni()) return
 
@@ -160,7 +139,7 @@ object GetFromSackApi {
         event.cancel()
     }
 
-    private fun bazaarHandler(event: MessageSendToServerEvent) {
+    internal fun bazaarHandler(event: MessageSendToServerEvent) {
         if (event.isCancelled) return
         if (!config.bazaarGFS || SkyBlockUtils.noTradeMode) return
         lastItemStack = commandValidator(event.splitMessage.drop(1)).second

--- a/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
@@ -387,7 +387,7 @@ enum class TabWidget(
     /** The current active information from tab list.
      *
      * When the widget isn't visible, it will be empty
-     * */
+     */
     var lines: List<Component> = emptyList()
         private set
 

--- a/src/main/java/at/hannibal2/skyhanni/events/ItemClickEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/ItemClickEvent.kt
@@ -3,5 +3,7 @@ package at.hannibal2.skyhanni.events
 import at.hannibal2.skyhanni.data.InteractClickType
 import at.hannibal2.skyhanni.utils.SafeItemStack
 
-// Left or right click into the world, with the item in hand
+/**
+ * Left or right click into the world, with the item in hand
+ */
 class ItemClickEvent(itemInHand: SafeItemStack?, clickType: InteractClickType) : WorldClickEvent(itemInHand, clickType)

--- a/src/main/java/at/hannibal2/skyhanni/events/MessageSendToServerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/MessageSendToServerEvent.kt
@@ -3,10 +3,26 @@ package at.hannibal2.skyhanni.events
 import at.hannibal2.skyhanni.api.event.CancellableSkyHanniEvent
 import at.hannibal2.skyhanni.utils.system.ModInstance
 
+/**
+ * Fired when a message or command is about to be sent from the client to the server.
+ * Cancelling this event prevents the message from being sent.
+ */
 class MessageSendToServerEvent(
     val message: String,
     val splitMessage: List<String>,
-    val originatingModContainer: ModInstance?
+    val originatingModContainer: ModInstance?,
 ) : CancellableSkyHanniEvent() {
-    val isCommand by lazy { message.startsWith("/") }
+    val isAnyCommand by lazy { message.startsWith("/") }
+
+    fun isCommand(commandWithSlash: String): Boolean = splitMessage.takeIf {
+        it.isNotEmpty()
+    }?.get(0) == commandWithSlash
+
+    fun isCommand(commandsWithSlash: Collection<String>): Boolean =
+        splitMessage.takeIf { it.isNotEmpty() }?.get(0) in commandsWithSlash
+
+    fun senderIsSkyhanni(): Boolean = originatingModContainer?.id == "skyhanni"
+
+    fun eventWithNewMessage(message: String): MessageSendToServerEvent =
+        MessageSendToServerEvent(message, message.split(" "), this.originatingModContainer)
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/combat/CocoonSpawnEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/combat/CocoonSpawnEvent.kt
@@ -4,5 +4,8 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.features.combat.cocoon.CocoonAPI.CocoonMob
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
+/**
+ * Fired when a new cocoon is detected in the world, carrying the cocooned mob data.
+ */
 @PrimaryFunction("onCocoonSpawn")
 class CocoonSpawnEvent(val cocoonMob: CocoonMob) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/hypixel/HypixelJoinEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/hypixel/HypixelJoinEvent.kt
@@ -2,7 +2,5 @@ package at.hannibal2.skyhanni.events.hypixel
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-/**
- * TODO: replace with [HypixelAPIJoinEvent](at.hannibal2.skyhanni.events.hypixel.modapi.HypixelAPIJoinEvent)
- * */
+// TODO: replace with [HypixelAPIJoinEvent](at.hannibal2.skyhanni.events.hypixel.modapi.HypixelAPIJoinEvent)
 object HypixelJoinEvent : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/AcceptLastPartyInvite.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/AcceptLastPartyInvite.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.RegexUtils.findMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/OpenLastStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/OpenLastStorage.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.NumberUtil.formatIntOrUserError
 import at.hannibal2.skyhanni.utils.SkyBlockUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/PreventEarlyCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/PreventEarlyCommands.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
@@ -43,7 +42,7 @@ object PreventEarlyCommands {
     fun onMessageSendToServer(event: MessageSendToServerEvent) {
         if (!config.preventEarlyExecution) return
         if (!SkyBlockUtils.onHypixel) return
-        if (!event.isCommand) return
+        if (!event.isAnyCommand) return
         if (event.senderIsSkyhanni()) return
         val command = event.message.removePrefix("/").lowercase()
         lastCommand = command

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/ViewRecipeCommand.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.recipe.NeuRecipeType
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/GetFromSacksTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/GetFromSacksTabComplete.kt
@@ -1,14 +1,13 @@
 package at.hannibal2.skyhanni.features.commands.tabcomplete
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.api.GetFromSackApi.commands
+import at.hannibal2.skyhanni.api.GetFromSackApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SackApi
 import at.hannibal2.skyhanni.events.MessageSendToServerEvent
 import at.hannibal2.skyhanni.events.chat.TabCompletionEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ChatUtils.eventWithNewMessage
-import at.hannibal2.skyhanni.utils.ChatUtils.senderIsSkyhanni
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 
 @SkyHanniModule
@@ -19,7 +18,7 @@ object GetFromSacksTabComplete {
     @HandleEvent
     fun onTabComplete(event: TabCompletionEvent) {
         if (!isEnabled()) return
-        if (commands.none { event.isCommand(it) }) return
+        if (GetFromSackApi.commands.none { event.isCommand(it) }) return
         if (!event.leftOfCursor.contains(" ")) return
 
         val query = event.lastWord
@@ -29,8 +28,24 @@ object GetFromSacksTabComplete {
         event.addSuggestionsUnchecked(matching)
     }
 
-    // No subscribe since it needs to be called from the GetFromSackAPI
-    fun handleUnderlineReplace(event: MessageSendToServerEvent): MessageSendToServerEvent {
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onMessageToServer(event: MessageSendToServerEvent) {
+        if (SkyBlockUtils.isOnAlphaServer) return
+        if (!event.isCommand(GetFromSackApi.commandsWithSlash)) return
+        val replacedEvent = handleUnderlineReplace(event)
+        GetFromSackApi.queuedHandler(replacedEvent)
+        GetFromSackApi.bazaarHandler(replacedEvent)
+        if (replacedEvent.isCancelled) {
+            event.cancel()
+            return
+        }
+        if (replacedEvent !== event) {
+            event.cancel()
+            ChatUtils.sendMessageToServer(replacedEvent.message)
+        }
+    }
+
+    private fun handleUnderlineReplace(event: MessageSendToServerEvent): MessageSendToServerEvent {
         if (!isEnabled()) return event
 
         if (event.senderIsSkyhanni()) return event
@@ -44,5 +59,5 @@ object GetFromSacksTabComplete {
         return event.eventWithNewMessage(event.message.replace(rawName, realName))
     }
 
-    fun isEnabled() = SkyBlockUtils.inSkyBlock && config.gfsSack
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.gfsSack
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/TabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/TabComplete.kt
@@ -29,12 +29,4 @@ object TabComplete {
 
         return null
     }
-
-    private fun buildResponse(arguments: List<String>, fullResponse: List<String>): List<String> {
-        if (arguments.size == 2) {
-            val start = arguments[1].lowercase()
-            return fullResponse.filter { it.lowercase().startsWith(start) }
-        }
-        return emptyList()
-    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/MagicalPowerDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/MagicalPowerDisplay.kt
@@ -44,7 +44,7 @@ object MagicalPowerDisplay {
      * REGEX-TEST: Auctions Browser
      * REGEX-TEST: Auctions: "ligma"
      * REGEX-TEST: Auctions: ""sugoma""
-     * */
+     */
     private val acceptedInvPattern by RepoPattern.pattern(
         "inv.acceptable",
         "^(?:Accessory Bag(?: \\(\\d+\\/\\d+\\))?|Auctions Browser|Manage Auctions|Auctions: \".*\"?)$",
@@ -60,7 +60,7 @@ object MagicalPowerDisplay {
      * REGEX-TEST: Abiphone XIII Pro
      * REGEX-TEST: Abiphone XIV Enormous Purple
      * REGEX-TEST: Abiphone Flip
-     * */
+     */
     private val abiphoneNamePattern by abiphoneGroup.pattern(
         "name",
         "Abiphone .*",
@@ -70,7 +70,7 @@ object MagicalPowerDisplay {
      * REGEX-TEST: Your contacts: 0/0
      * REGEX-TEST: Your contacts: 1/75
      * REGEX-TEST: Your contacts: 52/60
-     * */
+     */
     private val yourContactPattern by abiphoneGroup.pattern(
         "contacts",
         "Your contacts: (?<contacts>\\d+)\\/\\d+",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -35,7 +35,6 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.compat.command
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
@@ -106,6 +105,10 @@ object TrevorFeatures {
     private val areaTrappersDenPattern by patternGroup.pattern(
         "area.trappersden",
         "Trapper's Den",
+    )
+    private val clickArmorStandPattern by patternGroup.pattern(
+        "click.armorstand",
+        "CLICK",
     )
     // </editor-fold>
 
@@ -355,7 +358,7 @@ object TrevorFeatures {
     @HandleEvent(priority = HandleEvent.HIGHEST, onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
     fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!inTrapperDen || !config.cooldown) return
-        if (event.entity.name.formattedTextCompatLessResets() == "§e§lCLICK") event.cancel()
+        if (clickArmorStandPattern.matches(event.entity.name.string)) event.cancel()
     }
 
     private fun resetTrapper() {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -398,18 +398,6 @@ object ChatUtils {
 
     private fun canSendInstantly() = sendQueue.isEmpty() && lastMessageSent.passedSince() > messageDelay
 
-    fun MessageSendToServerEvent.isCommand(commandWithSlash: String) = splitMessage.takeIf {
-        it.isNotEmpty()
-    }?.get(0) == commandWithSlash
-
-    fun MessageSendToServerEvent.isCommand(commandsWithSlash: Collection<String>) =
-        splitMessage.takeIf { it.isNotEmpty() }?.get(0) in commandsWithSlash
-
-    fun MessageSendToServerEvent.senderIsSkyhanni() = originatingModContainer?.id == "skyhanni"
-
-    fun MessageSendToServerEvent.eventWithNewMessage(message: String) =
-        MessageSendToServerEvent(message, message.split(" "), this.originatingModContainer)
-
     fun chatAndOpenConfig(message: String, property: KProperty0<*>) {
         clickableChat(
             message,

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -348,7 +348,6 @@ object ItemUtils {
     fun SafeItemStack.getSkullTexture(): String? {
         if (!this.`is`(Items.PLAYER_HEAD)) return null
         return this.get(DataComponents.PROFILE)?.partialProfile()?.properties?.get("textures")?.firstOrNull()?.value
-
     }
 
     fun SafeItemStack.getSkullOwner(): String? {

--- a/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternExclusiveGroup.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternExclusiveGroup.kt
@@ -10,6 +10,6 @@ class RepoPatternExclusiveGroup internal constructor(prefix: String, owner: Repo
 
     /**
      * @return returns any pattern on the [prefix] key space (including list or any other complex structure, but as a simple pattern
-     * */
+     */
     fun getUnusedPatterns(): List<Pattern> = RepoPatternManager.getUnusedPatterns(prefix)
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternKeyOwner.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternKeyOwner.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KProperty
  * @param shares declares if the sub key space is allowed to be used by other [RepoPatternKeyOwner]
  * @param parent the [RepoPatternKeyOwner] that gives the permission to use a sub key from it sub key space that is locked, as [shares] is false for that[RepoPatternKeyOwner]
  * @param transient declares if it is just a ghost how can be replaced at any time in the [RepoPatternManager.exclusivity]
- * */
+ */
 data class RepoPatternKeyOwner(
     val ownerClass: Class<*>?,
     val property: KProperty<*>?,

--- a/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/repopatterns/RepoPatternManager.kt
@@ -299,7 +299,7 @@ object RepoPatternManager {
      *
      * @param prefix the prefix to search without the dot at the end (the match includes the .)
      * @return returns any pattern on the [prefix] key space (including list or any other complex structure, but as a simple pattern
-     * */
+     */
     internal fun getUnusedPatterns(prefix: String): List<Pattern> {
         if (localLoading) return emptyList()
         try {


### PR DESCRIPTION
## What
Various small cleanups across several files. Too small for changelog are:

- Added a repo pattern for the CLICK armor stand check in `TrevorFeatures`, making it remotely updatable.
- Removed dead `buildResponse` function from `TabComplete`.

## Changelog Technical Details
+ Moved `isCommand`, `senderIsSkyhanni`, and `eventWithNewMessage` helpers from `ChatUtils` into `MessageSendToServerEvent`; renamed `isCommand` property to `isAnyCommand`. - hannibal2
+ Moved the `GetFromSacks` command listener from `GetFromSackApi` into `GetFromSacksTabComplete`; restored missing alpha server guard. - hannibal2
+ Replaced deprecated `formattedTextCompatLessResets()` with `Component.string` in `TrevorFeatures`. - hannibal2
+ Removed dead code, fixed KDoc formatting, and removed unused imports. - hannibal2