### PR TITLE
Improvement: Disable Lock on Mousemat by default

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/MouseSensitivityReducerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/MouseSensitivityReducerConfig.kt
@@ -64,7 +64,7 @@ class MouseSensitivityReducerConfig {
     @Expose
     @ConfigOption(name = "Lock on Mousemat", desc = "Lock mouse when snapping to Squeaky Mousemat.")
     @ConfigEditorBoolean
-    var lockOnMousemat: Boolean = true
+    var lockOnMousemat: Boolean = false
 
     @Expose
     @ConfigOption(name = "Only on Ground", desc = "When enabled, lower sensitivity only while on or near the ground.")


### PR DESCRIPTION
## What
This should never have been enabled by default, it's too invasive for that. And many players are still confused by it despite the chat message.

## Changelog Improvements
+ Lock on Mousemat is no longer enabled by default. - Luna
    * If you're an existing user, you will have to manually disable it if you don't want it.
