### PR TITLE
Fix: PlayerNameFormatter error if the player has empty style

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
@@ -259,7 +259,7 @@ object PlayerNameFormatter {
         removeColor: String,
         rankColor: String,
     ): ComponentSpan {
-        val style = name.sampleStyleAtStart().takeUnlessEmpty() ?: error("style is empty")
+        val style = name.sampleStyleAtStart()
         return when {
             MarkedPlayerManager.isMarkedPlayer(removeColor) && MarkedPlayerManager.config.highlightInChat ->
                 (MarkedPlayerManager.replaceInChat(rankColor + removeColor)).asComponent()

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
@@ -31,7 +31,6 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.merge
 import at.hannibal2.skyhanni.utils.chat.TextHelper.style
 import at.hannibal2.skyhanni.utils.compat.changeColor
-import at.hannibal2.skyhanni.utils.compat.takeUnlessEmpty
 import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonArray


### PR DESCRIPTION
## What
Apperatly an empty style is possible.

I can't think of a good changelog comment...

exclude_from_changelog
