### PR TITLE
Fix: Traveling Zoo season error

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/calendar/TravelingZooPetInCalendar.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/calendar/TravelingZooPetInCalendar.kt
@@ -5,10 +5,9 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.CalendarApi
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.events.minecraft.add
+import at.hannibal2.skyhanni.features.inventory.calendar.TravelingZooPetInCalendar.ORINGO_PETS
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.SkyBlockTime
-import at.hannibal2.skyhanni.utils.SkyblockSeason
 import at.hannibal2.skyhanni.utils.SkyblockSeason.Companion.getSeasonByMonth
 
 @SkyHanniModule
@@ -23,15 +22,14 @@ object TravelingZooPetInCalendar {
     )
 
     @HandleEvent
-    fun onTooltip(event: ToolTipTextEvent) {
+    private fun onTooltip(event: ToolTipTextEvent) {
         if (!isEnabled()) return
 
         if (CalendarApi.inCalendar) {
             val skyblockEvents = CalendarApi.parseCalendarItem(event.itemStack) ?: return
             for (sbEvent in skyblockEvents) {
                 if (sbEvent.name == "Traveling Zoo") {
-                    val pet = getZooPet(sbEvent.startTime) ?: return
-                    event.toolTip.add(pet)
+                    event.toolTip.add(getZooPet(sbEvent.startTime))
                 }
             }
         }
@@ -40,35 +38,33 @@ object TravelingZooPetInCalendar {
             val sbEvent = CalendarApi.parseMainCalendarItem(event.itemStack) ?: return
             if (sbEvent.name == "Traveling Zoo") {
                 val approximateTime = SkyBlockTime.fromTimeMark(sbEvent.startTime)
-                val pet = getZooPet(approximateTime) ?: return
-                event.toolTip.add(pet)
+                event.toolTip.add(getZooPet(approximateTime))
             }
         }
     }
 
-    private fun getZooPet(time: SkyBlockTime): String? {
-        val zooNumber = getTravelZooNumber(time) ?: return null
+    private fun getZooPet(time: SkyBlockTime): String {
+        val zooNumber = getTravelZooNumber(time)
         val pet = ORINGO_PETS[zooNumber % ORINGO_PETS.size]
         return "§7Pet available: §6$pet"
     }
 
-    private fun getTravelZooNumber(time: SkyBlockTime): Int? {
-        val extraSeason = when (getSeasonByMonth(time.month).first) {
-            SkyblockSeason.SUMMER -> 0
-            SkyblockSeason.WINTER -> 1
-            SkyblockSeason.AUTUMN, SkyblockSeason.SPRING -> {
-                ErrorManager.logErrorStateWithData(
-                    "Unexpected season",
-                    "Unexpected season for Traveling Zoo",
-                    "time" to time.toString(),
-                    "month" to time.month.toString(),
-                    "year" to time.year.toString()
-                )
-                return null
-            }
+    /**
+     * Returns a continuous index over all Traveling Zoo events, two per SkyBlock year. Taken modulo the size of
+     * [ORINGO_PETS], it selects the legendary pet Oringo offers at that event.
+     *
+     * The zoo starts on the first day of Early Summer and Early Winter, exactly on a month boundary. The start time
+     * from the main calendar is only an approximation and can land slightly before or after that boundary, which
+     * would be Late Spring or Late Autumn. Mapping whole half years instead of just those two seasons absorbs that
+     * in both directions, with three SkyBlock months of tolerance either way.
+     */
+    private fun getTravelZooNumber(time: SkyBlockTime): Int {
+        val zooOfYear = when (getSeasonByMonth(time.month).first) {
+            SPRING, SUMMER -> 0
+            AUTUMN, WINTER -> 1
         }
 
-        return (time.year * 2 + extraSeason)
+        return time.year * 2 + zooOfYear
     }
 
     fun isEnabled() = SkyHanniMod.feature.inventory.oringoPetInCalendar


### PR DESCRIPTION
## What
The Traveling Zoo starts exactly on a month boundary (Early Summer 1st and Early Winter 1st).
The start time from the main calendar is derived from the `Starts in:` line, which is only accurate to the second, and one real second is 1.2 SkyBlock minutes.
Being off by less than two seconds already lands in Late Autumn or Late Spring, which `getTravelZooNumber` rejected with an error state on every tooltip render.

It now maps whole half years instead of just the two seasons. The zoo start sits in the middle of its half year, so this gives three SkyBlock months of tolerance either way.

## Changelog Fixes
+ Fixed an error when hovering over the Traveling Zoo event in the Calendar. - hannibal2