### PR TITLE
Fix: Unbreak DialogUtils

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -436,16 +436,14 @@ object GardenNextJacobContest {
         TitleManager.sendTitle("§eFarming Contest!")
         SoundUtils.playBeepSound()
 
-        val cropTextNoColor = crops.joinToString(", ") {
-            if (it == boostedCrop) "<b>${it.cropName}</b>" else it.cropName
-        }
         if (config.warnPopup && !Minecraft.getInstance().isWindowActive) {
-            CoroutineSettings("garden jacob contest openPopupWindow").launchCoroutine {
-                DialogUtils.openPopupWindow(
-                    title = "SkyHanni Jacob Contest Notification",
-                    message = "<html>Farming Contest soon!<br />Crops: $cropTextNoColor</html>",
-                )
+            val cropTextNoColor = crops.joinToString(", ") {
+                if (it == boostedCrop) "${it.cropName} (boosted)" else it.cropName
             }
+            DialogUtils.openPopupWindow(
+                title = "SkyHanni Jacob Contest Notification",
+                message = "Farming Contest soon!\nCrops: $cropTextNoColor",
+            )
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -57,8 +57,8 @@ import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Co
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonPrimitive
-import kotlinx.coroutines.sync.Mutex
 import net.minecraft.client.Minecraft
+import kotlinx.coroutines.sync.Mutex
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -57,12 +57,12 @@ import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Co
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonPrimitive
+import kotlinx.coroutines.sync.Mutex
 import net.minecraft.client.Minecraft
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.sync.Mutex
 
 @SkyHanniModule
 object GardenNextJacobContest {
@@ -145,7 +145,7 @@ object GardenNextJacobContest {
     )
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Garden Next Jacob Contest")
 
         if (!GardenApi.inGarden()) {
@@ -193,7 +193,7 @@ object GardenNextJacobContest {
     }
 
     @HandleEvent
-    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+    private fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.JACOB_CONTEST)) return
         simpleDisplay = Renderable.vertical {
             event.lines.forEach { add(Renderable.text(it)) }
@@ -218,19 +218,19 @@ object GardenNextJacobContest {
     }
 
     @HandleEvent(SecondPassedEvent::class)
-    fun onSecondPassed() {
+    private fun onSecondPassed() {
         if (!isEnabled() || calendarDetector.isInside()) return
         update()
     }
 
     @HandleEvent(InventoryCloseEvent::class, onlyOnIsland = IslandType.GARDEN)
-    fun onInventoryClose() {
+    private fun onInventoryClose() {
         if (!isEnabled()) return
         update()
     }
 
     @HandleEvent
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!isEnabled() || !calendarDetector.isInside()) return
         val (monthGroup, yearGroup) = monthPattern.matchGroups(
             event.inventoryName,

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -58,11 +58,11 @@ import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import com.google.gson.JsonPrimitive
 import net.minecraft.client.Minecraft
-import kotlinx.coroutines.sync.Mutex
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.sync.Mutex
 
 @SkyHanniModule
 object GardenNextJacobContest {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -421,6 +421,8 @@ object GardenNextJacobContest {
         addString("§7(§b${duration.format()}§7)")
     }
 
+    private fun shouldOpenPopup() = config.warnPopup && Minecraft.getInstance().isWindowActive
+
     private fun EliteFarmingContest.warnAbout() {
         val timeUntil = startTime.timeUntil()
         if (!config.warn || config.warnTime.seconds <= timeUntil) return
@@ -436,15 +438,16 @@ object GardenNextJacobContest {
         TitleManager.sendTitle("§eFarming Contest!")
         SoundUtils.playBeepSound()
 
-        if (config.warnPopup && !Minecraft.getInstance().isWindowActive) {
-            val cropTextNoColor = crops.joinToString(", ") {
-                if (it == boostedCrop) "${it.cropName} (boosted)" else it.cropName
-            }
-            DialogUtils.openPopupWindow(
-                title = "SkyHanni Jacob Contest Notification",
-                message = "Farming Contest soon!\nCrops: $cropTextNoColor",
-            )
+        if (!shouldOpenPopup()) return
+
+        val cropTextNoColor = crops.joinToString(", ") {
+            if (it == boostedCrop) "${it.cropName} (boosted)" else it.cropName
         }
+        DialogUtils.openPopupWindow(
+            title = "SkyHanni Jacob Contest Notification",
+            message = "Farming Contest soon!\nCrops: $cropTextNoColor",
+            condition = ::shouldOpenPopup,
+        )
     }
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -421,7 +421,7 @@ object GardenNextJacobContest {
         addString("§7(§b${duration.format()}§7)")
     }
 
-    private fun shouldOpenPopup() = config.warnPopup && Minecraft.getInstance().isWindowActive
+    private fun shouldOpenPopup() = config.warnPopup && !Minecraft.getInstance().isWindowActive
 
     private fun EliteFarmingContest.warnAbout() {
         val timeUntil = startTime.timeUntil()

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenNextJacobContest.kt
@@ -322,7 +322,7 @@ object GardenNextJacobContest {
     }
 
     @HandleEvent(ConfigLoadEvent::class)
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         val savedContests = SkyHanniMod.jacobContestsData.knownContests
         val savedYear = savedContests.firstOrNull()?.endTime?.toSkyBlockTime()?.year ?: return
         // Clear contests if from previous year
@@ -451,14 +451,14 @@ object GardenNextJacobContest {
     }
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
-    fun onGuiRenderOverlay() {
+    private fun onGuiRenderOverlay() {
         if (!isEnabled()) return
         val display = display ?: simpleDisplay ?: return
         config.position.renderRenderable(display, posLabel = "Next Jacob Contest")
     }
 
     @HandleEvent(GuiRenderEvent.ChestGuiOverlayRenderEvent::class)
-    fun onChestGuiRender() {
+    private fun onChestGuiRender() {
         if (!config.display || !calendarDetector.isInside()) return
         val display = display ?: return
         config.inventoryPosition.renderRenderable(display, posLabel = "Load SkyBlock Calendar")
@@ -518,7 +518,7 @@ object GardenNextJacobContest {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "garden.nextJacobContestDisplay", "garden.nextJacobContests.display")
         event.move(3, "garden.nextJacobContestEverywhere", "garden.nextJacobContests.everywhere")
         event.move(3, "garden.nextJacobContestOtherGuis", "garden.nextJacobContests.otherGuis")

--- a/src/main/java/at/hannibal2/skyhanni/utils/DialogUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DialogUtils.kt
@@ -43,37 +43,38 @@ object DialogUtils {
     private fun currentBackend(): String? = TinyFileDialogs.tinyfd_getGlobalChar("tinyfd_response")
 
     /**
-     * Opens a modal message box outside of the game window.
+     * Opens a modal message box outside the game window.
      *
      * [message] is plain text; only `\n` is supported for line breaks.
      */
-    fun openPopupWindow(title: String, message: String) {
-        popupCoroutine.launch {
-            runCatching {
-                if (!hasGraphicalBackend) {
-                    ErrorManager.logErrorStateWithData(
-                        "Failed to open a popup window",
-                        "No graphical dialog backend is available",
-                        "backend" to currentBackend(),
-                        // tinyfd unconditionally falls back to the console when this is set, even if empty
-                        "SSH_TTY" to System.getenv("SSH_TTY"),
-                        "title" to title,
-                        "message" to message,
-                    )
-                    return@runCatching
-                }
-                messageBox(title.stripQuotes(), message.stripQuotes())
-            }.onFailure { e ->
-                ErrorManager.logErrorWithData(
-                    e, "Failed to open a popup window",
+    fun openPopupWindow(title: String, message: String, condition: () -> Boolean = { true }) = popupCoroutine.launch {
+        runCatching {
+            if (!condition()) return@runCatching
+
+            if (!hasGraphicalBackend) {
+                ErrorManager.logErrorStateWithData(
+                    "Failed to open a popup window",
+                    "No graphical dialog backend is available",
+                    "backend" to currentBackend(),
+                    // tinyfd unconditionally falls back to the console when this is set, even if empty
+                    "SSH_TTY" to System.getenv("SSH_TTY"),
                     "title" to title,
                     "message" to message,
                 )
+                return@runCatching
             }
+
+            messageBox(title.stripForbiddenChars(), message.stripForbiddenChars())
+        }.onFailure { e ->
+            ErrorManager.logErrorWithData(
+                e, "Failed to open a popup window",
+                "title" to title,
+                "message" to message,
+            )
         }
     }
 
-    private fun String.stripQuotes(): String = filterNot { it in forbiddenCharacters }
+    private fun String.stripForbiddenChars(): String = filterNot { it in forbiddenCharacters }
 
     private fun messageBox(title: String, message: String): Boolean {
         //? if >= 26.1 {

--- a/src/main/java/at/hannibal2/skyhanni/utils/DialogUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DialogUtils.kt
@@ -1,46 +1,94 @@
 package at.hannibal2.skyhanni.utils
 
+import at.hannibal2.skyhanni.SkyHanniMod.launch
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import java.awt.event.MouseAdapter
-import java.awt.event.MouseEvent
-import javax.swing.JButton
-import javax.swing.JFrame
-import javax.swing.JOptionPane
-import javax.swing.UIManager
+import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
+import org.lwjgl.util.tinyfd.TinyFileDialogs
+import kotlin.time.Duration
+import kotlinx.coroutines.sync.Mutex
 
+@SkyHanniModule
 object DialogUtils {
 
-    private val closeListener = object : MouseAdapter() {
-        override fun mouseClicked(event: MouseEvent) {
-            (event.source as? JFrame)?.isVisible = false
-        }
-    }
+    private val dialogMutex = Mutex()
 
-    private val baseFrame by lazy {
-        JFrame().apply {
-            isUndecorated = true
-            isAlwaysOnTop = true
-            setLocationRelativeTo(null)
-            isVisible = true
-        }
-    }
-
-    private val okButton = JButton("Ok").apply { addMouseListener(closeListener) }
+    private val popupCoroutine = CoroutineSettings(
+        "openPopupWindow",
+        timeout = Duration.INFINITE,
+        withIOContext = true,
+    ).withMutex(dialogMutex)
 
     /**
-     * Taken and modified from Skytils
+     * tinyfd replaces the whole string with `INVALID MESSAGE WITH QUOTES` if any of these are present,
+     * as the Unix backends build a shell command line.
      */
-    fun openPopupWindow(title: String, message: String) = runCatching {
-        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
-        JOptionPane.showOptionDialog(
-            baseFrame, message, title,
-            JOptionPane.DEFAULT_OPTION, JOptionPane.INFORMATION_MESSAGE, null,
-            listOf(okButton).toTypedArray(), okButton,
-        )
-    }.onFailure { e ->
-        ErrorManager.logErrorWithData(
-            e, "Failed to open a popup window",
-            "message" to message,
-        )
+    private val forbiddenCharacters = charArrayOf('"', '\'', '`')
+
+    /**
+     * Passing this as the title displays nothing and instead reports whether a graphical backend is available.
+     * Without a backend, tinyfd falls back to a console prompt that would block the thread on stdin forever.
+     */
+    private const val QUERY_TITLE = "tinyfd_query"
+
+    private val hasGraphicalBackend by lazy { messageBox(QUERY_TITLE, "") }
+
+    /**
+     * The backend the query selected, e.g. `applescript` or `basicinput` for the console fallback.
+     * Only meaningful directly after a call, so it is read while still holding [dialogMutex].
+     */
+    private fun currentBackend(): String? = TinyFileDialogs.tinyfd_getGlobalChar("tinyfd_response")
+
+    /**
+     * Opens a modal message box outside of the game window.
+     *
+     * [message] is plain text; only `\n` is supported for line breaks.
+     */
+    fun openPopupWindow(title: String, message: String) {
+        popupCoroutine.launch {
+            runCatching {
+                if (!hasGraphicalBackend) {
+                    ErrorManager.logErrorStateWithData(
+                        "Failed to open a popup window",
+                        "No graphical dialog backend is available",
+                        "backend" to currentBackend(),
+                        // tinyfd unconditionally falls back to the console when this is set, even if empty
+                        "SSH_TTY" to System.getenv("SSH_TTY"),
+                        "title" to title,
+                        "message" to message,
+                    )
+                    return@runCatching
+                }
+                messageBox(title.stripQuotes(), message.stripQuotes())
+            }.onFailure { e ->
+                ErrorManager.logErrorWithData(
+                    e, "Failed to open a popup window",
+                    "title" to title,
+                    "message" to message,
+                )
+            }
+        }
+    }
+
+    private fun String.stripQuotes(): String = filterNot { it in forbiddenCharacters }
+
+    private fun messageBox(title: String, message: String): Boolean {
+        //? if >= 26.1 {
+        return TinyFileDialogs.tinyfd_messageBox(title, message, "ok", "info", 1) != 0
+        //?} else {
+        /*return TinyFileDialogs.tinyfd_messageBox(title, message, "ok", "info", true)
+        *///?}
+    }
+
+    @HandleEvent
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shtestdialog") {
+            description = "Opens a test dialog."
+            category = CommandCategory.DEVELOPER_TEST
+            simpleCallback { openPopupWindow("SkyHanni Test Dialog", "Hello World!") }
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/DialogUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DialogUtils.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import org.lwjgl.util.tinyfd.TinyFileDialogs
 import kotlin.time.Duration
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.sync.Mutex
 
 @SkyHanniModule
@@ -47,7 +48,11 @@ object DialogUtils {
      *
      * [message] is plain text; only `\n` is supported for line breaks.
      */
-    fun openPopupWindow(title: String, message: String, condition: () -> Boolean = { true }) = popupCoroutine.launch {
+    fun openPopupWindow(
+        title: String,
+        message: String,
+        condition: () -> Boolean = { true },
+    ): Job = popupCoroutine.launch {
         runCatching {
             if (!condition()) return@runCatching
 


### PR DESCRIPTION
## What
Fixes `DialogUtils` not working ever since the original 1.21.5 port. On modern Minecraft, GLFW effectively owns the graphics stack, so it intentionally sets `java.awt.headless=true` to prevent compatibility issues. Forcing headless mode to false is not safe – Windows and Linux X11 could theoretically work, but macOS and Linux Wayland would definitely break.

The solution is to use LWJGL's bundled TinyFileDialogs library instead. This is more bare-bones and doesn't support formatting, but it does the job – boosted Jacob Contest crops are now indicated with a "(boosted)" suffix instead of bold, which is arguably more clear anyway.

The implementation uses a single shared coroutine with a mutex – both for ease and use, and because TinyFD uses global state and therefore it is not safe to open multiple dialogs at once. There's also a couple other guards in place to prevent unexpected behavior.

It can be tested using a new `/shtestdialog` command.

## Changelog Fixes
+ Fixed Jacob Contest Warning Popup always failing to open. - Luna