### PR TITLE
Improvement: Compress Island Beacon Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
@@ -138,6 +138,11 @@ class GuiConfig {
     var beaconPowerStat: Boolean = true
 
     @Expose
+    @ConfigOption(name = "Compress Beacon Stat", desc = "Compress the beacon stat display to only show the value.")
+    @ConfigEditorBoolean
+    var beaconPowerCompressStat: Boolean = false
+
+    @Expose
     @ConfigLink(owner = GuiConfig::class, field = "beaconPower")
     val beaconPowerPosition: Position = Position(10, 10)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -122,12 +123,18 @@ object BeaconPower {
             if (config.beaconPowerStat) {
                 append {
                     append(" (")
-                    append(stat ?: Component.literal("§cNo stat"))
+                    append(getStatDisplay())
                     append(")")
                     withColor(ChatFormatting.GRAY)
                 }
             }
         }
+    }
+
+    private fun getStatDisplay(): Component {
+        val stat = stat ?: return Component.literal("§cNo stat")
+        if (!config.beaconPowerCompressStat) return stat
+        return TextHelper.split(stat, " ")?.firstOrNull() ?: stat
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
Provides a compressed view of the island beacon display as suggested in 
https://discord.com/channels/997079228510117908/1525327336936050832/1525327336936050832

<details>
<summary>Images</summary>
<img width="577" height="113" alt="image" src="https://github.com/user-attachments/assets/1a473084-b5f3-4d02-b802-37518d4a9dba" />

</details>

## Changelog Improvements
+ Compressed island beacon buff display. - T0R0NT0


