### PR TITLE
Fix: Detect non-book ultra rares at Superpairs flip time

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LocationUtils
@@ -238,7 +239,7 @@ object ExperimentationTableApi {
         private set
 
     // "Endcap Upgrade" items (Hypixel wiki) — same Ultra Rare RNG cost as T7 books (500k XP) but
-    // no in-game "ULTRA-RARE" lore header at flip time, so detected via processRewardOrNull() instead.
+    // no in-game "ULTRA-RARE" lore header at flip time, so detected via internal-name matching instead.
     var ultraRareMiscItems: List<NeuInternalName> = emptyList()
         private set
 
@@ -440,8 +441,9 @@ object ExperimentationTableApi {
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND, priority = HandleEvent.HIGH)
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!inTable) return
-        event.tryFireRareBookUncovered()
         event.tryUpdateCurrentActivity()
+        event.tryFireRareBookUncovered()
+        event.tryFireRareItemUncovered()
         refreshBottlesInInventory()
     }
 
@@ -530,14 +532,6 @@ object ExperimentationTableApi {
 
         val internalName = NeuInternalName.fromItemNameOrNull(this)
             ?: return ChatUtils.debug("Could not read item name from $this")
-        // Intentionally fires later than the book detection path (tryFireRareBookUncovered runs at
-        // card-flip time). Non-book Ultra Rares show no "ULTRA-RARE" lore text at flip time — unlike
-        // books — so lore-based flip-time detection is impossible. Whether their identity is readable
-        // at flip time some other way is unconfirmed; these drops are too rare to test live. The
-        // post-experiment summary is used instead because it is confirmed to work reliably.
-        if (currentExperimentData.type == ExperimentationTaskType.SUPERPAIRS && internalName in ultraRareMiscItems) {
-            TableRareUncoverEvent(this, isBook = false).post()
-        }
         currentExperimentData.addReward(internalName, 1)
     }
 
@@ -552,6 +546,18 @@ object ExperimentationTableApi {
                 currentExperimentData.rareFoundFired = true
                 return
             }
+        }
+    }
+
+    private fun InventoryOpenEvent.tryFireRareItemUncovered() {
+        if (currentExperimentData.rareFoundFired) return
+        if (!inSuperpairs) return
+        for ((_, item) in inventoryItems) {
+            val internalName = item.getInternalNameOrNull() ?: continue
+            if (internalName !in ultraRareMiscItems) continue
+            TableRareUncoverEvent(item.cleanName(), isBook = false).post()
+            currentExperimentData.rareFoundFired = true
+            return
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/events/experiments/TableRareUncoverEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/experiments/TableRareUncoverEvent.kt
@@ -7,6 +7,6 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
  *
  * @param dropName The display name of the uncovered item.
  * @param isBook Whether the drop is an enchanted book. False for non-book Ultra Rare items,
- *               which are detected via the post-experiment summary rather than the card flip lore.
+ *               which are detected at card-flip time via internal-name matching against the repo list.
  */
 class TableRareUncoverEvent(val dropName: String, val isBook: Boolean = true) : SkyHanniEvent()


### PR DESCRIPTION
## What
Non-book ultra rare items in Superpairs (Severed Pincer, Endstone Idol, etc.) are now detected at card-flip time via internal-name matching against the repo list, the same way ultra rare books are detected via lore. #5981 initially added detection for these items but was limited to the post-experiment summary screen, meaning the mid-game notification did not fire during the game.

Bug identified in 
- https://discord.com/channels/997079228510117908/1525679630923600045

## Changelog Fixes
+ Fixed non-book ultra rare items in Superpairs not triggering the mid-game notification immediately when uncovered. - RemainingDelta