### PR TITLE
Backend: Rename Self

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,8 +68,8 @@
   + Highlights completed categories in green.
 + Added Gift Clean Display: Show only 'CLICK TO OPEN' on gifts, hiding the From/To name. - LegentPc (https://github.com/hannibal002/SkyHanni/pull/5619)
 + Added Loadout Keybinds. - FabiHBBBT (https://github.com/hannibal002/SkyHanni/pull/6013)
-+ Added Option To Move `Insert Item Into Sack` button back to original placement. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5874)
-+ Block Overriding Rare Reforges in Blacksmith and Hex. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5856)
++ Added Option To Move `Insert Item Into Sack` button back to original placement. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5874)
++ Block Overriding Rare Reforges in Blacksmith and Hex. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5856)
 
 #### Garden
 
@@ -88,7 +88,7 @@
 
 + Added SkyHanni Achievements. - nopo (https://github.com/hannibal002/SkyHanni/pull/5472)
   + Do /shachievements to see them all.
-+ Added a chat message when you encounter a SkyHanni contributor for the first time. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5787)
++ Added a chat message when you encounter a SkyHanni contributor for the first time. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5787)
 
 #### Mining
 
@@ -171,13 +171,13 @@
 + Added Include Vacuum to Custom Keybinds. - LukV (https://github.com/hannibal002/SkyHanni/pull/5752)
 + Added enchantment color support to Toolkit Crop Icons. - Growling_Grizzly (https://github.com/hannibal002/SkyHanni/pull/5872)
 + Added tab completion for the `/shcroptime` command, suggesting crop names as you type. - A-N-07 (https://github.com/hannibal002/SkyHanni/pull/5883)
-+ Added Tel Kar Garden Visitor Dialogue. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5850)
++ Added Tel Kar Garden Visitor Dialogue. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5850)
 + Improved Mouse Sensitivity Reducer with mouse lock support. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5796)
     + Mouse rotation can now be fully locked instead of just reducing sensitivity.
     + Auto modes for Vacuum and Sprayonator.
     + Sensitivity reduction now uses a percentage instead of a division factor.
     + Ground tolerance option to prevent unlocking on small height drops.
-+ Added Tel Kar Garden Visitor to Dialoge Showing Exception list. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5850)
++ Added Tel Kar Garden Visitor to Dialoge Showing Exception list. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5850)
 + Added Lock Mouse when snapping to Squeaky Mousemat. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5939)
 + Added Reduce Sensitivity with Sun's Grasp active. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5939)
 + Improved Garden Shopping List to ignore any Visitor. - FabiHBBBT (https://github.com/hannibal002/SkyHanni/pull/5661)
@@ -196,16 +196,16 @@
 
 #### Chat
 
-+ Improved `/shmarkplayer` player completion. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5787)
-+ Improved Command Tab Completion to include Carry Customers. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5787)
++ Improved `/shmarkplayer` player completion. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5787)
++ Improved Command Tab Completion to include Carry Customers. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5787)
 
 #### Inventory
 
 + Added support for Turbo-Crop VI and VII in Estimated Item Value. - Luna (https://github.com/hannibal002/SkyHanni/pull/5666)
 + Added a `/shresetdrystreak` command to reset the Experimentation Table's dry-streak counter. - RemainingDelta (https://github.com/hannibal002/SkyHanni/pull/5981)
 + Added a manual reset button for the Experimentation Table's Dry-Streak Display. - RemainingDelta (https://github.com/hannibal002/SkyHanni/pull/5981)
-+ Added equipment wardrobe value estimation. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6036)
-+ Improved loadouts by letting you highlight currently equipped and favorite loadouts. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6067)
++ Added equipment wardrobe value estimation. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6036)
++ Improved loadouts by letting you highlight currently equipped and favorite loadouts. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6067)
 
 #### Fishing
 
