### PR TITLE
Fix: Update SkyblockStat to new stat icons + cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -42,7 +42,7 @@ enum class SkyblockStat(
     TRUE_DEFENSE(WHITE, '\uE027'),
     STRENGTH(RED, '\uE00D'),
     CRIT_CHANCE(DARK_BLUE, '\uE02C', hypixelId = "CRITICAL_CHANCE"),
-    CRIT_DAMAGE(DARK_BLUE, '\uE007'),
+    CRIT_DAMAGE(DARK_BLUE, '\uE007', hypixelId = "CRITICAL_DAMAGE"),
     BONUS_ATTACK_SPEED(YELLOW, '\uE001', displayName = "Attack Speed", hypixelId = "ATTACK_SPEED"),
     FEROCITY(RED, '\uE00B'),
     SWING_RANGE(YELLOW, '\uE024'),

--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.data.model
 
+import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.ProfileStorageData
@@ -8,12 +9,13 @@ import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.ResourcePackReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.EnumUtils.toFormattedName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.allLettersFirstUppercase
-import at.hannibal2.skyhanni.utils.compat.createResourceLocation
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
 import org.intellij.lang.annotations.Language
@@ -23,150 +25,129 @@ import kotlin.math.roundToInt
 @Language("RegExp")
 private const val VALUE_PATTERN = "(?<value>[\\d,.]+)(?: .*)?"
 
-@Suppress("MaxLineLength")
+private val patternGroup = RepoPattern.group("stats")
+
 enum class SkyblockStat(
-    val hypixelIcon: String,
-    @Language("RegExp") tabListPatternS: String,
-    @Language("RegExp") menuPatternS: String,
+    val color: LorenzColor,
+    val hypixelIcon: Char,
+    displayName: String? = null,
     private val hypixelId: String? = null,
+    generatePatterns: Boolean = true,
 ) {
-    DAMAGE("§c❁", "", ""), // Weapon only
-    HEALTH("§c❤", " *Health: ❤$VALUE_PATTERN", " *§c❤ Health §f$VALUE_PATTERN"), // TODO get from action bar
-    DEFENSE("§a❈", " *Defense: ❈$VALUE_PATTERN", " *§a❈ Defense §f$VALUE_PATTERN"), // TODO get from action bar
-    STRENGTH("§c❁", " *Strength: ❁$VALUE_PATTERN", " *§c❁ Strength §f$VALUE_PATTERN"),
-    INTELLIGENCE(
-        "§b✎",
-        " *Intelligence: ✎$VALUE_PATTERN",
-        " *§b✎ Intelligence §f$VALUE_PATTERN",
-    ), // TODO get from action bar
-    CRIT_DAMAGE(
-        "§9☠", " *Crit Damage: ☠$VALUE_PATTERN", " *§9☠ Crit Damage §f$VALUE_PATTERN",
-        hypixelId = "CRITICAL_DAMAGE",
-    ),
-    CRIT_CHANCE(
-        "§9☣", " *Crit Chance: ☣$VALUE_PATTERN", " *§9☣ Crit Chance §f$VALUE_PATTERN",
-        hypixelId = "CRITICAL_CHANCE",
-    ),
-    FEROCITY("§c⫽", " *Ferocity: ⫽$VALUE_PATTERN", " *§c⫽ Ferocity §f$VALUE_PATTERN"),
-    BONUS_ATTACK_SPEED(
-        "§e⚔",
-        " *Attack Speed: ⚔$VALUE_PATTERN",
-        " *§e⚔ Bonus Attack Speed §f$VALUE_PATTERN",
-        hypixelId = "ATTACK_SPEED",
-    ),
-    ABILITY_DAMAGE(
-        "§c๑", " *Ability Damage: ๑$VALUE_PATTERN", " *§c๑ Ability Damage §f$VALUE_PATTERN",
-        hypixelId = "ABILITY_DAMAGE_PERCENT",
-    ),
-    HEALTH_REGEN(
-        "§c❣",
-        " *Health Regen: ❣$VALUE_PATTERN",
-        " *§c❣ Health Regen §f$VALUE_PATTERN",
-        "HEALTH_REGENERATION",
-    ),
-    VITALITY("§4♨", " *Vitality: ♨$VALUE_PATTERN", " *§4♨ Vitality §f$VALUE_PATTERN"),
-    MENDING("§a☄", " *Mending: ☄$VALUE_PATTERN", " *§a☄ Mending §f$VALUE_PATTERN"),
-    TRUE_DEFENSE("§f❂", " *True Defense: ❂$VALUE_PATTERN", " *§f❂ True Defense §f$VALUE_PATTERN"),
-    SWING_RANGE("§eⓈ", " *Swing Range: Ⓢ$VALUE_PATTERN", " *§eⓈ Swing Range §f$VALUE_PATTERN"),
+    DAMAGE(RED, '\uE050', generatePatterns = false), // weapon only
 
-    // TODO add the way sba did get it (be careful with 500+ Speed)
-    SPEED(
-        "§f✦", " *Speed: ✦$VALUE_PATTERN", " *§f✦ Speed §f$VALUE_PATTERN",
-        hypixelId = "WALK_SPEED",
-    ),
-    SEA_CREATURE_CHANCE("§3α", " *Sea Creature Chance: α$VALUE_PATTERN", " *§3α Sea Creature Chance §f$VALUE_PATTERN"),
-    MAGIC_FIND("§b✯", " *Magic Find: ✯$VALUE_PATTERN", " *§b✯ Magic Find §f$VALUE_PATTERN"),
-    PET_LUCK("§d♣", " *Pet Luck: ♣$VALUE_PATTERN", " *§d♣ Pet Luck §f$VALUE_PATTERN"),
-    FISHING_SPEED("§b☂", " *Fishing Speed: ☂$VALUE_PATTERN", " *§b☂ Fishing Speed §f$VALUE_PATTERN"),
-    TROPHY_FISH_CHANCE("§6♔", "Trophy Fish Chance: ♔$VALUE_PATTERN", " *§6♔ Trophy Fish Chance §f(?<value>\\d+)%"),
-    DOUBLE_HOOK_CHANCE(
-        "§9⚓",
-        " *Double Hook Chance: ⚓$VALUE_PATTERN",
-        " *§9⚓ Double Hook Chance §f(?<value>\\d+(?:\\.\\d+)?)%",
-    ),
-    TREASURE_CHANCE("§6⛃", " *Treasure Chance: ⛃(?<value>\\d+(?:\\.\\d+)?)", " *§6⛃ Treasure Chance §f(?<value>\\d+(?:\\.\\d+)?)%"),
-    BONUS_PEST_CHANCE(
-        "§2",
-        " *(?:§r§7§m)?Bonus Pest Chance: $VALUE_PATTERN",
-        " *(?:§7§m|§2) Bonus Pest Chance (?:§f)?$VALUE_PATTERN",
-    ),
-    COMBAT_WISDOM("§3☯", " *Combat Wisdom: ☯$VALUE_PATTERN", " *§3☯ Combat Wisdom §f$VALUE_PATTERN"),
-    MINING_WISDOM("§3☯", " *Mining Wisdom: ☯$VALUE_PATTERN", " *§3☯ Mining Wisdom §f$VALUE_PATTERN"),
-    FARMING_WISDOM("§3☯", " *Farming Wisdom: ☯$VALUE_PATTERN", " *§3☯ Farming Wisdom §f$VALUE_PATTERN"),
-    FORAGING_WISDOM("§3☯", " *Foraging Wisdom: ☯$VALUE_PATTERN", " *§3☯ Foraging Wisdom §f$VALUE_PATTERN"),
-    FISHING_WISDOM("§3☯", " *Fishing Wisdom: ☯$VALUE_PATTERN", " *§3☯ Fishing Wisdom §f$VALUE_PATTERN"),
-    ENCHANTING_WISDOM("§3☯", " *Enchanting Wisdom: ☯$VALUE_PATTERN", " *§3☯ Enchanting Wisdom §f$VALUE_PATTERN"),
-    ALCHEMY_WISDOM("§3☯", " *Alchemy Wisdom: ☯$VALUE_PATTERN", " *§3☯ Alchemy Wisdom §f$VALUE_PATTERN"),
-    CARPENTRY_WISDOM("§3☯", " *Carpentry Wisdom: ☯$VALUE_PATTERN", " *§3☯ Carpentry Wisdom §f$VALUE_PATTERN"),
-    RUNECRAFTING_WISDOM("§3☯", " *Runecrafting Wisdom: ☯$VALUE_PATTERN", " *§3☯ Runecrafting Wisdom §f$VALUE_PATTERN"),
-    SOCIAL_WISDOM("§3☯", " *Social Wisdom: ☯$VALUE_PATTERN", " *§3☯ Social Wisdom §f$VALUE_PATTERN"),
-    TAMING_WISDOM("§3☯", " *Taming Wisdom: ☯$VALUE_PATTERN", " *§3☯ Taming Wisdom §f$VALUE_PATTERN"),
-    HUNTING_WISDOM("§3☯", " *Hunting Wisdom: ☯$VALUE_PATTERN", " *§3☯ Hunting Wisdom §f$VALUE_PATTERN"),
+    // <editor-fold desc="Combat Stats">
+    HEALTH(RED, '\uE010'), // TODO get from action bar
+    DEFENSE(GREEN, '\uE008'), // TODO get from action bar
+    TRUE_DEFENSE(WHITE, '\uE027'),
+    STRENGTH(RED, '\uE00D'),
+    CRIT_CHANCE(DARK_BLUE, '\uE02C', hypixelId = "CRITICAL_CHANCE"),
+    CRIT_DAMAGE(DARK_BLUE, '\uE007'),
+    BONUS_ATTACK_SPEED(YELLOW, '\uE001', displayName = "Attack Speed", hypixelId = "ATTACK_SPEED"),
+    FEROCITY(RED, '\uE00B'),
+    SWING_RANGE(YELLOW, '\uE024'),
+    INTELLIGENCE(AQUA, '\uE003'), // TODO get from action bar
+    ABILITY_DAMAGE(RED, '\uE002', hypixelId = "ABILITY_DAMAGE_PERCENT"),
+    HEALTH_REGEN(RED, '\uE011', hypixelId = "HEALTH_REGENERATION"),
+    VITALITY(DARK_RED, '\uE028'), // TODO get from action bar
+    MENDING(GREEN, '\uE014'),
 
-    MINING_SPEED("§6⸕", " *Mining Speed: ⸕$VALUE_PATTERN", " *§6⸕ Mining Speed §f$VALUE_PATTERN"),
-    BREAKING_POWER("§2Ⓟ", "", " *§2Ⓟ Breaking Power §f$VALUE_PATTERN"),
-    PRISTINE("§5✧", " *Pristine: ✧$VALUE_PATTERN", " *§5✧ Pristine §f$VALUE_PATTERN"),
-    FORAGING_FORTUNE("§6☘", " *Foraging Fortune: ☘$VALUE_PATTERN", " *§6☘ Foraging Fortune §f$VALUE_PATTERN"),
-    FARMING_FORTUNE(
-        "§6☘",
-        " *Farming Fortune: ☘$VALUE_PATTERN",
-        " *(?:§7§m|§6)☘ Farming Fortune (?:§f)?$VALUE_PATTERN",
-    ),
-    MINING_FORTUNE("§6☘", " *Mining Fortune: ☘$VALUE_PATTERN", " *§6☘ Mining Fortune §f$VALUE_PATTERN"),
-    FEAR("§5☠", " *Fear: ☠$VALUE_PATTERN", " *§5☠ Fear §f$VALUE_PATTERN"),
-    COLD_RESISTANCE("§b❄", " *Cold Resistance: ❄$VALUE_PATTERN", ""),
-    WHEAT_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Wheat Fortune $VALUE_PATTERN"),
-    CARROT_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Carrot Fortune $VALUE_PATTERN"),
-    POTATO_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Potato Fortune $VALUE_PATTERN"),
-    PUMPKIN_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Pumpkin Fortune $VALUE_PATTERN"),
-    MELON_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Melon Slice Fortune $VALUE_PATTERN"),
-    MUSHROOM_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Mushroom Fortune $VALUE_PATTERN"),
-    CACTUS_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Cactus Fortune $VALUE_PATTERN"),
-    NETHER_STALK_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Nether Wart Fortune $VALUE_PATTERN"),
-    COCOA_BEANS_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Cocoa Beans Fortune $VALUE_PATTERN"),
-    SUGAR_CANE_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Sugar Cane Fortune $VALUE_PATTERN"),
-    SUNFLOWER_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Sunflower Fortune $VALUE_PATTERN"),
-    MOONFLOWER_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Moonflower Fortune $VALUE_PATTERN"),
-    WILD_ROSE_FORTUNE("§6☘", "", " *(?:§7§m|§6)☘ Wild Rose Fortune $VALUE_PATTERN"),
-    OVERBLOOM("§e☀", "", " *(?:§7§m|§e)☀ Overbloom $VALUE_PATTERN"),
+    // <editor-fold desc="Mining Stats">
+    BREAKING_POWER(DARK_GREEN, '\uE005'),
+    MINING_SPEED(GOLD, '\uE015'),
+    MINING_SPREAD(YELLOW, '\uE016'),
+    GEMSTONE_SPREAD(YELLOW, '\uE00F'),
+    PRISTINE(DARK_PURPLE, '\uE01C'),
+    MINING_FORTUNE(GOLD, '\uE053'),
+    ORE_FORTUNE(GOLD, '\uE053'),
+    BLOCK_FORTUNE(GOLD, '\uE053'),
+    DWARVEN_METAL_FORTUNE(GOLD, '\uE053'),
+    GEMSTONE_FORTUNE(GOLD, '\uE053'),
+    // </editor-fold>
 
-    MINING_SPREAD(
-        "§e▚",
-        " *Mining Spread: ▚$VALUE_PATTERN",
-        " *(§7§m|§e)▚ Mining Spread (§f)?$VALUE_PATTERN",
-    ),
-    GEMSTONE_SPREAD(
-        "§e▚",
-        " *Mining Spread: ▚$VALUE_PATTERN",
-        " *(§7§m|§e)▚ Gemstone Spread (§f)?$VALUE_PATTERN",
-    ),
-    ORE_FORTUNE("§6☘", " *Ore Fortune: ☘$VALUE_PATTERN", " *§6☘ Ore Fortune §f103"),
-    DWARVEN_METAL_FORTUNE(
-        "§6☘",
-        " *Dwarven Metal Fortune: ☘$VALUE_PATTERN",
-        " *§6☘ Dwarven Metal Fortune §f$VALUE_PATTERN",
-    ),
-    BLOCK_FORTUNE("§6☘", " *Block Fortune: ☘$VALUE_PATTERN", " *§6☘ Block Fortune §f$VALUE_PATTERN"),
-    GEMSTONE_FORTUNE("§6☘", " *Gemstone Fortune: ☘$VALUE_PATTERN", " *§6☘ Gemstone Fortune §f$VALUE_PATTERN"),
-    HEAT_RESISTANCE("§c♨", " *Heat Resistance: ♨$VALUE_PATTERN", " *§c♨ Heat Resistance §f$VALUE_PATTERN"),
+    // <editor-fold desc="Farming Stats">
+    BONUS_PEST_CHANCE(DARK_GREEN, '\uE019'),
+    OVERBLOOM(YELLOW, '\uE02B'),
+    FARMING_FORTUNE(GOLD, '\uE051'),
+    WHEAT_FORTUNE(GOLD, '\uE051'),
+    CARROT_FORTUNE(GOLD, '\uE051'),
+    POTATO_FORTUNE(GOLD, '\uE051'),
+    PUMPKIN_FORTUNE(GOLD, '\uE051'),
+    SUGAR_CANE_FORTUNE(GOLD, '\uE051'),
+    MELON_FORTUNE(GOLD, '\uE051', displayName = "Melon Slice Fortune"),
+    CACTUS_FORTUNE(GOLD, '\uE051'),
+    COCOA_BEANS_FORTUNE(GOLD, '\uE051'),
+    MUSHROOM_FORTUNE(GOLD, '\uE051'),
+    NETHER_STALK_FORTUNE(GOLD, '\uE051', displayName = "Nether Wart Fortune"),
+    SUNFLOWER_FORTUNE(GOLD, '\uE051'),
+    MOONFLOWER_FORTUNE(GOLD, '\uE051'),
+    WILD_ROSE_FORTUNE(GOLD, '\uE051'),
+    // </editor-fold>
 
-    SWEEP("§2∮", " *Sweep: ∮$VALUE_PATTERN", " *§2∮ Sweep §f$VALUE_PATTERN"),
-    RESPIRATION("§3⚶", " *Respiration: ⚶$VALUE_PATTERN", " *§3⚶ Respiration §f$VALUE_PATTERN"),
-    PRESSURE_RESISTANCE("§9❍", " *Pressure Resistance: ❍$VALUE_PATTERN", " *§9❍ Pressure Resistance §f$VALUE_PATTERN"),
-    PULL("§bᛷ", " *Pull: ᛷ$VALUE_PATTERN", " *§bᛷ Pull §f$VALUE_PATTERN"),
-    HUNTER_FORTUNE("§d☘", " *Hunter Fortune: ☘$VALUE_PATTERN", " *§d☘ Hunter Fortune §f$VALUE_PATTERN"),
-    FIG_FORTUNE("§6☘", " *Fig Fortune: ☘$VALUE_PATTERN", " *§6☘ Fig Fortune §f$VALUE_PATTERN"),
-    MANGROVE_FORTUNE("§6☘", " *Mangrove Fortune: ☘$VALUE_PATTERN", " *§6☘ Mangrove Fortune §f$VALUE_PATTERN"),
+    // <editor-fold desc="Foraging Stats">
+    SWEEP(DARK_GREEN, '\uE023'),
+    FORAGING_FORTUNE(GOLD, '\uE054'),
+    FIG_FORTUNE(GOLD, '\uE054'),
+    MANGROVE_FORTUNE(GOLD, '\uE054'),
+    // </editor-fold>
 
-    RIFT_TIME("§aф", " *Rift Time: ф$VALUE_PATTERN", " *§aф Rift Time §f$VALUE_PATTERN"),
-    RIFT_DAMAGE("§5❁", " *Rift Damage: ❁$VALUE_PATTERN", " *§5❁ Rift Damage §f$VALUE_PATTERN"),
-    MANA_REGEN("§b⚡", " *Mana Regen: ⚡$VALUE_PATTERN", " *§b⚡ Mana Regen §f$VALUE_PATTERN"),
-    HEARTS("§c♥", " *Hearts: ♥$VALUE_PATTERN", " *§c♥ Hearts §f$VALUE_PATTERN"),
+    // <editor-fold desc="Fishing Stats">
+    FISHING_SPEED(AQUA, '\uE00C'),
+    SEA_CREATURE_CHANCE(DARK_AQUA, '\uE021'),
+    DOUBLE_HOOK_CHANCE(BLUE, '\uE009'),
+    TROPHY_FISH_CHANCE(GOLD, '\uE02A', displayName = "Trophy Chance"),
+    TREASURE_CHANCE(GOLD, '\uE025'),
 
-    TRACKING("§d❃", " *Tracking: ❃$VALUE_PATTERN", " *§d❃ Tracking §f$VALUE_PATTERN"),
+    // </editor-fold>
 
-    UNKNOWN("§c?", "", "")
+    // <editor-fold desc="Miscellaneous Stats">
+    // TODO get from Minecraft walk speed attribute (500+ Speed works fine now)
+    SPEED(WHITE, '\uE022', hypixelId = "WALK_SPEED"),
+    MAGIC_FIND(AQUA, '\uE01A'),
+    PET_LUCK(LIGHT_PURPLE, '\uE013'),
+    HEAT_RESISTANCE(RED, '\uE012'),
+    COLD_RESISTANCE(AQUA, '\uE006'),
+    RESPIRATION(DARK_AQUA, '\uE01D'),
+    PRESSURE_RESISTANCE(BLUE, '\uE01B'),
+    FEAR(DARK_PURPLE, '\uE00A'),
+    TRACKING(LIGHT_PURPLE, '\uE077'),
+    // </editor-fold>
+
+    // <editor-fold desc="Hunting Stats">
+    PULL(AQUA, '\uE02D'),
+    HUNTER_FORTUNE(LIGHT_PURPLE, '\uE05B'),
+    // </editor-fold>
+
+    // <editor-fold desc="Wisdom Stats">
+    COMBAT_WISDOM(DARK_AQUA, '☯'),
+    FARMING_WISDOM(DARK_AQUA, '☯'),
+    FISHING_WISDOM(DARK_AQUA, '☯'),
+    MINING_WISDOM(DARK_AQUA, '☯'),
+    FORAGING_WISDOM(DARK_AQUA, '☯'),
+    ENCHANTING_WISDOM(DARK_AQUA, '☯'),
+    ALCHEMY_WISDOM(DARK_AQUA, '☯'),
+    CARPENTRY_WISDOM(DARK_AQUA, '☯'),
+    RUNECRAFTING_WISDOM(DARK_AQUA, '☯'),
+    TAMING_WISDOM(DARK_AQUA, '☯'),
+    SOCIAL_WISDOM(DARK_AQUA, '☯'),
+    HUNTING_WISDOM(DARK_AQUA, '☯'),
+    // </editor-fold>
+
+    // <editor-fold desc="Rift Stats">
+    RIFT_TIME(GREEN, '\uE020'),
+    RIFT_DAMAGE(DARK_PURPLE, '\uE01E'),
+    // TODO get from Minecraft walk speed attribute
+    RIFT_SPEED(WHITE, '\uE022', displayName = "Speed", hypixelId = "RIFT_WALK_SPEED"),
+    RIFT_INTELLIGENCE(AQUA, '\uE003', displayName = "Intelligence"),
+    // MAGIC_FIND is just the overworld stat
+    MANA_REGEN(AQUA, '⚡'),
+    HEARTS(RED, '♥'),
+    // </editor-fold>
+
+    UNKNOWN(GRAY, '?', generatePatterns = false),
     ;
+
+    val displayName: String = displayName ?: toFormattedName()
 
     var lastKnownValue: Double?
         get() = ProfileStorageData.profileSpecific?.stats?.get(this)
@@ -176,7 +157,7 @@ enum class SkyblockStat(
 
     @Suppress("UNNECESSARY_SAFE_CALL")
     val icon: String
-        get() = resourcePackOverrides?.get(name) ?: hypixelIcon
+        get() = resourcePackOverrides?.get(name) ?: "${color.getChatColor()}$hypixelIcon"
 
     var lastSource: StatSourceType = StatSourceType.UNKNOWN
 
@@ -191,14 +172,20 @@ enum class SkyblockStat(
 
     val displayValue get() = lastKnownValue?.let { icon + it.roundToInt() }
 
-    val tablistPattern by RepoPattern.pattern("stats.tablist.no-color.$keyName", tabListPatternS)
-    val menuPattern by RepoPattern.pattern("stats.menu.$keyName", menuPatternS)
+    val tablistPattern by patternGroup.pattern(
+        "tablist.no-color.$keyName",
+        if (generatePatterns) " *${this@SkyblockStat.displayName}: $hypixelIcon$VALUE_PATTERN" else "",
+    )
+
+    val menuPattern by patternGroup.pattern(
+        "menu.no-color.$keyName",
+        if (generatePatterns) "$hypixelIcon ${this@SkyblockStat.displayName} $VALUE_PATTERN" else "",
+    )
 
     fun asString(value: Int) = (if (value > 0) "+" else "") + value.toString() + " " + this.icon
 
     @SkyHanniModule
     companion object {
-
         val fontSizeOfLargestIcon by lazy {
             entries.maxOf { Minecraft.getInstance().font.width(it.icon) } + 1
         }
@@ -225,10 +212,8 @@ enum class SkyblockStat(
         private var resourcePackOverrides = emptyMap<String, String>()
 
         @HandleEvent
-        fun onResourcePackLoad(event: ResourcePackReloadEvent) {
-            val packOverrides = event.getJsonResource<Map<String, String>>(
-                createResourceLocation("skyhanni", "icon_overrides.json"),
-            )
+        fun onResourcePackReload(event: ResourcePackReloadEvent) {
+            val packOverrides = event.getJsonResource<Map<String, String>>(SkyHanniMod.id("icon_overrides.json"))
 
             resourcePackOverrides = packOverrides.orEmpty()
         }
@@ -255,7 +240,7 @@ enum class SkyblockStat(
         }
 
         @HandleEvent
-        fun onTabList(event: WidgetUpdateEvent) {
+        fun onWidgetUpdate(event: WidgetUpdateEvent) {
             if (!event.isWidget(TabWidget.STATS, TabWidget.DUNGEON_SKILLS_AND_STATS)) return
             val type = if (event.isWidget(TabWidget.DUNGEON_SKILLS_AND_STATS)) StatSourceType.TABLIST_DUNGEON else StatSourceType.TABLIST
             assignEntry(event.lines.map { it.string }, type) { it.tablistPattern }
@@ -283,6 +268,7 @@ enum class SkyblockStat(
 }
 
 class SkyblockStatList : LinkedHashMap<SkyblockStat, Double>(), Map<SkyblockStat, Double> {
+
     operator fun minus(other: SkyblockStatList): SkyblockStatList {
         return SkyblockStatList().apply {
             val keys = this.keys + other.keys

--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -192,6 +192,8 @@ enum class SkyblockStat(
 
         fun getValueOrNull(string: String): SkyblockStat? = entries.firstOrNull { it.name == string || it.hypixelId == string }
 
+        fun getValueByDisplayNameOrNull(string: String): SkyblockStat? = entries.firstOrNull { it.displayName == string }
+
         fun getValue(string: String): SkyblockStat = getValueOrNull(string) ?: UNKNOWN
 
         init {
@@ -208,6 +210,8 @@ enum class SkyblockStat(
         }
 
         fun getIconOrNull(string: String): String? = resourcePackOverrides[string] ?: getValueOrNull(string)?.icon
+
+        fun getIconByDisplayNameOrNull(string: String): String? = getValueByDisplayNameOrNull(string)?.icon
 
         private var resourcePackOverrides = emptyMap<String, String>()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -35,8 +35,7 @@ object ColorfulItemStats {
         for ((index, line) in event.toolTip.withIndex()) {
             genericStat.findMatcher(line.string) {
                 val stat = group("stat")
-                val statId = stat.uppercase().replace(" ", "_")
-                val skyblockStatIcon = SkyblockStat.getIconOrNull(statId) ?: return@findMatcher
+                val skyblockStatIcon = SkyblockStat.getIconByDisplayNameOrNull(stat) ?: return@findMatcher
 
                 val bonusGroup = group("bonus")
                 var bonus = when {

--- a/src/test/java/at/hannibal2/skyhanni/test/SkyblockStatTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/SkyblockStatTest.kt
@@ -1,0 +1,15 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.data.model.SkyblockStat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class SkyblockStatTest {
+
+    @Test
+    fun `resolves stats by display name`() {
+        Assertions.assertEquals(SkyblockStat.STRENGTH, SkyblockStat.getValueByDisplayNameOrNull("Strength"))
+        Assertions.assertEquals(SkyblockStat.MELON_FORTUNE, SkyblockStat.getValueByDisplayNameOrNull("Melon Slice Fortune"))
+        Assertions.assertEquals(SkyblockStat.NETHER_STALK_FORTUNE, SkyblockStat.getValueByDisplayNameOrNull("Nether Wart Fortune"))
+    }
+}


### PR DESCRIPTION
## What
Updates `SkyblockStat` to use the new stat icons from the resource pack, plus does some general cleanup on the class's code to make it more maintainable and fix some mistakes that previously went unnoticed. Makes the menu pattern colorless as well.

While I'm at it, I also fixed Colorful Item Stats not working with stats that have an ID/display name mismatch, since I was asked to.

## Changelog Fixes
+ Fixed tab list and inventory detection for stats with the new official SkyBlock resource pack. - Luna
+ Fixed Colorful Item Stats not working with some stats. - Luna