### PR TITLE
Fix: Rift Stat Icons

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -140,8 +140,8 @@ enum class SkyblockStat(
     RIFT_SPEED(WHITE, '\uE022', displayName = "Speed", hypixelId = "RIFT_WALK_SPEED"),
     RIFT_INTELLIGENCE(AQUA, '\uE003', displayName = "Intelligence"),
     // MAGIC_FIND is just the overworld stat
-    MANA_REGEN(AQUA, '⚡'),
-    HEARTS(RED, '♥'),
+    MANA_REGEN(AQUA, '\uE004'),
+    HEARTS(RED, '\uE01F'),
     // </editor-fold>
 
     UNKNOWN(GRAY, '?', generatePatterns = false),


### PR DESCRIPTION
## What
I was too tired when making the original pull request, I forgot to change these. Literally nothing uses them though, so no user-facing changelog is needed.

exclude_from_changelog