### PR TITLE
Fix: Rendering issues with Longview

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/render/RoundedShapeDrawer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/RoundedShapeDrawer.kt
@@ -26,6 +26,9 @@ import org.joml.Matrix4f
 import org.joml.Vector3f
 import org.joml.Vector4f
 
+//? if >= 26.1
+import net.minecraft.client.renderer.Projection
+
 object RoundedShapeDrawer {
 
     val projectionMatrix = ProjectionMatrixBuffer(
@@ -81,8 +84,8 @@ object RoundedShapeDrawer {
             val w = window.width.toFloat() / window.guiScale.toFloat()
             val h = window.height.toFloat() / window.guiScale.toFloat()
             RenderSystem.setProjectionMatrix(
-                //~ if < 26.1 'Matrix4f().setOrtho(0f, w, h, 0f, 1000f, 11000f)' -> 'w, h'
-                projectionMatrix.getBuffer(Matrix4f().setOrtho(0f, w, h, 0f, 1000f, 11000f)),
+                //~ if < 26.1 'Projection().apply { this.setupOrtho(1000f, 11000f, w, h, true) }' -> 'w, h'
+                projectionMatrix.getBuffer(Projection().apply { this.setupOrtho(1000f, 11000f, w, h, true) }),
                 ProjectionType.ORTHOGRAPHIC,
             )
             val dynamicTransforms = RenderSystem.getDynamicUniforms().writeTransform(

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniRealtimeItemSlot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniRealtimeItemSlot.kt
@@ -12,7 +12,7 @@ import net.minecraft.client.renderer.state.gui.GuiRenderState
 import kotlin.math.roundToInt
 
 //? if >= 26.1
-import org.joml.Matrix4f
+import net.minecraft.client.renderer.Projection
 
 internal class SkyHanniRealtimeItemSlot(val slotSize: Int) : SkyHanniAbstractItemTexture() {
 
@@ -40,8 +40,8 @@ internal class SkyHanniRealtimeItemSlot(val slotSize: Int) : SkyHanniAbstractIte
         RenderSystem.getDevice().createCommandEncoder().clearColorAndDepthTextures(texture, 0, depthTexture, 1.0)
 
         val size = slotSize.toFloat()
-        //~ if < 26.1 'Matrix4f().setOrtho(0f, size, size, 0f, -1000f, 1000f)' -> 'size, size'
-        val bufferSlice = projectionBuffer.getBuffer(Matrix4f().setOrtho(0f, size, size, 0f, -1000f, 1000f))
+        //~ if < 26.1 'Projection().apply { this.setupOrtho(-1000f, 1000f, size, size, true) }' -> 'size, size'
+        val bufferSlice = projectionBuffer.getBuffer(Projection().apply { this.setupOrtho(-1000f, 1000f, size, size, true) })
 
         RenderSystem.setProjectionMatrix(bufferSlice, ProjectionType.ORTHOGRAPHIC)
         RenderSystem.outputColorTextureOverride = textureView

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/atlas/SkyHanniItemAtlasRenderer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/atlas/SkyHanniItemAtlasRenderer.kt
@@ -16,7 +16,7 @@ import net.minecraft.client.renderer.state.gui.GuiRenderState
 import kotlin.math.roundToInt
 
 //? if >= 26.1
-import org.joml.Matrix4f
+import net.minecraft.client.renderer.Projection
 
 internal class SkyHanniItemAtlasRenderer(
     private val sizePixels: Int,
@@ -31,8 +31,8 @@ internal class SkyHanniItemAtlasRenderer(
         block: () -> Unit,
     ) {
         val size = sizePixels.toFloat()
-        //~ if < 26.1 'Matrix4f().setOrtho(0f, size, size, 0f, -1000f, 1000f)' -> 'size, size'
-        val bufferSlice = projectionBuffer.getBuffer(Matrix4f().setOrtho(0f, size, size, 0f, -1000f, 1000f))
+        //~ if < 26.1 'Projection().apply { this.setupOrtho(-1000f, 1000f, size, size, true) }' -> 'size, size'
+        val bufferSlice = projectionBuffer.getBuffer(Projection().apply { this.setupOrtho(-1000f, 1000f, size, size, true) })
         RenderSystem.setProjectionMatrix(bufferSlice, ProjectionType.ORTHOGRAPHIC)
         RenderSystem.outputColorTextureOverride = textureView
         RenderSystem.outputDepthTextureOverride = depthTextureView


### PR DESCRIPTION
## What
This PR fixes compatibility issues with the Reverse Z technique by using Minecraft 26.1's `Projection` class. While the goal is to fix issues with Longview, this PR will future-proof this mod for Minecraft 26.2, since that version also implements the same Reverse Z + Z Zero-to-One techniques (the latter being disabled on systems that don't support it) that Longview implements.

While I made sure to carefully not touch Minecraft 1.21.11 (plus having tested this PR on Minecraft 26.2), I believe further testing there would be good.

<details>
<summary>Images</summary>

Before fix (with Longview):
<img width="2560" height="1440" alt="Screenshot of the Render Items debug renderable, broken by Reverse Z" src="https://github.com/user-attachments/assets/c268e04a-57dc-4697-920d-7dc706b1fceb" />

After fix (with Longview):
<img width="2560" height="1440" alt="Screenshot of the Render Items debug renderable, no longer broken by Reverse Z" src="https://github.com/user-attachments/assets/a6b45bb2-f5dc-4357-b6c5-472f27c84778" />


</details>

## Changelog Fixes
+ Fixed rendering issues when Longview is installed. - EnnuiL
