### PR TITLE
Fix: BetterContainers counting empty slots as blank

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
-import at.hannibal2.skyhanni.utils.ItemUtils.takeUnlessEmpty
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
@@ -291,7 +291,8 @@ object BetterContainers {
         val isSuperpairs = unformattedLower.startsWith("Superpairs") && !containsStakes
 
         for (index in 0..<size) {
-            val stack: SafeItemStack = handlerInventory.getItem(index).takeUnlessEmpty() ?: continue
+            // Intentionally counts empty slots as well, since we want to render them as well
+            val stack: SafeItemStack = handlerInventory.getItem(index)
             // Column and row index
             val cI = index % 9
             val rI = index / 9
@@ -310,7 +311,8 @@ object BetterContainers {
         }
 
         for (index in 0..<size) {
-            val stack: SafeItemStack = handlerInventory.getItem(index).takeUnlessEmpty() ?: continue
+            // Intentionally counts empty slots as well, since we want to render them as well
+            val stack: SafeItemStack = handlerInventory.getItem(index)
             val xi = index % 9
             val yi = index / 9
 


### PR DESCRIPTION
## What
This is my mistake from #5940, my bad.
Apparently it was intentionally counting empty stacks.
and the drawing of item stack is on a allow only list and not a deny list like I expected.

## Changelog Fixes
+ Fixed Better SkyBlock Containers not rendering slot background for empty slots. - AverageUser125

