### PR TITLE
Fix: Century Party Invitation highlighter not working

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -517,6 +517,7 @@ class MiscConfig {
     @Expose
     @ConfigOption(name = "Gift Clean Display", desc = "Show only 'CLICK TO OPEN' on gifts.")
     @ConfigEditorBoolean
+    @SearchTag("century cake slice")
     @FeatureToggle
     var giftCleanDisplay: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CenturyPartyInvitation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CenturyPartyInvitation.kt
@@ -19,7 +19,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sublistAfter
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import io.github.notenoughupdates.moulconfig.ChromaColour
@@ -75,10 +74,11 @@ object CenturyPartyInvitation {
     /**
      * REGEX-TEST: §8[§e80§8] - [§e119§8] §eYellow
      * REGEX-TEST: §8[§c440§8] - [§c479§8] §cRed
+     * REGEX-TEST: §8[§4480§8]+ §4Dark Red
      */
     private val itemMissingColorLinePattern by chatGroup.pattern(
         "item-lore.missing-color-line",
-        "§8\\[.*\\] - \\[.*\\] §(?<color>.).*",
+        "§8\\[.*]\\+?(?: - \\[.*])? §(?<color>.).*",
     )
 
     @HandleEvent
@@ -100,7 +100,9 @@ object CenturyPartyInvitation {
         if (hand.getInternalNameOrNull() != CENTURY_PARTY_INVITATION) return emptySet()
 
         return buildSet {
-            for (line in hand.getLore().sublistAfter({ itemMissingLineSeparatorPattern.matches(it) })) {
+            for (line in hand.getLore().drop(
+                hand.getLore().indexOfFirst { itemMissingLineSeparatorPattern.matches(it) } + 1
+            )) {
                 readLine(line, hand)?.let(::add)
             }
         }
@@ -113,7 +115,7 @@ object CenturyPartyInvitation {
 
         return colorCode.toCharArray().first().toLorenzColor() ?: run {
             ErrorManager.logErrorStateWithData(
-                "Error reading Cenutry Party Invitation colors missing",
+                "Error reading Century Party Invitation colors missing",
                 "unknown color code detected",
                 "colorCode" to colorCode,
                 "line" to line,
@@ -146,7 +148,7 @@ object CenturyPartyInvitation {
     }
 
     private fun addPlayer(mob: Mob) {
-        val displayName = mob.baseEntity.name.formattedTextCompatLessResets()
+        val displayName = mob.baseEntity.displayName.formattedTextCompatLessResets()
         val colorCode = playerRankColorPattern.matchMatcher(displayName) {
             group("color")
         } ?: run {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/CenturyPartyInvitation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/CenturyPartyInvitation.kt
@@ -99,9 +99,10 @@ object CenturyPartyInvitation {
         val hand = InventoryUtils.getItemInHand() ?: return emptySet()
         if (hand.getInternalNameOrNull() != CENTURY_PARTY_INVITATION) return emptySet()
 
+        val lore = hand.getLore()
         return buildSet {
-            for (line in hand.getLore().drop(
-                hand.getLore().indexOfFirst { itemMissingLineSeparatorPattern.matches(it) } + 1
+            for (line in lore.drop(
+                lore.indexOfFirst { itemMissingLineSeparatorPattern.matches(it) } + 1
             )) {
                 readLine(line, hand)?.let(::add)
             }


### PR DESCRIPTION
## What
Made the code work as we were pulling the wrong entity name
Made it actually highlight all missing colors and not just the first one listed
Made it work for level 400+ as well

Also added search tags to gift clean display


## Changelog Improvements
+ Improved Gift Clean Display to also appear when searching for Century Cake Slice in the config.

## Changelog Fixes
+ Fixed Century Party Invitation Highlighter not working. - CalMWolfs