### PR TITLE
Fix: Bonus Pest chance display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.garden.pests
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.model.SkyblockStat
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
@@ -25,12 +26,12 @@ object BonusPestChanceDisplay {
     private val patternGroup = RepoPattern.group("garden.bonuspestchance")
 
     /**
-     * WRAPPED-REGEX-TEST: " Bonus Pest Chance: 70"
-     * WRAPPED-REGEX-TEST: " Bonus Pest Chance: 70"
+     * WRAPPED-REGEX-TEST: " Bonus Pest Chance: 70"
+     * WRAPPED-REGEX-TEST: " Bonus Pest Chance: 70"
      */
     private val bonusPestChancePattern by patternGroup.pattern(
         "widget-no-color",
-        "\\s+Bonus Pest Chance: (?<amount>[\\d,.]+)",
+        "\\s+Bonus Pest Chance: ${SkyblockStat.BONUS_PEST_CHANCE.hypixelIcon}(?<amount>[\\d,.]+)",
     )
     private var display: Renderable? = null
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/BonusPestChanceDisplay.kt
@@ -27,7 +27,7 @@ object BonusPestChanceDisplay {
 
     /**
      * WRAPPED-REGEX-TEST: " Bonus Pest Chance: 70"
-     * WRAPPED-REGEX-TEST: " Bonus Pest Chance: 70"
+     * WRAPPED-REGEX-TEST: " Bonus Pest Chance: 100"
      */
     private val bonusPestChancePattern by patternGroup.pattern(
         "widget-no-color",


### PR DESCRIPTION
## What
Another reason to use SkyblockStat, it used the MobType symbol, and not the stat symbol.

## Changelog Fixes
+ Fixed bonus pest chance display not working. - AverageUser125
