### PR TITLE
Fix: shnav having colored command suggestions

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNode.kt
@@ -14,7 +14,7 @@ class GraphNode(
     val extraWeight: Int = 0,
 ) : GraphUtils.GenericNode {
 
-    val cleanName
+    val cleanName: String?
         get() = name?.removeColor()
 
     val tags: List<GraphNodeTag> by lazy {

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNode.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.features.misc.pathfind.NavigationHelper
 import at.hannibal2.skyhanni.test.graph.GraphEditor
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 
 class GraphNode(
     val id: Int,
@@ -12,6 +13,9 @@ class GraphNode(
     val tagNames: List<String> = emptyList(),
     val extraWeight: Int = 0,
 ) : GraphUtils.GenericNode {
+
+    val cleanName
+        get() = name?.removeColor()
 
     val tags: List<GraphNodeTag> by lazy {
         tagNames.mapNotNull { GraphNodeTag.byId(it) }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.onClick
@@ -52,7 +53,7 @@ object NavigationHelper {
 
         if (config.allowInstantNavigation) {
             val exactMatch = locations.firstOrNull { (name, _) ->
-                name.substringBefore(" §7(").equals(searchTerm, ignoreCase = true)
+                name.substringBefore(" (").equals(searchTerm, ignoreCase = true)
             }
 
             val target = exactMatch ?: locations.takeIf { it.size == 1 }?.first()
@@ -108,7 +109,7 @@ object NavigationHelper {
             // no need to navigate to the current area
             if (node.name == SkyBlockUtils.graphArea) continue
             val tag = node.tags.first { it in allowedTags }
-            val name = "${node.name} §7(${tag.displayName}§7)"
+            val name = "${node.cleanName} §7(${tag.displayName}§7)"
             if (name in names) continue
             names[name] = node
         }
@@ -124,7 +125,7 @@ object NavigationHelper {
         val distances = mutableMapOf<GraphNode, Double>()
         for (node in graph) {
             if (!node.enabled) continue
-            val name = node.name ?: continue
+            val name = node.cleanName ?: continue
             val remainingTags = node.tags.filter { it in allowedTags }
             if (remainingTags.isEmpty()) continue
             if (name.lowercase().contains(searchTerm)) {
@@ -148,7 +149,7 @@ object NavigationHelper {
             }
             argCallback("search", BrigadierArguments.greedyString(), BrigadierUtils.dynamicSuggestionProvider { getNames() }) {
                 SkyHanniMod.launchCoroutine("shnavigate command") {
-                    doCommandAsync(it.lowercase())
+                    doCommandAsync(it.lowercase().removeColor())
                 }
             }
             simpleCallback {
@@ -159,7 +160,7 @@ object NavigationHelper {
 
     private fun getNames(): List<String> {
         val graph = IslandGraphs.currentIslandGraph ?: return emptyList()
-        return graph.filterByActive { it.isValidAreaNode() }.mapNotNull { it.name }
+        return graph.filterByActive { it.isValidAreaNode() }.mapNotNull { it.cleanName }
     }
 
     private fun GraphNode.isValidAreaNode(): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -53,7 +53,7 @@ object NavigationHelper {
 
         if (config.allowInstantNavigation) {
             val exactMatch = locations.firstOrNull { (name, _) ->
-                name.substringBefore(" (").equals(searchTerm, ignoreCase = true)
+                name.substringBefore(" §7(").equals(searchTerm, ignoreCase = true)
             }
 
             val target = exactMatch ?: locations.takeIf { it.size == 1 }?.first()


### PR DESCRIPTION
## What
the command /shnav has color codes, so now it doesn't care about them.

Images of it working and not having suggestions be color codes:
<details>
<summary>Images</summary>
<img width="379" height="280" alt="image" src="https://github.com/user-attachments/assets/4f0cfca0-28c0-453d-988d-8186af3376d2" />
<img width="824" height="608" alt="image" src="https://github.com/user-attachments/assets/3c5d85cc-f40b-4e27-aa35-a388ded03d17" />

</details>

## Changelog Fixes
+ Fixed `/shnav` command not properly handling color codes in location names. - Avrg

