### PR TITLE
Backend: Ban @ModifyConstant

### DIFF
--- a/.github/workflows/illegal-imports.txt
+++ b/.github/workflows/illegal-imports.txt
@@ -9,6 +9,7 @@ at/hannibal2/skyhanni/ com.mojang.realmsclient.
 at/hannibal2/skyhanni/ com.ibm.icu.
 at/hannibal2/skyhanni/ io.netty.util.internal.
 at/hannibal2/skyhanni/ org.spongepowered.asm.mixin.Overwrite
+at/hannibal2/skyhanni/ org.spongepowered.asm.mixin.injection.ModifyConstant
 at/hannibal2/skyhanni/ org.spongepowered.asm.mixin.injection.Redirect
 # Here because SkyHanniDebugsAndTests references way too much stuff and this way we keep the internal dependencies lower
 at/hannibal2/skyhanni/ at.hannibal2.skyhanni.test.SkyHanniDebugsAndTests


### PR DESCRIPTION
## What

We should never use `@ModifyConstant` in mixins unless we are intentionally trying to be incompatible with other mods. This PR bans importing its annotation (no existing uses).

`@ModifyConstant`s can always be replaced with a `@ModifyExpressionValue` @ `value = "CONSTANT"`

Follow-up to Luna's PR because I just saw a `@ModifyConstant` in the wild and reminded me of that PR, and then realized that this was left out.

## Changelog Technical Details
+ Banned `@ModifyConstant`. - Microcontrollers
