### PR TITLE
Fix: Pest spawn chat message shown twice when using Compact chat format

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -3,8 +3,8 @@ package at.hannibal2.skyhanni.features.garden.pests
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.garden.pests.PestSpawnConfig
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.title.TitleManager
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestSpawnEvent
 import at.hannibal2.skyhanni.features.garden.pests.PestApi.lastPestSpawnTime
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -64,7 +64,7 @@ object PestSpawn {
     )
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onChat(event: SystemMessageEvent.Allow) {
+    fun onChat(event: SkyHanniChatEvent.Allow) {
         val message = event.cleanMessage
         var blocked = false
 


### PR DESCRIPTION
## What
Pest spawn messages in the Garden appear twice when Chat Message Format is set to Compact.

`PestSpawn.onChat` was listening on `SystemMessageEvent.Allow`. Since `SkyHanniChatEvent.Allow` is a subclass of it, the event system triggers the handler once when `SkyHanniChatEvent.Allow` fires, then again when `PlayerChatManager` posts a separate `SystemMessageEvent.Allow` for the same message. Two triggers means the spawn message gets sent twice.

This was introduced in #5839, which switched the event from `SkyHanniChatEvent.Allow` to `SystemMessageEvent.Allow` as extra protection against a false positive, on top of tightening the regex from `.*!` to `^\w+!`. I tested and confirmed the regex change alone is enough to prevent the false positive, so the event switch was unnecessary and caused this bug.

Fix: switched `PestSpawn.onChat` back to `SkyHanniChatEvent.Allow`, which fires once per message. The `^\w+!` regex stays, and still prevents the original false positive.

Bug identified in:
- https://discord.com/channels/997079228510117908/1518858917835440209

## Changelog Fixes
+ Fixed the Pest Spawn chat message appearing twice when Chat Message Format is set to Compact. - RemainingDelta