@@ -248,9 +248,9 @@
 + Made the Pet Symbiosis Achievement trigger as soon as you hold the weapon. - Luna (https://github.com/hannibal002/SkyHanni/pull/5562)
 + The day counter fix in the debug menu (F3) now works correctly when using a time changer mod. - Luna (https://github.com/hannibal002/SkyHanni/pull/5583)
 + Added mineshaft types to /shtestisland. - Rain (https://github.com/hannibal002/SkyHanni/pull/5625)
-+ Enabled Better Wiki for everyone. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5893)
++ Enabled Better Wiki for everyone. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5893)
 + Added search tags to Improved SkyBlock Menus option to make it easier to find. - Luna (https://github.com/hannibal002/SkyHanni/pull/5930)
-+ Improved island detection for better performance. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5951)
++ Improved island detection for better performance. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5951)
 + Improved scrolling in the /shwords editor: faster and smoother. - Luna (https://github.com/hannibal002/SkyHanni/pull/5980)
 + Added an on-screen display for active reminders. - RemainingDelta (https://github.com/hannibal002/SkyHanni/pull/6008)
 + Pet Display will now display best-effort cached data even if some tab list information is missing. - Luna (https://github.com/hannibal002/SkyHanni/pull/6035)
@@ -309,18 +309,18 @@
 + Fixed `/shsensreduce` not working. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5796)
 + Fixed garden warp keybinds having an unnecessary cooldown. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5796)
 + Fixed /shmouselock and /shsensreduce not locking mouse right away. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5939)
-+ Fixed In-Season Crop Timer sometimes showing a very large number. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5909)
++ Fixed In-Season Crop Timer sometimes showing a very large number. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5909)
 + Fixed some pest features not working with the new resource pack. - CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/6021)
 + Fixed the Pest fortune buff has expired message saying click to call Phillip even if it is set to teleport to the barn. - Luna (https://github.com/hannibal002/SkyHanni/pull/6007)
 + Fixed the Pest Spawn chat message appearing twice when Chat Message Format is set to Compact. - RemainingDelta (https://github.com/hannibal002/SkyHanni/pull/6004)
 + Fixed Rare Crop Tracker sometimes throwing an Internal name found with color codes error. - Luna (https://github.com/hannibal002/SkyHanni/pull/6057)
-+ Fixed pest farming fortune bonus not being detected. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6031)
-+ Fixed pest profit tracker not detecting rare drops. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6034)
++ Fixed pest farming fortune bonus not being detected. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6031)
++ Fixed pest profit tracker not detecting rare drops. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6034)
 + Fixed Harvest Feast incorrectly detecting a Grand Feast when Finnegan is mayor. - Luna (https://github.com/hannibal002/SkyHanni/pull/6040)
 + Fixed Harvest Feast incorrectly detecting a Grand Feast when Finnegan is minister. - RemainingDelta (https://github.com/hannibal002/SkyHanni/pull/6038)
 + Fixed Jacob Contest Personal Bests not being detected from chat because of the Farming Fortune icon change. - Luna (https://github.com/hannibal002/SkyHanni/pull/6059)
-+ Fixed bonus pest chance display not working. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6056)
-+ Fixed crop money display error when switching farming tools. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6090)
++ Fixed bonus pest chance display not working. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6056)
++ Fixed crop money display error when switching farming tools. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6090)
 
 #### Combat
 
