### PR TITLE
Fix: Maxwell feature with second page of power stones

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
@@ -94,9 +94,14 @@ object MaxwellApi {
         "inventory.magicalpower",
         "§7Magical Power: §6(?<mp>[\\d,]+)",
     )
+
+    /**
+     * REGEX-TEST: (1/2) Accessory Bag Thaumaturgy
+     * REGEX-TEST: Accessory Bag Thaumaturgy
+     */
     private val thaumaturgyGuiPattern by patternGroup.pattern(
         "gui.thaumaturgy",
-        "Accessory Bag Thaumaturgy",
+        "(?:\\(\\d/\\d\\) )?Accessory Bag Thaumaturgy",
     )
     private val thaumaturgyStartPattern by patternGroup.pattern(
         "gui.thaumaturgy.start",


### PR DESCRIPTION
## What
nopo said it was broken so i fixed

## Changelog Fixes
+ Fixed maxwell features when you have a second page of power stones. - CalMWolfs

