### PR TITLE
Fix: Maybe Finally fix `ConcurrentModificationException`

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
@@ -13,11 +13,7 @@ sealed class InventoryOpenEvent(private val inventory: OtherInventoryData.Invent
     val inventoryId: Int get() = inventory.windowId
     val inventoryName: String get() = inventory.title
     val inventorySize: Int get() = inventory.slotCount
-    val inventoryItems: Map<Int, SafeItemStack> = run {
-        val items = inventory.items
-        items.entries.removeIf { !it.value.isNotEmpty() }
-        items
-    }
+    val inventoryItems: Map<Int, SafeItemStack> = inventory.items.filterValues { it.isNotEmpty() }
     val inventoryItemsWithNull: Map<Int, SafeItemStack?> by lazy {
         (0 until inventorySize).associateWith { inventoryItems[it] }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
@@ -250,7 +250,8 @@ object HoppityApi {
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         // Remove any processed stray slots that are no longer in the inventory.
         processedStraySlots.entries.removeIf {
-            !event.inventoryItems.containsKey(it.key) || event.inventoryItems[it.key]?.hoverName.formattedTextCompatLeadingWhiteLessResets() != it.value
+            !event.inventoryItems.containsKey(it.key) ||
+                event.inventoryItems[it.key]?.hoverName.formattedTextCompatLeadingWhiteLessResets() != it.value
         }
 
         // Only process if we're in the Chocolate Factory.

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityApi.kt
@@ -250,7 +250,7 @@ object HoppityApi {
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         // Remove any processed stray slots that are no longer in the inventory.
         processedStraySlots.entries.removeIf {
-            it.key !in event.inventoryItems || event.inventoryItems[it.key]?.hoverName.formattedTextCompatLeadingWhiteLessResets() != it.value
+            !event.inventoryItems.containsKey(it.key) || event.inventoryItems[it.key]?.hoverName.formattedTextCompatLeadingWhiteLessResets() != it.value
         }
 
         // Only process if we're in the Chocolate Factory.


### PR DESCRIPTION
## What
Okay, stuff like `CFShopPrices` actually holds a refrence to the inventory items and keeps it.
Which means that when the map is mutated it causes a problem.
So perhaps just creating a completly new map is best?

Also, should I also make it copy the individual `ItemStack` inside the inventory for the event?

The `HoppityApi` change is just cause it gave me a warning that it was confused whether the "in" meant the key or the value.

## Changelog Fixes
+ Reduced the number of random errors happening in inventories. - AverageUser125