@@ -352,7 +352,7 @@
 + Fixed Crown of Avarice Counter to support changing between them. - Tryp0xd (https://github.com/hannibal002/SkyHanni/pull/6010)
   + Coin per hour metric should stay intact, the value on the counter will only change.
 + Fixed Remaining Slayer Kills Display not detecting decimal Combat Wisdom. - Fazfoxy (https://github.com/hannibal002/SkyHanni/pull/5847)
-+ Fixed ghost tracker not detecting rare drops. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6034)
++ Fixed ghost tracker not detecting rare drops. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6034)
 + Fixed ConcurrentModificationException error in Hide Slayer Spawn Particles. - Luna (https://github.com/hannibal002/SkyHanni/pull/6051)
 
 #### GUI
@@ -374,7 +374,7 @@
 + Fixed some GUI features incorrectly detecting two objects as being hovered at once. - Luna (https://github.com/hannibal002/SkyHanni/pull/5980)
 + Fixed Pet Display sometimes not updating after Autopet switches pets. - akinsoft (https://github.com/hannibal002/SkyHanni/pull/5993)
 + Fixed Pet Display requiring Pet widget overflow XP when exact total/overflow XP text is not enabled. - akinsoft (https://github.com/hannibal002/SkyHanni/pull/6003)
-+ Fixed custom wardrobe freezing after the first click. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6036)
++ Fixed custom wardrobe freezing after the first click. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6036)
 + Fixed Pet Display visually keeping removed pet items. - Akinsoft (https://github.com/hannibal002/SkyHanni/pull/6066)
 
 #### Item Ability
@@ -398,7 +398,7 @@
 + Fixed occasional error in chat when opening Chocolate Factory. - Luna (https://github.com/hannibal002/SkyHanni/pull/5729)
 + Fixed Mute Bugged Spade Sounds not muting all bugged music. - Luna (https://github.com/hannibal002/SkyHanni/pull/5773)
 + Fixed Hoppity's Hunt Unclaimed Eggs feature never sending a notification when you restart your game during a hunt and don't collect any eggs. - Luna (https://github.com/hannibal002/SkyHanni/pull/5808)
-+ Fixed Hoppity rabbit count not being detected in the collection menu. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5960)
++ Fixed Hoppity rabbit count not being detected in the collection menu. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5960)
 + Fixed the Century Raffle Task Highlighter for the Year 500 raffle event. - Alex (https://github.com/hannibal002/SkyHanni/pull/5925)
 
 #### Fishing
@@ -407,8 +407,8 @@
 + Fixed Tiki Mask being added to the Fishing Profit Tracker every time it was taken off the head. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5294)
 + Fixed Thunder Sparks triggering Custom Circles from the Fire Freeze feature. - Fazfoxy (https://github.com/hannibal002/SkyHanni/pull/5319)
 + Added support for new Reindrake spawn message. - Luna (https://github.com/hannibal002/SkyHanni/pull/5513)
-+ Fixed Personal Sea Creature Cap. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5692)
-+ Fixed bait change warning detecting other peoples bait as a bait change. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5698)
++ Fixed Personal Sea Creature Cap. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5692)
++ Fixed bait change warning detecting other peoples bait as a bait change. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5698)
   + Uses the 9th slot for bait detection now.
 + Fixed false fishing bait change warnings when opening a GUI while holding a fishing rod. - Luna (https://github.com/hannibal002/SkyHanni/pull/5806)
 + Fixed fishing profit tracker falsely reporting gaining bait when using it. - Luna (https://github.com/hannibal002/SkyHanni/pull/5819)
@@ -418,7 +418,7 @@
 + Fixed exception thrown while parsing Fishing Bestiary level. - Twarug (https://github.com/hannibal002/SkyHanni/pull/5914)
 + Fixed Sea Creature Tracker error when attempting to migrate outdated sea creature names to new ones. - Luna (https://github.com/hannibal002/SkyHanni/pull/5900)
 + Fixed Fishing Tracker disappearing while killing mobs occasionally. - Fazfoxy (https://github.com/hannibal002/SkyHanni/pull/5708)
-+ Fixed Obfuscated Fish 1 and 2 not counting as bait. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5833)
++ Fixed Obfuscated Fish 1 and 2 not counting as bait. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5833)
 + Fixed Trophy Fish related features not working. - Fazfoxy (https://github.com/hannibal002/SkyHanni/pull/6022)
 
 #### Item
@@ -434,11 +434,11 @@
 
 + Fixed Croesus Highlight not working on chests made on a separate game instance. - Fazfoxy (https://github.com/hannibal002/SkyHanni/pull/5322)
 + Fixed Dungeon Clean End feature not working. - Luna (https://github.com/hannibal002/SkyHanni/pull/5386)
-+ Fixed Dungeon Finder class and Catacombs level detection. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5910)
-+ Fixed Dungeon Finder features not detecting classes. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6014)
-+ Fixed Dungeon Finder features not working outside of dungeon hub. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6014)
-+ Fixed dungeon floor detection being broken due to new update. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6018)
-+ Fixed dungeon chat filter not filter certain blessings. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6053)
++ Fixed Dungeon Finder class and Catacombs level detection. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5910)
++ Fixed Dungeon Finder features not detecting classes. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6014)
++ Fixed Dungeon Finder features not working outside of dungeon hub. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6014)
++ Fixed dungeon floor detection being broken due to new update. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6018)
++ Fixed dungeon chat filter not filter certain blessings. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6053)
 
 #### Foraging
 
