### PR TITLE
Fix: They added a space to the skymall perk thingy

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxPatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hotx/HotxPatterns.kt
@@ -23,10 +23,11 @@ object HotxPatterns {
      * REGEX-TEST: ■ -20% Pickaxe Ability cooldowns.
      * REGEX-TEST: ■ 10x chance to find Golden and
      * REGEX-TEST: ■ Gain 5x Titanium drops.
+     * WRAPPED-REGEX-TEST: " ■ -20% Pickaxe Ability cooldowns."
      */
     val rotatingPerkPattern by patternGroup.pattern(
         "perk.generic",
-        """(?:New buff: |■ )(?<perk>.*)"""
+        """ ?(?:New buff: |■ )(?<perk>.*)"""
     )
 
     // The line that appears before the "current" perk effect in the item tooltip.


### PR DESCRIPTION
## What
10/10 PR name btw.
Anyways, they added a space at the front.
Idk if I should do like "/s+?" for the regex, but this is probably fine

## Changelog Fixes
+ Fixed SkyMall/Mayhem perks not being detected from the inventory. - Avrg
