### PR TITLE
Backend: Add IntelliJ required plugins + custom import order

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,11 +24,12 @@ max_line_length = 140
 ij_java_names_count_to_use_import_on_demand = 2147483647
 ij_java_class_count_to_use_import_on_demand = 2147483647
 ij_java_packages_to_use_import_on_demand = 2147483647
+ij_java_imports_layout = *,java.**,javax.**,kotlin.**,kotlinx.**,$*
 
 # Kotlin Files
 [*.kt]
 ktlint_code_style = intellij_idea
-
+ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,kotlinx.**,^
 # Kotlin files should not use wildcard imports
 ij_kotlin_name_count_to_use_star_import = 2147483647
 ij_kotlin_name_count_to_use_star_import_for_members = 2147483647

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/**/*.*
 !.idea/icon.svg
 !.idea/dictionaries/default_user.xml
+!.idea/externalDependencies.xml
 !.idea/scopes/Mixins.xml
 !.idea/liveTemplates/SkyHanni.xml
 .vscode/

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="com.demonwav.minecraft-dev" />
+    <plugin id="dev.kikugie.stonecutter" />
+    <plugin id="org.editorconfig.editorconfigjetbrains" />
+    <plugin id="skyhanni.plugin" />
+  </component>
+</project>

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ExternalDependencies">
     <plugin id="com.demonwav.minecraft-dev" />
+    <plugin id="detekt" />
     <plugin id="dev.kikugie.stonecutter" />
     <plugin id="org.editorconfig.editorconfigjetbrains" />
     <plugin id="skyhanni.plugin" />


### PR DESCRIPTION
## What
Adds "Required Plugins" for IntelliJ (as far as I can tell, this is not "brick the editor if the plugins are not installed" – it is "yell at the user if they're missing one of these plugins"), and added our custom import ordering rules to `.editorconfig`, which is a nice place to put them because it can be put in VCS and won't get overwritten by the user messing with their IntelliJ settings.

exclude_from_changelog