### PR TITLE
Backend: Fix log files not being grouped properly due to Lazy fullFormat

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniLogger.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniLogger.kt
@@ -19,7 +19,9 @@ open class SkyHanniLogger(filePath: String) {
 
     companion object {
         private var deletedExpired = false
-        val fullFormat = SimpleDateFormat("yyyy_MM_dd/HH_mm_ss").formatCurrentTime()
+        private val fullFormat by lazy {
+            SimpleDateFormat("yyyy_MM_dd/HH_mm_ss").formatCurrentTime()
+        }
     }
 
     @Suppress("PrintStackTrace")

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniLogger.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniLogger.kt
@@ -13,15 +13,13 @@ import kotlin.time.Duration.Companion.days
 open class SkyHanniLogger(filePath: String) {
 
     private val format = SimpleDateFormat("HH:mm:ss")
-    private val fullFormat by lazy {
-        SimpleDateFormat("yyyy_MM_dd/HH_mm_ss").formatCurrentTime()
-    }
     internal open val logsDir = File("config/skyhanni/logs")
     internal open val timedFormattedDir by lazy { "$logsDir/$fullFormat" }
     private val logFileName by lazy { "$timedFormattedDir/$filePath.log" }
 
     companion object {
         private var deletedExpired = false
+        val fullFormat = SimpleDateFormat("yyyy_MM_dd/HH_mm_ss").formatCurrentTime()
     }
 
     @Suppress("PrintStackTrace")


### PR DESCRIPTION
## What
This is maybe the stupidest fix but it works somehow to make the log files *actually* stick together

## Changelog Technical Details
+ Changed fullFormat into the companion object of SkyHanniLogger to fix log folder splitting. - Fazfoxy