### PR TITLE
 Improvement: Add title and sound notifications to /shremind

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/RemindersConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/RemindersConfig.kt
@@ -21,7 +21,7 @@ class RemindersConfig {
         name = "Reminder Interval",
         desc = "The interval in minutes in which reminders are shown again, after they have been shown once."
     )
-    @ConfigEditorSlider(minValue = 0f, maxValue = 60f, minStep = 1f)
+    @ConfigEditorSlider(minValue = 1f, maxValue = 60f, minStep = 1f)
     var interval: Float = 5f
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/RemindersConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/RemindersConfig.kt
@@ -25,6 +25,11 @@ class RemindersConfig {
     var interval: Float = 5f
 
     @Expose
+    @ConfigOption(name = "Show Title", desc = "Show a title on screen when a reminder is due.")
+    @ConfigEditorBoolean
+    var showTitle: Boolean = true
+
+    @Expose
     @ConfigOption(
         name = "Show Reminders HUD",
         desc = "Display active reminders on screen with time remaining."

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
@@ -4,10 +4,12 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
+import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -153,10 +155,12 @@ object ReminderManager {
     @HandleEvent
     fun onSecondPassed(event: SecondPassedEvent) {
         val remindersToSend = mutableListOf<Component>()
+        val firedReasons = mutableListOf<String>()
 
         for ((id, reminder) in getSortedReminders()) {
             if (!reminder.shouldRemind(config.interval.minutes)) continue
             reminder.lastReminder = SimpleTimeMark.now()
+            firedReasons.add(reminder.reason)
             var actionsComponent: Component? = null
 
             if (!config.autoDeleteReminders) {
@@ -189,6 +193,12 @@ object ReminderManager {
         }
 
         if (remindersToSend.isNotEmpty()) {
+            SoundUtils.repeatSound(150, 3, SoundUtils.createSound("block.note_block.pling", 1.5f))
+            if (config.showTitle) {
+                val subtitle = if (firedReasons.size == 1) "§e${firedReasons.first()}" else null
+                val titleText = if (firedReasons.size == 1) "§cReminder!" else "§c${firedReasons.size} Reminders!"
+                TitleManager.sendTitle(titleText, subtitleText = subtitle, duration = 3.seconds)
+            }
             val id = if (config.autoDeleteReminders) 0 else REMINDERS_MESSAGE_ID
             TextHelper.join(remindersToSend, separator = TextHelper.NEWLINE).send(id)
         }


### PR DESCRIPTION
## What
When a `/shremind` reminder is due, a title now appears on screen and a sound plays to make it harder to miss. The title shows the reminder text as a subtitle beneath it. A config option under Misc > Reminders controls whether the title is shown. 

The reminder interval slider minimum has also been raised to 1 minute to prevent reminders from firing every second at 0.

<details>
<summary>Images</summary>

Reminder Title:  
<img width="395" height="148" alt="herinder!" src="https://github.com/user-attachments/assets/1b32983e-4278-4c05-b117-02c2b2e3ec94" />

New Title Config Option:  
<img width="635" height="490" alt="7 Reminders" src="https://github.com/user-attachments/assets/ea969412-5ce2-44c2-a088-4b1962214e63" />
</details>


## Changelog Improvements
+ Added title and sound notification when a `/shremind` reminder is due. - RemainingDelta

