### PR TITLE
Fix: Incorrect grand feast detection when Finnegan is minister

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
@@ -269,7 +269,7 @@ object HarvestFeastManager {
 
     private fun assumeGrandFeast(): Boolean {
         val mayorGrandFeast = ElectionApi.currentMayor?.let { Perk.GRAND_FEAST in it.perks } ?: false
-        val ministerGrandFeast = ElectionApi.currentMinister?.let { Perk.GRAND_FEAST in it.perks } ?: false
+        val ministerGrandFeast = ElectionApi.currentMinister?.let { Perk.GRAND_FEAST in it.activePerks } ?: false
         val timeBasedGrandFeast = currentFeastData?.let {
             it.month !in 7..9 && it.year == SkyBlockTime.now().year && it.current.isNotEmpty()
         } ?: false


### PR DESCRIPTION
## What
Fixes Harvest Feast incorrectly assuming a Grand Feast is active when Finnegan is minister with Blooming Business.
The check was using `it.perks` (all possible perks for the candidate) instead of `it.activePerks` (only the currently active perk), causing the Grand Feast perk to always be detected whenever Finnegan holds any position.
  
This resulted in SkyHanni spamming "Harvest feast data is not yet available" every 10 minutes.

Hotfix in REPO to silence the error:
- https://github.com/hannibal002/SkyHanni-REPO/pull/782

## Changelog Fixes
+ Fixed Harvest Feast incorrectly detecting a Grand Feast when Finnegan is minister. - RemainingDelta

