### PR TITLE
Fix: "Forgot to Turn off the PC" achievement granted after 45 minutes in Limbo instead of 6 hours

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboTimeTracker.kt
@@ -153,7 +153,7 @@ object LimboTimeTracker {
     }
 
     private fun leaveLimbo() {
-        val passedSince = limboJoinTime.passedSince()
+        val passedSince = limboJoinTime.takeIfInitialized()?.passedSince() ?: return
         val duration = passedSince.format()
         val currentPB = (storage?.personalBest ?: 0).seconds
         val oldLuck = storage?.userLuck ?: 0f


### PR DESCRIPTION
## What
The "Forgot to Turn off the PC" achievement (requires 6+ hours in Limbo) was granted to a player after only 45 minutes 32 seconds in Limbo.

`limboJoinTime` is initialized to `SimpleTimeMark.farPast()` (Unix epoch 0, year 1970) as a default/unset value. If `enterLimbo()` was never called due to a timing issue with the Hypixel Mod API's location packet, `limboJoinTime` stayed at that default. When `leaveLimbo()` then fired, it calculated `passedSince = now - 1970`, roughly 56 years, trivially clearing the `passedSince > 6.hours` check and granting the achievement.

Added a `takeIfInitialized()` guard at the top of `leaveLimbo()`. If `limboJoinTime` is still at its unset default, the function returns immediately without granting anything.

Bug identified in:
- https://discord.com/channels/997079228510117908/1523532598289236170

## Changelog Fixes
+ Fixed the "Forgot to Turn off the PC" achievement being granted after spending less than 6 hours in Limbo. - RemainingDelta