### PR TITLE
Fix + Backend: Pest Repellent Not Being Detected + EffectsApi Cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -300,7 +301,8 @@ object EffectApi {
      * to the range implied by the displayed precision.
      *
      * Hypixel truncates omitted units:
-     * - 1h      -> [1h, 2h)
+     * - 1w      -> [1w, 2w)
+     * - 1d 5h   -> [1d5h, 1d6h)
      * - 1h 20m  -> [1h20m, 1h21m)
      * - 20m     -> [20m, 21m)
      * - 20s     -> [20s, 21s)
@@ -313,25 +315,17 @@ object EffectApi {
             return duration
         }
 
-        val hours = duration.inWholeHours
-        val minutes = duration.inWholeMinutes % 60
-        val seconds = duration.inWholeSeconds % 60
-
-        val hasHours = hours > 0
-        val hasMinutes = minutes > 0
-        val hasSeconds = seconds > 0
-
-        val lowerBound = duration
-
         val upperBound = when {
-            hasSeconds -> duration + 1.seconds
-            hasMinutes -> duration + 1.minutes
-            hasHours -> duration + 1.hours
+            duration.inWholeSeconds % 60 != 0L -> duration + 1.seconds
+            duration.inWholeMinutes % 60 != 0L -> duration + 1.minutes
+            duration.inWholeHours % 24 != 0L -> duration + 1.hours
+            duration.inWholeDays % 7 != 0L -> duration + 1.days
+            duration.inWholeDays > 0L -> duration + 7.days
             else -> duration + 1.seconds
         }
 
         return when {
-            existing < lowerBound -> lowerBound
+            existing < duration -> duration
             existing >= upperBound -> upperBound - 1.seconds
             else -> existing
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -16,6 +16,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getCleanLore
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchAll
 import at.hannibal2.skyhanni.utils.RegexUtils.matchAllComponents
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -70,7 +71,7 @@ object EffectApi {
      * REGEX-TEST: Filter
      */
     private val filterPattern by RepoPattern.pattern(
-        "inventory.effects.filter.colorlesss",
+        "inventory.effects.filter.colorless",
         "Filter",
     )
 
@@ -192,15 +193,15 @@ object EffectApi {
 
     @HandleEvent(onlyOnSkyblock = true)
     private fun onWidgetUpdate(event: WidgetUpdateEvent) {
-        when(event.widget) {
+        when (event.widget) {
             TabWidget.ACTIVE_EFFECTS -> {
-                godPotTabPattern.firstMatcher(event.lines.map { it.string }) {
+                godPotTabPattern.firstMatcher(event.cleanLines) {
                     profileStorage?.godPotExpiry = SimpleTimeMark.now() + TimeUtils.getDuration(group("time"))
                 }
                 event.lines.readNonGodPotEffects()
             }
             TabWidget.SALTS -> {
-                saltTabPattern.matchAll(event.lines.map { it.string }) {
+                saltTabPattern.matchAll(event.cleanLines) {
                     val effect = group("effect")
                     val duration = TimeUtils.getDuration(group("time"))
                     val salt = NonGodPotEffect.entries.firstOrNull {
@@ -210,8 +211,9 @@ object EffectApi {
                 }
             }
             TabWidget.PESTS -> {
-                repellentPattern.firstMatcher(event.lines.map { it.string }) {
-                    val duration = TimeUtils.getDurationOrNull(group("time")) ?: return@firstMatcher
+                repellentPattern.firstMatcher(event.cleanLines) {
+                    val timeStr = groupOrNull("time") ?: return@firstMatcher
+                    val duration = TimeUtils.getDurationOrNull(timeStr) ?: return@firstMatcher
                     val tier = group("tier").uppercase()
                     val propTier = when (tier) {
                         "MAX" -> NonGodPotEffect.PEST_REPELLENT_MAX
@@ -231,8 +233,8 @@ object EffectApi {
         } ?: return@matchAllComponents
         try {
             val duration = TimeUtils.getDuration(group("time"))
-            EffectDurationChangeEvent(nonGodPotEffect, EffectDurationChangeType.SET, duration).post()
-        } catch (e: Exception) {
+            EffectDurationChangeEvent(nonGodPotEffect, EffectDurationChangeType.PARTIAL_SET, duration).post()
+        } catch (_: Exception) {
             ChatUtils.debug("Error while reading non god pot effects from tab list! line: '$this'")
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -99,7 +99,7 @@ object EffectApi {
      */
     private val repellentPattern by RepoPattern.pattern(
         "misc.nongodpot.repellant-no-color",
-        "( +)?Repellent: (?<tier>\\w+)?(?: \\((?<time>[dhms0-9 ]+)\\))?",
+        "(?: +)?Repellent: (?<tier>\\w+)?(?: \\((?<time>[dhms0-9 ]+)\\))?",
     )
 
     /**
@@ -136,7 +136,7 @@ object EffectApi {
      * REGEX-TEST: Time Remaining: 1h 2m
      * REGEX-TEST: Time Remaining: 1h 2m 3s
      * REGEX-TEST: Remaining: 1h 2m 3s
-     * REGEX-TEST: PAUSED
+     * REGEX-FAIL: PAUSED
      */
     private val remainingPattern by RepoPattern.pattern(
         "effects.remaining",

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -1,8 +1,6 @@
 package at.hannibal2.skyhanni.data.effect
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -152,7 +150,7 @@ object EffectApi {
 
     // Todo: Add support for poison candy I, and add support for splash / other formats
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         val msg = event.cleanMessage
         hotChocolateMixinConsumePattern.matchMatcher(msg) {
             val durationAdded = TimeUtils.getDuration(group("time"))
@@ -187,18 +185,44 @@ object EffectApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTabUpdate(event: TablistFooterUpdateEvent) {
+    private fun onTabUpdate(event: TablistFooterUpdateEvent) {
         val footerLines = TextHelper.split(event.footer, "\n") ?: listOf(event.footer)
         footerLines.readNonGodPotEffects()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun readEffects(event: WidgetUpdateEvent) {
-        if (!event.isWidget(TabWidget.ACTIVE_EFFECTS)) return
-        godPotTabPattern.firstMatcher(event.lines.map { it.string }) {
-            profileStorage?.godPotExpiry = SimpleTimeMark.now() + TimeUtils.getDuration(group("time"))
+    private fun onWidgetUpdate(event: WidgetUpdateEvent) {
+        when(event.widget) {
+            TabWidget.ACTIVE_EFFECTS -> {
+                godPotTabPattern.firstMatcher(event.lines.map { it.string }) {
+                    profileStorage?.godPotExpiry = SimpleTimeMark.now() + TimeUtils.getDuration(group("time"))
+                }
+                event.lines.readNonGodPotEffects()
+            }
+            TabWidget.SALTS -> {
+                saltTabPattern.matchAll(event.lines.map { it.string }) {
+                    val effect = group("effect")
+                    val duration = TimeUtils.getDuration(group("time"))
+                    val salt = NonGodPotEffect.entries.firstOrNull {
+                        it.tablistNamePattern.pattern() == effect
+                    } ?: return@matchAll
+                    EffectDurationChangeEvent(salt, EffectDurationChangeType.PARTIAL_SET, duration).post()
+                }
+            }
+            TabWidget.PESTS -> {
+                repellentPattern.firstMatcher(event.lines.map { it.string }) {
+                    val duration = TimeUtils.getDurationOrNull(group("time")) ?: return@firstMatcher
+                    val tier = group("tier").uppercase()
+                    val propTier = when (tier) {
+                        "MAX" -> NonGodPotEffect.PEST_REPELLENT_MAX
+                        "REGULAR" -> NonGodPotEffect.PEST_REPELLENT
+                        else -> return@firstMatcher
+                    }
+                    EffectDurationChangeEvent(propTier, EffectDurationChangeType.PARTIAL_SET, duration).post()
+                }
+            }
+            else -> {}
         }
-        event.lines.readNonGodPotEffects()
     }
 
     private fun List<Component>.readNonGodPotEffects() = tabEffectPattern.matchAllComponents(this) {
@@ -213,37 +237,8 @@ object EffectApi {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun readPestRepellent(event: WidgetUpdateEvent) {
-        if (!event.isWidget(TabWidget.PESTS)) return
-
-        repellentPattern.firstMatcher(event.lines.map { it.string }) {
-            val duration = TimeUtils.getDurationOrNull(group("time")) ?: return@firstMatcher
-            val tier = group("tier").uppercase()
-            val propTier = when (tier) {
-                "MAX" -> NonGodPotEffect.PEST_REPELLENT_MAX
-                "REGULAR" -> NonGodPotEffect.PEST_REPELLENT
-                else -> return@firstMatcher
-            }
-            EffectDurationChangeEvent(propTier, EffectDurationChangeType.PARTIAL_SET, duration).post()
-        }
-    }
-
-    @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
-    fun readSalts(event: WidgetUpdateEvent) {
-        if (!event.isWidget(TabWidget.SALTS)) return
-        saltTabPattern.matchAll(event.lines.map { it.string }) {
-            val effect = group("effect")
-            val duration = TimeUtils.getDuration(group("time"))
-            val salt = NonGodPotEffect.entries.firstOrNull {
-                it.tablistNamePattern.pattern() == effect
-            } ?: return@matchAll
-            EffectDurationChangeEvent(salt, EffectDurationChangeType.PARTIAL_SET, duration).post()
-        }
-    }
-
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+    private fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!event.isGodPotEffectsFilterSelect()) return
 
         val potionLore = event.inventoryItems[10]?.getCleanLore() ?: run {
@@ -272,7 +267,7 @@ object EffectApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!effectsInventoryPattern.matches(event.inventoryName)) return
 
         loop@ for (stack in event.inventoryItems.values) {

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -150,7 +150,7 @@ object EffectApi {
     // </editor-fold>
 
     init {
-        NonGodPotEffect.entries.forEach { it.tabListName }
+        NonGodPotEffect.entries.forEach { it.displayName }
     }
 
     private val profileStorage get() = ProfileStorageData.profileSpecific
@@ -270,7 +270,7 @@ object EffectApi {
             } ?: false
 
     private fun SafeItemStack.getNonGodPotEffectOrNull(): NonGodPotEffect? = NonGodPotEffect.entries.firstOrNull {
-        cleanName.contains(it.inventoryItemName)
+        it.inventoryItemNamePattern.matches(cleanName)
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -135,18 +135,6 @@ object EffectApi {
         "tab.footer.effects",
         " Press TAB or type /effects to view your active effects!",
     )
-
-    /**
-     * REGEX-TEST: Time Remaining: 1h 2m
-     * REGEX-TEST: Time Remaining: 1h 2m 3s
-     * REGEX-TEST: Remaining: 1h 2m 3s
-     * REGEX-FAIL: Time Remaining: Completed!
-     * REGEX-FAIL: PAUSED
-     */
-    private val remainingPattern by RepoPattern.pattern(
-        "effects.remaining",
-        ".*Remaining: (?<time>[dhms0-9 ]+)$",
-    )
     // </editor-fold>
 
     init {
@@ -280,7 +268,7 @@ object EffectApi {
         loop@ for (stack in event.inventoryItems.values) {
             val effect = stack.getNonGodPotEffectOrNull() ?: continue
             val lore = stack.getCleanLore()
-            remainingPattern.firstMatcher(lore) {
+            potionRemainingLoreTimerPattern.firstMatcher(lore) {
                 val duration = try {
                     TimeUtils.getDuration(group("time"))
                 } catch (e: Exception) {

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -28,6 +28,10 @@ import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object EffectApi {
@@ -288,6 +292,48 @@ object EffectApi {
                 }
                 EffectDurationChangeEvent(effect, EffectDurationChangeType.SET, duration).post()
             }
+        }
+    }
+
+    /**
+     * Applies a PARTIAL_SET update by constraining the existing ticking estimate
+     * to the range implied by the displayed precision.
+     *
+     * Hypixel truncates omitted units:
+     * - 1h      -> [1h, 2h)
+     * - 1h 20m  -> [1h20m, 1h21m)
+     * - 20m     -> [20m, 21m)
+     * - 20s     -> [20s, 21s)
+     *
+     * The existing estimate is preserved if it falls within the valid range;
+     * otherwise it is clamped to the nearest valid value.
+     */
+    fun clampUsingPartialSet(existing: Duration, duration: Duration): Duration {
+        if (existing == Duration.ZERO) {
+            return duration
+        }
+
+        val hours = duration.inWholeHours
+        val minutes = duration.inWholeMinutes % 60
+        val seconds = duration.inWholeSeconds % 60
+
+        val hasHours = hours > 0
+        val hasMinutes = minutes > 0
+        val hasSeconds = seconds > 0
+
+        val lowerBound = duration
+
+        val upperBound = when {
+            hasSeconds -> duration + 1.seconds
+            hasMinutes -> duration + 1.minutes
+            hasHours -> duration + 1.hours
+            else -> duration + 1.seconds
+        }
+
+        return when {
+            existing < lowerBound -> lowerBound
+            existing >= upperBound -> upperBound - 1.seconds
+            else -> existing
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getCleanLore
-import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchAll
 import at.hannibal2.skyhanni.utils.RegexUtils.matchAllComponents
@@ -27,11 +26,8 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.chat.TextHelper
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 @SkyHanniModule
 object EffectApi {
@@ -222,10 +218,8 @@ object EffectApi {
         if (!event.isWidget(TabWidget.PESTS)) return
 
         repellentPattern.firstMatcher(event.lines.map { it.string }) {
-            // Update repellent timer when near expiration to sync with the in-game countdown delay (which is slow)
-            val time = group("time")?.toIntOrNull() ?: return@firstMatcher
+            val duration = TimeUtils.getDurationOrNull(group("time")) ?: return@firstMatcher
             val tier = group("tier").uppercase()
-            val duration = time.toDuration(DurationUnit.SECONDS)
             val propTier = when (tier) {
                 "MAX" -> NonGodPotEffect.PEST_REPELLENT_MAX
                 "REGULAR" -> NonGodPotEffect.PEST_REPELLENT

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -103,7 +103,7 @@ object EffectApi {
      */
     private val repellentPattern by RepoPattern.pattern(
         "misc.nongodpot.repellant-no-color",
-        " Repellent: (?<tier>\\w+)?(?: \\((?<time>\\d)s\\))?",
+        "( +)?Repellent: (?<tier>\\w+)?(?: \\((?<time>[dhms0-9 ]+)\\))?",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
+import java.util.EnumSet
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -160,6 +161,14 @@ object EffectApi {
         NonGodPotEffect.entries.forEach { it.displayName }
     }
 
+    private val saltEffects = EnumSet.of<NonGodPotEffect>(
+        LUSHLILAC_BONBON,
+        PRIME_LUSHLILAC_BONBON,
+        EXALTED_LUSHLILAC_BONBON,
+        OCEANDY,
+        CANDYCOMB,
+    )
+
     private val profileStorage get() = ProfileStorageData.profileSpecific
     internal var totalEffectsCount = 0
 
@@ -221,8 +230,8 @@ object EffectApi {
                 saltTabPattern.matchAll(event.cleanLines) {
                     val effect = group("effect")
                     val duration = TimeUtils.getDuration(group("time"))
-                    val salt = NonGodPotEffect.entries.firstOrNull {
-                        it.tablistNamePattern.pattern() == effect
+                    val salt = saltEffects.firstOrNull {
+                        it.tablistNamePattern.matches(effect)
                     } ?: return@matchAll
                     EffectDurationChangeEvent(salt, EffectDurationChangeType.PARTIAL_SET, duration).post()
                 }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -132,10 +132,10 @@ object EffectApi {
     )
 
     /**
-     * REGEX-TEST: Time Remaining: Completed!
      * REGEX-TEST: Time Remaining: 1h 2m
      * REGEX-TEST: Time Remaining: 1h 2m 3s
      * REGEX-TEST: Remaining: 1h 2m 3s
+     * REGEX-FAIL: Time Remaining: Completed!
      * REGEX-FAIL: PAUSED
      */
     private val remainingPattern by RepoPattern.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -15,6 +15,8 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getCleanLore
+import at.hannibal2.skyhanni.utils.RegexUtils.anyMatchesComponent
+import at.hannibal2.skyhanni.utils.RegexUtils.firstComponentMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchAll
@@ -25,7 +27,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.replace
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils
-import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
 import kotlin.time.Duration
@@ -38,11 +39,13 @@ import kotlin.time.Duration.Companion.seconds
 object EffectApi {
 
     // <editor-fold desc="Patterns">
+    private val patternGroup = RepoPattern.group("api.effects")
+
     /**
      * REGEX-TEST: God Potion: 4d
      */
-    private val godPotTabPattern by RepoPattern.pattern(
-        "stats.tabpatterns.godpot-no-color",
+    private val godPotTabPattern by patternGroup.pattern(
+        "tab.god-pot",
         "God Potion: (?<time>[dhms0-9 ]+)",
     )
 
@@ -50,8 +53,8 @@ object EffectApi {
      * REGEX-TEST: SCHLURP! The effects of the Hot Chocolate Mixin have been extended by 86h 24m!
      * They will pause if your God Potion expires.
      */
-    private val hotChocolateMixinConsumePattern by RepoPattern.pattern(
-        "stats.chatpatterns.hotchocolatemixinconsume.colorless",
+    private val hotChocolateMixinConsumePattern by patternGroup.pattern(
+        "chat.hot-chocolate-mixin-consume",
         ".*Hot Chocolate Mixin have been extended by (?<time>[dhms0-9 ]*)!.*",
     )
 
@@ -60,40 +63,40 @@ object EffectApi {
      * REGEX-TEST: SIP! The God Potion grants you powers for 28h 48m!
      * REGEX-TEST: SLURP! The God Potion grants you powers for 28h 48m!
      */
-    private val godPotConsumePattern by RepoPattern.pattern(
-        "stats.chatpatterns.godpotconsume.colorless",
+    private val godPotConsumePattern by patternGroup.pattern(
+        "chat.god-pot-consume",
         ".*God Potion grants you powers for (?<time>[dhms0-9 ]*)!.*",
     )
 
     /**
      * REGEX-TEST: (1/2) Active Effects
      */
-    private val effectsInventoryPattern by RepoPattern.pattern(
-        "inventory.effects",
+    private val effectsInventoryPattern by patternGroup.pattern(
+        "inventory.title",
         "(?:\\(\\d+/\\d+\\) )?Active Effects",
     )
 
     /**
      * REGEX-TEST: Filter
      */
-    private val filterPattern by RepoPattern.pattern(
-        "inventory.effects.filter.colorless",
+    private val filterPattern by patternGroup.pattern(
+        "inventory.filter",
         "Filter",
     )
 
     /**
      * REGEX-TEST: ▶ God Potion Effects
      */
-    private val godPotEffectsFilterSelectPattern by RepoPattern.pattern(
-        "inventory.effects.filtergodpotselect.colorless",
+    private val godPotEffectsFilterSelectPattern by patternGroup.pattern(
+        "inventory.filter.god-pot-selected",
         "▶ God Potion Effects",
     )
 
     /**
      * REGEX-TEST: Remaining: 105:01:34
      */
-    private val potionRemainingLoreTimerPattern by RepoPattern.pattern(
-        "inventory.effects.effecttimeleft.colorless",
+    private val potionRemainingLoreTimerPattern by patternGroup.pattern(
+        "inventory.effect-remaining",
         "Remaining: (?<time>[\\d:]+)",
     )
 
@@ -102,8 +105,8 @@ object EffectApi {
      * WRAPPED-REGEX-TEST: " Repellent: Regular (58m)"
      * WRAPPED-REGEX-TEST: " Repellent: Max (58m)"
      */
-    private val repellentPattern by RepoPattern.pattern(
-        "misc.nongodpot.repellant-no-color",
+    private val repellentPattern by patternGroup.pattern(
+        "tab.repellent",
         "(?: +)?Repellent: (?<tier>\\w+)?(?: \\((?<time>[dhms0-9 ]+)\\))?",
     )
 
@@ -113,8 +116,8 @@ object EffectApi {
      * WRAPPED-REGEX-TEST: "     Mushed Glowy Tonic I 43m"
      * REGEX-TEST: Wisp's Ice-Flavored Water I 10m
      */
-    private val tabEffectPattern by RepoPattern.pattern(
-        "tab.effects-no-color",
+    private val tabEffectPattern by patternGroup.pattern(
+        "tab.effect",
         " *(?<effect>[\\w\\-' ]+ (?<tier>[IVXLC]+)) ?(?:|[: ])+(?<time>[dhms0-9 ]+)",
     )
 
@@ -123,17 +126,33 @@ object EffectApi {
      * REGEX-TEST: Prime Lushlilac Bonbon: 18h
      * REGEX-TEST: Prime Lushlilac Bonbon: 17h 58m
      */
-    private val saltTabPattern by RepoPattern.pattern(
-        "tab.salts-no-color",
+    private val saltTabPattern by patternGroup.pattern(
+        "tab.salt",
         " (?<effect>[\\w\\-' ]+)*: *(?<time>[dhms0-9 ]+)",
     )
 
     /**
      * WRAPPED-REGEX-TEST: " Press TAB or type /effects to view your active effects!"
      */
-    private val tabListFooterPattern by RepoPattern.pattern(
-        "tab.footer.effects",
+    private val tabListFooterPattern by patternGroup.pattern(
+        "footer.effects-hint",
         " Press TAB or type /effects to view your active effects!",
+    )
+
+    /**
+     * REGEX-TEST: You have 10 non-god effects.
+     */
+    private val effectsCountPattern by patternGroup.pattern(
+        "footer.effects-count",
+        "You have (?<count>\\d+) non-god effects\\.",
+    )
+
+    /**
+     * REGEX-TEST: Active Effects
+     */
+    private val activeEffectsFooterPattern by patternGroup.pattern(
+        "footer.title",
+        "Active Effects",
     )
     // </editor-fold>
 
@@ -142,6 +161,7 @@ object EffectApi {
     }
 
     private val profileStorage get() = ProfileStorageData.profileSpecific
+    internal var totalEffectsCount = 0
 
     // Todo: Add support for poison candy I, and add support for splash / other formats
     @HandleEvent(onlyOnSkyblock = true)
@@ -180,8 +200,12 @@ object EffectApi {
 
     @HandleEvent(onlyOnSkyblock = true)
     private fun onTabUpdate(event: TablistFooterUpdateEvent) {
-        val footerLines = TextHelper.split(event.footer, "\n") ?: listOf(event.footer)
-        footerLines.readNonGodPotEffects()
+        if (!activeEffectsFooterPattern.anyMatchesComponent(event.footer)) return
+        event.footer.readNonGodPotEffects()
+
+        totalEffectsCount = effectsCountPattern.firstComponentMatcher(event.footer) {
+            group("count").toIntOrNull()
+        } ?: 0
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchAll
 import at.hannibal2.skyhanni.utils.RegexUtils.matchAllComponents
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RegexUtils.replace
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils
@@ -152,7 +153,7 @@ object EffectApi {
     // Todo: Add support for poison candy I, and add support for splash / other formats
     @HandleEvent(onlyOnSkyblock = true)
     private fun onChat(event: SkyHanniChatEvent.Allow) {
-        val msg = event.cleanMessage
+        var msg = event.cleanMessage
         hotChocolateMixinConsumePattern.matchMatcher(msg) {
             val durationAdded = TimeUtils.getDuration(group("time"))
             EffectDurationChangeEvent(
@@ -166,9 +167,8 @@ object EffectApi {
             val existingValue = profileStorage?.godPotExpiry?.takeIfInitialized() ?: SimpleTimeMark.now()
             profileStorage?.godPotExpiry = existingValue + durationAdded
         }
-        if (tabListFooterPattern.matches(msg)) {
-            return
-        }
+
+        msg = tabListFooterPattern.replace(msg) { "" }.trim()
 
         for (effect in NonGodPotEffect.entries) {
             if (effect.effectRemovedPattern?.pattern() == msg) {

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -69,6 +69,14 @@ object EffectApi {
     )
 
     /**
+     * WRAPPED-REGEX-TEST: " Press TAB or type /effects to view your active effects!"
+     */
+    private val effectsUsageHint by patternGroup.pattern(
+        "chat.effects-hint",
+        " Press TAB or type /effects to view your active effects!",
+    )
+
+    /**
      * REGEX-TEST: (1/2) Active Effects
      */
     private val effectsInventoryPattern by patternGroup.pattern(
@@ -132,14 +140,6 @@ object EffectApi {
     )
 
     /**
-     * WRAPPED-REGEX-TEST: " Press TAB or type /effects to view your active effects!"
-     */
-    private val tabListFooterPattern by patternGroup.pattern(
-        "footer.effects-hint",
-        " Press TAB or type /effects to view your active effects!",
-    )
-
-    /**
      * REGEX-TEST: You have 10 non-god effects.
      */
     private val effectsCountPattern by patternGroup.pattern(
@@ -181,7 +181,7 @@ object EffectApi {
             profileStorage?.godPotExpiry = existingValue + durationAdded
         }
 
-        msg = tabListFooterPattern.replace(msg) { "" }.trim()
+        msg = effectsUsageHint.replace(msg) { "" }.trim()
 
         for (effect in NonGodPotEffect.entries) {
             if (effect.effectRemovedPattern?.matches(msg) == true) {

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -140,7 +140,7 @@ object EffectApi {
      */
     private val remainingPattern by RepoPattern.pattern(
         "effects.remaining",
-        "^.*Remaining: (?<time>.+)$",
+        ".*Remaining: (?<time>.+)$",
     )
     // </editor-fold>
 

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -234,7 +234,7 @@ object EffectApi {
 
     private fun List<Component>.readNonGodPotEffects() = tabEffectPattern.matchAllComponents(this) {
         val nonGodPotEffect = NonGodPotEffect.entries.firstOrNull { effect ->
-            effect.tablistNamePattern.pattern() == group("effect")
+            effect.tablistNamePattern.matches(group("effect"))
         } ?: return@matchAllComponents
         try {
             val duration = TimeUtils.getDuration(group("time"))

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -225,7 +225,7 @@ object EffectApi {
                 "REGULAR" -> NonGodPotEffect.PEST_REPELLENT
                 else -> return@firstMatcher
             }
-            EffectDurationChangeEvent(propTier, EffectDurationChangeType.SET, duration).post()
+            EffectDurationChangeEvent(propTier, EffectDurationChangeType.PARTIAL_SET, duration).post()
         }
     }
 
@@ -238,7 +238,7 @@ object EffectApi {
             val salt = NonGodPotEffect.entries.firstOrNull {
                 it.tablistNamePattern.pattern() == effect
             } ?: return@matchAll
-            EffectDurationChangeEvent(salt, EffectDurationChangeType.SET, duration).post()
+            EffectDurationChangeEvent(salt, EffectDurationChangeType.PARTIAL_SET, duration).post()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -15,6 +15,8 @@ import at.hannibal2.skyhanni.events.effects.EffectDurationChangeType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
+import at.hannibal2.skyhanni.utils.ItemUtils.getCleanLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchAll
@@ -44,22 +46,22 @@ object EffectApi {
     )
 
     /**
-     * REGEX-TEST: §a§lSCHLURP! §r§eThe effects of the §r§9Hot Chocolate Mixin §r§ehave been extended by §r§986h 24m§r§e!
-     * They will pause if your §r§cGod Potion §r§eexpires.
+     * REGEX-TEST: SCHLURP! The effects of the Hot Chocolate Mixin have been extended by 86h 24m!
+     * They will pause if your God Potion expires.
      */
     private val hotChocolateMixinConsumePattern by RepoPattern.pattern(
-        "stats.chatpatterns.hotchocolatemixinconsume",
-        "(?:§.)+.*(?:§.)+Hot Chocolate Mixin ?(?:§.)+.*extended by (?:§.)+(?<time>[dhms0-9 ]*)(?:§.)+!.*",
+        "stats.chatpatterns.hotchocolatemixinconsume.colorless",
+        ".*Hot Chocolate Mixin have been extended by (?<time>[dhms0-9 ]*)!.*",
     )
 
     /**
-     * REGEX-TEST: §a§lGULP! §r§eThe §r§cGod Potion §r§egrants you powers for §r§928h 48m§r§e!
-     * REGEX-TEST: §a§lSIP! §r§eThe §r§cGod Potion §r§egrants you powers for §r§928h 48m§r§e!
-     * REGEX-TEST: §a§lSLURP! §r§eThe §r§cGod Potion §r§egrants you powers for §r§928h 48m§r§e!
+     * REGEX-TEST: GULP! The God Potion grants you powers for 28h 48m!
+     * REGEX-TEST: SIP! The God Potion grants you powers for 28h 48m!
+     * REGEX-TEST: SLURP! The God Potion grants you powers for 28h 48m!
      */
     private val godPotConsumePattern by RepoPattern.pattern(
-        "stats.chatpatterns.godpotconsume",
-        "(?:§.)+.*(?:§.)+God Potion ?(?:§.)+.*grants you powers for (?:§.)+(?<time>[dhms0-9 ]*)(?:§.)+!.*",
+        "stats.chatpatterns.godpotconsume.colorless",
+        ".*God Potion grants you powers for (?<time>[dhms0-9 ]*)!.*",
     )
 
     /**
@@ -67,35 +69,37 @@ object EffectApi {
      */
     private val effectsInventoryPattern by RepoPattern.pattern(
         "inventory.effects",
-        "(?:§.)?(?:[(\\d\\/)]* )?Active Effects",
+        "(?:\\(\\d+/\\d+\\) )?Active Effects",
     )
 
     /**
-     * REGEX-TEST: §aFilter
+     * REGEX-TEST: Filter
      */
     private val filterPattern by RepoPattern.pattern(
-        "inventory.effects.filter",
-        "§aFilter",
+        "inventory.effects.filter.colorlesss",
+        "Filter",
     )
 
     /**
-     * REGEX-TEST: §b▶ God Potion Effects
+     * REGEX-TEST: ▶ God Potion Effects
      */
     private val godPotEffectsFilterSelectPattern by RepoPattern.pattern(
-        "inventory.effects.filtergodpotselect",
-        "§b▶ God Potion Effects",
+        "inventory.effects.filtergodpotselect.colorless",
+        "▶ God Potion Effects",
     )
 
     /**
-     * REGEX-TEST: §7Remaining: §f105:01:34
+     * REGEX-TEST: Remaining: 105:01:34
      */
     private val potionRemainingLoreTimerPattern by RepoPattern.pattern(
-        "inventory.effects.effecttimeleft",
-        "§7Remaining: §f(?<time>[\\d:]+)",
+        "inventory.effects.effecttimeleft.colorless",
+        "Remaining: (?<time>[\\d:]+)",
     )
 
     /**
      * WRAPPED-REGEX-TEST: " Repellent: MAX (12s)"
+     * WRAPPED-REGEX-TEST: " Repellent: Regular (58m)"
+     * WRAPPED-REGEX-TEST: " Repellent: Max (58m)"
      */
     private val repellentPattern by RepoPattern.pattern(
         "misc.nongodpot.repellant-no-color",
@@ -122,6 +126,26 @@ object EffectApi {
         "tab.salts-no-color",
         " (?<effect>[\\w\\-' ]+)*: *(?<time>[dhms0-9 ]+)",
     )
+
+    /**
+     * WRAPPED-REGEX-TEST: " Press TAB or type /effects to view your active effects!"
+     */
+    private val tabListFooterPattern by RepoPattern.pattern(
+        "tab.footer.effects",
+        " Press TAB or type /effects to view your active effects!",
+    )
+
+    /**
+     * REGEX-TEST: Time Remaining: Completed!
+     * REGEX-TEST: Time Remaining: 1h 2m
+     * REGEX-TEST: Time Remaining: 1h 2m 3s
+     * REGEX-TEST: Remaining: 1h 2m 3s
+     * REGEX-TEST: PAUSED
+     */
+    private val remainingPattern by RepoPattern.pattern(
+        "effects.remaining",
+        "^.*Remaining: (?<time>.+)$",
+    )
     // </editor-fold>
 
     init {
@@ -133,7 +157,8 @@ object EffectApi {
     // Todo: Add support for poison candy I, and add support for splash / other formats
     @HandleEvent(onlyOnSkyblock = true)
     fun onChat(event: SkyHanniChatEvent.Allow) {
-        hotChocolateMixinConsumePattern.matchMatcher(event.message) {
+        val msg = event.cleanMessage
+        hotChocolateMixinConsumePattern.matchMatcher(msg) {
             val durationAdded = TimeUtils.getDuration(group("time"))
             EffectDurationChangeEvent(
                 NonGodPotEffect.HOT_CHOCOLATE,
@@ -141,24 +166,22 @@ object EffectApi {
                 durationAdded,
             ).post()
         }
-        godPotConsumePattern.matchMatcher(event.message) {
+        godPotConsumePattern.matchMatcher(msg) {
             val durationAdded = TimeUtils.getDuration(group("time"))
             val existingValue = profileStorage?.godPotExpiry?.takeIfInitialized() ?: SimpleTimeMark.now()
             profileStorage?.godPotExpiry = existingValue + durationAdded
         }
-
-        val modifiedMessage = event.message.replace(
-            " Press TAB or type /effects to view your active effects!",
-            "",
-        )
+        if (tabListFooterPattern.matches(msg)) {
+            return
+        }
 
         for (effect in NonGodPotEffect.entries) {
-            if (effect.effectRemovedPattern?.pattern() == modifiedMessage) {
+            if (effect.effectRemovedPattern?.pattern() == msg) {
                 EffectDurationChangeEvent(effect, EffectDurationChangeType.REMOVE, null).post()
                 return
             }
 
-            if (effect.effectGainedPattern?.pattern() != modifiedMessage) continue
+            if (effect.effectGainedPattern?.pattern() != msg) continue
             val changeType = effect.effectChangeType ?: continue
             val duration = effect.effectDuration ?: continue
 
@@ -201,7 +224,7 @@ object EffectApi {
         repellentPattern.firstMatcher(event.lines.map { it.string }) {
             // Update repellent timer when near expiration to sync with the in-game countdown delay (which is slow)
             val time = group("time")?.toIntOrNull() ?: return@firstMatcher
-            val tier = group("tier")
+            val tier = group("tier").uppercase()
             val duration = time.toDuration(DurationUnit.SECONDS)
             val propTier = when (tier) {
                 "MAX" -> NonGodPotEffect.PEST_REPELLENT_MAX
@@ -229,7 +252,7 @@ object EffectApi {
     fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!event.isGodPotEffectsFilterSelect()) return
 
-        val potionLore = event.inventoryItems[10]?.getLore() ?: run {
+        val potionLore = event.inventoryItems[10]?.getCleanLore() ?: run {
             // No active god pot effects found, reset the expiry time
             profileStorage?.godPotExpiry = SimpleTimeMark.farPast()
             return
@@ -245,32 +268,32 @@ object EffectApi {
     private fun InventoryUpdatedEvent.isGodPotEffectsFilterSelect(): Boolean =
         effectsInventoryPattern.matches(this.inventoryName) &&
             this.inventoryItems.values.firstOrNull {
-                filterPattern.matches(it.hoverName.formattedTextCompatLeadingWhiteLessResets())
-            }?.getLore()?.any {
+                filterPattern.matches(it.cleanName)
+            }?.getCleanLore()?.any {
                 godPotEffectsFilterSelectPattern.matches(it)
             } ?: false
 
     private fun SafeItemStack.getNonGodPotEffectOrNull(): NonGodPotEffect? = NonGodPotEffect.entries.firstOrNull {
-        hoverName.formattedTextCompatLeadingWhiteLessResets().contains(it.inventoryItemName)
+        cleanName.contains(it.inventoryItemName)
     }
 
     @HandleEvent(onlyOnSkyblock = true)
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
-        if (!event.inventoryName.endsWith("Active Effects")) return
+        if (!effectsInventoryPattern.matches(event.inventoryName)) return
 
-        for (stack in event.inventoryItems.values) {
+        loop@ for (stack in event.inventoryItems.values) {
             val effect = stack.getNonGodPotEffectOrNull() ?: continue
-            for (line in stack.getLore()) {
-                if (!line.contains("Remaining") || line == "§7Time Remaining: §aCompleted!" || line.contains("Remaining Uses")) continue
-                if (line.endsWith("PAUSED")) continue
+            val lore = stack.getCleanLore()
+            remainingPattern.firstMatcher(lore) {
                 val duration = try {
-                    TimeUtils.getDuration(line.split("§f")[1])
-                } catch (e: IndexOutOfBoundsException) {
+                    TimeUtils.getDuration(group("time"))
+                } catch (e: Exception) {
                     ErrorManager.logErrorWithData(
-                        e, "Error while reading Non God-Potion effects from tab list",
-                        "line" to line,
+                        e,
+                        "Error while reading Non God-Potion effects from inventory",
+                        "lore" to lore,
                     )
-                    continue
+                    continue@loop
                 }
                 EffectDurationChangeEvent(effect, EffectDurationChangeType.SET, duration).post()
             }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -176,12 +176,12 @@ object EffectApi {
         msg = tabListFooterPattern.replace(msg) { "" }.trim()
 
         for (effect in NonGodPotEffect.entries) {
-            if (effect.effectRemovedPattern?.pattern() == msg) {
+            if (effect.effectRemovedPattern?.matches(msg) == true) {
                 EffectDurationChangeEvent(effect, EffectDurationChangeType.REMOVE, null).post()
                 return
             }
 
-            if (effect.effectGainedPattern?.pattern() != msg) continue
+            if (effect.effectGainedPattern?.matches(msg) != true) continue
             val changeType = effect.effectChangeType ?: continue
             val duration = effect.effectDuration ?: continue
 

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -140,7 +140,7 @@ object EffectApi {
      */
     private val remainingPattern by RepoPattern.pattern(
         "effects.remaining",
-        ".*Remaining: (?<time>.+)$",
+        ".*Remaining: (?<time>[dhms0-9 ]+)$",
     )
     // </editor-fold>
 

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -9,12 +9,16 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
 enum class NonGodPotEffect(
-    val tabListName: String,
-    val isMixin: Boolean = false,
-    val inventoryItemName: String = tabListName,
+    @param:Language("RegExp")
+    private val tabListName: String,
+    @param:Language("RegExp")
+    private val inventoryItemName: String = ".*${tabListName}.*",
+    @param:Language("RegExp")
+    private val effectGainedMessage: String? = null,
+    @param:Language("RegExp")
+    private val effectRemovedMessage: String? = null,
     val displayName: String,
-    @param:Language("RegExp") val effectGainedMessage: String? = null,
-    @param:Language("RegExp") val effectRemovedMessage: String? = null,
+    val isMixin: Boolean = false,
     val effectDuration: Duration? = null,
     val effectChangeType: EffectDurationChangeType? = null,
 ) {
@@ -112,7 +116,7 @@ enum class NonGodPotEffect(
 
     GREAT_SPOOK(
         "Great Spook I",
-        inventoryItemName = "Great Spook Potion",
+        inventoryItemName = ".*Great Spook Potion.*",
         displayName = "Great Spook I",
         effectGainedMessage = "You consumed a Great Spook Potion!",
         effectDuration = 24.hours,
@@ -217,5 +221,10 @@ enum class NonGodPotEffect(
                 it
             )
         },
+    )
+
+    val inventoryItemNamePattern by RepoPattern.pattern(
+        "misc.nongodpot.effects.inventoryitemname.$patternName",
+        inventoryItemName,
     )
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -12,7 +12,7 @@ enum class NonGodPotEffect(
     @param:Language("RegExp")
     private val tabListName: String,
     @param:Language("RegExp")
-    private val inventoryItemName: String = ".*${tabListName}.*",
+    private val inventoryItemName: String = ".*$tabListName.*",
     @param:Language("RegExp")
     private val effectGainedMessage: String? = null,
     @param:Language("RegExp")

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.data.effect
 import at.hannibal2.skyhanni.events.effects.EffectDurationChangeType
 import at.hannibal2.skyhanni.utils.repopatterns.NullableRepoPatternDelegate
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import org.intellij.lang.annotations.Language
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -12,37 +13,37 @@ enum class NonGodPotEffect(
     val isMixin: Boolean = false,
     val inventoryItemName: String = tabListName,
     val displayName: String,
-    val effectGainedMessage: String? = null,
-    val effectRemovedMessage: String? = null,
+    @param:Language("RegExp") val effectGainedMessage: String? = null,
+    @param:Language("RegExp") val effectRemovedMessage: String? = null,
     val effectDuration: Duration? = null,
     val effectChangeType: EffectDurationChangeType? = null,
 ) {
     SMOLDERING(
         "Smoldering Polarization I",
         displayName = "§aSmoldering Polarization I",
-        effectGainedMessage = "§aYou ate a §r§aRe-heated Gummy Polar Bear§r§a!",
+        effectGainedMessage = "You ate a Re-heated Gummy Polar Bear!",
         effectDuration = 1.hours,
         effectChangeType = EffectDurationChangeType.ADD,
     ),
     GLOWY(
         "Mushed Glowy Tonic I",
         displayName = "§2Mushed Glowy Tonic I",
-        effectGainedMessage = "§a§lBUFF! §fYou have gained §r§2Mushed Glowy Tonic I§r§f!",
+        effectGainedMessage = "BUFF! You have gained Mushed Glowy Tonic I!",
         effectDuration = 1.hours,
         effectChangeType = EffectDurationChangeType.SET,
     ),
     WISP(
         "Wisp's Ice-Flavored Water I",
         displayName = "§bWisp's Ice-Flavored Water I",
-        effectGainedMessage = "§a§lBUFF! §fYou splashed yourself with §r§bWisp's Ice-Flavored Water I§r§f!",
+        effectGainedMessage = "BUFF! You splashed yourself with Wisp's Ice-Flavored Water I!",
         effectDuration = 5.minutes,
         effectChangeType = EffectDurationChangeType.SET,
     ),
     GOBLIN(
         "King's Scent I",
         displayName = "§2King's Scent I",
-        effectGainedMessage = "§e[NPC] §6King Yolkar§f: §rThis egg will help me stomach my pain.",
-        effectRemovedMessage = "§cThe Goblin King's §r§afoul stench §r§chas dissipated!",
+        effectGainedMessage = "[NPC] King Yolkar: This egg will help me stomach my pain.",
+        effectRemovedMessage = "The Goblin King's foul stench has dissipated!",
         effectDuration = 20.minutes,
         effectChangeType = EffectDurationChangeType.SET,
     ),
@@ -111,9 +112,9 @@ enum class NonGodPotEffect(
 
     GREAT_SPOOK(
         "Great Spook I",
-        inventoryItemName = "§fGreat Spook Potion",
+        inventoryItemName = "Great Spook Potion",
         displayName = "Great Spook I",
-        effectGainedMessage = "§eYou consumed a §r§fGreat Spook Potion§r§e!",
+        effectGainedMessage = "You consumed a Great Spook Potion!",
         effectDuration = 24.hours,
         effectChangeType = EffectDurationChangeType.SET,
     ),
@@ -121,7 +122,7 @@ enum class NonGodPotEffect(
     DOUCE_PLUIE_DE_STINKY_CHEESE(
         "Douce Pluie de Stinky Cheese I",
         displayName = "§eDouce Pluie de Stinky Cheese I",
-        effectGainedMessage = "§a§lBUFF! §fYou have gained §r§eDouce Pluie de Stinky Cheese I§r§f!",
+        effectGainedMessage = "BUFF! You have gained Douce Pluie de Stinky Cheese I!",
         effectDuration = 1.hours,
         effectChangeType = EffectDurationChangeType.SET,
     ),
@@ -129,7 +130,7 @@ enum class NonGodPotEffect(
     HARVEST_HARBINGER(
         "Harvest Harbinger V",
         displayName = "§6Harvest Harbinger V",
-        effectGainedMessage = "§a§lBUFF! §fYou have gained §r§6Harvest Harbinger V§r§f!",
+        effectGainedMessage = "BUFF! You have gained Harvest Harbinger V!",
         effectDuration = 25.minutes,
         effectChangeType = EffectDurationChangeType.SET,
     ),
@@ -137,14 +138,14 @@ enum class NonGodPotEffect(
     PEST_REPELLENT(
         "Pest Repellent I",
         displayName = "§6Pest Repellent I§r",
-        effectGainedMessage = "§a§lYUM! §r§2 Pests §r§7will now spawn §r§a2x §r§7less while you break crops for the next §r§a60m§r§7!",
+        effectGainedMessage = "YUM!  Pests will now spawn 2x less while you break crops for the next 60m!",
         effectDuration = 1.hours,
         effectChangeType = EffectDurationChangeType.SET,
     ),
     PEST_REPELLENT_MAX(
         "Pest Repellent II",
         displayName = "§6Pest Repellent II",
-        effectGainedMessage = "§a§lYUM! §r§2 Pests §r§7will now spawn §r§a4x §r§7less while you break crops for the next §r§a60m§r§7!",
+        effectGainedMessage = "YUM!  Pests will now spawn 4x less while you break crops for the next 60m!",
         effectDuration = 1.hours,
         effectChangeType = EffectDurationChangeType.SET,
     ),
@@ -202,13 +203,19 @@ enum class NonGodPotEffect(
     )
     val effectGainedPattern by NullableRepoPatternDelegate(
         effectGainedMessage?.let {
-            RepoPattern.pattern("misc.nongodpot.effects.gained.$patternName", it)
+            RepoPattern.pattern(
+                "misc.nongodpot.effects.gained.$patternName.colorless",
+                it
+            )
         },
     )
 
     val effectRemovedPattern by NullableRepoPatternDelegate(
         effectRemovedMessage?.let {
-            RepoPattern.pattern("misc.nongodpot.effects.removed.$patternName", it)
+            RepoPattern.pattern(
+                "misc.nongodpot.effects.removed.$patternName.colorless",
+                it
+            )
         },
     )
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/TablistFooterUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/TablistFooterUpdateEvent.kt
@@ -3,4 +3,4 @@ package at.hannibal2.skyhanni.events
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import net.minecraft.network.chat.Component
 
-class TablistFooterUpdateEvent(val footer: Component) : SkyHanniEvent()
+class TablistFooterUpdateEvent(val footer: List<Component>) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/WidgetUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/WidgetUpdateEvent.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.EnumUtils.isAnyOf
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import net.minecraft.network.chat.Component
 
 /** The events get send on change of the widget and on island switch */
@@ -12,6 +13,8 @@ class WidgetUpdateEvent(
     val widget: TabWidget,
     val lines: List<Component>,
 ) : SkyHanniEvent() {
+
+    val cleanLines by lazy { lines.map { it.string.removeColor() } }
 
     fun isWidget(widgetType: TabWidget) = widget == widgetType
     fun isWidget(vararg widgetType: TabWidget) = widget.isAnyOf(*widgetType)

--- a/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
@@ -4,9 +4,6 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Fired when the tracked duration of a [NonGodPotEffect] changes.
@@ -32,10 +29,5 @@ enum class EffectDurationChangeType {
     ADD,
     REMOVE,
     SET,
-    PARTIAL_SET,
-    ;
-
-    companion object {
-
-    }
+    PARTIAL_SET
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
@@ -36,47 +36,46 @@ enum class EffectDurationChangeType {
     ;
 
     companion object {
-        // Applies a PARTIAL_SET update by replacing only the specified time units
-        // and preserving lower-order units from the existing duration.
-        //
-        // Examples:
-        // - 2h      -> updates hours only
-        // - 2h 10m  -> updates hours and minutes, preserves seconds
-        // - 2h 10m 5s -> replaces the entire duration
+        /**
+         * Applies a PARTIAL_SET update by constraining the existing ticking estimate
+         * to the range implied by the displayed precision.
+         *
+         * Hypixel truncates omitted units:
+         * - 1h      -> [1h, 2h)
+         * - 1h 20m  -> [1h20m, 1h21m)
+         * - 20m     -> [20m, 21m)
+         * - 20s     -> [20s, 21s)
+         *
+         * The existing estimate is preserved if it falls within the valid range;
+         * otherwise it is clamped to the nearest valid value.
+         */
         fun updateUsingPartialSet(existing: Duration, duration: Duration): Duration {
             if (existing == Duration.ZERO) {
                 return duration
             }
-            val existingMinutes = existing.inWholeMinutes % 60
-            val existingSeconds = existing.inWholeSeconds % 60
-            val newHours = duration.inWholeHours
-            val newMinutes = duration.inWholeMinutes % 60
-            val hasSeconds = duration.inWholeSeconds % 60 != 0L
-            val hasMinutes = newMinutes != 0L || hasSeconds
-            val hasHours = newHours != 0L
-            val result = when {
-                // Full precision update (contains seconds)
-                hasSeconds -> {
-                    duration
-                }
-                // Minutes are known, seconds are not
-                hasMinutes -> {
-                    newHours.hours +
-                        newMinutes.minutes +
-                        existingSeconds.seconds
-                }
-                // Only hours are known
-                hasHours -> {
-                    newHours.hours +
-                        existingMinutes.minutes +
-                        existingSeconds.seconds
-                }
-                // Zero duration
-                else -> {
-                    duration
-                }
+
+            val hours = duration.inWholeHours
+            val minutes = duration.inWholeMinutes % 60
+            val seconds = duration.inWholeSeconds % 60
+
+            val hasHours = hours > 0
+            val hasMinutes = minutes > 0
+            val hasSeconds = seconds > 0
+
+            val lowerBound = duration
+
+            val upperBound = when {
+                hasSeconds -> duration + 1.seconds
+                hasMinutes -> duration + 1.minutes
+                hasHours -> duration + 1.hours
+                else -> duration + 1.seconds
             }
-            return result
+
+            return when {
+                existing < lowerBound -> lowerBound
+                existing >= upperBound -> upperBound - 1.seconds
+                else -> existing
+            }
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
@@ -36,46 +36,6 @@ enum class EffectDurationChangeType {
     ;
 
     companion object {
-        /**
-         * Applies a PARTIAL_SET update by constraining the existing ticking estimate
-         * to the range implied by the displayed precision.
-         *
-         * Hypixel truncates omitted units:
-         * - 1h      -> [1h, 2h)
-         * - 1h 20m  -> [1h20m, 1h21m)
-         * - 20m     -> [20m, 21m)
-         * - 20s     -> [20s, 21s)
-         *
-         * The existing estimate is preserved if it falls within the valid range;
-         * otherwise it is clamped to the nearest valid value.
-         */
-        fun updateUsingPartialSet(existing: Duration, duration: Duration): Duration {
-            if (existing == Duration.ZERO) {
-                return duration
-            }
 
-            val hours = duration.inWholeHours
-            val minutes = duration.inWholeMinutes % 60
-            val seconds = duration.inWholeSeconds % 60
-
-            val hasHours = hours > 0
-            val hasMinutes = minutes > 0
-            val hasSeconds = seconds > 0
-
-            val lowerBound = duration
-
-            val upperBound = when {
-                hasSeconds -> duration + 1.seconds
-                hasMinutes -> duration + 1.minutes
-                hasHours -> duration + 1.hours
-                else -> duration + 1.seconds
-            }
-
-            return when {
-                existing < lowerBound -> lowerBound
-                existing >= upperBound -> upperBound - 1.seconds
-                else -> existing
-            }
-        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
@@ -36,6 +36,13 @@ enum class EffectDurationChangeType {
     ;
 
     companion object {
+        // Applies a PARTIAL_SET update by replacing only the specified time units
+        // and preserving lower-order units from the existing duration.
+        //
+        // Examples:
+        // - 2h      -> updates hours only
+        // - 2h 10m  -> updates hours and minutes, preserves seconds
+        // - 2h 10m 5s -> replaces the entire duration
         fun updateUsingPartialSet(existing: Duration, duration: Duration): Duration {
             if (existing == Duration.ZERO) {
                 return duration

--- a/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
@@ -13,5 +13,6 @@ class EffectDurationChangeEvent(
 enum class EffectDurationChangeType {
     ADD,
     REMOVE,
-    SET
+    SET,
+    PARTIAL_SET
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.events.effects
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -20,6 +21,7 @@ import kotlin.time.Duration.Companion.seconds
  * @param duration The duration value associated with the change.
  *   Always `null` when [durationChangeType] is [EffectDurationChangeType.REMOVE].
  */
+@PrimaryFunction("onEffectUpdate")
 class EffectDurationChangeEvent(
     val effect: NonGodPotEffect,
     val durationChangeType: EffectDurationChangeType,

--- a/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/effects/EffectDurationChangeEvent.kt
@@ -3,6 +3,9 @@ package at.hannibal2.skyhanni.events.effects
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class EffectDurationChangeEvent(
     val effect: NonGodPotEffect,
@@ -14,5 +17,44 @@ enum class EffectDurationChangeType {
     ADD,
     REMOVE,
     SET,
-    PARTIAL_SET
+    PARTIAL_SET,
+    ;
+
+    companion object {
+        fun updateUsingPartialSet(existing: Duration, duration: Duration): Duration {
+            if (existing == Duration.ZERO) {
+                return duration
+            }
+            val existingMinutes = existing.inWholeMinutes % 60
+            val existingSeconds = existing.inWholeSeconds % 60
+            val newHours = duration.inWholeHours
+            val newMinutes = duration.inWholeMinutes % 60
+            val hasSeconds = duration.inWholeSeconds % 60 != 0L
+            val hasMinutes = newMinutes != 0L || hasSeconds
+            val hasHours = newHours != 0L
+            val result = when {
+                // Full precision update (contains seconds)
+                hasSeconds -> {
+                    duration
+                }
+                // Minutes are known, seconds are not
+                hasMinutes -> {
+                    newHours.hours +
+                        newMinutes.minutes +
+                        existingSeconds.seconds
+                }
+                // Only hours are known
+                hasHours -> {
+                    newHours.hours +
+                        existingMinutes.minutes +
+                        existingSeconds.seconds
+                }
+                // Zero duration
+                else -> {
+                    duration
+                }
+            }
+            return result
+        }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -35,7 +35,6 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.StringUtils.firstLetterUppercase
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.compat.append

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -274,7 +274,7 @@ object DungeonApi {
     }
 
     @HandleEvent
-    fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
+    private fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
         val cleanAdded = event.added.map { it.removeColor() }
         // TODO: move this under inDungeon check when we use Hypixel's ModAPI for island detection
         floorPattern.firstMatcher(cleanAdded) {
@@ -296,7 +296,7 @@ object DungeonApi {
     }
 
     @HandleEvent
-    fun onTablistChange(event: TabListUpdateEvent) {
+    private fun onTablistChange(event: TabListUpdateEvent) {
         if (!inDungeon()) return
         if (dungeonFloor == null || playerClass != null) return
 
@@ -312,7 +312,7 @@ object DungeonApi {
     }
 
     @HandleEvent
-    fun onTabUpdate(event: TablistFooterUpdateEvent) {
+    private fun onTabUpdate(event: TablistFooterUpdateEvent) {
         if (!inDungeon()) return
         for (line in event.footer) {
             if (noBlessingPattern.matches(line)) {
@@ -332,7 +332,7 @@ object DungeonApi {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         dungeonFloor = null
         started = false
         inBossRoom = false

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonApi.kt
@@ -315,8 +315,7 @@ object DungeonApi {
     @HandleEvent
     fun onTabUpdate(event: TablistFooterUpdateEvent) {
         if (!inDungeon()) return
-        val lines = TextHelper.split(event.footer, "\n") ?: listOf(event.footer)
-        for (line in lines) {
+        for (line in event.footer) {
             if (noBlessingPattern.matches(line)) {
                 DungeonBlessings.reset()
                 return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
@@ -59,7 +59,7 @@ object CFBlockOpen {
     private var commandSentTimer = SimpleTimeMark.farPast()
 
     @HandleEvent
-    fun onEffectUpdate(event: EffectDurationChangeEvent) {
+    private fun onEffectUpdate(event: EffectDurationChangeEvent) {
         if (event.effect != NonGodPotEffect.HOT_CHOCOLATE || event.duration == null) return
         val chocolateFactory = profileStorage?.chocolateFactory ?: return
 
@@ -67,12 +67,16 @@ object CFBlockOpen {
             EffectDurationChangeType.ADD -> chocolateFactory.hotChocolateMixinExpiry + event.duration
             EffectDurationChangeType.REMOVE -> SimpleTimeMark.farPast()
             EffectDurationChangeType.SET -> SimpleTimeMark.now() + event.duration
-            else -> chocolateFactory.hotChocolateMixinExpiry
+            EffectDurationChangeType.PARTIAL_SET ->
+                EffectDurationChangeType.updateUsingPartialSet(
+                    chocolateFactory.hotChocolateMixinExpiry.timeUntil(),
+                    event.duration,
+                ).let { SimpleTimeMark.now() + it }
         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         val slotDisplayName = event.slot?.item?.hoverName.formattedTextCompatLeadingWhiteLessResets()
         if (!openCfItemPattern.matches(slotDisplayName)) return
         if (EnchantedClockHelper.enchantedClockPattern.matches(InventoryUtils.openInventoryName())) return
@@ -82,7 +86,7 @@ object CFBlockOpen {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onCommandSend(event: MessageSendToServerEvent) {
+    private fun onCommandSend(event: MessageSendToServerEvent) {
         if (!commandPattern.matches(event.message)) return
         if (commandSentTimer.passedSince() < 5.seconds) return
         if (SkyBlockUtils.isBingoProfile) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.IslandGraphs.pathFind
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.effect.EffectApi
 import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
 import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
 import at.hannibal2.skyhanni.data.title.TitleManager
@@ -68,7 +69,7 @@ object CFBlockOpen {
             EffectDurationChangeType.REMOVE -> SimpleTimeMark.farPast()
             EffectDurationChangeType.SET -> SimpleTimeMark.now() + event.duration
             EffectDurationChangeType.PARTIAL_SET ->
-                EffectDurationChangeType.updateUsingPartialSet(
+                EffectApi.clampUsingPartialSet(
                     chocolateFactory.hotChocolateMixinExpiry.timeUntil(),
                     event.duration,
                 ).let { SimpleTimeMark.now() + it }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFBlockOpen.kt
@@ -67,6 +67,7 @@ object CFBlockOpen {
             EffectDurationChangeType.ADD -> chocolateFactory.hotChocolateMixinExpiry + event.duration
             EffectDurationChangeType.REMOVE -> SimpleTimeMark.farPast()
             EffectDurationChangeType.SET -> SimpleTimeMark.now() + event.duration
+            else -> chocolateFactory.hotChocolateMixinExpiry
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
@@ -127,20 +127,20 @@ object TabListReader {
     )
 
     @HandleEvent
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         ConditionalUtils.onToggle(config.enabled) {
             rebuildRenderColumns()
         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTabListUpdate(event: TabListUpdateEvent) {
+    private fun onTabListUpdate(event: TabListUpdateEvent) {
         lastTab = event.tabList
         rebuildRenderColumns()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTabListFooterUpdate(event: TablistFooterUpdateEvent) {
+    private fun onTabListFooterUpdate(event: TablistFooterUpdateEvent) {
         lastFooter = event.footer
         rebuildRenderColumns()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
@@ -28,7 +28,7 @@ object TabListReader {
         private set
 
     private var lastTab: List<Component>? = null
-    private var lastFooter: Component? = null
+    private var lastFooter: List<Component>? = null
 
     private var inUpgrades = false
 
@@ -267,10 +267,8 @@ object TabListReader {
     // TODO refactor
     @Suppress("CyclomaticComplexMethod")
     private fun parseFooterAsColumn(): TabColumn? {
-        val component = lastFooter ?: return null
+        val lines = lastFooter ?: return null
         inUpgrades = false
-
-        val lines = TextHelper.split(component, "\n") ?: listOf(component)
 
         val godPotTimer = lines.firstNotNullOfOrNull {
             godPotPattern.matchMatcher(it.string) { group("timer") }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
@@ -31,6 +31,8 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sorted
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -84,6 +86,44 @@ object NonGodPotEffectDisplay {
 
             EffectDurationChangeType.REMOVE -> {
                 effectDuration.remove(event.effect)
+            }
+
+            EffectDurationChangeType.PARTIAL_SET -> {
+                val existing = effectDuration[event.effect]?.duration ?: Duration.ZERO
+                if (existing == Duration.ZERO) {
+                    effectDuration[event.effect] = Timer(duration)
+                    return
+                }
+                val existingMinutes = existing.inWholeMinutes % 60
+                val existingSeconds = existing.inWholeSeconds % 60
+                val newHours = duration.inWholeHours
+                val newMinutes = duration.inWholeMinutes % 60
+                val hasSeconds = duration.inWholeSeconds % 60 != 0L
+                val hasMinutes = newMinutes != 0L || hasSeconds
+                val hasHours = newHours != 0L
+                val result = when {
+                    // Full precision update (contains seconds)
+                    hasSeconds -> {
+                        duration
+                    }
+                    // Minutes are known, seconds are not
+                    hasMinutes -> {
+                        newHours.hours +
+                            newMinutes.minutes +
+                            existingSeconds.seconds
+                    }
+                    // Only hours are known
+                    hasHours -> {
+                        newHours.hours +
+                            existingMinutes.minutes +
+                            existingSeconds.seconds
+                    }
+                    // Zero duration
+                    else -> {
+                        duration
+                    }
+                }
+                effectDuration[event.effect] = Timer(result)
             }
         }
         update()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
@@ -56,13 +56,13 @@ object NonGodPotEffectDisplay {
     private var totalEffectsCount = 0
 
     @HandleEvent
-    fun onProfileJoin(event: ProfileJoinEvent) {
+    private fun onProfileJoin() {
         effectDuration.clear()
         display = emptyList()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (event.message == "§aYou cleared all of your active effects!") {
             effectDuration.clear()
             update()
@@ -70,7 +70,7 @@ object NonGodPotEffectDisplay {
     }
 
     @HandleEvent
-    fun onEffectUpdate(event: EffectDurationChangeEvent) {
+    private fun onEffectUpdate(event: EffectDurationChangeEvent) {
         val duration = event.duration ?: Duration.ZERO
         when (event.durationChangeType) {
             EffectDurationChangeType.ADD -> {
@@ -89,7 +89,9 @@ object NonGodPotEffectDisplay {
             }
 
             EffectDurationChangeType.PARTIAL_SET -> {
-
+                val existing = effectDuration[event.effect]?.duration ?: Duration.ZERO
+                val newDuration = EffectDurationChangeType.updateUsingPartialSet(existing, duration)
+                effectDuration[event.effect] = Timer(newDuration)
             }
         }
         update()
@@ -130,7 +132,7 @@ object NonGodPotEffectDisplay {
     }
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed() {
         if (!isEnabled()) return
         if (!ProfileStorageData.loaded) return
 
@@ -153,12 +155,12 @@ object NonGodPotEffectDisplay {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         checkFooter = true
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTabUpdate(event: TablistFooterUpdateEvent) {
+    private fun onTabUpdate(event: TablistFooterUpdateEvent) {
         if (!checkFooter) return
         val lines = TextHelper.split(event.footer, "\n") ?: listOf(event.footer)
         if (!lines.any { it.string.contains("Active Effects") }) return
@@ -170,7 +172,7 @@ object NonGodPotEffectDisplay {
     }
 
     @HandleEvent
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    private fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled() || !config.displayEnabled) return
         if (RiftApi.inRift()) return
 
@@ -182,7 +184,7 @@ object NonGodPotEffectDisplay {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "misc.nonGodPotEffectDisplay", "misc.potionEffect.nonGodPotEffectDisplay")
         event.move(3, "misc.nonGodPotEffectShowMixins", "misc.potionEffect.nonGodPotEffectShowMixins")
         event.move(3, "misc.nonGodPotEffectPos", "misc.potionEffect.nonGodPotEffectPos")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.data.effect.EffectApi
 import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.TablistFooterUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.effects.EffectDurationChangeEvent
 import at.hannibal2.skyhanni.events.effects.EffectDurationChangeType
@@ -17,7 +16,6 @@ import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.RegexUtils.firstComponentMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderStrings
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playPlingSound
@@ -25,10 +23,8 @@ import at.hannibal2.skyhanni.utils.TimeUnit
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.timerColor
 import at.hannibal2.skyhanni.utils.Timer
-import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sorted
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -36,21 +32,11 @@ import kotlin.time.Duration.Companion.seconds
 object NonGodPotEffectDisplay {
 
     private val config get() = SkyHanniMod.feature.misc.nonGodPotEffect
-    private var checkFooter = false
     private val effectDuration = mutableMapOf<NonGodPotEffect, Timer>()
     private val setRecently: TimeLimitedSet<NonGodPotEffect> = TimeLimitedSet(5.seconds)
     private var display = emptyList<String>()
 
     fun isActive(effect: NonGodPotEffect): Boolean = effectDuration.any { it.key == effect && !it.value.ended }
-
-    /**
-     * REGEX-TEST: You have 10 non-god effects.
-     */
-    private val effectsCountPattern by RepoPattern.pattern(
-        "misc.nongodpot.effects.colorless",
-        "You have (?<count>\\d+) non-god effects\\.",
-    )
-    private var totalEffectsCount = 0
 
     @HandleEvent
     private fun onProfileJoin() {
@@ -95,12 +81,6 @@ object NonGodPotEffectDisplay {
     }
 
     private fun update() {
-        if (effectDuration.values.removeIf { it.ended }) {
-            // to fetch the real amount of active pots
-            totalEffectsCount = 0
-            checkFooter = true
-        }
-
         display = drawDisplay()
     }
 
@@ -119,11 +99,10 @@ object NonGodPotEffectDisplay {
             val displayName = effect.displayName
             newDisplay.add("$displayName $color$format")
         }
-        val diff = totalEffectsCount - effectDuration.size
+        val diff = EffectApi.totalEffectsCount - effectDuration.size
         if (diff > 0) {
             newDisplay.add("§eOpen the /effects inventory")
             newDisplay.add("§eto show the missing $diff effects!")
-            checkFooter = true
         }
         return newDisplay
     }
@@ -151,22 +130,6 @@ object NonGodPotEffectDisplay {
         }
     }
 
-    @HandleEvent
-    private fun onWorldChange() {
-        checkFooter = true
-    }
-
-    @HandleEvent(onlyOnSkyblock = true)
-    private fun onTabUpdate(event: TablistFooterUpdateEvent) {
-        if (!checkFooter) return
-        val lines = TextHelper.split(event.footer, "\n") ?: listOf(event.footer)
-        if (!lines.any { it.string.contains("Active Effects") }) return
-
-        checkFooter = false
-        totalEffectsCount = effectsCountPattern.firstComponentMatcher(lines) {
-            group("count").toIntOrNull()
-        } ?: 0
-    }
 
     @HandleEvent
     private fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.data.effect.EffectApi
 import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -86,7 +87,7 @@ object NonGodPotEffectDisplay {
 
             EffectDurationChangeType.PARTIAL_SET -> {
                 val existing = effectDuration[event.effect]?.duration ?: Duration.ZERO
-                val newDuration = EffectDurationChangeType.updateUsingPartialSet(existing, duration)
+                val newDuration = EffectApi.clampUsingPartialSet(existing, duration)
                 effectDuration[event.effect] = Timer(newDuration)
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
@@ -7,8 +7,6 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.ProfileJoinEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.TablistFooterUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.effects.EffectDurationChangeEvent
@@ -31,8 +29,6 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sorted
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/effects/NonGodPotEffectDisplay.kt
@@ -89,41 +89,7 @@ object NonGodPotEffectDisplay {
             }
 
             EffectDurationChangeType.PARTIAL_SET -> {
-                val existing = effectDuration[event.effect]?.duration ?: Duration.ZERO
-                if (existing == Duration.ZERO) {
-                    effectDuration[event.effect] = Timer(duration)
-                    return
-                }
-                val existingMinutes = existing.inWholeMinutes % 60
-                val existingSeconds = existing.inWholeSeconds % 60
-                val newHours = duration.inWholeHours
-                val newMinutes = duration.inWholeMinutes % 60
-                val hasSeconds = duration.inWholeSeconds % 60 != 0L
-                val hasMinutes = newMinutes != 0L || hasSeconds
-                val hasHours = newHours != 0L
-                val result = when {
-                    // Full precision update (contains seconds)
-                    hasSeconds -> {
-                        duration
-                    }
-                    // Minutes are known, seconds are not
-                    hasMinutes -> {
-                        newHours.hours +
-                            newMinutes.minutes +
-                            existingSeconds.seconds
-                    }
-                    // Only hours are known
-                    hasHours -> {
-                        newHours.hours +
-                            existingMinutes.minutes +
-                            existingSeconds.seconds
-                    }
-                    // Zero duration
-                    else -> {
-                        duration
-                    }
-                }
-                effectDuration[event.effect] = Timer(result)
+
             }
         }
         update()

--- a/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
@@ -9,6 +9,8 @@ import at.hannibal2.skyhanni.events.TablistFooterUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.mixins.hooks.tabListGuarded
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
+import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import com.google.common.collect.ComparisonChain
@@ -104,7 +106,8 @@ object TabListData {
         if (newFooter != footer) {
             footer = newFooter
             if (newFooter == null || newFooter.string.isEmpty()) return
-            TablistFooterUpdateEvent(newFooter).post()
+            val footerLines = TextHelper.split(newFooter, "\n") ?: listOf(newFooter)
+            TablistFooterUpdateEvent(footerLines).post()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
@@ -79,12 +79,12 @@ object TabListData {
     }
 
     @HandleEvent(receiveCancelled = true)
-    fun onPacketReceive(event: PacketReceivedEvent) {
+    private fun onPacketReceive(event: PacketReceivedEvent) {
         if (event.packet is ClientboundPlayerInfoUpdatePacket) dirty = true
     }
 
     @HandleEvent
-    fun onTick() {
+    private fun onTick() {
         if (!dirty) return
         dirty = false
 
@@ -111,7 +111,7 @@ object TabListData {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shcopytablistcomponent") {
             description = "Copies the tab list data to the clipboard"
             category = CommandCategory.DEVELOPER_DEBUG

--- a/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TabListData.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.TablistFooterUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.mixins.hooks.tabListGuarded
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
 import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat


### PR DESCRIPTION
## What

Changes Done:
1. The code had color codes for matching, so removed all that.
2. Hypixel changed it from "REGULAR" -> "Regular" for pest repellant, so did "uppercase"
3. It only checks for seconds when "55m" was possible and the such for pest repellant. so It now uses this partial data.
4. onInventoryFullyOpened didn't use the repo pattern for the inventory name

(If wanted any of this changes can either be split, or just removed)

## Changelog Fixes
+ Fixed Pest Repellent time not being detected. - Avrg

## Changelog Technical Details
+ Made EffectApi matching colorless. - Avrg