### PR TITLE
Fix: Hoppity's Hunt Stats chat spam 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityEventSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityEventSummary.kt
@@ -87,7 +87,7 @@ object HoppityEventSummary {
     private fun MutableList<StatString>.addEmptyLine() = this.addStr("", false)
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shresethoppityeventstats") {
             description = "Reset Hoppity Event stats for all years."
             category = CommandCategory.USERS_RESET
@@ -105,12 +105,12 @@ object HoppityEventSummary {
     }
 
     @HandleEvent
-    fun onEggSpawned() {
+    private fun onEggSpawned() {
         yearSpawnCache.remove(currentSbYear)
     }
 
     @HandleEvent
-    fun onRabbitFound(event: RabbitFoundEvent) {
+    private fun onRabbitFound(event: RabbitFoundEvent) {
         yearSpawnCache.remove(currentSbYear)
         val stats = getYearStats() ?: return
         if (!HoppityApi.isHoppityEvent()) {
@@ -134,7 +134,7 @@ object HoppityEventSummary {
     }
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!HoppityApi.isHoppityEvent()) return
         val stats = getYearStats() ?: return
 
@@ -144,7 +144,7 @@ object HoppityEventSummary {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(64, "event.hoppity.preventMissingFish", "event.hoppity.preventMissingRabbitTheFish")
         event.move(65, "hoppityStatLiveDisplayToggled", "hoppityStatLiveDisplayToggledOff")
 
@@ -160,7 +160,7 @@ object HoppityEventSummary {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSecondPassed() {
+    private fun onSecondPassed() {
         checkStatsTypeCountInit()
         checkLbUpdateWarning()
         checkEnded()
@@ -169,7 +169,7 @@ object HoppityEventSummary {
     }
 
     @HandleEvent
-    fun onProfileJoin() {
+    private fun onProfileJoin() {
         lastSnapshotServer = null
         checkEnded()
     }
@@ -265,11 +265,21 @@ object HoppityEventSummary {
             it.key < currentSbYear || (it.key == currentSbYear && currentSeason > SkyblockSeason.SPRING)
         }.forEach { (year, stats) ->
             storage?.hoppityEventStats?.get(year)?.let {
-                // Only send the message if we're going to be able to set the stats as summarized
-                sendStatsMessage(stats, year)
+                if (stats.hasParticipated()) {
+                    sendStatsMessage(stats, year)
+                }
                 it.summarized = true
             }
         }
+    }
+
+    private fun HoppityEventStats.hasParticipated(): Boolean {
+        if (mealsFound.isNotEmpty()) return true
+        if (rabbitsFound.isNotEmpty()) return true
+
+        if (millisInCf != Duration.ZERO) return true
+
+        return false
     }
 
     private fun inSameServer(): Boolean {
@@ -508,7 +518,7 @@ object HoppityEventSummary {
             ).toMutableList()
         } else statList
 
-        return finalStatList.chromafyHoppityStats()
+        return finalStatList.applyPartyMode()
     }
 
     private fun sendStatsMessage(stats: HoppityEventStats, eventYear: Int?) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityEventSummary.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityEventSummary.kt
@@ -75,7 +75,7 @@ object HoppityEventSummary {
     private var lastSnapshotServer: String? = null
     var statYear: Int = currentSbYear
 
-    private fun MutableList<StatString>.chromafyHoppityStats(): MutableList<StatString> = map {
+    private fun MutableList<StatString>.applyPartyMode(): MutableList<StatString> = map {
         if (CFApi.config.partyMode.get()) it.copy(string = CFApi.partyModeReplace(it.string))
         else it
     }.toMutableList()


### PR DESCRIPTION
## What
When `checkEnded` ran after a missed event, empty entries triggered a "Nothing to show!" summary in chat. The fix adds a `hasParticipated` check before calling `sendStatsMessage`. `summarized` is still set unconditionally so skipped entries are not re-evaluated on the next login.

<details>
<summary>Image of the bug</summary>

<img width="638" height="280" alt="image" src="https://github.com/user-attachments/assets/b8b03a26-fe44-4b4d-8d8b-31a2afc1cfdc" />

</details>


## Changelog Fixes
+ Fixed Hoppity's Hunt event stats being shown in chat on login for events where the player did not participate. - hannibal2

## Changelog Technical Details
+ Renamed `chromafyHoppityStats` to `applyPartyMode` in `HoppityEventSummary`. - hannibal2