### PR TITLE
Fix: Overflow Skill Level not being correctly detected

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -336,9 +336,9 @@ object SkillApi {
             lore@ for ((index, line) in lore.withIndex()) {
                 val cleanLine = line.removeColor()
                 if (!cleanLine.startsWith("                    ")) continue@lore
-                val previousLine = lore.getOrNull(index - 1) ?: continue@lore
+                val previousLine = lore.getOrNull(index - 1)?.removeColor() ?: continue@lore
                 val progress = cleanLine.substring(cleanLine.lastIndexOf(' ') + 1)
-                if (previousLine == "§7§8Max Skill level reached!") {
+                if (previousLine == "Max Skill level reached!") {
                     onUpdateMax(progress, skill, skillInfo, skillLevel)
                 } else {
                     onUpdateNotMax(progress, skillLevel, skillInfo)

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -38,6 +38,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLongOrUserError
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -128,6 +129,14 @@ object SkillApi {
     private val skillTabNoPercentPattern by patternGroup.pattern(
         "skill.tab.nopercent.colorless",
         " (?<type>\\w+)(?: (?<level>\\d+))?: (?<current>[0-9,.]+)/(?<needed>[\\d,.]+[kMB]?+)",
+    )
+
+    /**
+     * Regex-TEST: Max Skill level reached!
+     */
+    private val skillMaxLevelMenuPattern by patternGroup.pattern(
+        "skiil.menu.max",
+        "Max Skill level reached!"
     )
 
     var skillXPInfoMap = mutableMapOf<SkillType, SkillXPInfo>()
@@ -338,7 +347,7 @@ object SkillApi {
                 if (!cleanLine.startsWith("                    ")) continue@lore
                 val previousLine = lore.getOrNull(index - 1)?.removeColor() ?: continue@lore
                 val progress = cleanLine.substring(cleanLine.lastIndexOf(' ') + 1)
-                if (previousLine == "Max Skill level reached!") {
+                if (skillMaxLevelMenuPattern.matches(previousLine)) {
                     onUpdateMax(progress, skill, skillInfo, skillLevel)
                 } else {
                     onUpdateNotMax(progress, skillLevel, skillInfo)

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -135,7 +135,7 @@ object SkillApi {
      * Regex-TEST: Max Skill level reached!
      */
     private val skillMaxLevelMenuPattern by patternGroup.pattern(
-        "skiil.menu.max",
+        "skill.menu.maxreached",
         "Max Skill level reached!"
     )
 


### PR DESCRIPTION
## What
Rain pinpointed the issue & supplied half the fix, just without he colour code removal necessary
a further PR that I'm working on will remove as much of the shenanigans from this file It's just got gremlin problems so this is being made.

## Changelog Fixes
+ Fixed Overflow Skill Level in tooltip showing inaccurate XP & not calculating level properly. - Rain