### PR TITLE
Fix: skymall & lottery

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.api
 
 import at.hannibal2.skyhanni.data.hotx.HotxPatterns.asPatternId
 import at.hannibal2.skyhanni.data.hotx.RotatingPerk
+import at.hannibal2.skyhanni.data.model.SkyblockStat
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import org.intellij.lang.annotations.Language
@@ -17,19 +18,19 @@ object HotfApi {
         @field:Language("RegExp") val itemFallback: String,
     ) : RotatingPerk {
         SWEEP(
-            displayDescription = "§a+5% §r§2\uE023 Sweep",
-            chatFallback = "Gain \\+5% \uE023 Sweep\\.",
-            itemFallback = "Gain \\+5% \uE023 Sweep\\.",
+            displayDescription = "§a+5% §r§2${SkyblockStat.SWEEP.hypixelIcon} Sweep",
+            chatFallback = "Gain \\+5% ${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
+            itemFallback = "Gain \\+5% ${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
         ),
         MANGROVE_FORTUNE(
-            displayDescription = "§a+50 §r§6\uE054 Mangrove Fortune",
-            chatFallback = "Gain \\+50 \uE054 Mangrove Fortune\\.",
-            itemFallback = "Gain \\+50 \uE054 Mangrove Fortune\\.",
+            displayDescription = "§a+50 §r§6${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune",
+            chatFallback = "Gain \\+50 ${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
+            itemFallback = "Gain \\+50 ${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
         ),
         FIG_FORTUNE(
-            displayDescription = "§a+50 §r§6\uE054 Fig Fortune",
-            chatFallback = "Gain \\+50 \uE054 Fig Fortune\\.",
-            itemFallback = "Gain \\+50 \uE054 Fig Fortune\\.",
+            displayDescription = "§a+50 §r§6${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune",
+            chatFallback = "Gain \\+50 ${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
+            itemFallback = "Gain \\+50 ${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
         ),
         ;
 

--- a/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
@@ -12,22 +12,22 @@ object HotfApi {
     var lottery: LotteryPerk? = null
 
     enum class LotteryPerk(
-        override val perkDescription: String,
+        override val displayDescription: String,
         @field:Language("RegExp") val chatFallback: String,
         @field:Language("RegExp") val itemFallback: String,
     ) : RotatingPerk {
         SWEEP(
-            perkDescription = "+5% \uE023 Sweep",
+            displayDescription = "§a+5% §r§2\uE023 Sweep",
             chatFallback = "Gain \\+5% \uE023 Sweep\\.",
             itemFallback = "Gain \\+5% \uE023 Sweep\\.",
         ),
         MANGROVE_FORTUNE(
-            perkDescription = "+50 \uE054 Mangrove Fortune",
+            displayDescription = "§a+50 §r§6\uE054 Mangrove Fortune",
             chatFallback = "Gain \\+50 \uE054 Mangrove Fortune\\.",
             itemFallback = "Gain \\+50 \uE054 Mangrove Fortune\\.",
         ),
         FIG_FORTUNE(
-            perkDescription = "+50 \uE054 Fig Fortune",
+            displayDescription = "§a+50 §r§6\uE054 Fig Fortune",
             chatFallback = "Gain \\+50 \uE054 Fig Fortune\\.",
             itemFallback = "Gain \\+50 \uE054 Fig Fortune\\.",
         ),

--- a/src/main/java/at/hannibal2/skyhanni/api/HotmApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotmApi.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.hotx.HotmData
 import at.hannibal2.skyhanni.data.hotx.HotxPatterns.asPatternId
 import at.hannibal2.skyhanni.data.hotx.RotatingPerk
+import at.hannibal2.skyhanni.data.model.SkyblockStat
 import at.hannibal2.skyhanni.events.mining.PowderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -113,14 +114,14 @@ object HotmApi {
         @field:Language("RegExp") val itemFallback: String,
     ) : RotatingPerk {
         MINING_SPEED(
-            displayDescription = "§6+100\uE015 Mining Speed",
-            chatFallback = "Gain \\+100\uE015 Mining Speed\\.",
-            itemFallback = "Gain \\+100\uE015 Mining Speed\\.",
+            displayDescription = "§6+100${SkyblockStat.MINING_SPEED.hypixelIcon} Mining Speed",
+            chatFallback = "Gain \\+100${SkyblockStat.MINING_SPEED.hypixelIcon} Mining Speed\\.",
+            itemFallback = "Gain \\+100${SkyblockStat.MINING_SPEED.hypixelIcon} Mining Speed\\.",
         ),
         MINING_FORTUNE(
-            displayDescription = "§6+50\uE053 Mining Fortune",
-            chatFallback = "Gain \\+50\uE053 Mining Fortune\\.",
-            itemFallback = "Gain \\+50\uE053 Mining Fortune\\.",
+            displayDescription = "§6+50${SkyblockStat.MINING_FORTUNE.hypixelIcon} Mining Fortune",
+            chatFallback = "Gain \\+50${SkyblockStat.MINING_FORTUNE.hypixelIcon} Mining Fortune\\.",
+            itemFallback = "Gain \\+50${SkyblockStat.MINING_FORTUNE.hypixelIcon} Mining Fortune\\.",
         ),
         EXTRA_POWDER(
             displayDescription = "§a+15% §7more Powder",
@@ -155,7 +156,7 @@ object HotmApi {
         SCRAP_CHANCE("Your Suspicious Scrap chance was buffed by your Mineshaft Mayhem perk!"),
         MINING_FORTUNE("You received a Mining Fortune buff from your Mineshaft Mayhem perk!"),
         MINING_SPEED("You received a Mining Speed buff from your Mineshaft Mayhem perk!"),
-        COLD_RESISTANCE("You received a ❄ Cold Resistance buff from your Mineshaft Mayhem perk!"),
+        COLD_RESISTANCE("You received a ${SkyblockStat.COLD_RESISTANCE.hypixelIcon} Cold Resistance buff from your Mineshaft Mayhem perk!"),
         ABILITY_COOLDOWN("Your Pickaxe Ability cooldown was reduced from your Mineshaft Mayhem perk!"),
         ;
 

--- a/src/main/java/at/hannibal2/skyhanni/api/HotmApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotmApi.kt
@@ -108,37 +108,37 @@ object HotmApi {
     var mineshaftMayhem: MayhemPerk? = null
 
     enum class SkymallPerk(
-        override val perkDescription: String,
+        override val displayDescription: String,
         @field:Language("RegExp") val chatFallback: String,
         @field:Language("RegExp") val itemFallback: String,
     ) : RotatingPerk {
         MINING_SPEED(
-            perkDescription = "+100\uE015 Mining Speed",
+            displayDescription = "§6+100\uE015 Mining Speed",
             chatFallback = "Gain \\+100\uE015 Mining Speed\\.",
             itemFallback = "Gain \\+100\uE015 Mining Speed\\.",
         ),
         MINING_FORTUNE(
-            perkDescription = "+50\uE053 Mining Fortune",
+            displayDescription = "§6+50\uE053 Mining Fortune",
             chatFallback = "Gain \\+50\uE053 Mining Fortune\\.",
             itemFallback = "Gain \\+50\uE053 Mining Fortune\\.",
         ),
         EXTRA_POWDER(
-            perkDescription = "+15% more Powder",
+            displayDescription = "§a+15% §7more Powder",
             chatFallback = "Gain \\+15% more Powder while mining\\.",
             itemFallback = "Gain \\+15% more Powder while mining\\.",
         ),
         ABILITY_COOLDOWN(
-            perkDescription = "-20% Pickaxe Ability cooldowns",
+            displayDescription = "§a-20% §7Pickaxe Ability cooldowns",
             chatFallback = "-20% Pickaxe Ability cooldowns\\.",
             itemFallback = "-20% Pickaxe Ability cooldowns\\.",
         ),
         GOBLIN_CHANCE(
-            perkDescription = "10x Gold & Diamond Goblin chance",
+            displayDescription = "§a10x §6Gold §7& §bDiamond §7Goblin chance",
             chatFallback = "10x chance to find Golden and Diamond Goblins\\.",
             itemFallback = "10x chance to find Golden and",
         ),
         TITANIUM(
-            perkDescription = "5x Titanium drops",
+            displayDescription = "§a5x §9Titanium §7drops",
             chatFallback = "Gain 5x Titanium drops",
             itemFallback = "Gain 5x Titanium drops\\.",
         ),

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -323,11 +323,11 @@ enum class HotfData(
         )
 
         /**
-         * REGEX-TEST: Level 21/50
+         * REGEX-TEST: §7Level 21§8/50
          */
         override val levelPattern: Pattern by patternGroup.pattern(
-            "perk.level",
-            """Level (?<level>\d+).*"""
+            "perk.level.colorfull",
+            "(?:§.)*Level (?<level>\\d+).*"
         )
 
         /**

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotfData.kt
@@ -326,7 +326,7 @@ enum class HotfData(
          * REGEX-TEST: §7Level 21§8/50
          */
         override val levelPattern: Pattern by patternGroup.pattern(
-            "perk.level.colorfull",
+            "perk.level",
             "(?:§.)*Level (?<level>\\d+).*"
         )
 

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -452,12 +452,12 @@ enum class HotmData(
 
         // <editor-fold desc="Patterns">
         /**
-         * REGEX-TEST: Level 1/50 (0 0%):skull:
-         * REGEX-TEST: Level 1/50
+         * REGEX-TEST: §5§o§7Level 1§8/50 §7(§b0 §l0%§7):skull:
+         * REGEX-TEST: §7Level 1§8/50
          */
         override val levelPattern by patternGroup.pattern(
-            "perk.level",
-            """Level (?<level>\d+).*"""
+            "perk.level.colorfull",
+            "(?:§.)*§(?<color>.)Level (?<level>\\d+).*"
         )
         /**
          * REGEX-TEST: Requires Mining Speed
@@ -597,6 +597,7 @@ enum class HotmData(
             }
         }
 
+        // Color is needed due to blue goblin omelet
         override val readingLevelTransform: Matcher.() -> Int = {
             group("level").toInt().transformIf({ group("color") == "b" }, { this.minus(1) })
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotmData.kt
@@ -456,7 +456,7 @@ enum class HotmData(
          * REGEX-TEST: §7Level 1§8/50
          */
         override val levelPattern by patternGroup.pattern(
-            "perk.level.colorfull",
+            "perk.level",
             "(?:§.)*§(?<color>.)Level (?<level>\\d+).*"
         )
         /**

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxHandler.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
+import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
 import at.hannibal2.skyhanni.utils.ItemUtils.takeUnlessEmpty
 import at.hannibal2.skyhanni.utils.RegexUtils.indexOfFirstMatch
@@ -89,6 +90,7 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
         entry.slot = this
         entry.item = item
 
+        val rawLore = item.getLore()
         val lore = item.getLoreComponent().takeIf { it.isNotEmpty() }?.map { it.string.removeColor() } ?: return
 
         if (entry != core && notUnlockedPattern.matches(lore.last())) {
@@ -100,7 +102,8 @@ abstract class HotxHandler<Data : HotxData<Reward>, Reward, RotPerkE>(val data: 
 
         entry.isUnlocked = true
 
-        entry.rawLevel = levelPattern.matchMatcher(lore.first(), readingLevelTransform) ?: entry.maxLevel
+        // This needs color codes
+        entry.rawLevel = levelPattern.matchMatcher(rawLore.first(), readingLevelTransform) ?: entry.maxLevel
 
         // raw level to ignore the blue egg buff
         if (entry.rawLevel > entry.maxLevel) {

--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/RotatingPerk.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/RotatingPerk.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.data.hotx
 import java.util.regex.Pattern
 
 interface RotatingPerk {
-    val perkDescription: String
+    val displayDescription: String
     val chatPattern: Pattern
     val itemPattern: Pattern
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HotxFeatures.kt
@@ -40,7 +40,7 @@ object HotxFeatures {
         if (!rotatingPerkEntry.isUnlocked || !rotatingPerkEntry.enabled) return
         val currentPerk = currentRotPerk
 
-        val perkDescriptionFormat = currentPerk?.perkDescription
+        val perkDescriptionFormat = currentPerk?.displayDescription
             ?: "§cUnknown! Run ${"§b/${name.lowercase()}"} §cto fix this."
         val finalFormat = "§b${rotatingPerkEntry.guiName}§8: $perkDescriptionFormat"
 


### PR DESCRIPTION
## What
due to blue goblin omelate, color is needed to find out the level of a HOTM perk.
Which is what caused it to not detect the perk in the UI.

Also I renamed "perkDescription" to "displayDescription", and readded colors to it.

## Changelog Fixes
+ Fixed Skymall/Lottery display being colorless. - AverageUser125
+ Fixed Skymall/Lottery not being detected in the hotm/hotf menu. - AverageUser125