### PR TITLE
Fix: Switch to colorless match in RareCropTracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/RareCropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/RareCropTracker.kt
@@ -115,7 +115,7 @@ object RareCropTracker {
          */
         val chatPattern by patternGroup.pattern(
             "${name.lowercase().replace('_', '-')}.colorless",
-            "(?:VERY )?RARE CROP! ${cleanName}(?: .*)?",
+            "(?:VERY )?RARE CROP! $cleanName(?: .*)?",
         )
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/RareCropTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/RareCropTracker.kt
@@ -103,18 +103,26 @@ object RareCropTracker {
         WARTY("§5Warty"),
         ;
 
+        val cleanName = dropName.removeColor()
+
         val canDropFromPests: Boolean = pestType != null
 
+        /**
+         * REGEX-TEST: RARE CROP! Cropie (+97)
+         * REGEX-TEST: RARE CROP! Cane Knot (+137.6)
+         * REGEX-TEST: RARE CROP! Seasoning (+115) (automatically donated)
+         * REGEX-TEST: VERY RARE CROP! Burrowing Spores
+         */
         val chatPattern by patternGroup.pattern(
-            name.lowercase().replace('_', '-'),
-            "(?:§.)*(?:VERY )?RARE CROP! (?:§.)*${dropName.removeColor()}.*",
+            "${name.lowercase().replace('_', '-')}.colorless",
+            "(?:VERY )?RARE CROP! ${cleanName}(?: .*)?",
         )
     }
 
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent.Allow) {
         for (dropType in RareCropDropType.entries) {
-            if (!dropType.chatPattern.matches(event.message)) continue
+            if (!dropType.chatPattern.matches(event.cleanMessage)) continue
             addDrop(dropType)
             PestProfitTracker.addRareCropDrop(dropType)
             if (config.hideChat) {


### PR DESCRIPTION
## What
Fixes some people getting "Internal name found with color codes". Did not remove the color coded names because they are used for display. They could technically pull from NEU repo, but I'll leave that to someone else to do another day.

## Changelog Fixes
+ Fixed Rare Crop Tracker sometimes throwing an "Internal name found with color codes" error. - Luna
