### PR TITLE
Fix: Restore accidentally broken/deleted functionality

### DIFF
--- a/detekt/baseline-main.xml
+++ b/detekt/baseline-main.xml
@@ -3642,8 +3642,6 @@
     <ID>UnsafeCallOnNullableType:NumberUtil.kt:NumberUtil$romanSymbols[this]!!</ID>
     <ID>UnsafeCallOnNullableType:ReminderManager.kt:ReminderManager$storage[args.drop(1).first()]!!</ID>
     <ID>UnsafeCallOnNullableType:ReminderManager.kt:ReminderManager$storage[args.first()]!!</ID>
-    <ID>UnsafeCallOnNullableType:RenderEntityOutlineEvent.kt:RenderEntityOutlineEvent$entitiesToChooseFrom!!</ID>
-    <ID>UnsafeCallOnNullableType:RenderEntityOutlineEvent.kt:RenderEntityOutlineEvent$entitiesToOutline!!</ID>
     <ID>UnsafeCallOnNullableType:SackApi.kt:SackApi$match.groups[1]!!</ID>
     <ID>UnsafeCallOnNullableType:SackApi.kt:SackApi$match.groups[2]!!</ID>
     <ID>UnsafeCallOnNullableType:SackApi.kt:SackApi$match.groups[3]!!</ID>

--- a/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
@@ -18,12 +18,17 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
     /**
      * The entities to outline. This is progressively cumulated from [.entitiesToChooseFrom]
      */
-    var entitiesToOutline: HashMap<Entity, Color>? = null
+    var entitiesToOutline: HashMap<Entity, Color> = hashMapOf()
 
     /**
      * The entities we can outline. Note that this set and [.entitiesToOutline] are disjoint at all times.
      */
-    var entitiesToChooseFrom: HashSet<Entity>? = null
+    var entitiesToChooseFrom: HashSet<Entity> = hashSetOf()
+
+    /**
+     * Whether [.entitiesToChooseFrom] has been computed already.
+     */
+    private var computed: Boolean = false
 
     /**
      * Constructs the event, given the type and optional entities to outline.
@@ -56,15 +61,13 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
         if (outlineColor == null) {
             return
         }
-        if (entitiesToChooseFrom == null) {
-            computeAndCacheEntitiesToChooseFrom()
-        }
-        val itr: MutableIterator<Entity> = entitiesToChooseFrom!!.iterator()
+        computeAndCacheEntitiesToChooseFrom()
+        val itr: MutableIterator<Entity> = entitiesToChooseFrom.iterator()
         while (itr.hasNext()) {
             val e: Entity = itr.next()
             val i: Color? = outlineColor(e)
             if (i != null) {
-                entitiesToOutline!![e] = i
+                entitiesToOutline[e] = i
                 itr.remove()
             }
         }
@@ -80,20 +83,21 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
         if (entity == null) {
             return
         }
-        if (entitiesToChooseFrom == null) {
-            computeAndCacheEntitiesToChooseFrom()
-        }
-        if (!entitiesToChooseFrom!!.contains(entity)) {
+        computeAndCacheEntitiesToChooseFrom()
+        if (!entitiesToChooseFrom.contains(entity)) {
             return
         }
-        entitiesToOutline!![entity] = outlineColor
-        entitiesToChooseFrom!!.remove(entity)
+        entitiesToOutline[entity] = outlineColor
+        entitiesToChooseFrom.remove(entity)
     }
 
     /**
      * Used for on-the-fly generation of entities. Driven by event handlers in a decentralized fashion
      */
