### PR TITLE
Backend: Scatter Debug options

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.config.features.dev
 
-import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.data.ElectionCandidate
 import at.hannibal2.skyhanni.features.misc.update.SkyHanniUpdateSource
 import com.google.gson.annotations.Expose
@@ -8,7 +7,6 @@ import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
-import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
 import org.lwjgl.glfw.GLFW

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
@@ -29,15 +29,6 @@ class DebugConfig {
 
     @Expose
     @ConfigOption(
-        name = "Mod Menu Log",
-        desc = "Enable debug messages when the currently opened GUI changes, with the path to the gui class. " +
-            "Useful for adding more mods to quick mod menu switch.",
-    )
-    @ConfigEditorBoolean
-    var modMenuLog: Boolean = false
-
-    @Expose
-    @ConfigOption(
         name = "ApiUtils Never Silent",
         desc = "Forces ApiUtils' `silentError` to always be false, so that errors always debug to ErrorManager.",
     )
@@ -185,14 +176,6 @@ class DebugConfig {
     var eventCounter: Boolean = false
 
     @Expose
-    @ConfigOption(
-        name = "Bypass Advanced Tab List",
-        desc = "The Advanced Player Tab list is disabled while pressing this hotkey.",
-    )
-    @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
-    var bypassAdvancedPlayerTabList: Int = GLFW.GLFW_KEY_UNKNOWN
-
-    @Expose
     @ConfigOption(name = "Ore Event Messages", desc = "Shows debug messages every time the Ore Event happens.")
     @ConfigEditorBoolean
     var oreEventMessages: Boolean = false
@@ -231,30 +214,6 @@ class DebugConfig {
     @ConfigOption(name = "Always Hoppity's", desc = "Always act as if Hoppity's Hunt is active.")
     @ConfigEditorBoolean
     var alwaysHoppitys: Boolean = false
-
-    @Expose
-    @ConfigOption(name = "Always Great Spook", desc = "Assumes the Great Spook is always active.")
-    @ConfigEditorBoolean
-    val forceGreatSpook: Property<Boolean> = Property.of(false)
-
-    @Expose
-    @ConfigOption(name = "Moonglade Beacon", desc = "Add more debug information to the beacon solver.")
-    @ConfigEditorBoolean
-    var moongladeBeacon: Boolean = false
-
-    @Expose
-    @ConfigOption(name = "Addons Debug", desc = "Enable extra Superpairs Addons debug info.")
-    @ConfigEditorBoolean
-    var addonsDebug: Boolean = false
-
-    @Expose
-    @ConfigLink(owner = DebugConfig::class, field = "addonsDebug")
-    val addonsDebugPosition: Position = Position(300, 300)
-
-    @Expose
-    @ConfigOption(name = "Remaining Kills Debug", desc = "Enables Extra Debug messages for Remaining Slayer Kills.")
-    @ConfigEditorBoolean
-    var remainingKillsDebug: Boolean = false
 
     @Expose
     @ConfigOption(name = "Track Sound", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/GreatSpookConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/GreatSpookConfig.kt
@@ -1,12 +1,14 @@
 package at.hannibal2.skyhanni.config.features.event
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyDebug
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
 
 class GreatSpookConfig {
     @Expose
@@ -53,4 +55,10 @@ class GreatSpookConfig {
     @Accordion
     @Expose
     val primalFearSolver: PrimalFearSolverConfig = PrimalFearSolverConfig()
+
+    @Expose
+    @ConfigOption(name = "Always Great Spook", desc = "Assumes the Great Spook is always active.")
+    @ConfigEditorBoolean
+    @OnlyDebug
+    val forceGreatSpook: Property<Boolean> = Property.of(false)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/MoongladeBeaconConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/MoongladeBeaconConfig.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.features.foraging
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyDebug
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
@@ -32,7 +33,12 @@ class MoongladeBeaconConfig {
     var beaconAlert: Boolean = true
 
     @Expose
+    @ConfigOption(name = "Beacon Debug Info", desc = "Add more debug information to the beacon solver.")
+    @ConfigEditorBoolean
+    @OnlyDebug
+    var extraDebugInfo: Boolean = false
+
+    @Expose
     @ConfigLink(owner = MoongladeBeaconConfig::class, field = "enabled")
     val displayPosition: Position = Position(-300, 140)
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.config.features.inventory.experimentationtable
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.OnlyDebug
 import at.hannibal2.skyhanni.config.core.config.Position
-import at.hannibal2.skyhanni.config.features.dev.DebugConfig
 import at.hannibal2.skyhanni.utils.LorenzColor
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.ChromaColour
@@ -66,7 +65,6 @@ class ExperimentsAddonsConfig {
     var addonsDebug: Boolean = false
 
     @Expose
-    @ConfigLink(owner = DebugConfig::class, field = "addonsDebug")
-    @OnlyDebug
+    @ConfigLink(owner = ExperimentsAddonsConfig::class, field = "addonsDebug")
     val addonsDebugPosition: Position = Position(300, 300)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
@@ -1,16 +1,19 @@
 package at.hannibal2.skyhanni.config.features.inventory.experimentationtable
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyDebug
+import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.dev.DebugConfig
 import at.hannibal2.skyhanni.utils.LorenzColor
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class ExperimentsAddonsConfig {
-
     @Expose
     @ConfigOption(
         name = "Enabled",
@@ -56,4 +59,14 @@ class ExperimentsAddonsConfig {
     @FeatureToggle
     var maxSequenceAlert: Boolean = true
 
+    @Expose
+    @ConfigOption(name = "Addons Debug", desc = "Enable extra Superpairs Addons debug info.")
+    @ConfigEditorBoolean
+    @OnlyDebug
+    var addonsDebug: Boolean = false
+
+    @Expose
+    @ConfigLink(owner = DebugConfig::class, field = "addonsDebug")
+    @OnlyDebug
+    val addonsDebugPosition: Position = Position(300, 300)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsAddonsConfig.kt
@@ -66,5 +66,6 @@ class ExperimentsAddonsConfig {
 
     @Expose
     @ConfigLink(owner = ExperimentsAddonsConfig::class, field = "addonsDebug")
+    @OnlyDebug
     val addonsDebugPosition: Position = Position(300, 300)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/QuickModMenuSwitchConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/QuickModMenuSwitchConfig.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.features.misc
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyDebug
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
@@ -26,6 +27,16 @@ class QuickModMenuSwitchConfig {
     )
     @ConfigEditorBoolean
     var insidePlayerInventory: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Mod Menu Log",
+        desc = "Enable debug messages when the currently opened GUI changes, with the path to the gui class. " +
+            "Useful for adding more mods to quick mod menu switch.",
+    )
+    @ConfigEditorBoolean
+    @OnlyDebug
+    var modMenuLog: Boolean = false
 
     @Expose
     @ConfigLink(owner = QuickModMenuSwitchConfig::class, field = "enabled")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/compacttablist/AdvancedPlayerListConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/compacttablist/AdvancedPlayerListConfig.kt
@@ -1,9 +1,12 @@
 package at.hannibal2.skyhanni.config.features.misc.compacttablist
 
+import at.hannibal2.skyhanni.config.OnlyDebug
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import org.lwjgl.glfw.GLFW
 
 class AdvancedPlayerListConfig {
     @Expose
@@ -81,4 +84,13 @@ class AdvancedPlayerListConfig {
     )
     @ConfigEditorBoolean
     var markSpecialPersons: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Bypass Advanced Tab List",
+        desc = "The Advanced Player Tab list is disabled while pressing this hotkey.",
+    )
+    @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
+    @OnlyDebug
+    var bypassAdvancedPlayerTabList: Int = GLFW.GLFW_KEY_UNKNOWN
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerRemainingKillsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerRemainingKillsConfig.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.config.features.slayer
 
 import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.OnlyDebug
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
@@ -33,6 +34,12 @@ class SlayerRemainingKillsConfig {
     @ConfigOption(name = "Show Health", desc = "Include the mob Health in the display.")
     @ConfigEditorBoolean
     var includeMobHealth: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Remaining Kills Debug", desc = "Enables Extra Debug messages for Remaining Slayer Kills.")
+    @ConfigEditorBoolean
+    @OnlyDebug
+    var remainingKillsDebug: Boolean = false
 
     @Expose
     @ConfigLink(owner = SlayerRemainingKillsConfig::class, field = "display")

--- a/src/main/java/at/hannibal2/skyhanni/features/event/spook/TheGreatSpook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/spook/TheGreatSpook.kt
@@ -111,7 +111,7 @@ object TheGreatSpook {
 
     @HandleEvent
     fun onConfigLoad() {
-        val config = SkyHanniMod.feature.dev.debug.forceGreatSpook
+        val config = config.forceGreatSpook
         config.afterChange {
             if (config.get()) {
                 isGreatSpookActive = true
@@ -217,7 +217,7 @@ object TheGreatSpook {
         val endTime = data["end_time"] ?: SimpleTimeMark.farPast()
 
         greatSpookTimeRange = startTime..endTime
-        greatSpookEndTime = if (SkyHanniMod.feature.dev.debug.forceGreatSpook.get()) SimpleTimeMark.farFuture() else endTime
+        greatSpookEndTime = if (config.forceGreatSpook.get()) SimpleTimeMark.farFuture() else endTime
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/MoongladeBeacon.kt
@@ -57,7 +57,6 @@ import kotlin.time.times
 object MoongladeBeacon {
 
     private val config get() = SkyHanniMod.feature.foraging.moongladeBeacon
-    private val debugConfig get() = SkyHanniMod.feature.dev.debug
 
     // <editor-fold desc="Enums & Enum Helpers">
     /**
@@ -234,7 +233,7 @@ object MoongladeBeacon {
 
     @HandleEvent
     fun onTick() {
-        if (!debugConfig.moongladeBeacon || nextDevUpdate.isInFuture()) return
+        if (!config.extraDebugInfo || nextDevUpdate.isInFuture()) return
         display = drawDisplay()
         nextDevUpdate = SimpleTimeMark.now() + 100.milliseconds
     }
@@ -567,7 +566,7 @@ object MoongladeBeacon {
             appendLine(" §7Ref Speed: §a${speedPair.reference.formatOrDefault("§eCalculating..")}")
             appendLine(" §7Ref Pitch: §a${pitchPair.reference.formatOrDefault()}")
 
-            if (debugConfig.moongladeBeacon) {
+            if (config.extraDebugInfo) {
                 appendLine("  §8Our Color: ${colorPair.ours.formatOrDefault()}")
                 appendLine("  §8Our Speed: §a${speedPair.ours.formatOrDefault()}")
                 appendLine("  §8Our Pitch: §a${pitchPair.ours.formatOrDefault()}")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
@@ -44,7 +44,6 @@ object ExperimentsAddonsHelper {
     private const val ROUND_STATUS_SLOT = 4
     private const val PHASE_STATUS_SLOT = 49
 
-    private val debugConfig get() = SkyHanniMod.feature.dev.debug
     private val config get() = SkyHanniMod.feature.inventory.experimentationTable.addons
     private val hypixelChronomatronData: MutableList<LorenzColor> = mutableListOf()
     private val userChronomatronProgress: MutableList<LorenzColor> = mutableListOf()
@@ -335,7 +334,7 @@ object ExperimentsAddonsHelper {
     init {
         RenderDisplayHelper(
             inventory = ExperimentationTableApi.experimentationTableInventory,
-            condition = { ExperimentationTableApi.inAddon && debugConfig.addonsDebug },
+            condition = { ExperimentationTableApi.inAddon && config.addonsDebug },
             onlyOnIsland = IslandType.PRIVATE_ISLAND,
             onRender = {
                 val renderable = Renderable.vertical {
@@ -360,7 +359,7 @@ object ExperimentsAddonsHelper {
                         addString("Dye Map: $ultrasequencerDyeMap")
                     } else return@vertical
                 }
-                debugConfig.addonsDebugPosition.renderRenderable(renderable, posLabel = "Addons Debug")
+                config.addonsDebugPosition.renderRenderable(renderable, posLabel = "Addons Debug")
             },
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/QuickModMenuSwitch.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/QuickModMenuSwitch.kt
@@ -63,7 +63,7 @@ object QuickModMenuSwitch {
         if (latestGuiPath != openGui) {
             latestGuiPath = openGui
 
-            if (SkyHanniMod.feature.dev.debug.modMenuLog) {
+            if (config.modMenuLog) {
                 ChatUtils.debug("Open GUI: $latestGuiPath")
             }
         }
@@ -149,10 +149,5 @@ object QuickModMenuSwitch {
         DrawContextUtils.pushPop {
             config.pos.renderRenderables(display, posLabel = "Quick Mod Menu Switch")
         }
-    }
-
-    @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
-        event.move(3, "dev.modMenuLog", "dev.debug.modMenuLog")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/QuickModMenuSwitch.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/QuickModMenuSwitch.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.misc
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.SkyHanniMod.launch
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.enums.OutsideSBFeature
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ModGuiSwitcherJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -24,7 +24,6 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.merge
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import kotlinx.coroutines.flow.merge
 import net.minecraft.client.Minecraft
 import net.minecraft.network.chat.Component
 import java.util.regex.Matcher
@@ -167,7 +166,7 @@ object AdvancedPlayerList {
     }
 
     fun ignoreCustomTabList(): Boolean {
-        val denyKeyPressed = SkyHanniMod.feature.dev.debug.bypassAdvancedPlayerTabList.isKeyHeld()
+        val denyKeyPressed = config.bypassAdvancedPlayerTabList.isKeyHeld()
         return GlobalRender.renderDisabled || denyKeyPressed
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.features.slayer
 
-import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
 import at.hannibal2.skyhanni.api.pet.CurrentPetApi
@@ -47,7 +46,6 @@ import kotlin.time.Duration.Companion.minutes
 object RemainingSlayerKills {
 
     private val config get() = SlayerApi.config.slayerRemainingKills
-    private val debugToggle get() = SkyHanniMod.feature.dev.debug.remainingKillsDebug
 
     private val patternGroup = RepoPattern.group("slayer.remaining-kills")
 
@@ -344,7 +342,7 @@ object RemainingSlayerKills {
     }
 
     private fun debugMessage(message: String) {
-        if (debugToggle) ChatUtils.debug(message)
+        if (config.remainingKillsDebug) ChatUtils.debug(message)
     }
 
     private fun remindToUpdateCombatWisdom() {


### PR DESCRIPTION
## What
Moves the debug options to the places it makes sense using the "OnlyDebug" annotation.
Also removed a config move on a debug option.

Whoever is reading this: should I also make it not have the "Expose" annotation?

## Changelog Technical Details
+ Moved debug config options to relevant places. - Avrg