@@ -465,24 +465,24 @@
 + Fixed Wardrobe background rendering over entities. - FabiHBBBT (https://github.com/hannibal002/SkyHanni/pull/5577)
 + Fixed not being able to move both displays while in the trade menu. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5680)
 + Fixed Recipe Achievement not being possible. - nopo (https://github.com/hannibal002/SkyHanni/pull/5558)
-+ Fixed Croesus chest tracker sometimes producing an error for expired chests. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5884)
++ Fixed Croesus chest tracker sometimes producing an error for expired chests. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5884)
 + Fixed enchant parsing for Fatal Tempo and stacked enchants. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5892)
 + Fixed enchant parsing for items with Fatal Tempo or missing color code prefixes. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5908)
-+ Fixed random errors happening while in inventories. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5895)
++ Fixed random errors happening while in inventories. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5895)
 + Fixed stacking enchant progress not displaying. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5908)
-+ Fixed Bazaar cancelled Buy Order clipboard not working. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5936)
++ Fixed Bazaar cancelled Buy Order clipboard not working. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5936)
 + Fixed some HUD overlays moving or resizing when opening inventories with a separate inventory GUI scale. - akinsoft (https://github.com/hannibal002/SkyHanni/pull/5851)
 + Fixed Improved SkyBlock Menus treating all black stained glass pane items as filler menu items. - Luna (https://github.com/hannibal002/SkyHanni/pull/5930)
 + Fixed Stacking Enchant Progress always displaying progress out of 0. - BonkersTurnip (https://github.com/hannibal002/SkyHanni/pull/5800)
 + Fixed a very important typo in the ULTRA-RARE Book alert feature. - Stella (https://github.com/hannibal002/SkyHanni/pull/5986)
 + Fixed the Experimentation Table dry-streak tracker not resetting when finding a non-book Ultra-Rare item (e.g. Severed Pincer or End Stone Idol). - RemainingDelta (https://github.com/hannibal002/SkyHanni/pull/5981)
-+ Reduced the number of random errors happening in inventories. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5977)
++ Reduced the number of random errors happening in inventories. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5977)
 + Fixed error when opening pets menu when there are pets without alternate skin data. - akinsoft (https://github.com/hannibal002/SkyHanni/pull/5990)
-+ Fixed Better SkyBlock Containers not rendering slot background for empty slots. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6005)
++ Fixed Better SkyBlock Containers not rendering slot background for empty slots. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6005)
 + Fixed Colorful Item Stats not working with some stats. - Luna (https://github.com/hannibal002/SkyHanni/pull/6023)
-+ Fixed Custom wardrobe not working with new hypixel update. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5933)
++ Fixed Custom wardrobe not working with new hypixel update. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5933)
 + Fixed maxwell features when you have a second page of power stones. - CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/6025)
-+ Fixed Maxwell tuning stats sometimes not being detected correctly. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6011)
++ Fixed Maxwell tuning stats sometimes not being detected correctly. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6011)
 + Fixed tab list and inventory detection for stats with the new official SkyBlock resource pack. - Luna (https://github.com/hannibal002/SkyHanni/pull/6023)
 + Fixed non-book ultra rare items in Superpairs not triggering the mid-game notification immediately when uncovered. - RemainingDelta (https://github.com/hannibal002/SkyHanni/pull/6071)
 + Fixed prevent missing rabbit the fish sometimes causing you to not be able to close other inventories. - CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/6087)
@@ -491,10 +491,10 @@
 
 + Fixed colored item names in `/viewrecipe` autocomplete. - Daveed (https://github.com/hannibal002/SkyHanni/pull/5434)
 + Fixed issues with GFS auto-complete. - Daveed (https://github.com/hannibal002/SkyHanni/pull/5494)
-+ Fixed SkyHanni command arguments containing quotes getting truncated. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5787)
++ Fixed SkyHanni command arguments containing quotes getting truncated. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5787)
 + Fixed /shnav ignoring exact location matches when similarly named locations exist. - legentpc (https://github.com/hannibal002/SkyHanni/pull/5966)
 + Fixed `/gfs` tab-complete showing internal names on 26.1.2. - legentpc (https://github.com/hannibal002/SkyHanni/pull/5958)
-+ Fixed /shminingspeed and /shblockstrength giving not being able to read your stats. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6088)
++ Fixed /shminingspeed and /shblockstrength giving not being able to read your stats. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6088)
 
 #### Mining
 
@@ -508,9 +508,9 @@
 + Fixed Mineshaft Cave-in Timer estimate not working. - FabiHBBBT (https://github.com/hannibal002/SkyHanni/pull/5907)
 + Fixed description for Auto-Load Shaft Routes giving incorrect examples for route names. - Luna (https://github.com/hannibal002/SkyHanni/pull/5904)
 + Fixed Glacite Mineshaft entrance/ladder waypoints being set to wrong location. - Piggered (https://github.com/hannibal002/SkyHanni/pull/5858)
-+ Fixed glacite tunnels auto commision not working due to hypixel update. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6015)
-+ Fixed mineshaft mayham perk buff giving an error. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6055)
-+ Fixed gemstones not being detected in treasure chests. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6030)
++ Fixed glacite tunnels auto commision not working due to hypixel update. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6015)
++ Fixed mineshaft mayham perk buff giving an error. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6055)
++ Fixed gemstones not being detected in treasure chests. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6030)
 
 #### Chat
 