-    private fun computeAndCacheEntitiesToChooseFrom() {
+    private fun computeAndCacheEntitiesToChooseFrom(force: Boolean = false) {
+        if (computed && !force) return
+        computed = true
+
         @OptIn(AllEntitiesGetter::class)
         val entities: List<Entity> = EntityUtils.getAllEntities().toList()
         // Only render outlines around non-null entities within the camera frustum
@@ -101,10 +105,10 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
         // Empty invisible armor stands are common and never render an outlineable model
         for (entity in entities) {
             if (!entity.isEmptyInvisibleArmorStand() && entity !is ItemFrame) {
-                entitiesToChooseFrom!!.add(entity)
+                entitiesToChooseFrom.add(entity)
             }
         }
-        entitiesToOutline = HashMap(entitiesToChooseFrom!!.size)
+        entitiesToOutline = HashMap(entitiesToChooseFrom.size)
     }
 
     /**
@@ -113,7 +117,6 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
      * [.NO_XRAY] means that this directly precedes entities whose outlines are rendered only when visible to the client
      */
     enum class Type {
-
         XRAY,
         NO_XRAY
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -31,7 +31,7 @@ object RenderLivingEntityHelper {
     @JvmStatic
     fun postNoXrayOutlineEvent() {
         isUsingCustomGlow = entityColorCondition.values.any { it() } ||
-            currentGlowEvent?.entitiesToOutline?.isNotEmpty() == true
+            currentGlowEvent?.entitiesToOutline.orEmpty().isNotEmpty()
 
         val event = RenderEntityOutlineEvent(NO_XRAY)
         currentGlowEvent = event

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinAbstractContainerScreen.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinAbstractContainerScreen.java
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.events.render.gui.GuiMouseInputEvent;
 import at.hannibal2.skyhanni.features.inventory.BetterContainers;
 import at.hannibal2.skyhanni.features.inventory.MiddleClickFix;
 import at.hannibal2.skyhanni.features.inventory.wardrobe.CustomWardrobe;
+import at.hannibal2.skyhanni.mixins.hooks.GuiContainerHook;
 import at.hannibal2.skyhanni.utils.DelayedRun;
 import at.hannibal2.skyhanni.utils.KeyboardManager;
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat;
@@ -20,13 +21,19 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
@@ -36,7 +43,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Mixin(AbstractContainerScreen.class)
-public abstract class MixinAbstractContainerScreen {
+public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMenu> extends Screen {
+
+    @Shadow
+    @Nullable
+    protected Slot hoveredSlot;
+
+    @Unique
+    private final GuiContainerHook skyhanni$hook = new GuiContainerHook(this);
+
+    protected MixinGuiContainer(Component title) {
+        super(title);
+    }
 
     //~ if < 26.1 '"extractRenderState"' -> '"render"' {
     @Inject(method = "extractRenderState", at = @At(value = "HEAD"), cancellable = true)
@@ -120,5 +138,72 @@ public abstract class MixinAbstractContainerScreen {
     private boolean fixMiddleClick(boolean original) {
         if (!MiddleClickFix.INSTANCE.isEnabled()) return original;
         return true;
+    }
+
+    @Inject(method = "keyPressed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/inventory/AbstractContainerScreen;onClose()V", shift = At.Shift.BEFORE), cancellable = true)
+    private void closeWindowPressed(KeyEvent input, CallbackInfoReturnable<Boolean> cir) {
+        skyhanni$hook.closeWindowPressed(cir);
+    }
+
+    @Inject(
+        method = "extractContents",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/screens/inventory/AbstractContainerScreen;extractSlotHighlightBack(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V"
+        )
+    )
+    private void backgroundDrawn(GuiGraphicsExtractor context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+        skyhanni$hook.backgroundDrawn(context, mouseX, mouseY, deltaTicks);
+    }
+
+    //~ if < 26.1 'extractRenderState' -> 'render' {
+    @Inject(method = "extractRenderState", at = @At("HEAD"), cancellable = true)
+    private void preDraw(GuiGraphicsExtractor context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+        skyhanni$hook.preDraw(context, mouseX, mouseY, deltaTicks, ci);
+    }
+
+    @Inject(method = "extractRenderState", at = @At("TAIL"))
+    private void postDraw(GuiGraphicsExtractor context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+        skyhanni$hook.postDraw(context, mouseX, mouseY, deltaTicks);
+    }
+    //~}
+
+    @Inject(
+        method = "extractContents",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/screens/inventory/AbstractContainerScreen;extractSlotHighlightFront(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V",
+            shift = At.Shift.AFTER
+        )
+    )
+    private void onForegroundDraw(GuiGraphicsExtractor context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+        skyhanni$hook.foregroundDrawn(context, mouseX, mouseY, deltaTicks);
+    }
+
+    @Inject(method = "extractSlot", at = @At("HEAD"), cancellable = true)
+    private void onDrawSlot(GuiGraphicsExtractor guiGraphics, Slot slot, int i, int j, CallbackInfo ci) {
+        skyhanni$hook.onDrawSlot(slot, ci);
+    }
+
+    @Inject(method = "extractSlot", at = @At("RETURN"))
+    private void onDrawSlotReturn(GuiGraphicsExtractor guiGraphics, Slot slot, int i, int j, CallbackInfo ci) {
+        skyhanni$hook.onDrawSlotPost(slot);
+    }
+
+    @Inject(method = "slotClicked(Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ContainerInput;)V", at = @At("HEAD"), cancellable = true)
+    private void onMouseClick(Slot slot, int slotId, int button, ContainerInput actionType, CallbackInfo cir) {
+        skyhanni$hook.onMouseClick(slot, slotId, button, actionType, cir);
+    }
+
+    @Inject(
+        method = "extractContents",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/screens/inventory/AbstractContainerScreen;extractSlotHighlightBack(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V",
+            shift = At.Shift.AFTER
+        )
+    )
+    private void renderBackgroundTexture(GuiGraphicsExtractor context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+        ToolTipData.INSTANCE.setLastSlot(this.hoveredSlot);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinAbstractContainerScreen.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinAbstractContainerScreen.java
@@ -52,7 +52,7 @@ public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMe
     @Unique
     private final GuiContainerHook skyhanni$hook = new GuiContainerHook(this);
 
-    protected MixinGuiContainer(Component title) {
+    protected MixinAbstractContainerScreen(Component title) {
         super(title);
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinAbstractContainerScreen.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinAbstractContainerScreen.java
@@ -203,7 +203,7 @@ public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMe
             shift = At.Shift.AFTER
         )
     )
-    private void renderBackgroundTexture(GuiGraphicsExtractor context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+    private void renderTooltipBackgroundTexture(GuiGraphicsExtractor context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
         ToolTipData.INSTANCE.setLastSlot(this.hoveredSlot);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
@@ -1,0 +1,7 @@
+package at.hannibal2.skyhanni.mixins.transformers.gui;
+
+
+@Mixin(AbstractContainerScreen.class)
+public abstract class MixinGuiContainer<T extends AbstractContainerMenu> extends Screen {
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/gui/MixinGuiContainer.java
@@ -1,7 +1,0 @@
-package at.hannibal2.skyhanni.mixins.transformers.gui;
-
-
-@Mixin(AbstractContainerScreen.class)
-public abstract class MixinGuiContainer<T extends AbstractContainerMenu> extends Screen {
-
-}


### PR DESCRIPTION
## What
#6145 inadvertently deleted `MixinGuiContainer` without merging its mixins into `MixinAbstractContainerScreen`. There was also some subtle breakage in `RenderEntityOutlineEvent` from my refactor. This PR fixes both and restores broken functionality.

## Changelog Fixes
+ Fixed some glow-related SkyHanni features potentially not working. - Luna
+ Fixed various GUI-related SkyHanni features being broken because some code was accidentally deleted. - Luna