### PR TITLE
Fix: CME in HideSlayerSpawnParticles

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/HideSlayerSpawnParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/HideSlayerSpawnParticles.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.core.particles.ParticleType

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/HideSlayerSpawnParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/HideSlayerSpawnParticles.kt
@@ -8,10 +8,10 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
+import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.core.particles.ParticleType
 import net.minecraft.core.particles.ParticleTypes
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -19,7 +19,7 @@ object HideSlayerSpawnParticles {
 
     private val config get() = SlayerApi.config
 
-    private val mobRecentDeaths = ConcurrentHashMap<LorenzVec, SimpleTimeMark>()
+    private val mobRecentDeaths = TimeLimitedCache<LorenzVec, SimpleTimeMark>(3.seconds)
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onParticle(event: ParticleEvent) {
@@ -45,11 +45,5 @@ object HideSlayerSpawnParticles {
         mobRecentDeaths[event.entity.getLorenzVec()] = SimpleTimeMark.now()
     }
 
-    @HandleEvent(onlyOnSkyblock = true)
-    fun onSecondPassed() {
-        mobRecentDeaths.removeIf { it.value.passedSince() > 3.seconds }
-    }
-
     private fun LorenzVec.distanceToNearestDeadMob() = mobRecentDeaths.minOfOrNull { it.key.distanceSq(this) }
 }
-

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/HideSlayerSpawnParticles.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/HideSlayerSpawnParticles.kt
@@ -11,14 +11,15 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.core.particles.ParticleType
 import net.minecraft.core.particles.ParticleTypes
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object HideSlayerSpawnParticles {
+
     private val config get() = SlayerApi.config
 
-    @Suppress("VarCouldBeVal")
-    private var mobRecentDeaths = mutableMapOf<LorenzVec, SimpleTimeMark>()
+    private val mobRecentDeaths = ConcurrentHashMap<LorenzVec, SimpleTimeMark>()
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onParticle(event: ParticleEvent) {


### PR DESCRIPTION
## What
Fixes a [ConcurrentModificationException](https://discord.com/channels/997079228510117908/1000669238035497022/1525143182583791817) in HideSlayerSpawnParticles by making it use a ~~ConcurrentHashMap~~ TimeLimitedCache. Also removes a dumbass suppression that uses more code than just fixing it does.

## Changelog Fixes
+ Fixed ConcurrentModificationException error in Hide Slayer Spawn Particles. - Luna