### PR TITLE
Fix: Allow manual Harvest Feast data fetch with auto fetch disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/harvestfeast/HarvestFeastManager.kt
@@ -285,10 +285,12 @@ object HarvestFeastManager {
             ).asTimeMark()
     }
 
-    private fun fetch() {
-        if (!config.fetchAutomatically) return
-        if (!isCurrentOutdated) return
-        if (lastFetched.passedSince() < 10.minutes) return
+    private fun fetch(force: Boolean = false) {
+        if (!force) {
+            if (!config.fetchAutomatically) return
+            if (!isCurrentOutdated) return
+            if (lastFetched.passedSince() < 10.minutes) return
+        }
         if (fetchingFeastDataMutex.isLocked) return
 
         CoroutineSettings("harvest feast data fetch").withIOContext().withMutex(fetchingFeastDataMutex).launchCoroutine {
@@ -340,6 +342,7 @@ object HarvestFeastManager {
         lastSubmit = null
         profileStorage.lastHarvestFeastSubmitYear = -1
         profileStorage.lastHarvestFeastSubmitMonth = -1
+        fetch(force = true)
     }
 
     private fun updateDisplay() {


### PR DESCRIPTION
## What
If the "Fetch Upcoming Feast Data" option was disabled for Harvest Feast, `/shresetfeastdata` would also do nothing, because all fetches were "automatic". This PR fixes that.

## Changelog Fixes
+ Fixed /shresetfeastdata not working if "Fetch Upcoming Feast Data" is disabled. - Luna

