### PR TITLE
Fix: typo in RescueMissionConfig

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/RescueMissionConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/RescueMissionConfig.kt
@@ -14,7 +14,7 @@ class RescueMissionConfig {
     @Expose
     @ConfigOption(
         name = "Agent Path",
-        desc = "Show a path to the §eUndercover Agent §fwhen talking to the Rescue Recruter",
+        desc = "Show a path to the §eUndercover Agent §fwhen talking to the Rescue Recruiter",
     )
     @ConfigEditorBoolean
     @FeatureToggle

--- a/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/RescueMissionConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/crimsonisle/RescueMissionConfig.kt
@@ -14,7 +14,7 @@ class RescueMissionConfig {
     @Expose
     @ConfigOption(
         name = "Agent Path",
-        desc = "Show a path to the §eUndercover Agent §fwhen talking to the Rescue Recruiter",
+        desc = "Show a path to the §eUndercover Agent §7when talking to the Rescue Recruiter.",
     )
     @ConfigEditorBoolean
     @FeatureToggle


### PR DESCRIPTION
## What
Fixes a typo in the word "Recruiter" in RescueMissionConfig

## Changelog Fixes
+ Fixed typo in Crimson Isle rescue mission config. - jejebecarte