### PR TITLE
Fix: wardrobe not working after pressing button

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/EstimatedItemValueConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/EstimatedItemValueConfig.kt
@@ -58,6 +58,12 @@ class EstimatedItemValueConfig {
     var armor: Boolean = true
 
     @Expose
+    @ConfigOption(name = "Show Equipment Value", desc = "Show the value of the full equipment set in the Equipment Wardrobe inventory.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var equipment: Boolean = true
+
+    @Expose
     @ConfigOption(name = "Ignore Helmet Skins", desc = "Ignore helmet Skins from the total value.")
     @ConfigEditorBoolean
     val ignoreHelmetSkins: Property<Boolean> = Property.of(false)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
@@ -4,12 +4,12 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
-import at.hannibal2.skyhanni.events.minecraft.add
 import at.hannibal2.skyhanni.events.minecraft.addAll
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.indexOfFirstOrNull
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
@@ -19,9 +19,13 @@ object EstimatedWardrobePrice {
 
     private val config get() = SkyHanniMod.feature.inventory.estimatedItemValues
 
+    /**
+     * REGEX-TEST: Click to equip!
+     * REGEX-TEST: Click to unequip!
+     */
     private val clickToEquipPattern by RepoPattern.pattern(
         "inventory.wardrobe.clicktoequip",
-        "Click to (un)equip!"
+        "Click to (?:un)?equip!"
     )
 
     @HandleEvent
@@ -59,7 +63,7 @@ object EstimatedWardrobePrice {
     }
 
     private fun getClickToEquipIndex(tooltip: MutableList<Component>): Int? =
-        tooltip.indexOfFirstOrNull { clickToEquipPattern.matches(it) }
+        tooltip.indexOfFirstOrNull { clickToEquipPattern.matches(it.string.removeColor()) }
 
     private fun isEnabled() = SkyBlockUtils.inSkyBlock &&
         (config.armor && WardrobeApi.inWardrobe()) || (config.equipment && WardrobeApi.inEquipmentWardrobe()) &&

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
@@ -7,26 +7,12 @@ import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.events.minecraft.addAll
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.indexOfFirstOrNull
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.network.chat.Component
 
 @SkyHanniModule
 object EstimatedWardrobePrice {
 
     private val config get() = SkyHanniMod.feature.inventory.estimatedItemValues
-
-    /**
-     * REGEX-TEST: Click to equip!
-     * REGEX-TEST: Click to unequip!
-     */
-    private val clickToEquipPattern by RepoPattern.pattern(
-        "inventory.wardrobe.clicktoequip",
-        "Click to (?:un)?equip!"
-    )
 
     @HandleEvent
     fun onToolTip(event: ToolTipTextEvent) {
@@ -43,15 +29,10 @@ object EstimatedWardrobePrice {
 
 
         val tooltip = event.toolTip
-        val index = getClickToEquipIndex(tooltip)
 
         try {
-            if (index != null) {
-                tooltip.removeAt(index)
-                tooltip.addAll(index, lore)
-            } else {
-                tooltip.addAll(lore)
-            }
+            tooltip.add("")
+            tooltip.addAll(lore)
         } catch (e: IndexOutOfBoundsException) {
             ErrorManager.logErrorStateWithData(
                 "Can not show Estimated Wardrobe Price",
@@ -61,9 +42,6 @@ object EstimatedWardrobePrice {
             )
         }
     }
-
-    private fun getClickToEquipIndex(tooltip: MutableList<Component>): Int? =
-        tooltip.indexOfFirstOrNull { clickToEquipPattern.matches(it.string.removeColor()) }
 
     private fun isEnabled() = SkyBlockUtils.inSkyBlock &&
         (config.armor && WardrobeApi.inWardrobe()) || (config.equipment && WardrobeApi.inEquipmentWardrobe()) &&

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
@@ -44,7 +44,8 @@ object EstimatedWardrobePrice {
         tooltip.addAll(index, lore)
     }
 
-    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.armor && (WardrobeApi.inWardrobe() || WardrobeApi.inEquipmentWardrobe()) &&
+    //     private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.armor && (WardrobeApi.inWardrobe() || WardrobeApi.inEquipmentWardrobe()) &&
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.armor && WardrobeApi.inWardrobe() &&
         (!WardrobeApi.inCustomWardrobe || CustomWardrobe.editMode)
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
@@ -8,12 +8,21 @@ import at.hannibal2.skyhanni.events.minecraft.add
 import at.hannibal2.skyhanni.events.minecraft.addAll
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.indexOfFirstOrNull
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.network.chat.Component
 
 @SkyHanniModule
 object EstimatedWardrobePrice {
 
     private val config get() = SkyHanniMod.feature.inventory.estimatedItemValues
+
+    private val clickToEquipPattern by RepoPattern.pattern(
+        "inventory.wardrobe.clicktoequip",
+        "Click to (un)equip!"
+    )
 
     @HandleEvent
     fun onToolTip(event: ToolTipTextEvent) {
@@ -28,11 +37,17 @@ object EstimatedWardrobePrice {
         val lore = WardrobeApi.createPriceLore(slot)
         if (lore.isEmpty()) return
 
+
         val tooltip = event.toolTip
-        var index = 3
+        val index = getClickToEquipIndex(tooltip)
 
         try {
-            tooltip.add(index++, "")
+            if (index != null) {
+                tooltip.removeAt(index)
+                tooltip.addAll(index, lore)
+            } else {
+                tooltip.addAll(lore)
+            }
         } catch (e: IndexOutOfBoundsException) {
             ErrorManager.logErrorStateWithData(
                 "Can not show Estimated Wardrobe Price",
@@ -41,10 +56,13 @@ object EstimatedWardrobePrice {
                 "lore" to lore,
             )
         }
-        tooltip.addAll(index, lore)
     }
 
-    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.armor && (WardrobeApi.inWardrobe() || WardrobeApi.inEquipmentWardrobe()) &&
+    private fun getClickToEquipIndex(tooltip: MutableList<Component>): Int? =
+        tooltip.indexOfFirstOrNull { clickToEquipPattern.matches(it) }
+
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock &&
+        (config.armor && WardrobeApi.inWardrobe()) || (config.equipment && WardrobeApi.inEquipmentWardrobe()) &&
         (!WardrobeApi.inCustomWardrobe || CustomWardrobe.editMode)
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
+import at.hannibal2.skyhanni.events.minecraft.add
 import at.hannibal2.skyhanni.events.minecraft.addAll
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
@@ -38,7 +38,6 @@ object EstimatedWardrobePrice {
             ErrorManager.logErrorStateWithData(
                 "Can not show Estimated Wardrobe Price",
                 "IndexOutOfBoundsException while trying to add the estimated wardrobe price line to the tooltip",
-                "index" to index,
                 "lore" to lore,
             )
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/EstimatedWardrobePrice.kt
@@ -44,8 +44,7 @@ object EstimatedWardrobePrice {
         tooltip.addAll(index, lore)
     }
 
-    //     private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.armor && (WardrobeApi.inWardrobe() || WardrobeApi.inEquipmentWardrobe()) &&
-    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.armor && WardrobeApi.inWardrobe() &&
+    private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.armor && (WardrobeApi.inWardrobe() || WardrobeApi.inEquipmentWardrobe()) &&
         (!WardrobeApi.inCustomWardrobe || CustomWardrobe.editMode)
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
@@ -195,13 +195,14 @@ object WardrobeApi {
     @HandleEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
         if (!inWardrobe && !inEquipmentWardrobe) return
+
         DelayedRun.runDelayed(250.milliseconds) {
-            if (!inventoryPattern.matches(InventoryUtils.openInventoryName())) {
-                inWardrobe = false
-                currentPage = null
-            }
-            if (!equipmentInventoryPattern.matches(InventoryUtils.openInventoryName())) {
-                inEquipmentWardrobe = false
+            val inventoryName = InventoryUtils.openInventoryName()
+
+            inWardrobe = inventoryPattern.matches(inventoryName)
+            inEquipmentWardrobe = equipmentInventoryPattern.matches(inventoryName)
+
+            if (!inWardrobe && !inEquipmentWardrobe) {
                 currentPage = null
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
@@ -105,13 +105,9 @@ object WardrobeApi {
 
     fun inEquipmentWardrobe() = InventoryUtils.inInventory() && inEquipmentWardrobe
 
-    fun createPriceLore(slot: WardrobeSlot, equipment: Boolean = inEquipmentWardrobe) = buildList {
+    fun createPriceLore(slot: WardrobeSlot) = buildList {
         if (slot.isEmpty()) return@buildList
-        if (equipment) {
-            add("§aEstimated Equipment Value:")
-        } else {
-            add("§aEstimated Armor Value:")
-        }
+        add("§aEstimated Armor Value:")
         var totalPrice = 0.0
         for (stack in slot.armor.filterNotNull().filter { it.getInternalNameOrNull() != null }) {
             EstimatedItemValueCalculator.getTotalPrice(stack)?.let { price ->

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/WardrobeApi.kt
@@ -105,9 +105,13 @@ object WardrobeApi {
 
     fun inEquipmentWardrobe() = InventoryUtils.inInventory() && inEquipmentWardrobe
 
-    fun createPriceLore(slot: WardrobeSlot) = buildList {
+    fun createPriceLore(slot: WardrobeSlot, equipment: Boolean = inEquipmentWardrobe) = buildList {
         if (slot.isEmpty()) return@buildList
-        add("§aEstimated Armor Value:")
+        if (equipment) {
+            add("§aEstimated Equipment Value:")
+        } else {
+            add("§aEstimated Armor Value:")
+        }
         var totalPrice = 0.0
         for (stack in slot.armor.filterNotNull().filter { it.getInternalNameOrNull() != null }) {
             EstimatedItemValueCalculator.getTotalPrice(stack)?.let { price ->


### PR DESCRIPTION
## What
It currently sets currentPage to null always, even if you cycle inside the wardrobe menu.
Also fixed the equipment thingy while I was here.

Should be quite resilient.

## Changelog Improvements
+ Added equipment wardrobe value estimation. - AverageUser125

## Changelog Fixes
+ Fixed custom wardrobe freezing after the first click. - AverageUser125
