### PR TITLE
Fix: Rare tile crash

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -210,9 +210,9 @@ object EntityUtils {
         }.asSequence()
 
         return blockEntityTickers.mapNotNull { invoker ->
+            // This can be null due to other mods
             @Suppress("UNNECESSARY_SAFE_CALL")
-            val pos = invoker.pos ?: return@mapNotNull null
-            invoker.pos.let(world::getBlockEntity)
+            invoker.pos?.let(world::getBlockEntity)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -209,7 +209,11 @@ object EntityUtils {
             if (Minecraft.getInstance().isSameThread) it else it.toMutableList()
         }.asSequence()
 
-        return blockEntityTickers.mapNotNull { invoker -> world.getBlockEntity(invoker.pos) }
+        return blockEntityTickers.mapNotNull { invoker ->
+            @Suppress("UNNECESSARY_SAFE_CALL")
+            val pos = invoker.pos ?: return@mapNotNull null
+            invoker.pos.let(world::getBlockEntity)
+        }
     }
 
     fun Entity.canBeSeen(viewDistance: Number = 150.0, vecYOffset: Double = 0.5, ignoreFrustum: Boolean = false): Boolean {


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1526894409579495495
Basically, somehow this block tile entity can be null somehow. maybe mod incompatibility.

## Changelog Fixes
+ Fixed rare error/crash with Crimson Isle Miniboss Timer (likely a mod conflict). - Avrg