### PR TITLE
Fix: Pet Display overflow widget warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -66,14 +66,14 @@ object PetStorageApi {
     private var petWidgetState: PetWidgetState = PetWidgetState.NOT_READY
 
     val isPetWidgetReadyForDisplay: Boolean
-        get() = petWidgetState == PetWidgetState.READY
+        get() = petWidgetState != PetWidgetState.NOT_READY
 
-    fun getPetWidgetDisplayMessage(): List<String>? = when {
+    fun getPetWidgetDisplayMessage(requireExactPetXp: Boolean): List<String>? = when {
         !TabWidget.PET.isActive && SkyBlockUtils.lastWorldSwitch.passedSince() >= WIDGET_LOAD_GRACE -> listOf(
             "§cPet Tab Widget Missing",
             "§cDo /widget and enable the pet widget",
         )
-        petWidgetState == PetWidgetState.MAXED_WITHOUT_OVERFLOW_XP -> listOf(
+        requireExactPetXp && petWidgetState == PetWidgetState.MAXED_WITHOUT_OVERFLOW_XP -> listOf(
             "§cPet Widget Overflow XP Missing",
             "§cEnable overflow XP in the pet widget",
         )

--- a/src/main/java/at/hannibal2/skyhanni/config/features/pets/display/PetDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/pets/display/PetDisplayConfig.kt
@@ -38,7 +38,8 @@ class PetDisplayConfig : Config() {
         @ConfigOption(
             name = "§cXP Accuracy",
             desc = "Pet Display requires the Pet display in Hypixel's /widget menu. " +
-                "SkyHanni estimates live XP between widget updates. For maxed pets, enable Pet widget overflow XP too."
+                "SkyHanni estimates live XP between widget updates. " +
+                "For exact total or overflow XP on maxed pets, enable Pet widget overflow XP too."
         )
         @ConfigEditorInfoText
         var xpAccuracyWarning: String = ""

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/CurrentPetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/CurrentPetDisplay.kt
@@ -61,6 +61,12 @@ private typealias ETextCenter = TextPetDisplayConfig.EquippedPetTextConfig.Cente
 private typealias EXPSharePlace = ExpSharePetOrganizationConfig.ExpShareLocationOption
 private typealias EXPShareGO = ExpSharePetOrganizationConfig.GroupOrientation
 
+internal fun PetDisplayConfig.requiresExactCurrentPetXp(): Boolean {
+    val enabledTexts = text.equippedPet.enabledTexts.get()
+    return TextPetDisplayConfig.TextElement.OVERFLOW_XP in enabledTexts ||
+        TextPetDisplayConfig.TextElement.TOTAL_XP in enabledTexts
+}
+
 @SkyHanniModule
 object CurrentPetDisplay {
 
@@ -480,7 +486,7 @@ object CurrentPetDisplay {
     fun onRenderOverlayPost(event: GameOverlayRenderPostEvent) {
         if (event.type != RenderLayer.HOTBAR) return
         if (RiftApi.inRift() || !config.general.enabled.get()) return
-        PetStorageApi.getPetWidgetDisplayMessage()?.let { lines ->
+        PetStorageApi.getPetWidgetDisplayMessage(config.requiresExactCurrentPetXp())?.let { lines ->
             invalidateRenderable()
             config.general.position.renderRenderable(
                 buildWidgetMessageRenderable(lines, config.text.equippedPet),


### PR DESCRIPTION
## What
Fixes Pet Display treating a maxed pet without Pet widget overflow XP as unusable even when exact XP text is disabled.

Pet widget itself is still required. The overflow XP warning now only appears when equipped pet text includes Total XP or Overflow XP, so the default display can still render from the pet widget's name/level/item data.

## Changelog Fixes
+ Fixed Pet Display requiring Pet widget overflow XP when exact total/overflow XP text is not enabled. - akinsoft