### PR TITLE
Improvement: Clean gift display also works here

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -128,7 +128,6 @@ class MiscConfig {
     val enchantedClock: EnchantedClockConfig = EnchantedClockConfig()
 
     @ConfigOption(name = "Century Party Invitation", desc = "Features for the Century Party Invitation")
-    @SearchTag("century cake slice")
     @Accordion
     @Expose
     val centuryPartyInvitation: CenturyPartyInvitationConfig = CenturyPartyInvitationConfig()
@@ -517,6 +516,7 @@ class MiscConfig {
 
     @Expose
     @ConfigOption(name = "Gift Clean Display", desc = "Show only 'CLICK TO OPEN' on gifts.")
+    @SearchTag("century cake slice")
     @ConfigEditorBoolean
     @FeatureToggle
     var giftCleanDisplay: Boolean = false


### PR DESCRIPTION
## What
Undid the move but added more context.

## Changelog Improvements
+ Improved Gift Clean Display to also apply to Century Cake Slices. - CalMWolfs
