### PR TITLE
Fix: MaxwellApi detecting Air as a tuning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
@@ -231,9 +231,8 @@ object MaxwellApi {
     private fun loadThaumaturgyTuningsFromTuning(inventoryItems: Map<Int, SafeItemStack>) {
         val map = mutableListOf<ThaumaturgyPowerTuning>()
         for (stack in inventoryItems.values) {
-            stack.takeUnlessEmpty() ?: continue
+            val stackName = stack.takeUnlessEmpty()?.cleanName() ?: continue
             for (line in stack.getLore()) {
-                val stackName = stack.cleanName()
                 statsTuningDataPattern.readTuningFromLine(line)?.let {
                     it.name = tuningNamePattern.matchMatcher(stackName) {
                         group("name")

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
@@ -11,7 +11,9 @@ import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardConfigEleme
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.takeUnlessEmpty
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
@@ -158,6 +160,21 @@ object MaxwellApi {
         "(?:§.)*Requires (?:§.)*Redstone Collection I+(?:§.)*\\.",
     )
 
+    /**
+     * REGEX-TEST: ❤ Health
+     * REGEX-TEST: ❈ Defense
+     * REGEX-TEST: ✦ Speed
+     * REGEX-TEST: ❁ Strength
+     * REGEX-TEST: ☠ Crit Damage
+     * REGEX-TEST: ☣ Crit Chance
+     * REGEX-TEST: ⚔ Attack Speed
+     * REGEX-TEST: ✎ Intelligence
+     */
+    private val tuningNamePattern by patternGroup.pattern(
+        "tuning.name",
+        ". (?<name>.+)",
+    )
+
     fun isThaumaturgyInventory(inventoryName: String) = thaumaturgyGuiPattern.matches(inventoryName)
 
     @HandleEvent
@@ -214,13 +231,15 @@ object MaxwellApi {
     private fun loadThaumaturgyTuningsFromTuning(inventoryItems: Map<Int, SafeItemStack>) {
         val map = mutableListOf<ThaumaturgyPowerTuning>()
         for (stack in inventoryItems.values) {
+            stack.takeUnlessEmpty() ?: continue
             for (line in stack.getLore()) {
+                val stackName = stack.cleanName()
                 statsTuningDataPattern.readTuningFromLine(line)?.let {
-                    it.name = "§.. (?<name>.+)".toPattern().matchMatcher(stack.hoverName.formattedTextCompatLeadingWhiteLessResets()) {
+                    it.name = tuningNamePattern.matchMatcher(stackName) {
                         group("name")
                     } ?: ErrorManager.skyHanniError(
                         "found no name in thaumaturgy",
-                        "stack name" to stack.hoverName.formattedTextCompatLeadingWhiteLessResets(),
+                        "stack name" to stackName,
                         "line" to line,
                     )
                     map.add(it)

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -1118,5 +1118,5 @@ object ItemUtils {
         }
     }
 
-    fun SafeItemStack.takeUnlessEmpty(): SafeItemStack? = takeUnless { it.isEmpty || it.item == Items.AIR }
+    fun SafeItemStack.takeUnlessEmpty(): SafeItemStack? = takeUnless { it.isEmpty }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -1118,5 +1118,5 @@ object ItemUtils {
         }
     }
 
-    fun SafeItemStack.takeUnlessEmpty(): SafeItemStack? = takeUnless { it.isEmpty() }
+    fun SafeItemStack.takeUnlessEmpty(): SafeItemStack? = takeUnless { it.isEmpty || it.item == Items.AIR }
 }


### PR DESCRIPTION
## What
The stack name could have been air, and it would have failed.
Also made it use clean name for the item stack and moved the pattern to repo pattern while I was here.

## Changelog Fixes
+ Fixed Maxwell tuning stats sometimes not being detected correctly. - AverageUser125
