### PR TITLE
Fix: Being locked out of closing inventories

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityRabbitTheFishChecker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityRabbitTheFishChecker.kt
@@ -96,6 +96,11 @@ object HoppityRabbitTheFishChecker {
         event.sendPreventClosureTitle()
     }
 
+    @HandleEvent
+    fun onInventoryClose() {
+        rabbitTheFishIndex = null
+    }
+
     private fun SkyHanniEvent.Cancellable.sendPreventClosureTitle() {
         TitleManager.sendTitle(
             "§cRabbit the Fish Prevented Close",


### PR DESCRIPTION
## What
Now you are no longer soft locked randomly.

## Changelog Fixes
+ Fixed prevent missing rabbit the fish sometimes causing you to not be able to close other inventories. - CalMWolfs

