### PR TITLE
Fix: Ghost tracker + Pest profit tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.data.ChatManager
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.IslandType.Companion.isInAnyIsland
 import at.hannibal2.skyhanni.data.ItemAddManager
+import at.hannibal2.skyhanni.data.model.SkyblockStat.MAGIC_FIND
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.features.misc.UserLuckBreakdown
@@ -100,7 +101,7 @@ object RareDropMessages {
      */
     private val enchantedBookPattern by repoGroup.pattern(
         "enchantedbook.colorless",
-        "RARE DROP! Enchanted Book(?: \\(\\+\\d+%? ✯ Magic Find\\))?.*",
+        "RARE DROP! Enchanted Book(?: \\(\\+\\d+%? ${MAGIC_FIND.hypixelIcon} Magic Find\\))?.*",
     )
 
     private val petPatterns = listOf(
@@ -195,7 +196,7 @@ object RareDropMessages {
             category = CommandCategory.DEVELOPER_TEST
 
             simpleCallback {
-                ChatUtils.chat("§6§lRARE DROP! §r§fEnchanted Book §r§b(+§r§b208% §r§b✯ Magic Find§r§b)", prefix = false)
+                ChatUtils.chat("§6§lRARE DROP! §r§fEnchanted Book §r§b(+§r§b208% §r§b${MAGIC_FIND.hypixelIcon} Magic Find§r§b)", prefix = false)
                 ChatUtils.chat("Testing Enchanted Book Name")
                 onItemAdd(ItemAddEvent("ANGLER;6".toInternalName(), 1, ItemAddManager.Source.ITEM_ADD))
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/RareDropMessages.kt
@@ -189,6 +189,7 @@ object RareDropMessages {
         event.move(71, "chat.petRarityDropMessage", "chat.rareDropMessages.petRarity")
     }
 
+    @Suppress("MaxLineLength")
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shtestenchantedbookname") {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/ghosttracker/GhostTracker.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.GhostDropsJson
+import at.hannibal2.skyhanni.data.model.SkyblockStat.MAGIC_FIND
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.IslandChangeEvent
@@ -119,12 +120,12 @@ object GhostTracker {
     private val patternGroup = RepoPattern.group("combat.ghosttracker")
 
     /**
-     * REGEX-TEST: §6§lRARE DROP! §r§9Sorrow §r§b(+§r§b210% §r§b✯ Magic Find§r§b)
-     * REGEX-TEST: §6§lRARE DROP! §r§9Sorrow §r§b(+§r§b210 §r§b✯ Magic Find§r§b)
+     * REGEX-TEST: §6§lRARE DROP! §r§9Sorrow §r§b(+§r§b210% §r§b Magic Find§r§b)
+     * REGEX-TEST: §6§lRARE DROP! §r§9Sorrow §r§b(+§r§b210 §r§b Magic Find§r§b)
      */
     private val itemDropPattern by patternGroup.pattern(
         "itemdrop",
-        "§6§lRARE DROP! §r§9(?<item>[^§]*) §r§b\\([+](?:§.)*(?<mf>\\d*)%? §r§b✯ Magic Find§r§b\\)",
+        "§6§lRARE DROP! §r§9(?<item>[^§]*) §r§b\\([+](?:§.)*(?<mf>\\d*)%? §r§b${MAGIC_FIND.hypixelIcon} Magic Find§r§b\\)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -92,7 +92,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     @Suppress("MaxLineLength")
     private val pestRareDropPattern by patternGroup.pattern(
         "raredrop",
-        "§6§l(?:RARE|PET) DROP! (?:§r)?(?<item>.+?)(?: §8x(?<amount>\\d+))? (?:§.)*\\((?:§.)?(?:\\+[\\d.,]+[${FARMING_FORTUNE.hypixelIcon}$|${OVERBLOOM.hypixelIcon}]|Cocoaleech)\\)",
+        "§6§l(?:RARE|PET) DROP! (?:§r)?(?<item>.+?)(?: §8x(?<amount>\\d+))? (?:§.)*\\((?:§.)?(?:\\+[\\d.,]+[${FARMING_FORTUNE.hypixelIcon}|${OVERBLOOM.hypixelIcon}]|Cocoaleech)\\)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -11,6 +11,8 @@ import at.hannibal2.skyhanni.data.BitsApi
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.addCollectionCounter
+import at.hannibal2.skyhanni.data.model.SkyblockStat.FARMING_FORTUNE
+import at.hannibal2.skyhanni.data.model.SkyblockStat.OVERBLOOM
 import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.PurseChangeCause
@@ -75,21 +77,22 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     private val patternGroup = RepoPattern.group("garden.pests.tracker")
 
     /**
-     * REGEX-TEST: §6§lRARE DROP! §9Mutant Nether Wart §8x9 §e(§e+134☀)
-     * REGEX-TEST: §6§lRARE DROP! §9Enchanted Cookie §8x9 §6(§6+1,810☘)
-     * REGEX-TEST: §6§lPET DROP! §r§5Slug §6(§6+1300☘)
-     * REGEX-TEST: §6§lPET DROP! §r§6Slug §e(§e+78☀)
-     * REGEX-TEST: §6§lRARE DROP! §9Squeaky Toy §6(§6+1,549☘)
-     * REGEX-TEST: §6§lRARE DROP! §6Squeaky Mousemat §6(§6+1,549☘)
-     * REGEX-TEST: §6§lRARE DROP! §aWings of Harmony Vinyl §e(§e+139.5☀)
+     * REGEX-TEST: §6§lRARE DROP! §9Mutant Nether Wart §8x9 §e(§e+134)
+     * REGEX-TEST: §6§lRARE DROP! §9Enchanted Cookie §8x9 §6(§6+1,810)
+     * REGEX-TEST: §6§lPET DROP! §r§5Slug §6(§6+1300)
+     * REGEX-TEST: §6§lPET DROP! §r§6Slug §e(§e+78)
+     * REGEX-TEST: §6§lRARE DROP! §9Squeaky Toy §6(§6+1,549)
+     * REGEX-TEST: §6§lRARE DROP! §6Squeaky Mousemat §6(§6+1,549)
+     * REGEX-TEST: §6§lRARE DROP! §aWings of Harmony Vinyl §e(§e+139.5)
      * REGEX-TEST: §6§lRARE DROP! §r§aNot Just a Pest Vinyl §r§6(Cocoaleech)
-     * REGEX-FAIL: §6§lRARE CROP! §aCane Knot §e(§e+139.5☀)
+     * REGEX-FAIL: §6§lRARE CROP! §aCane Knot §e(§e+139.5)
      */
     // TODO consider if we want to add Harvest Feast drops to Pest Profit Tracker - we need a way to distinguish drops
     //  from breaking crops vs. killing pests since they use the same message
+    @Suppress("MaxLineLength")
     private val pestRareDropPattern by patternGroup.pattern(
         "raredrop",
-        "§6§l(?:RARE|PET) DROP! (?:§r)?(?<item>.+?)(?: §8x(?<amount>\\d+))? (?:§.)*\\((?:§.)?(?:\\+[\\d.,]+[☘☀]|Cocoaleech)\\)",
+        "§6§l(?:RARE|PET) DROP! (?:§r)?(?<item>.+?)(?: §8x(?<amount>\\d+))? (?:§.)*\\((?:§.)?(?:\\+[\\d.,]+[${FARMING_FORTUNE.hypixelIcon}$|${OVERBLOOM.hypixelIcon}]|Cocoaleech)\\)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -92,7 +92,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     @Suppress("MaxLineLength")
     private val pestRareDropPattern by patternGroup.pattern(
         "raredrop",
-        "§6§l(?:RARE|PET) DROP! (?:§r)?(?<item>.+?)(?: §8x(?<amount>\\d+))? (?:§.)*\\((?:§.)?(?:\\+[\\d.,]+[${FARMING_FORTUNE.hypixelIcon}|${OVERBLOOM.hypixelIcon}]|Cocoaleech)\\)",
+        "§6§l(?:RARE|PET) DROP! (?:§r)?(?<item>.+?)(?: §8x(?<amount>\\d+))? (?:§.)*\\((?:§.)?(?:\\+[\\d.,]+[${FARMING_FORTUNE.hypixelIcon}${OVERBLOOM.hypixelIcon}]|Cocoaleech)\\)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/MayorOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/MayorOverlay.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.data.ElectionApi
 import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.Perk.Companion.toPerk
+import at.hannibal2.skyhanni.data.model.SkyblockStat.MAGIC_FIND
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -95,7 +96,7 @@ enum class MayorOverlay(private val configLine: String, private val createLines:
 private fun renderPerson(title: String, name: String?, perks: List<Perk>?): Renderable {
     val colorCode = ElectionApi.mayorNameToColorCode(name.orEmpty())
     val perkLines = perks?.takeIf { config.showPerks }?.map { perk ->
-        " ${if (perk.minister) "§6✯ " else ""}§e${perk.perkName}" to "§7${perk.description}"
+        " ${if (perk.minister) "§6${MAGIC_FIND.hypixelIcon} " else ""}§e${perk.perkName}" to "§7${perk.description}"
     }.orEmpty()
 
     return Renderable.vertical(


### PR DESCRIPTION
## What
they used the old stat icons.
I can probably remove the farming fortune part, but imma keep it.

## Changelog Fixes
+ Fixed ghost tracker not detecting rare drops. - AverageUser125
+ Fixed pest profit tracker not detecting rare drops. - AverageUser125