### PR TITLE
Fix: Stat reading was wrong

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -181,7 +181,7 @@ enum class SkyblockStat(
 
     val menuPattern by patternGroup.pattern(
         "menu.no-color.$keyName",
-        if (generatePatterns) "$hypixelIcon ${this@SkyblockStat.displayName} $VALUE_PATTERN" else "",
+        if (generatePatterns) "\\s*$hypixelIcon ${this@SkyblockStat.displayName} $VALUE_PATTERN" else "",
     )
 
     fun asString(value: Int) = (if (value > 0) "+" else "") + value.toString() + " " + this.icon

--- a/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/SkyblockStat.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.events.minecraft.ResourcePackReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EnumUtils.toFormattedName
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
+import at.hannibal2.skyhanni.utils.ItemUtils.getCleanLore
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -228,17 +228,19 @@ enum class SkyblockStat(
 
         private fun onSkyblockMenu(event: InventoryFullyOpenedEvent) {
             if (event.inventoryName != "SkyBlock Menu") return
-            val list = event.inventoryItems[PLAYER_STATS_SLOT_INDEX]?.getLore() ?: return
+            val list = event.inventoryItems[PLAYER_STATS_SLOT_INDEX]?.getCleanLore() ?: return
             DelayedRun.runNextTick { // Delayed to not impact opening time
                 assignEntry(list, StatSourceType.SKYBLOCK_MENU) { it.menuPattern }
             }
         }
 
-        private val statsMenuRelevantSlotIndexes = listOf(15, 16, 24, 25, 33)
+        private val statsMenuRelevantSlotIndexes = listOf(14, 15, 16, 23, 24, 25, 32, 33, 34)
 
         private fun onStatsMenu(event: InventoryFullyOpenedEvent) {
             if (event.inventoryName != "Your Equipment and Stats") return
-            val list = statsMenuRelevantSlotIndexes.mapNotNull { event.inventoryItems[it]?.getLore() }.flatten()
+            val list = statsMenuRelevantSlotIndexes
+                .mapNotNull { event.inventoryItems[it]?.getCleanLore() }
+                .flatten()
             if (list.isEmpty()) return
             DelayedRun.runNextTick { // Delayed to not impact opening time
                 assignEntry(list, StatSourceType.STATS_MENU) { it.menuPattern }


### PR DESCRIPTION
## What
1. it was using getLore with a colorless regex
2. it uses matchMatcher which did the whole string, and it didn't count since there was a space upfront in the real string
3. they made it 3x3 now, so that had to be fixed.

## Changelog Fixes
+ Fixed /shminingspeed and /shblockstrength giving not being able to read your stats. - AverageUser125

## Changelog Technical Details
+ Fixed reading stats from skyblock menu not working. - AverageUser125
