### PR TITLE
Fix: ClassCastException on empty hover components in EnchantParser

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -396,7 +396,9 @@ object EnchantParser {
             }
 
             if (fromChatComponent) {
-                if (!(loreList[i].contents as PlainTextContents.LiteralContents).text.contains("\n")) {
+                // Only the component's own text matters here, siblings are separate tooltip lines
+                val ownText = (loreList[i].contents as? PlainTextContents)?.text().orEmpty()
+                if (!ownText.contains("\n")) {
                     maxComponentEnchantsPerLine++
                 } else {
                     maxEnchantsPerLine =


### PR DESCRIPTION
## What
Fixes an unchecked cast that so far has only caused issues on Lunar Client, but was technically wrong on our end nonetheless. The `PlainTextContents.EMPTY` singleton cannot be cast to `PlainTextContents` (thanks Mojang), so it was erroring out.

## Changelog Fixes
+ Fixed an error from Enchant Parsing when hovering over a /shown item on Lunar Client. - Luna