### PR TITLE
Fix: Correct plural name for Praying Mantis

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -125,6 +125,7 @@ enum class PestType(
         VinylType.PRAY_FOR_ME,
         "PEST_PRAYING_MANTIS_MONSTER".toInternalName(),
         CropType.WILD_ROSE,
+        pluralName = "Praying Mantises",
         eliteLbName = "mantis",
     ),
     FIREFLY(


### PR DESCRIPTION
## What
Adds a proper `pluralName` to the Praying Mantis pest.

## Changelog Fixes
+ Fixed Pest Profit Tracker saying "Praying Mantiss" instead of "Praying Mantises". - Luna