### PR TITLE
Fix: PestSpawnTimer Partial Pest Widget robust

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -88,6 +88,7 @@ object PestSpawnTimer {
     private var shouldRepeatWarning = false
     private var countdownTitleContext: TitleContext? = null
     private var lastPlayedSound: SimpleTimeMark = SimpleTimeMark.farPast()
+    private var cooldownNotDetected = false
 
     private fun getCustomCooldownTime(): Duration = with(config) {
         if (Perk.PEST_ERADICATOR.isActive) customCooldownTimeFinnegan
@@ -105,6 +106,7 @@ object PestSpawnTimer {
             maxPests = true
             pestCooldownEndTime = SimpleTimeMark.farPast()
             shouldRepeatWarning = false
+            cooldownNotDetected = false
             return
         }
 
@@ -112,6 +114,7 @@ object PestSpawnTimer {
             val time = groupOrNull("time")?.let { getTablistEndTime(it, pestCooldownEndTime) }
             ready = hasGroup("ready")
             maxPests = hasGroup("maxPests")
+            cooldownNotDetected = false
 
             if (ready || maxPests) {
                 pestCooldownEndTime = SimpleTimeMark.farPast()
@@ -128,6 +131,8 @@ object PestSpawnTimer {
                 hasReminderShown = false
                 pestSpawned = false
             }
+        } ?: run {
+            cooldownNotDetected = true
         }
     }
 
@@ -248,6 +253,7 @@ object PestSpawnTimer {
             "§cPests Widget not detected! Enable via /widget!"
         } else {
             val cooldownValue = when {
+                cooldownNotDetected -> "§cUnknown"
                 maxPests -> "§cMax Pests!"
                 ready -> "§aReady!"
                 pestCooldownEndTime.isFarPast() -> "§cUnknown"

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
-import at.hannibal2.skyhanni.events.garden.farming.CropClickEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestSpawnEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
@@ -164,7 +163,7 @@ object PestSpawnTimer {
     }
 
     @HandleEvent
-    fun onCropBreak(event: CropClickEvent) {
+    fun onCropClick() {
         val timeDiff = lastCropBrokenTime.passedSince()
 
         if (timeDiff > longestCropBrokenTime) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -131,6 +131,8 @@ object PestSpawnTimer {
             }
         } ?: run {
             if (widgetLines.all { it.isBlank() }) return
+            // If somehow only the "Pests: " line is visible.
+            if (widgetLines.size == 1) return
 
             ErrorManager.logErrorStateWithData(
                 "Could not find pest cooldown time from widget.",

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -28,7 +28,6 @@ import at.hannibal2.skyhanni.features.garden.pests.PestApi.lastPestSpawnTime
 import at.hannibal2.skyhanni.features.inventory.wardrobe.ArmorWardrobeApi
 import at.hannibal2.skyhanni.features.inventory.wardrobe.EquipmentWardrobeApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
@@ -63,10 +62,17 @@ object PestSpawnTimer {
      * WRAPPED-REGEX-TEST: " Cooldown: 58s"
      * WRAPPED-REGEX-TEST: " Cooldown: MAX PESTS"
      */
-
     private val pestCooldownPattern by patternGroup.pattern(
         "cooldowntime-no-color",
         "\\sCooldown: (?<time>\\d{1,2}[ms](?: \\d{1,2}s?)?)?(?<ready>READY)?(?<maxPests>MAX PESTS)?.*",
+    )
+
+    /**
+     * WRAPPED-REGEX-TEST: " Alive: 8"
+     */
+    private val maxPestsAlivePattern by patternGroup.pattern(
+        "max-pests-alive",
+        "\\sAlive: 8",
     )
 
     private val pestSpawnTimes: MutableList<Duration> = mutableListOf()
@@ -93,6 +99,15 @@ object PestSpawnTimer {
         if (!event.isWidget(TabWidget.PESTS)) return
         val widgetLines = event.widget.lines.map { it.string }
 
+        // Hypixel can sometimes send partial widget.
+        // so we first check if the maximum number of pests is present as a workaround that.
+        maxPestsAlivePattern.firstMatcher(widgetLines) {
+            maxPests = true
+            pestCooldownEndTime = SimpleTimeMark.farPast()
+            shouldRepeatWarning = false
+            return
+        }
+
         pestCooldownPattern.firstMatcher(widgetLines) {
             val time = groupOrNull("time")?.let { getTablistEndTime(it, pestCooldownEndTime) }
             ready = hasGroup("ready")
@@ -113,14 +128,6 @@ object PestSpawnTimer {
                 hasReminderShown = false
                 pestSpawned = false
             }
-        } ?: run {
-            if (widgetLines.all { it.isBlank() }) return
-
-            ErrorManager.logErrorStateWithData(
-                "Could not find pest cooldown time from widget.",
-                internalMessage = "Could not find pest cooldown time in widget update event.",
-                "widgetLines" to widgetLines,
-            )
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -28,6 +28,7 @@ import at.hannibal2.skyhanni.features.garden.pests.PestApi.lastPestSpawnTime
 import at.hannibal2.skyhanni.features.inventory.wardrobe.ArmorWardrobeApi
 import at.hannibal2.skyhanni.features.inventory.wardrobe.EquipmentWardrobeApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
@@ -128,6 +129,14 @@ object PestSpawnTimer {
                 hasReminderShown = false
                 pestSpawned = false
             }
+        } ?: run {
+            if (widgetLines.all { it.isBlank() }) return
+
+            ErrorManager.logErrorStateWithData(
+                "Could not find pest cooldown time from widget.",
+                internalMessage = "Could not find pest cooldown time in widget update event.",
+                "widgetLines" to widgetLines,
+            )
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -28,7 +28,6 @@ import at.hannibal2.skyhanni.features.garden.pests.PestApi.lastPestSpawnTime
 import at.hannibal2.skyhanni.features.inventory.wardrobe.ArmorWardrobeApi
 import at.hannibal2.skyhanni.features.inventory.wardrobe.EquipmentWardrobeApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.afterChange
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
@@ -129,16 +128,6 @@ object PestSpawnTimer {
                 hasReminderShown = false
                 pestSpawned = false
             }
-        } ?: run {
-            if (widgetLines.all { it.isBlank() }) return
-            // If somehow only the "Pests: " line is visible.
-            if (widgetLines.size == 1) return
-
-            ErrorManager.logErrorStateWithData(
-                "Could not find pest cooldown time from widget.",
-                internalMessage = "Could not find pest cooldown time in widget update event.",
-                "widgetLines" to widgetLines,
-            )
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -100,8 +100,8 @@ object PestSpawnTimer {
         if (!event.isWidget(TabWidget.PESTS)) return
         val widgetLines = event.widget.lines.map { it.string }
 
-        // Hypixel can sometimes send partial widget.
-        // so we first check if the maximum number of pests is present as a workaround that.
+        // Hypixel can sometimes send partial widget
+        // so we first check if the maximum number of pests is present as a workaround
         maxPestsAlivePattern.firstMatcher(widgetLines) {
             maxPests = true
             pestCooldownEndTime = SimpleTimeMark.farPast()


### PR DESCRIPTION
## What
Hypixel can send the pest widget partial.
So I made it first check for "Alive: 8" line, and since it's the second line in the widget it should make this more robust.

## Changelog Fixes
+ Fixed Pest Spawn Timer giving error when Tab List is still loading when joining the Garden. - Avrg