### PR TITLE
Fix: Deployables not being detected sometimes cause missing cleanName

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/combat/Deployable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/Deployable.kt
@@ -31,6 +31,9 @@ enum class Deployable(
     UMBERELLA("Umberella", "§9Umberella", 30, DeployableType.UMBERELLA),
     ;
 
+    /**
+     * REGEX-TEST: Umberella 298s
+     */
     val pattern by RepoPattern.pattern(
         "combat.deployable.${name.lowercase().replace("_", "-")}",
         "$deployableName (?<time>\\d+)s",

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/DeployableDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/DeployableDisplay.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
@@ -36,7 +37,7 @@ object DeployableDisplay {
         if (!config.enabled) return
         val entity = event.entity
         for (deployable in Deployable.entries) {
-            deployable.pattern.matchMatcher(entity.name) {
+            deployable.pattern.matchMatcher(entity.cleanName) {
                 if (!deployable.isInRange(entity)) return@matchMatcher
                 val time = SimpleTimeMark.now() + group("time").formatInt().toDuration(DurationUnit.SECONDS)
                 if (deployable.expiryTime > time && deployable.isActive()) return@matchMatcher


### PR DESCRIPTION
## What
If the crimson isles somehow happens to use legacy color codes, this detection would fail.
It should have used cleanName.

## Changelog Fixes
+ Fixed Deployables not being detected sometimes. - Avrg