### PR TITLE
Fix: Wrong click action message on pest fortune buff expiry

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -223,7 +223,7 @@ object FarmingFortuneDisplay {
             ChatUtils.clickToActionOrDisable(
                 "§cPest fortune buff has expired!",
                 config::bonusFortuneChat,
-                "call Phillip",
+                if (config.callPhillip) "call Phillip" else "teleport to the barn",
                 action = {
                     if (config.callPhillip) {
                         HypixelCommands.call("Phillip")


### PR DESCRIPTION
## What
Makes the `clickToActionOrDisable` text properly conditional on pest fortune buff expiry so that it doesn't tell the user it's going to call Phillip and then teleport them to the barn anyway.

## Changelog Fixes
+ Fixed the "Pest fortune buff has expired" message saying "click to call Phillip" even if it is set to teleport to the barn. - Luna