### PR TITLE
Fix: Update Pet Display after item removal

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -387,6 +387,10 @@ object PetStorageApi {
             updateCurrentPetHeldItem(petHeldItem)
         }
 
+        PetStoragePatterns.petItemRemovedMessagePattern.matchMatcher(event.message.removeColor().removeResets()) {
+            updateCurrentPetHeldItem(null)
+        }
+
         PetStoragePatterns.autoPetMessagePattern.matchMatcher(event.message.removeResets()) {
             if (config.hideAutopet) event.blockedReason = "autopet"
 
@@ -442,7 +446,7 @@ object PetStorageApi {
         return PetUtils.resolvePetItemOrNull(itemName)
     }
 
-    private fun updateCurrentPetHeldItem(heldItem: NeuInternalName) {
+    private fun updateCurrentPetHeldItem(heldItem: NeuInternalName?) {
         val currentPet = CurrentPetApi.currentPet ?: return
         if (currentPet.heldItemInternalName == heldItem) return
         currentPet.heldItemInternalName = heldItem

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -387,7 +387,7 @@ object PetStorageApi {
             updateCurrentPetHeldItem(petHeldItem)
         }
 
-        PetStoragePatterns.petItemRemovedMessagePattern.matchMatcher(event.message.removeColor().removeResets()) {
+        PetStoragePatterns.petItemRemovedMessagePattern.matchMatcher(event.cleanMessage) {
             updateCurrentPetHeldItem(null)
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
@@ -143,4 +143,12 @@ internal object PetStoragePatterns {
         "chat.helditem",
         "Your pet is now holding (?<item>.+?)\\.",
     )
+
+    /**
+     * REGEX-TEST: You removed Quick Claw from your pet!
+     */
+    val petItemRemovedMessagePattern by patternGroup.pattern(
+        "chat.removedhelditem",
+        "You removed (?<item>.+?) from your pet!",
+    )
 }


### PR DESCRIPTION
## What
Updates Pet Display when Hypixel confirms that a pet item was removed, including removals made with a Super Scrubber.

## Changelog Fixes
+ Fixed Pet Display visually keeping removed pet items. - Akinsoft