### PR TITLE
Improvement: Add bazzar link to gummy bear warning

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/slayer/SlayerConfig.kt
@@ -178,7 +178,11 @@ class SlayerConfig {
     var damageSplashHider: Boolean = false
 
     @Expose
-    @ConfigOption(name = "No Gummy Warning", desc = "Send a warning when you don't have a Re-Heated Gummy Polar Bear active.")
+    @ConfigOption(
+        name = "No Gummy Warning",
+        desc = "Sends a warning when you don't have a Re-Heated Gummy Polar Bear active " +
+            "while you have Habanero Tactics on your gear, or are in the Smoldering Tomb."
+    )
     @ConfigEditorBoolean
     @FeatureToggle
     var gummyWarning: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/GummyWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/GummyWarning.kt
@@ -21,7 +21,6 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.getHypixelEnchantments
-import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import at.hannibal2.skyhanni.utils.renderables.Renderable

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/GummyWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/GummyWarning.kt
@@ -14,6 +14,7 @@ import at.hannibal2.skyhanni.features.misc.effects.NonGodPotEffectDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -51,18 +52,18 @@ object GummyWarning {
     private val display = Renderable.text("§4§lNo Polar Bear Active!", scale = 2.0)
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onAreaChange(event: GraphAreaChangeEvent) {
-        inSmolderingArea = smolderingAreaPattern.matches(SkyBlockUtils.graphArea)
+    private fun onAreaChange(event: GraphAreaChangeEvent) {
+        inSmolderingArea = smolderingAreaPattern.matches(event.area)
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<RemainingSlayerKills.SlayerData>("Slayer")
         slayerWeapons = data.weapons.mapValues { it.value.keys }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onArmorChange(event: OwnInventoryArmorUpdateEvent) {
+    private fun onArmorChange(event: OwnInventoryArmorUpdateEvent) {
         if (!config.gummyWarning) return
         val armor = InventoryUtils.getArmor()
         hasHabanero = armor.any { piece ->
@@ -73,7 +74,7 @@ object GummyWarning {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onItemInHandChange(event: ItemInHandChangeEvent) {
+    private fun onItemInHandChange(event: ItemInHandChangeEvent) {
         if (!isEnabled()) return
         val activeSlayer = SlayerApi.activeType ?: run {
             holdingSlayerWeapon = false
@@ -83,7 +84,7 @@ object GummyWarning {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onEntityClick(event: EntityClickEvent) {
+    private fun onEntityClick(event: EntityClickEvent) {
         if (!isEnabled()) return
         if (event.action != EntityClickEvent.ActionType.ATTACK) return
         if (!holdingSlayerWeapon) return
@@ -99,15 +100,17 @@ object GummyWarning {
         DelayedRun.runDelayed(0.5.seconds) {
             lastWarningShown = SimpleTimeMark.now()
             SoundUtils.createSound("block.anvil.land", 0.5f).playSound()
-            ChatUtils.notifyOrDisable(
+            ChatUtils.clickToActionOrDisable(
                 message = "You do not have an active Re-Heated Gummy Polar Bear!",
                 option = config::gummyWarning,
+                actionName = "Open Bazaar",
+                action = { HypixelCommands.bazaar("Re-Heated Gummy Polar Bear") },
             )
         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    private fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (lastWarningShown.passedSince() > 3.seconds) return
         config.gummyWarningPosition.renderRenderable(display, posLabel = "Gummy Warning")


### PR DESCRIPTION
## What
Makes the gummy bear warning also link you to the bazzar to buy more.
Also reworded the description slightly.

## Changelog Improvements
+ Added a button to the "No Gummy Warning" chat message to open the bazaar for Re-Heated Gummy Polar Bears. - Avrg
