### PR TITLE
Fix: TreeProgressDisplay being colorless

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
@@ -5,14 +5,14 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.AllEntitiesGetter
+import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.matchStyledMatcher
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+import at.hannibal2.skyhanni.utils.compat.append
+import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -51,15 +51,27 @@ object TreeProgressDisplay {
             return
         }
         for (entity in EntityUtils.getEntities<ArmorStand>()) {
-            val name = entity.displayName.formattedTextCompat().removeColor()
-            currentTreeProgressPattern.matchMatcher(name) {
+            val displayName = entity.displayName
+
+            currentTreeProgressPattern.matchStyledMatcher(displayName) {
                 display = if (config.compact) {
-                    Renderable.text("${group("treeType")} §b§l${group("percent")}%")
+                    val treeType = componentOrThrow("treeType")
+                    val percent = groupOrThrow("percent")
+                    val percentStyle = percent.sampleStyleAtStart()
+                    Renderable.text(
+                        componentBuilder {
+                            append(treeType)
+                            append(" ")
+                            append(percent.intoComponent())
+                            append("%") {
+                                style = percentStyle
+                            }
+                        }
+                    )
                 } else {
-                    Renderable.text(name)
+                    Renderable.text(displayName)
                 }
                 return
-
             }
         }
         display = null


### PR DESCRIPTION
## What
I figured out the point of `styledMatcher` finally.
Maybe I should have done `sampleStyleAtEnd` but it's fine.
And I was not the one who caused it this time lol.
Idk if componentBuilder got some way to just... extend the style? or like append to some string/component.
So that I can add the "%". but whatever.

## Changelog Fixes
+ Fixed Tree Progress Display being colorless. - Avrg