### PR TITLE
Improvement: Hide Blazetekk Ham Radio Useless Warning Messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatFilter.kt
@@ -285,6 +285,9 @@ object ChatFilter {
         "§cWhoa! Slow down there!",
         "§cWait a moment before confirming!",
         "§cYou cannot open the SkyBlock menu while in combat!",
+        "§7Your radio is weak. Find another enjoyer to boost it.",
+        "§7Your radio signal is strong!",
+        "§7Your radio lost signal. There's too many enjoyers on this channel.",
     )
 
     // Annoying Spam


### PR DESCRIPTION
## What
Added Blazetek ham radio useless warning to the chat filter.
Unsure if the correct category for them, but still.

## Changelog Improvements
+ Added Blazetekk Ham Radio warnings to chat filter. - Avrg