### PR TITLE
Fix: Colorless party finder helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -243,7 +243,6 @@ object DungeonApi {
 
     fun getLevelComponent(level: Int): Component {
         val formatting: ChatFormatting = when {
-            level >= 50 -> RED
             level >= 45 -> RED
             level >= 40 -> GOLD
             level >= 35 -> LIGHT_PURPLE

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -252,8 +252,8 @@ object DungeonApi {
             level >= 20 -> DARK_GREEN
             level >= 15 -> GREEN
             level >= 10 -> YELLOW
-            level >= 5  -> WHITE
-            else        -> GRAY
+            level >= 5 -> WHITE
+            else -> GRAY
         }
         return componentBuilder {
             append("$level") {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -245,7 +245,7 @@ object DungeonApi {
         val formatting: ChatFormatting = when {
             level >= 45 -> RED
             level >= 40 -> GOLD
-            level >= 35 -> LIGHT_PURPLE
+            level >= 35 -> DARK_PURPLE
             level >= 30 -> BLUE
             level >= 25 -> AQUA
             level >= 20 -> DARK_GREEN

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -37,7 +37,6 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.compat.append
-import at.hannibal2.skyhanni.utils.compat.appendWithColor
 import at.hannibal2.skyhanni.utils.compat.bold
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.compat.withColor
@@ -293,7 +292,7 @@ object DungeonApi {
 
         val playerTeam = event.tabList.find { it.string.contains(PlayerUtils.getName()) }?.string ?: return
         for (dungeonClass in DungeonClass.entries) {
-            if (playerTeam.contains("(${dungeonClass.scoreboardName} ")) {
+            if (playerTeam.contains("(${dungeonClass.displayName} ")) {
                 val level = playerTeam.split(" ").last().trimEnd(')').romanToDecimalIfNecessary()
                 playerClass = dungeonClass
                 playerClassLevel = level
@@ -452,7 +451,7 @@ object DungeonApi {
         }
     }
 
-    enum class DungeonClass(val scoreboardName: String) {
+    enum class DungeonClass(val displayName: String) {
         ARCHER("Archer"),
         BERSERK("Berserk"),
         HEALER("Healer"),
@@ -462,7 +461,7 @@ object DungeonApi {
 
         companion object {
             fun getByClassName(className: String): DungeonClass? {
-                return DungeonClass.entries.firstOrNull { it.scoreboardName.equals(className, ignoreCase = true) }
+                return DungeonClass.entries.firstOrNull { it.displayName.equals(className, ignoreCase = true) }
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -36,7 +36,14 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
+import at.hannibal2.skyhanni.utils.compat.append
+import at.hannibal2.skyhanni.utils.compat.appendWithColor
+import at.hannibal2.skyhanni.utils.compat.bold
+import at.hannibal2.skyhanni.utils.compat.componentBuilder
+import at.hannibal2.skyhanni.utils.compat.withColor
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.Component
 import net.minecraft.world.level.block.Blocks
 
 @Suppress("MemberVisibilityCanBePrivate")
@@ -220,6 +227,7 @@ object DungeonApi {
     private const val WATER_ROOM_ID = "-60,-60"
     val inWaterRoom: Boolean get() = roomId == WATER_ROOM_ID
 
+    @Deprecated("Use getLevelComponent instead for better formatting", replaceWith = ReplaceWith("getLevelComponent(level)"))
     fun getColor(level: Int): String = when {
         level >= 50 -> "§c§l"
         level >= 45 -> "§c"
@@ -232,6 +240,28 @@ object DungeonApi {
         level >= 10 -> "§e"
         level >= 5 -> "§f"
         else -> "§7"
+    }
+
+    fun getLevelComponent(level: Int): Component {
+        val formatting: ChatFormatting = when {
+            level >= 50 -> RED
+            level >= 45 -> RED
+            level >= 40 -> GOLD
+            level >= 35 -> LIGHT_PURPLE
+            level >= 30 -> BLUE
+            level >= 25 -> AQUA
+            level >= 20 -> DARK_GREEN
+            level >= 15 -> GREEN
+            level >= 10 -> YELLOW
+            level >= 5  -> WHITE
+            else        -> GRAY
+        }
+        return componentBuilder {
+            append("$level") {
+                withColor(formatting)
+                if (level >= 50) bold = true
+            }
+        }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -22,8 +22,11 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.compat.appendWithColor
+import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.Component
 
 // TODO also fix up this all being coded very poorly and having the same patterns in multiple places
 @SkyHanniModule
@@ -174,7 +177,7 @@ object DungeonFinderFeatures {
     private var selectedClass: String? = null
     private var floorStackSize = mapOf<Int, String>()
     private var highlightParty = mapOf<Int, LorenzColor>()
-    private var toolTipMap = mapOf<Int, List<String>>()
+    private var toolTipMap = mapOf<Int, List<Component>>()
     private var inInventory = false
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -314,8 +317,8 @@ object DungeonFinderFeatures {
         return map
     }
 
-    private fun toolTipHandler(event: InventoryOpenEvent): Map<Int, List<String>> {
-        val map = mutableMapOf<Int, List<String>>()
+    private fun toolTipHandler(event: InventoryOpenEvent): Map<Int, List<Component>> {
+        val map = mutableMapOf<Int, List<Component>>()
         val inventoryName = event.inventoryName
         if (!partyFinderTitlePattern.matches(inventoryName)) return map
         inInventory = true
@@ -323,14 +326,19 @@ object DungeonFinderFeatures {
             // TODO use enum
             val classNames = mutableListOf("Healer", "Mage", "Berserk", "Archer", "Tank")
             val cleanLore = stack.getCleanLore()
-            val toolTip = cleanLore.toMutableList()
+            val toolTip = stack.getLoreComponent().toMutableList()
             for ((index, line) in cleanLore.withIndex()) {
                 memberPattern.matchMatcher(line) {
                     val playerName = group("playerName")
                     val className = group("className")
                     val level = group("level").toInt()
-                    val color = DungeonApi.getColor(level)
-                    if (config.coloredClassLevel) toolTip[index] = " §b$playerName§f: §e$className $color$level"
+                    val levelComponent = DungeonApi.getLevelComponent(level)
+                    if (config.coloredClassLevel) toolTip[index] = componentBuilder {
+                        appendWithColor(" $playerName", ChatFormatting.AQUA)
+                        appendWithColor(": ", ChatFormatting.WHITE)
+                        appendWithColor("$className ", ChatFormatting.YELLOW)
+                        append(levelComponent)
+                    }
                     classNames.remove(className)
                 }
             }
@@ -340,7 +348,12 @@ object DungeonFinderFeatures {
                     classNames[classNames.indexOf(selectedClass)] = "§a$selectedClass§7"
                 }
                 toolTip.add("")
-                toolTip.add("§cMissing: §7" + classNames.createCommaSeparatedList())
+                toolTip.add(
+                    componentBuilder {
+                        appendWithColor("Missing: ", ChatFormatting.RED)
+                        appendWithColor(classNames.createCommaSeparatedList(), ChatFormatting.GRAY)
+                    }
+                )
             }
             if (toolTip.isNotEmpty()) {
                 map[slot] = toolTip
@@ -360,13 +373,15 @@ object DungeonFinderFeatures {
 
         val toolTip = toolTipMap[event.slot.index]
         if (toolTip.isNullOrEmpty()) return
-        val oldToolTip = event.toolTip.map { it.string.removeColor() }
+        val oldToolTip = event.toolTip
         for ((index, line) in toolTip.withIndex()) {
             if (index >= event.toolTip.size - 1) {
                 event.toolTip.add(line)
                 continue
             }
-            if (oldToolTip[index] != line) event.toolTip[index + 1] = line.asComponent()
+            if (oldToolTip[index].string.removeColor() != line.string.removeColor()) {
+                event.toolTip[index + 1] = line
+            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -22,7 +22,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeFirst
 import at.hannibal2.skyhanni.utils.compat.appendWithColor
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -311,7 +310,7 @@ object DungeonFinderFeatures {
                 }
             }
 
-            if (config.markMissingClass && memberClasses.none { it == selectedClass }) {
+            if (config.markMissingClass && memberClasses.none { it == selectedClass?.displayName }) {
                 map[slot] = LorenzColor.GREEN
             }
         }
@@ -324,7 +323,7 @@ object DungeonFinderFeatures {
         if (!partyFinderTitlePattern.matches(inventoryName)) return map
         inInventory = true
         for ((slot, stack) in event.inventoryItems) {
-            val missingClasses = DungeonClass.entries
+            val missingClasses = DungeonClass.entries.toMutableList()
             val cleanLore = stack.getCleanLore()
             val toolTip = stack.getLoreComponent().toMutableList()
             for ((index, line) in cleanLore.withIndex()) {
@@ -339,7 +338,7 @@ object DungeonFinderFeatures {
                         appendWithColor("$className ", ChatFormatting.YELLOW)
                         append(levelComponent)
                     }
-                    missingClasses.removeFirst { it.displayName == className }
+                    missingClasses.remove(DungeonClass.getByClassName(className))
                 }
             }
             val name = cleanLore.firstOrNull()

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -299,7 +299,7 @@ object DungeonFinderFeatures {
             }
             val memberClasses = members.map {
                 memberPattern.matchMatcher(it) {
-                    group("className")
+                    DungeonClass.getByClassName(group("className"))
                 }
             }
             if (config.markBelowClassLevel != 0) {
@@ -310,7 +310,7 @@ object DungeonFinderFeatures {
                 }
             }
 
-            if (config.markMissingClass && memberClasses.none { it == selectedClass?.displayName }) {
+            if (config.markMissingClass && memberClasses.none { it == selectedClass }) {
                 map[slot] = LorenzColor.GREEN
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.features.dungeon
 
-import at.hannibal2.skyhanni.features.dungeon.DungeonApi.DungeonClass
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
@@ -10,6 +9,7 @@ import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.events.minecraft.add
+import at.hannibal2.skyhanni.features.dungeon.DungeonApi.DungeonClass
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLoreComponent

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -379,7 +379,7 @@ object DungeonFinderFeatures {
 
         val toolTip = toolTipMap[event.slot.index]
         if (toolTip.isNullOrEmpty()) return
-        val oldToolTip = event.toolTip
+        val oldToolTip = event.toolTip.toList()
         for ((index, line) in toolTip.withIndex()) {
             if (index >= event.toolTip.size - 1) {
                 event.toolTip.add(line)

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -354,7 +354,6 @@ object DungeonFinderFeatures {
                                 appendWithColor(dungeonClass.displayName, ChatFormatting.GRAY)
                             }
 
-                            // Add comma and space between items
                             if (index < missingClasses.size - 1) {
                                 appendWithColor(", ", ChatFormatting.GRAY)
                             }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonFinderFeatures.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.features.dungeon
 
+import at.hannibal2.skyhanni.features.dungeon.DungeonApi.DungeonClass
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
@@ -20,8 +21,8 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.highlight
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.StringUtils.createCommaSeparatedList
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeFirst
 import at.hannibal2.skyhanni.utils.compat.appendWithColor
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -174,7 +175,7 @@ object DungeonFinderFeatures {
     )
 
     //  Variables used
-    private var selectedClass: String? = null
+    private var selectedClass: DungeonClass? = null
     private var floorStackSize = mapOf<Int, String>()
     private var highlightParty = mapOf<Int, LorenzColor>()
     private var toolTipMap = mapOf<Int, List<Component>>()
@@ -235,7 +236,7 @@ object DungeonFinderFeatures {
             if (it.size > 3 && detectDungeonClassPattern.matches(it[0])) {
                 getDungeonClassPattern.matchMatcher(it[2]) {
                     // This intentionally does not get cleared between lobbies
-                    selectedClass = group("class")
+                    selectedClass = DungeonClass.getByClassName(group("class"))
                 }
             }
         }
@@ -323,8 +324,7 @@ object DungeonFinderFeatures {
         if (!partyFinderTitlePattern.matches(inventoryName)) return map
         inInventory = true
         for ((slot, stack) in event.inventoryItems) {
-            // TODO use enum
-            val classNames = mutableListOf("Healer", "Mage", "Berserk", "Archer", "Tank")
+            val missingClasses = DungeonClass.entries
             val cleanLore = stack.getCleanLore()
             val toolTip = stack.getLoreComponent().toMutableList()
             for ((index, line) in cleanLore.withIndex()) {
@@ -339,19 +339,27 @@ object DungeonFinderFeatures {
                         appendWithColor("$className ", ChatFormatting.YELLOW)
                         append(levelComponent)
                     }
-                    classNames.remove(className)
+                    missingClasses.removeFirst { it.displayName == className }
                 }
             }
             val name = cleanLore.firstOrNull()
             if (config.showMissingClasses && dungeonFloorPattern.matches(name)) {
-                if (classNames.contains(selectedClass)) {
-                    classNames[classNames.indexOf(selectedClass)] = "§a$selectedClass§7"
-                }
                 toolTip.add("")
                 toolTip.add(
                     componentBuilder {
                         appendWithColor("Missing: ", ChatFormatting.RED)
-                        appendWithColor(classNames.createCommaSeparatedList(), ChatFormatting.GRAY)
+                        missingClasses.forEachIndexed { index, dungeonClass ->
+                            if (dungeonClass == selectedClass) {
+                                appendWithColor(dungeonClass.displayName, ChatFormatting.GREEN)
+                            } else {
+                                appendWithColor(dungeonClass.displayName, ChatFormatting.GRAY)
+                            }
+
+                            // Add comma and space between items
+                            if (index < missingClasses.size - 1) {
+                                appendWithColor(", ", ChatFormatting.GRAY)
+                            }
+                        }
                     }
                 )
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSpiritLeapOverlay.kt
@@ -130,7 +130,7 @@ object DungeonSpiritLeapOverlay {
         val player = playerStackInfo.playerInfo ?: return null
         val classInfo = buildString {
             player.dungeonClass?.let {
-                append(it.scoreboardName)
+                append(it.displayName)
                 if (config.showDungeonClassLevel) append(" ${player.classLevel}")
                 if (player.playerDead) append(" (Dead)")
             }


### PR DESCRIPTION
## What
It was being colorless, also the code didn't use DungeonClass enum for some reason, so I did that "TODO".
Also, the entire `DungeonRankTabListColor` is literally broken since the event `TabListLineRenderEvent` isn't posted EVER. so that should probably be fixed.

<details>
<summary>Images</summary>
It not working:
<br>
<img width="439" height="303" alt="image" src="https://github.com/user-attachments/assets/0cfaae78-5bba-4222-a2b9-27e9e5911c61" />

It after my fix:
<br>
<img width="361" height="330" alt="image" src="https://github.com/user-attachments/assets/6a3abf29-5afa-4224-9e9c-541eb59a23ee" />

</details>

## Changelog Fixes
+ Fixed Dungeon Party Finder features making tooltip colorless. - Avrg
