### PR TITLE
Fix + Improvement: Reset dry-streak on non-book Ultra Rare drops, add manual reset button

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -333,7 +333,7 @@ object ExperimentationTableApi {
     fun onRepoReload(event: RepositoryReloadEvent) {
         val experiments = event.getConstant<ExperimentsJson>("ExperimentationTable")
         miscRepoRewards = experiments.miscRewards
-        ultraRareMiscItems = experiments.ultraRareRewards ?: emptyList()
+        ultraRareMiscItems = experiments.ultraRareRewards.orEmpty()
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -146,6 +146,34 @@ object ExperimentationTableApi {
     )
 
     /**
+     * Not used for matching — provides the title string for non-book Ultra Rare drops,
+     * remotely editable via SkyHanni-Repo without a mod update.
+     * REGEX-TEST: §d§kXX§5 ULTRA-RARE ITEM! §d§kXX
+     */
+    private val ultraRareItemPattern by patternGroup.pattern(
+        "ultrarareitem",
+        "§d§kXX§5 ULTRA-RARE ITEM! §d§kXX",
+    )
+
+    /**
+     * Middle text for the chat message's componentBuilder — no obfuscated XX wrapper,
+     * since the builder constructs those separately around this string.
+     * REGEX-TEST:  ULTRA-RARE BOOK!
+     */
+    private val ultraRareBookLabelPattern by patternGroup.pattern(
+        "ultrarare.label",
+        " ULTRA-RARE BOOK! ",
+    )
+
+    /**
+     * REGEX-TEST:  ULTRA-RARE ITEM!
+     */
+    private val ultraRareItemLabelPattern by patternGroup.pattern(
+        "ultrarareitem.label",
+        " ULTRA-RARE ITEM! ",
+    )
+
+    /**
      * REGEX-TEST: §9Smite VII
      */
     private val bookPattern by patternGroup.pattern(
@@ -247,6 +275,12 @@ object ExperimentationTableApi {
         "SEVERED_HAND", "GOLD_BOTTLE_CAP", "CHAIN_END_TIMES", "OCTOPUS_TENDRIL",
         "TROUBLED_BUBBLE", "PESTHUNTING_GUIDE", "FATEFUL_STINGER", "VIBRANT_CORAL",
     ).toInternalNames()
+
+    // Accessors so callers don't need to call Java's Pattern.pattern() directly.
+    internal val ultraRareBookTitle: String get() = ultraRarePattern.pattern()
+    internal val ultraRareItemTitle: String get() = ultraRareItemPattern.pattern()
+    internal val ultraRareBookLabel: String get() = ultraRareBookLabelPattern.pattern()
+    internal val ultraRareItemLabel: String get() = ultraRareItemLabelPattern.pattern()
 
     enum class ExperimentationMessages(private val displayName: String) {
         DONE("§eYou claimed the §dSuperpairs §erewards! §8(§7Claim§8)"),

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -530,6 +530,11 @@ object ExperimentationTableApi {
 
         val internalName = NeuInternalName.fromItemNameOrNull(this)
             ?: return ChatUtils.debug("Could not read item name from $this")
+        // Intentionally fires later than the book detection path (tryFireRareBookUncovered runs at
+        // card-flip time). Non-book Ultra Rares show no "ULTRA-RARE" lore text at flip time — unlike
+        // books — so lore-based flip-time detection is impossible. Whether their identity is readable
+        // at flip time some other way is unconfirmed; these drops are too rare to test live. The
+        // post-experiment summary is used instead because it is confirmed to work reliably.
         if (currentExperimentData.type == ExperimentationTaskType.SUPERPAIRS && internalName in ultraRareMiscItems) {
             TableRareUncoverEvent(this, isBook = false).post()
         }

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -146,8 +146,6 @@ object ExperimentationTableApi {
     )
 
     /**
-     * Not used for matching — provides the title string for non-book Ultra Rare drops,
-     * remotely editable via SkyHanni-Repo without a mod update.
      * REGEX-TEST: §d§kXX§5 ULTRA-RARE ITEM! §d§kXX
      */
     private val ultraRareItemPattern by patternGroup.pattern(
@@ -156,8 +154,6 @@ object ExperimentationTableApi {
     )
 
     /**
-     * Middle text for the chat message's componentBuilder — no obfuscated XX wrapper,
-     * since the builder constructs those separately around this string.
      * REGEX-TEST:  ULTRA-RARE BOOK!
      */
     private val ultraRareBookLabelPattern by patternGroup.pattern(
@@ -266,17 +262,14 @@ object ExperimentationTableApi {
     var miscRepoRewards: List<NeuInternalName> = emptyList()
         private set
 
-    // "Endcap Upgrade" items per the Hypixel wiki — share the same Ultra Rare RNG meter cost
-    // (500,000 Experimental XP) as T7 enchant books, but produce no in-game "ULTRA-RARE" lore
-    // header at card-flip time, so tryFireRareBookUncovered() cannot detect them. Detection
-    // happens instead in processRewardOrNull() via the post-experiment summary screen.
+    // "Endcap Upgrade" items (Hypixel wiki) — same Ultra Rare RNG cost as T7 books (500k XP) but
+    // no in-game "ULTRA-RARE" lore header at flip time, so detected via processRewardOrNull() instead.
     private val ultraRareMiscItems = setOf(
         "SEVERED_PINCER", "ENDSTONE_IDOL", "ENSNARED_SNAIL", "GOLDEN_BOUNTY",
         "SEVERED_HAND", "GOLD_BOTTLE_CAP", "CHAIN_END_TIMES", "OCTOPUS_TENDRIL",
         "TROUBLED_BUBBLE", "PESTHUNTING_GUIDE", "FATEFUL_STINGER", "VIBRANT_CORAL",
     ).toInternalNames()
 
-    // Accessors so callers don't need to call Java's Pattern.pattern() directly.
     internal val ultraRareBookTitle: String get() = ultraRarePattern.pattern()
     internal val ultraRareItemTitle: String get() = ultraRareItemPattern.pattern()
     internal val ultraRareBookLabel: String get() = ultraRareBookLabelPattern.pattern()
@@ -568,7 +561,6 @@ object ExperimentationTableApi {
 
         val internalName = NeuInternalName.fromItemNameOrNull(this)
             ?: return ChatUtils.debug("Could not read item name from $this")
-        // Only Superpairs drops can be Ultra Rare misc items; skip the check for other experiment types.
         if (currentExperimentData.type == ExperimentationTaskType.SUPERPAIRS && internalName in ultraRareMiscItems) {
             TableRareUncoverEvent(this, isBook = false).post()
         }

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -145,30 +145,6 @@ object ExperimentationTableApi {
     )
 
     /**
-     * REGEX-TEST: §d§kXX§5 ULTRA-RARE ITEM! §d§kXX
-     */
-    private val ultraRareItemPattern by patternGroup.pattern(
-        "ultrarareitem",
-        "§d§kXX§5 ULTRA-RARE ITEM! §d§kXX",
-    )
-
-    /**
-     * REGEX-TEST:  ULTRA-RARE BOOK!
-     */
-    private val ultraRareBookLabelPattern by patternGroup.pattern(
-        "ultrarare.label",
-        " ULTRA-RARE BOOK! ",
-    )
-
-    /**
-     * REGEX-TEST:  ULTRA-RARE ITEM!
-     */
-    private val ultraRareItemLabelPattern by patternGroup.pattern(
-        "ultrarareitem.label",
-        " ULTRA-RARE ITEM! ",
-    )
-
-    /**
      * REGEX-TEST: §9Smite VII
      */
     private val bookPattern by patternGroup.pattern(
@@ -265,11 +241,6 @@ object ExperimentationTableApi {
     // no in-game "ULTRA-RARE" lore header at flip time, so detected via processRewardOrNull() instead.
     var ultraRareMiscItems: List<NeuInternalName> = emptyList()
         private set
-
-    internal val ultraRareBookTitle: String get() = ultraRarePattern.pattern()
-    internal val ultraRareItemTitle: String get() = ultraRareItemPattern.pattern()
-    internal val ultraRareBookLabel: String get() = ultraRareBookLabelPattern.pattern()
-    internal val ultraRareItemLabel: String get() = ultraRareItemLabelPattern.pattern()
 
     enum class ExperimentationMessages(private val displayName: String) {
         DONE("§eYou claimed the §dSuperpairs §erewards! §8(§7Claim§8)"),

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -35,6 +35,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalNames
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
@@ -236,6 +237,16 @@ object ExperimentationTableApi {
     private var currentBottlesInInventory: Map<NeuInternalName, Int> = mapOf()
     var miscRepoRewards: List<NeuInternalName> = emptyList()
         private set
+
+    // "Endcap Upgrade" items per the Hypixel wiki — share the same Ultra Rare RNG meter cost
+    // (500,000 Experimental XP) as T7 enchant books, but produce no in-game "ULTRA-RARE" lore
+    // header at card-flip time, so tryFireRareBookUncovered() cannot detect them. Detection
+    // happens instead in processRewardOrNull() via the post-experiment summary screen.
+    private val ultraRareMiscItems = setOf(
+        "SEVERED_PINCER", "ENDSTONE_IDOL", "ENSNARED_SNAIL", "GOLDEN_BOUNTY",
+        "SEVERED_HAND", "GOLD_BOTTLE_CAP", "CHAIN_END_TIMES", "OCTOPUS_TENDRIL",
+        "TROUBLED_BUBBLE", "PESTHUNTING_GUIDE", "FATEFUL_STINGER", "VIBRANT_CORAL",
+    ).toInternalNames()
 
     enum class ExperimentationMessages(private val displayName: String) {
         DONE("§eYou claimed the §dSuperpairs §erewards! §8(§7Claim§8)"),
@@ -523,6 +534,10 @@ object ExperimentationTableApi {
 
         val internalName = NeuInternalName.fromItemNameOrNull(this)
             ?: return ChatUtils.debug("Could not read item name from $this")
+        // Only Superpairs drops can be Ultra Rare misc items; skip the check for other experiment types.
+        if (currentExperimentData.type == ExperimentationTaskType.SUPERPAIRS && internalName in ultraRareMiscItems) {
+            TableRareUncoverEvent(this, isBook = false).post()
+        }
         currentExperimentData.addReward(internalName, 1)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -35,7 +35,6 @@ import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzRarity
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalNames
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
@@ -264,11 +263,8 @@ object ExperimentationTableApi {
 
     // "Endcap Upgrade" items (Hypixel wiki) — same Ultra Rare RNG cost as T7 books (500k XP) but
     // no in-game "ULTRA-RARE" lore header at flip time, so detected via processRewardOrNull() instead.
-    private val ultraRareMiscItems = setOf(
-        "SEVERED_PINCER", "ENDSTONE_IDOL", "ENSNARED_SNAIL", "GOLDEN_BOUNTY",
-        "SEVERED_HAND", "GOLD_BOTTLE_CAP", "CHAIN_END_TIMES", "OCTOPUS_TENDRIL",
-        "TROUBLED_BUBBLE", "PESTHUNTING_GUIDE", "FATEFUL_STINGER", "VIBRANT_CORAL",
-    ).toInternalNames()
+    var ultraRareMiscItems: List<NeuInternalName> = emptyList()
+        private set
 
     internal val ultraRareBookTitle: String get() = ultraRarePattern.pattern()
     internal val ultraRareItemTitle: String get() = ultraRareItemPattern.pattern()
@@ -364,7 +360,9 @@ object ExperimentationTableApi {
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
-        miscRepoRewards = event.getConstant<ExperimentsJson>("ExperimentationTable").miscRewards
+        val experiments = event.getConstant<ExperimentsJson>("ExperimentationTable")
+        miscRepoRewards = experiments.miscRewards
+        ultraRareMiscItems = experiments.ultraRareRewards ?: emptyList()
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsDryStreakConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsDryStreakConfig.kt
@@ -2,8 +2,10 @@ package at.hannibal2.skyhanni.config.features.inventory.experimentationtable
 
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.features.inventory.experimentationtable.ExperimentsDryStreakDisplay
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
@@ -23,6 +25,10 @@ class ExperimentsDryStreakConfig {
     @ConfigOption(name = "XP", desc = "Display XP since.")
     @ConfigEditorBoolean
     var xpSince: Boolean = true
+
+    @ConfigOption(name = "Reset Dry Streak", desc = "Manually resets the dry-streak counter to zero. This cannot be undone.")
+    @ConfigEditorButton(buttonText = "Reset")
+    val resetDryStreak: Runnable = Runnable { ExperimentsDryStreakDisplay.resetManually() }
 
     @Expose
     @ConfigLink(owner = ExperimentsDryStreakConfig::class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ExperimentsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ExperimentsJson.kt
@@ -5,5 +5,6 @@ import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 
 data class ExperimentsJson(
-    @Expose @SerializedName("misc_rewards") val miscRewards: List<NeuInternalName>
+    @Expose @SerializedName("misc_rewards") val miscRewards: List<NeuInternalName>,
+    @Expose @SerializedName("ultra_rare_rewards") val ultraRareRewards: List<NeuInternalName>? = null,
 )

--- a/src/main/java/at/hannibal2/skyhanni/events/experiments/TableRareUncoverEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/experiments/TableRareUncoverEvent.kt
@@ -2,4 +2,5 @@ package at.hannibal2.skyhanni.events.experiments
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-class TableRareUncoverEvent(val dropName: String) : SkyHanniEvent()
+// isBook defaults to true so the existing book-detection call site needs no changes
+class TableRareUncoverEvent(val dropName: String, val isBook: Boolean = true) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/experiments/TableRareUncoverEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/experiments/TableRareUncoverEvent.kt
@@ -2,5 +2,4 @@ package at.hannibal2.skyhanni.events.experiments
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
-// isBook defaults to true so the existing book-detection call site needs no changes
 class TableRareUncoverEvent(val dropName: String, val isBook: Boolean = true) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/experiments/TableRareUncoverEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/experiments/TableRareUncoverEvent.kt
@@ -2,4 +2,11 @@ package at.hannibal2.skyhanni.events.experiments
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 
+/**
+ * Fired when an Ultra Rare reward is uncovered in the Superpairs Experimentation Table game.
+ *
+ * @param dropName The display name of the uncovered item.
+ * @param isBook Whether the drop is an enchanted book. False for non-book Ultra Rare items,
+ *               which are detected via the post-experiment summary rather than the card flip lore.
+ */
 class TableRareUncoverEvent(val dropName: String, val isBook: Boolean = true) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
@@ -29,6 +29,14 @@ object ExperimentsDryStreakDisplay {
     private var display = emptyList<String>()
     private var ignoreNextFinish = false
 
+    fun resetManually() {
+        val storage = storage ?: return
+        storage.attemptsSince = 0
+        storage.xpSince = 0
+        display = drawDisplay()
+        ChatUtils.chat("Dry-streak counter reset")
+    }
+
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
     fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled() || !ExperimentationTableApi.inTable) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsDryStreakDisplay.kt
@@ -3,6 +3,8 @@ package at.hannibal2.skyhanni.features.inventory.experimentationtable
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.ExperimentationTableApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -35,6 +37,15 @@ object ExperimentsDryStreakDisplay {
         storage.xpSince = 0
         display = drawDisplay()
         ChatUtils.chat("Dry-streak counter reset")
+    }
+
+    @HandleEvent
+    fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shresetdrystreak") {
+            description = "Resets the Experimentation Table dry-streak counter."
+            category = CommandCategory.USERS_RESET
+            simpleCallback { resetManually() }
+        }
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
@@ -36,7 +36,7 @@ object UltraRareBookAlert {
     private fun notification(enchantsName: String, isBook: Boolean) {
         lastNotificationTime = SimpleTimeMark.now()
         dragonSound.playSound()
-        val typeLabel = if (isBook) ExperimentationTableApi.ultraRareBookLabel else ExperimentationTableApi.ultraRareItemLabel
+        val typeLabel = if (isBook) " ULTRA-RARE BOOK! " else " ULTRA-RARE ITEM! "
         ChatUtils.chat(
             componentBuilder {
                 append("You have uncovered a ")
@@ -59,7 +59,7 @@ object UltraRareBookAlert {
         if (lastNotificationTime.passedSince() > 5.seconds) return
 
         TitleManager.sendTitle(
-            titleText = if (lastUncoveredWasBook) ExperimentationTableApi.ultraRareBookTitle else ExperimentationTableApi.ultraRareItemTitle,
+            titleText = if (lastUncoveredWasBook) "§d§kXX§5 ULTRA-RARE BOOK! §d§kXX" else "§d§kXX§5 ULTRA-RARE ITEM! §d§kXX",
             duration = 2.seconds,
             location = TitleManager.TitleLocation.INVENTORY,
         )

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
@@ -29,17 +29,21 @@ object UltraRareBookAlert {
     private var enchantsFound = false
 
     private var lastNotificationTime = SimpleTimeMark.farPast()
+    // Carries isBook from onTableRareUncover into onChestGuiRender, which polls
+    // lastNotificationTime rather than receiving the event directly.
+    private var lastUncoveredWasBook = true
 
-    private fun notification(enchantsName: String) {
+    private fun notification(enchantsName: String, isBook: Boolean) {
         lastNotificationTime = SimpleTimeMark.now()
         dragonSound.playSound()
+        val typeLabel = if (isBook) " ULTRA-RARE BOOK! " else " ULTRA-RARE ITEM! "
         ChatUtils.chat(
             componentBuilder {
                 append("You have uncovered a ")
                 appendWithColor("XX", ChatFormatting.LIGHT_PURPLE) {
                     obfuscated = true
                 }
-                appendWithColor(" ULTRA-RARE BOOK! ", ChatFormatting.DARK_PURPLE)
+                appendWithColor(typeLabel, ChatFormatting.DARK_PURPLE)
                 appendWithColor("XX", ChatFormatting.LIGHT_PURPLE) {
                     obfuscated = true
                 }
@@ -55,7 +59,7 @@ object UltraRareBookAlert {
         if (lastNotificationTime.passedSince() > 5.seconds) return
 
         TitleManager.sendTitle(
-            titleText = "§d§kXX§5 ULTRA-RARE BOOK! §d§kXX",
+            titleText = if (lastUncoveredWasBook) "§d§kXX§5 ULTRA-RARE BOOK! §d§kXX" else "§d§kXX§5 ULTRA-RARE ITEM! §d§kXX",
             duration = 2.seconds,
             location = TitleManager.TitleLocation.INVENTORY,
         )
@@ -64,7 +68,8 @@ object UltraRareBookAlert {
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
     fun onTableRareUncover(event: TableRareUncoverEvent) {
         if (enchantsFound || !isEnabled()) return
-        notification(event.dropName)
+        lastUncoveredWasBook = event.isBook
+        notification(event.dropName, event.isBook)
         enchantsFound = true
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
@@ -36,7 +36,7 @@ object UltraRareBookAlert {
     private fun notification(enchantsName: String, isBook: Boolean) {
         lastNotificationTime = SimpleTimeMark.now()
         dragonSound.playSound()
-        val typeLabel = if (isBook) " ULTRA-RARE BOOK! " else " ULTRA-RARE ITEM! "
+        val typeLabel = if (isBook) ExperimentationTableApi.ultraRareBookLabel else ExperimentationTableApi.ultraRareItemLabel
         ChatUtils.chat(
             componentBuilder {
                 append("You have uncovered a ")
@@ -59,7 +59,7 @@ object UltraRareBookAlert {
         if (lastNotificationTime.passedSince() > 5.seconds) return
 
         TitleManager.sendTitle(
-            titleText = if (lastUncoveredWasBook) "§d§kXX§5 ULTRA-RARE BOOK! §d§kXX" else "§d§kXX§5 ULTRA-RARE ITEM! §d§kXX",
+            titleText = if (lastUncoveredWasBook) ExperimentationTableApi.ultraRareBookTitle else ExperimentationTableApi.ultraRareItemTitle,
             duration = 2.seconds,
             location = TitleManager.TitleLocation.INVENTORY,
         )


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/777

## What
Fixes the dry-streak tracker not resetting when a non-book Ultra Rare item is found in the Experimentation Table, and adds a manual reset button as a fallback.

The current detection (`tryFireRareBookUncovered()`) only catches Ultra Rare **books**. It looks for the text "ULTRA-RARE BOOK!" that appears in an item's lore when a card flips during Superpairs. But some non-book items are just as rare as max-tier books (same 500k XP on RNG meter) and never show that text, so pulling one doesn't reset the dry-streak.

**Items affected (added to `ultraRareMiscItems`):**
- Severed Pincer
- End Stone Idol
- Ensnared Snail
- Golden Bounty
- Severed Hand
- Gold Bottle Cap
- Chain of the End Times
- Octopus Tendril
- Troubled Bubble
- A Beginner's Guide to Pesthunting
- Fateful Stinger
- Vibrant Coral

Added a manual reset button in the Dry-Streak Display config, and a `/shresetdrystreak` command as an alternative for those who prefer commands over config menus. Both call the same reset function.

New dry streak reset button: 
<img width="641" height="492" alt="7 Dry-Streak Display" src="https://github.com/user-attachments/assets/2faba867-a192-4f49-876d-6a0d94598d36" />

Bug identified in: 
- https://discord.com/channels/997079228510117908/1521604574623043781 
- https://discord.com/channels/997079228510117908/1487732376661524603


## Changelog Improvements
+ Added a manual reset button for the Experimentation Table's Dry-Streak Display. - RemainingDelta
+ Added a `/shresetdrystreak` command to reset the Experimentation Table's dry-streak counter. - RemainingDelta

## Changelog Fixes
+ Fixed the Experimentation Table dry-streak tracker not resetting when finding a non-book Ultra-Rare item (e.g. Severed Pincer or End Stone Idol). - RemainingDelta
