### PR TITLE
Improvement: Fall back to cached data in Pet Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.api.pet
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigFileType
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.PetData
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuItemJson
@@ -65,18 +66,16 @@ object PetStorageApi {
     private var lastExactPetMenuClick: SimpleTimeMark = SimpleTimeMark.farPast()
     private var petWidgetState: PetWidgetState = PetWidgetState.NOT_READY
 
-    val isPetWidgetReadyForDisplay: Boolean
-        get() = petWidgetState != PetWidgetState.NOT_READY
+    private fun isPetWidgetUnavailable(): Boolean = IslandType.CATACOMBS.isInIsland()
 
-    fun getPetWidgetDisplayMessage(requireExactPetXp: Boolean): List<String>? = when {
-        !TabWidget.PET.isActive && SkyBlockUtils.lastWorldSwitch.passedSince() >= WIDGET_LOAD_GRACE -> listOf(
-            "§cPet Tab Widget Missing",
-            "§cDo /widget and enable the pet widget",
-        )
-        requireExactPetXp && petWidgetState == PetWidgetState.MAXED_WITHOUT_OVERFLOW_XP -> listOf(
-            "§cPet Widget Overflow XP Missing",
-            "§cEnable overflow XP in the pet widget",
-        )
+    fun getPetWidgetWarning(showMissingOverflowXpWarning: Boolean): String? = when {
+        isPetWidgetUnavailable() -> null
+        !TabWidget.PET.isActive && SkyBlockUtils.lastWorldSwitch.passedSince() >= WIDGET_LOAD_GRACE -> {
+            "§cInaccurate! Enable /tab → Pet Widget"
+        }
+        showMissingOverflowXpWarning && petWidgetState == PetWidgetState.MAXED_WITHOUT_OVERFLOW_XP -> {
+            "§cInaccurate! Enable /tab → Pet Widget → Show Overflow Pet XP"
+        }
         else -> null
     }
 
@@ -730,5 +729,4 @@ object PetStorageApi {
         val allowedError = (readExp * expErrorFactor).coerceAtLeast(1.0)
         abs((this.exp ?: 0.0) - readExp) <= allowedError
     } ?: true
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/CurrentPetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/CurrentPetDisplay.kt
@@ -486,19 +486,22 @@ object CurrentPetDisplay {
     fun onRenderOverlayPost(event: GameOverlayRenderPostEvent) {
         if (event.type != RenderLayer.HOTBAR) return
         if (RiftApi.inRift() || !config.general.enabled.get()) return
-        PetStorageApi.getPetWidgetDisplayMessage(config.requiresExactCurrentPetXp())?.let { lines ->
-            invalidateRenderable()
-            config.general.position.renderRenderable(
-                buildWidgetMessageRenderable(lines, config.text.equippedPet),
-                posLabel = "Pet Display",
-            )
-            return
-        }
-        if (!PetStorageApi.isPetWidgetReadyForDisplay) return invalidateRenderable()
+        val widgetWarning = PetStorageApi.getPetWidgetWarning(
+            config.text.equippedPet.requiresOverflowXpForAccuracy(),
+        )
         val currentPet = CurrentPetApi.currentPet ?: return invalidateRenderable()
-        currentPet.withAnimatedExp().buildRenderable()?.also {
-            config.general.position.renderRenderable(it, posLabel = "Pet Display")
-        }
+        currentPet.withAnimatedExp()
+            .buildRenderable()
+            ?.withWidgetWarning(widgetWarning, config.text.equippedPet)
+            ?.also {
+                config.general.position.renderRenderable(it, posLabel = "Pet Display")
+            }
+    }
+
+    private fun TextPetDisplayConfig.EquippedPetTextConfig.requiresOverflowXpForAccuracy(): Boolean {
+        val enabledTexts = enabledTexts.get()
+        return TextPetDisplayConfig.TextElement.OVERFLOW_XP in enabledTexts ||
+            TextPetDisplayConfig.TextElement.TOTAL_XP in enabledTexts
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/PetDisplayTextRenderables.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/PetDisplayTextRenderables.kt
@@ -187,22 +187,25 @@ internal fun combineMainAndExpShareTextRenderables(
     )
 }
 
-internal fun buildWidgetMessageRenderable(
-    lines: List<String>,
+internal fun Renderable.withWidgetWarning(
+    warning: String?,
     textConfig: TextPetDisplayConfig.EquippedPetTextConfig,
 ): Renderable {
+    warning ?: return this
     val textScale = textConfig.textScale.get().toDouble()
     val horizontalAlign = textConfig.horizontalAlign.get()
     return Renderable.vertical(
-        lines.map {
+        listOf(
+            this,
             StringRenderable(
-                it,
+                warning,
                 scale = textScale,
                 horizontalAlign = horizontalAlign,
-            )
-        },
-        horizontalAlign = horizontalAlign,
-        verticalAlign = textConfig.verticalAlign.get(),
+            ),
+        ),
+        spacing = 2,
+        horizontalAlign = this.horizontalAlign,
+        verticalAlign = this.verticalAlign,
     )
 }
 


### PR DESCRIPTION
## What
Makes it so that Pet Display will always make a best-effort attempt to show the data it can, but warn the user with a single line at the bottom if something needs to be enabled (tab widget, overflow XP line).

## Changelog Improvements
+ Pet Display will now display best-effort cached data even if some tab list information is missing. - Luna