@@ -568,7 +568,7 @@
 + Fixed errors with legacy Fishing Weapon items. - Luna (https://github.com/hannibal002/SkyHanni/pull/5647)
 + Fixed overbloom being an unknown stat. - Rain (https://github.com/hannibal002/SkyHanni/pull/5648)
 + Fixed reforge detection for new Farming Tool item category. - Luna (https://github.com/hannibal002/SkyHanni/pull/5647)
-+ Fixed the Bouncy Ball thresholds not matching the updated values. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5643)
++ Fixed the Bouncy Ball thresholds not matching the updated values. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5643)
 + Fixed config being written when on Alpha. - Rain
     * The mod won't write to config anymore when on Alpha, removing data sync/overwriting errors between Alpha and prod.
 + Adjusted Trapper Cooldown to permanently use the lower cooldown now that Pelt-pocalypse is permanent. - Luna
@@ -606,31 +606,31 @@
     + This includes any feature that relied on the Graph system to check current area such as Slayer/Carnival features.
 + Fixed in-world chroma text not rendering properly (especially with Everything Chroma). - Luna (https://github.com/hannibal002/SkyHanni/pull/5863)
 + Fixed Kotlin being bundled in the 26.1 JAR which may have caused compatibility issues with some mods. - Luna (https://github.com/hannibal002/SkyHanni/pull/5828)
-+ Fixed minor spelling mistakes. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5875)
++ Fixed minor spelling mistakes. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5875)
 + Fixed error with Lava Replacement when switching lobbies. - Luna (https://github.com/hannibal002/SkyHanni/pull/5878)
 + Fixed Lava Replacement not working on 26.1. - Luna (https://github.com/hannibal002/SkyHanni/pull/5878)
 + Fixed mods that interfere with lava rendering (e.g. IQ Addons) making SkyHanni's Lava Replacement translucent. - Luna (https://github.com/hannibal002/SkyHanni/pull/5878)
 + Fixed Trapper Cooldown often showing as ready up to a second too early. - Luna (https://github.com/hannibal002/SkyHanni/pull/5890)
 + Fixed a rare case with error handling sometimes infinitely recursing and causing the game to freeze or crash. - Luna (https://github.com/hannibal002/SkyHanni/pull/5943)
 + Fixed API errors not including the server response in error logs, making bug reports easier to act on. - Luna (https://github.com/hannibal002/SkyHanni/pull/5830)
-+ Fixed Notice Me Senpai Achievement description. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5947)
-+ Fixed memory leaks caused by caches keeping unused objects alive. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5934)
++ Fixed Notice Me Senpai Achievement description. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5947)
++ Fixed memory leaks caused by caches keeping unused objects alive. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5934)
 + Fixed Trevor highlight & cooldown status above Trevor not working. - Luna (https://github.com/hannibal002/SkyHanni/pull/5891)
 + Fixed memory leak and out-of-memory errors caused by the item cache never getting cleared on 26.1. - Luna (https://github.com/hannibal002/SkyHanni/pull/5971)
 + Fixed rare IllegalStateException in ServerBlockChangeEvent errors when joining Hypixel or switching lobbies. - Luna (https://github.com/hannibal002/SkyHanni/pull/5979)
 + Fixed SkyHanni causing the game to freeze for multiple seconds on the Loading Terrain screen on 26.1. - Luna (https://github.com/hannibal002/SkyHanni/pull/5971)
     + This would mainly happen the first time you joined a world (e.g. by connecting to Hypixel) after a game restart, but could also happen later.
-+ Fixed not being able to detect particles hidden by Sodium-Extra. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5991)
-+ Fixed area detection being broken due to new texture pack. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6016)
++ Fixed not being able to detect particles hidden by Sodium-Extra. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5991)
++ Fixed area detection being broken due to new texture pack. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6016)
 + Fixed contributors' suffixes in nametags being too close to the username when no emblem is equipped. - Piggered (https://github.com/hannibal002/SkyHanni/pull/5996)
-+ Fixed other mods breaking particle detection. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6002)
-+ Fixed Skymall / Lottery perks giving an error. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6012)
-+ Fixed Skymall/Lottery display being colorless. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6048)
-+ Fixed Skymall/Lottery not being detected in the hotm/hotf menu. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6048)
-+ Fixed skyhanni user luck breakdown randomly giving an error. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6054)
++ Fixed other mods breaking particle detection. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6002)
++ Fixed Skymall / Lottery perks giving an error. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6012)
++ Fixed Skymall/Lottery display being colorless. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6048)
++ Fixed Skymall/Lottery not being detected in the hotm/hotf menu. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6048)
++ Fixed skyhanni user luck breakdown randomly giving an error. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6054)
 + Fixed pet names displaying incorrectly in trackers. - CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/6046)
 + Fixed /shresetfeastdata not working if Fetch Upcoming Feast Data is disabled. - Luna (https://github.com/hannibal002/SkyHanni/pull/6043)
-+ Fixed cold detection not working due to skyblock NOT using the new cold icon. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6074)
++ Fixed cold detection not working due to skyblock NOT using the new cold icon. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6074)
 + Fixed fusion display not showing outside Galatea (for when calling Kysha). - CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/6065)
 + Fixed Overflow Skill Level in tooltip showing inaccurate XP & not calculating level properly. - Rain (https://github.com/hannibal002/SkyHanni/pull/6082)
 
@@ -868,14 +868,14 @@
 + Added incremental cache for primary functions. - Daveed (https://github.com/hannibal002/SkyHanni/pull/5642)
 + Added support for the 2026 Cake Hat colors to the Item Resolution Query. - jani (https://github.com/hannibal002/SkyHanni/pull/5865)
 + Fixed generateRepoPatterns Gradle task not working. - Luna (https://github.com/hannibal002/SkyHanni/pull/5840)
-+ Added Component, UUID, and Player Brigadier Argument types. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5787)
++ Added Component, UUID, and Player Brigadier Argument types. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5787)
 + Added comprehensive docs to the chat event classes. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5903)
 + Added prodClient Gradle task for testing non-dev-env behavior. - Luna (https://github.com/hannibal002/SkyHanni/pull/5704)
-+ Added storage for seen SkyHanni contributors. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5787)
-+ Added storage for tracking timestamps of when another player mentioned a SkyHanni contributor in chat (only active for contributor players). - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5787)
++ Added storage for seen SkyHanni contributors. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5787)
++ Added storage for tracking timestamps of when another player mentioned a SkyHanni contributor in chat (only active for contributor players). - Avrg (https://github.com/hannibal002/SkyHanni/pull/5787)
 + Changed backup repo from .zip to .tar.gz. - Luna (https://github.com/hannibal002/SkyHanni/pull/5633)
 + Changed repo download from JGit/.zip to .tar.gz. - Luna (https://github.com/hannibal002/SkyHanni/pull/5633)
-+ Fixed all the Detekt warnings. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5785)
++ Fixed all the Detekt warnings. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5785)
 + Improved GitHub Actions build process. - Luna (https://github.com/hannibal002/SkyHanni/pull/5877)
     + All versions are now built in parallel and the uploaded JARs are no longer zipped.
 + Removed the unused `blockedReason` parameter from all Modify chat event classes. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5903)
@@ -885,11 +885,11 @@
 + Documented KSP annotation processing and mixin coding conventions in CONTRIBUTING.md. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5918)
 + Fixed invalid Classtweaker entries for 26.1. - Luna (https://github.com/hannibal002/SkyHanni/pull/5845)
 + Re-enabled Classtweaker validation for 26.1. - Luna (https://github.com/hannibal002/SkyHanni/pull/5845)
-+ Added DelayedServerRun utility. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5790)
-+ Changed `PlayerUtils` to use `localUser` instead of `localPlayer` for player name and UUID lookup. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5947)
++ Added DelayedServerRun utility. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5790)
++ Changed `PlayerUtils` to use `localUser` instead of `localPlayer` for player name and UUID lookup. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5947)
 + Cleaned up code duplication around InventoryUtils. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5809)
