### PR TITLE
Backend: Suppress deprecations in TestLegacyColorFormat

### DIFF
--- a/src/test/java/at/hannibal2/skyhanni/test/TestLegacyColorFormat.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/TestLegacyColorFormat.kt
@@ -33,30 +33,35 @@ class TestLegacyColorFormat {
         .append(Component.literal("Done").setStyle(Style.EMPTY.withObfuscated(true)))
 
     @Test
+    @Suppress("DEPRECATION")
     fun `test formatted text compat`() {
         Assertions.assertEquals("§8[§r§9302§r§8] §r§6♫ §r§b[MVP§r§d+§r§b] lrg89§r§f: test", testText1.formattedTextCompat())
         Assertions.assertEquals("Test §r§lExtra §rResets §r§r§r§kDone", testText2.formattedTextCompat())
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `test formatted text compat less resets`() {
         Assertions.assertEquals("§8[§9302§8] §6♫ §b[MVP§d+§b] lrg89§f: test", testText1.formattedTextCompatLessResets())
         Assertions.assertEquals("Test §lExtra Resets §r§kDone", testText2.formattedTextCompatLessResets())
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `test formatted text compat leading white`() {
         Assertions.assertEquals("§8[§r§9302§r§8] §r§6♫ §r§b[MVP§r§d+§r§b] lrg89§r§f: test", testText1.formattedTextCompatLeadingWhite())
         Assertions.assertEquals("§fTest §r§lExtra §rResets §r§r§r§kDone", testText2.formattedTextCompatLeadingWhite())
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `test formatted text compat leading white less resets`() {
         Assertions.assertEquals("§8[§9302§8] §6♫ §b[MVP§d+§b] lrg89§f: test", testText1.formattedTextCompatLeadingWhiteLessResets())
         Assertions.assertEquals("§fTest §lExtra Resets §r§kDone", testText2.formattedTextCompatLeadingWhiteLessResets())
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `test unformatted text`() {
         Assertions.assertEquals("[302] ♫ [MVP+] lrg89: test", testText1.unformattedTextCompat())
         Assertions.assertEquals("Test Extra Resets §rDone", testText2.unformattedTextCompat())


### PR DESCRIPTION
## What
Forgot to add this in my last PR. These are intentionally testing deprecated methods, so they shouldn't be flagged.

exclude_from_changelog