### PR TITLE
Fix: Skill Progress Display adding cap XP twice when a goal is set

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -269,6 +269,17 @@ object SkillProgress {
         return newList
     }
 
+    /**
+     * Progress towards [SkillApi.SkillInfo.customGoalLevel], expressed as cumulative XP out of the
+     * cumulative XP that goal level requires.
+     *
+     * [SkillApi.SkillInfo.totalXp] is already cumulative, so it can be compared against
+     * [SkillUtil.xpRequiredForLevel] directly. [SkillApi.SkillInfo.overflowTotalXp] can not: it only
+     * counts the XP gained past the level cap.
+     */
+    private fun SkillApi.SkillInfo.customGoalProgress() =
+        SkillLevel(overflowLevel, totalXp, SkillUtil.xpRequiredForLevel(customGoalLevel), totalXp)
+
     private fun drawAllDisplay() = buildMap {
         val skillMap = SkillApi.storage ?: return@buildMap
         val sortedMap = SkillType.entries.filter { it.displayName.isNotEmpty() }.sortedBy { it.displayName.take(2) }
@@ -278,19 +289,9 @@ object SkillProgress {
             val lockedLevels = skillInfo.overflowCurrentXp > skillInfo.overflowCurrentXpMax
             val useCustomGoalLevel =
                 skillInfo.customGoalLevel != 0 && skillInfo.customGoalLevel > skillInfo.overflowLevel && customGoalConfig.enableInAllDisplay
-            val targetLevel = skillInfo.customGoalLevel
-            var xp = skillInfo.overflowTotalXp
-            if (targetLevel in 50..60 && skillInfo.overflowLevel >= 50) xp += SkillUtil.xpRequiredForLevel(50)
-            else if (targetLevel > 60 && skillInfo.overflowLevel >= 60) xp += SkillUtil.xpRequiredForLevel(60)
-
-            var have = skillInfo.overflowTotalXp
-            val need = SkillUtil.xpRequiredForLevel(targetLevel)
-            if (targetLevel in 51..59) have += SkillUtil.xpRequiredForLevel(50)
-            else if (targetLevel > 60) have += SkillUtil.xpRequiredForLevel(60)
-
             val (level, currentXP, currentXPMax, totalXP) =
                 if (useCustomGoalLevel)
-                    SkillLevel(skillInfo.overflowLevel, have, need, xp)
+                    skillInfo.customGoalProgress()
                 else if (config.overflowConfig.enableInAllDisplay.get() && !lockedLevels)
                     SkillLevel(
                         skillInfo.overflowLevel,
@@ -415,14 +416,10 @@ object SkillProgress {
         val skillMap = SkillApi.storage ?: return@buildList
         val skill = skillMap[activeSkill] ?: return@buildList
         val useCustomGoalLevel = skill.customGoalLevel != 0 && skill.customGoalLevel > skill.overflowLevel
-        val targetLevel = skill.customGoalLevel
-        // `totalXp` is the cumulative xp of the skill, matching what `xpRequiredForLevel` returns
-        val xp = skill.totalXp
-        val need = SkillUtil.xpRequiredForLevel(targetLevel)
 
         val (level, currentXP, currentXPMax, _) =
             if (useCustomGoalLevel && customGoalConfig.enableInDisplay)
-                SkillLevel(skill.overflowLevel, xp, need, xp)
+                skill.customGoalProgress()
             else if (config.overflowConfig.enableInDisplay.get())
                 SkillLevel(skill.overflowLevel, skill.overflowCurrentXp, skill.overflowCurrentXpMax, skill.overflowTotalXp)
             else

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.config.features.skillprogress.SkillProgressConfig
 import at.hannibal2.skyhanni.events.ActionBarUpdateEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.SkillOverflowLevelUpEvent
-import at.hannibal2.skyhanni.features.skillprogress.SkillUtil.calculateSkillLevel
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils.chat
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
@@ -417,22 +416,13 @@ object SkillProgress {
         val skill = skillMap[activeSkill] ?: return@buildList
         val useCustomGoalLevel = skill.customGoalLevel != 0 && skill.customGoalLevel > skill.overflowLevel
         val targetLevel = skill.customGoalLevel
+        // `totalXp` is the cumulative xp of the skill, matching what `xpRequiredForLevel` returns
         val xp = skill.totalXp
-        val lvl = skill.level
-        val cap = activeSkill.maxLevel
-        // This code is probably still wrong for hunting
-        // But I can not understand why we are doing this in the first place
-        val add = if (lvl >= 50) {
-            SkillUtil.xpRequiredForLevel(cap)
-        } else {
-            0
-        }
-        val (currentLevel, _, _, xpTotalCurrent) = calculateSkillLevel(xp + add, cap)
         val need = SkillUtil.xpRequiredForLevel(targetLevel)
 
         val (level, currentXP, currentXPMax, _) =
             if (useCustomGoalLevel && customGoalConfig.enableInDisplay)
-                SkillLevel(currentLevel, xp + add, need, xpTotalCurrent)
+                SkillLevel(skill.overflowLevel, xp, need, xp)
             else if (config.overflowConfig.enableInDisplay.get())
                 SkillLevel(skill.overflowLevel, skill.overflowCurrentXp, skill.overflowCurrentXpMax, skill.overflowTotalXp)
             else

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillUtil.kt
@@ -8,8 +8,9 @@ import com.google.common.base.Splitter
 
 object SkillUtil {
 
-    val SPACE_SPLITTER = Splitter.on("  ").omitEmptyStrings().trimResults()
     private const val XP_NEEDED_FOR_60 = 111_672_425L
+
+    val SPACE_SPLITTER = Splitter.on("  ").omitEmptyStrings().trimResults()
 
     fun getSkillInfo(skill: SkillType): SkillApi.SkillInfo? {
         return SkillApi.storage?.get(skill)
@@ -61,7 +62,7 @@ object SkillUtil {
         var xpCurrent = currentXP
         var level = 0
 
-        // up to level 60 the cost of every single level is listed in the leveling table
+        // Up to level 60 the cost of every single level is listed in the leveling table
         while (level < 60) {
             val xpForNextLevel = levelingMap[level + 1]?.toLong() ?: break
             if (xpCurrent < xpForNextLevel) break
@@ -71,7 +72,7 @@ object SkillUtil {
 
         var xpForNext = levelingMap[level + 1]?.toLong() ?: 0L
 
-        // past level 60 the cost grows by a slope that doubles every tenth level instead
+        // Past level 60 the cost grows by a slope that doubles every tenth level instead
         if (level >= 60) {
             var slope = 600_000L
             xpForNext = 7_000_000L + slope
@@ -88,5 +89,4 @@ object SkillUtil {
 
         return SkillLevel(level, xpCurrent, xpForNext, overflowXP)
     }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillUtil.kt
@@ -52,62 +52,39 @@ object SkillUtil {
         return SkillApi.levelArray.asSequence().take(level + 1).sumOf { it.toDouble() }
     }
 
-    fun calculateXPForCurrentLevel(level: Int): Long {
-        return SkillApi.levelArray.getOrNull(level)?.toLong() ?: 4000000L
-    }
-
-    fun calculateXPToNextLevel(currentLevel: Int): Long {
-        val xpForCurrentLevel = SkillApi.levelArray.getOrNull(currentLevel)?.toLong() ?: 4000000L
-        val xpForNextLevel = SkillApi.levelArray.getOrNull(currentLevel + 1)?.toLong() ?: 4300000L
-
-        return xpForNextLevel - xpForCurrentLevel
-    }
-
+    /**
+     * The returned level is uncapped, so it keeps counting past [maxSkillCap]. Only
+     * [SkillLevel.overflowXP] is relative to the cap; callers that want the capped level have to
+     * coerce it themselves.
+     */
     fun calculateSkillLevel(currentXP: Long, maxSkillCap: Int): SkillLevel {
         var xpCurrent = currentXP
         var level = 0
-        val maxLevel = maxSkillCap.coerceAtMost(60)
 
-        while (level < maxLevel && xpCurrent >= (levelingMap[level + 1]?.toLong() ?: Long.MAX_VALUE)) {
-            val xpForNextLevel = levelingMap[level + 1]?.toLong() ?: Long.MAX_VALUE
+        // up to level 60 the cost of every single level is listed in the leveling table
+        while (level < 60) {
+            val xpForNextLevel = levelingMap[level + 1]?.toLong() ?: break
+            if (xpCurrent < xpForNextLevel) break
             xpCurrent -= xpForNextLevel
             level++
         }
 
         var xpForNext = levelingMap[level + 1]?.toLong() ?: 0L
-        var overflowXP = 0L
 
-        if (level >= maxLevel) {
-            val xpNeeded = xpRequiredForLevel(maxLevel)
-
-            if (currentXP >= xpNeeded) {
-                overflowXP = currentXP - xpNeeded
-
-                xpCurrent = overflowXP
-                var slope = calculateXPToNextLevel(maxLevel)
-                var xpForCurr = calculateXPForCurrentLevel(maxLevel) + slope
-
-                while (xpCurrent >= xpForCurr && level < 60) {
-                    level++
-                    xpCurrent -= xpForCurr
-                    slope = calculateXPToNextLevel(level)
-                    xpForCurr += slope
-                }
-
-                if (level >= 60) {
-                    slope = 600000L
-                    xpForCurr = 7000000L + slope
-                    while (xpCurrent >= xpForCurr) {
-                        level++
-                        xpCurrent -= xpForCurr
-                        xpForCurr += slope
-                        if (level % 10 == 0) slope *= 2
-                    }
-                }
-
-                xpForNext = xpForCurr
+        // past level 60 the cost grows by a slope that doubles every tenth level instead
+        if (level >= 60) {
+            var slope = 600_000L
+            xpForNext = 7_000_000L + slope
+            while (xpCurrent >= xpForNext) {
+                level++
+                xpCurrent -= xpForNext
+                xpForNext += slope
+                if (level % 10 == 0) slope *= 2
             }
         }
+
+        val xpForCap = xpRequiredForLevel(maxSkillCap.coerceAtMost(60))
+        val overflowXP = (currentXP - xpForCap).coerceAtLeast(0L)
 
         return SkillLevel(level, xpCurrent, xpForNext, overflowXP)
     }


### PR DESCRIPTION
## What
https://discord.com/channels/997079228510117908/1531798408111591584

## Changelog Fixes
+ Fixed Skill Progress Display adding the level 60 XP twice when custom goal is enabled and set. - Luna
+ Fixed All Skill Display showing wrong overflow level and current XP for skills with a cap below level 60. - Luna