### PR TITLE
Fix: Lottery Perk Item Regex detection in alpha

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
@@ -19,23 +19,27 @@ object HotfApi {
     ) : RotatingPerk {
         SWEEP(
             displayDescription = "§a+5% §r§2${SkyblockStat.SWEEP.hypixelIcon} Sweep",
-            chatFallback = "Gain \\+5% ${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
-            itemFallback = "Gain \\+5% ${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
+            chatFallback = "Gain \\+5% ?${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
+            itemFallback = "(?: ■ )?Gain \\+5% ?${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
         ),
         MANGROVE_FORTUNE(
             displayDescription = "§a+50 §r§6${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune",
-            chatFallback = "Gain \\+50 ${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
-            itemFallback = "Gain \\+50 ${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
+            chatFallback = "Gain \\+50 ?${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
+            /**
+             * WRAPPED-REGEX-TEST: " ■ Gain +50 Mangrove Fortune."
+             * REGEX-TEST: Gain +50  Mangrove Fortune.
+             */
+            itemFallback = "(?: ■ )?Gain \\+50 ?${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
         ),
         FIG_FORTUNE(
             displayDescription = "§a+50 §r§6${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune",
-            chatFallback = "Gain \\+50 ${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
-            itemFallback = "Gain \\+50 ${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
+            chatFallback = "Gain \\+50 ?${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
+            itemFallback = "(?: ■ )?Gain \\+50 ?${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
         ),
         HELIX_FORTUNE(
             displayDescription = "§a+50 §r§6${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune",
-            chatFallback = "Gain \\+50 ${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
-            itemFallback = "Gain \\+50 ${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
+            chatFallback = "Gain \\+50 ?${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
+            itemFallback = "(?: ■ )?Gain \\+50 ?${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
         ),
         ;
 

--- a/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
@@ -18,22 +18,22 @@ object HotfApi {
         @field:Language("RegExp") val itemFallback: String,
     ) : RotatingPerk {
         SWEEP(
-            displayDescription = "§a+5% §r§2${SkyblockStat.SWEEP.hypixelIcon} Sweep",
+            displayDescription = "§a+5%§r§2${SkyblockStat.SWEEP.hypixelIcon} Sweep",
             chatFallback = "Gain \\+5% ?${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
             itemFallback = "Gain \\+5% ?${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
         ),
         MANGROVE_FORTUNE(
-            displayDescription = "§a+50 §r§6${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune",
+            displayDescription = "§a+50§r§6${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune",
             chatFallback = "Gain \\+50 ?${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
             itemFallback = "Gain \\+50 ?${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
         ),
         FIG_FORTUNE(
-            displayDescription = "§a+50 §r§6${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune",
+            displayDescription = "§a+50§r§6${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune",
             chatFallback = "Gain \\+50 ?${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
             itemFallback = "Gain \\+50 ?${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
         ),
         HELIX_FORTUNE(
-            displayDescription = "§a+50 §r§6${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune",
+            displayDescription = "§a+50§r§6${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune",
             chatFallback = "Gain \\+50 ?${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
             itemFallback = "Gain \\+50 ?${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
         ),

--- a/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/HotfApi.kt
@@ -20,26 +20,22 @@ object HotfApi {
         SWEEP(
             displayDescription = "§a+5% §r§2${SkyblockStat.SWEEP.hypixelIcon} Sweep",
             chatFallback = "Gain \\+5% ?${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
-            itemFallback = "(?: ■ )?Gain \\+5% ?${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
+            itemFallback = "Gain \\+5% ?${SkyblockStat.SWEEP.hypixelIcon} Sweep\\.",
         ),
         MANGROVE_FORTUNE(
             displayDescription = "§a+50 §r§6${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune",
             chatFallback = "Gain \\+50 ?${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
-            /**
-             * WRAPPED-REGEX-TEST: " ■ Gain +50 Mangrove Fortune."
-             * REGEX-TEST: Gain +50  Mangrove Fortune.
-             */
-            itemFallback = "(?: ■ )?Gain \\+50 ?${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
+            itemFallback = "Gain \\+50 ?${SkyblockStat.MANGROVE_FORTUNE.hypixelIcon} Mangrove Fortune\\.",
         ),
         FIG_FORTUNE(
             displayDescription = "§a+50 §r§6${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune",
             chatFallback = "Gain \\+50 ?${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
-            itemFallback = "(?: ■ )?Gain \\+50 ?${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
+            itemFallback = "Gain \\+50 ?${SkyblockStat.FIG_FORTUNE.hypixelIcon} Fig Fortune\\.",
         ),
         HELIX_FORTUNE(
             displayDescription = "§a+50 §r§6${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune",
             chatFallback = "Gain \\+50 ?${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
-            itemFallback = "(?: ■ )?Gain \\+50 ?${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
+            itemFallback = "Gain \\+50 ?${SkyblockStat.HELIX_FORTUNE.hypixelIcon} Helix Fortune\\.",
         ),
         ;
 


### PR DESCRIPTION
## What
They removed the space, this was already like that for skymall.
So makes sense why they made that change.

## Changelog Fixes
+ Fixed Lottery Perk not getting detected in Torrhus Canyon Alpha. - Avrg