### PR TITLE
Fix: Crown of Avarice multiple crown support

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
@@ -48,7 +48,7 @@ object CrownOfAvariceCounter {
         InventoryUtils.getHelmet()?.getInternalNameOrNull() == internalName
     }
 
-    private var currentCrownUUID: String = ""
+    private var currentUUID: String = ""
     private var totalCoins: Long? = null
     private var coinsEarned: Long = 0L
     private var sessionUptime: Stopwatch = Stopwatch()
@@ -92,8 +92,8 @@ object CrownOfAvariceCounter {
         val coins = item.getCoinsOfAvarice() ?: return
         val itemUUID = item.getItemUuid() ?: return // this should never return unless hypixel changed something
         // Changing the current crown uuid and then returning ensures no coin change happens (like swapping in 482m coa => 1b)
-        if (currentCrownUUID != itemUUID) {
-            currentCrownUUID = itemUUID
+        if (currentUUID != itemUUID) {
+            currentUUID = itemUUID
             totalCoins = coins
             update()
             return
@@ -122,7 +122,7 @@ object CrownOfAvariceCounter {
         isWearingCrown && (totalCoins ?: 0) < MAX_AVARICE_COINS
 
     @HandleEvent(IslandJoinEvent::class)
-    fun onIslandChange() {
+    fun onIslandJoin() {
         if (config.resetOnWorldChange) reset()
         totalCoins = InventoryUtils.getHelmet()?.getCoinsOfAvarice()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/CrownOfAvariceCounter.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.itemability.CrownOfAvariceConfig.CrownOfAvariceLines
 import at.hannibal2.skyhanni.data.Perk
-import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.OwnInventoryArmorUpdateEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.utils.RecalculatingValue
 import at.hannibal2.skyhanni.utils.RenderDisplayHelper
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getCoinsOfAvarice
+import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getItemUuid
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.Stopwatch
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -47,6 +48,7 @@ object CrownOfAvariceCounter {
         InventoryUtils.getHelmet()?.getInternalNameOrNull() == internalName
     }
 
+    private var currentCrownUUID: String = ""
     private var totalCoins: Long? = null
     private var coinsEarned: Long = 0L
     private var sessionUptime: Stopwatch = Stopwatch()
@@ -88,6 +90,15 @@ object CrownOfAvariceCounter {
         val item = event.itemStack
         if (item.getInternalNameOrNull() != internalName) return
         val coins = item.getCoinsOfAvarice() ?: return
+        val itemUUID = item.getItemUuid() ?: return // this should never return unless hypixel changed something
+        // Changing the current crown uuid and then returning ensures no coin change happens (like swapping in 482m coa => 1b)
+        if (currentCrownUUID != itemUUID) {
+            currentCrownUUID = itemUUID
+            totalCoins = coins
+            update()
+            return
+        }
+
         if (totalCoins == null) totalCoins = coins
         coinsDifference = coins - (totalCoins ?: 0)
 
@@ -110,7 +121,7 @@ object CrownOfAvariceCounter {
     fun isAvariceConsuming(): Boolean =
         isWearingCrown && (totalCoins ?: 0) < MAX_AVARICE_COINS
 
-    @HandleEvent(IslandChangeEvent::class)
+    @HandleEvent(IslandJoinEvent::class)
     fun onIslandChange() {
         if (config.resetOnWorldChange) reset()
         totalCoins = InventoryUtils.getHelmet()?.getCoinsOfAvarice()


### PR DESCRIPTION
## What
Changing crowns caused an incorrect and unintended change to your coin per hour metric and last coins gained. Adding a UUID check and setting totalCoins to the coins on helmet ensures the coin changes between the crowns are not counted while keeping the coin per hour metric accurate.

## Changelog Fixes
+ Fixed Crown of Avarice Counter to support changing between them. - Tryp0xd
    * Coin per hour metric should stay intact, the value on the counter will only change.

