### PR TITLE
Fix: Small sutff since last beta

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/CustomScoreboardConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/customscoreboard/CustomScoreboardConfig.kt
@@ -18,7 +18,7 @@ class CustomScoreboardConfig {
 
     @ConfigOption(
         name = "Deprecated Feature",
-        desc = "SkyHanni's CustomScoreboard will not receive Updates in the future. Please switch to the mod for more & unique features",
+        desc = "SkyHanni's CustomScoreboard will not receive Updates in the future. Please switch to the mod for more & unique features.",
     )
     @ConfigEditorButton(buttonText = "Download the Mod")
     val customScoreboardMod: Runnable = Runnable { openBrowser("https://modrinth.com/mod/skyblock-custom-scoreboard") }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/endermen/EndermanConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/endermen/EndermanConfig.kt
@@ -52,4 +52,3 @@ class EndermanConfig {
     @ConfigEditorSlider(minStep = 1f, minValue = 1f, maxValue = 10f)
     var slayerLineWidth: Int = 3
 }
-

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
@@ -50,7 +51,7 @@ object TreeProgressDisplay {
             return
         }
         for (entity in EntityUtils.getEntities<ArmorStand>()) {
-            val name = entity.displayName.formattedTextCompat()
+            val name = entity.displayName.formattedTextCompat().removeColor()
             currentTreeProgressPattern.matchMatcher(name) {
                 display = if (config.compact) {
                     Renderable.text("${group("treeType")} §b§l${group("percent")}%")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/NoBreak.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/NoBreak.kt
@@ -9,16 +9,14 @@ import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.features.fishing.FishingApi.isFishingRod
 import at.hannibal2.skyhanni.features.garden.CropType.Companion.getCropType
 import at.hannibal2.skyhanni.features.garden.GardenApi
+import at.hannibal2.skyhanni.features.garden.pests.PestApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import com.google.gson.JsonArray
 
 @SkyHanniModule
 object NoBreak {
-
-    private val SPRAYONATOR_ITEM = "SPRAYONATOR".toInternalName()
 
     private val config get() = GardenApi.config
 
@@ -50,7 +48,7 @@ object NoBreak {
         val predicate: (NeuInternalName) -> Boolean,
     ) {
         FISHING_ROD("Fishing Rod", { it.isFishingRod() }),
-        SPRAYONATOR("Sprayonator", { it == SPRAYONATOR_ITEM }),
+        SPRAYONATOR("Sprayonator", { PestApi.hasSprayonatorInHand() }),
         ;
 
         override fun toString() = displayName

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -74,12 +74,12 @@ object PestApi {
     var lastTimeVacuumHeld = SimpleTimeMark.farPast()
     var lastTimeLassoHeld = SimpleTimeMark.farPast()
 
-
     fun hasVacuumInHand() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.VACUUM
     fun hasLassoInHand() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.LASSO
     fun hasVacuumOrLassoInHand() = hasVacuumInHand() || hasLassoInHand()
 
     private fun NeuInternalName.isSprayonator() = equalsOneOf(SPRAYONATOR, JUICY_SPRAYONATOR, SALTY_SPRAYONATOR)
+
     fun hasSprayonatorInHand(): Boolean = InventoryUtils.itemInHandId.isSprayonator()
 
     fun SprayType.getPests() = PestType.filterableEntries.filter { it.spray == this }
@@ -164,7 +164,7 @@ object PestApi {
      */
     private val stereoInventoryPattern by patternGroup.pattern(
         "stereo.inventory",
-        "Stereo Harmony"
+        "Stereo Harmony",
     )
     val stereoInventory = InventoryDetector { name -> stereoInventoryPattern.matches(name) }
 
@@ -174,7 +174,7 @@ object PestApi {
      */
     val stereoPlayingPattern by patternGroup.pattern(
         "stereo.playing",
-        "§7Now Playing: (?:§.)*(?<vinyl>[^§]+).*"
+        "§7Now Playing: (?:§.)*(?<vinyl>[^§]+).*",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -258,7 +258,7 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     }
 
     private fun SkyHanniChatEvent.Allow.checkSprayChats() {
-        GardenPlotApi.plotSprayedPattern.matchMatcher(message) {
+        GardenPlotApi.plotSprayedPattern.matchMatcher(cleanMessage) {
             val spray = group("spray")
             val amount = groupOrNull("amount")?.formatInt() ?: 1
             SprayType.getByNameOrNull(spray)?.addSprayUsed(amount)

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/corpse/CorpseLoot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/glacitemineshaft/corpse/CorpseLoot.kt
@@ -55,7 +55,7 @@ object CorpseLoot {
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onIslandChange() {
-        pendingKeyConsumed = false
+        pendingKeyConsumed = true
     }
 
     @HandleEvent(onlyOnIsland = IslandType.MINESHAFT)
@@ -69,7 +69,7 @@ object CorpseLoot {
             return
         }
 
-        if (resourceFulPerkProcPattern.matches(message)) {
+        if (resourceFulPerkProcPattern.matches(event.cleanMessage)) {
             pendingKeyConsumed = false
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/DelayedRun.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DelayedRun.kt
@@ -29,14 +29,21 @@ object DelayedRun {
         return time to runnable
     }
 
+    // TODO maybe rename to runOnNextMinecraftTick
     /**
-     * Runs in the next game tick (up to 50ms delay), always on the main thread.
+     * Schedules a task via Minecraft's internal scheduler, which runs it on the main thread
+     * at some point in the next game tick. The exact point relative to SkyHanni's own event
+     * handlers is not guaranteed.
      */
     fun runNextTick(run: () -> Unit) = Minecraft.getInstance().schedule(run)
 
-    // TODO find out why, then fix/remove duplicate function
+    // TODO maybe rename to runAfterCurrentTickEvents
     /**
-     * I'm not sure why, but this acts different to the above one
+     * Runs at the end of the next game tick, after all other event handlers have processed.
+     * Unlike [runNextTick], this goes through SkyHanni's own tick handler at [HandleEvent.LOWEST]
+     * priority, guaranteeing that all event handlers for the current tick have finished first.
+     * Use this when the task reads state that other handlers (e.g. chat handlers) may still
+     * modify during the current tick.
      */
     fun runNextTickOld(run: () -> Unit) = futureTasks.add(run to SimpleTimeMark.farPast())
 


### PR DESCRIPTION
## What
Fixed small stuff that broke since last beta or so.

## Changelog Fixes
+ Fixed Juicy Sprayonator and Salty Sprayonator not being blocked by the No-Break feature in the Garden. - hannibal2
+ Fixed Corpse Loot incorrectly tracking whether a key was consumed after leaving the Mineshaft. - hannibal2
+ Fixed Spray usage not being tracked in the Pest Profit Tracker. - hannibal2
+ Fixed Tree Progress Display not updating. - hannibal2

### Technical Details
+ Documented the behavioral difference between `DelayedRun.runNextTick` and `runNextTickOld`, added TODOs. - hannibal2