### PR TITLE
Backend: Mark long-running threads as daemon

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -80,7 +80,7 @@ class ConfigManager {
         }
 
         // TODO use SecondPassedEvent
-        fixedRateTimer(name = "skyhanni-config-auto-save", period = 60_000L, initialDelay = 60_000L) {
+        fixedRateTimer(name = "skyhanni-config-auto-save", daemon = true, period = 60_000L, initialDelay = 60_000L) {
             saveConfig(ConfigFileType.FEATURES, "auto-save-60s")
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/FixedRateTimerManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/FixedRateTimerManager.kt
@@ -11,7 +11,7 @@ object FixedRateTimerManager {
     private var totalSeconds = 0
 
     init {
-        fixedRateTimer(name = "skyhanni-fixed-rate-timer-manager", period = 1000L) {
+        fixedRateTimer(name = "skyhanni-fixed-rate-timer-manager", daemon = true, period = 1000L) {
             DelayedRun.runOrNextTick {
                 if (!SkyBlockUtils.onHypixel) return@runOrNextTick
                 SecondPassedEvent(totalSeconds).post()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/GardenCropSpeed.kt
@@ -30,7 +30,7 @@ object GardenCropSpeed {
 
     init {
         // TODO use SecondPassedEvent + passedSince
-        fixedRateTimer(name = "skyhanni-crop-milestone-speed", period = 1000L) {
+        fixedRateTimer(name = "skyhanni-crop-milestone-speed", daemon = true, period = 1000L) {
             if (isEnabled()) {
                 checkSpeed()
             }


### PR DESCRIPTION
## What
Marks long-running threads as daemon to ensure a clean game/JVM shutdown. This is currently just "good practice", but it will be required on 26.2 and above to not get client shutdown watchdog timeouts.

## Changelog Technical Details
+ Marked long-running threads as daemon to ensure they don't hold up client shutdown. - Luna