### PR TITLE
Feature + Fix + Improvement + Backend: shnavall command

### DIFF
--- a/.idea/dictionaries/default_user.xml
+++ b/.idea/dictionaries/default_user.xml
@@ -203,6 +203,7 @@
       <w>hideonleaf</w>
       <w>hideonsun</w>
       <w>hideparticles</w>
+      <w>hideyho</w>
       <w>highlite</w>
       <w>hina</w>
       <w>hitbox</w>

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/EnumArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/EnumArgumentType.kt
@@ -78,7 +78,7 @@ class EnumArgumentType<E : Enum<E>> private constructor(
         }
 
         /**
-         * To filtering of an enum should not change during runtime.
+         * The filtering of an enum should not change during runtime.
          */
         inline fun <reified E : Enum<E>> filtered(
             noinline toString: (E) -> String,

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/EnumArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/EnumArgumentType.kt
@@ -18,9 +18,10 @@ class EnumArgumentType<E : Enum<E>> private constructor(
     clazz: Class<E>,
     val isGreedy: Boolean = false,
     toString: (E) -> String,
+    predicate: (E) -> Boolean,
 ) : ArgumentType<E> {
 
-    private val mapping: Map<String, E> = clazz.enumConstants.associateBy { constant ->
+    private val mapping: Map<String, E> = clazz.enumConstants.filter { predicate(it) }.associateBy { constant ->
         val string = toString(constant)
         require(string.none { it.isWhitespace() }) {
             "String representation of constant ${constant.name} of enum ${clazz.simpleName} contains whitespace: '$string'"
@@ -53,25 +54,43 @@ class EnumArgumentType<E : Enum<E>> private constructor(
     override fun getExamples(): Collection<String> = mapping.keys
 
     companion object {
-        fun <E : Enum<E>> create(clazz: Class<E>, isGreedy: Boolean = false, toString: (E) -> String): EnumArgumentType<E> {
-            return EnumArgumentType(clazz, isGreedy, toString)
+        fun <E : Enum<E>> create(
+            clazz: Class<E>,
+            isGreedy: Boolean = false,
+            toString: (E) -> String,
+            predicate: (E) -> Boolean = { true },
+        ): EnumArgumentType<E> {
+            return EnumArgumentType(clazz, isGreedy, toString) { predicate(it) }
         }
 
         /**
          * To use enum name arguments do `EnumArgumentType.name<Enum>()`
          */
         inline fun <reified E : Enum<E>> name(isGreedy: Boolean = false): EnumArgumentType<E> {
-            return create(E::class.java, isGreedy) { it.name }
+            return create(E::class.java, isGreedy, toString = { it.name })
         }
 
         /**
          * To use enum lowercase name arguments do `EnumArgumentType.lowercase<Enum>()`
          */
         inline fun <reified E : Enum<E>> lowercase(isGreedy: Boolean = false): EnumArgumentType<E> {
-            return create(E::class.java, isGreedy) { it.name.lowercase() }
+            return create(E::class.java, isGreedy, toString = { it.name.lowercase() })
         }
 
-        /** The string representation of the enum should not change during runtime. */
+        /**
+         * To filtering of an enum should not change during runtime.
+         */
+        inline fun <reified E : Enum<E>> filtered(
+            noinline toString: (E) -> String,
+            isGreedy: Boolean = false,
+            crossinline predicate: (E) -> Boolean,
+        ): EnumArgumentType<E> {
+            return create(E::class.java, isGreedy, toString) { predicate(it) }
+        }
+
+        /**
+         * The string representation of the enum should not change during runtime.
+         */
         inline fun <reified E : Enum<E>> custom(noinline toString: (E) -> String, isGreedy: Boolean = false): EnumArgumentType<E> {
             return create(E::class.java, isGreedy, toString)
         }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/LorenzVecArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/LorenzVecArgumentType.kt
@@ -59,7 +59,7 @@ sealed class LorenzVecArgumentType : ArgumentType<LorenzVec> {
         override fun toVec(x: kotlin.Double, y: kotlin.Double, z: kotlin.Double) = LorenzVec(x, y, z)
 
         override fun getExamples(): Collection<String> =
-            listOf("1.0 2.5 -3", "0.0 0.0 0.0", "-1.7 ~ ~", "-78.8:68.0:-28.7", "LorenzVec(-91.7, 70.0, 29.3), x=-262.0, y=58.0, z=117.0")
+            listOf("1.0 2.5 -3", "0.0 0.0 0.0", "-1.7 ~ ~", "-78.8:68.0:-28.7", "LorenzVec(-91.7, 70.0, 29.3)", "x=-262.0, y=58.0, z=117.0")
     }
 
     @SkyHanniModule
@@ -107,7 +107,7 @@ sealed class LorenzVecArgumentType : ArgumentType<LorenzVec> {
          */
         private val namedParameterPattern by patternGroup.pattern(
             "named-parameter",
-            "x=(?<x>-?\\d+(?:\\.\\d+)?),\\s*y=(?<y>-?\\d+(?:\\.\\d+)?),\\s*z=(?<z>-?\\d+(?:\\.\\d+)?)"
+            "x=(?<x>-?\\d+(?:\\.\\d+)?),\\s*y=(?<y>-?\\d+(?:\\.\\d+)?),\\s*z=(?<z>-?\\d+(?:\\.\\d+)?)",
         )
 
         private val patterns = listOf(lorenzVecPattern, colonPattern, spacePattern, namedParameterPattern)

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/LorenzVecArgumentType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/arguments/LorenzVecArgumentType.kt
@@ -51,14 +51,15 @@ sealed class LorenzVecArgumentType : ArgumentType<LorenzVec> {
         override fun toVec(x: kotlin.Double, y: kotlin.Double, z: kotlin.Double) =
             LorenzVec(x.toInt(), y.toInt(), z.toInt())
 
-        override fun getExamples(): Collection<String> = listOf("1 2 3", "-4 0 5", "~ 64 ~", "1:2:3", "LorenzVec(1, 2, 3)")
+        override fun getExamples(): Collection<String> =
+            listOf("1 2 3", "-4 0 5", "~ 64 ~", "1:2:3", "LorenzVec(1, 2, 3), x=-262, y=58, z=117")
     }
 
     data object Double : LorenzVecArgumentType() {
         override fun toVec(x: kotlin.Double, y: kotlin.Double, z: kotlin.Double) = LorenzVec(x, y, z)
 
         override fun getExamples(): Collection<String> =
-            listOf("1.0 2.5 -3", "0.0 0.0 0.0", "-1.7 ~ ~", "-78.8:68.0:-28.7", "LorenzVec(-91.7, 70.0, 29.3)")
+            listOf("1.0 2.5 -3", "0.0 0.0 0.0", "-1.7 ~ ~", "-78.8:68.0:-28.7", "LorenzVec(-91.7, 70.0, 29.3), x=-262.0, y=58.0, z=117.0")
     }
 
     @SkyHanniModule
@@ -74,7 +75,7 @@ sealed class LorenzVecArgumentType : ArgumentType<LorenzVec> {
          */
         private val lorenzVecPattern by patternGroup.pattern(
             "lorenz",
-            """LorenzVec\((?<x>-?\d+(?:\.\d+)?),\s*(?<y>-?\d+(?:\.\d+)?),\s*(?<z>-?\d+(?:\.\d+)?)\)""",
+            "LorenzVec\\((?<x>-?\\d+(?:\\.\\d+)?),\\s*(?<y>-?\\d+(?:\\.\\d+)?),\\s*(?<z>-?\\d+(?:\\.\\d+)?)\\)",
         )
 
         /**
@@ -85,7 +86,7 @@ sealed class LorenzVecArgumentType : ArgumentType<LorenzVec> {
          */
         private val colonPattern by patternGroup.pattern(
             "colon",
-            """(?<x>~|-?\d+(?:\.\d+)?):(?<y>~|-?\d+(?:\.\d+)?):(?<z>~|-?\d+(?:\.\d+)?)""",
+            "(?<x>~|-?\\d+(?:\\.\\d+)?):(?<y>~|-?\\d+(?:\\.\\d+)?):(?<z>~|-?\\d+(?:\\.\\d+)?)",
         )
 
         /**
@@ -98,10 +99,18 @@ sealed class LorenzVecArgumentType : ArgumentType<LorenzVec> {
          */
         private val spacePattern by patternGroup.pattern(
             "space",
-            """(?<x>~|-?\d+(?:\.\d+)?)\s+(?<y>~|-?\d+(?:\.\d+)?)\s+(?<z>~|-?\d+(?:\.\d+)?)""",
+            "(?<x>~|-?\\d+(?:\\.\\d+)?)\\s+(?<y>~|-?\\d+(?:\\.\\d+)?)\\s+(?<z>~|-?\\d+(?:\\.\\d+)?)",
         )
 
-        private val patterns = listOf(lorenzVecPattern, colonPattern, spacePattern)
+        /**
+         * REGEX-TEST: x=-262.0, y=58.0, z=117.0
+         */
+        private val namedParameterPattern by patternGroup.pattern(
+            "named-parameter",
+            "x=(?<x>-?\\d+(?:\\.\\d+)?),\\s*y=(?<y>-?\\d+(?:\\.\\d+)?),\\s*z=(?<z>-?\\d+(?:\\.\\d+)?)"
+        )
+
+        private val patterns = listOf(lorenzVecPattern, colonPattern, spacePattern, namedParameterPattern)
 
         private val invalidCoordinates = SimpleCommandExceptionType(LiteralMessage("Invalid coordinates"))
 

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/Graph.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/Graph.kt
@@ -29,8 +29,8 @@ value class Graph(
         nodes.filter { node -> tag.all { node.hasTag(it) } }
     fun getNodesWithName(name: String): List<GraphNode> =
         nodes.filter { it.name == name }
-    fun getActiveNodeTags(): List<GraphNodeTag> =
-        nodes.flatMap { it.tags }
+    fun getActiveNodeTags(): Set<GraphNodeTag> =
+        nodes.flatMap { it.tags }.toSet()
     fun getNodesWithNameAndTags(name: String, tag: GraphNodeTag): List<GraphNode> =
         getNodesWithTags(tag).filter { it.name == name }
     fun getClosestNode(nodeName: String, tag: GraphNodeTag): GraphNode? =

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/Graph.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/Graph.kt
@@ -15,7 +15,6 @@ import com.google.gson.stream.JsonToken
 import com.google.gson.stream.JsonWriter
 import java.util.Collection
 import java.util.function.IntFunction
-import kotlin.collections.iterator
 
 // TODO: This class should be disambiguated into a NodePath and a Graph class
 @JvmInline
@@ -30,6 +29,8 @@ value class Graph(
         nodes.filter { node -> tag.all { node.hasTag(it) } }
     fun getNodesWithName(name: String): List<GraphNode> =
         nodes.filter { it.name == name }
+    fun getActiveNodeTags(): List<GraphNodeTag> =
+        nodes.flatMap { it.tags }
     fun getNodesWithNameAndTags(name: String, tag: GraphNodeTag): List<GraphNode> =
         getNodesWithTags(tag).filter { it.name == name }
     fun getClosestNode(nodeName: String, tag: GraphNodeTag): GraphNode? =

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNode.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNode.kt
@@ -34,7 +34,7 @@ class GraphNode(
 
     fun sameNameAndTags(other: GraphNode): Boolean = name == other.name && allowedTags == other.allowedTags
 
-    private val allowedTags get() = tags.filter { it in NavigationHelper.allowedTags }
+    private val allowedTags get() = tags.filter { it in NavigationHelper.allowedSingleNavigationTags }
 
     // Identity is by id alone - two GraphNode references with the same id are the same node regardless
     // of mutable state (neighbors, enabled), which must not participate in equality.

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
@@ -185,6 +185,14 @@ enum class GraphNodeTag(
         onlyIsland = IslandType.SAFARI,
     ),
 
+    HIDEYHO_HIDING_LOCATION(
+        "hideyho_hiding_location",
+        LorenzColor.LIGHT_PURPLE,
+        "Hideyho Hiding Location",
+        "A location that Hideyho can teleport to while hiding.",
+        onlyIsland = IslandType.SAFARI,
+    ),
+
     ;
 
     val displayName: String = color.getChatColor() + cleanName

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
@@ -185,11 +185,11 @@ enum class GraphNodeTag(
         onlyIsland = IslandType.SAFARI,
     ),
 
-    HIDEYHO_HIDING_LOCATION(
-        "hideyho_hiding_location",
+    HIDEYHO_LOCATION(
+        "hideyho_location",
         LorenzColor.LIGHT_PURPLE,
-        "Hideyho Hiding Location",
-        "A location that Hideyho can teleport to while hiding.",
+        "Hideyho Location",
+        "A location that Hideyho can be found.",
         onlyIsland = IslandType.SAFARI,
     ),
 

--- a/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/graph/GraphNodeTag.kt
@@ -161,18 +161,16 @@ enum class GraphNodeTag(
         onlyIsland = IslandType.TORRHUS_CANYON,
     ),
 
-    // TODO fix inconsistent name
     TREE_PROTECTION_ORDER(
-        "tree_protection",
+        "tree_protection_order",
         LorenzColor.RED,
         "Tree Protection Order",
         "Tree Protected by the Protection Order.",
         onlyIslands = IslandTypeTag.FORAGING_CUSTOM_TREES,
     ),
 
-    // TODO fix inconsistent name
     HONEY_HIVE(
-        "hive",
+        "honey_hive",
         LorenzColor.GOLD,
         "Honey Hive",
         "Lootable Honey Hive.",

--- a/src/main/java/at/hannibal2/skyhanni/features/hunting/ShulkerFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/hunting/ShulkerFinder.kt
@@ -78,7 +78,7 @@ object ShulkerFinder {
 
     private fun calculateRoute(shulkerType: ShulkerType): MutableList<LorenzVec>? {
         val graph = IslandGraphs.currentIslandGraph ?: return null
-        val list = graph.filter { it.hasTag(shulkerType.nodeTag) }
+        val list = graph.getNodesWithTags(shulkerType.nodeTag)
 
         return NavigationUtils.getRoute(list, maxIterations = 300, neighborhoodSize = 50).toMutableList()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/hunting/ShulkerFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/hunting/ShulkerFinder.kt
@@ -80,7 +80,7 @@ object ShulkerFinder {
         val graph = IslandGraphs.currentIslandGraph ?: return null
         val list = graph.getNodesWithTags(shulkerType.nodeTag)
 
-        return NavigationUtils.getRoute(list, maxIterations = 300, neighborhoodSize = 50).toMutableList()
+        return NavigationUtils.getRoute(list).toMutableList()
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -52,7 +52,7 @@ object FastFairySoulsPathfinder {
 
     private var data: Data? = null
 
-    private val soulPathFindConfig = CoroutineSettings("fairy souls pathfind")
+    private val pathfindCoroutine = CoroutineSettings("fairy souls pathfind")
     private val patternGroup = RepoPattern.group("misc.fairy-souls")
 
     /**
@@ -268,7 +268,7 @@ object FastFairySoulsPathfinder {
         calculatingStart = SimpleTimeMark.now()
         "§e[SkyHanni] Calculating Fairy Soul route §b0s".asComponent().send(calculatingMessageId)
 
-        soulPathFindConfig.launch {
+        pathfindCoroutine.launch {
             val route = NavigationUtils.getRoute(missingSouls, maxIterations = 300, neighborhoodSize = 50).toMutableList()
             val duration = calculatingStart.passedSince()
             "§e[SkyHanni] Calculated Fairy Soul route in §b${duration.format(showMilliSeconds = true)}".asComponent()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FastFairySoulsPathfinder.kt
@@ -269,7 +269,7 @@ object FastFairySoulsPathfinder {
         "§e[SkyHanni] Calculating Fairy Soul route §b0s".asComponent().send(calculatingMessageId)
 
         pathfindCoroutine.launch {
-            val route = NavigationUtils.getRoute(missingSouls, maxIterations = 300, neighborhoodSize = 50).toMutableList()
+            val route = NavigationUtils.getRoute(missingSouls).toMutableList()
             val duration = calculatingStart.passedSince()
             "§e[SkyHanni] Calculated Fairy Soul route in §b${duration.format(showMilliSeconds = true)}".asComponent()
                 .send(calculatingMessageId)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/SpiderDenRelicPathfinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/SpiderDenRelicPathfinder.kt
@@ -250,11 +250,7 @@ object SpiderDenRelicPathfinder {
 
         val currentIsland = SkyBlockUtils.currentIsland
         relicPathFindConfig.launch {
-            val route = NavigationUtils.getRoute(
-                missingRelics,
-                maxIterations = 300,
-                neighborhoodSize = 50,
-            ).toMutableList()
+            val route = NavigationUtils.getRoute(missingRelics).toMutableList()
 
             val duration = calculatingStart.passedSince().format(showMilliSeconds = true)
             "§e[SkyHanni] Calculated Relic route in §b$duration".asComponent().send(calculatingMessageId)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
@@ -24,6 +24,7 @@ object NavigateAllHelper {
     private val allowedMultiNavigationTags = setOf(
         GraphNodeTag.HOPPITY,
         GraphNodeTag.RIFT_EFFIGY,
+        GraphNodeTag.RIFT_MONTEZUMA,
         GraphNodeTag.CRIMSON_MINIBOSS,
         GraphNodeTag.SPIDER_RELIC,
         GraphNodeTag.END_GOLEM,
@@ -35,7 +36,7 @@ object NavigateAllHelper {
         GraphNodeTag.TREE_PROTECTION_ORDER,
         GraphNodeTag.HONEY_HIVE,
         GraphNodeTag.SAFARI_BELL,
-        GraphNodeTag.HIDEYHO_HIDING_LOCATION,
+        GraphNodeTag.HIDEYHO_LOCATION,
     )
 
     private val pathfindCoroutine = CoroutineSettings("navigate all pathfind")
@@ -57,6 +58,7 @@ object NavigateAllHelper {
         val targetNodes = graph.getNodesWithTags(nodeType)
         currentNodeType = nodeType
 
+        // Coroutine for calculateRoute()
         pathfindCoroutine.launch {
             route = emptyList()
             route = calculateRoute(targetNodes)
@@ -126,6 +128,9 @@ object NavigateAllHelper {
             }
             literalCallback("skip") {
                 handleSkip()
+            }
+            simpleCallback {
+                ChatUtils.userError("Usage: /shnavigateall <location type>")
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
@@ -1,0 +1,105 @@
+package at.hannibal2.skyhanni.features.misc.pathfind
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils
+import at.hannibal2.skyhanni.config.commands.brigadier.arguments.EnumArgumentType
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.navigation.NavigationUtils
+
+@SkyHanniModule
+object NavigateAllHelper {
+
+    private val route: MutableList<LorenzVec> = mutableListOf()
+    private var total = 0
+
+    val allowedMultiNavigationTags = setOf(
+        GraphNodeTag.HOPPITY,
+        GraphNodeTag.RIFT_EFFIGY,
+        GraphNodeTag.CRIMSON_MINIBOSS,
+        GraphNodeTag.SPIDER_RELIC,
+        GraphNodeTag.END_GOLEM,
+        GraphNodeTag.FISHING_HOTSPOT,
+        GraphNodeTag.FISHING_WORMHOLE,
+        GraphNodeTag.FAIRY_SOUL,
+        GraphNodeTag.HIDEONLEAF,
+        GraphNodeTag.HIDEONSUN,
+        GraphNodeTag.TREE_PROTECTION_ORDER,
+        GraphNodeTag.HONEY_HIVE,
+        GraphNodeTag.SAFARI_BELL,
+    )
+
+    /**
+     * Navigate to all nodes with the selected tag
+     *
+     * In future this should be changed to take in a predicate for nodes
+     * Existing features should be switched to use a more abstract version of this
+     * These features include: Fast Fairy Souls, Spider Relic Pathfind, Shulker Finder
+     *
+     * As TSP algorithm is so quick, it should be able to recalculate the remaining order
+     * every few targets reached
+     *
+     */
+    private fun navigateAll(nodeTagType: GraphNodeTag) {
+        if (nodeTagType !in getValidNodeNames()) {
+            ChatUtils.userError("Target type is invalid on this island!")
+            return
+        }
+
+        val graph = IslandGraphs.currentIslandGraph ?: return
+        val list = graph.getNodesWithTags(nodeTagType)
+
+        route.clear()
+        route.addAll(NavigationUtils.getRoute(list, maxIterations = 300, neighborhoodSize = 50))
+        total = route.size
+
+        recursiveNavigate(nodeTagType)
+    }
+
+    private fun recursiveNavigate(nodeTagType: GraphNodeTag) {
+        if (route.isEmpty()) return
+
+        IslandGraphs.pathFind(
+            route.removeFirstOrNull() ?: error("No more nodes found"),
+            "${nodeTagType.displayName} ${total - route.size}/$total",
+            onFound = { recursiveNavigate(nodeTagType) },
+            condition = { SkyBlockUtils.inSkyBlock },
+        )
+    }
+
+    @HandleEvent
+    private fun onIslandChange() {
+        route.clear()
+        total = 0
+    }
+
+    @HandleEvent
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shnavigateall") {
+            description = "Use the path finder to go to all locations of a type"
+            aliases = listOf("shnavall")
+
+            argCallback(
+                "nodeType",
+                EnumArgumentType.filtered<GraphNodeTag>(
+                    { it.cleanName.replace(" ", "_") },
+                    isGreedy = true,
+                ) { it in allowedMultiNavigationTags },
+                BrigadierUtils.dynamicSuggestionProvider { getValidNodeNames().map { it.cleanName } },
+            ) { nodeType ->
+                navigateAll(nodeType)
+            }
+        }
+    }
+
+    private fun getValidNodeNames(): List<GraphNodeTag> {
+        val activeTags = IslandGraphs.currentIslandGraph?.getActiveNodeTags() ?: return emptyList()
+        return activeTags.filter { it in allowedMultiNavigationTags }
+    }
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
@@ -41,8 +41,8 @@ object NavigateAllHelper {
      * Existing features should be switched to use a more abstract version of this
      * These features include: Fast Fairy Souls, Spider Relic Pathfind, Shulker Finder
      *
-     * As TSP algorithm is so quick, it should be able to recalculate the remaining order
-     * every few targets reached
+     * As TSP algorithm is so quick, in future it should recalculate the remaining order
+     * of nodes every few nodes reached for the most optimal pathing.
      *
      */
     private fun navigateAll(nodeTagType: GraphNodeTag) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
@@ -48,7 +48,7 @@ object NavigateAllHelper {
      * These features include: Fast Fairy Souls, Spider Relic Pathfind, Shulker Finder
      */
     private fun navigateAll(nodeType: GraphNodeTag) {
-        if (nodeType !in getValidNodeNames()) {
+        if (nodeType !in getValidTagNames()) {
             ChatUtils.userError("Target type is invalid on this island!")
             return
         }
@@ -71,32 +71,38 @@ object NavigateAllHelper {
     private fun recursiveNavigate() {
         if (route.isEmpty()) return
 
-        val target = route.firstOrNull() ?: error("No more nodes found")
+        val target = route.first()
         route = route.drop(1)
 
         IslandGraphs.pathFind(
             target,
             "${currentNodeType?.displayName} ${total - route.size}/$total",
-            onFound = { recursiveNavigate() },
-            condition = { route.isNotEmpty() },
+            onFound = {
+                if (route.isEmpty()) currentNodeType = null
+                recursiveNavigate()
+            },
+            condition = { currentNodeType != null },
         )
     }
 
-    private fun calculateRoute(targetNodes: List<GraphNode>): List<LorenzVec> =
-        NavigationUtils.getRoute(targetNodes)
+    private fun calculateRoute(targetNodes: List<GraphNode>): List<LorenzVec> = NavigationUtils.getRoute(targetNodes)
 
     private fun handleSkip() {
         if (route.isEmpty()) {
-            ChatUtils.userError("No current navigation to skip. §eUse /shnavigateall to start navigation")
+            if (currentNodeType != null) {
+                currentNodeType = null
+            } else {
+                ChatUtils.userError("No current navigation to skip. §eUse /shnavigateall to start navigation")
+            }
             return
         }
 
-        // TODO handle recalculation of remaining route without the current node
+        // TODO In future it should recalculate the route taking into account that we dont need the skipped node anymore
         recursiveNavigate()
     }
 
     @HandleEvent
-    private fun onIslandChange() {
+    private fun onIslandLeave() {
         route = emptyList()
         total = 0
         currentNodeType = null
@@ -114,7 +120,7 @@ object NavigateAllHelper {
                     { it.cleanName.replace(" ", "_") },
                     isGreedy = true,
                 ) { it in allowedMultiNavigationTags },
-                BrigadierUtils.dynamicSuggestionProvider { getValidNodeNames().map { it.cleanName } },
+                BrigadierUtils.dynamicSuggestionProvider { getValidTagNames().map { it.cleanName } },
             ) { nodeType ->
                 navigateAll(nodeType)
             }
@@ -124,9 +130,8 @@ object NavigateAllHelper {
         }
     }
 
-    private fun getValidNodeNames(): List<GraphNodeTag> {
+    private fun getValidTagNames(): List<GraphNodeTag> {
         val activeTags = IslandGraphs.currentIslandGraph?.getActiveNodeTags() ?: return emptyList()
         return activeTags.filter { it in allowedMultiNavigationTags }
     }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
@@ -1,24 +1,27 @@
 package at.hannibal2.skyhanni.features.misc.pathfind
 
+import at.hannibal2.skyhanni.SkyHanniMod.launch
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils
 import at.hannibal2.skyhanni.config.commands.brigadier.arguments.EnumArgumentType
 import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.model.graph.GraphNode
 import at.hannibal2.skyhanni.data.model.graph.GraphNodeTag
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.navigation.NavigationUtils
 
 @SkyHanniModule
 object NavigateAllHelper {
 
-    private val route: MutableList<LorenzVec> = mutableListOf()
+    private var route: List<LorenzVec> = listOf()
     private var total = 0
+    private var currentNodeType: GraphNodeTag? = null
 
-    val allowedMultiNavigationTags = setOf(
+    private val allowedMultiNavigationTags = setOf(
         GraphNodeTag.HOPPITY,
         GraphNodeTag.RIFT_EFFIGY,
         GraphNodeTag.CRIMSON_MINIBOSS,
@@ -34,48 +37,68 @@ object NavigateAllHelper {
         GraphNodeTag.SAFARI_BELL,
     )
 
+    private val pathfindCoroutine = CoroutineSettings("navigate all pathfind")
+
     /**
-     * Navigate to all nodes with the selected tag
+     * Navigate to all nodes with the selected [GraphNodeTag]
      *
      * In future this should be changed to take in a predicate for nodes
      * Existing features should be switched to use a more abstract version of this
      * These features include: Fast Fairy Souls, Spider Relic Pathfind, Shulker Finder
-     *
-     * As TSP algorithm is so quick, in future it should recalculate the remaining order
-     * of nodes every few nodes reached for the most optimal pathing.
-     *
      */
-    private fun navigateAll(nodeTagType: GraphNodeTag) {
-        if (nodeTagType !in getValidNodeNames()) {
+    private fun navigateAll(nodeType: GraphNodeTag) {
+        if (nodeType !in getValidNodeNames()) {
             ChatUtils.userError("Target type is invalid on this island!")
             return
         }
 
         val graph = IslandGraphs.currentIslandGraph ?: return
-        val list = graph.getNodesWithTags(nodeTagType)
+        val targetNodes = graph.getNodesWithTags(nodeType)
+        currentNodeType = nodeType
 
-        route.clear()
-        route.addAll(NavigationUtils.getRoute(list, maxIterations = 300, neighborhoodSize = 50))
-        total = route.size
+        pathfindCoroutine.launch {
+            route = emptyList()
+            route = calculateRoute(targetNodes)
+            total = route.size
 
-        recursiveNavigate(nodeTagType)
+            ChatUtils.chat("Navigating to $total ${nodeType.displayName}")
+
+            recursiveNavigate()
+        }
     }
 
-    private fun recursiveNavigate(nodeTagType: GraphNodeTag) {
+    private fun recursiveNavigate() {
         if (route.isEmpty()) return
 
+        val target = route.firstOrNull() ?: error("No more nodes found")
+        route = route.drop(1)
+
         IslandGraphs.pathFind(
-            route.removeFirstOrNull() ?: error("No more nodes found"),
-            "${nodeTagType.displayName} ${total - route.size}/$total",
-            onFound = { recursiveNavigate(nodeTagType) },
-            condition = { SkyBlockUtils.inSkyBlock },
+            target,
+            "${currentNodeType?.displayName} ${total - route.size}/$total",
+            onFound = { recursiveNavigate() },
+            condition = { route.isNotEmpty() },
         )
+    }
+
+    private fun calculateRoute(targetNodes: List<GraphNode>): List<LorenzVec> =
+        NavigationUtils.getRoute(targetNodes)
+
+    private fun handleSkip() {
+        if (route.isEmpty()) {
+            ChatUtils.userError("No current navigation to skip. §eUse /shnavigateall to start navigation")
+            return
+        }
+
+        // TODO handle recalculation of remaining route without the current node
+        recursiveNavigate()
     }
 
     @HandleEvent
     private fun onIslandChange() {
-        route.clear()
+        route = emptyList()
         total = 0
+        currentNodeType = null
     }
 
     @HandleEvent
@@ -93,6 +116,9 @@ object NavigateAllHelper {
                 BrigadierUtils.dynamicSuggestionProvider { getValidNodeNames().map { it.cleanName } },
             ) { nodeType ->
                 navigateAll(nodeType)
+            }
+            literalCallback("skip") {
+                handleSkip()
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
@@ -130,8 +130,8 @@ object NavigateAllHelper {
         }
     }
 
-    private fun getValidTagNames(): List<GraphNodeTag> {
-        val activeTags = IslandGraphs.currentIslandGraph?.getActiveNodeTags() ?: return emptyList()
-        return activeTags.filter { it in allowedMultiNavigationTags }
+    private fun getValidTagNames(): Set<GraphNodeTag> {
+        val activeTags = IslandGraphs.currentIslandGraph?.getActiveNodeTags() ?: return emptySet()
+        return activeTags.filter { it in allowedMultiNavigationTags }.toSet()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllHelper.kt
@@ -35,6 +35,7 @@ object NavigateAllHelper {
         GraphNodeTag.TREE_PROTECTION_ORDER,
         GraphNodeTag.HONEY_HIVE,
         GraphNodeTag.SAFARI_BELL,
+        GraphNodeTag.HIDEYHO_HIDING_LOCATION,
     )
 
     private val pathfindCoroutine = CoroutineSettings("navigate all pathfind")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationHelper.kt
@@ -29,7 +29,7 @@ object NavigationHelper {
 
     private val messageId = ChatUtils.getUniqueMessageId()
 
-    val allowedTags = listOf(
+    val allowedSingleNavigationTags = setOf(
         GraphNodeTag.NPC,
         GraphNodeTag.AREA,
         GraphNodeTag.SMALL_AREA,
@@ -84,7 +84,7 @@ object NavigationHelper {
                 node.pathFind(label = name, allowRerouting = true, condition = { true })
                 sendNavigateMessage(name, goBack)
             }
-            val tag = node.tags.first { it in allowedTags }
+            val tag = node.tags.first { it in allowedSingleNavigationTags }
             val hoverText = "Name: $name\n§7Type: §r${tag.displayName}\n§7Distance: §e$distance blocks\n§eClick to start navigating!"
             component.hover = hoverText.asComponent()
             component
@@ -108,7 +108,7 @@ object NavigationHelper {
             if (node.name == AreaNode.NO_AREA) continue
             // no need to navigate to the current area
             if (node.name == SkyBlockUtils.graphArea) continue
-            val tag = node.tags.first { it in allowedTags }
+            val tag = node.tags.first { it in allowedSingleNavigationTags }
             val name = "${node.cleanName} §7(${tag.displayName}§7)"
             if (name in names) continue
             names[name] = node
@@ -126,7 +126,7 @@ object NavigationHelper {
         for (node in graph) {
             if (!node.enabled) continue
             val name = node.cleanName ?: continue
-            val remainingTags = node.tags.filter { it in allowedTags }
+            val remainingTags = node.tags.filter { it in allowedSingleNavigationTags }
             if (remainingTags.isEmpty()) continue
             if (name.lowercase().contains(searchTerm)) {
                 distances[node] = GraphUtils.findShortestDistance(closestNode, node)
@@ -139,12 +139,12 @@ object NavigationHelper {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shnavigate") {
-            description = "Using path finder to go to locations"
+            description = "Use the path finder to go to a specific location"
             aliases = listOf("shnav")
             argCallback("coords", LorenzVecArgumentType.double()) { location ->
-                pathFind(location.add(-1, -1, -1), "Custom Goal", condition = { true })
+                pathFind(location, "Custom Goal", condition = { true })
                 ChatUtils.chat("Started Navigating to custom goal at §f${location.toLocalFormat()}", messageId = messageId)
             }
             argCallback("search", BrigadierArguments.greedyString(), BrigadierUtils.dynamicSuggestionProvider { getNames() }) {
@@ -167,6 +167,6 @@ object NavigationHelper {
         val name = name ?: return false
         if (name == AreaNode.NO_AREA) return false
         if (name == SkyBlockUtils.graphArea) return false
-        return tags.any { it in allowedTags }
+        return tags.any { it in allowedSingleNavigationTags }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
@@ -84,7 +84,6 @@ object MatriarchHelper {
         if (config.useShortestDistance) {
             val path = tspCache ?: NavigationUtils.getRoute(
                 pearlList.map { it.second },
-                maxIterations = 5,
             ).also {
                 val pearls = path.size
                 if (pearls != lastTspPearls) {

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
@@ -84,6 +84,7 @@ object MatriarchHelper {
         if (config.useShortestDistance) {
             val path = tspCache ?: NavigationUtils.getRoute(
                 pearlList.map { it.second },
+                maxIterations = 5
             ).also {
                 val pearls = path.size
                 if (pearls != lastTspPearls) {

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorBugFinder.kt
@@ -129,8 +129,8 @@ object GraphEditorBugFinder {
 
     private fun checkConflictingTags(graph: Graph, errorsInWorld: MutableMap<GraphNode, String>) {
         for (node in graph) {
-            if (!node.tags.any { it in NavigationHelper.allowedTags }) continue
-            val remainingTags = node.tags.filter { it in NavigationHelper.allowedTags }
+            if (!node.tags.any { it in NavigationHelper.allowedSingleNavigationTags }) continue
+            val remainingTags = node.tags.filter { it in NavigationHelper.allowedSingleNavigationTags }
             if (remainingTags.size != 1) {
                 errorsInWorld[node] = "Conflicting tags: $remainingTags"
             }

--- a/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
@@ -1,61 +1,72 @@
 package at.hannibal2.skyhanni.utils.navigation
 
+import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.model.graph.GraphNode
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.GraphUtils
-import at.hannibal2.skyhanni.utils.LocationUtils
+import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 
 object NavigationUtils {
 
     fun getRoute(
-        input: List<GraphNode>,
-        maxIterations: Int = 50,
-        neighborhoodSize: Int = 8,
+        nodes: List<GraphNode>,
+        maxIterations: Int = 300,
+        neighborhoodSize: Int = 50,
     ): List<LorenzVec> {
-        if (input.isEmpty()) return emptyList()
+        if (nodes.isEmpty()) return emptyList()
+        val graph = IslandGraphs.currentIslandGraph ?: error("no active island graph")
 
-        val route = calculateTravelingSalesman(input, maxIterations, neighborhoodSize)
+        val closestNode = graph.minByOrNull { it.position.distanceSqToPlayer() } ?: error("no closest node")
+        val route = calculateTravelingSalesman(nodes, closestNode, maxIterations, neighborhoodSize)
 
-        if (route.size != input.size) {
+        val closestNodeIsTarget = nodes.any { it.position == closestNode.position }
+        val amountOffset = if (closestNodeIsTarget) 0 else 1
+
+        if (route.size != nodes.size + amountOffset) {
             ErrorManager.skyHanniError(
                 "calculateTravelingSalesman could not reach all goals",
-                "input" to input.size,
+                "targetNodes" to nodes.size,
                 "output" to route.size,
                 "island" to SkyBlockUtils.currentIsland,
             )
         }
 
-        return route.map { it.position }
+        return route.drop(amountOffset).map { it.position }
     }
 
     private fun calculateTravelingSalesman(
         nodes: List<GraphNode>,
+        startNode: GraphNode,
         maxIterations: Int,
         neighborhoodSize: Int,
     ): List<GraphNode> {
-        val distanceMap = computeDistanceMap(nodes)
+        val distanceMap = computeDistanceMap(nodes, startNode)
 
-        val route = directedTwoOpt(greedyTSP(distanceMap), distanceMap, maxIterations, neighborhoodSize)
+        val route = directedTwoOpt(
+            greedyTSP(distanceMap, startNode),
+            distanceMap,
+            maxIterations,
+            neighborhoodSize,
+        )
 
-        ChatUtils.debug("Total distance of graph: ${calculateRouteDistance(route, distanceMap)}")
+        ChatUtils.debug("Total distance of route: ${calculateRouteDistance(route, distanceMap).toInt()}")
 
-        return adjustRouteForCurrentLocation(route, LocationUtils.playerLocation())
+        return route
     }
 
     private fun computeDistanceMap(
         nodes: List<GraphNode>,
+        startNode: GraphNode,
     ): Map<GraphNode, Map<GraphNode, Double>> {
         val result = HashMap<GraphNode, Map<GraphNode, Double>>(nodes.size)
 
-        for (node in nodes) {
+        for (node in nodes + startNode) {
             val distances = GraphUtils.findAllShortestDistances(node).distances
 
-            result[node] = nodes.associateWith {
-                distances[it] ?: Double.POSITIVE_INFINITY
-            }
+            result[node] = nodes.associateWith { distances[it] ?: Double.POSITIVE_INFINITY }
         }
 
         return result
@@ -63,24 +74,18 @@ object NavigationUtils {
 
     private fun greedyTSP(
         distanceMap: Map<GraphNode, Map<GraphNode, Double>>,
+        start: GraphNode,
     ): MutableList<GraphNode> {
-        val start = distanceMap.keys.first()
-
         val route = mutableListOf(start)
-        val visited = HashSet<GraphNode>()
-        visited.add(start)
+        val visited = hashSetOf(start)
 
         var current = start
 
         while (visited.size < distanceMap.size) {
-            val next = distanceMap[current]
-                ?.filter { !visited.contains(it.key) }
-                ?.minByOrNull { it.value }
-                ?.key
-                ?: break
+            val next = distanceMap[current]?.filterKeys { it !in visited }?.minByOrNull { it.value }?.key ?: break
 
-            route.add(next)
-            visited.add(next)
+            route += next
+            visited += next
             current = next
         }
 
@@ -102,15 +107,14 @@ object NavigationUtils {
             improved = false
 
             for (i in 1 until route.size - 2) {
-                val maxJ = minOf(route.size - 1, i + neighborhoodSize)
+                val maxJ = minOf(route.size - 2, i + neighborhoodSize)
 
                 for (j in i + 1..maxJ) {
-                    val oldCost = edge(route[i - 1], route[i], distanceMap) + edge(route[j], route.getOrNull(j + 1), distanceMap)
-                    val newCost = edge(route[i - 1], route[j], distanceMap) + edge(route[i], route.getOrNull(j + 1), distanceMap)
+                    val oldCost = edge(route[i - 1], route[i], distanceMap) + edge(route[j], route[j + 1], distanceMap)
+                    val newCost = edge(route[i - 1], route[j], distanceMap) + edge(route[i], route[j + 1], distanceMap)
 
                     if (newCost < oldCost) {
                         route.subList(i, j + 1).reverse()
-
                         improved = true
                         break
                     }
@@ -131,7 +135,6 @@ object NavigationUtils {
         map: Map<GraphNode, Map<GraphNode, Double>>,
     ): Double {
         if (a == null || b == null) return 0.0
-
         return map[a]?.get(b) ?: Double.POSITIVE_INFINITY
     }
 
@@ -145,23 +148,14 @@ object NavigationUtils {
             val distance = distanceMap[route[i]]?.get(route[i + 1]) ?: Double.POSITIVE_INFINITY
 
             if (!distance.isFinite()) {
-                ChatUtils.debug("Missing route between ${route[i].position} and ${route[i + 1].position}")
+                ChatUtils.debug(
+                    "Missing route between ${route[i].position} and ${route[i + 1].position}",
+                )
             }
 
             total += distance
         }
 
         return total
-    }
-
-    private fun adjustRouteForCurrentLocation(
-        route: List<GraphNode>,
-        currentLocation: LorenzVec,
-    ): List<GraphNode> {
-        val closest = route.minByOrNull { it.position.distanceSq(currentLocation) } ?: return route
-
-        val index = route.indexOf(closest)
-
-        return route.drop(index) + route.take(index)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
@@ -28,7 +28,7 @@ object NavigationUtils {
         if (route.size != nodes.size + amountOffset) {
             ErrorManager.skyHanniError(
                 "calculateTravelingSalesman could not reach all goals",
-                "targetNodes" to nodes.size,
+                "targetNodes" to nodes.size + amountOffset,
                 "output" to route.size,
                 "island" to SkyBlockUtils.currentIsland,
             )

--- a/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
@@ -109,7 +109,6 @@ object NavigationUtils {
                     val newCost = edge(route[i - 1], route[j], distanceMap) + edge(route[i], route.getOrNull(j + 1), distanceMap)
 
                     if (newCost < oldCost) {
-
                         route.subList(i, j + 1).reverse()
 
                         improved = true

--- a/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
@@ -1,11 +1,9 @@
 package at.hannibal2.skyhanni.utils.navigation
 
-import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.model.graph.GraphNode
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.GraphUtils
-import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 
@@ -17,9 +15,8 @@ object NavigationUtils {
         neighborhoodSize: Int = 50,
     ): List<LorenzVec> {
         if (nodes.isEmpty()) return emptyList()
-        val graph = IslandGraphs.currentIslandGraph ?: error("no active island graph")
 
-        val closestNode = graph.minByOrNull { it.position.distanceSqToPlayer() } ?: error("no closest node")
+        val closestNode = GraphUtils.nearestNodeOnCurrentIsland()
         val route = calculateTravelingSalesman(nodes, closestNode, maxIterations, neighborhoodSize)
 
         val closestNodeIsTarget = nodes.any { it.position == closestNode.position }
@@ -93,7 +90,7 @@ object NavigationUtils {
     }
 
     private fun directedTwoOpt(
-        routeInput: MutableList<GraphNode>,
+        routeInput: List<GraphNode>,
         distanceMap: Map<GraphNode, Map<GraphNode, Double>>,
         maxIterations: Int,
         neighborhoodSize: Int,
@@ -130,11 +127,10 @@ object NavigationUtils {
     }
 
     private fun edge(
-        a: GraphNode?,
-        b: GraphNode?,
+        a: GraphNode,
+        b: GraphNode,
         map: Map<GraphNode, Map<GraphNode, Double>>,
     ): Double {
-        if (a == null || b == null) return 0.0
         return map[a]?.get(b) ?: Double.POSITIVE_INFINITY
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/navigation/NavigationUtils.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.utils.navigation
 
 import at.hannibal2.skyhanni.data.model.graph.GraphNode
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
@@ -9,278 +10,159 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 
 object NavigationUtils {
 
-    fun getRoute(input: List<GraphNode>, maxIterations: Int = 50, neighborhoodSize: Int = 6): List<LorenzVec> {
+    fun getRoute(
+        input: List<GraphNode>,
+        maxIterations: Int = 50,
+        neighborhoodSize: Int = 8,
+    ): List<LorenzVec> {
         if (input.isEmpty()) return emptyList()
-        val output = calculateTravelingSalesman(input, maxIterations, neighborhoodSize)
 
-        if (input.size != output.size) {
+        val route = calculateTravelingSalesman(input, maxIterations, neighborhoodSize)
+
+        if (route.size != input.size) {
             ErrorManager.skyHanniError(
                 "calculateTravelingSalesman could not reach all goals",
                 "input" to input.size,
-                "output" to output.size,
+                "output" to route.size,
                 "island" to SkyBlockUtils.currentIsland,
             )
         }
 
-        return output
+        return route.map { it.position }
     }
 
     private fun calculateTravelingSalesman(
-        targetNodes: List<GraphNode>,
+        nodes: List<GraphNode>,
         maxIterations: Int,
         neighborhoodSize: Int,
-    ): List<LorenzVec> {
-        val distanceMap = computeDistanceMap(targetNodes)
-        var tspRoute = improvedTSP(distanceMap, maxIterations, neighborhoodSize)
+    ): List<GraphNode> {
+        val distanceMap = computeDistanceMap(nodes)
 
-        optimizeCriticalSegments(tspRoute, distanceMap)
+        val route = directedTwoOpt(greedyTSP(distanceMap), distanceMap, maxIterations, neighborhoodSize)
 
-        // Re-run TSP with an optimized (intra- and inter-cluster) distance map.
-        val optimizedDistanceMap = computeDistanceMapOptimized(tspRoute)
-        tspRoute = improvedTSP(optimizedDistanceMap, maxIterations, neighborhoodSize)
+        ChatUtils.debug("Total distance of graph: ${calculateRouteDistance(route, distanceMap)}")
 
-        // Apply 3‑opt for further refinement.
-        tspRoute = threeOpt(tspRoute, optimizedDistanceMap, maxIterations)
-        val currentPosition = LocationUtils.playerLocation()
-
-        val adjustedRoute = adjustRouteForCurrentLocation(tspRoute, currentPosition)
-
-        return adjustedRoute.map { it.position }
+        return adjustRouteForCurrentLocation(route, LocationUtils.playerLocation())
     }
 
-    private fun computeDistanceMap(targetNodes: List<GraphNode>): Map<GraphNode, Map<GraphNode, Double>> {
-        val distanceMap = mutableMapOf<GraphNode, MutableMap<GraphNode, Double>>()
-        for (node in targetNodes) {
-            val dijkstraTree = GraphUtils.findAllShortestDistances(node)
-            val nodeDistances = mutableMapOf<GraphNode, Double>()
-            for (target in targetNodes) {
-                nodeDistances[target] = dijkstraTree.distances[target] ?: Double.POSITIVE_INFINITY
+    private fun computeDistanceMap(
+        nodes: List<GraphNode>,
+    ): Map<GraphNode, Map<GraphNode, Double>> {
+        val result = HashMap<GraphNode, Map<GraphNode, Double>>(nodes.size)
+
+        for (node in nodes) {
+            val distances = GraphUtils.findAllShortestDistances(node).distances
+
+            result[node] = nodes.associateWith {
+                distances[it] ?: Double.POSITIVE_INFINITY
             }
-            distanceMap[node] = nodeDistances
         }
-        return distanceMap
+
+        return result
     }
 
-    private fun improvedTSP(
+    private fun greedyTSP(
+        distanceMap: Map<GraphNode, Map<GraphNode, Double>>,
+    ): MutableList<GraphNode> {
+        val start = distanceMap.keys.first()
+
+        val route = mutableListOf(start)
+        val visited = HashSet<GraphNode>()
+        visited.add(start)
+
+        var current = start
+
+        while (visited.size < distanceMap.size) {
+            val next = distanceMap[current]
+                ?.filter { !visited.contains(it.key) }
+                ?.minByOrNull { it.value }
+                ?.key
+                ?: break
+
+            route.add(next)
+            visited.add(next)
+            current = next
+        }
+
+        return route
+    }
+
+    private fun directedTwoOpt(
+        routeInput: MutableList<GraphNode>,
         distanceMap: Map<GraphNode, Map<GraphNode, Double>>,
         maxIterations: Int,
         neighborhoodSize: Int,
     ): MutableList<GraphNode> {
-        val route = greedyTSP(distanceMap).toMutableList()
-        var iteration = 0
+        val route = routeInput.toMutableList()
+
         var improved = true
+        var iteration = 0
 
         while (improved && iteration < maxIterations) {
             improved = false
-            for (i in 1 until route.size - 1) {
-                val jMax = (i + neighborhoodSize).coerceAtMost(route.size)
-                for (j in i + 1 until jMax) {
-                    val costCurrent = (distanceMap[route[i - 1]]?.get(route[i]) ?: Double.POSITIVE_INFINITY) +
-                        (distanceMap[route[j - 1]]?.get(route[j]) ?: Double.POSITIVE_INFINITY)
-                    val costNew = (distanceMap[route[i - 1]]?.get(route[j]) ?: Double.POSITIVE_INFINITY) +
-                        (distanceMap[route[j - 1]]?.get(route[i]) ?: Double.POSITIVE_INFINITY)
-                    if (costNew < costCurrent) {
-                        route.subList(i, j).reverse()
+
+            for (i in 1 until route.size - 2) {
+                val maxJ = minOf(route.size - 1, i + neighborhoodSize)
+
+                for (j in i + 1..maxJ) {
+                    val oldCost = edge(route[i - 1], route[i], distanceMap) + edge(route[j], route.getOrNull(j + 1), distanceMap)
+                    val newCost = edge(route[i - 1], route[j], distanceMap) + edge(route[i], route.getOrNull(j + 1), distanceMap)
+
+                    if (newCost < oldCost) {
+
+                        route.subList(i, j + 1).reverse()
+
                         improved = true
-                        break // break inner loop on improvement
+                        break
                     }
                 }
-                if (improved) break // restart iteration after a change
+
+                if (improved) break
             }
+
             iteration++
         }
+
         return route
     }
 
-    // Updated to compute both intra- and inter-cluster distances.
-    private fun computeDistanceMapOptimized(targetNodes: List<GraphNode>): Map<GraphNode, Map<GraphNode, Double>> {
-        val clusters = computeClusters(targetNodes)
-        val result = mutableMapOf<GraphNode, MutableMap<GraphNode, Double>>()
+    private fun edge(
+        a: GraphNode?,
+        b: GraphNode?,
+        map: Map<GraphNode, Map<GraphNode, Double>>,
+    ): Double {
+        if (a == null || b == null) return 0.0
 
-        // Compute intra-cluster distances.
-        clusters.forEach { cluster ->
-            cluster.parallelStream().forEach { node ->
-                val dijkstraTree = GraphUtils.findAllShortestDistances(node)
-                result[node] = cluster.associateWith { target ->
-                    dijkstraTree.distances[target] ?: Double.POSITIVE_INFINITY
-                }.toMutableMap()
-            }
-        }
-
-        // Compute inter-cluster distances.
-        for (i in clusters.indices) {
-            for (j in i + 1 until clusters.size) {
-                val clusterA = clusters[i]
-                val clusterB = clusters[j]
-                for (nodeA in clusterA) {
-                    val dijkstraTreeA = GraphUtils.findAllShortestDistances(nodeA)
-                    for (nodeB in clusterB) {
-                        val distance = dijkstraTreeA.distances[nodeB] ?: Double.POSITIVE_INFINITY
-                        result[nodeA]?.put(nodeB, distance)
-                    }
-                }
-                for (nodeB in clusterB) {
-                    val dijkstraTreeB = GraphUtils.findAllShortestDistances(nodeB)
-                    for (nodeA in clusterA) {
-                        val distance = dijkstraTreeB.distances[nodeA] ?: Double.POSITIVE_INFINITY
-                        result[nodeB]?.put(nodeA, distance)
-                    }
-                }
-            }
-        }
-        return result
+        return map[a]?.get(b) ?: Double.POSITIVE_INFINITY
     }
 
-    private fun computeClusters(targetNodes: List<GraphNode>): List<List<GraphNode>> {
-        val clusters = mutableListOf<MutableList<GraphNode>>()
-        val visited = mutableSetOf<GraphNode>()
+    private fun calculateRouteDistance(
+        route: List<GraphNode>,
+        distanceMap: Map<GraphNode, Map<GraphNode, Double>>,
+    ): Double {
+        var total = 0.0
 
-        fun dfs(node: GraphNode, cluster: MutableList<GraphNode>) {
-            visited.add(node)
-            cluster.add(node)
-            for (neighbor in node.neighbors) {
-                // Ensure neighbor.key equals one of the target nodes.
-                if (targetNodes.contains(neighbor.key) && !visited.contains(neighbor.key)) {
-                    dfs(neighbor.key, cluster)
-                }
+        for (i in 0 until route.lastIndex) {
+            val distance = distanceMap[route[i]]?.get(route[i + 1]) ?: Double.POSITIVE_INFINITY
+
+            if (!distance.isFinite()) {
+                ChatUtils.debug("Missing route between ${route[i].position} and ${route[i + 1].position}")
             }
+
+            total += distance
         }
 
-        for (node in targetNodes) {
-            if (!visited.contains(node)) {
-                val cluster = mutableListOf<GraphNode>()
-                dfs(node, cluster)
-                clusters.add(cluster)
-            }
-        }
-        return clusters
-    }
-
-    private fun greedyTSP(distanceMap: Map<GraphNode, Map<GraphNode, Double>>): List<GraphNode> {
-        val startNode = distanceMap.keys.first()
-        val route = mutableListOf(startNode)
-        val visited = mutableSetOf(startNode)
-        var current = startNode
-
-        while (visited.size < distanceMap.size) {
-            var nextNode: GraphNode? = null
-            var bestDistance = Double.POSITIVE_INFINITY
-
-            distanceMap[current]?.forEach { (candidate, distance) ->
-                if (!visited.contains(candidate) && distance < bestDistance) {
-                    bestDistance = distance
-                    nextNode = candidate
-                }
-            }
-
-            if (nextNode == null) {
-                for (candidate in distanceMap.keys.filter { !visited.contains(it) }) {
-                    val candidateMinDistance =
-                        visited.mapNotNull { distanceMap[it]?.get(candidate) }.minOrNull() ?: Double.POSITIVE_INFINITY
-                    if (candidateMinDistance < bestDistance) {
-                        bestDistance = candidateMinDistance
-                        nextNode = candidate
-                    }
-                }
-            }
-
-            nextNode?.let {
-                route.add(it)
-                visited.add(it)
-                current = it
-            } ?: break
-        }
-        return route
+        return total
     }
 
     private fun adjustRouteForCurrentLocation(
         route: List<GraphNode>,
         currentLocation: LorenzVec,
     ): List<GraphNode> {
-        val closestNode = route.minByOrNull { it.position.distanceSq(currentLocation) } ?: route.first()
-        val idx = route.indexOf(closestNode)
-        return route.drop(idx) + route.take(idx)
-    }
+        val closest = route.minByOrNull { it.position.distanceSq(currentLocation) } ?: return route
 
-    private fun optimizeCriticalSegments(
-        route: MutableList<GraphNode>,
-        distanceMap: Map<GraphNode, Map<GraphNode, Double>>,
-    ) {
-        if (route.size < 2) return
+        val index = route.indexOf(closest)
 
-        val edgeCosts = mutableListOf<Pair<Int, Double>>()
-        for (i in 0 until route.size - 1) {
-            val cost = distanceMap[route[i]]?.get(route[i + 1]) ?: Double.POSITIVE_INFINITY
-            edgeCosts.add(Pair(i, cost))
-        }
-        val cycleCost = distanceMap[route.last()]?.get(route.first()) ?: Double.POSITIVE_INFINITY
-        edgeCosts.add(Pair(route.size - 1, cycleCost))
-
-        val averageCost = edgeCosts.map { it.second }.average()
-        val threshold = 1.2 * averageCost
-
-        val criticalEdges = edgeCosts.filter { it.second > threshold }
-        if (criticalEdges.isNotEmpty()) {
-            val sortedCritical = criticalEdges.sortedByDescending { it.second }
-            for ((index, _) in sortedCritical) {
-                if (index < route.size - 1 && index > 0) {
-                    for (j in index + 2 until route.size) {
-                        if (j - index >= 2) {
-                            val costBefore = (distanceMap[route[index]]?.get(route[index + 1]) ?: Double.POSITIVE_INFINITY) +
-                                (distanceMap[route[j - 1]]?.get(route[j]) ?: Double.POSITIVE_INFINITY)
-                            val costAfter = (distanceMap[route[index]]?.get(route[j - 1]) ?: Double.POSITIVE_INFINITY) +
-                                (distanceMap[route[index + 1]]?.get(route[j]) ?: Double.POSITIVE_INFINITY)
-                            if (costAfter < costBefore) {
-                                route.subList(index + 1, j).reverse()
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun threeOpt(
-        route: MutableList<GraphNode>,
-        distanceMap: Map<GraphNode, Map<GraphNode, Double>>,
-        maxIterations: Int = 50,
-    ): MutableList<GraphNode> {
-        var improved = true
-        var iteration = 0
-        val n = route.size
-        while (improved && iteration < maxIterations) {
-            improved = false
-            for (i in 0 until n - 2) {
-                for (j in i + 1 until n - 1) {
-                    for (k in j + 1 until n) {
-                        val a = route[i]
-                        val b = route[i + 1]
-                        val c = route[j]
-                        val d = route[j + 1]
-                        val e = route[k]
-                        val f = route[(k + 1) % n]
-
-                        val costAB = distanceMap[a]?.get(b) ?: Double.POSITIVE_INFINITY
-                        val costCD = distanceMap[c]?.get(d) ?: Double.POSITIVE_INFINITY
-                        val costEF = distanceMap[e]?.get(f) ?: Double.POSITIVE_INFINITY
-                        val currentCost = costAB + costCD + costEF
-
-                        // One reconnection: reverse segments (i+1..j) and (j+1..k)
-                        val costAC = distanceMap[a]?.get(c) ?: Double.POSITIVE_INFINITY
-                        val costBE = distanceMap[b]?.get(e) ?: Double.POSITIVE_INFINITY
-                        val costDF = distanceMap[d]?.get(f) ?: Double.POSITIVE_INFINITY
-                        val newCost = costAC + costBE + costDF
-
-                        if (newCost < currentCost) {
-                            route.subList(i + 1, j + 1).reverse()
-                            route.subList(j + 1, k + 1).reverse()
-                            improved = true
-                        }
-                    }
-                }
-            }
-            iteration++
-        }
-        return route
+        return route.drop(index) + route.take(index)
     }
 }


### PR DESCRIPTION
## What
Added /shnavall which navigates to all nodes with a certain tag.
In adding this I fixed our travelling salesman algorithm being super super slow. Now hub fairy souls on my device takes ~0.15 seconds compared to the 8.4 seconds it was taking before (50x speed up).
We were running and saving dijkstra calculations way too frequently along with not considering that we have a directional graph leading wrong shortest path calculations.

The new NavigateAllHelper logic is currently just used for the new command but can later allow for existing features to be abstracted and for new features to be made easily. 

## Changelog New Features
+ Added /shnavall. - CalMWolfs
    * Navigate to all occurrences of a target on an island.
    * May be useful for new points of interest on Honey Hives (Torrhus Canyon), and the Bells and Hideyho (Safari).

## Changelog Improvements
+ Sped up pathfinding and optimized routes for the Fast Fairy Souls, Spider's Den Relics, and Shulker Finder. - CalMWolfs

## Changelog Fixes
+ Fixed /shnav <coordinates> making the end location offset by a block diagonally. - CalMWolfs

## Changelog Technical Details
+ Allowed EnumArgumentType to take in a filtered subset of the whole enum. - CalMWolfs
