### PR TITLE
Fix: Auto pet rule hider regex not detecting gdrag overflow skin

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
@@ -124,7 +124,7 @@ internal object PetStoragePatterns {
     @Suppress("MaxLineLength")
     val autoPetMessagePattern by patternGroup.pattern(
         "autopet.message.formatted",
-       "§cAutopet §eequipped your §7\\[Lvl (?<level>\\d+)] §(?<rarity>.)(?:\\[(?:§.)*\\d+(?:§.)*(?<altskin>✦)(?:§.)*] (?:§.)*)?(?<pet>[^§!]+?)(?<skin>§. ✦)?§e! §a§lVIEW RULE(?: \\(\\d+\\))?"
+        "§cAutopet §eequipped your §7\\[Lvl (?<level>\\d+)] §(?<rarity>.)(?:\\[(?:§.)*\\d+(?:§.)*(?<altskin>✦)(?:§.)*] (?:§.)*)?(?<pet>[^§!]+?)(?<skin>§. ✦)?§e! §a§lVIEW RULE(?: \\(\\d+\\))?"
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
@@ -124,7 +124,7 @@ internal object PetStoragePatterns {
     @Suppress("MaxLineLength")
     val autoPetMessagePattern by patternGroup.pattern(
         "autopet.message.formatted",
-        "§cAutopet §eequipped your §7\\[Lvl (?<level>\\d+)] §(?<rarity>.)(?:\\[(?:§.)*\\d+(?:§.)*(?<altskin>✦)(?:§.)*] (?:§.)*)?(?<pet>[^§!]+?)(?<skin>§. ✦)?§e! §a§lVIEW RULE(?: \\(\\d+\\))?"
+        "§cAutopet §eequipped your §7\\[Lvl (?<level>\\d+)] §(?<rarity>.)(?:\\[(?:§.)*\\d+(?:§.)*(?<altskin>✦)(?:§.)*] (?:§.)*)?(?<pet>[^§!]+?)(?<skin>§. ✦)?§e! §a§lVIEW RULE(?: \\(\\d+\\))?",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
@@ -107,6 +107,7 @@ internal object PetStoragePatterns {
      * REGEX-TEST: Autopet equipped your [Lvl 200] [122✦] Golden Dragon! VIEW RULE
      * REGEX-TEST: Autopet equipped your [Lvl 200] [34✦] Golden Dragon! VIEW RULE
      * REGEX-TEST: Autopet equipped your [Lvl 67] T-Rex! VIEW RULE
+     * REGEX-TEST: Autopet equipped your [Lvl 200] [335✦] Golden Dragon! VIEW RULE
      */
     @Suppress("MaxLineLength")
     val autoPetMessageColorlessPattern by patternGroup.pattern(
@@ -118,11 +119,12 @@ internal object PetStoragePatterns {
      * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 100] §6Mosquito§e! §a§lVIEW RULE
      * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 100] §5Rabbit§9 ✦§e! §a§lVIEW RULE
      * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 200] §6[122✦] Golden Dragon§e! §a§lVIEW RULE
+     * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 200] §8[§6335§8§4✦§8] §6Golden Dragon§e! §a§lVIEW RULE
      */
     @Suppress("MaxLineLength")
     val autoPetMessagePattern by patternGroup.pattern(
         "autopet.message.formatted",
-        "§cAutopet §eequipped your §7\\[Lvl (?<level>\\d+)] §(?<rarity>.)(?:\\[\\d+(?<altskin>✦)] )?(?<pet>[^§!]+?)(?<skin>§. ✦)?§e! §a§lVIEW RULE(?: \\(\\d+\\))?",
+       "§cAutopet §eequipped your §7\\[Lvl (?<level>\\d+)] §(?<rarity>.)(?:\\[(?:§.)*\\d+(?:§.)*(?<altskin>✦)(?:§.)*] (?:§.)*)?(?<pet>[^§!]+?)(?<skin>§. ✦)?§e! §a§lVIEW RULE(?: \\(\\d+\\))?"
     )
 
     /**


### PR DESCRIPTION
## What
for a specific skin it did not detect the message.
This should later use `matchStyledMatcher`, but for now this is fine.

## Changelog Fixes
+ Fixed not detecting Auto Pet Rule message for Golden Dragon overflow skin. - Avrg
