### PR TITLE
Fix: Pet Display Autopet swaps

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -388,14 +388,15 @@ object PetStorageApi {
             updateCurrentPetHeldItem(petHeldItem)
         }
 
-        PetStoragePatterns.autoPetMessagePattern.matchStyledMatcher(event.chatComponent) {
+        PetStoragePatterns.autoPetMessagePattern.matchMatcher(event.message.removeResets()) {
             if (config.hideAutopet) event.blockedReason = "autopet"
 
-            val (petName, rarity) = petNameAndRarityOrNull() ?: return
-            val level = matcher.group("level").toInt()
+            val rarity = LorenzRarity.getByColorCode(group("rarity")[0]) ?: return@matchMatcher
+            val petName = group("pet").trim()
+            val level = group("level").toInt()
             val petInternalName = PetUtils.petWithRarityToInternalName(petName, rarity)
-            val petSkin = getPetSkinOrNull(petInternalName)
-            val petSkinTag = getPetSkinTagOrNull()
+            val petSkinTag = groupOrNull("skin")?.replace(" ", "")
+            val petSkin = petSkinTag?.let { PetUtils.findPetSkinOrNull(petInternalName, it) }
 
             val hoverInfoComponents = event.chatComponent.hoverTextComponents()
             val hoverInfo = hoverInfoComponents.toColorlessText()
@@ -699,7 +700,7 @@ object PetStorageApi {
         this.skinTag == skinTag
 
     fun isAutopetMessage(message: String): Boolean =
-        PetStoragePatterns.autoPetMessagePattern.matches(message.removeColor().removeResets())
+        PetStoragePatterns.autoPetMessageColorlessPattern.matches(message.removeColor().removeResets())
 
     fun markDirty() {
         jsonNeedsSave = true

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
@@ -109,9 +109,15 @@ internal object PetStoragePatterns {
      * REGEX-TEST: Autopet equipped your [Lvl 67] T-Rex! VIEW RULE
      */
     @Suppress("MaxLineLength")
-    val autoPetMessagePattern by patternGroup.pattern(
+    val autoPetMessageColorlessPattern by patternGroup.pattern(
         "autopet.message.colorless",
         "Autopet equipped your \\[Lvl (?<level>\\d+)] (?:\\[\\d+(?<altskin>✦)\\] )?(?<pet>[\\w -]+)(?<skin> ✦)?! VIEW RULE",
+    )
+
+    @Suppress("MaxLineLength")
+    val autoPetMessagePattern by patternGroup.pattern(
+        "autopet.message.formatted",
+        "§cAutopet §eequipped your §7\\[Lvl (?<level>\\d+)] §(?<rarity>.)(?:\\[\\d+(?<altskin>✦)] )?(?<pet>[^§!]+?)(?<skin>§. ✦)?§e! §a§lVIEW RULE(?: \\(\\d+\\))?",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
@@ -114,6 +114,11 @@ internal object PetStoragePatterns {
         "Autopet equipped your \\[Lvl (?<level>\\d+)] (?:\\[\\d+(?<altskin>✦)\\] )?(?<pet>[\\w -]+)(?<skin> ✦)?! VIEW RULE",
     )
 
+    /**
+     * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 100] §6Mosquito§e! §a§lVIEW RULE
+     * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 100] §5Rabbit§9 ✦§e! §a§lVIEW RULE
+     * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 200] §6[122✦] Golden Dragon§e! §a§lVIEW RULE
+     */
     @Suppress("MaxLineLength")
     val autoPetMessagePattern by patternGroup.pattern(
         "autopet.message.formatted",


### PR DESCRIPTION
## What

Autopet pet parsing now reads the formatted chat message directly, like normal pet summons do.

The old path matched the component text, then tried to get rarity from the matched component style. That style be missing on the pet span, so Autopet would silently skip updating the current pet. So like kabloom.

## Changelog Fixes
+ Fixed Pet Display sometimes not updating after Autopet switches pets. - akinsoft