### PR TITLE
Backend: Enable Warnings as Errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -351,6 +351,7 @@ tasks.withType<KotlinCompile> {
         val jvmTargetStr = if (isDeobf) target.minecraftVersion.formattedKotlinJvmTarget
                            else target.minecraftVersion.formattedJavaLanguageVersion
         jvmTarget.set(JvmTarget.fromTarget(jvmTargetStr))
+        allWarningsAsErrors = true
         optIn.addAll(
             "kotlin.concurrent.atomics.ExperimentalAtomicApi",
             "kotlin.time.ExperimentalTime"


### PR DESCRIPTION
## What
This makes the compiler error when it previously only warned/yapped.
The kotlin compiler is already quite linent, which is why detekt is used.

But there should be no reason for compiler warnings to ever pop up really.
As most of the time they are really basic mistakes.

exclude_from_changelog