### PR TITLE
Backend: Enable Configure on Demand

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ fabric.loom.dropNonIntermediateRootMethods=true
 org.gradle.daemon=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
+org.gradle.configureondemand=true
 
 kotlin.incremental=true
 kotlin.daemon.jvm.options=-Xmx2g -XX:+UseParallelGC


### PR DESCRIPTION
## What
Enables Configure on Demand in Gradle, which makes it skip unnecessarily configuring versions that aren't being built (for example, if you're specifically building 26.1, it skips configuring 1.21.11). This may result in a slight speedup to builds and stops them from failing on random unrelated issues.

exclude_from_changelog
