### PR TITLE
Fix: Event Handlers weren't actually being uncached on LOCATION_CHANGE

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -135,8 +135,10 @@ object SkyHanniEvents {
             DirtyReason.OUTSIDE_SB_FEATURE_CHANGED,
             -> listenerCacheGeneration.incrementAndGet()
 
-            DirtyReason.LOCATION_CHANGED ->
+            DirtyReason.LOCATION_CHANGED -> {
                 currentStateIndex.set(ListenerCollection.getCurrentStateIndex())
+                listenerCacheGeneration.incrementAndGet()
+            }
 
             DirtyReason.SERVER_DISCONNECTED -> {
                 listenerCacheGeneration.incrementAndGet()

--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -136,8 +136,8 @@ object SkyHanniEvents {
             -> listenerCacheGeneration.incrementAndGet()
 
             DirtyReason.LOCATION_CHANGED -> {
-                currentStateIndex.set(ListenerCollection.getCurrentStateIndex())
                 listenerCacheGeneration.incrementAndGet()
+                currentStateIndex.set(ListenerCollection.getCurrentStateIndex())
             }
 
             DirtyReason.SERVER_DISCONNECTED -> {


### PR DESCRIPTION
## What
I spent like 10 minutes waiting for 26.1 to boot to prove this actually worked just for my own sanity

## Changelog Fixes
+ Fixed certain OnlyOnSkyblock toggles not activating until full server disconnect. - Avrg