### PR TITLE
Fix: LoadOutApi does not update MaxwellApi about powerstone & tunings

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
@@ -106,7 +106,7 @@ object MaxwellApi {
         "gui.thaumaturgy.start",
         "§7Your tuning:",
     )
-    private val thaumaturgyDataPattern by patternGroup.pattern(
+    val thaumaturgyDataPattern by patternGroup.pattern(
         "gui.thaumaturgy.data",
         "§(?<color>.)\\+(?<amount>[^ ]+)(?<icon>.) (?<name>.+)",
     )
@@ -118,7 +118,7 @@ object MaxwellApi {
         "gui.thaumaturgy.magicalpower",
         "§7Total: §6(?<mp>[\\d.,]+) Magical Power",
     )
-    private val statsTuningGuiPattern by patternGroup.pattern(
+    val statsTuningGuiPattern by patternGroup.pattern(
         "gui.thaumaturgy.statstuning",
         "Stats Tuning",
     )
@@ -252,7 +252,7 @@ object MaxwellApi {
         tunings = map
     }
 
-    private fun Pattern.readTuningFromLine(line: String): ThaumaturgyPowerTuning? {
+    fun Pattern.readTuningFromLine(line: String): ThaumaturgyPowerTuning? {
         return matchMatcher(line) {
             val color = "§" + group("color")
             val icon = group("icon")

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
@@ -106,7 +106,7 @@ object MaxwellApi {
         "gui.thaumaturgy.start",
         "§7Your tuning:",
     )
-    val thaumaturgyDataPattern by patternGroup.pattern(
+    private val thaumaturgyDataPattern by patternGroup.pattern(
         "gui.thaumaturgy.data",
         "§(?<color>.)\\+(?<amount>[^ ]+)(?<icon>.) (?<name>.+)",
     )
@@ -118,7 +118,7 @@ object MaxwellApi {
         "gui.thaumaturgy.magicalpower",
         "§7Total: §6(?<mp>[\\d.,]+) Magical Power",
     )
-    val statsTuningGuiPattern by patternGroup.pattern(
+    private val statsTuningGuiPattern by patternGroup.pattern(
         "gui.thaumaturgy.statstuning",
         "Stats Tuning",
     )
@@ -252,7 +252,7 @@ object MaxwellApi {
         tunings = map
     }
 
-    fun Pattern.readTuningFromLine(line: String): ThaumaturgyPowerTuning? {
+    private fun Pattern.readTuningFromLine(line: String): ThaumaturgyPowerTuning? {
         return matchMatcher(line) {
             val color = "§" + group("color")
             val icon = group("icon")
@@ -260,6 +260,10 @@ object MaxwellApi {
             val value = group("amount")
             ThaumaturgyPowerTuning(value, color, name, icon)
         }
+    }
+
+    fun readTuningFromLine(line: String): ThaumaturgyPowerTuning? {
+        return thaumaturgyDataPattern.readTuningFromLine(line) ?: statsTuningDataPattern.readTuningFromLine(line)
     }
 
     private fun loadThaumaturgyCurrentPower(inventoryItems: Map<Int, SafeItemStack>) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutApi.kt
@@ -2,6 +2,8 @@ package at.hannibal2.skyhanni.features.inventory.loadout
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.MaxwellApi
+import at.hannibal2.skyhanni.data.MaxwellApi.readTuningFromLine
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
@@ -196,6 +198,11 @@ object LoadoutApi {
         data.hotf = itemsList[HOTF_SLOT].parseCurrentSelection()
 
         EquipmentSlot.entries.forEach { EquipmentApi.setEquipment(it, data.equipment[it.ordinal]) }
+
+        MaxwellApi.currentPower = data.powerstone
+        data.tunings?.let { tuningLines ->
+            MaxwellApi.tunings = tuningLines.mapNotNull { MaxwellApi.thaumaturgyDataPattern.readTuningFromLine(it) }
+        }
     }
 
     // This is for Hotm, Hotf and Powerstone

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/loadout/LoadoutApi.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.inventory.loadout
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.MaxwellApi
-import at.hannibal2.skyhanni.data.MaxwellApi.readTuningFromLine
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
@@ -201,7 +200,7 @@ object LoadoutApi {
 
         MaxwellApi.currentPower = data.powerstone
         data.tunings?.let { tuningLines ->
-            MaxwellApi.tunings = tuningLines.mapNotNull { MaxwellApi.thaumaturgyDataPattern.readTuningFromLine(it) }
+            MaxwellApi.tunings = tuningLines.mapNotNull { MaxwellApi.readTuningFromLine(it) }
         }
     }
 


### PR DESCRIPTION
## What
Made it tell MaxwellApi the new tunings and powerstone.
Don't know if making this public is the best solution, but it was the easiest.

Has been tested and it works.

## Changelog Fixes
+ Fixed changing loadouts not updating Power Stone and tunings in Custom Scoreboard. - Avrg