### PR TITLE
Improvement: Add reminders hud display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/RemindersConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/RemindersConfig.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.config.features.misc
 
-import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
@@ -31,7 +30,6 @@ class RemindersConfig {
         desc = "Display active reminders on screen with time remaining."
     )
     @ConfigEditorBoolean
-    @FeatureToggle
     var showHud: Boolean = false
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/RemindersConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/RemindersConfig.kt
@@ -1,8 +1,11 @@
 package at.hannibal2.skyhanni.config.features.misc
 
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class RemindersConfig {
@@ -21,4 +24,17 @@ class RemindersConfig {
     )
     @ConfigEditorSlider(minValue = 0f, maxValue = 60f, minStep = 1f)
     var interval: Float = 5f
+
+    @Expose
+    @ConfigOption(
+        name = "Show Reminders HUD",
+        desc = "Display active reminders on screen with time remaining."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var showHud: Boolean = false
+
+    @Expose
+    @ConfigLink(owner = RemindersConfig::class, field = "showHud")
+    val hudPosition: Position = Position(10, -130)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderHudDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderHudDisplay.kt
@@ -1,0 +1,62 @@
+package at.hannibal2.skyhanni.features.misc.reminders
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.SecondPassedEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.TimeUnit
+import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+
+@SkyHanniModule
+object ReminderHudDisplay {
+
+    private val config get() = SkyHanniMod.feature.misc.reminders
+    private val storage get() = SkyHanniMod.feature.storage.reminders
+
+    private var display: Renderable? = null
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onSecondPassed(event: SecondPassedEvent) {
+        if (!isEnabled()) return
+        val reminders = storage.values.sortedBy { it.remindAt }
+        if (reminders.isEmpty()) {
+            display = null
+            return
+        }
+        val lines = reminders.map { reminder ->
+            val timeUntil = reminder.remindAt.timeUntil()
+            val timeText = if (timeUntil.isNegative()) "§cNow!" else "§e${timeUntil.formatForHud()}"
+            Renderable.text("$timeText §7— §6${reminder.reason}")
+        }
+        display = Renderable.vertical(lines, spacing = 1)
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (!isEnabled()) return
+        val display = display ?: return
+        config.hudPosition.renderRenderable(display, posLabel = "Reminders HUD")
+    }
+
+    fun isEnabled() = SkyBlockUtils.inSkyBlock && config.showHud
+
+    private fun Duration.formatForHud(): String = when {
+        this >= TimeUnit.YEAR.factor.milliseconds -> format(biggestUnit = TimeUnit.YEAR, maxUnits = 2)
+        this >= 7.days -> format(biggestUnit = TimeUnit.DAY, maxUnits = 1)
+        this >= 1.days -> format(biggestUnit = TimeUnit.DAY, maxUnits = 2)
+        this >= 1.hours -> format(biggestUnit = TimeUnit.HOUR, maxUnits = 2)
+        this >= 1.minutes -> format(biggestUnit = TimeUnit.MINUTE, maxUnits = 2)
+        else -> format(biggestUnit = TimeUnit.SECOND, maxUnits = 1)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderHudDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderHudDisplay.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
@@ -22,7 +21,7 @@ object ReminderHudDisplay {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onSecondPassed(event: SecondPassedEvent) {
-        if (!isEnabled()) return
+        if (!config.showHud) return
         val reminders = storage.values.sortedBy { it.remindAt }
         if (reminders.isEmpty()) {
             display = null
@@ -38,10 +37,8 @@ object ReminderHudDisplay {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-        if (!isEnabled()) return
+        if (!config.showHud) return
         val display = display ?: return
         config.hudPosition.renderRenderable(display, posLabel = "Reminders HUD")
     }
-
-    fun isEnabled() = SkyBlockUtils.inSkyBlock && config.showHud
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderHudDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderHudDisplay.kt
@@ -7,16 +7,10 @@ import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
 
 @SkyHanniModule
 object ReminderHudDisplay {
@@ -36,7 +30,7 @@ object ReminderHudDisplay {
         }
         val lines = reminders.map { reminder ->
             val timeUntil = reminder.remindAt.timeUntil()
-            val timeText = if (timeUntil.isNegative()) "§cNow!" else "§e${timeUntil.formatForHud()}"
+            val timeText = if (timeUntil.isNegative()) "§cNow!" else "§e${timeUntil.format(maxUnits = 2)}"
             Renderable.text("$timeText §7— §6${reminder.reason}")
         }
         display = Renderable.vertical(lines, spacing = 1)
@@ -50,13 +44,4 @@ object ReminderHudDisplay {
     }
 
     fun isEnabled() = SkyBlockUtils.inSkyBlock && config.showHud
-
-    private fun Duration.formatForHud(): String = when {
-        this >= TimeUnit.YEAR.factor.milliseconds -> format(biggestUnit = TimeUnit.YEAR, maxUnits = 2)
-        this >= 7.days -> format(biggestUnit = TimeUnit.DAY, maxUnits = 1)
-        this >= 1.days -> format(biggestUnit = TimeUnit.DAY, maxUnits = 2)
-        this >= 1.hours -> format(biggestUnit = TimeUnit.HOUR, maxUnits = 2)
-        this >= 1.minutes -> format(biggestUnit = TimeUnit.MINUTE, maxUnits = 2)
-        else -> format(biggestUnit = TimeUnit.SECOND, maxUnits = 1)
-    }
 }


### PR DESCRIPTION
## What
Adds an on-screen HUD display for `/shremind` reminders. Instead of only being notified via chat when a timer fires, active reminders are now visible on screen with their time remaining, updating every second.
 
The HUD is toggleable under **Misc → Reminders → Show Reminders HUD** and is repositionable via `/shmovegui`. 

<details>
<summary>Images</summary>

New config option:   

<img width="642" height="376" alt="image" src="https://github.com/user-attachments/assets/7a826e60-b71c-4574-aa3b-42371aab5658" />

New HUD:   

<img width="222" height="137" alt="image" src="https://github.com/user-attachments/assets/538fefbe-5106-45a1-9076-69c9d1a60105" />

</details>

Requested in:
- https://discord.com/channels/997079228510117908/1524016187007176704

## Changelog Improvements
+ Added an on-screen display for active reminders. - RemainingDelta


