### PR TITLE
Fix: Pest Spawn message appearing twice

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -39,7 +39,7 @@ object PestSpawn {
     /**
      * REGEX-TEST: YUCK! 4 ൠ Pest have spawned in Plot - 14!
      * REGEX-TEST: YUCK! 4 ൠ Pest have spawned in The Barn!
-     * REGEX-TEST: [SkyHanni] YUCK! 4 ൠ Pest have spawned in Plot - 14!
+     * REGEX-FAIL: [SkyHanni] YUCK! 4 ൠ Pest have spawned in Plot - 14!
      * REGEX-FAIL: From [MVP+] ThePleader: YUCK! 6 ൠ Pest have spawned in Plot - 7!
      */
     private val multiplePestsPattern by patternGroup.list(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -27,32 +27,35 @@ object PestSpawn {
     /**
      * REGEX-TEST: GROSS! A ൠ Pest has appeared in Plot - S 4!
      * REGEX-TEST: GROSS! A ൠ Pest has appeared in The Barn!
+     * REGEX-FAIL: [SkyHanni] GROSS! A ൠ Pest has appeared in Plot - S 4!
      * REGEX-FAIL: From [MVP+] ThePleader: GROSS! A ൠ Pest has appeared in Plot - 67!
      */
     private val onePestPattern by patternGroup.list(
         "one.colorless",
-        "^\\w+! A ൠ Pest has appeared in Plot - (?<plot>.*)!",
-        "^\\w+! A ൠ Pest has appeared in (?<plot>The Barn)!",
+        "^(?!\\[SkyHanni])\\w+! A ൠ Pest has appeared in Plot - (?<plot>.*)!",
+        "^(?!\\[SkyHanni])\\w+! A ൠ Pest has appeared in (?<plot>The Barn)!",
     )
 
     /**
      * REGEX-TEST: YUCK! 4 ൠ Pest have spawned in Plot - 14!
      * REGEX-TEST: YUCK! 4 ൠ Pest have spawned in The Barn!
+     * REGEX-TEST: [SkyHanni] YUCK! 4 ൠ Pest have spawned in Plot - 14!
      * REGEX-FAIL: From [MVP+] ThePleader: YUCK! 6 ൠ Pest have spawned in Plot - 7!
      */
     private val multiplePestsPattern by patternGroup.list(
         "multiple.colorless",
-        "^\\w+! (?<amount>\\d) ൠ Pests? have spawned in Plot - (?<plot>.*)!",
-        "^\\w+! (?<amount>\\d) ൠ Pests? have spawned in (?<plot>The Barn)!",
+        "^(?!\\[SkyHanni])\\w+! (?<amount>\\d) ൠ Pests? have spawned in Plot - (?<plot>.*)!",
+        "^(?!\\[SkyHanni])\\w+! (?<amount>\\d) ൠ Pests? have spawned in (?<plot>The Barn)!",
     )
 
     /**
      * REGEX-TEST: GROSS! While you were offline, ൠ Pest spawned in Plots 12, 9, 5, 11 and 3!
+     * REGEX-FAIL: [SkyHanni] GROSS! While you were offline, ൠ Pest spawned in Plots 6 and 7!
      * REGEX-FAIL: From [MVP+] ThePleader: GROSS! While you were offline, ൠ Pest spawned in Plots 6 and 7!
      */
     private val offlinePestsPattern by patternGroup.pattern(
         "offline.colorless",
-        "^\\w+! While you were offline, ൠ Pests? spawned in Plots (?<plots>.*)!",
+        "^(?!\\[SkyHanni])\\w+! While you were offline, ൠ Pests? spawned in Plots (?<plots>.*)!",
     )
 
     /**


### PR DESCRIPTION
## What
On SkyHanni 7.3.10 each pest spawn started to appear twice as in the logs shown below:
<code>[20:43:56] [Render thread/INFO]: [CHAT] [SkyHanni] §e5 §aPests Spawned in §b15§a!
[20:43:56] [Render thread/INFO]: [CHAT] [SkyHanni] §e5 §aPests Spawned in §b15§a!
[20:43:56] [Render thread/INFO]: [CHAT] [SkyHanni] Pests spawned in §b2m 39s\n§e[CLICK to disable this feature]
[20:43:56] [Render thread/INFO]: [CHAT] [SkyHanni] Pests spawned in §b0.0s\n§e[CLICK to disable this feature]</code>
I have no idea what truly caused the issue, but my initial assumption that a SkyHanni clickable message got detected by the chat event again turned out to be the cause. Modified regex to ignore pest messages with a SkyHanni prefix and this issue no longer appears. 

<b>I'm not sure if I made regex fails correctly, my try at installing the IDEA plugin gave me even more errors that I do not understand and have no clue how to fix.</b>

## Changelog Fixes
+ Fixed pest message appearing twice. - heyn