-+ Fixed ServerTimeMark having underflow issues. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5790)
-+ Fixed SimpleTimeMark having overflow issues. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5790)
++ Fixed ServerTimeMark having underflow issues. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5790)
++ Fixed SimpleTimeMark having overflow issues. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5790)
 + Merged all mouse sensitivity features into `MouseSensitivityReducer`. - zumbiepig (https://github.com/hannibal002/SkyHanni/pull/5796)
     + `MouseMixin` now hooks into `player.turn(x, y)` rather than `options.sensitivity().get()`.
 + Moved lootshare-related rendering and range to LootshareUtils. - Fazfoxy (https://github.com/hannibal002/SkyHanni/pull/5708)
@@ -908,26 +908,26 @@
     + Used a workflow_run two-workflow split so fork PRs are handled securely without running fork-controlled code with write permissions.
     + Managed a "Detekt" label on the PR based on whether violations are found.
 + Added `post_detekt_review.main.kts` Kotlin script for parsing SARIF output and calling the GitHub review API. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5905)
-+ Bumped Kotlin version to 2.4.0. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5959)
++ Bumped Kotlin version to 2.4.0. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5959)
 + Fixed REI transitive dependencies not being properly excluded, leading to a bunch of log spam at compile time from Loom remap warnings. - Luna (https://github.com/hannibal002/SkyHanni/pull/5940)
-+ Resolved all compilation warnings. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5940)
-+ Suppressed deprecation warnings in build process. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5940)
++ Resolved all compilation warnings. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5940)
++ Suppressed deprecation warnings in build process. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5940)
 + Updated `detekt.yml` to save the SARIF output as a workflow artifact. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5905)
 + Updated INSTALLING.md with installation instructions for modern Fabric-based Minecraft versions. - protocol4 (https://github.com/hannibal002/SkyHanni/pull/5984)
 + Removed unused Git commit-related data classes. - Luna (https://github.com/hannibal002/SkyHanni/pull/5944)
-+ Removed unused kotest and power-assert dependencies. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5955)
++ Removed unused kotest and power-assert dependencies. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5955)
 + Removed unused Year 300 features. - Luna (https://github.com/hannibal002/SkyHanni/pull/5974)
 + Fixed `InventoryUtils.getItemInHand` returning an AIR `ItemStack` instead of null for an empty main hand. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5768)
 + Fixed config migrator not adding values to all profiles. - FabiHBBBT (https://github.com/hannibal002/SkyHanni/pull/5807)
 + Made a way to generate nullable repo patterns. - CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/6024)
