### PR TITLE
Backend: Mark as incompatible with more spoofer mods

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -55,7 +55,9 @@
     },
     "breaks": {
         "clientspoofer": "*",
-        "exordium": "*"
+        "exordium": "*",
+        "opsec": "*",
+        "spoofified": "*"
     },
     "contact": {
         "homepage": "https://modrinth.com/mod/skyhanni",


### PR DESCRIPTION
## What
Like ClientSpoofer, these mods break our ability to detect that the player is on Hypixel and receive location information via the Mod API. I am not going to bother writing a compatibility layer for them, anyone who really wants to use them can use local dependency overrides and figure it out themselves.

## Changelog Technical Details
+ Marked SkyHanni as incompatible with the mods "OpSec" and "Spoofifed". - Luna
    * These mods break our ability to communicate with the Hypixel Mod API.