### PR TITLE
Improvement: Make foraging feature work on Torrhus Canyon

### DIFF
--- a/.idea/dictionaries/default_user.xml
+++ b/.idea/dictionaries/default_user.xml
@@ -172,6 +172,7 @@
       <w>fragilis</w>
       <w>fraiser</w>
       <w>framebuffer</w>
+      <w>froggles</w>
       <w>garlacius</w>
       <w>geonathan</w>
       <w>getfromsacks</w>

--- a/detekt/baseline-main.xml
+++ b/detekt/baseline-main.xml
@@ -529,10 +529,8 @@
     <ID>UseOrEmpty:ItemUtils.kt:ItemUtils$lore ?: emptyList()</ID>
     <ID>UselessCallOnNotNull:EssenceShopHelper.kt:EssenceShopHelper$essenceHeaderStack?.hoverName.formattedTextCompatLeadingWhiteLessResets().orEmpty()</ID>
     <ID>UselessCallOnNotNull:IslandExceptions.kt:IslandExceptions$armorStand?.name.formattedTextCompatLessResets().orEmpty()</ID>
-    <ID>UselessCallOnNotNull:MoongladeBeacon.kt:MoongladeBeacon$listOfNotNull(normalTuning, enchantedTuning)</ID>
     <ID>UselessCallOnNotNull:ScoreboardData.kt:ScoreboardData$MinecraftCompat.localWorldOrNull?.scoreboard?.getSidebarObjective()?.displayName.formattedTextCompat().orEmpty()</ID>
     <ID>VarCouldBeVal:CommandBuilder.kt:ComplexCommandBuilder$private var realDescription: String = ""</ID>
