### PR TITLE
Improvement: repeat pest cooldown warning tweaks

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTimerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/pests/PestTimerConfig.kt
@@ -64,10 +64,18 @@ class PestTimerConfig {
     @Expose
     @ConfigOption(
         name = "Repeat Warning",
-        desc = "Repeats the warning sound and title until the wardrobe is opened or the pest cooldown expires."
+        desc = "Repeats the warning sound and title until the pest cooldown expires.",
     )
     @ConfigEditorBoolean
     var repeatWarning: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Stop Repeat Warning",
+        desc = "Stops repeating the warning when an inventory GUI is opened.",
+    )
+    @ConfigEditorBoolean
+    var stopRepeatWarning: Boolean = true
 
     @Expose
     @ConfigOption(name = "Warn Before Cooldown End", desc = "Warn this many seconds before the cooldown is over.")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -25,11 +25,11 @@ import at.hannibal2.skyhanni.features.garden.GardenApi.pestCooldownEndTime
 import at.hannibal2.skyhanni.features.garden.pests.PestApi.hasLassoInHand
 import at.hannibal2.skyhanni.features.garden.pests.PestApi.hasVacuumInHand
 import at.hannibal2.skyhanni.features.garden.pests.PestApi.lastPestSpawnTime
-import at.hannibal2.skyhanni.features.inventory.wardrobe.WardrobeApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.hasGroup
@@ -181,7 +181,7 @@ object PestSpawnTimer {
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onTick(event: SkyHanniTickEvent) {
         if (shouldRepeatWarning) {
-            if (WardrobeApi.inWardrobe()) {
+            if (config.stopRepeatWarning && InventoryUtils.inInventory()) {
                 shouldRepeatWarning = false
                 countdownTitleContext?.stop()
                 countdownTitleContext = null


### PR DESCRIPTION
## What
read changelog

## Changelog Improvements
+ Added support for loadouts and equipment wardrobe to Repeat Pest Cooldown Warning. - zumbiepig
    * The warning will stop repeating when any menu is opened, rather than only the wardrobe.
    * Added a separate option to stop repeating warning when a GUI is opened.
