### PR TITLE
Fix: Minion Craft Helper not detecting wrapped ingredient line

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
@@ -19,9 +19,10 @@ import at.hannibal2.skyhanni.utils.ItemUtils.setLoreString
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
-import at.hannibal2.skyhanni.utils.RegexUtils.firstWrappedMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.StringUtils.withWrappedLines
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.player.Inventory
@@ -53,7 +54,7 @@ object MinionUpgradeHelper {
         if (!config.minionConfigHelper) return
         lastMinionOpen = SimpleTimeMark.now()
         val lore = event.inventoryItems[50]?.getCleanLore() ?: return
-        requiredItemsPattern.firstWrappedMatcher(lore) {
+        requiredItemsPattern.firstMatcher(lore.withWrappedLines()) {
             internalName = NeuInternalName.fromItemName(group("itemName"))
             itemsNeeded = group("amount")?.toInt() ?: 0
         } ?: resetItems()

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.StringUtils.windowedToJoin
+import at.hannibal2.skyhanni.utils.StringUtils.withWrappedLines
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.player.Inventory
@@ -54,7 +54,7 @@ object MinionUpgradeHelper {
         if (!config.minionConfigHelper) return
         lastMinionOpen = SimpleTimeMark.now()
         val lore = event.inventoryItems[50]?.getCleanLore() ?: return
-        requiredItemsPattern.firstMatcher(lore.windowedToJoin()) {
+        requiredItemsPattern.firstMatcher(lore.withWrappedLines()) {
             internalName = NeuInternalName.fromItemName(group("itemName"))
             itemsNeeded = group("amount")?.toInt() ?: 0
         } ?: resetItems()

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.StringUtils.withWrappedLines
+import at.hannibal2.skyhanni.utils.StringUtils.windowedToJoin
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.player.Inventory
@@ -54,7 +54,7 @@ object MinionUpgradeHelper {
         if (!config.minionConfigHelper) return
         lastMinionOpen = SimpleTimeMark.now()
         val lore = event.inventoryItems[50]?.getCleanLore() ?: return
-        requiredItemsPattern.firstMatcher(lore.withWrappedLines()) {
+        requiredItemsPattern.firstMatcher(lore.windowedToJoin()) {
             internalName = NeuInternalName.fromItemName(group("itemName"))
             itemsNeeded = group("amount")?.toInt() ?: 0
         } ?: resetItems()

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
@@ -19,10 +19,9 @@ import at.hannibal2.skyhanni.utils.ItemUtils.setLoreString
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
-import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.firstWrappedMatcher
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.setCustomItemName
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.player.Inventory
@@ -54,8 +53,8 @@ object MinionUpgradeHelper {
         if (!config.minionConfigHelper) return
         lastMinionOpen = SimpleTimeMark.now()
         val lore = event.inventoryItems[50]?.getCleanLore() ?: return
-        requiredItemsPattern.firstMatcher(lore) {
-            internalName = NeuInternalName.fromItemName(group("itemName").removeColor())
+        requiredItemsPattern.firstWrappedMatcher(lore) {
+            internalName = NeuInternalName.fromItemName(group("itemName"))
             itemsNeeded = group("amount")?.toInt() ?: 0
         } ?: resetItems()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -63,6 +63,35 @@ object RegexUtils {
         return null
     }
 
+    inline fun <T> Pattern.firstWrappedMatcher(
+        sequence: Sequence<String>,
+        consumer: Matcher.() -> T,
+    ): T? {
+        val lines = sequence.toList()
+
+        for (i in lines.indices) {
+            // Normal single-line match
+            matcher(lines[i]).let {
+                if (it.matches()) return consumer(it)
+            }
+
+            // Wrapped across two lines
+            if (i + 1 < lines.size) {
+                val merged = lines[i] + " " + lines[i + 1]
+                matcher(merged).let {
+                    if (it.matches()) return consumer(it)
+                }
+            }
+        }
+
+        return null
+    }
+
+    inline fun <T> Pattern.firstWrappedMatcher(
+        list: List<String>,
+        consumer: Matcher.() -> T,
+    ): T? = firstWrappedMatcher(list.asSequence(), consumer)
+
     fun List<Pattern>.allMatches(list: List<String>): List<String> = list.filter { line -> any { it.matches(line) } }
     fun List<Pattern>.anyMatches(list: List<String>?): Boolean = list?.any { line -> any { it.matches(line) } } ?: false
     fun List<Pattern>.anyMatches(string: String): Boolean = any { it.matches(string) }

--- a/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/RegexUtils.kt
@@ -63,35 +63,6 @@ object RegexUtils {
         return null
     }
 
-    inline fun <T> Pattern.firstWrappedMatcher(
-        sequence: Sequence<String>,
-        consumer: Matcher.() -> T,
-    ): T? {
-        val lines = sequence.toList()
-
-        for (i in lines.indices) {
-            // Normal single-line match
-            matcher(lines[i]).let {
-                if (it.matches()) return consumer(it)
-            }
-
-            // Wrapped across two lines
-            if (i + 1 < lines.size) {
-                val merged = lines[i] + " " + lines[i + 1]
-                matcher(merged).let {
-                    if (it.matches()) return consumer(it)
-                }
-            }
-        }
-
-        return null
-    }
-
-    inline fun <T> Pattern.firstWrappedMatcher(
-        list: List<String>,
-        consumer: Matcher.() -> T,
-    ): T? = firstWrappedMatcher(list.asSequence(), consumer)
-
     fun List<Pattern>.allMatches(list: List<String>): List<String> = list.filter { line -> any { it.matches(line) } }
     fun List<Pattern>.anyMatches(list: List<String>?): Boolean = list?.any { line -> any { it.matches(line) } } ?: false
     fun List<Pattern>.anyMatches(string: String): Boolean = any { it.matches(string) }

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -597,7 +597,6 @@ object StringUtils {
         "${URLEncoder.encode(k, "UTF-8")}=${URLEncoder.encode(v.toString(), "UTF-8")}"
     }.joinToString("&")
 
-
     fun Sequence<String>.withWrappedLines(): Sequence<String> = sequence {
         val lines = toList()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -597,53 +597,19 @@ object StringUtils {
         "${URLEncoder.encode(k, "UTF-8")}=${URLEncoder.encode(v.toString(), "UTF-8")}"
     }.joinToString("&")
 
+    fun Sequence<String>.withWrappedLines(): Sequence<String> = sequence {
+        val lines = toList()
 
+        for (i in lines.indices) {
+            yield(lines[i])
 
-    /**
-     * Creates joined sliding windows of lines.
-     *
-     * Example with size = 3:
-     *
-     * A
-     * B
-     * C
-     *
-     * produces:
-     *
-     * A
-     * A B
-     * A B C
-     * B
-     * B C
-     * C
-     */
-    fun List<String>.windowedToJoin(
-        size: Int = 2,
-        separator: String = " ",
-    ): Sequence<String> {
-        if (size <= 0) return emptySequence()
-
-        return sequence {
-            for (start in indices) {
-                subList(start, size + start.coerceAtMost(lastIndex + 1))
-                    .indices
-                    .forEach { windowSize ->
-                        yield(
-                            subList(start, start + windowSize + 1)
-                                .joinToString(separator)
-                        )
-                    }
+            if (i + 1 < lines.size) {
+                yield(lines[i] + " " + lines[i + 1])
             }
         }
     }
 
-    fun Sequence<String>.windowedToJoin(
-        size: Int = 2,
-        separator: String = " ",
-    ): Sequence<String> = toList().windowedToJoin(size, separator)
+    fun List<String>.withWrappedLines(): Sequence<String> = asSequence().withWrappedLines()
 
-    fun Iterator<String>.windowedToJoin(
-        size: Int = 2,
-        separator: String = " ",
-    ): Sequence<String> = asSequence().windowedToJoin(size, separator)
+    fun Iterator<String>.withWrappedLines(): Sequence<String> = asSequence().withWrappedLines()
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -597,19 +597,53 @@ object StringUtils {
         "${URLEncoder.encode(k, "UTF-8")}=${URLEncoder.encode(v.toString(), "UTF-8")}"
     }.joinToString("&")
 
-    fun Sequence<String>.withWrappedLines(): Sequence<String> = sequence {
-        val lines = toList()
 
-        for (i in lines.indices) {
-            yield(lines[i])
 
-            if (i + 1 < lines.size) {
-                yield(lines[i] + " " + lines[i + 1])
+    /**
+     * Creates joined sliding windows of lines.
+     *
+     * Example with size = 3:
+     *
+     * A
+     * B
+     * C
+     *
+     * produces:
+     *
+     * A
+     * A B
+     * A B C
+     * B
+     * B C
+     * C
+     */
+    fun List<String>.windowedToJoin(
+        size: Int = 2,
+        separator: String = " ",
+    ): Sequence<String> {
+        if (size <= 0) return emptySequence()
+
+        return sequence {
+            for (start in indices) {
+                subList(start, size + start.coerceAtMost(lastIndex + 1))
+                    .indices
+                    .forEach { windowSize ->
+                        yield(
+                            subList(start, start + windowSize + 1)
+                                .joinToString(separator)
+                        )
+                    }
             }
         }
     }
 
-    fun List<String>.withWrappedLines(): Sequence<String> = asSequence().withWrappedLines()
+    fun Sequence<String>.windowedToJoin(
+        size: Int = 2,
+        separator: String = " ",
+    ): Sequence<String> = toList().windowedToJoin(size, separator)
 
-    fun Iterator<String>.withWrappedLines(): Sequence<String> = asSequence().withWrappedLines()
+    fun Iterator<String>.windowedToJoin(
+        size: Int = 2,
+        separator: String = " ",
+    ): Sequence<String> = asSequence().windowedToJoin(size, separator)
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -596,4 +596,21 @@ object StringUtils {
     fun Map<String, Any>.toQueryString(): String = "?" + map { (k, v) ->
         "${URLEncoder.encode(k, "UTF-8")}=${URLEncoder.encode(v.toString(), "UTF-8")}"
     }.joinToString("&")
+
+
+    fun Sequence<String>.withWrappedLines(): Sequence<String> = sequence {
+        val lines = toList()
+
+        for (i in lines.indices) {
+            yield(lines[i])
+
+            if (i + 1 < lines.size) {
+                yield(lines[i] + " " + lines[i + 1])
+            }
+        }
+    }
+
+    fun List<String>.withWrappedLines(): Sequence<String> = asSequence().withWrappedLines()
+
+    fun Iterator<String>.withWrappedLines(): Sequence<String> = asSequence().withWrappedLines()
 }


### PR DESCRIPTION
## What
Hypixel made the line split to the next one in the case it's too long. like "8 Enchanted Redstone Blocks".

Has been confirmed working by the user who reported it.

## Changelog Fixes
+ Fixed Minion Upgrade Helper not detecting wrapped ingredient line. - Avrg