### PR TITLE
Fix: Pet storage selected pet skin parsing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ComponentMatcherUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComponentMatcherUtils.kt
@@ -112,7 +112,11 @@ class ComponentMatcher internal constructor(
      * Return a span equivalent to the group with the given name found by [matches] or [find]
      */
     fun group(name: String): ComponentSpan? {
-        val start = matcher.start(name)
+        val start = try {
+            matcher.start(name)
+        } catch (_: IllegalArgumentException) {
+            return null
+        }
         if (start < 0) return null
         return this.span.slice(start, matcher.end(name))
     }

--- a/src/test/java/at/hannibal2/skyhanni/test/ComponentSpanTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ComponentSpanTest.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.compat.withColor
 import net.minecraft.ChatFormatting
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import java.util.regex.Pattern
 
@@ -69,6 +70,16 @@ class ComponentSpanTest {
             }!!
         Pattern.compile("(?<whole>c)").findStyledMatcher(middlePartExtracted) {
             assertEquals(ChatFormatting.RED.color, groupOrThrow("whole").sampleStyleAtStart().color?.value)
+        }
+    }
+
+    @Test
+    fun testUndeclaredOptionalGroup() {
+        val component = componentBuilder {
+            append("Selected pet: Rift Ferret")
+        }
+        Pattern.compile("Selected pet: (?<pet>[\\w ]+)(?<skin> ✦)?").matchStyledMatcher(component) {
+            assertNull(component("skin") ?: component("altskin"))
         }
     }
 


### PR DESCRIPTION
## What

Fixes a Pet Storage crash when reading selected pet lore for pets without alternate skin data.

Missing nullable matcher groups are now handled safely, matching the existing regex helper behavior. Added a regression test, bazinga!

## Changelog Fixes
+ Fixed error when opening pets menu when there are pets without alternate skin data. - akinsoft