### PR TITLE
Fix: Add space for contributors' nametag suffix without emblems

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -77,6 +77,17 @@ object ContributorManager {
         """\b(?:sh|skyhann?[iu])\b.*\b(?:dev\w*|contrib\w*|contrubit\w*)\b"""
     )
 
+    /**
+     * REGEX-TEST: [MVP+] hannibal2
+     * REGEX-TEST: [MVP+] hannibal2 [✪DK✪]
+     * REGEX-TEST: [450] hannibal2
+     * REGEX-FAIL: [450] hannibal2 ⛃
+     */
+    private val contribNametagAppendSpacePattern by patternGroup.pattern(
+        "nametag.appendspace",
+        """[0-9A-Za-z_\]]$"""
+    )
+
     private val repoReloadCoroutine = CoroutineSettings("contributor list repo reload")
 
     @HandleEvent
@@ -315,6 +326,7 @@ object ContributorManager {
         getSuffix(gameProfile.id)?.let {
             recordSeenContributor(gameProfile.id, gameProfile.name)
             if (!config.contributorNametags) return
+            if (contribNametagAppendSpacePattern.find(event.chatComponent)) event.chatComponent.append(" ")
             event.chatComponent.append(it)
         }
     }


### PR DESCRIPTION
## What
Very nitpicky detail, but I noticed that a contributor's suffix in a nametag would appear too close to their username if they do not have an emblem equipped. The pattern also checks for `]` for guild tags in Hypixel lobbies outside SkyBlock.

## Changelog Fixes
+ Fixed contributors' suffixes in nametags being too close to the username when no emblem is equipped. - Piggered