-+ Made dungeon floor detection use repo patterns. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6018)
-+ Made DungeonFinderFeatures regex colorless. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6014)
-+ Made Hotx features colorless. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6012)
++ Made dungeon floor detection use repo patterns. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6018)
++ Made DungeonFinderFeatures regex colorless. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6014)
++ Made Hotx features colorless. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6012)
 + Made non god pot data use the repo. - CalMWolfs (https://github.com/hannibal002/SkyHanni/pull/6024)
 + Made the StorageVarOrVal detekt rule enforce `val` for config entries annotated with `@ConfigEditorInfoText`. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5988)
-+ Made TunnelsMaps regex colorless. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6015)
++ Made TunnelsMaps regex colorless. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6015)
 + Refactored Achievement constructors and enforced named parameters. - hannibal2 (https://github.com/hannibal002/SkyHanni/pull/5902)
-+ Reworked ParticleEvent to fire early while deferring cancellation until later in packet handling, improving mod interoperability. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6002)
++ Reworked ParticleEvent to fire early while deferring cancellation until later in packet handling, improving mod interoperability. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6002)
 + Added DataComponentMap.getLoreComponent and DataComponentMap.getCleanLore. - Luna (https://github.com/hannibal002/SkyHanni/pull/5596)
 + Added FakePlayer.fromLocalPlayer and FakePlayer.fromLocalPlayerOrThrow methods. - Luna (https://github.com/hannibal002/SkyHanni/pull/5579)
 + Added ItemStack.getCleanLore. - Luna (https://github.com/hannibal002/SkyHanni/pull/5596)
@@ -941,11 +941,11 @@
 + Renamed ElectionCandidate.perks to allPerks. - Luna (https://github.com/hannibal002/SkyHanni/pull/6040)
 + Replaced ItemStack.getSingleLineLore with new List\<String>.toSingleLineLore method. - Luna (https://github.com/hannibal002/SkyHanni/pull/5596)
 + Restricted /shreloadlisteners and /shstoplisteners to development environment. - Luna (https://github.com/hannibal002/SkyHanni/pull/6044)
-+ Added fallback island api name. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6080)
++ Added fallback island api name. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6080)
 + Changed Entity.cleanName and SafeItemStack.cleanName from a method to a property. - Luna (https://github.com/hannibal002/SkyHanni/pull/5597)
 + Event handler functions are no longer required to be public. - Luna (https://github.com/hannibal002/SkyHanni/pull/5584)
-+ Fixed reading stats from skyblock menu not working. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6088)
-+ Moved some old stat icons regex usage to new ones. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/6068)
++ Fixed reading stats from skyblock menu not working. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6088)
++ Moved some old stat icons regex usage to new ones. - Avrg (https://github.com/hannibal002/SkyHanni/pull/6068)
 + Renamed MinecraftCompat.localPlayer to MinecraftCompat.localPlayerOrThrow. - Luna (https://github.com/hannibal002/SkyHanni/pull/5887)
 + Renamed MinecraftCompat.localWorld to MinecraftCompat.localWorldOrThrow. - Luna (https://github.com/hannibal002/SkyHanni/pull/5887)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -75,7 +75,7 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
     + Plays bark sound when 'woof' appears in chat.
 + Added option to shorten coin amounts in chat messages. - Daveed (https://github.com/hannibal002/SkyHanni/pull/3231)
 + Added filters for reward bundles reminders, redundant shard hunting messages, and unmineable trees. - Erymanthus (https://github.com/hannibal002/SkyHanni/pull/4327)
-+ Added a chat message when you encounter a SkyHanni contributor for the first time. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5787)
++ Added a chat message when you encounter a SkyHanni contributor for the first time. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5787)
 
 </details>
 <details open><summary>
@@ -319,8 +319,8 @@ Use `/sh` or `/skyhanni` to open the SkyHanni config in game.
   + Highlights completed categories in green.
 + Added Gift Clean Display: Show only 'CLICK TO OPEN' on gifts, hiding the From/To name. - LegentPc (https://github.com/hannibal002/SkyHanni/pull/5619)
 + Added Loadout Keybinds. - FabiHBBBT (https://github.com/hannibal002/SkyHanni/pull/6013)
-+ Added Option To Move `Insert Item Into Sack` button back to original placement. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5874)
-+ Block Overriding Rare Reforges in Blacksmith and Hex. - AverageUser125 (https://github.com/hannibal002/SkyHanni/pull/5856)
++ Added Option To Move `Insert Item Into Sack` button back to original placement. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5874)
++ Block Overriding Rare Reforges in Blacksmith and Hex. - Avrg (https://github.com/hannibal002/SkyHanni/pull/5856)
 
 </details>
 <details open><summary>


### PR DESCRIPTION
## What
This doesn't really matter, and since the mod uses modrinth to get the changelog and this doesn't even update it.
But eh.
I would rather start being consistent.
I just changed "AverageUser125" -> "Avrg".
This way definitely no more changelogs over 2000 characters.

exclude_from_changelog

