### PR TITLE
Backend: Fix Check PR Dependencies failing after merge (hopefully)

### DIFF
--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -20,6 +20,8 @@ jobs:
             -   name: Check out the repository
                 uses: actions/checkout@v7
                 with:
+                    # Avoid treating the trusted merge commit as fork code on merged PRs.
+                    ref: ${{ github.event.pull_request.base.ref }}
                     persist-credentials: false
 
             -   name: Evaluate dependency PRs


### PR DESCRIPTION
## What
This should hopefully stop Check PR Dependencies from failing on every PR after it's merged. We love GitHub jank.

exclude_from_changelog