### PR TITLE
Fix: Visual Words editor scrolling + overlapping hover

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
@@ -136,6 +136,7 @@ object VisualWordGui {
                 screen.modifiedWords.mapIndexed { index, word -> buildWordRow(screen, index, word) },
                 height = 150,
                 scrollValue = screen.listScrollValue,
+                velocity = 4.0,
                 bypassChecks = true,
                 showScrollableTipsInList = false,
                 showScrollbar = true,

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMouse.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinMouse.java
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.utils.DelayedRun;
 import at.hannibal2.skyhanni.utils.compat.MouseCompat;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.MouseHandler;
 import net.minecraft.client.input.MouseButtonInfo;
 import net.minecraft.client.player.LocalPlayer;
@@ -42,14 +41,6 @@ public class MixinMouse {
     @Inject(method = "onButton", at = @At("HEAD"))
     private void onMouseButton(long window, MouseButtonInfo input, int action, CallbackInfo ci) {
         MouseCompat.INSTANCE.handleMouseButton(input, action);
-    }
-
-    @Inject(
-        method = "handleAccumulatedMovement",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;isWindowActive()Z")
-    )
-    private void onMouseButtonHead(CallbackInfo ci, @Local(ordinal = 0) double timeDelta) {
-        MouseCompat.INSTANCE.setTimeDelta(timeDelta * 10000);
     }
 
     @WrapOperation(

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MouseCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MouseCompat.kt
@@ -5,14 +5,24 @@ import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
 import at.hannibal2.skyhanni.utils.DelayedRun
 import net.minecraft.client.Minecraft
 import net.minecraft.client.input.MouseButtonInfo
+import kotlin.math.sign
 
 object MouseCompat {
     private const val NUMBER_OF_MOUSE_BUTTONS = 6
 
     var deltaMouseY = 0.0
+        set(value) {
+            field = value
+            mouseMoveEventId++
+        }
     var deltaMouseX = 0.0
     var scroll = 0.0
-    var timeDelta = 0.0
+        set(value) {
+            field = value
+            if (value != 0.0) scrollEventId++
+        }
+    private var mouseMoveEventId = 0L
+    private var scrollEventId = 0L
     private val buttonStates = BooleanArray(NUMBER_OF_MOUSE_BUTTONS)
 
     private val mouse by lazy {
@@ -31,10 +41,22 @@ object MouseCompat {
     }
 
     fun getScrollDelta(): Int {
+        return (getPreciseScrollDelta() * 120).toInt()
+    }
+
+    fun getPreciseScrollDelta(): Double {
         val delta = scroll
         DelayedRun.runNextTickOld { scroll = 0.0 }
-        return delta.toInt() * 120
+        val options = Minecraft.getInstance().options
+        val scrollAmount = if (options.discreteMouseScroll().get()) delta.sign else delta
+        return scrollAmount * options.mouseWheelSensitivity().get()
     }
+
+    fun hasScrollDelta(): Boolean = scroll != 0.0
+
+    fun getMouseMoveEventId(): Long = mouseMoveEventId
+
+    fun getScrollEventId(): Long = scrollEventId
 
     fun getX(): Int {
         return mouse.xpos().toInt()
@@ -50,7 +72,6 @@ object MouseCompat {
     fun getEventY(): Int = getY()
 
     fun getEventButtonState(): Boolean = buttonStates.any { it }
-    fun getEventNanoseconds(): Long = timeDelta.toLong()
 
     fun getEventDY(): Int {
         return deltaMouseY.toInt()

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -46,6 +46,7 @@ import net.minecraft.client.gui.screens.inventory.SignEditScreen
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
 import java.awt.Color
+import kotlin.math.floor
 import kotlin.math.max
 
 @Suppress("TooManyFunctions")
@@ -933,59 +934,45 @@ interface Renderable {
             scrollbarTrackColor: ChromaColour = Companion.scrollbarTrackColor,
             scrollbarThumbColor: ChromaColour = Companion.scrollbarThumbColor,
         ) {
-            val end = scroll.asInt() + height + 1
+            val topTipHeight = if (showScrollableTipsInList && !scroll.atMinimum()) scrollUpTip.height else 0
+            val bottomTipHeight = if (showScrollableTipsInList && !scroll.atMaximum()) scrollDownTip.height else 0
+            val contentBottom = (height - bottomTipHeight).coerceAtLeast(topTipHeight)
+            val contentHeight = contentBottom - topTipHeight
 
-            var renderY = 0
-            var virtualY = 0
-            var found = false
+            if (topTipHeight > 0) renderAtY(scrollUpTip, mouseOffsetX, mouseOffsetY, width, 0.0)
 
-            var negativeSpace1 = 0
-            var negativeSpace2 = 0
+            if (contentHeight > 0) {
+                GuiRenderUtils.enableScissor(0, topTipHeight, width, contentBottom)
+                try {
+                    val scrollOffset = scroll.asDouble()
+                    val visibleEnd = scrollOffset + contentHeight
+                    var virtualY = 0
 
-            // If showScrollableTipsInList is true, and we are scrolled 'down', display a tip indicating
-            // there are more items above
-            if (showScrollableTipsInList && !scroll.atMinimum()) {
-                scrollUpTip.renderXAligned(mouseOffsetX, mouseOffsetY, width)
-                DrawContextUtils.translate(0f, scrollUpTip.height.toFloat())
-                renderY += scrollUpTip.height
-                negativeSpace1 -= scrollUpTip.height
-            }
-
-            val atScrollEnd = scroll.atMaximum()
-            if (!atScrollEnd) {
-                negativeSpace2 -= scrollDownTip.height
-            }
-
-            val window = scroll.asInt()..(end + negativeSpace1 + negativeSpace2)
-
-            for (renderable in list) {
-                if ((virtualY..virtualY + renderable.height) in window) {
-                    renderable.renderXAligned(mouseOffsetX, mouseOffsetY + renderY, width)
-                    DrawContextUtils.translate(0f, renderable.height.toFloat())
-                    renderY += renderable.height
-                    found = true
-                } else if (found) {
-                    if (renderY + renderable.height <= height + negativeSpace2) {
-                        renderable.renderXAligned(mouseOffsetX, mouseOffsetY + renderY, width)
-                        DrawContextUtils.translate(0f, renderable.height.toFloat())
-                        renderY += renderable.height
+                    for (renderable in list) {
+                        val renderableEnd = virtualY + renderable.height
+                        if (renderableEnd >= scrollOffset && virtualY <= visibleEnd) {
+                            val renderY = topTipHeight + virtualY - scrollOffset
+                            renderAtY(renderable, mouseOffsetX, mouseOffsetY, width, renderY)
+                        }
+                        if (virtualY > visibleEnd) {
+                            break
+                        }
+                        virtualY = renderableEnd
                     }
-                    break
+                } finally {
+                    GuiRenderUtils.disableScissor()
                 }
-                virtualY += renderable.height
             }
 
-            // If showScrollableTipsInList is true, and we are scrolled 'up', display a tip indicating
-            // there are more items below
-            if (showScrollableTipsInList && !atScrollEnd) {
-                scrollDownTip.renderXAligned(mouseOffsetX, mouseOffsetY + height - scrollDownTip.height, width)
+            if (bottomTipHeight > 0) {
+                renderAtY(scrollDownTip, mouseOffsetX, mouseOffsetY, width, (height - bottomTipHeight).toDouble())
             }
-
-            DrawContextUtils.translate(0f, -renderY.toFloat())
 
             if (showScrollbar && virtualHeight > height) {
                 val barX = width - 4
-                val maxScroll = (virtualHeight - height).coerceAtLeast(1).toFloat()
+                val maxScroll = (virtualHeight - height + if (showScrollableTipsInList) scrollUpTip.height else 0)
+                    .coerceAtLeast(1)
+                    .toFloat()
                 val thumbRatio = height.toFloat() / virtualHeight
                 val thumbHeight = (thumbRatio * height).toInt().coerceAtLeast(8)
                 val thumbY = ((scroll.asDouble() / maxScroll) * (height - thumbHeight)).toInt()
@@ -994,6 +981,18 @@ interface Renderable {
                 ShaderRenderUtils.drawRoundRectDeferred(barX, 0, 4, height, trackRgb, 2, 1f)
                 ShaderRenderUtils.drawRoundRectDeferred(barX, thumbY, 4, thumbHeight, thumbRgb, 2, 1f)
             }
+        }
+
+        private fun renderAtY(
+            renderable: Renderable,
+            mouseOffsetX: Int,
+            mouseOffsetY: Int,
+            width: Int,
+            y: Double,
+        ) {
+            DrawContextUtils.translate(0f, y.toFloat())
+            renderable.renderXAligned(mouseOffsetX, mouseOffsetY + floor(y).toInt(), width)
+            DrawContextUtils.translate(0f, -y.toFloat())
         }
 
         fun filterList(content: Map<Renderable, String?>, textBox: String) =

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -59,11 +59,11 @@ interface Renderable {
     val verticalAlign: VerticalAlignment
 
     fun isHovered(mouseOffsetX: Int, mouseOffsetY: Int) = currentRenderPassMousePosition?.let { (x, y) ->
-        x in (mouseOffsetX..mouseOffsetX + width) && y in (mouseOffsetY..mouseOffsetY + height)
+        x >= mouseOffsetX && x < mouseOffsetX + width && y >= mouseOffsetY && y < mouseOffsetY + height
     } ?: false
 
     fun isBoxHovered(mouseOffsetX: Int, width: Int, mouseOffsetY: Int, height: Int) = currentRenderPassMousePosition?.let { (x, y) ->
-        x in (mouseOffsetX..mouseOffsetX + width) && y in (mouseOffsetY..mouseOffsetY + height)
+        x >= mouseOffsetX && x < mouseOffsetX + width && y >= mouseOffsetY && y < mouseOffsetY + height
     } ?: false
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/ScrollInput.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/ScrollInput.kt
@@ -22,8 +22,8 @@ abstract class ScrollInput(
         }
         get() = scrollValue.getValue()
 
-    fun atMinimum() = asInt() == minValue
-    fun atMaximum() = asInt() == maxValue
+    fun atMinimum() = scroll <= minValue
+    fun atMaximum() = scroll >= maxValue
     fun asInt() = scroll.toInt()
     fun asDouble() = scroll
     fun asDirection() =
@@ -44,7 +44,8 @@ abstract class ScrollInput(
             scroll = scroll.coerceIn(minValue.toDouble(), maxValue.toDouble())
         }
 
-    protected fun isMouseEventValid(): Boolean = scrollValue.isMouseEventValid()
+    protected fun consumeMouseMoveEvent(): Boolean = scrollValue.consumeMouseMoveEvent()
+    protected fun consumeScrollEvent(): Boolean = scrollValue.consumeScrollEvent()
     protected fun isPureScrollEvent() = scrollValue.isPureScrollEvent()
 
     abstract fun update(isValid: Boolean)
@@ -61,13 +62,22 @@ abstract class ScrollInput(
         ) : ScrollInput(scrollValue, minHeight, maxHeight, velocity, dragScrollMouseButton, startValue) {
             override fun update(isValid: Boolean) {
                 if (maxValue < minValue) return
-                if (!isValid || !isMouseEventValid()) return
-                if (dragScrollMouseButton != null && MouseCompat.isButtonDown(dragScrollMouseButton)) {
+                if (!isValid) return
+                var changed = false
+                if (
+                    dragScrollMouseButton != null &&
+                    MouseCompat.isButtonDown(dragScrollMouseButton) &&
+                    consumeMouseMoveEvent()
+                ) {
                     scroll += MouseCompat.getEventDY() * velocity
+                    changed = true
                 }
-                val deltaWheel = MouseCompat.getScrollDelta()
-                scroll += -deltaWheel.coerceIn(-1, 1) * 2.5 * velocity
-                coerceInLimit()
+                if (consumeScrollEvent()) {
+                    val deltaWheel = MouseCompat.getPreciseScrollDelta()
+                    scroll += -deltaWheel * 2.5 * velocity
+                    changed = true
+                }
+                if (changed) coerceInLimit()
             }
         }
 
@@ -99,7 +109,8 @@ abstract class ScrollInput(
 
 class ScrollValue {
     private var field: Double? = null
-    private var mouseEventTime = 0L
+    private var lastMouseMoveEventId = 0L
+    private var lastScrollEventId = 0L
     private var lastMouseX = 0
     private var lastMouseY = 0
 
@@ -115,17 +126,26 @@ class ScrollValue {
         field = value
     }
 
-    fun isMouseEventValid(): Boolean {
-        val mouseEvent = MouseCompat.getEventNanoseconds()
-        val mouseEventsValid = mouseEvent - mouseEventTime > 20L
-        mouseEventTime = mouseEvent
-        return mouseEventsValid
+    fun isMouseEventValid(): Boolean = consumeScrollEvent()
+
+    fun consumeMouseMoveEvent(): Boolean {
+        val eventId = MouseCompat.getMouseMoveEventId()
+        if (eventId == lastMouseMoveEventId) return false
+        lastMouseMoveEventId = eventId
+        return true
+    }
+
+    fun consumeScrollEvent(): Boolean {
+        val eventId = MouseCompat.getScrollEventId()
+        if (eventId == lastScrollEventId || !MouseCompat.hasScrollDelta()) return false
+        lastScrollEventId = eventId
+        return true
     }
 
     fun isPureScrollEvent(): Boolean {
         val mouseX = MouseCompat.getEventX()
         val mouseY = MouseCompat.getEventY()
-        val isScrollEvent = MouseCompat.getScrollDelta() != 0
+        val isScrollEvent = MouseCompat.hasScrollDelta()
         val hasMouseMoved = mouseX != lastMouseX || mouseY != lastMouseY
 
         // Update last mouse position

--- a/src/test/java/at/hannibal2/skyhanni/test/renderables/RenderableTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/renderables/RenderableTest.kt
@@ -1,0 +1,46 @@
+package at.hannibal2.skyhanni.test.renderables
+
+import at.hannibal2.skyhanni.utils.RenderUtils.HorizontalAlignment
+import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RenderableTest {
+
+    @Test
+    fun `hover bounds are half open`() {
+        Renderable.withMousePosition(10, 20) {
+            assertTrue(testRenderable.isHovered(10, 20))
+            assertFalse(testRenderable.isHovered(0, 10))
+        }
+    }
+
+    @Test
+    fun `box hover bounds are half open`() {
+        Renderable.withMousePosition(10, 20) {
+            assertTrue(testRenderable.isBoxHovered(10, 10, 20, 10))
+            assertFalse(testRenderable.isBoxHovered(0, 10, 10, 10))
+        }
+    }
+
+    @Test
+    fun `adjacent renderables do not share an edge hover`() {
+        Renderable.withMousePosition(5, 10) {
+            assertFalse(testRenderable.isHovered(0, 0))
+            assertTrue(testRenderable.isHovered(0, 10))
+        }
+    }
+
+    private companion object {
+        val testRenderable = object : Renderable {
+            override val width = 10
+            override val height = 10
+            override val horizontalAlign = HorizontalAlignment.LEFT
+            override val verticalAlign = VerticalAlignment.TOP
+
+            override fun render(mouseOffsetX: Int, mouseOffsetY: Int) = Unit
+        }
+    }
+}


### PR DESCRIPTION
## What
Fixes the `/shwords` editor scrolling being slow and janky, and a general renderable fix that prevents multiple objects from being detected as hovered at once (was affecting the editor specifically too).

## Changelog Improvements
+ Improved scrolling in the /shwords editor: faster and smoother. - Luna

## Changelog Fixes
+ Fixed some GUI features incorrectly detecting two objects as being hovered at once. - Luna