-    <ID>VarCouldBeVal:MoongladeBeacon.kt:MoongladeBeacon.BeaconTuneData$private var recentTicks: MutableList&lt;Int&gt; = mutableListOf()</ID>
     <ID>VarCouldBeVal:RepoPatternGui.kt:RepoPatternGui$private var searchCache = ObservableList(mutableListOf&lt;RepoPatternInfo&gt;())</ID>
     <ID>VarCouldBeVal:RepoPatternManager.kt:RepoPatternManager$/** * Map containing all keys and their repo patterns. Used for filling in new regexes after an update, and for * checking duplicate registrations. */ private var usedKeys: NavigableMap&lt;String, CommonPatternInfo&lt;*, *&gt;&gt; = TreeMap()</ID>
     <ID>VarCouldBeVal:SkyHanniItemTracker.kt:SkyHanniItemTracker$private var scrollValue = ScrollValue()</ID>

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -13,7 +13,7 @@ import com.google.gson.JsonPrimitive
 object ConfigUpdaterMigrator {
 
     val logger = SkyHanniLogger("ConfigMigration")
-    const val CONFIG_VERSION = 138
+    const val CONFIG_VERSION = 139
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingBeaconConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingBeaconConfig.kt
@@ -7,7 +7,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
-class MoongladeBeaconConfig {
+class ForagingBeaconConfig {
 
     @Expose
     @ConfigOption(name = "Beacon Solver", desc = "Shows which slots to click on to solve the beacon.")
@@ -26,13 +26,13 @@ class MoongladeBeaconConfig {
     var preventOverClicking: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Alert when ready", desc = "Sends a title when the moonglade beacon is ready to be activated.")
+    @ConfigOption(name = "Alert when ready", desc = "Sends a title when the foraging beacons are ready to be activated.")
     @FeatureToggle
     @ConfigEditorBoolean
     var beaconAlert: Boolean = true
 
     @Expose
-    @ConfigLink(owner = MoongladeBeaconConfig::class, field = "enabled")
+    @ConfigLink(owner = ForagingBeaconConfig::class, field = "enabled")
     val displayPosition: Position = Position(-300, 140)
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
@@ -20,7 +20,7 @@ class ForagingConfig {
 
     @Expose
     @ConfigOption(name = "Starlyn Contests", desc = "")
-    @SearchTag("Agatha")
+    @SearchTag("Agatha Miria")
     @Accordion
     val starlynContest: StarlynContestsConfig = StarlynContestsConfig()
 
@@ -30,9 +30,10 @@ class ForagingConfig {
     val tutorialQuest: ForagingTutorialQuestConfig = ForagingTutorialQuestConfig()
 
     @Expose
-    @ConfigOption(name = "Moonglade Beacon", desc = "Settings for the moonglade beacon.")
+    @ConfigOption(name = "Foraging Beacon", desc = "Settings for the foraging beacons.")
     @Accordion
-    var moongladeBeacon = MoongladeBeaconConfig()
+    // TODO: RENAME and config fix
+    var moongladeBeacon = ForagingBeaconConfig()
 
     @Expose
     @ConfigOption(name = "Foraging Tracker", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
@@ -33,7 +33,7 @@ class ForagingConfig {
     @ConfigOption(name = "Foraging Beacon", desc = "Settings for the foraging beacons.")
     @Accordion
     // TODO: RENAME and config fix
-    var moongladeBeacon = ForagingBeaconConfig()
+    val moongladeBeacon = ForagingBeaconConfig()
 
     @Expose
     @ConfigOption(name = "Foraging Tracker", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingConfig.kt
@@ -32,8 +32,7 @@ class ForagingConfig {
     @Expose
     @ConfigOption(name = "Foraging Beacon", desc = "Settings for the foraging beacons.")
     @Accordion
-    // TODO: RENAME and config fix
-    val moongladeBeacon = ForagingBeaconConfig()
+    val foragingBeacon = ForagingBeaconConfig()
 
     @Expose
     @ConfigOption(name = "Foraging Tracker", desc = "")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/StarlynContestsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/StarlynContestsConfig.kt
@@ -6,28 +6,33 @@ import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class StarlynContestsConfig {
 
     @Expose
-    @ConfigOption(name = "Agatha Coupon Prices", desc = "Help to identify profitable items to buy at Agatha's shop.")
+    @ConfigOption(name = "Coupon Prices", desc = "Help to identify profitable items to buy at Starlyn Sister shops.")
     @ConfigEditorBoolean
     @FeatureToggle
+    // TODO: RENAME and config fix
     var agathaCouponProfitEnabled = true
 
     @Expose
     @ConfigOption(name = "Compact Results", desc = "Compacts the messages for your placement in a §dStarlyn Sister §7contest.")
+    @SearchTag("Agatha Miria")
     @ConfigEditorBoolean
     @FeatureToggle
     var compactResults = false
 
     @Expose
     @ConfigOption(name = "Compact Personal Bests", desc = "Compact messages from log collection §dpersonal bests §7during contests.")
+    @SearchTag("Agatha Miria")
     @ConfigEditorBoolean
     @FeatureToggle
     var compactPersonalBest = false
 
     @Expose
+    // TODO: RENAME and config fix
     @ConfigLink(owner = StarlynContestsConfig::class, field = "agathaCouponProfitEnabled")
     val agathaCouponProfitPos: Position = Position(206, 158)
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/StarlynContestsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/StarlynContestsConfig.kt
@@ -14,8 +14,7 @@ class StarlynContestsConfig {
     @ConfigOption(name = "Coupon Prices", desc = "Help to identify profitable items to buy at Starlyn Sister shops.")
     @ConfigEditorBoolean
     @FeatureToggle
-    // TODO: RENAME and config fix
-    var agathaCouponProfitEnabled = true
+    var starlynCouponProfitEnabled = true
 
     @Expose
     @ConfigOption(name = "Compact Results", desc = "Compacts the messages for your placement in a §dStarlyn Sister §7contest.")
@@ -32,8 +31,7 @@ class StarlynContestsConfig {
     var compactPersonalBest = false
 
     @Expose
-    // TODO: RENAME and config fix
-    @ConfigLink(owner = StarlynContestsConfig::class, field = "agathaCouponProfitEnabled")
-    val agathaCouponProfitPos: Position = Position(206, 158)
+    @ConfigLink(owner = StarlynContestsConfig::class, field = "starlynCouponProfitEnabled")
+    val starlynCouponProfitPos: Position = Position(206, 158)
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/TreesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/TreesConfig.kt
@@ -13,7 +13,7 @@ class TreesConfig {
     @ConfigOption(name = "Clean Tree View", desc = "Hides the floating blocks when mining trees in galatea.")
     @ConfigEditorBoolean
     @FeatureToggle
-    @SearchTag("fig mangrove")
+    @SearchTag("fig mangrove helix")
     var cleanView = true
 
     @Expose
@@ -34,7 +34,8 @@ class TreesConfig {
     var muteBreaking = true
 
     @Expose
-    @ConfigOption(name = "Also on Galatea", desc = "Also mutes tree breaking sounds on Galatea.")
+    @ConfigOption(name = "Also on Galatea", desc = "Also mute tree breaking sounds on Galatea.")
+    @SearchTag("fig mangrove helix")
     @ConfigEditorBoolean
     var muteBreakingOnGalatea = false
 

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.data.effect
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -211,7 +212,7 @@ object EffectApi {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun readSalts(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.SALTS)) return
         saltTabPattern.matchAll(event.lines.map { it.string }) {

--- a/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
@@ -351,9 +351,10 @@ enum class TabWidget(
         // language=RegExp
         "Agatha's Contest:.*",
     ),
+    // TODO rename to FORAGING_BEACON
     MOONGLADE_BEACON(
         // language=RegExp
-        "Moonglade Beacon: (?<stacks>\\d+) Stacks?",
+        "(?<beaconType>\\w+) Beacon: (?<stacks>\\d+) Stacks?",
     ),
     SALTS(
         // language=RegExp

--- a/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TabWidget.kt
@@ -351,6 +351,10 @@ enum class TabWidget(
         // language=RegExp
         "Agatha's Contest:.*",
     ),
+    MIRIA_CONTEST(
+        // language=RegExp
+        "Miria's Contest:.*",
+    ),
     // TODO rename to FORAGING_BEACON
     MOONGLADE_BEACON(
         // language=RegExp
@@ -360,9 +364,10 @@ enum class TabWidget(
         // language=RegExp
         "Salts:",
     ),
+    // TODO rename to WHISPERS
     FOREST_WHISPERS(
         // language=RegExp
-        "Forest Whispers: (?<amount>.*)",
+        "(?<whisperType>\\w+) Whispers: (?<amount>.*)",
     ),
     SHARD_TRAPS(
         // language=RegExp

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactStarlynSisters.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactStarlynSisters.kt
@@ -3,10 +3,8 @@ package at.hannibal2.skyhanni.features.foraging
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.storage.Resettable
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.data.achievements.Achievement
-import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.achievements.AchievementRegistrationEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.features.achievements.AchievementManager
@@ -155,8 +153,7 @@ object CompactStarlynSisters {
     }
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
-        if (event.oldIsland != IslandType.GALATEA) return
+    fun onIslandLeave() {
         resetContestResultVariables()
         resetPersonalBestVariables()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactStarlynSisters.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactStarlynSisters.kt
@@ -28,7 +28,7 @@ import net.minecraft.network.chat.Component
 object CompactStarlynSisters {
 
     private val config get() = SkyHanniMod.feature.foraging.starlynContest
-    private val patternGroup = RepoPattern.group("foraging.agatha")
+    private val patternGroup = RepoPattern.group("foraging.starlyn-contest")
 
     /**
      * REGEX-TEST: §e[NPC] §bAgatha§f: §rYou reached the §r§lCOMMON §fBracket in my contest!
@@ -169,22 +169,22 @@ object CompactStarlynSisters {
             compactContestResults(message)
     }
 
-    private const val AGATHA_ACHIEVEMENT = "Very Special Bracket"
+    private const val STARLYN_CONTEST_ACHIEVEMENT = "Very Special Bracket"
 
     @HandleEvent
     fun onAchievementRegistration(event: AchievementRegistrationEvent) {
         val achievement = Achievement(
             name = "Very Special Contest".asComponent(),
-            description = Component.literal("Get 20,000 Agatha points in a contest").withColor(ChatFormatting.RED),
+            description = Component.literal("Get 20,000 Starlyn Sister points in a contest").withColor(ChatFormatting.RED),
             userLuckAmount = 20f,
         )
-        event.register(achievement, AGATHA_ACHIEVEMENT)
+        event.register(achievement, STARLYN_CONTEST_ACHIEVEMENT)
     }
 
     private fun SkyHanniChatEvent.Allow.achievements() {
         pointsEarnedPattern.matchMatcher(message) {
             if (group("pointsInteger").formatInt() >= 20_000) {
-                AchievementManager.completeAchievement(AGATHA_ACHIEVEMENT)
+                AchievementManager.completeAchievement(STARLYN_CONTEST_ACHIEVEMENT)
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactSweepDetails.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/CompactSweepDetails.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.storage.Resettable
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.IslandTypeTag
-import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -144,7 +143,7 @@ object CompactSweepDetails {
     }
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
+    fun onIslandLeave() {
         resetSweepDetailsVariables()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
@@ -3,17 +3,17 @@ package at.hannibal2.skyhanni.features.foraging
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.storage.Resettable
-import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.data.NotificationManager
 import at.hannibal2.skyhanni.data.SkyHanniNotification
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
-import at.hannibal2.skyhanni.features.foraging.MoongladeBeacon.BeaconColor.Companion.getColorOrNull
-import at.hannibal2.skyhanni.features.foraging.MoongladeBeacon.BeaconColor.Companion.getLoreColorOrNull
-import at.hannibal2.skyhanni.features.foraging.MoongladeBeacon.BeaconPitch.Companion.getBeaconPitchOrNull
-import at.hannibal2.skyhanni.features.foraging.MoongladeBeacon.BeaconSpeed.Companion.getBeaconSpeedOrNull
+import at.hannibal2.skyhanni.features.foraging.ForagingBeaconSolver.BeaconColor.Companion.getColorOrNull
+import at.hannibal2.skyhanni.features.foraging.ForagingBeaconSolver.BeaconColor.Companion.getLoreColorOrNull
+import at.hannibal2.skyhanni.features.foraging.ForagingBeaconSolver.BeaconPitch.Companion.getBeaconPitchOrNull
+import at.hannibal2.skyhanni.features.foraging.ForagingBeaconSolver.BeaconSpeed.Companion.getBeaconSpeedOrNull
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EnumUtils.toFormattedName
 import at.hannibal2.skyhanni.utils.InventoryDetector
@@ -53,7 +53,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.times
 
 @SkyHanniModule
-object MoongladeBeacon {
+object ForagingBeaconSolver {
 
     private val config get() = SkyHanniMod.feature.foraging.moongladeBeacon
     private val debugConfig get() = SkyHanniMod.feature.dev.debug
@@ -269,7 +269,7 @@ object MoongladeBeacon {
         nextDevUpdate = SimpleTimeMark.now() + 100.milliseconds
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!solverEnabled()) return
         if (event.blockOverClick()) {
@@ -300,13 +300,13 @@ object MoongladeBeacon {
 
     private var currentServerTicks = 0
 
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun onServerTick() {
         if (!colorMinigameInventory.isInside()) return
         currentServerTicks++
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun onPlaySound(event: PlaySoundEvent) {
         if (!colorMinigameInventory.isInside() || event.soundName != "block.note_block.bass") return
         val pitch = BeaconPitch.getByPitch(event.pitch) ?: return
@@ -327,15 +327,14 @@ object MoongladeBeacon {
             outsideInventory = false,
             inOwnInventory = false,
             inventory = colorMinigameInventory,
-            condition = { config.enabled },
-            onlyOnIsland = IslandType.GALATEA,
+            condition = { config.enabled && IslandTypeTag.FORAGING_CUSTOM_TREES.isInIsland() },
             onRender = {
                 config.displayPosition.renderRenderables(display, posLabel = "Moonglade Beacon")
             },
         )
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun onBackgroundDrawn() {
         if (!solverEnabled()) return
         InventoryUtils.getItemsInOpenChest().forEach { slot ->
@@ -344,14 +343,14 @@ object MoongladeBeacon {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun onRenderItemTip(event: RenderInventoryItemTipEvent) {
         if (!solverEnabled()) return
         normalTuning.tryLabelIfAble(event)
         enchantedTuning.tryLabelIfAble(event)
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun onInventoryUpdated() {
         if (!solverEnabled()) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
@@ -316,7 +316,7 @@ object ForagingBeaconSolver {
     }
 
     private fun BeaconPitch.handleMultipleSet() {
-        val bestSet = listOfNotNull(normalTuning, enchantedTuning).filter {
+        val bestSet = listOf(normalTuning, enchantedTuning).filter {
             it.untilNextRefPitch <= acceptablePitchMargin && it.untilNextOurPitch > it.untilNextRefPitch
         }.minByOrNull { it.untilNextRefPitch } ?: return
         bestSet.handlePitch(this)
@@ -462,7 +462,7 @@ object ForagingBeaconSolver {
 
         private var paused = false
         private var lastServerTickCount = 0
-        private var recentTicks: MutableList<Int> = mutableListOf()
+        private val recentTicks: MutableList<Int> = mutableListOf()
         private var currentRefSlot: Int = BeaconSlotRange.MATCH.range.first
 
         val untilNextRefPitch get() = nextPitchPair.referenceUntil

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
@@ -55,7 +55,7 @@ import kotlin.time.times
 @SkyHanniModule
 object ForagingBeaconSolver {
 
-    private val config get() = SkyHanniMod.feature.foraging.moongladeBeacon
+    private val config get() = SkyHanniMod.feature.foraging.foragingBeacon
     private val debugConfig get() = SkyHanniMod.feature.dev.debug
 
     private val patternGroup = RepoPattern.group("foraging.beacon")

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconSolver.kt
@@ -444,7 +444,7 @@ object ForagingBeaconSolver {
     private data class BeaconTuneData(
         val isEnchanted: Boolean = false,
     ) : Resettable {
-        private val title = if (isEnchanted) "§aEnchanted Tuning" else "§d§lMoonglade Beacon Solver"
+        private val title = if (isEnchanted) "§aEnchanted Tuning" else "§d§lForaging Beacon Solver"
         private val slotOffset = if (upgradingStrength && !isEnchanted) -9 else 0
 
         private val colorPair = NullableDataPair<BeaconColor>()

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconWarning.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.features.foraging
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration.Companion.minutes
 
 @SkyHanniModule
-object MoongladeBeaconWarning {
+object ForagingBeaconWarning {
 
     private var lastAlert = SimpleTimeMark.farPast()
 
@@ -23,7 +23,7 @@ object MoongladeBeaconWarning {
         " Cooldown: AVAILABLE",
     )
 
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun onWidget(event: WidgetUpdateEvent) {
         if (!isEnabled()) return
         if (!event.isWidget(TabWidget.MOONGLADE_BEACON)) return

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingBeaconWarning.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.foraging
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleManager
@@ -35,6 +36,11 @@ object ForagingBeaconWarning {
         }
     }
 
-    fun isEnabled() = SkyHanniMod.feature.foraging.moongladeBeacon.beaconAlert
+    fun isEnabled() = SkyHanniMod.feature.foraging.foragingBeacon.beaconAlert
+
+    @HandleEvent
+    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+        event.move(139, "foraging.moongladeBeacon", "foraging.foragingBeacon")
+    }
 
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.config.features.foraging.ForagingTrackerConfig
 import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.data.jsonobjects.repo.TreeGiftBonusDropsJson
-import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
@@ -358,8 +357,8 @@ object ForagingTracker : SkyHanniBucketedItemTracker<ForagingTrackerLegacy.TreeT
         lastHover = null
     }
 
-    @HandleEvent(IslandChangeEvent::class)
-    fun onIslandChange() {
+    @HandleEvent
+    fun onIslandLeave() {
         if (!isInIsland()) return
         firstUpdate()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/MuteTreeSounds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/MuteTreeSounds.kt
@@ -2,18 +2,19 @@ package at.hannibal2.skyhanni.features.foraging
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 
 @SkyHanniModule
 object MuteTreeSounds {
+
     val config get() = SkyHanniMod.feature.foraging.trees
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onPlaySound(event: PlaySoundEvent) {
         if (event.soundName == "entity.creaking.death" && config.muteBreaking) {
-            if (IslandType.GALATEA.isInIsland() && !config.muteBreakingOnGalatea) return
+            if (IslandTypeTag.FORAGING_CUSTOM_TREES.isInIsland() && !config.muteBreakingOnGalatea) return
             event.cancel()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/StarlynSisterCouponProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/StarlynSisterCouponProfit.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SafeItemStack
@@ -32,27 +31,28 @@ import at.hannibal2.skyhanni.utils.renderables.RenderableUtils
 import net.minecraft.network.chat.Component
 
 @SkyHanniModule
-object AgathaCouponProfit {
+object StarlynSisterCouponProfit {
 
     private val config get() = SkyHanniMod.feature.foraging.starlynContest
 
     private var display = emptyList<Renderable>()
 
     // TODO replace with inventory detector
-    private var inInventory = false
-    private val AGATHA_COUPON = "AGATHA_COUPON".toInternalName()
+    private var currentSisterType: StarlynSisterType? = null
 
     @HandleEvent
     fun onInventoryClose() {
-        inInventory = false
+        currentSisterType = null
         display = emptyList()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!config.agathaCouponProfitEnabled) return
-        if (event.inventoryName != "Agatha's Shop") return
-        inInventory = true
+        StarlynSisterType.entries.forEach { sisterType ->
+            if (event.inventoryName == sisterType.inventoryName) currentSisterType = sisterType
+        }
+        if (currentSisterType == null) return
 
         val table = mutableListOf<DisplayTableEntry>()
         for ((slot, item) in event.inventoryItems) {
@@ -62,7 +62,7 @@ object AgathaCouponProfit {
                 }
             } catch (e: Throwable) {
                 ErrorManager.logErrorWithData(
-                    e, "Error in AgathaCouponProfit while reading item '${item.repoItemName}'",
+                    e, "Error in StarlynSisterCouponProfit while reading item '${item.repoItemName}'",
                     "item" to item,
                     "name" to item.repoItemName,
                     "inventory name" to event.inventoryName,
@@ -71,7 +71,7 @@ object AgathaCouponProfit {
         }
 
         display = buildList {
-            addString("§eProfit per Agatha Coupon")
+            addString("§eProfit per Coupon")
             add(RenderableUtils.fillTable(table, padding = 5, itemScale = 0.7))
         }
     }
@@ -86,7 +86,7 @@ object AgathaCouponProfit {
         for ((name, amount) in requiredItems) {
             val itemPrice = name.getPriceOrNull() ?: continue
             totalCost += itemPrice * amount
-            if (name == AGATHA_COUPON) {
+            if (name == currentSisterType?.couponName) {
                 couponAmount = amount
             }
         }
@@ -144,7 +144,7 @@ object AgathaCouponProfit {
             val originalPair = ItemUtils.readItemAmount(rawItemName)
             if (originalPair == null) {
                 ErrorManager.logErrorStateWithData(
-                    "Error in AnitaCoupon Profit", "Could not read item amount",
+                    "Error in StarlynSisterCouponProfit", "Could not read item amount",
                     "rawItemName" to rawItemName,
                     "name" to item.hoverName.formattedTextCompatLeadingWhiteLessResets(),
                     "lore" to lore,
@@ -165,11 +165,11 @@ object AgathaCouponProfit {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
-        if (!inInventory) return
+        if (currentSisterType == null) return
         config.agathaCouponProfitPos.renderRenderables(
             display,
             extraSpace = 5,
-            posLabel = "Anita Medal Profit",
+            posLabel = "Starlyn Sister Coupon Profit",
         )
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/StarlynSisterCouponProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/StarlynSisterCouponProfit.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.foraging
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -48,7 +49,7 @@ object StarlynSisterCouponProfit {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!config.agathaCouponProfitEnabled) return
+        if (!config.starlynCouponProfitEnabled) return
         StarlynSisterType.entries.forEach { sisterType ->
             if (event.inventoryName == sisterType.inventoryName) currentSisterType = sisterType
         }
@@ -166,10 +167,16 @@ object StarlynSisterCouponProfit {
     @HandleEvent(onlyOnSkyblock = true)
     fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (currentSisterType == null) return
-        config.agathaCouponProfitPos.renderRenderables(
+        config.starlynCouponProfitPos.renderRenderables(
             display,
             extraSpace = 5,
             posLabel = "Starlyn Sister Coupon Profit",
         )
+    }
+
+    @HandleEvent
+    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+        event.move(139, "foraging.starlynContest.agathaCouponProfitEnabled", "foraging.starlynContest.starlynCouponProfitEnabled")
+        event.move(139, "foraging.starlynContest.agathaCouponProfitPos", "foraging.starlynContest.starlynCouponProfitPos")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/StarlynSisterType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/StarlynSisterType.kt
@@ -1,0 +1,9 @@
+package at.hannibal2.skyhanni.features.foraging
+
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+
+enum class StarlynSisterType(val inventoryName: String, val couponName: NeuInternalName) {
+    AGATHA("Agatha's Shop", "AGATHA_COUPON".toInternalName()),
+    MIRIA("Miria's Shop", "MIRIA_COUPON".toInternalName()),
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.features.foraging
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.AllEntitiesGetter
 import at.hannibal2.skyhanni.utils.EntityUtils
@@ -32,7 +32,7 @@ object TreeProgressDisplay {
         "(?<treeType>\\w+) TREE (?<percent>\\d+)%",
     )
 
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun onGuiRenderOverlay() {
         if (!config.enabled) return
         display?.let {
@@ -42,7 +42,7 @@ object TreeProgressDisplay {
 
     // TODO: optimize to not use getEntities
     @OptIn(AllEntitiesGetter::class)
-    @HandleEvent(onlyOnIsland = IslandType.GALATEA)
+    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
     fun onTick() {
         if (!config.enabled) return
         if (config.onlyHoldingAxe && InventoryUtils.getItemInHand()?.getItemCategoryOrNull() != ItemCategory.AXE) {

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/WormholeFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/WormholeFinder.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.graph.GraphNode
 import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
 import at.hannibal2.skyhanni.data.title.TitleManager
-import at.hannibal2.skyhanni.events.IslandLeaveEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
@@ -119,7 +118,7 @@ object WormholeFinder {
         TitleManager.sendTitle("§cWormhole closed!")
     }
 
-    @HandleEvent(IslandLeaveEvent::class)
+    @HandleEvent
     fun onIslandLeave() {
         matchedWormholes = emptyList()
         currentTarget = null

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/TabWidgetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/TabWidgetDisplay.kt
@@ -46,7 +46,8 @@ enum class TabWidgetDisplay(
         TabWidget.FAIRY_SOULS,
     ),
     EYES("Eyes placed", TabWidget.EYES_PLACED),
-    MOONGLADE_BEACON("Moonglade Beacon", TabWidget.MOONGLADE_BEACON),
+    // TODO rename to FORAGING_BEACON
+    MOONGLADE_BEACON("Foraging Beacon", TabWidget.MOONGLADE_BEACON),
     STARBORN_TEMPLE("Starborn Temple", TabWidget.STARBORN_TEMPLE),
     SHARD_TRAPS("Shard Traps", TabWidget.SHARD_TRAPS),
     FOREST_WHISPERS("Forest Whispers", TabWidget.FOREST_WHISPERS),

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/TabWidgetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/TabWidgetDisplay.kt
@@ -50,12 +50,14 @@ enum class TabWidgetDisplay(
     MOONGLADE_BEACON("Foraging Beacon", TabWidget.MOONGLADE_BEACON),
     STARBORN_TEMPLE("Starborn Temple", TabWidget.STARBORN_TEMPLE),
     SHARD_TRAPS("Shard Traps", TabWidget.SHARD_TRAPS),
-    FOREST_WHISPERS("Forest Whispers", TabWidget.FOREST_WHISPERS),
+    // TODO rename to WHISPERS
+    FOREST_WHISPERS("Whispers", TabWidget.FOREST_WHISPERS),
     AGATHA_CONTEST("Agatha's Contest", TabWidget.AGATHA_CONTEST),
     COMMISSIONS("Mining Commissions", TabWidget.COMMISSIONS),
     SLAYER("Slayer", TabWidget.SLAYER),
     PITY("Pity", TabWidget.PITY),
     PICKAXE_COOLDOWN("Pickaxe Cooldown", TabWidget.PICKAXE_COOLDOWN),
+    MIRIA_CONTEST("Miria's Contest", TabWidget.MIRIA_CONTEST),
     ;
 
     val position get() = config.displayPositions[ordinal]

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -945,10 +945,12 @@ object ScoreboardPattern {
      * REGEX-TEST: Whispers: §3141§b (+1)
      * REGEX-TEST: Whispers: §317.5k§b (+50)
      * REGEX-TEST: §fWhispers: §317k§b (+40)
+     * REGEX-TEST: §fWhispers: §317k§b (+40)
+     * REGEX-TEST: §fWhispers: §64.2k§b (+44)
      */
     val whispersPattern by galateaSB.pattern(
         "whispers",
-        "(?:§f)?Whispers: §3[\\w,.]+.*",
+        "(?:§f)?Whispers: §[36][\\w,.]+.*",
     )
 
     /**
@@ -966,6 +968,14 @@ object ScoreboardPattern {
     val agathasContestPattern by galateaSB.pattern(
         "agathas-contest",
         "§eAgatha's Contest §a.*",
+    )
+
+    /**
+     * REGEX-TEST: §eMiria's Contest §a0m35s
+     */
+    val miriasContestPattern by galateaSB.pattern(
+        "mirias-contest",
+        "§eMiria's Contest §a.*",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -945,7 +945,6 @@ object ScoreboardPattern {
      * REGEX-TEST: Whispers: §3141§b (+1)
      * REGEX-TEST: Whispers: §317.5k§b (+50)
      * REGEX-TEST: §fWhispers: §317k§b (+40)
-     * REGEX-TEST: §fWhispers: §317k§b (+40)
      * REGEX-TEST: §fWhispers: §64.2k§b (+44)
      */
     val whispersPattern by galateaSB.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -165,7 +165,6 @@ object UnknownLinesHandler {
         return filtered
     }
 
-
     private fun warn(line: String, reason: String) {
         if (!CustomScoreboard.config.unknownLinesWarning) return
         ErrorManager.logErrorWithData(

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -90,6 +90,18 @@ object UnknownLinesHandler {
             }
         }
 
+        // Remove Miria contest
+        for (i in 1..2) {
+            unknownLines = unknownLines.filter {
+                sidebarLines.nextAfter(
+                    sidebarLines.firstOrNull { line ->
+                        SBPattern.agathasContestPattern.matches(line)
+                    } ?: "§eMiria's Contest",
+                    i,
+                ) != it
+            }
+        }
+
         // Remove slayer
         for (i in 1..2) {
             unknownLines = unknownLines.filter {

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/UnknownLinesHandler.kt
@@ -66,71 +66,51 @@ object UnknownLinesHandler {
             line != nextLine && line != secondNextLine && line != thirdNextLine && !SBPattern.thirdObjectiveLinePattern.matches(line)
         }
 
-        // Remove jacobs contest
-        for (i in 1..3) {
-            unknownLines = unknownLines.filter {
-                sidebarLines.nextAfter(
-                    sidebarLines.firstOrNull { line ->
-                        SBPattern.jacobsContestPattern.matches(line)
-                    } ?: "§eJacob's Contest",
-                    i,
-                ) != it
-            }
-        }
+        unknownLines = removeSidebarSection(
+            unknownLines,
+            sidebarLines,
+            SBPattern.jacobsContestPattern,
+            "§eJacob's Contest",
+            3,
+        )
 
-        // Remove Agatha contest
-        for (i in 1..2) {
-            unknownLines = unknownLines.filter {
-                sidebarLines.nextAfter(
-                    sidebarLines.firstOrNull { line ->
-                        SBPattern.agathasContestPattern.matches(line)
-                    } ?: "§eAgatha's Contest",
-                    i,
-                ) != it
-            }
-        }
+        unknownLines = removeSidebarSection(
+            unknownLines,
+            sidebarLines,
+            SBPattern.agathasContestPattern,
+            "§eAgatha's Contest",
+            2,
+        )
 
-        // Remove Miria contest
-        for (i in 1..2) {
-            unknownLines = unknownLines.filter {
-                sidebarLines.nextAfter(
-                    sidebarLines.firstOrNull { line ->
-                        SBPattern.agathasContestPattern.matches(line)
-                    } ?: "§eMiria's Contest",
-                    i,
-                ) != it
-            }
-        }
+        unknownLines = removeSidebarSection(
+            unknownLines,
+            sidebarLines,
+            SBPattern.miriasContestPattern,
+            "§eMiria's Contest",
+            2,
+        )
 
-        // Remove slayer
-        for (i in 1..2) {
-            unknownLines = unknownLines.filter {
-                sidebarLines.nextAfter(
-                    sidebarLines.firstOrNull { line ->
-                        SBPattern.slayerQuestPattern.matches(line)
-                    } ?: "Slayer Quest",
-                    i,
-                ) != it
-            }
-        }
+        unknownLines = removeSidebarSection(
+            unknownLines,
+            sidebarLines,
+            SBPattern.slayerQuestPattern,
+            "Slayer Quest",
+            2,
+        )
 
-        // remove trapper mob location
-        unknownLines = unknownLines.filter {
-            sidebarLines.nextAfter(
-                sidebarLines.firstOrNull { line ->
-                    SBPattern.mobLocationPattern.matches(line)
-                } ?: "Tracker Mob Location:",
-            ) != it
-        }
+        unknownLines = removeSidebarSection(
+            unknownLines,
+            sidebarLines,
+            SBPattern.mobLocationPattern,
+            "Tracker Mob Location:",
+        )
 
-        // da
-        unknownLines = unknownLines.filter {
-            sidebarLines.nextAfter(
-                sidebarLines.firstOrNull { line ->
-                    SBPattern.darkAuctionCurrentItemPattern.matches(line)
-                } ?: "Current Item:",
-            ) != it
-        }
+        unknownLines = removeSidebarSection(
+            unknownLines,
+            sidebarLines,
+            SBPattern.darkAuctionCurrentItemPattern,
+            "Current Item:",
+        )
 
         /*
          * Handle broken scoreboard lines
@@ -165,6 +145,26 @@ object UnknownLinesHandler {
             }
         }
     }
+
+    private fun removeSidebarSection(
+        unknownLines: List<String>,
+        sidebarLines: List<String>,
+        pattern: Pattern,
+        fallbackHeader: String,
+        linesAfter: Int = 1,
+    ): List<String> {
+        var filtered = unknownLines
+
+        val header = sidebarLines.firstOrNull { pattern.matches(it) } ?: fallbackHeader
+
+        for (i in 1..linesAfter) {
+            val lineToRemove = sidebarLines.nextAfter(header, i)
+            filtered = filtered.filter { it != lineToRemove }
+        }
+
+        return filtered
+    }
+
 
     private fun warn(line: String, reason: String) {
         if (!CustomScoreboard.config.unknownLinesWarning) return

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventGalatea.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/events/ScoreboardEventGalatea.kt
@@ -20,6 +20,13 @@ object ScoreboardEventGalatea : ScoreboardEvent() {
                     .filter { !ScoreboardPattern.footerPattern.matches(it) },
             )
         }
+        ScoreboardPattern.miriasContestPattern.firstMatches(getSBLines())?.let { line ->
+            add(line)
+            addAll(
+                getSBLines().sublistAfter(line, amount = 2)
+                    .filter { !ScoreboardPattern.footerPattern.matches(it) },
+            )
+        }
     }
 
     override val configLine = "§7(All Galatea Lines)"
@@ -28,5 +35,6 @@ object ScoreboardEventGalatea : ScoreboardEvent() {
         ScoreboardPattern.whispersPattern,
         ScoreboardPattern.hotfPattern,
         ScoreboardPattern.agathasContestPattern,
+        ScoreboardPattern.miriasContestPattern,
     )
 }


### PR DESCRIPTION
## What
Made stuff work, changed checks from galatea to custom foraging trees.
In future some of the tab widgets and tab widget displays have to be renamed but they dont matter rn

## Changelog Improvements
+ Made all existing skyhanni foraging features work on Torrhus Canyon. - CalMWolfs
    * If any feature doesn't work on the new island and you think it should, make a bug report.
