### PR TITLE
Fix: CropMoneyDisplay called from wrong thread

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/garden/GardenToolChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/GardenToolChangeEvent.kt
@@ -2,6 +2,12 @@ package at.hannibal2.skyhanni.events.garden
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.features.garden.CropType
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.SafeItemStack
 
+/** Fired when the player changes the tool they are holding in their hand.
+ *
+ * Can be from both networking and render threads.
+ */
+@PrimaryFunction("onGardenToolChange")
 class GardenToolChangeEvent(val crop: CropType?, val toolItem: SafeItemStack?, val toolInHand: String?) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/garden/GardenToolChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/GardenToolChangeEvent.kt
@@ -5,7 +5,8 @@ import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.SafeItemStack
 
-/** Fired when the player changes the tool they are holding in their hand.
+/**
+ * Fired when the player changes the tool they are holding in their hand.
  *
  * Can be from both networking and render threads.
  */

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -89,7 +89,7 @@ object CropMoneyDisplay {
         }
     }
 
-    @HandleEvent(GardenToolChangeEvent::class)
+    @HandleEvent
     fun onGardenToolChange() {
         DelayedRun.runOrNextTick {
             update()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -91,7 +91,9 @@ object CropMoneyDisplay {
 
     @HandleEvent(GardenToolChangeEvent::class)
     fun onGardenToolChange() {
-        update()
+        DelayedRun.runOrNextTick {
+            update()
+        }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/CropMoneyDisplay.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
-import at.hannibal2.skyhanni.events.garden.GardenToolChangeEvent
 import at.hannibal2.skyhanni.events.pets.PetChangeEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.features.garden.GardenApi


### PR DESCRIPTION
## What
It was called from wrong thread, should probably find root cause. but this does fix the symptom.
this doesn't feel like a user changelog tbh. but whatever.

## Changelog Fixes
+ Fixed crop money display error when switching farming tools. - AverageUser125
