### PR TITLE
Fix: Not detecting overflow garden levels

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenLevelDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenLevelDisplay.kt
@@ -65,9 +65,13 @@ object GardenLevelDisplay {
         "inventory.name",
         "Garden (?:Desk|Level (?<currentLevel>.*))",
     )
+
+    /**
+     * REGEX-TEST: §e§l§m                     §6325,396
+     */
     private val overflowPattern by patternGroup.pattern(
         "inventory.overflow",
-        ".*§r §6(?<overflow>.*)",
+        "§e§l§m\\s+ §6(?<overflow>[\\d,]+)",
     )
 
     /**


### PR DESCRIPTION
## What
Hypixel removed the reset sometime in the last 6 months.

## Changelog Fixes
+ Fixed not properly detecting overflow Garden XP from the desk. - CalMWolfs
