### PR TITLE
Backend: detektGitDiff

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -1,4 +1,3 @@
-# Execution context: PR branch code
 name: Detekt
 
 on:
@@ -35,6 +34,19 @@ jobs:
                 if: github.repository == 'hannibal002/SkyHanni'
             -   uses: ./.github/actions/setup-normal-workspace
                 if: github.repository != 'hannibal002/SkyHanni'
+
+            -   name: Run detekt git diff w/gradle retry
+                if: github.repository == 'hannibal002/SkyHanni'
+                uses: ./.github/actions/gradle-retry
+                with:
+                    gradle-command: detektGitDiff --stacktrace
+
+            -   name: Run detekt git diff w/gradle retry
+                if: github.repository != 'hannibal002/SkyHanni'
+                uses: ./.github/actions/gradle-retry
+                with:
+                    gradle-command: detektGitDiff --stacktrace
+
             -   name: Run detekt main (w/ typing analysis) w/gradle retry
                 id: run_detekt
                 if: github.repository == 'hannibal002/SkyHanni'

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -1,3 +1,4 @@
+# Execution context: PR branch code
 name: Detekt
 
 on:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -500,9 +500,9 @@ tasks.register("detektGitDiff", Detekt::class) {
     val detektDir = rootProject.layout.buildDirectory.dir("reports/detekt").get().asFile.absolutePath
     reports {
         html.required.set(true)
-        html.outputLocation.set(file("$detektDir/detekt-git-diff.html"))
+        html.outputLocation.set(file("$detektDir/main.html"))
         sarif.required.set(true)
-        sarif.outputLocation.set(file("$detektDir/detekt-git-diff.sarif"))
+        sarif.outputLocation.set(file("$detektDir/main.sarif"))
     }
 }.configure {
     val repoRoot = rootProject.projectDir

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -508,7 +508,7 @@ tasks.register("detektGitDiff", Detekt::class) {
     val repoRoot = rootProject.projectDir
     try {
         val gitOutput = providers.exec {
-            commandLine("git", "diff", "--name-only", "origin/beta")
+            commandLine("/usr/bin/git", "diff", "--name-only", "origin/beta")
         }.standardOutput.asText.get()
 
         if (gitOutput.isBlank()) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -506,37 +506,37 @@ tasks.register("detektGitDiff", Detekt::class) {
     }
 }.configure {
     val repoRoot = rootProject.projectDir
-
     try {
-
         val gitOutput = providers.exec {
             commandLine("git", "diff", "--name-only", "origin/beta")
         }.standardOutput.asText.get()
 
-        if (gitOutput.isNotBlank()) {
-            val modifiedKotlinFiles = gitOutput
-                .split("\n")
-                .filter { it.isNotBlank() && (it.endsWith(".kt") || it.endsWith(".java")) }
-                .map { repoRoot.resolve(it) }
-                .filter { it.exists() }
-
-            println("[detektGitDiff] Kotlin files found: ${modifiedKotlinFiles.size}")
-            modifiedKotlinFiles.forEach { println("[detektGitDiff]   - ${it.absolutePath}") }
-
-            if (modifiedKotlinFiles.isNotEmpty()) {
-                // Include files relative to the repository root so files anywhere in the repo are picked up
-                source = fileTree(repoRoot) {
-                    include(modifiedKotlinFiles.map { it.relativeTo(repoRoot).path })
-                }
-                println("[detektGitDiff] Source set to ${modifiedKotlinFiles.size} files")
-            } else {
-                println("[detektGitDiff] No Kotlin files found, disabling task")
-                onlyIf { false }
-            }
-        } else {
+        if (gitOutput.isBlank()) {
             println("[detektGitDiff] No files from git diff, disabling task")
             onlyIf { false }
+            return@configure
         }
+
+        val modifiedKotlinFiles = gitOutput
+            .split("\n")
+            .filter { it.isNotBlank() && (it.endsWith(".kt") || it.endsWith(".java")) }
+            .map { repoRoot.resolve(it) }
+            .filter { it.exists() }
+
+        println("[detektGitDiff] Kotlin files found: ${modifiedKotlinFiles.size}")
+        modifiedKotlinFiles.forEach { println("[detektGitDiff]   - ${it.absolutePath}") }
+
+        if (modifiedKotlinFiles.isEmpty()) {
+            println("[detektGitDiff] No Kotlin files found, disabling task")
+            onlyIf { false }
+            return@configure
+        }
+
+        source = fileTree(repoRoot) {
+            include(modifiedKotlinFiles.map { it.relativeTo(repoRoot).path })
+        }
+        println("[detektGitDiff] Source set to ${modifiedKotlinFiles.size} files")
+
     } catch (e: Exception) {
         println("[detektGitDiff] Error running git diff: ${e.message}")
         e.printStackTrace()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -489,6 +489,60 @@ tasks.withType<Detekt>().configureEach {
     }
 }
 
+tasks.register("detektGitDiff", Detekt::class) {
+    jvmTarget = target.minecraftVersion.formattedJavaLanguageVersion
+
+    config.setFrom(rootProject.layout.projectDirectory.file("detekt/detekt.yml"))
+    baseline = file(rootProject.layout.projectDirectory.file("detekt/baseline-main.xml"))
+    outputs.cacheIf { false }
+    outputs.upToDateWhen { false }
+
+    val detektDir = rootProject.layout.buildDirectory.dir("reports/detekt").get().asFile.absolutePath
+    reports {
+        html.required.set(true)
+        html.outputLocation.set(file("$detektDir/detekt-git-diff.html"))
+        sarif.required.set(true)
+        sarif.outputLocation.set(file("$detektDir/detekt-git-diff.sarif"))
+    }
+}.configure {
+    val repoRoot = rootProject.projectDir
+
+    try {
+
+        val gitOutput = providers.exec {
+            commandLine("git", "diff", "--name-only", "origin/beta")
+        }.standardOutput.asText.get()
+
+        if (gitOutput.isNotBlank()) {
+            val modifiedKotlinFiles = gitOutput
+                .split("\n")
+                .filter { it.isNotBlank() && (it.endsWith(".kt") || it.endsWith(".java")) }
+                .map { repoRoot.resolve(it) }
+                .filter { it.exists() }
+
+            println("[detektGitDiff] Kotlin files found: ${modifiedKotlinFiles.size}")
+            modifiedKotlinFiles.forEach { println("[detektGitDiff]   - ${it.absolutePath}") }
+
+            if (modifiedKotlinFiles.isNotEmpty()) {
+                // Include files relative to the repository root so files anywhere in the repo are picked up
+                source = fileTree(repoRoot) {
+                    include(modifiedKotlinFiles.map { it.relativeTo(repoRoot).path })
+                }
+                println("[detektGitDiff] Source set to ${modifiedKotlinFiles.size} files")
+            } else {
+                println("[detektGitDiff] No Kotlin files found, disabling task")
+                onlyIf { false }
+            }
+        } else {
+            println("[detektGitDiff] No files from git diff, disabling task")
+            onlyIf { false }
+        }
+    } catch (e: Exception) {
+        println("[detektGitDiff] Error running git diff: ${e.message}")
+        e.printStackTrace()
+        onlyIf { false }
+    }
+}
 tasks.withType<DetektCreateBaselineTask>().configureEach {
     val isTargetVersion = target == primaryTarget
     jvmTarget = target.minecraftVersion.formattedJavaLanguageVersion

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -80,7 +80,8 @@ object ClientEvents {
         ClientReceiveMessageEvents.MODIFY_GAME.register(::onModify)
         ClientReceiveMessageEvents.GAME_CANCELED.register(::onCanceled)
 
-        ClientLifecycleEvents.CLIENT_STOPPING.register { ClientShutdownEvent.post() }
+        ClientLifecycleEvents.CLIENT_STOPPING.register {   ClientShutdownEvent.post()
+        }
     }
 
     var currentMessage: Component? = null


### PR DESCRIPTION
## What
This is mostly just a concept. To see if this is even wanted/desired.

Basically it runs plain regular detekt, no analyzer, on all files changed relative to the upstream beta.
It runs this before detektMain since most detekt warnings that happen don't need the analyzer.
And the code for detektGitDiff itself is definitly a cobbled mess.

## Changelog Technical Details
+ Added detektGitDiff gradle target. - Avrg

