### PR TITLE
Fix: Check for world existence in ServerBlockChangeEvent

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/BlockData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BlockData.kt
@@ -3,8 +3,8 @@ package at.hannibal2.skyhanni.data
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
-import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket
 import net.minecraft.network.protocol.game.ClientboundSectionBlocksUpdatePacket
 

--- a/src/main/java/at/hannibal2/skyhanni/data/BlockData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BlockData.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.data
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket
 import net.minecraft.network.protocol.game.ClientboundSectionBlocksUpdatePacket
@@ -12,6 +13,10 @@ object BlockData {
 
     @HandleEvent(priority = HandleEvent.LOW, receiveCancelled = true)
     fun onBlockReceivePacket(event: PacketReceivedEvent) {
+        // The server can send us block update packets while the [ClientLevel] doesn't exist,
+        // apparently
+        if (!MinecraftCompat.localWorldExists) return
+
         if (event.packet is ClientboundBlockUpdatePacket) {
             val blockPos = event.packet.pos ?: return
             val blockState = event.packet.blockState ?: return


### PR DESCRIPTION
## What
Apparently the server can send us block update packets while our local world doesn't even exist yet.

https://discord.com/channels/997079228510117908/1522715986543906966

## Changelog Fixes
+ Fixed rare "IllegalStateException in ServerBlockChangeEvent" errors when joining Hypixel or switching lobbies. - Luna

