### PR TITLE
Backend: Move stuff to MinecraftCompat to help with 26.2 transition

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -46,7 +46,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.resources.Identifier
 import org.apache.logging.log4j.Level
@@ -101,7 +100,7 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
             OtherInventoryData.close(title)
         }
         shouldCloseScreen = true
-        Minecraft.getInstance().setScreen(screenToOpen)
+        MinecraftCompat.screen = screenToOpen
         screenTicks = 0
         this.screenToOpen = null
     }

--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
@@ -22,6 +22,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.StringUtils.cleanString
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.UtilsPatterns
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.container
 import at.hannibal2.skyhanni.utils.compat.getCompoundOrDefault
 import at.hannibal2.skyhanni.utils.compat.getIntOrDefault
@@ -30,7 +31,6 @@ import at.hannibal2.skyhanni.utils.ensureComponentsBound
 import at.hannibal2.skyhanni.utils.itemType
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonObject
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.core.component.DataComponentMap
@@ -194,7 +194,7 @@ class ItemResolutionQuery {
     }
 
     fun withCurrentGuiContext(): ItemResolutionQuery {
-        this.guiContext = Minecraft.getInstance().screen
+        this.guiContext = MinecraftCompat.screen
         return this
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -1,4 +1,3 @@
-//~ if < 26.1 'ClientLevelEvents' -> 'ClientWorldEvents' {
 package at.hannibal2.skyhanni.api.minecraftevents
 
 import at.hannibal2.skyhanni.SkyHanniMod
@@ -17,13 +16,11 @@ import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLevelEvents
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents
 import net.fabricmc.fabric.api.resource.v1.ResourceLoader
-import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.chat.GuiMessage
 import net.minecraft.client.multiplayer.chat.GuiMessageTag
 import net.minecraft.network.chat.Component
@@ -31,8 +28,12 @@ import net.minecraft.resources.Identifier
 import net.minecraft.server.packs.PackType
 import java.util.concurrent.CompletableFuture
 
-//? if >= 26.1
+//? if >= 26.1 {
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLevelEvents
 import net.minecraft.client.multiplayer.chat.GuiMessageSource
+//?} else {
+/*import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientWorldEvents
+*///?}
 
 @SkyHanniModule
 object ClientEvents {
@@ -60,7 +61,7 @@ object ClientEvents {
         }
 
         // World change event
-        //~ if < 26.1 'AFTER_CLIENT_LEVEL_CHANGE' -> 'AFTER_CLIENT_WORLD_CHANGE'
+        //~ if < 26.1 'ClientLevelEvents.AFTER_CLIENT_LEVEL_CHANGE' -> 'ClientWorldEvents.AFTER_CLIENT_WORLD_CHANGE'
         ClientLevelEvents.AFTER_CLIENT_LEVEL_CHANGE.register { _, _ ->
             EventListeners.markEventCacheDirty()
             WorldChangeEvent.post()
@@ -86,11 +87,11 @@ object ClientEvents {
     var currentMessage: Component? = null
 
     private fun onAllow(message: Component, actionBar: Boolean): Boolean {
-        // if we created the message we don't want to pipe it back into our events
+        // If we created the message we don't want to pipe it back into our events
         if (message.skyhanniCreated) return true
 
         if (actionBar) {
-            // we never cancel the action bar
+            // We never cancel the action bar
             return true
         }
 
@@ -99,14 +100,22 @@ object ClientEvents {
         val cancel = ChatManager.onChatAllow(message)
 
         if (cancel) {
-            // the message doesn't get logged if we cancel it, so we do that ourselves
-            val inGameHud = Minecraft.getInstance().gui
-            //~ if < 26.1 'GuiMessageSource.SYSTEM_CLIENT, GuiMessageTag.system()' -> 'GuiMessageTag.system()'
-            val chatHudLine = GuiMessage(inGameHud.guiTicks, message, null, GuiMessageSource.SYSTEM_CLIENT, GuiMessageTag.system())
-            inGameHud.chat.logChatMessage(chatHudLine)
+            // The message doesn't get logged if we cancel it, so we do that ourselves
+            val chatHudLine = GuiMessage(
+                MinecraftCompat.hud.guiTicks,
+                message,
+                null,
+                //? if >= 26.1 {
+                GuiMessageSource.SYSTEM_CLIENT,
+                GuiMessageTag.system(),
+                //?} else {
+                /*GuiMessageTag.system(),
+                *///?}
+            )
+            MinecraftCompat.hud.chat.logChatMessage(chatHudLine)
         }
 
-        // if we cancel then we don't allow the message
+        // If we cancel then we don't allow the message
         return !cancel
     }
 
@@ -114,9 +123,9 @@ object ClientEvents {
         if (message.skyhanniCreated) return message
 
         if (actionBar) {
-            // we don't have to worry about cancelling the action bar
-            // this is more compatible with other mods changing the action bar as well
-            // ie to remove hp/mana
+            // We don't have to worry about cancelling the action bar
+            // This is more compatible with other mods changing the action bar as well
+            // e.g. to remove HP/Mana
             val result = ActionBarData.onChatReceive(message)
             if (result == null) {
                 return if (rainbowConfig()) {
@@ -142,7 +151,7 @@ object ClientEvents {
         }
 
         val new = ChatManager.onChatModify(message)
-        // if new is null then we didn't want to change the message
+        // If new is null then we didn't want to change the message
         new?.let { return it }
 
         currentMessage?.let {
@@ -162,6 +171,4 @@ object ClientEvents {
     }
 
     fun rainbowConfig() = SkyHanniMod.feature.misc.rainbowActionBar
-
 }
-//~}

--- a/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/core/config/gui/GuiPositionEditor.kt
@@ -30,6 +30,7 @@ import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.MouseCompat
 import at.hannibal2.skyhanni.utils.compat.SkyHanniBaseScreen
 import at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer
@@ -41,6 +42,7 @@ import org.lwjgl.glfw.GLFW
 import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.javaField
+
 //? if < 26.1 {
 /*import at.hannibal2.skyhanni.utils.compat.RenderCompat
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
@@ -298,7 +300,7 @@ class GuiPositionEditor(
         if (oldScreen == null) {
             super.onClose()
         } else {
-            Minecraft.getInstance().screen = oldScreen
+            MinecraftCompat.screen = oldScreen
         }
     }
 }
@@ -418,7 +420,7 @@ private class OldScreenRenderContext(
         val top = oldScreen.containerTop()
         val entityScale = (30 * ((scaleX + scaleY) / 2f)).roundToInt()
 
-        //~ if < 26.1 'extractEntityInInventoryFollowsMouse' -> 'renderEntityInInventoryFollowsMouse'
+        //~ if < 26.1 'extract' -> 'render'
         InventoryScreen.extractEntityInInventoryFollowsMouse(
             DrawContextUtils.drawContext,
             ((left + 26) * scaleX).roundToInt(),

--- a/src/main/java/at/hannibal2/skyhanni/data/BossbarData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BossbarData.kt
@@ -3,11 +3,12 @@ package at.hannibal2.skyhanni.data
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.BossbarUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
-import net.minecraft.client.Minecraft
 
 @SkyHanniModule
 object BossbarData {
+
     private var bossbar: String? = null
     private var previousServerBossbar = ""
 
@@ -23,7 +24,7 @@ object BossbarData {
     @HandleEvent
     fun onTick() {
         var multipleBossBars = false
-        for (bossBar in Minecraft.getInstance().gui.bossOverlay.events.values) {
+        for (bossBar in MinecraftCompat.hud.bossOverlay.events.values) {
             if (multipleBossBars) {
                 return
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ChatManager.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.stripHypixelMessage
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.append
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.system.PlatformUtils.getModInstance
@@ -36,8 +37,9 @@ import kotlin.math.floor
 
 //? if >= 26.1 {
 import net.minecraft.client.multiplayer.chat.GuiMessageSource
-//?} else
-//import at.hannibal2.skyhanni.mixins.hooks.MessageStore.Companion.parent
+//?} else {
+/*import at.hannibal2.skyhanni.mixins.hooks.MessageStore.Companion.parent
+*///?}
 
 @SkyHanniModule
 object ChatManager {
@@ -255,7 +257,7 @@ object ChatManager {
         predicate: (GuiMessage) -> Boolean = { true },
     ) = DelayedRun.runOrNextTick {
         val mc = Minecraft.getInstance()
-        val chatGui = mc.gui.chat
+        val chatGui = MinecraftCompat.hud.chat
 
         val (messageIndex, message) = chatGui.allMessages.withIndex().firstOrNull {
             predicate(it.value)
@@ -279,8 +281,9 @@ object ChatManager {
             counter,
             newComponent,
             id,
-            //? if >= 26.1
+            //? if >= 26.1 {
             GuiMessageSource.SYSTEM_CLIENT,
+            //?}
             GuiMessageTag.system(),
         )
         chatGui.allMessages[messageIndex] = newMessage
@@ -336,8 +339,7 @@ object ChatManager {
         reason: String? = null,
         predicate: (GuiMessage) -> Boolean = { true },
     ) = DelayedRun.runOrNextTick {
-        val mc = Minecraft.getInstance()
-        val chatGui = mc.gui.chat
+        val chatGui = MinecraftCompat.hud.chat
 
         val iterator = chatGui.allMessages.iterator()
         var removed = 0
@@ -408,7 +410,7 @@ object ChatManager {
             description = "Force Minecraft to refresh chat lines"
             category = CommandCategory.DEVELOPER_TEST
             simpleCallback {
-                Minecraft.getInstance().gui.chat.refreshTrimmedMessages()
+                MinecraftCompat.hud.chat.refreshTrimmedMessages()
                 ChatUtils.chat("Refreshed chat.")
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/GuiData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiData.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.KeyboardManager.isActive
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import org.lwjgl.glfw.GLFW
@@ -61,7 +62,7 @@ object GuiData {
     @HandleEvent
     fun onInventoryClose(event: InventoryCloseEvent) {
         DelayedRun.runNextTick {
-            if (Minecraft.getInstance().screen !is ContainerScreen) {
+            if (MinecraftCompat.screen !is ContainerScreen) {
                 preDrawEventCancelled = false
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/GuiEditManager.kt
@@ -14,8 +14,8 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
@@ -45,7 +45,7 @@ object GuiEditManager {
         }
         if (isInGui()) return
 
-        val guiScreen = Minecraft.getInstance().screen
+        val guiScreen = MinecraftCompat.screen
         val openGui = guiScreen?.javaClass?.name ?: "none"
         val isInNeuPv = openGui == "io.github.moulberry.notenoughupdates.profileviewer.GuiProfileViewer"
         if (isInNeuPv) return
@@ -86,7 +86,7 @@ object GuiEditManager {
         SkyHanniMod.screenToOpen = GuiPositionEditor(
             positions.map { it.position },
             2,
-            Minecraft.getInstance().screen as? SkyHanniGuiContainer,
+            MinecraftCompat.screen as? SkyHanniGuiContainer,
             positions.filter { it.isChestGuiOverlay }.map { it.position }.toSet(),
         )
         if (hotkeyReminder && lastHotkeyReminded.passedSince() > 30.minutes) {
@@ -109,7 +109,7 @@ object GuiEditManager {
 
         RenderData.renderOverlay(context)
 
-        val editor = Minecraft.getInstance().screen as? GuiPositionEditor
+        val editor = MinecraftCompat.screen as? GuiPositionEditor
         editor?.renderWithOldScreenMetrics {
             renderChestOverlay(context)
         } ?: renderChestOverlay(context)
@@ -134,7 +134,7 @@ object GuiEditManager {
         }
     }
 
-    fun isInGui() = Minecraft.getInstance().screen is GuiPositionEditor
+    fun isInGui() = MinecraftCompat.screen is GuiPositionEditor
 
     fun Position.getDummySize(random: Boolean = false): Vector2i {
         if (random) return Vector2i(5, 5)

--- a/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ItemTipHelper.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.drawSlotText
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.container
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
@@ -40,7 +41,7 @@ object ItemTipHelper {
     fun onRenderInventoryItemOverlayPost(event: DrawScreenAfterEvent) {
         if (GlobalRender.renderDisabled) return
 
-        val gui = Minecraft.getInstance().screen
+        val gui = MinecraftCompat.screen
         if (gui !is ContainerScreen) return
         val inventoryName = InventoryUtils.openInventoryName()
 

--- a/src/main/java/at/hannibal2/skyhanni/data/PurseApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/PurseApi.kt
@@ -10,8 +10,8 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatDouble
 import at.hannibal2.skyhanni.utils.NumberUtil.million
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -69,7 +69,7 @@ object PurseApi {
                 return PurseChangeCause.GAIN_DICE_ROLL
             }
 
-            if (Minecraft.getInstance().screen == null) {
+            if (MinecraftCompat.screen == null) {
                 if (inventoryCloseTime.passedSince() > 2.seconds) {
                     return PurseChangeCause.GAIN_MOB_KILL
                 }

--- a/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/RenderData.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.features.misc.visualwords.VisualWordGui
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
-import net.minecraft.client.Minecraft
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.client.gui.screens.ChatScreen
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
@@ -18,7 +18,7 @@ object RenderData {
     fun postRenderOverlay(context: GuiGraphicsExtractor) {
         if (GlobalRender.renderDisabled) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
-        val screen = Minecraft.getInstance().screen
+        val screen = MinecraftCompat.screen
 
         DrawContextUtils.setContext(context)
         renderOverlay(DrawContextUtils.drawContext, screen != null && screen !is ChatScreen)
@@ -29,7 +29,7 @@ object RenderData {
     fun onBackgroundDraw() {
         if (GlobalRender.renderDisabled) return
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return
-        val currentScreen = Minecraft.getInstance().screen ?: return
+        val currentScreen = MinecraftCompat.screen ?: return
         if (currentScreen !is InventoryScreen && currentScreen !is ContainerScreen) return
 
         DrawContextUtils.pushPop {

--- a/src/main/java/at/hannibal2/skyhanni/data/ScreenData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ScreenData.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.data
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import net.minecraft.client.Minecraft
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 
 @SkyHanniModule
 object ScreenData {
@@ -11,7 +11,7 @@ object ScreenData {
 
     @HandleEvent
     fun onTick() {
-        val isOpen = Minecraft.getInstance().screen != null
+        val isOpen = MinecraftCompat.screen != null
         if (wasOpen == isOpen) return
         wasOpen = isOpen
         if (!wasOpen) {

--- a/src/main/java/at/hannibal2/skyhanni/data/title/TitleContext.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/title/TitleContext.kt
@@ -10,12 +10,12 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.now
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.renderXYAligned
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import net.minecraft.client.Minecraft
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -127,7 +127,7 @@ open class TitleContext(
     }
 
     fun tryRenderInventoryTitle() {
-        val gui = Minecraft.getInstance().screen as? SkyHanniGuiContainer ?: return
+        val gui = MinecraftCompat.screen as? SkyHanniGuiContainer ?: return
 
         val stringRenderable = with(Renderable) {
             vertical(horizontalAlign = RenderUtils.HorizontalAlignment.CENTER) {

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/card/BingoCardDisplay.kt
@@ -25,12 +25,12 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.renderables.toRenderables
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.ChatScreen
 import kotlin.time.Duration.Companion.days
 
@@ -139,7 +139,7 @@ object BingoCardDisplay {
             }
         }
         if (!config.stepHelper && displayMode == 1) displayMode = 2
-        if (displayMode == 0 && Minecraft.getInstance().screen !is ChatScreen) {
+        if (displayMode == 0 && MinecraftCompat.screen !is ChatScreen) {
             config.bingoCardPos.renderRenderables(displayCache, posLabel = "Bingo Card")
         } else if (displayMode == 1) {
             val helpRenderable = Renderable.vertical(

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatPeek.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatPeek.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.features.misc.visualwords.VisualWordGui
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.SignEditScreen
 import org.lwjgl.glfw.GLFW
 
@@ -18,7 +17,7 @@ object ChatPeek {
 
         if (!MinecraftCompat.localPlayerExists) return false
         if (key <= GLFW.GLFW_KEY_UNKNOWN) return false
-        if (Minecraft.getInstance().screen is SignEditScreen) return false
+        if (MinecraftCompat.screen is SignEditScreen) return false
         if (ConfigUtils.configScreenCurrentlyOpen) return false
 
         if (GuiEditManager.isInGui() || VisualWordGui.isInGui()) return false

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/CurrentChatDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/CurrentChatDisplay.kt
@@ -18,10 +18,10 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.ChatScreen
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -133,7 +133,7 @@ object CurrentChatDisplay {
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
     fun onGuiRenderOverlay() {
         if (!isEnabled()) return
-        if (Minecraft.getInstance().screen !is ChatScreen && lastClosedChatTime.passedSince() > 2.seconds) return
+        if (MinecraftCompat.screen !is ChatScreen && lastClosedChatTime.passedSince() > 2.seconds) return
         val display = display ?: return
         config.currentChatDisplayPos.renderRenderable(display, posLabel = "Current Chat")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowWarpHelper.kt
@@ -25,10 +25,10 @@ import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sorted
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import com.google.gson.JsonArray
-import net.minecraft.client.Minecraft
 import org.lwjgl.glfw.GLFW
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -88,7 +88,7 @@ object BurrowWarpHelper {
         warpQueued = false
         if (!DianaApi.isDoingDiana()) return
         if (!config.burrowNearestWarp) return
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
         val warp = currentWarp ?: return
         if (lastWarpTime.passedSince() < 1.seconds) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
@@ -30,10 +30,10 @@ import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import net.minecraft.client.player.RemotePlayer
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Matcher
@@ -212,7 +212,7 @@ object RareMobWaypointShare {
     @HandleEvent
     fun onKeyPress(event: KeyPressEvent) {
         if (!isEnabled()) return
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
         if (event.keyCode == config.keyBindShare) sendRareMob()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityLiveDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityLiveDisplay.kt
@@ -41,6 +41,7 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumAllValues
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.addCenteredString
 import at.hannibal2.skyhanni.utils.renderables.container.ContainerRenderable
@@ -48,7 +49,6 @@ import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRend
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import org.lwjgl.glfw.GLFW
@@ -132,7 +132,7 @@ object HoppityLiveDisplay {
         if (!config.enabled) return
         if (config.toggleKeybind == GLFW.GLFW_KEY_UNKNOWN || config.toggleKeybind != event.keyCode) return
         // Only toggle from inventory if the user is in the Chocolate Factory
-        if (Minecraft.getInstance().screen != null && !CFApi.inChocolateFactory) return
+        if (MinecraftCompat.screen != null && !CFApi.inChocolateFactory) return
         if (lastToggleMark.passedSince() < 250.milliseconds) return
         val storage = storage ?: return
         storage.hoppityStatLiveDisplayToggledOff = !storage.hoppityStatLiveDisplayToggledOff
@@ -192,7 +192,7 @@ object HoppityLiveDisplay {
 
     private fun inMatchingInventory(): Boolean {
         val setting = config.specificInventories
-        val currentScreen = Minecraft.getInstance().screen
+        val currentScreen = MinecraftCompat.screen
             ?: return HoppityLiveDisplayInventoryType.NO_INVENTORY in setting
 
         // Get the inventory name and check if it matches any of the specific inventories
@@ -212,7 +212,7 @@ object HoppityLiveDisplay {
     }
 
     private fun isInInventory(): Boolean =
-        Minecraft.getInstance().screen is InventoryScreen || Minecraft.getInstance().screen is ContainerScreen
+        MinecraftCompat.screen is InventoryScreen || MinecraftCompat.screen is ContainerScreen
 
     private fun HoppityEventStats.buildMealEggHover(statYear: Int): List<String> = buildList {
         val spawnedEggs: Map<HoppityEggType, Int> = getSpawnedEggCountsWithInfPossible(statYear).takeIfNotEmpty() ?: return@buildList

--- a/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fame/CityProjectFeatures.kt
@@ -39,11 +39,11 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.client.gui.screens.inventory.SignEditScreen
 import net.minecraft.world.inventory.ChestMenu
@@ -190,7 +190,7 @@ object CityProjectFeatures {
     private fun materialLink(name: String, amount: Int): Renderable = Renderable.optionalLink(
         "$name §ex${amount.addSeparators()}",
         {
-            if (Minecraft.getInstance().screen is SignEditScreen) {
+            if (MinecraftCompat.screen is SignEditScreen) {
                 SignUtils.setTextIntoSign("$amount")
             } else {
                 BazaarApi.searchForBazaarItemOrRecipe(name, amount)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -37,6 +37,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getExtraAttributes
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.addLavas
 import at.hannibal2.skyhanni.utils.compat.addWaters
 import at.hannibal2.skyhanni.utils.compat.deceased
@@ -45,7 +46,6 @@ import at.hannibal2.skyhanni.utils.compat.getCompoundOrDefault
 import at.hannibal2.skyhanni.utils.compat.getStringOrDefault
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import net.minecraft.world.entity.decoration.ArmorStand
@@ -247,7 +247,7 @@ object FishingApi {
     }
 
     private fun hasGuiOpen(): Boolean {
-        val screen = Minecraft.getInstance().screen
+        val screen = MinecraftCompat.screen
         return screen is AbstractContainerScreen<*> && screen !is InventoryScreen
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/LavaReplacement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/LavaReplacement.kt
@@ -7,11 +7,10 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.OpaqueWaterFluid
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
-import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import com.google.gson.JsonArray
 import com.google.gson.JsonPrimitive
-import net.minecraft.client.Minecraft
 import net.minecraft.core.Registry
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.world.level.material.Fluid
@@ -24,8 +23,7 @@ import net.minecraft.client.renderer.block.FluidModel
 import net.minecraft.client.renderer.block.FluidStateModelSet
 import net.minecraft.client.resources.model.sprite.MaterialBaker
 //?} else {
-/*import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry
+/*import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry
 import net.fabricmc.fabric.api.client.render.fluid.v1.SimpleFluidRenderHandler
 import net.fabricmc.fabric.api.client.rendering.v1.BlockRenderLayerMap
 import net.minecraft.client.renderer.BiomeColors
@@ -99,9 +97,7 @@ object LavaReplacement {
         val newActive = shouldReplace()
         if (newActive == isActive) return
         isActive = newActive
-        DelayedRun.runNextTick {
-            Minecraft.getInstance().levelRenderer.allChanged()
-        }
+        MinecraftCompat.reloadChunks()
     }
 
     private fun shouldReplace(): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
@@ -33,11 +33,11 @@ import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSingl
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.table.TableRenderable.Companion.table
 import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -294,7 +294,7 @@ object TrophyFishDisplay {
 
     private fun canRender(): Boolean = when (config.whenToShow.get()!!) {
         WhenToShow.ALWAYS -> true
-        WhenToShow.ONLY_IN_INVENTORY -> Minecraft.getInstance().screen is InventoryScreen
+        WhenToShow.ONLY_IN_INVENTORY -> MinecraftCompat.screen is InventoryScreen
         WhenToShow.ONLY_WITH_ROD_IN_HAND -> FishingApi.holdingLavaRod
         WhenToShow.ONLY_WITH_KEYBIND -> config.keybind.isKeyHeld()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -60,7 +60,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.addSkyHanniUtm
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.containsKeys
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
-import net.minecraft.client.Minecraft
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.world.phys.AABB
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -123,7 +123,7 @@ object GardenApi {
             if (cropInHand.isTimeFlower()) checkItemInHand()
 
             // We ignore random hypixel moments
-            Minecraft.getInstance().screen ?: return
+            MinecraftCompat.screen ?: return
             checkItemInHand()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotBorders.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenPlotBorders.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.features.garden.GardenPlotApi.renderPlot
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzColor
-import net.minecraft.client.Minecraft
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import org.lwjgl.glfw.GLFW
 
 @SkyHanniModule
@@ -19,7 +19,7 @@ object GardenPlotBorders {
     @HandleEvent
     fun onKeyDown(event: KeyDownEvent) {
         if (!isEnabled()) return
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
         if (event.keyCode == config.plotBorderKey) {
             showBorders = !showBorders
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenWarpCommands.kt
@@ -7,8 +7,8 @@ import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 
 @SkyHanniModule
 object GardenWarpCommands {
@@ -42,7 +42,7 @@ object GardenWarpCommands {
             return
         }
 
-        tpPlotPattern.matchMatcher(message) {
+        tpPlotPattern.matchMatcher(event.message) {
             event.cancel()
             val plotName = group("plot")
             HypixelCommands.teleportToPlot(plotName)
@@ -52,7 +52,7 @@ object GardenWarpCommands {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onKeyDown(event: KeyDownEvent) {
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
 
         when (event.keyCode) {
             config.homeHotkey -> HypixelCommands.warp("garden")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/MouseSensitivityReducer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/MouseSensitivityReducer.kt
@@ -21,12 +21,12 @@ import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonArray
 import com.google.gson.JsonPrimitive
-import net.minecraft.client.Minecraft
 import kotlin.reflect.KProperty0
 
 @SkyHanniModule
@@ -240,7 +240,7 @@ object MouseSensitivityReducer {
     }
 
     enum class AutoEnableMode(private val displayName: String, val condition: () -> Boolean) {
-        KEYBIND("Holding Keybind", { config.keybind.isKeyHeld() && Minecraft.getInstance().screen == null }),
+        KEYBIND("Holding Keybind", { config.keybind.isKeyHeld() && MinecraftCompat.screen == null }),
         TOOL("Farming tool", { GardenApi.hasFarmingToolInHand() }),
         FISHING_ROD("Fishing Rod", { FishingApi.holdingRod }),
         MOUSEMAT("Squeaky Mousemat", { GardenApi.hasMousematInHand() }),

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/SeeThroughWindow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/SeeThroughWindow.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.client.Minecraft
 import org.lwjgl.glfw.GLFW
 
@@ -27,7 +28,7 @@ object SeeThroughWindow {
     @HandleEvent
     fun onKeyPressed(event: KeyDownEvent) {
         if (event.keyCode != config.keybind) return
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
         isActive = !isActive
         setOpacity()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCustomKeybinds.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import io.github.notenoughupdates.moulconfig.observer.Property
 import net.minecraft.client.KeyMapping
 import net.minecraft.client.Minecraft
@@ -67,7 +68,7 @@ object GardenCustomKeybinds {
     @HandleEvent
     fun onTick() {
         if (!isEnabled()) return
-        val screen = Minecraft.getInstance().screen ?: return
+        val screen = MinecraftCompat.screen ?: return
         if (screen !is SignEditScreen) return
         lastWindowOpenTime = SimpleTimeMark.now()
     }
@@ -171,7 +172,7 @@ object GardenCustomKeybinds {
             !hasGuiOpen() &&
             lastWindowOpenTime.passedSince() > 300.milliseconds
 
-    private fun hasGuiOpen() = Minecraft.getInstance().screen != null
+    private fun hasGuiOpen() = MinecraftCompat.screen != null
 
     @JvmStatic
     fun disableAll() {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestFinder.kt
@@ -35,11 +35,11 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactPlayerEyeLocation
 import at.hannibal2.skyhanni.utils.renderables.Renderable
-import net.minecraft.client.Minecraft
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -222,7 +222,7 @@ object PestFinder {
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onKeyPress(event: KeyPressEvent) {
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
 
         if (event.keyCode != config.teleportHotkey) return
         if (lastKeyPress.passedSince() < 2.seconds) return

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorShoppingList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorShoppingList.kt
@@ -33,10 +33,10 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addItemStack
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import net.minecraft.client.gui.screens.inventory.SignEditScreen
 import kotlin.time.Duration.Companion.minutes
@@ -152,7 +152,7 @@ object GardenVisitorShoppingList {
                     tips = internalName.createBuyTip(),
                     onLeftClick = {
                         if (!GardenApi.inGarden()) return@clickable
-                        if (Minecraft.getInstance().screen is SignEditScreen) {
+                        if (MinecraftCompat.screen is SignEditScreen) {
                             SignUtils.setTextIntoSign("$amount")
                         } else {
                             internalName.buy(amount)
@@ -221,7 +221,7 @@ object GardenVisitorShoppingList {
             val renderable = Renderable.clickable(
                 "§aCraftable!",
                 {
-                    if (Minecraft.getInstance().screen is SignEditScreen) {
+                    if (MinecraftCompat.screen is SignEditScreen) {
                         SignUtils.setTextIntoSign("$leftToCraft")
                     } else {
                         HypixelCommands.viewRecipe(internalName)
@@ -343,7 +343,7 @@ object GardenVisitorShoppingList {
         if (VisitorApi.inInventory) return true
         if (BazaarApi.inBazaarInventory) return true
 
-        val currentScreen = Minecraft.getInstance().screen ?: return true
+        val currentScreen = MinecraftCompat.screen ?: return true
         val isInOwnInventory = currentScreen is InventoryScreen
         if (isInOwnInventory) return true
         if (currentScreen is SignEditScreen &&

--- a/src/main/java/at/hannibal2/skyhanni/features/hunting/HideonleafFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/hunting/HideonleafFinder.kt
@@ -11,8 +11,8 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.navigation.NavigationUtils
-import net.minecraft.client.Minecraft
 
 @SkyHanniModule
 object HideonleafFinder {
@@ -23,7 +23,7 @@ object HideonleafFinder {
 
     @HandleEvent(onlyOnIsland = IslandType.GALATEA)
     fun onKeyPress(event: KeyPressEvent) {
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
         if (event.keyCode != config.nextHideonleafKeybind) return
         if (!config.hideonleafFinder) return
         if (navigating) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedGlassPane
 import at.hannibal2.skyhanni.utils.compat.DyeCompat.Companion.isDye
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.container
 import at.hannibal2.skyhanni.utils.compat.getTooltip
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -236,7 +237,7 @@ object BetterContainers {
 
     fun getTextureIdentifier(original: Identifier): Identifier {
         if (!chestOpen) return original
-        val inv = (Minecraft.getInstance().screen as? ContainerScreen)?.container
+        val inv = (MinecraftCompat.screen as? ContainerScreen)?.container
             ?: return original
         if (inv !is ChestMenu) return original
         val invHash = inv.hashCode()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ChestValue.kt
@@ -87,7 +87,7 @@ object ChestValue {
     fun onTick(event: SkyHanniTickEvent) {
         if (!isEnabled()) return
         if (!event.isMod(5)) return
-        val inInv = Minecraft.getInstance().screen is InventoryScreen
+        val inInv = MinecraftCompat.screen is InventoryScreen
         inOwnInventory = inInv && config.enableInOwnInventory
         if (!inInventory) return
         update()
@@ -244,7 +244,7 @@ object ChestValue {
     private fun isValidStorage(): Boolean {
         if (inOwnInventory) return true
         val name = InventoryUtils.openInventoryName().removeColor()
-        if (Minecraft.getInstance().screen !is ContainerScreen) return false
+        if (MinecraftCompat.screen !is ContainerScreen) return false
         if (BazaarApi.inBazaarInventory) return false
         if (MinionFeatures.minionInventoryOpen) return false
         if (MinionFeatures.minionStorageInventoryOpen) return false
@@ -259,15 +259,15 @@ object ChestValue {
     }
 
     private fun String.reduceStringLength(targetLength: Int, char: Char): String {
-        val mc = Minecraft.getInstance()
-        val spaceWidth = mc.font.width(char.toString())
+        val font = Minecraft.getInstance().font
+        val spaceWidth = font.width(char.toString())
 
         var currentString = this
-        var currentLength = mc.font.width(currentString)
+        var currentLength = font.width(currentString)
 
         while (currentLength > targetLength) {
             currentString = currentString.dropLast(1)
-            currentLength = mc.font.width(currentString)
+            currentLength = font.width(currentString)
         }
 
         val difference = targetLength - currentLength

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.anyMatches
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat.Companion.isStainedClay
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.container
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -107,7 +108,7 @@ object HarpFeatures {
     }
 
     private fun updateScale() {
-        if (Minecraft.getInstance().screen == null) {
+        if (MinecraftCompat.screen == null) {
             DelayedRun.runNextTick {
                 updateScale()
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -51,8 +51,8 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.world.inventory.ChestMenu
 import kotlin.time.Duration.Companion.seconds
@@ -141,7 +141,7 @@ object HideNotClickableItems {
         if (!isEnabled()) return
         if (bypassActive()) return
 
-        val guiChest = Minecraft.getInstance().screen
+        val guiChest = MinecraftCompat.screen
         if (guiChest !is ContainerScreen) return
         val chestName = InventoryUtils.openInventoryName()
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFCustomReminder.kt
@@ -27,10 +27,10 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.minutes
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 
 @SkyHanniModule
@@ -144,7 +144,7 @@ object CFCustomReminder {
     fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (!configReminder.always) return
-        if (Minecraft.getInstance().screen is ContainerScreen) return
+        if (MinecraftCompat.screen is ContainerScreen) return
         if (ReminderUtils.isBusy()) return
 
         configReminder.position.renderRenderables(display, posLabel = "Chocolate Factory Custom Reminder")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/wardrobe/CustomWardrobe.kt
@@ -32,6 +32,7 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer
 import at.hannibal2.skyhanni.utils.compat.getTooltip
 import at.hannibal2.skyhanni.utils.compat.getTooltipCompat
@@ -126,7 +127,7 @@ object CustomWardrobe {
     fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (!editMode) return
-        val gui = Minecraft.getInstance().screen as? SkyHanniGuiContainer ?: return
+        val gui = MinecraftCompat.screen as? SkyHanniGuiContainer ?: return
         val renderable = inventoryButton ?: addReEnableButton().also { inventoryButton = it }
         val posX = gui.leftPos + (1.05 * gui.imageWidth).toInt()
         val posY = gui.topPos + (gui.imageHeight - renderable.height) / 2

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbilityCooldown.kt
@@ -33,8 +33,8 @@ import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getItemUuid
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.mapKeysNotNull
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import kotlin.math.max
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -371,7 +371,7 @@ object ItemAbilityCooldown {
 
         val stack = event.stack
 
-        val guiOpen = Minecraft.getInstance().screen != null
+        val guiOpen = MinecraftCompat.screen != null
         val uuid = stack.getIdentifier() ?: return
         val list = items[uuid] ?: return
 
@@ -392,7 +392,7 @@ object ItemAbilityCooldown {
         if (!isEnabled()) return
         if (!config.itemAbilityCooldownBackground) return
 
-        val guiOpen = Minecraft.getInstance().screen != null
+        val guiOpen = MinecraftCompat.screen != null
         val stack = event.stack
 
         val uuid = stack?.getIdentifier() ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
@@ -18,8 +18,8 @@ import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import net.minecraft.world.item.DyeColor
 import net.minecraft.world.level.block.state.BlockState
 import kotlin.time.Duration.Companion.seconds
@@ -118,7 +118,7 @@ object MiningCommissionsBlocksColor {
 
         if (reload) {
             replaceBlocksMapCache = mutableMapOf()
-            Minecraft.getInstance().levelRenderer.allChanged()
+            MinecraftCompat.reloadChunks()
             dirty = false
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/TunnelsMaps.kt
@@ -49,6 +49,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.filterNotNullKeys
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DPathWithWaypoint
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.renderables.Renderable
@@ -58,7 +59,6 @@ import at.hannibal2.skyhanni.utils.renderables.primitives.emptyText
 import at.hannibal2.skyhanni.utils.renderables.primitives.placeholder
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import java.awt.Color
 import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.seconds
@@ -486,7 +486,7 @@ object TunnelsMaps {
     @HandleEvent
     fun onKeyPress(event: KeyPressEvent) {
         if (!isEnabled()) return
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
         campfireKey(event)
         nextSpotKey(event)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -19,6 +19,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
@@ -26,7 +27,6 @@ import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
 import at.hannibal2.skyhanni.utils.tracker.SessionUptime
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import com.google.gson.annotations.Expose
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 
 @SkyHanniModule
@@ -202,7 +202,7 @@ object ExcavatorProfitTracker {
     private fun shouldShowDisplay(): Boolean {
         if (!config.enabled) return false
         if (!isEnabled()) return false
-        if (Minecraft.getInstance().screen !is ContainerScreen) return true
+        if (MinecraftCompat.screen !is ContainerScreen) return true
         // Only show in excavation menu
         return FossilExcavatorApi.inExcavatorMenu
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/MineshaftWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/MineshaftWaypoints.kt
@@ -22,7 +22,6 @@ import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.toLorenzVec
-import net.minecraft.client.Minecraft
 import net.minecraft.core.Direction
 import net.minecraft.core.Vec3i
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket
@@ -98,7 +97,7 @@ object MineshaftWaypoints {
 
     @HandleEvent
     fun onKeyPress(event: KeyPressEvent) {
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
         if (event.keyCode != config.shareWaypointLocation) return
         if (timeLastShared.passedSince() < 500.milliseconds) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -51,6 +51,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
@@ -59,7 +60,6 @@ import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.toLorenzVec
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.world.entity.decoration.ArmorStand
 import net.minecraft.world.level.block.Blocks
@@ -304,7 +304,7 @@ object MinionFeatures {
     fun onTick() {
         if (display != null) return
 
-        if (Minecraft.getInstance().screen is ContainerScreen && config.hopperProfitDisplay) {
+        if (MinecraftCompat.screen is ContainerScreen && config.hopperProfitDisplay) {
             display = if (minionInventoryOpen) Renderable.text(updateCoinsPerDay()) else null
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/QuickModMenuSwitch.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/QuickModMenuSwitch.kt
@@ -17,11 +17,11 @@ import at.hannibal2.skyhanni.utils.ReflectionUtils.getPublicFieldValue
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.addLine
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import net.minecraft.client.Minecraft
 
 @SkyHanniModule
 object QuickModMenuSwitch {
@@ -58,7 +58,7 @@ object QuickModMenuSwitch {
     }
 
     private fun update() {
-        var openGui = Minecraft.getInstance().screen?.javaClass?.name ?: "none"
+        var openGui = MinecraftCompat.screen?.javaClass?.name ?: "none"
         openGui = handleAbstractGuis(openGui)
         if (latestGuiPath != openGui) {
             latestGuiPath = openGui
@@ -92,14 +92,14 @@ object QuickModMenuSwitch {
     private fun handleAbstractGuis(openGui: String): String =
         if (openGui == "gg.essential.vigilance.gui.SettingsGui") {
             val clazz = Class.forName("gg.essential.vigilance.gui.SettingsGui")
-            val titleBarDelegate = clazz.getPrivateFieldValue("titleBar\$delegate", Minecraft.getInstance().screen)
+            val titleBarDelegate = clazz.getPrivateFieldValue("titleBar\$delegate", MinecraftCompat.screen)
             val titleBar = titleBarDelegate.getPrivateFieldValue(0)
             val gui = titleBar.getPrivateFieldValue("gui")
             val config = gui.getPrivateFieldValue("config")
 
             config.javaClass.name
         } else if (openGui == "cc.polyfrost.oneconfig.gui.OneConfigGui") {
-            val actualGui = Minecraft.getInstance().screen ?: return openGui
+            val actualGui = MinecraftCompat.screen ?: return openGui
             val currentPage = actualGui.getPrivateFieldValue("currentPage")
             if (currentPage.javaClass.simpleName == "ModConfigPage") {
                 val optionPage = currentPage.getPrivateFieldValue("page")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -1,6 +1,5 @@
 package at.hannibal2.skyhanni.features.misc.compacttablist
 
-//~ if < 26.1 'PlayerFaceExtractor' -> 'PlayerFaceRenderer' {
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.minecraftevents.RenderLayer
@@ -17,10 +16,16 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.filterToMutable
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.Minecraft
-import net.minecraft.client.gui.components.PlayerFaceExtractor
 import net.minecraft.network.chat.Component
+
+//? if >= 26.1 {
+import net.minecraft.client.gui.components.PlayerFaceExtractor
+//?} else {
+/*import net.minecraft.client.gui.components.PlayerFaceRenderer
+*///?}
 
 @SkyHanniModule
 object TabListRenderer {
@@ -47,7 +52,7 @@ object TabListRenderer {
     @HandleEvent(onlyOnSkyblock = true, priority = HandleEvent.LOWEST)
     fun onGuiRenderOverlay() {
         if (GlobalRender.renderDisabled || !config.enabled.get() || !config.toggleTab) return
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
 
         val playerListKeyActive = Minecraft.getInstance().options.keyPlayerList.isActive()
         if (playerListKeyActive && !isPressed) {
@@ -158,13 +163,23 @@ object TabListRenderer {
 
                 val hideIcons = config.advancedPlayerList.hidePlayerIcons && !AdvancedPlayerList.ignoreCustomTabList()
                 if (tabLine.type == TabStringType.PLAYER && !hideIcons) {
-                    val playerInfo = tabLine.getInfo()
-                    if (playerInfo != null) {
+                    tabLine.getInfo()?.let { playerInfo ->
                         //~ if < 26.1 'texturePath' -> 'id'
                         val texture = playerInfo.skin.body().texturePath()
-                        //~ if < 26.1 'extractRenderState' -> 'draw'
+
+                        //? if >= 26.1 {
                         PlayerFaceExtractor.extractRenderState(
-                            DrawContextUtils.drawContext, texture, middleX, middleY, 8, playerInfo.showHat(), false, -1,
+                        //?} else {
+                        /*PlayerFaceRenderer.draw(
+                        *///?}
+                            DrawContextUtils.drawContext,
+                            texture,
+                            middleX,
+                            middleY,
+                            8,
+                            playerInfo.showHat(),
+                            false,
+                            -1,
                         )
                     }
                     middleX += 8 + 2
@@ -202,4 +217,3 @@ object TabListRenderer {
         event.move(31, "misc.compactTabList", "gui.compactTabList")
     }
 }
-//~}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListRenderer.kt
@@ -169,7 +169,7 @@ object TabListRenderer {
 
                         //? if >= 26.1 {
                         PlayerFaceExtractor.extractRenderState(
-                        //?} else {
+                            //?} else {
                         /*PlayerFaceRenderer.draw(
                         *///?}
                             DrawContextUtils.drawContext,

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -30,11 +30,11 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
-import net.minecraft.client.Minecraft
 import org.lwjgl.glfw.GLFW
 import kotlin.math.roundToLong
 
@@ -63,7 +63,7 @@ object EstimatedItemValue {
     internal var stackingEnchants: Map<String, Enchant.Stacking> = emptyMap()
         private set
 
-    fun isCurrentlyShowing() = currentlyShowing && Minecraft.getInstance().screen != null
+    fun isCurrentlyShowing() = currentlyShowing && MinecraftCompat.screen != null
 
     @HandleEvent
     fun onNeuRepoReload(event: NeuRepositoryReloadEvent) = neuRepoReloadCoroutine.launch {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigOptionGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/massconfiguration/DefaultConfigOptionGui.kt
@@ -4,10 +4,12 @@ import at.hannibal2.skyhanni.utils.GuiRenderUtils
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.StringUtils.splitLines
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.MouseCompat
 import at.hannibal2.skyhanni.utils.compat.SkyHanniBaseScreen
 import at.hannibal2.skyhanni.utils.renderables.RenderableTooltips
 import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
+import net.minecraft.client.Minecraft
 import kotlin.math.max
 import kotlin.math.min
 
@@ -53,6 +55,7 @@ class DefaultConfigOptionGui(
         val isMouseInScrollArea =
             x in 0..xSize && mouseY in ((height - ySize) / 2) + barSize..((height + ySize) / 2 - barSize)
         var y = mouseY - ((height - ySize) / 2 + barSize) + currentScrollOffset
+        val font = Minecraft.getInstance().font
 
         DrawContextUtils.pushPop {
             DrawContextUtils.translate(width / 2F, (height - ySize) / 2F)
@@ -62,7 +65,7 @@ class DefaultConfigOptionGui(
             GuiRenderUtils.drawStringCenteredScaledMaxWidth(
                 guiTitle,
                 0F,
-                mc.font.lineHeight.toFloat(),
+                font.lineHeight.toFloat(),
                 false,
                 xSize / 2 - padding,
                 -1,
@@ -71,11 +74,11 @@ class DefaultConfigOptionGui(
 
         DrawContextUtils.translatedPushPopResult(
             x = (width - xSize) / 2F + padding,
-            y = (height + ySize) / 2F - mc.font.lineHeight * 2,
+            y = (height + ySize) / 2F - font.lineHeight * 2,
         ) {
             var i = 0
             fun button(title: String, tooltip: List<String>, func: () -> Unit) {
-                val width = mc.font.width(title)
+                val width = font.width(title)
                 var overMouse = false
                 if (mouseX - ((this.width - xSize) / 2 + padding) in i..(i + width) &&
                     mouseY - (height + ySize) / 2 in -barSize..0
@@ -98,7 +101,7 @@ class DefaultConfigOptionGui(
             }
             button("Apply choices", listOf()) {
                 DefaultConfigFeatures.applyCategorySelections(resetSuggestionState, orderedOptions)
-                mc.setScreen(null)
+                MinecraftCompat.screen = null
             }
             button("Turn all on", listOf()) {
                 for (entry in resetSuggestionState.entries) {
@@ -125,7 +128,7 @@ class DefaultConfigOptionGui(
                 }
             }
             button("Cancel", listOf()) {
-                mc.setScreen(null)
+                MinecraftCompat.screen = null
             }
         }
 
@@ -142,7 +145,7 @@ class DefaultConfigOptionGui(
             )
 
             for ((cat) in orderedOptions.entries) {
-                val suggestionState = resetSuggestionState[cat]!!
+                val suggestionState = resetSuggestionState[cat] ?: continue
 
                 GuiRenderUtils.drawRect(0, 0, xSize - padding * 2, 1, 0xFF808080.toInt())
                 GuiRenderUtils.drawRect(0, 30, xSize - padding * 2, cardHeight + 1, 0xFF808080.toInt())

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/IslandAreaFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/IslandAreaFeatures.kt
@@ -25,13 +25,13 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.SearchTextInput
 import at.hannibal2.skyhanni.utils.renderables.Searchable
 import at.hannibal2.skyhanni.utils.renderables.buildSearchBox
 import at.hannibal2.skyhanni.utils.renderables.toSearchable
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import kotlin.time.Duration.Companion.seconds
 
@@ -110,7 +110,7 @@ object IslandAreaFeatures {
     fun onGuiRenderOverlay() {
         if (!isAreaListEnabled()) return
         if (!areaListConfig.showAlways) return
-        val isInOwnInventory = Minecraft.getInstance().screen is InventoryScreen
+        val isInOwnInventory = MinecraftCompat.screen is InventoryScreen
         if (!isInOwnInventory) {
             doRender()
         }
@@ -119,7 +119,7 @@ object IslandAreaFeatures {
     @HandleEvent
     fun onChestGuiRender() {
         if (!isAreaListEnabled()) return
-        val isInOwnInventory = Minecraft.getInstance().screen is InventoryScreen
+        val isInOwnInventory = MinecraftCompat.screen is InventoryScreen
         if (isInOwnInventory) {
             doRender()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorFeatures.kt
@@ -34,6 +34,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.command
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
@@ -43,7 +44,6 @@ import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import at.hannibal2.skyhanni.utils.roundedUpSeconds
-import net.minecraft.client.Minecraft
 import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.decoration.ArmorStand
 import kotlin.time.Duration.Companion.milliseconds
@@ -334,7 +334,7 @@ object TrevorFeatures {
 
     @HandleEvent(onlyOnIsland = IslandType.THE_FARMING_ISLANDS)
     fun onKeyPress(event: KeyPressEvent) {
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
 
         if (event.keyCode != config.keyBind) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangelogViewer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/ChangelogViewer.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.toQueryString
 import at.hannibal2.skyhanni.utils.api.ApiUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.containsKeys
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.json.fromJson
 import at.hannibal2.skyhanni.utils.system.ModVersion
@@ -20,7 +21,6 @@ import com.google.gson.Gson
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.future.await
 import moe.nea.libautoupdate.GithubReleaseUpdateSource.GithubRelease
-import net.minecraft.client.Minecraft
 import java.util.NavigableMap
 import java.util.TreeMap
 import kotlin.time.Duration.Companion.seconds
@@ -71,7 +71,7 @@ object ChangelogViewer {
     }
 
     private fun openChangelog() {
-        if (Minecraft.getInstance().screen !is ChangeLogViewerScreen) SkyHanniMod.screenToOpen = ChangeLogViewerScreen()
+        if (MinecraftCompat.screen !is ChangeLogViewerScreen) SkyHanniMod.screenToOpen = ChangeLogViewerScreen()
     }
 
     private suspend fun getChangelog() {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -4,8 +4,8 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.TimeAndSizeLimitedCache
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.OrderedTextUtils.requiredStyleChangeString
-import net.minecraft.client.Minecraft
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.FormattedText
 import net.minecraft.network.chat.Style
@@ -34,7 +34,7 @@ object ModifyVisualWords {
         componentCache.clear()
         SkyHanniMod.visualWordsData.modifiedWords =
             userModifiedWords.map { it.toVisualWord() }.toMutableList()
-        Minecraft.getInstance().gui.chat.refreshTrimmedMessages()
+        MinecraftCompat.hud.chat.refreshTrimmedMessages()
     }
 
     var changeWords = true

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordGui.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.convertToFormatted
 import at.hannibal2.skyhanni.utils.compat.ColoredBlockCompat
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
@@ -26,7 +27,6 @@ import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Co
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import com.google.gson.JsonObject
 import io.github.notenoughupdates.moulconfig.ChromaColour
-import net.minecraft.client.Minecraft
 import java.awt.Color
 import java.io.File
 import java.io.FileInputStream
@@ -85,7 +85,7 @@ object VisualWordGui {
         }
     }
 
-    fun isInGui(): Boolean = Minecraft.getInstance().screen is VisualWordScreen
+    fun isInGui(): Boolean = MinecraftCompat.screen is VisualWordScreen
 
     fun onCommand() {
         if (!SkyBlockUtils.onHypixel && !OutsideSBFeature.MODIFY_VISUAL_WORDS.isSelected()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/VanquisherWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/VanquisherWaypointShare.kt
@@ -22,12 +22,12 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatchers
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.renderBeaconBeam
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import java.awt.Color
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.component1
@@ -148,7 +148,7 @@ object VanquisherWaypointShare {
     @HandleEvent
     fun onKeyPressEvent(event: KeyPressEvent) {
         if (!isEnabled()) return
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
         if (event.keyCode == config.keybindSharing) sendSpawn()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/reputationhelper/CrimsonIsleReputationHelper.kt
@@ -24,9 +24,9 @@ import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 
 @SkyHanniModule
@@ -136,7 +136,7 @@ object CrimsonIsleReputationHelper {
     }
 
     fun isHotkeyHeld(): Boolean {
-        val isAllowedGui = Minecraft.getInstance().screen.let {
+        val isAllowedGui = MinecraftCompat.screen.let {
             it == null || it is InventoryScreen
         }
         if (!isAllowedGui) return false

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/PetDisplayConfigGuiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/PetDisplayConfigGuiManager.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.ConfigUtils
 import at.hannibal2.skyhanni.utils.GuiRenderUtils
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
 import at.hannibal2.skyhanni.utils.compat.GuiScreenUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.MouseCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import io.github.notenoughupdates.moulconfig.gui.MoulConfigEditor
@@ -53,7 +54,7 @@ object PetDisplayConfigGuiManager {
 
     fun isOpen(): Boolean {
         val currentEditor = editor ?: return false
-        val screen = Minecraft.getInstance().screen as? MoulConfigScreenComponent ?: return false
+        val screen = MinecraftCompat.screen as? MoulConfigScreenComponent ?: return false
         val root = screen.guiContext.root as? MoulConfigEditorComponent ?: return false
         return root.editor === currentEditor
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerDaggerHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerDaggerHelper.kt
@@ -18,13 +18,13 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.compat.findHealthReal
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import net.minecraft.client.Minecraft
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -245,7 +245,7 @@ object BlazeSlayerDaggerHelper {
     fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.daggers) return
 
-        val currentScreen = Minecraft.getInstance().screen
+        val currentScreen = MinecraftCompat.screen
         if (currentScreen != null && currentScreen !is GuiPositionEditor) return
 
         textTop?.let { config.positionTop.renderRenderable(it, "Blaze Slayer Dagger Top") }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiPlayerTabOverlayHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiPlayerTabOverlayHook.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.mixins.hooks
 
 import at.hannibal2.skyhanni.events.TabListLineRenderEvent
-import net.minecraft.client.Minecraft
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.client.gui.components.PlayerTabOverlay
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 import kotlin.reflect.KProperty
@@ -9,7 +9,7 @@ import kotlin.reflect.KProperty
 fun <T> tabListGuarded(block: (PlayerTabOverlay) -> T): T {
     tabListGuard = true
     try {
-        return block(Minecraft.getInstance().gui.tabList)
+        return block(MinecraftCompat.hud.tabList)
     } finally {
         tabListGuard = false
     }

--- a/src/main/java/at/hannibal2/skyhanni/test/ParkourWaypointSaver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/ParkourWaypointSaver.kt
@@ -16,9 +16,9 @@ import at.hannibal2.skyhanni.utils.ParkourHelper
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.expandBlock
-import net.minecraft.client.Minecraft
 import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
@@ -33,7 +33,7 @@ object ParkourWaypointSaver {
     fun onKeyPress(event: KeyPressEvent) {
         @Suppress("InSkyBlockEarlyReturn")
         if (!SkyBlockUtils.inSkyBlock && !config.parkourOutsideSB) return
-        if (Minecraft.getInstance().screen != null) return
+        if (MinecraftCompat.screen != null) return
         if (GraphEditor.isEnabled()) return
         if (timeLastSaved.passedSince() < 250.milliseconds) return
 

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorInput.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorInput.kt
@@ -23,9 +23,9 @@ import at.hannibal2.skyhanni.utils.RaycastUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import net.minecraft.client.KeyMapping
-import net.minecraft.client.Minecraft
 import net.minecraft.client.player.LocalPlayer
 import org.lwjgl.glfw.GLFW
 
@@ -162,7 +162,7 @@ object GraphEditorInput {
     }
 
     private fun handleUndoRedo(): Boolean {
-        if (Minecraft.getInstance().screen == null) {
+        if (MinecraftCompat.screen == null) {
             if (KeyboardManager.isControlKeyDown() && GLFW.GLFW_KEY_Y.isKeyClicked()) {
                 GraphEditorHistory.undo()
                 return true
@@ -322,7 +322,7 @@ object GraphEditorInput {
     }
 
     private fun isAnyGuiActive(): Boolean {
-        val gui = Minecraft.getInstance().screen != null
+        val gui = MinecraftCompat.screen != null
         if (gui) {
             lastGuiTime = 3.ticks.fromNow()
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ChatUtils.kt
@@ -24,7 +24,6 @@ import at.hannibal2.skyhanni.utils.compat.hover
 import at.hannibal2.skyhanni.utils.compat.url
 import at.hannibal2.skyhanni.utils.compat.withColor
 import net.minecraft.ChatFormatting
-import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.ClientPacketListener
 import net.minecraft.client.multiplayer.chat.GuiMessage
 import net.minecraft.network.chat.Component
@@ -344,7 +343,7 @@ object ChatUtils {
         if (autoOpen) OSUtils.openBrowser(url)
     }
 
-    private val chatGui get() = Minecraft.getInstance().gui.chat
+    private val chatGui get() = MinecraftCompat.hud.chat
 
     val chatMessages: MutableList<GuiMessage>
         get() = chatGui.allMessages
@@ -480,7 +479,7 @@ object ChatUtils {
         }
 
     val GuiMessage.chatMessage get() = content.formattedTextCompat().stripHypixelMessage()
-    fun GuiMessage.passedSinceSent() = (Minecraft.getInstance().gui.guiTicks - addedTime()).ticks
+    fun GuiMessage.passedSinceSent() = (MinecraftCompat.hud.guiTicks - addedTime()).ticks
 
     fun consoleLog(text: String) {
         SkyHanniMod.consoleLog(text)

--- a/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ConfigUtils.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.config.ConfigGuiManager
 import at.hannibal2.skyhanni.config.MoulConfigEditorComponent
 import at.hannibal2.skyhanni.features.pets.PetDisplayConfigGuiManager
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
 import io.github.notenoughupdates.moulconfig.common.text.StructuredText
@@ -12,7 +13,6 @@ import io.github.notenoughupdates.moulconfig.gui.GuiContext
 import io.github.notenoughupdates.moulconfig.gui.MoulConfigEditor
 import io.github.notenoughupdates.moulconfig.platform.MoulConfigScreenComponent
 import io.github.notenoughupdates.moulconfig.processor.ProcessedOption
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.network.chat.Component
 import java.lang.reflect.Field
@@ -110,7 +110,7 @@ object ConfigUtils {
         MoulConfigScreenComponent(Component.empty(), GuiContext(MoulConfigEditorComponent(editor)), previousScreen)
 
     val configScreenCurrentlyOpen: Boolean
-        get() = Minecraft.getInstance().screen is MoulConfigScreenComponent
+        get() = MinecraftCompat.screen is MoulConfigScreenComponent
 
     fun String.asStructuredText() = StructuredText.of(this)
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer
 import at.hannibal2.skyhanni.utils.compat.normalizeAsArray
 import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import net.minecraft.client.resources.language.I18n
@@ -29,7 +28,8 @@ import net.minecraft.world.inventory.Slot
 import net.minecraft.world.item.Items
 import kotlin.time.Duration.Companion.seconds
 
-@Suppress("TooManyFunctions", "Unused", "MemberVisibilityCanBePrivate")
+// TODO refactor
+@Suppress("MemberVisibilityCanBePrivate", "TooManyFunctions", "Unused")
 object InventoryUtils {
 
     var itemInHandId = NeuInternalName.NONE
@@ -66,7 +66,7 @@ object InventoryUtils {
     }
 
     fun getItemsInOpenChestWithNull(): List<Slot> {
-        val guiChest = Minecraft.getInstance().screen as? ContainerScreen ?: return emptyList()
+        val guiChest = MinecraftCompat.screen as? ContainerScreen ?: return emptyList()
         return guiChest.slots()
             .filter { it.container !is Inventory }
     }
@@ -77,20 +77,20 @@ object InventoryUtils {
 
     // only works while not in an inventory
     fun getSlotsInOwnInventory(): List<Slot> {
-        val guiInventory = Minecraft.getInstance().screen as? SkyHanniGuiContainer ?: return emptyList()
+        val guiInventory = MinecraftCompat.screen as? SkyHanniGuiContainer ?: return emptyList()
         return guiInventory.slots()
             .filter { it.container is Inventory && it.item.isNotEmpty() }
     }
 
     fun openInventoryName(): String = OtherInventoryData.currentInventoryName
 
-    fun inInventory() = Minecraft.getInstance().screen is ContainerScreen
+    fun inInventory() = MinecraftCompat.screen is ContainerScreen
 
-    fun inOwnInventory() = Minecraft.getInstance().screen is InventoryScreen
+    fun inOwnInventory() = MinecraftCompat.screen is InventoryScreen
 
     fun inAnyInventory() = inInventory() || inOwnInventory()
 
-    fun inContainer() = Minecraft.getInstance().screen is SkyHanniGuiContainer
+    fun inContainer() = MinecraftCompat.screen is SkyHanniGuiContainer
 
     fun getItemsInOwnInventory(): List<SafeItemStack> =
         getItemsInOwnInventoryWithNull()?.filterNotNullOrEmpty().orEmpty()
@@ -191,7 +191,7 @@ object InventoryUtils {
     fun Container.isTopInventory() = this is SimpleContainer
 
     fun closeInventory() {
-        Minecraft.getInstance().screen = null
+        MinecraftCompat.screen = null
     }
 
     fun isInNormalChest(name: String = openInventoryName()): Boolean = name in normalChestInternalNames.map { I18n.get(it) }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RenderDisplayHelper.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
-import net.minecraft.client.Minecraft
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 
 /**
@@ -51,7 +51,7 @@ class RenderDisplayHelper(
 
         @HandleEvent
         fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
-            val isInOwnInventory = Minecraft.getInstance().screen is InventoryScreen
+            val isInOwnInventory = MinecraftCompat.screen is InventoryScreen
             for (display in currentlyVisibleDisplays) {
                 if (display.renderIn(isInOwnInventory)) {
                     if (display.outsideInventory && isInOwnInventory) {
@@ -67,7 +67,7 @@ class RenderDisplayHelper(
 
         @HandleEvent
         fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
-            val isInOwnInventory = Minecraft.getInstance().screen is InventoryScreen
+            val isInOwnInventory = MinecraftCompat.screen is InventoryScreen
             for (display in currentlyVisibleDisplays) {
                 if (display.outsideInventory && !display.renderIn(isInOwnInventory)) {
                     display.render()

--- a/src/main/java/at/hannibal2/skyhanni/utils/SignUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SignUtils.kt
@@ -5,9 +5,9 @@ import at.hannibal2.skyhanni.utils.StringUtils.capAtMinecraftLength
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.screens.inventory.AbstractSignEditScreen
 import net.minecraft.client.gui.screens.inventory.SignEditScreen
@@ -23,7 +23,7 @@ object SignUtils {
     private val pasteConfig = CoroutineSettings("sign utils paste config")
 
     fun setTextIntoSign(text: String, line: Int = 0) {
-        val gui = Minecraft.getInstance().screen
+        val gui = MinecraftCompat.screen
         if (gui !is AbstractSignEditScreen) return
         val oldRow = gui.line
         gui.line = line
@@ -32,7 +32,7 @@ object SignUtils {
     }
 
     private fun addTextIntoSign(addedText: String) {
-        val gui = Minecraft.getInstance().screen
+        val gui = MinecraftCompat.screen
         if (gui !is AbstractSignEditScreen) return
         val lines = gui.signText
         val index = gui.line

--- a/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
@@ -15,7 +15,6 @@ import com.google.common.collect.ComparisonChain
 import com.google.common.collect.Ordering
 import net.fabricmc.api.EnvType
 import net.fabricmc.api.Environment
-import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.PlayerInfo
 import net.minecraft.network.chat.Component
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket
@@ -99,7 +98,7 @@ object TabListData {
         tablistCache = newTablistCache
         TabListUpdateEvent(newTablistCache).post()
 
-        val tabListOverlay = Minecraft.getInstance().gui.tabList
+        val tabListOverlay = MinecraftCompat.hud.tabList
         header = tabListOverlay.header
         val newFooter = tabListOverlay.footer
         if (newFooter != footer) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.utils.chat
 import at.hannibal2.skyhanni.utils.ColorUtils
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.addDeletableMessageToChat
 import at.hannibal2.skyhanni.utils.compat.append
 import at.hannibal2.skyhanni.utils.compat.command
@@ -65,7 +66,7 @@ object TextHelper {
 
     fun Component.fitToChat(): Component {
         val width = this.width()
-        val maxWidth = Minecraft.getInstance().gui.chat.width
+        val maxWidth = MinecraftCompat.hud.chat.width
         if (width < maxWidth) {
             val repeat = maxWidth / width
             val component = "".asComponent()
@@ -75,7 +76,7 @@ object TextHelper {
         return this
     }
 
-    fun Component.center(width: Int = Minecraft.getInstance().gui.chat.width): Component {
+    fun Component.center(width: Int = MinecraftCompat.hud.chat.width): Component {
         val textWidth = this.width()
         val spaceWidth = SPACE.width().coerceAtLeast(1)
         val padding = (width - textWidth).coerceAtLeast(0) / 2

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -50,7 +50,7 @@ object InventoryCompat {
      */
     internal fun clickInventorySlot(windowId: Int, slotId: Int, mouseButton: Int, mode: ContainerInput) {
         val controller = Minecraft.getInstance().gameMode ?: return
-        val player = Minecraft.getInstance().player ?: return
+        val player = MinecraftCompat.localPlayerOrNull ?: return
         //~ if < 26.1 'handleContainerInput' -> 'handleInventoryMouseClick'
         controller.handleContainerInput(windowId, slotId, mouseButton, mode, player)
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/InventoryCompat.kt
@@ -24,7 +24,7 @@ fun LocalPlayer.getItemOnCursor(): SafeItemStack? {
 }
 
 fun stackUnderCursor(): SafeItemStack? {
-    val screen = Minecraft.getInstance().screen as? SkyHanniGuiContainer ?: return null
+    val screen = MinecraftCompat.screen as? SkyHanniGuiContainer ?: return null
     val stack = screen.hoveredSlot?.item
     if (stack != null) return stack
     // TODO 26.1 REI compat needed
@@ -36,7 +36,7 @@ fun stackUnderCursor(): SafeItemStack? {
 }
 
 fun slotUnderCursor(): Slot? {
-    val screen = Minecraft.getInstance().screen as? SkyHanniGuiContainer ?: return null
+    val screen = MinecraftCompat.screen as? SkyHanniGuiContainer ?: return null
     return screen.hoveredSlot
 }
 
@@ -60,7 +60,7 @@ object InventoryCompat {
      */
     internal fun mouseClickInventorySlot(slot: Int, mouseButton: Int, mode: ContainerInput) {
         if (slot < 0) return
-        val gui = Minecraft.getInstance().screen
+        val gui = MinecraftCompat.screen
         if (gui is AbstractContainerScreen<*>) {
             val slotObj = gui.menu.getSlot(slot)
             gui.slotClicked(slotObj, slot, mouseButton, mode)
@@ -71,7 +71,7 @@ object InventoryCompat {
         container.menu.slots
 
     fun getWindowIdOrNull(): Int? =
-        (Minecraft.getInstance().screen as? ContainerScreen)?.menu?.containerId
+        (MinecraftCompat.screen as? ContainerScreen)?.menu?.containerId
 
     fun getWindowId(): Int =
         getWindowIdOrNull() ?: ErrorManager.skyHanniError("windowId is null")

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
@@ -3,7 +3,10 @@ package at.hannibal2.skyhanni.utils.compat
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.DelayedRun
 import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.Gui
+import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.User
 import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.client.player.LocalPlayer
@@ -16,6 +19,9 @@ import net.minecraft.world.entity.Entity
  */
 @SkyHanniModule
 object MinecraftCompat {
+
+    private val mc = Minecraft.getInstance()
+
     // <editor-fold desc="World">
     /**
      * Returns the active [ClientLevel] or throws an exception if it doesn't exist.
@@ -45,7 +51,7 @@ object MinecraftCompat {
      * The local user's information, such as the username and UUID.
      * This is always non-null, even if the player is not in a world / singleplayer.
      */
-    val localUser get(): User = Minecraft.getInstance().user
+    val localUser get(): User = mc.user
     // </editor-fold>
 
 
@@ -99,8 +105,22 @@ object MinecraftCompat {
     }
     // </editor-fold>
 
+    // <editor-fold desc="Miscellaneous">
+    @JvmStatic
+    var screen: Screen?
+        get() = mc.screen
+        set(value) {
+            mc.setScreen(value)
+        }
 
-    val hideGui get(): Boolean = Minecraft.getInstance().options.hideGui
+    val hud get(): Gui = mc.gui
+
+    val hideGui get(): Boolean = mc.options.hideGui
 
     val showDebugHud get(): Boolean = Minecraft.getInstance().debugEntries.isOverlayVisible
+
+    fun reloadChunks() = DelayedRun.runOrNextTick {
+        Minecraft.getInstance().levelRenderer.allChanged()
+    }
+    // </editor-fold>
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/MinecraftCompat.kt
@@ -35,7 +35,7 @@ object MinecraftCompat {
     /**
      * Returns the active [ClientLevel] or null if it doesn't exist.
      */
-    val localWorldOrNull get(): ClientLevel? = Minecraft.getInstance().level
+    val localWorldOrNull get(): ClientLevel? = mc.level
 
     /**
      * Returns whether there is an active [ClientLevel].
@@ -68,7 +68,7 @@ object MinecraftCompat {
     /**
      * Returns the active [LocalPlayer] or null if it doesn't exist.
      */
-    val localPlayerOrNull get(): LocalPlayer? = Minecraft.getInstance().player
+    val localPlayerOrNull get(): LocalPlayer? = mc.player
 
     /**
      * Returns whether there is an active [LocalPlayer].
@@ -117,10 +117,10 @@ object MinecraftCompat {
 
     val hideGui get(): Boolean = mc.options.hideGui
 
-    val showDebugHud get(): Boolean = Minecraft.getInstance().debugEntries.isOverlayVisible
+    val showDebugHud get(): Boolean = mc.debugEntries.isOverlayVisible
 
     fun reloadChunks() = DelayedRun.runOrNextTick {
-        Minecraft.getInstance().levelRenderer.allChanged()
+        mc.levelRenderer.allChanged()
     }
     // </editor-fold>
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import net.minecraft.ChatFormatting
 import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.chat.GuiMessageTag
@@ -32,7 +33,6 @@ import kotlin.time.Duration.Companion.minutes
 //? if >= 26.1 {
 import net.minecraft.client.multiplayer.chat.GuiMessageSource
 import net.minecraft.world.item.ItemStackTemplate
-
 //?}
 
 // TODO do the same thing here as in EntityCompat, no more functions/members that are classless
@@ -125,13 +125,13 @@ private fun Component?.computeFormattedTextCompat(noExtraResets: Boolean, leadin
 }
 
 private val textColorLUT = ChatFormatting.entries
-    .mapNotNull { formatting -> formatting.color?.let { it to formatting } }
+    .mapNotNull { formatting -> TextColor.fromLegacyFormat(formatting)?.let { it.value to formatting } }
     .toMap()
 
 fun Style?.orEmpty(): Style = this ?: Style.EMPTY
 
 fun Style.chatStyle() = buildString {
-    color?.let { append(it.toChatFormatting()?.toString() ?: "<${it.formatValue()}>") }
+    color?.let { append(it.toChatFormatting()?.toString() ?: "<${it.serialize()}>") }
     if (isBold) append("§l")
     if (isItalic) append("§o")
     if (isUnderlined) append("§n")
@@ -276,14 +276,15 @@ fun addChatMessageToChat(message: Component, bypassSelfMessages: Boolean = false
 fun addDeletableMessageToChat(component: Component, id: Int, bypassSelfMessages: Boolean = false) {
     if (!bypassSelfMessages) component.skyhanniCreated = true
     DelayedRun.runOrNextTick {
-        val chat = Minecraft.getInstance().gui.chat
+        val chat = MinecraftCompat.hud.chat
         ChatManager.deleteMessage { it.signature == idToMessageSignature(id) }
         DelayedRun.runOrNextTick {
             chat.addMessage(
                 component,
                 idToMessageSignature(id),
-                //? if >= 26.1
+                //? if >= 26.1 {
                 GuiMessageSource.SYSTEM_CLIENT,
+                //?}
                 GuiMessageTag.system(),
             )
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/renderables/Renderable.kt
@@ -26,6 +26,7 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyHanniLogger
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.contains
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.RenderCompat
 import at.hannibal2.skyhanni.utils.compat.createResourceLocation
 import at.hannibal2.skyhanni.utils.guide.GuideGui
@@ -303,14 +304,14 @@ interface Renderable {
         }
 
         internal fun shouldAllowLink(debug: Boolean = false, bypassChecks: Boolean): Boolean {
-            val guiScreen = Minecraft.getInstance().screen.takeIf { it != null } ?: return false
+            val guiScreen = MinecraftCompat.screen.takeIf { it != null } ?: return false
 
             // Never support grayed out inventories
             if (RenderData.outsideInventory) return false
 
             if (bypassChecks) return true
 
-            val inMenu = Minecraft.getInstance().screen !is PauseScreen
+            val inMenu = MinecraftCompat.screen !is PauseScreen
             val isGuiPositionEditor = guiScreen !is GuiPositionEditor
             val isNotInSignAndOnSlot = if (guiScreen !is SignEditScreen && guiScreen !is GuideGui<*>) {
                 ToolTipData.lastSlot == null

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/SkyHanniTracker.kt
@@ -32,6 +32,7 @@ import at.hannibal2.skyhanni.utils.TimeUtils.weekToLocalDate
 import at.hannibal2.skyhanni.utils.TimeUtils.yearFormatter
 import at.hannibal2.skyhanni.utils.TimeUtils.yearToLocalDate
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addAll
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.RenderableUtils.addRenderableNullableButton
 import at.hannibal2.skyhanni.utils.renderables.SearchTextInput
@@ -41,7 +42,6 @@ import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRender
 import at.hannibal2.skyhanni.utils.renderables.primitives.empty
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.renderables.toRenderable
-import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import java.time.LocalDate
@@ -126,7 +126,7 @@ open class SkyHanniTracker<Data : TrackerData<*>, Config : GenericIndividualTrac
     fun renderDisplay(position: Position) {
         if (hideInEstimatedItemValue() && EstimatedItemValue.isCurrentlyShowing()) return
 
-        var currentlyOpen = Minecraft.getInstance().screen?.let { it is InventoryScreen || it is ContainerScreen } ?: false
+        var currentlyOpen = MinecraftCompat.screen?.let { it is InventoryScreen || it is ContainerScreen } ?: false
         if (!currentlyOpen && hideOutsideInventory() && this is SkyHanniItemTracker) {
             return
         }


### PR DESCRIPTION
## What
I just took #6124, and took all the KOTLIN files where Luna changed it to use MinecraftCompat.screen and the such.
I didn't change the mixins to use these since lunas PR moved them all. and I don't feel like causing too many conflicts.

## Changelog Technical Details
+ Added MinecraftCompat helpers to ease 26.2 transition. - Luna