### PR TITLE
Improvement: Add "Always Show" toggle to Hunting Profit Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/hunting/HuntingProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/hunting/HuntingProfitTrackerConfig.kt
@@ -23,10 +23,18 @@ class HuntingProfitTrackerConfig {
     @Expose
     @ConfigOption(
         name = "Show When Pickup",
-        desc = "Show the hunting tracker for a couple of seconds after hunting something."
+        desc = "Show the hunting tracker for a couple of seconds after hunting something.\n§eIgnored if Always Show is enabled."
     )
     @ConfigEditorBoolean
     var showWhenPickup: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Always Show",
+        desc = "Always show the tracker, regardless of what you are holding.\n§eIf enabled, ignore the Show When Pickup setting."
+    )
+    @ConfigEditorBoolean
+    var alwaysShow: Boolean = false
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/hunting/HuntingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/hunting/HuntingProfitTracker.kt
@@ -114,7 +114,7 @@ object HuntingProfitTracker {
         RenderDisplayHelper(
             outsideInventory = true,
             inOwnInventory = true,
-            condition = { isEnabled() && config.enabled && (isRecentPickup || heldItemEnabled()) },
+            condition = { isEnabled() && config.enabled && (config.alwaysShow || isRecentPickup || heldItemEnabled()) },
             onRender = {
                 tracker.renderDisplay(config.position)
             },


### PR DESCRIPTION
## What
The Hunting Profit Tracker currently only displays while holding a hunting tool, or for ~10 seconds after a catch if "Show When Pickup" is enabled. This adds an opt-in "Always Show" toggle so the tracker can stay permanently visible instead.

Off by default, existing behavior is unchanged unless a player explicitly enables it.

When "Always Show" is on, "Show When Pickup" doesn't do anything anymore. The tracker's already visible all the time, so turning that setting on or off makes no difference. Both option descriptions now cross-reference each other, following the existing convention used in `SkillProgressBarConfig.kt`'s Chroma/Bar Color pair.

New always show toggle:
<img width="637" height="366" alt="7 Hunting Profit Tracker" src="https://github.com/user-attachments/assets/41989f52-706b-465d-8aa2-fdfe7c992ec2" />

Requested in:
- https://discord.com/channels/997079228510117908/1521649144392061069

## Changelog Improvements
+ Added an "Always Show" option to the Hunting Profit Tracker, to keep it visible on screen at all times. - RemainingDelta
