### PR TITLE
Backend: Shwords causing crash if text is somehow null

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/VisualWordsHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/VisualWordsHook.kt
@@ -12,17 +12,18 @@ object VisualWordsHook {
     val caxtonLoaded by lazy { PlatformUtils.isModInstalled("caxton") }
 
     @JvmStatic
-    fun modifyOrderedText(value: FormattedCharSequence): FormattedCharSequence =
+    fun modifyOrderedText(value: FormattedCharSequence?): FormattedCharSequence? =
         ModifyVisualWords.transformText(value) ?: value
 
     @JvmStatic
-    fun modifyString(value: String): String {
+    fun modifyString(value: String?): String? {
+        if (value == null) return null
         val replaced = ModifyVisualWords.transformText(OrderedTextUtils.legacyTextToOrderedText(value)) ?: return value
         return OrderedTextUtils.orderedTextToLegacyString(replaced)
     }
 
     @JvmStatic
-    fun modifyFormattedText(value: FormattedText): FormattedText =
+    fun modifyFormattedText(value: FormattedText?): FormattedText? =
         ModifyVisualWords.transformFormattedText(value) ?: value
 
     @JvmStatic


### PR DESCRIPTION
## What
Apparently the text can be null. so just made it compatible.
This ain't a fix since too techincal.

## Changelog Technical Details
+ Fixed shwords Kotlin hook causing a crash on null strings. - Avrg