### PR TITLE
Fix: Giant's Sword item ability cooldown detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -122,7 +122,7 @@ object ItemAbilityCooldown {
                 ItemAbility.SHADOW_FURY.sound()
             }
             // Giant's Sword
-            event.soundName == "block.anvil.land" && event.pitch == 0.4920635f && event.volume == 1f -> {
+            event.soundName == "block.anvil.land" && event.pitch == 0.4920635f && event.volume == 0.5f -> {
                 ItemAbility.GIANTS_SWORD.sound()
             }
             // Atomsplit Katana


### PR DESCRIPTION
## What
The item ability cooldown display does not currently work for the Giant's Sword. This PR fixes it by changing the volume.

## Changelog Fixes
+ Fixed the item ability cooldown detection for the Giant's Sword. - Maratons4

