### PR TITLE
stop emailing me failures

### DIFF
--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
     check-dependencies:
         runs-on: ubuntu-latest
+        # 511310721 is the Repository ID for SkyHanni
+        if: ${{ github.repository_id == '511310721' }}
         steps:
             -   name: Check out the repository
                 uses: actions/checkout@v7


### PR DESCRIPTION
we only run the check dependencies action on the actual repo

exclude_from_changelog