### PR TITLE
Fix: PestFinder wrong thread

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/hypixelapi/HypixelLocationApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/hypixelapi/HypixelLocationApi.kt
@@ -160,8 +160,9 @@ object HypixelLocationApi {
             }
         }
         if (island != IslandType.NONE) {
+            val captured = previousIsland
             DelayedRun.runOrNextTick {
-                IslandJoinEvent(island = island, previousIsland = previousIsland).post()
+                IslandJoinEvent(island = island, previousIsland = captured).post()
             }
             previousIsland = island
         }

--- a/src/main/java/at/hannibal2/skyhanni/api/hypixelapi/HypixelLocationApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/hypixelapi/HypixelLocationApi.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.events.hypixel.modapi.HypixelApiServerChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.ScoreboardTitleUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SkyHanniLogger
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -154,14 +155,20 @@ object HypixelLocationApi {
         EventListeners.markEventCacheDirty()
 
         if (oldIsland != IslandType.NONE) {
-            IslandLeaveEvent(oldIsland).post()
+            DelayedRun.runOrNextTick {
+                IslandLeaveEvent(oldIsland).post()
+            }
         }
         if (island != IslandType.NONE) {
-            IslandJoinEvent(island = island, previousIsland = previousIsland).post()
+            DelayedRun.runOrNextTick {
+                IslandJoinEvent(island = island, previousIsland = previousIsland).post()
+            }
             previousIsland = island
         }
 
-        IslandChangeEvent(island, oldIsland).post()
+        DelayedRun.runOrNextTick {
+            IslandChangeEvent(island, oldIsland).post()
+        }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -26,6 +26,7 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotApi.sendTeleportTo
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
@@ -125,8 +126,10 @@ object PestFinder {
 
     @HandleEvent
     fun onIslandChange(event: IslandChangeEvent) {
-        display = listOf()
-        update()
+        DelayedRun.runOrNextTick {
+            display = listOf()
+            update()
+        }
     }
 
     init {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.config.features.garden.pests.PestFinderConfig.WhenT
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleManager
+import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestUpdateEvent
@@ -122,8 +123,8 @@ object PestFinder {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onIslandJoin() {
+    @HandleEvent
+    fun onIslandChange(event: IslandChangeEvent) {
         display = listOf()
         update()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.config.features.garden.pests.PestFinderConfig.WhenT
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleManager
-import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestUpdateEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.config.features.garden.pests.PestFinderConfig.WhenT
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleManager
-import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestUpdateEvent
@@ -124,8 +124,8 @@ object PestFinder {
         }
     }
 
-    @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    fun onIslandJoin() {
         DelayedRun.runOrNextTick {
             display = listOf()
             update()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -25,7 +25,6 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotApi.sendTeleportTo
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils
-import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
@@ -125,10 +124,8 @@ object PestFinder {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onIslandJoin() {
-        DelayedRun.runOrNextTick {
-            display = listOf()
-            update()
-        }
+        display = listOf()
+        update()
     }
 
     init {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -114,10 +114,10 @@ object PestSpawnTimer {
                 pestSpawned = false
             }
         } ?: run {
-            if (widgetLines.all { it.isBlank() }) return
+            if (widgetLines.isEmpty() || widgetLines.all { it.isBlank() }) return
 
             ErrorManager.logErrorStateWithData(
-                "Could not find pest cooldown time in widget update event.",
+                "Could not find pest cooldown time from widget.",
                 internalMessage = "Could not find pest cooldown time in widget update event.",
                 "widgetLines" to widgetLines,
             )

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -28,6 +28,7 @@ import at.hannibal2.skyhanni.features.garden.pests.PestApi.lastPestSpawnTime
 import at.hannibal2.skyhanni.features.inventory.wardrobe.ArmorWardrobeApi
 import at.hannibal2.skyhanni.features.inventory.wardrobe.EquipmentWardrobeApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
@@ -111,6 +112,14 @@ object PestSpawnTimer {
                 hasReminderShown = false
                 pestSpawned = false
             }
+        } ?: run {
+            if (event.widget.lines.all { it.string.isBlank() }) return
+
+            ErrorManager.logErrorStateWithData(
+                "Could not find pest cooldown time in widget update event.",
+                internalMessage = "Could not find pest cooldown time in widget update event.",
+                "widgetLines" to event.widget.lines.map { it.string },
+            )
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -113,12 +113,13 @@ object PestSpawnTimer {
                 pestSpawned = false
             }
         } ?: run {
-            if (event.widget.lines.all { it.string.isBlank() }) return
+            val widgetLines = event.widget.lines.map { it.string }
+            if (widgetLines.all { it.isBlank() }) return
 
             ErrorManager.logErrorStateWithData(
                 "Could not find pest cooldown time in widget update event.",
                 internalMessage = "Could not find pest cooldown time in widget update event.",
-                "widgetLines" to event.widget.lines.map { it.string },
+                "widgetLines" to widgetLines,
             )
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -91,8 +91,9 @@ object PestSpawnTimer {
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.PESTS)) return
+        val widgetLines = event.widget.lines.map { it.string }
 
-        pestCooldownPattern.firstMatcher(event.widget.lines.map { it.string }) {
+        pestCooldownPattern.firstMatcher(widgetLines) {
             val time = groupOrNull("time")?.let { getTablistEndTime(it, pestCooldownEndTime) }
             ready = hasGroup("ready")
             maxPests = hasGroup("maxPests")
@@ -113,7 +114,6 @@ object PestSpawnTimer {
                 pestSpawned = false
             }
         } ?: run {
-            val widgetLines = event.widget.lines.map { it.string }
             if (widgetLines.all { it.isBlank() }) return
 
             ErrorManager.logErrorStateWithData(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -114,7 +114,7 @@ object PestSpawnTimer {
                 pestSpawned = false
             }
         } ?: run {
-            if (widgetLines.isEmpty() || widgetLines.all { it.isBlank() }) return
+            if (widgetLines.all { it.isBlank() }) return
 
             ErrorManager.logErrorStateWithData(
                 "Could not find pest cooldown time from widget.",


### PR DESCRIPTION
## What
I tried to figure out why the pest timer randomly didn't work, and had a wrong thread happend in pest finder. so fixed that.
I couldn't figure out why, so I for now just added an error in the case it couldn't fix the time remaining time part.
and the widget wasn't completely empty. (which happened when joining the island)

I just hope this error won't have alot of false positive for when they first join the garden.

## Changelog Fixes
+ Fixed Pest Finder giving an error when joining the Garden. - Avrg

## Changelog Technical Details
+ Made IslandLeaveEvent, IslandJoinEvent and IslandChangeEvent run on the render thread. - Avrg
