### PR TITLE
Improvement: Loadout slot highlighting

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customloadout/CustomLoadoutConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customloadout/CustomLoadoutConfig.kt
@@ -10,4 +10,9 @@ class CustomLoadoutConfig {
     @ConfigOption(name = "Keybinds", desc = "")
     @Accordion
     val keybinds: LoadoutKeybindConfig = LoadoutKeybindConfig()
+
+    @Expose
+    @ConfigOption(name = "Highlighting", desc = "")
+    @Accordion
+    val highlighting: LoadoutHighlightingConfig = LoadoutHighlightingConfig()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customloadout/LoadoutHighlightingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customloadout/LoadoutHighlightingConfig.kt
@@ -1,0 +1,37 @@
+package at.hannibal2.skyhanni.config.features.inventory.customloadout
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.utils.LorenzColor
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.ChromaColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class LoadoutHighlightingConfig {
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Enable highlighting of loadouts in the inventory.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enabled: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Currently Equipped", desc = "Highlight the currently equipped loadout in the inventory.")
+    @ConfigEditorBoolean
+    var currentlyEquipped: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Currently Equipped Color", desc = "The color used to highlight loadouts in the inventory.")
+    @ConfigEditorColour
+    var equippedColor: ChromaColour = LorenzColor.GREEN.toChromaColor()
+
+    @Expose
+    @ConfigOption(name = "Favorites", desc = "Highlight favorite loadouts in the inventory.")
+    @ConfigEditorBoolean
+    var favorites: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Favorite Color", desc = "The color used to highlight favorite loadouts in the inventory.")
+    @ConfigEditorColour
+    var favoriteColor: ChromaColour = LorenzColor.YELLOW.toChromaColor()
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customloadout/LoadoutHighlightingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/customloadout/LoadoutHighlightingConfig.kt
@@ -21,7 +21,7 @@ class LoadoutHighlightingConfig {
     var currentlyEquipped: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Currently Equipped Color", desc = "The color used to highlight loadouts in the inventory.")
+    @ConfigOption(name = "Currently Equipped Color", desc = "The color used to highlight the currently equipped loadout in the inventory.")
     @ConfigEditorColour
     var equippedColor: ChromaColour = LorenzColor.GREEN.toChromaColor()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutApi.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.inventory.loadout
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ProfileStorageData
-import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.features.inventory.EquipmentApi
@@ -12,13 +11,11 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
-import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.find
 import at.hannibal2.skyhanni.utils.RegexUtils.findMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedGlassPane
 import at.hannibal2.skyhanni.utils.compat.DyeCompat
@@ -229,14 +226,6 @@ object LoadoutApi {
         if (!slot.isInCurrentPage() || slot.locked) return
         currentSlot = slot.id
         InventoryUtils.clickSlot(slot.inventorySlot)
-    }
-
-    @HandleEvent
-    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
-        if (!inLoadouts) return
-        val loadoutSlotFromId = getLoadoutSlotFromId(currentSlot) ?: return
-        if (!(loadoutSlotFromId.isInCurrentPage())) return
-        event.container.getSlot(loadoutSlotFromId.inventorySlot).highlight(LorenzColor.GREEN)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 object LoadoutSlotHighlight {
     val config get() = SkyHanniMod.feature.inventory.customLoadout.highlighting
 
-    @HandleEvent
+    @HandleEvent(onlyOnSkyblock = true)
     fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!isEnabled()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
@@ -18,11 +18,9 @@ object LoadoutSlotHighlight {
             .filter { it.isInCurrentPage() }
             .forEach { loadoutSlot ->
                 val slot = event.container.getSlot(loadoutSlot.inventorySlot)
-                if (config.currentlyEquipped && LoadoutApi.currentSlot == loadoutSlot.id) {
-                    slot.highlight(config.equippedColor)
-                }
-                if (config.favorites && loadoutSlot.favorite) {
-                    slot.highlight(config.favoriteColor)
+                when {
+                    config.currentlyEquipped && LoadoutApi.currentSlot == loadoutSlot.id -> slot.highlight(config.equippedColor)
+                    config.favorites && loadoutSlot.favorite -> slot.highlight(config.favoriteColor)
                 }
             }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
@@ -1,0 +1,29 @@
+package at.hannibal2.skyhanni.features.inventory.loadout
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RenderUtils.highlight
+
+@SkyHanniModule
+object LoadoutSlotHighlight {
+    val config get() = SkyHanniMod.feature.inventory.customLoadout.highlighting
+
+    @HandleEvent
+    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+        if (!isEnabled()) return
+
+        LoadoutApi.slots
+            .filter { it.isInCurrentPage() }
+            .forEach { loadoutSlot ->
+                if (config.currentlyEquipped && LoadoutApi.currentSlot == loadoutSlot.id) {
+                    event.container.getSlot(loadoutSlot.inventorySlot).highlight(config.equippedColor)
+                } else if (config.favorites && loadoutSlot.favorite) {
+                    event.container.getSlot(loadoutSlot.inventorySlot).highlight(config.favoriteColor)
+                }
+            }
+    }
+
+    fun isEnabled() = config.enabled && LoadoutApi.inLoadouts()
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
@@ -20,7 +20,8 @@ object LoadoutSlotHighlight {
                 val slot = event.container.getSlot(loadoutSlot.inventorySlot)
                 if (config.currentlyEquipped && LoadoutApi.currentSlot == loadoutSlot.id) {
                     slot.highlight(config.equippedColor)
-                } else if (config.favorites && loadoutSlot.favorite) {
+                }
+                if (config.favorites && loadoutSlot.favorite) {
                     slot.highlight(config.favoriteColor)
                 }
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutSlotHighlight.kt
@@ -17,10 +17,11 @@ object LoadoutSlotHighlight {
         LoadoutApi.slots
             .filter { it.isInCurrentPage() }
             .forEach { loadoutSlot ->
+                val slot = event.container.getSlot(loadoutSlot.inventorySlot)
                 if (config.currentlyEquipped && LoadoutApi.currentSlot == loadoutSlot.id) {
-                    event.container.getSlot(loadoutSlot.inventorySlot).highlight(config.equippedColor)
+                    slot.highlight(config.equippedColor)
                 } else if (config.favorites && loadoutSlot.favorite) {
-                    event.container.getSlot(loadoutSlot.inventorySlot).highlight(config.favoriteColor)
+                    slot.highlight(config.favoriteColor)
                 }
             }
     }


### PR DESCRIPTION
## What
I ain't sold on my config naming/descriptions, but still.

Previously you couldn't even disable the loadouts highlighting, nor change the color from green.
Now you can do both.

And since it felt odd making the config so small I also added favorite highlighting.

## Changelog Improvements
+ Improved loadouts by letting you highlight currently equipped and favorite loadouts. - AverageUser125
